### PR TITLE
fix(sports-ingestion): make ESPN parsing resilient to missing optiona…

### DIFF
--- a/ingestion/sports_service/src/database.rs
+++ b/ingestion/sports_service/src/database.rs
@@ -52,19 +52,19 @@ pub struct LeagueConfigs {
 pub struct CleanedData {
     pub league: String,
     pub external_game_id: String,
-    pub link: String,
+    pub link: Option<String>,
     pub home_team: Team,
     pub away_team: Team,
     pub start_time: chrono::DateTime<Utc>,
-    pub short_detail: String,
+    pub short_detail: Option<String>,
     pub state: String,
 }
 
 #[derive(Debug)]
 pub struct Team {
     pub name: String,
-    pub logo: String,
-    pub score: i32
+    pub logo: Option<String>,
+    pub score: Option<i32>,
 }
 
 pub struct LiveLeagueList {


### PR DESCRIPTION
…l fields

Previously, parse_espn_game used the ? operator on every field, causing the entire game to be silently dropped if any single optional field (link, logo, score, short_detail) was missing from ESPN's response.

- Split fields into required (id, teams, date, state) and optional (link, logo, score, short_detail) with proper Option<T> types
- Make CleanedData and Team structs use Option for nullable DB columns
- Add explicit error logging when required fields are missing
- Replace silent 'let _ =' on upsert_game with match that logs failures
- Add per-league summary logging (games found, upserted, failed)