### PR TITLE
feat(yahoo): add fantasy baseball (MLB) support

### DIFF
--- a/api/yahoo.go
+++ b/api/yahoo.go
@@ -240,7 +240,7 @@ func YahooLeagues(c *fiber.Ctx) error {
 	}
 
 	// Fallback to Live API
-	body, err := fetchYahoo(c, "https://fantasysports.yahooapis.com/fantasy/v2/users;use_login=1/games;game_keys=nfl,nba,nhl/leagues")
+	body, err := fetchYahoo(c, "https://fantasysports.yahooapis.com/fantasy/v2/users;use_login=1/games;game_keys=nfl,nba,nhl,mlb/leagues")
 	if err != nil { 
 		log.Printf("[Yahoo Error] Fetch failed: %v", err)
 		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{Status: "unauthorized", Error: "Failed to fetch data from Yahoo"}) 

--- a/ingestion/yahoo_service/yahoo_fantasy/src/api.rs
+++ b/ingestion/yahoo_service/yahoo_fantasy/src/api.rs
@@ -74,6 +74,7 @@ pub async fn get_user_leagues(tokens: &Tokens, client: Client) -> anyhow::Result
     let mut nba = Vec::new();
     let mut nfl = Vec::new();
     let mut nhl = Vec::new();
+    let mut mlb = Vec::new();
 
     let users = cleaned.users.user;
     let games = users[0].games.game.clone();
@@ -126,6 +127,7 @@ pub async fn get_user_leagues(tokens: &Tokens, client: Client) -> anyhow::Result
                 "nba" => nba.push(user_league),
                 "nfl" => nfl.push(user_league),
                 "nhl" => nhl.push(user_league),
+                "mlb" => mlb.push(user_league),
                 _ => (),
             }
         }
@@ -135,6 +137,7 @@ pub async fn get_user_leagues(tokens: &Tokens, client: Client) -> anyhow::Result
         nba,
         nfl,
         nhl,
+        mlb,
     };
     
     return Ok((leagues, opt_tokens));
@@ -286,11 +289,13 @@ pub async fn debug_league_stats(client: Client, tokens: &Tokens) -> anyhow::Resu
     leagues_info.nba.iter().for_each(|league| league_keys.push(&league.league_key));
     leagues_info.nfl.iter().for_each(|league| league_keys.push(&league.league_key));
     leagues_info.nhl.iter().for_each(|league| league_keys.push(&league.league_key));
+    leagues_info.mlb.iter().for_each(|league| league_keys.push(&league.league_key));
 
     let mut stats = LeagueStats {
         nfl: Vec::new(),
         nba: Vec::new(),
         nhl: Vec::new(),
+        mlb: Vec::new(),
     };
 
     let mut new_tokens: Option<(String, String)> = None;
@@ -320,6 +325,7 @@ pub async fn debug_league_stats(client: Client, tokens: &Tokens) -> anyhow::Resu
             "nfl" => stats.nfl.push(stat),
             "nba" => stats.nba.push(stat),
             "nhl" => stats.nhl.push(stat),
+            "mlb" => stats.mlb.push(stat),
             _ => ()
         }
     }

--- a/ingestion/yahoo_service/yahoo_fantasy/src/debug.rs
+++ b/ingestion/yahoo_service/yahoo_fantasy/src/debug.rs
@@ -7,4 +7,5 @@ pub struct LeagueStats {
     pub nfl: Vec<Vec<Stat>>,
     pub nba: Vec<Vec<Stat>>,
     pub nhl: Vec<Vec<Stat>>,
+    pub mlb: Vec<Vec<Stat>>,
 }

--- a/ingestion/yahoo_service/yahoo_fantasy/src/types.rs
+++ b/ingestion/yahoo_service/yahoo_fantasy/src/types.rs
@@ -22,6 +22,7 @@ pub struct Leagues {
     pub nba: Vec<UserLeague>,
     pub nfl: Vec<UserLeague>,
     pub nhl: Vec<UserLeague>,
+    pub mlb: Vec<UserLeague>,
 }
 
 #[derive(Serialize, Debug, Clone)]


### PR DESCRIPTION
- Add BaseballStats struct with dynamic stat decoding from stat_pairs_mlb.json
- Add mlb field to Leagues struct for league discovery
- Update api.rs to collect and return MLB leagues alongside NBA/NFL/NHL
- Add mlb to LeagueStats debug struct
- Update Go API to include mlb in game_keys query parameter