### PR TITLE
refactor: shard Hub into 16 independent dispatch workers

### DIFF
--- a/api/core/constants.go
+++ b/api/core/constants.go
@@ -41,6 +41,11 @@ const (
 	SSEHeartbeatInterval = 15 * time.Second
 	SSERetryIntervalMs   = 3000
 	SSEClientBufferSize  = 100
+
+	// HubShardCount is the number of independent Hub dispatch workers.
+	// Must be a power of 2 for efficient hash-to-shard mapping.
+	// 16 shards = 16 goroutines, each handling ~1/16th of all users.
+	HubShardCount = 16
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Split the single Hub goroutine into 16 independent shard workers
- Each shard subscribes to its own Redis PSUBSCRIBE pattern (`events:user:{hex}:*`)
- Shard assignment via FNV-1a hash of user ID with bit mask
- Redis channel names updated: `events:user:{shard}:{sub}`
- Uses `*clientList` wrapper for sync.Map CAS (lesson from Phase 1 hotfix)

## Files Changed
| File | Change |
|------|--------|
| `api/core/constants.go` | `HubShardCount = 16` |
| `api/core/events.go` | Full rewrite: `hubShard` type, `shardFor()`, `userChannel()`, per-shard `listenToRedis` |

## Impact
Lifts the Unlimited user ceiling from ~15K-20K to ~50K-100K during peak hours. Each shard handles ~1/16th of all messages independently with no cross-shard coordination.

## Migration
- Internal-only change (Redis channel naming is purely inside the core API binary)
- No frontend/extension changes required
- Atomic deploy: publisher (`SendToUser`/`SendToUsers`) and subscriber (sharded `PSUBSCRIBE`) are in the same binary
- Rollback: revert the binary, both sides revert together

## Public API
All function signatures unchanged from Phase 1: `RegisterClient`, `UnregisterClient`, `ClientCount`, `SendToUser`, `SendToUsers`, `RouteToRecordOwner`