### PR TITLE
refactor: topic-based PubSub for O(1) CDC fan-out (Phase 3)

### DIFF
--- a/api/core/constants.go
+++ b/api/core/constants.go
@@ -41,11 +41,20 @@ const (
 	SSEHeartbeatInterval = 15 * time.Second
 	SSERetryIntervalMs   = 3000
 	SSEClientBufferSize  = 100
+)
 
-	// HubShardCount is the number of independent Hub dispatch workers.
-	// Must be a power of 2 for efficient hash-to-shard mapping.
-	// 16 shards = 16 goroutines, each handling ~1/16th of all users.
-	HubShardCount = 16
+// =============================================================================
+// Topic Channel Prefixes
+// =============================================================================
+
+const (
+	// Each CDC event is published to exactly one topic channel.
+	// The Hub subscribes to all topic patterns and fans out in-memory.
+	TopicPrefixFinance = "cdc:finance:" // cdc:finance:{SYMBOL}
+	TopicPrefixSports  = "cdc:sports:"  // cdc:sports:{LEAGUE}
+	TopicPrefixRSS     = "cdc:rss:"     // cdc:rss:{feed_url_fnv_hash}
+	TopicPrefixFantasy = "cdc:fantasy:" // cdc:fantasy:{league_key}
+	TopicPrefixCore    = "cdc:core:user:" // cdc:core:user:{logto_sub}
 )
 
 // =============================================================================

--- a/api/core/events.go
+++ b/api/core/events.go
@@ -13,7 +13,6 @@ import (
 // Client represents a single SSE connection tied to an authenticated user.
 type Client struct {
 	UserID string
-	Shard  int
 	Ch     chan []byte
 }
 
@@ -25,9 +24,7 @@ type clientList struct {
 	entries []*Client
 }
 
-// trySend attempts a non-blocking send to a client's buffered channel.
-// Recovers from "send on closed channel" panic that can occur when unregister
-// closes a client's channel while the dispatch goroutine holds a stale snapshot.
+// trySend attempts a non-blocking send, recovering from closed-channel panics.
 func trySend(client *Client, payload []byte) bool {
 	defer func() { recover() }()
 	select {
@@ -38,86 +35,62 @@ func trySend(client *Client, payload []byte) bool {
 	}
 }
 
-// hubShard is an independent dispatch worker with its own Redis subscription
-// and client registry.
-type hubShard struct {
-	id      int
-	clients sync.Map // userID -> *clientList
-}
-
-// Hub maintains sharded per-user SSE client connections and routes messages
-// from Redis per-user channels to the correct clients.
+// Hub maintains per-user SSE client connections and a topic subscription
+// registry. Messages arrive on topic channels (one per CDC event) and are
+// fanned out to subscribed clients in-memory.
 type Hub struct {
-	shards      [HubShardCount]*hubShard
+	// clients maps userID -> *clientList
+	clients     sync.Map
 	clientCount atomic.Int64
+
+	// Topic subscription registry
+	registry *topicRegistry
 }
 
 var globalHub *Hub
 
-// shardFor returns the shard index for a given user ID.
-func shardFor(userID string) int {
-	h := fnv.New32a()
-	h.Write([]byte(userID))
-	return int(h.Sum32()) & (HubShardCount - 1) // bit mask for power-of-2
-}
-
-// shardPrefix returns the hex-encoded shard prefix for a user ID.
-// This is embedded in the Redis channel name for pattern-based routing.
-func shardPrefix(userID string) string {
-	return fmt.Sprintf("%x", shardFor(userID))
-}
-
-// userChannel returns the full Redis channel name for a user, including shard prefix.
-func userChannel(userID string) string {
-	return fmt.Sprintf("%s%s:%s", RedisEventsUserPrefix, shardPrefix(userID), userID)
-}
-
-// InitHub creates the sharded hub and starts all workers.
+// InitHub creates the topic-based hub and starts the listener.
 func InitHub(ctx context.Context) {
-	hub := &Hub{}
-	for i := 0; i < HubShardCount; i++ {
-		hub.shards[i] = &hubShard{id: i}
+	globalHub = &Hub{
+		registry: &topicRegistry{},
 	}
-	globalHub = hub
 
-	for i := 0; i < HubShardCount; i++ {
-		go hub.shards[i].listenToRedis(ctx)
-	}
+	go globalHub.listenToTopics(ctx)
 
 	// Shutdown watcher
 	go func() {
 		<-ctx.Done()
 		log.Println("[EventHub] Hub shutting down")
-		for _, shard := range hub.shards {
-			shard.clients.Range(func(key, value any) bool {
-				list := value.(*clientList)
-				for _, c := range list.entries {
-					close(c.Ch)
-				}
-				shard.clients.Delete(key)
-				return true
-			})
-		}
+		globalHub.clients.Range(func(key, value any) bool {
+			list := value.(*clientList)
+			for _, c := range list.entries {
+				close(c.Ch)
+			}
+			globalHub.clients.Delete(key)
+			return true
+		})
 	}()
 
-	log.Printf("[EventHub] Hub started with %d shards", HubShardCount)
+	log.Println("[EventHub] Hub started (topic-based mode)")
 }
 
-// listenToRedis subscribes to this shard's Redis pattern and dispatches
-// messages to registered clients.
-func (s *hubShard) listenToRedis(ctx context.Context) {
-	// Pattern: events:user:{shard_hex}:*
-	pattern := fmt.Sprintf("%s%x:*", RedisEventsUserPrefix, s.id)
-	pubsub := PSubscribe(ctx, pattern)
+// listenToTopics subscribes to all CDC topic patterns and dispatches to
+// registered clients based on the topic subscription registry.
+func (h *Hub) listenToTopics(ctx context.Context) {
+	pubsub := PSubscribe(ctx,
+		TopicPrefixFinance+"*",
+		TopicPrefixSports+"*",
+		TopicPrefixRSS+"*",
+		TopicPrefixFantasy+"*",
+		TopicPrefixCore+"*",
+	)
 	defer pubsub.Close()
 
 	ch := pubsub.Channel()
 
-	log.Printf("[EventHub] Shard %d listening to pattern: %s", s.id, pattern)
-
-	// The shard-specific prefix to strip when extracting the user ID.
-	// e.g., "events:user:a:" for shard 10
-	prefix := fmt.Sprintf("%s%x:", RedisEventsUserPrefix, s.id)
+	log.Printf("[EventHub] Listening to topic patterns: %s* %s* %s* %s* %s*",
+		TopicPrefixFinance, TopicPrefixSports, TopicPrefixRSS,
+		TopicPrefixFantasy, TopicPrefixCore)
 
 	for {
 		select {
@@ -128,56 +101,73 @@ func (s *hubShard) listenToRedis(ctx context.Context) {
 				return
 			}
 
-			// Extract userID by stripping the shard prefix
-			if !strings.HasPrefix(msg.Channel, prefix) {
-				continue
-			}
-			userID := msg.Channel[len(prefix):]
-			if userID == "" {
+			topic := msg.Channel
+			payload := []byte(msg.Payload)
+
+			// Special case: core user-specific topics (user_preferences, user_channels).
+			// These target a single user directly -- no registry lookup needed.
+			if strings.HasPrefix(topic, TopicPrefixCore) {
+				userID := topic[len(TopicPrefixCore):]
+				h.dispatchToUser(userID, payload)
 				continue
 			}
 
-			// Lock-free dispatch via sync.Map
-			value, ok := s.clients.Load(userID)
-			if !ok {
+			// Look up all users subscribed to this topic
+			users := h.registry.getUsersForTopic(topic)
+			if users == nil {
 				continue
 			}
-			list := value.(*clientList)
-			payload := []byte(msg.Payload)
-			for _, client := range list.entries {
-				trySend(client, payload)
+
+			// Fan-out in memory (no Redis, no network)
+			for userID := range users {
+				h.dispatchToUser(userID, payload)
 			}
 		}
 	}
 }
 
-// register adds a client to the correct shard.
-func (s *hubShard) register(client *Client) {
+// dispatchToUser sends a payload to all SSE clients for a given user.
+func (h *Hub) dispatchToUser(userID string, payload []byte) {
+	value, ok := h.clients.Load(userID)
+	if !ok {
+		return
+	}
+	list := value.(*clientList)
+	for _, client := range list.entries {
+		trySend(client, payload)
+	}
+}
+
+// register adds an authenticated client to the hub.
+func (h *Hub) register(client *Client) {
 	for {
-		existing, loaded := s.clients.Load(client.UserID)
+		existing, loaded := h.clients.Load(client.UserID)
 		if loaded {
 			old := existing.(*clientList)
 			newList := &clientList{
 				entries: append(old.entries, client),
 			}
-			if s.clients.CompareAndSwap(client.UserID, old, newList) {
+			if h.clients.CompareAndSwap(client.UserID, old, newList) {
 				break
 			}
 			// CAS failed -- another goroutine modified the list; retry
 		} else {
 			newList := &clientList{entries: []*Client{client}}
-			if _, swapped := s.clients.LoadOrStore(client.UserID, newList); !swapped {
+			if _, swapped := h.clients.LoadOrStore(client.UserID, newList); !swapped {
 				break
 			}
 			// Another goroutine stored first; retry with Load path
 		}
 	}
+	h.clientCount.Add(1)
 }
 
-// unregister removes a client from its shard and closes the channel.
-func (s *hubShard) unregister(client *Client) {
+// unregister removes a client from the hub, closes its channel, and removes
+// all topic subscriptions if this was the user's last connection.
+func (h *Hub) unregister(client *Client) {
+	var lastConnection bool
 	for {
-		existing, ok := s.clients.Load(client.UserID)
+		existing, ok := h.clients.Load(client.UserID)
 		if !ok {
 			return
 		}
@@ -196,63 +186,47 @@ func (s *hubShard) unregister(client *Client) {
 			return
 		}
 		if len(newEntries) == 0 {
-			if s.clients.CompareAndDelete(client.UserID, old) {
+			lastConnection = true
+			if h.clients.CompareAndDelete(client.UserID, old) {
 				break
 			}
 		} else {
 			newList := &clientList{entries: newEntries}
-			if s.clients.CompareAndSwap(client.UserID, old, newList) {
+			if h.clients.CompareAndSwap(client.UserID, old, newList) {
 				break
 			}
 		}
 		// CAS failed; retry
 	}
-}
+	h.clientCount.Add(-1)
 
-// --- Public API (unchanged signatures from Phase 1) ---
-
-// SendToUser publishes a message to a specific user's sharded Redis channel.
-func SendToUser(sub string, msg []byte) {
-	channel := userChannel(sub)
-	if err := PublishRaw(channel, msg); err != nil {
-		log.Printf("[EventHub] Failed to send to user %s: %v", sub, err)
+	// Clean up topic subscriptions when the user's last connection closes
+	if lastConnection {
+		h.registry.unsubscribeAll(client.UserID)
 	}
 }
 
-// SendToUsers publishes a message to multiple users' sharded Redis channels
-// in a single pipeline round-trip.
-func SendToUsers(subs []string, msg []byte) {
-	if len(subs) == 0 {
-		return
-	}
+// --- Public API ---
 
-	channels := make([]string, len(subs))
-	for i, sub := range subs {
-		channels[i] = userChannel(sub)
-	}
-
-	if errCount := PublishBatch(channels, msg); errCount > 0 {
-		log.Printf("[EventHub] Failed to send to %d/%d users", errCount, len(subs))
-	}
-}
-
-// RegisterClient adds an authenticated client to the correct hub shard.
+// RegisterClient adds an authenticated client to the hub and subscribes
+// them to the correct topics based on their channel configuration.
 func RegisterClient(userID string) *Client {
-	shard := shardFor(userID)
 	client := &Client{
 		UserID: userID,
-		Shard:  shard,
 		Ch:     make(chan []byte, SSEClientBufferSize),
 	}
-	globalHub.shards[shard].register(client)
-	globalHub.clientCount.Add(1)
+	globalHub.register(client)
+
+	// Subscribe to topics on first connection for this user.
+	// If the user already has connections, this is a no-op (idempotent).
+	go subscribeUserToTopics(userID)
+
 	return client
 }
 
-// UnregisterClient removes a client from its hub shard.
+// UnregisterClient removes a client from the hub.
 func UnregisterClient(client *Client) {
-	globalHub.shards[client.Shard].unregister(client)
-	globalHub.clientCount.Add(-1)
+	globalHub.unregister(client)
 }
 
 // ClientCount returns the total number of connected SSE clients.
@@ -260,11 +234,172 @@ func ClientCount() int {
 	return int(globalHub.clientCount.Load())
 }
 
+// SubscribeToTopic adds a user to a topic in the registry.
+func SubscribeToTopic(userID, topic string) {
+	globalHub.registry.subscribe(userID, topic)
+}
+
+// UnsubscribeFromTopic removes a user from a topic in the registry.
+func UnsubscribeFromTopic(userID, topic string) {
+	globalHub.registry.unsubscribe(userID, topic)
+}
+
+// UpdateUserTopicSubscriptions rebuilds a user's topic subscriptions.
+// Called from channel CRUD handlers when a user modifies their channels.
+// Only operates if the user has an active SSE connection.
+func UpdateUserTopicSubscriptions(userID string) {
+	if _, ok := globalHub.clients.Load(userID); !ok {
+		return // No active connection, nothing to update
+	}
+	globalHub.registry.unsubscribeAll(userID)
+	go subscribeUserToTopics(userID)
+}
+
 // RouteToRecordOwner sends a CDC event directly to the user identified in the record.
+// In Phase 3, this publishes to the core topic channel instead of per-user Redis.
 func RouteToRecordOwner(record map[string]interface{}, field string, payload []byte) {
 	sub, ok := record[field].(string)
 	if !ok || sub == "" {
 		return
 	}
-	SendToUser(sub, payload)
+	if err := PublishRaw(TopicPrefixCore+sub, payload); err != nil {
+		log.Printf("[EventHub] Failed to publish to core topic for %s: %v", sub, err)
+	}
+}
+
+// PublishToTopic publishes a CDC payload to a topic channel.
+// This is the Phase 3 replacement for SendToUsers.
+func PublishToTopic(topic string, payload []byte) {
+	if err := PublishRaw(topic, payload); err != nil {
+		log.Printf("[EventHub] Failed to publish to topic %s: %v", topic, err)
+	}
+}
+
+// TopicForRSSFeed returns the topic channel for an RSS feed URL.
+// Uses FNV-1a hash because RSS URLs can contain characters that break
+// Redis channel patterns (:, *, ?).
+func TopicForRSSFeed(feedURL string) string {
+	h := fnv.New32a()
+	h.Write([]byte(feedURL))
+	return fmt.Sprintf("%s%08x", TopicPrefixRSS, h.Sum32())
+}
+
+// subscribeUserToTopics reads the user's channel subscriptions from the DB
+// and registers them in the Hub's topic registry.
+func subscribeUserToTopics(userID string) {
+	ctx := context.Background()
+
+	// Core user-specific topics (user_preferences, user_channels) are handled
+	// by direct dispatch in listenToTopics -- no registry entry needed.
+
+	channels, err := GetUserChannels(userID)
+	if err != nil {
+		log.Printf("[EventHub] Failed to load channels for %s: %v", userID, err)
+		return
+	}
+
+	for _, ch := range channels {
+		if !ch.Enabled {
+			continue
+		}
+
+		switch ch.ChannelType {
+		case "finance":
+			symbols := extractSymbolsFromConfig(ch.Config)
+			for _, sym := range symbols {
+				globalHub.registry.subscribe(userID, TopicPrefixFinance+sym)
+			}
+
+		case "sports":
+			// Subscribe to all leagues. Per-league filtering via config
+			// can be added later.
+			for _, league := range SportsLeagues {
+				globalHub.registry.subscribe(userID, TopicPrefixSports+league)
+			}
+
+		case "rss":
+			feeds := extractFeedURLsFromConfig(ch.Config)
+			for _, feedURL := range feeds {
+				globalHub.registry.subscribe(userID, TopicForRSSFeed(feedURL))
+			}
+
+		case "fantasy":
+			leagueKeys, err := getUserFantasyLeagues(ctx, userID)
+			if err != nil {
+				log.Printf("[EventHub] Failed to load fantasy leagues for %s: %v", userID, err)
+				continue
+			}
+			for _, lk := range leagueKeys {
+				globalHub.registry.subscribe(userID, TopicPrefixFantasy+lk)
+			}
+		}
+	}
+}
+
+// extractSymbolsFromConfig reads the "symbols" array from a channel's config JSONB.
+// Config shape: {"symbols": ["AAPL", "GOOG", ...]}
+func extractSymbolsFromConfig(config map[string]interface{}) []string {
+	raw, ok := config["symbols"]
+	if !ok {
+		return nil
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	symbols := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s != "" {
+			symbols = append(symbols, s)
+		}
+	}
+	return symbols
+}
+
+// extractFeedURLsFromConfig reads feed URLs from a channel's config JSONB.
+// Config shape: {"feeds": [{"url": "https://...", "name": "..."}, ...]}
+func extractFeedURLsFromConfig(config map[string]interface{}) []string {
+	raw, ok := config["feeds"]
+	if !ok {
+		return nil
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	urls := make([]string, 0, len(arr))
+	for _, v := range arr {
+		feed, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if u, ok := feed["url"].(string); ok && u != "" {
+			urls = append(urls, u)
+		}
+	}
+	return urls
+}
+
+// getUserFantasyLeagues returns the Yahoo league keys a user has imported.
+func getUserFantasyLeagues(ctx context.Context, userID string) ([]string, error) {
+	rows, err := DBPool.Query(ctx, `
+		SELECT yl.league_key
+		FROM yahoo_leagues yl
+		INNER JOIN yahoo_users yu ON yu.guid = yl.guid
+		WHERE yu.logto_sub = $1
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query fantasy leagues: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
 }

--- a/api/core/redis.go
+++ b/api/core/redis.go
@@ -65,9 +65,9 @@ func PublishBatch(channels []string, data []byte) int {
 	return errCount
 }
 
-// PSubscribe listens to Redis channels matching a pattern.
-func PSubscribe(ctx context.Context, pattern string) *redis.PubSub {
-	return Rdb.PSubscribe(ctx, pattern)
+// PSubscribe listens to Redis channels matching one or more patterns.
+func PSubscribe(ctx context.Context, patterns ...string) *redis.PubSub {
+	return Rdb.PSubscribe(ctx, patterns...)
 }
 
 // InvalidateDashboardCache removes the cached dashboard response for a user.

--- a/api/core/registry.go
+++ b/api/core/registry.go
@@ -1,0 +1,124 @@
+package core
+
+import "sync"
+
+// topicRegistry maintains bidirectional mappings between users and topics.
+// It enables O(1) topic -> user lookups for message dispatch.
+//
+// Inner maps use COPY-ON-WRITE semantics. The subscribe/unsubscribe methods
+// never mutate a map in place -- they clone it, modify the clone, and store
+// the clone atomically. This ensures the dispatch goroutine can safely iterate
+// a snapshot without holding any lock.
+type topicRegistry struct {
+	// topicToUsers maps a topic to an immutable snapshot of user IDs.
+	topicToUsers sync.Map // topic string -> map[string]struct{} (immutable after store)
+
+	// userToTopics maps a user ID to an immutable snapshot of topic strings.
+	userToTopics sync.Map // userID string -> map[string]struct{} (immutable after store)
+
+	mu sync.Mutex // serializes write operations (clone + store)
+}
+
+// cloneSet creates a shallow copy of a string set.
+func cloneSet(src map[string]struct{}) map[string]struct{} {
+	dst := make(map[string]struct{}, len(src)+1)
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// subscribe adds a user to a topic (copy-on-write).
+func (r *topicRegistry) subscribe(userID, topic string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Clone topic -> users, add user, store new snapshot
+	var newUsers map[string]struct{}
+	if existing, ok := r.topicToUsers.Load(topic); ok {
+		newUsers = cloneSet(existing.(map[string]struct{}))
+	} else {
+		newUsers = make(map[string]struct{}, 1)
+	}
+	newUsers[userID] = struct{}{}
+	r.topicToUsers.Store(topic, newUsers)
+
+	// Clone user -> topics, add topic, store new snapshot
+	var newTopics map[string]struct{}
+	if existing, ok := r.userToTopics.Load(userID); ok {
+		newTopics = cloneSet(existing.(map[string]struct{}))
+	} else {
+		newTopics = make(map[string]struct{}, 1)
+	}
+	newTopics[topic] = struct{}{}
+	r.userToTopics.Store(userID, newTopics)
+}
+
+// unsubscribe removes a user from a topic (copy-on-write).
+func (r *topicRegistry) unsubscribe(userID, topic string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.topicToUsers.Load(topic); ok {
+		old := existing.(map[string]struct{})
+		if _, found := old[userID]; found {
+			if len(old) == 1 {
+				r.topicToUsers.Delete(topic)
+			} else {
+				newUsers := cloneSet(old)
+				delete(newUsers, userID)
+				r.topicToUsers.Store(topic, newUsers)
+			}
+		}
+	}
+
+	if existing, ok := r.userToTopics.Load(userID); ok {
+		old := existing.(map[string]struct{})
+		if _, found := old[topic]; found {
+			if len(old) == 1 {
+				r.userToTopics.Delete(userID)
+			} else {
+				newTopics := cloneSet(old)
+				delete(newTopics, topic)
+				r.userToTopics.Store(userID, newTopics)
+			}
+		}
+	}
+}
+
+// unsubscribeAll removes a user from all topics. Called on disconnect.
+func (r *topicRegistry) unsubscribeAll(userID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	topicsVal, ok := r.userToTopics.Load(userID)
+	if !ok {
+		return
+	}
+	topics := topicsVal.(map[string]struct{})
+
+	for topic := range topics {
+		if existing, ok := r.topicToUsers.Load(topic); ok {
+			old := existing.(map[string]struct{})
+			if len(old) <= 1 {
+				r.topicToUsers.Delete(topic)
+			} else {
+				newUsers := cloneSet(old)
+				delete(newUsers, userID)
+				r.topicToUsers.Store(topic, newUsers)
+			}
+		}
+	}
+
+	r.userToTopics.Delete(userID)
+}
+
+// getUsersForTopic returns an immutable snapshot of user IDs subscribed to a
+// topic. Safe for concurrent iteration -- the returned map is never mutated.
+func (r *topicRegistry) getUsersForTopic(topic string) map[string]struct{} {
+	usersVal, ok := r.topicToUsers.Load(topic)
+	if !ok {
+		return nil
+	}
+	return usersVal.(map[string]struct{})
+}


### PR DESCRIPTION
## Summary
- Replace per-user Redis PUBLISH (O(N)) with topic-based PUBLISH (O(1)) per CDC event
- Core API routes CDC events directly to topic channels (`cdc:finance:AAPL`, `cdc:sports:NFL`, etc.) without calling channel APIs' `/internal/cdc` endpoints in the hot path
- Hub maintains an in-memory topic subscription registry with copy-on-write semantics for lock-free dispatch
- Subscriptions rebuilt from `user_channels` DB table on SSE connect, torn down on disconnect
- Channel CRUD handlers call `UpdateUserTopicSubscriptions` for live topic registry updates

## Architecture change
```
Before (Phase 2):
  1 CDC event → channel API HTTP call → N Redis PUBLISH (pipelined) → 16 Hub shards

After (Phase 3):
  1 CDC event → 1 Redis PUBLISH to topic → Hub in-memory fan-out to N clients
```

## Files changed
| File | Change |
|------|--------|
| `constants.go` | Add `TopicPrefix*` constants, remove `HubShardCount` |
| `registry.go` | **New**: `topicRegistry` with bidirectional sync.Map + copy-on-write |
| `events.go` | Full rewrite: topic-based Hub, `subscribeUserToTopics()`, config parsers, `getUserFantasyLeagues()` |
| `handlers_webhook.go` | Replace `forwardCDCToChannel` + `SendToUsers` with `topicForRecord()` + `PublishToTopic()` |
| `redis.go` | `PSubscribe` now variadic (`...string`) |
| `channels.go` | Add `UpdateUserTopicSubscriptions` calls in add/remove subscription helpers |

## Depends on
- Phase 1 (PR #11) and Phase 2 (PR #12) — both merged to staging

## Impact
Lifts Unlimited-tier SSE ceiling from ~50K-100K to ~100K-500K concurrent users.
Redis operations per CDC event drop from O(N_users) to O(1).

## Breaking changes
- Channel API `POST /internal/cdc` endpoints no longer called in the hot path (kept for backward compat)
- `HubShardCount` constant removed
- `Client.Shard` field removed
- `SendToUser`/`SendToUsers` functions removed (replaced by `PublishToTopic`)