### PR TITLE
fix(desktop): v0.2.1 — macOS interaction fix, polish, type safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ count.txt
 .claude/
 __pycache__/
 *.pyc
-.venv/
+.venv/channels/sports/api/scrollr-sports
+scaling-changes/

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ count.txt
 .claude/
 __pycache__/
 *.pyc
-.venv/channels/sports/api/scrollr-sports
+.venv/
+channels/sports/api/scrollr-sports
 scaling-changes/

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -545,6 +545,14 @@ pub fn run() {
 
             let _ = ticker.show();
 
+            // ── App window: strip native chrome on Linux/Windows ─
+            // macOS keeps native decorations (traffic lights). On
+            // other platforms we use our custom TitleBar component.
+            #[cfg(not(target_os = "macos"))]
+            if let Some(app_win) = app.get_webview_window("app") {
+                let _ = app_win.set_decorations(false);
+            }
+
             // ── System tray ──────────────────────────────────────
             let open = MenuItemBuilder::with_id("open", "Open Scrollr").build(app)?;
             let show_ticker = MenuItemBuilder::with_id("show_ticker", "Show/Hide Ticker").build(app)?;

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -40,7 +40,7 @@
         "height": 640,
         "minWidth": 720,
         "minHeight": 480,
-        "decorations": false,
+        "decorations": true,
         "alwaysOnTop": false,
         "resizable": true,
         "skipTaskbar": false,

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -15,9 +15,11 @@ import {
   getTier,
 } from "./auth";
 import type { SubscriptionTier } from "./auth";
-import type { Channel } from "./api/client";
+import type { Channel, ChannelType } from "./api/client";
 import { channelsApi } from "./api/client";
 import {
+  loadPref,
+  savePref,
   loadPrefs,
   savePrefs,
   TICKER_GAPS,
@@ -33,21 +35,6 @@ const POLL_INTERVALS: Record<SubscriptionTier, number> = {
   uplink: 30_000,
   uplink_unlimited: 30_000,
 };
-
-// ── Local storage helpers ────────────────────────────────────────
-
-function loadPref<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(`scrollr:${key}`);
-    return raw !== null ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function savePref<T>(key: string, value: T): void {
-  localStorage.setItem(`scrollr:${key}`, JSON.stringify(value));
-}
 
 // ── App (Ticker Window) ─────────────────────────────────────────
 
@@ -399,7 +386,7 @@ export default function App() {
   useEffect(() => {
     const shell = document.getElementById("desktop-shell");
     if (!shell) return;
-    (shell as HTMLElement).style.zoom =
+    shell.style.zoom =
       prefs.appearance.uiScale === 100
         ? ""
         : `${prefs.appearance.uiScale}%`;
@@ -466,7 +453,7 @@ export default function App() {
   // ── Channel quick-toggle (for context menu) ────────────────────
 
   const handleChannelToggle = useCallback(
-    async (channelType: string, visible: boolean) => {
+    async (channelType: ChannelType, visible: boolean) => {
       const token = await getValidToken();
       if (!token) return;
       try {

--- a/desktop/src/MainApp.tsx
+++ b/desktop/src/MainApp.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { getVersion } from "@tauri-apps/api/app";
 import {
   enable as enableAutostart,
   disable as disableAutostart,
   isEnabled as isAutostartEnabled,
 } from "@tauri-apps/plugin-autostart";
 
+import clsx from "clsx";
 import TitleBar from "./components/TitleBar";
 import Sidebar from "./components/Sidebar";
 import type { Section, SettingsTab } from "./components/Sidebar";
@@ -22,7 +24,7 @@ import {
   getTier,
 } from "./auth";
 import type { SubscriptionTier } from "./auth";
-import type { Channel } from "./api/client";
+import type { Channel, ChannelType } from "./api/client";
 import { channelsApi } from "./api/client";
 import {
   loadPref,
@@ -39,6 +41,11 @@ const API_URL = "https://api.myscrollr.relentnet.dev";
 // ── Canonical channel order ─────────────────────────────────────
 
 const CHANNEL_ORDER = ["finance", "sports", "rss", "fantasy"];
+
+// ── Platform detection ──────────────────────────────────────────
+// macOS uses native window decorations (traffic lights). Linux and
+// Windows use the custom TitleBar component with JS-based drag.
+const IS_MACOS = /Mac/.test(navigator.platform);
 
 // ── App ─────────────────────────────────────────────────────────
 
@@ -63,9 +70,13 @@ export default function MainApp() {
   const [activeTab, setActiveTab] = useState(
     () => loadPref("activeTab", "finance"),
   );
-  const [feedMode] = useState<FeedMode>(
-    () => loadPref<FeedMode>("feedMode", "comfort"),
-  );
+  const feedMode = loadPref<FeedMode>("feedMode", "comfort");
+
+  // App version (read from tauri.conf.json at runtime)
+  const [appVersion, setAppVersion] = useState("0.0.0");
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => {});
+  }, []);
 
   // Preferences
   const [prefs, setPrefs] = useState<AppPreferences>(loadPrefs);
@@ -138,7 +149,7 @@ export default function MainApp() {
   useEffect(() => {
     const shell = document.getElementById("app-shell");
     if (!shell) return;
-    (shell as HTMLElement).style.zoom =
+    shell.style.zoom =
       prefs.appearance.uiScale === 100
         ? ""
         : `${prefs.appearance.uiScale}%`;
@@ -257,7 +268,7 @@ export default function MainApp() {
   // ── Channel handlers ────────────────────────────────────────
 
   const handleToggleChannel = useCallback(
-    async (channelType: string, visible: boolean) => {
+    async (channelType: ChannelType, visible: boolean) => {
       const token = await getValidToken();
       if (!token) return;
       try {
@@ -281,7 +292,7 @@ export default function MainApp() {
   );
 
   const handleAddChannel = useCallback(
-    async (channelType: string) => {
+    async (channelType: ChannelType) => {
       const token = await getValidToken();
       if (!token) return;
       try {
@@ -299,7 +310,7 @@ export default function MainApp() {
   );
 
   const handleDeleteChannel = useCallback(
-    async (channelType: string) => {
+    async (channelType: ChannelType) => {
       const token = await getValidToken();
       if (!token) return;
       try {
@@ -396,9 +407,12 @@ export default function MainApp() {
     <div
       id="app-shell"
       data-theme="dark"
-      className="flex flex-col h-screen w-screen overflow-hidden bg-surface text-fg"
+      className={clsx(
+        "flex flex-col h-screen w-screen overflow-hidden bg-surface text-fg",
+        !IS_MACOS && "custom-chrome",
+      )}
     >
-      <TitleBar />
+      {!IS_MACOS && <TitleBar />}
 
       <div className="flex flex-1 min-h-0 overflow-hidden">
       <Sidebar
@@ -408,6 +422,7 @@ export default function MainApp() {
         onToggleTicker={handleToggleStandaloneTicker}
         settingsTab={settingsTab}
         onSettingsTabChange={handleSettingsTab}
+        appVersion={appVersion}
       />
 
       <main className="flex-1 flex flex-col min-w-0 overflow-hidden relative">
@@ -471,6 +486,7 @@ export default function MainApp() {
                 savePref("activeTab", tab);
               }}
               onLogin={handleLogin}
+              onNavigateToChannels={() => handleNavigate("channels")}
             />
           )}
 
@@ -500,7 +516,7 @@ export default function MainApp() {
                 const ch = channels.find((c) => c.channel_type === activeTab);
                 if (ch) handleToggleChannel(ch.channel_type, !ch.visible);
               }}
-              onDelete={() => handleDeleteChannel(activeTab)}
+              onDelete={() => handleDeleteChannel(activeTab as ChannelType)}
               onChannelUpdate={handleChannelUpdate}
               onLogin={handleLogin}
             />
@@ -536,6 +552,7 @@ export default function MainApp() {
             <AccountSection
               authenticated={authenticated}
               tier={tier}
+              appVersion={appVersion}
               onLogin={handleLogin}
               onLogout={handleLogout}
             />
@@ -562,15 +579,6 @@ export default function MainApp() {
   );
 }
 
-// ── Dashboard key map (mirrors FeedBar) ──────────────────────────
-
-const DASHBOARD_KEY_MAP: Record<string, string> = {
-  finance: "finance",
-  sports: "sports",
-  rss: "rss",
-  fantasy: "fantasy",
-};
-
 // ── Feed Section ─────────────────────────────────────────────────
 
 function FeedSection({
@@ -582,6 +590,7 @@ function FeedSection({
   activeTab,
   onActiveTabChange,
   onLogin,
+  onNavigateToChannels,
 }: {
   authenticated: boolean;
   loading: boolean;
@@ -591,15 +600,13 @@ function FeedSection({
   activeTab: string;
   onActiveTabChange: (tab: string) => void;
   onLogin: () => void;
+  onNavigateToChannels: () => void;
 }) {
   const visibleChannels = channels.filter((ch) => ch.enabled && ch.visible);
 
   // Build channelConfig for the active FeedTab (same pattern as FeedBar)
   const channelConfig = useMemo(() => {
-    const dashboardKey = DASHBOARD_KEY_MAP[activeTab];
-    const initialItems = dashboardKey
-      ? (dashboard?.data?.[dashboardKey] ?? [])
-      : [];
+    const initialItems = dashboard?.data?.[activeTab] ?? [];
     return {
       __initialItems: initialItems,
       __dashboardLoaded: dashboard !== null,
@@ -649,7 +656,7 @@ function FeedSection({
         title="No active channels"
         description="Enable some channels to see live data in your feed."
         action="Go to Channels"
-        onAction={() => {}}
+        onAction={onNavigateToChannels}
       />
     );
   }
@@ -709,9 +716,9 @@ function ChannelsSection({
 }: {
   authenticated: boolean;
   channels: Channel[];
-  onToggle: (channelType: string, visible: boolean) => void;
-  onAdd: (channelType: string) => void;
-  onDelete: (channelType: string) => void;
+  onToggle: (channelType: ChannelType, visible: boolean) => void;
+  onAdd: (channelType: ChannelType) => void;
+  onDelete: (channelType: ChannelType) => void;
   onLogin: () => void;
 }) {
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
@@ -817,13 +824,13 @@ function ChannelsSection({
       )}
 
       {/* Available channels to add */}
-      {allManifests.filter((m) => !addedTypes.has(m.id)).length > 0 && (
+      {allManifests.filter((m) => !addedTypes.has(m.id as ChannelType)).length > 0 && (
         <div className="space-y-2">
           <h3 className="text-xs font-semibold text-fg-3 uppercase tracking-wider">
             Available
           </h3>
           {allManifests
-            .filter((m) => !addedTypes.has(m.id))
+            .filter((m) => !addedTypes.has(m.id as ChannelType))
             .map((manifest) => (
               <div
                 key={manifest.id}
@@ -842,7 +849,7 @@ function ChannelsSection({
                   </div>
                 </div>
                 <button
-                  onClick={() => onAdd(manifest.id)}
+                  onClick={() => onAdd(manifest.id as ChannelType)}
                   className="px-3 py-1.5 rounded-lg text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
                 >
                   Add
@@ -967,11 +974,13 @@ function DashboardSection({
 function AccountSection({
   authenticated,
   tier,
+  appVersion,
   onLogin,
   onLogout,
 }: {
   authenticated: boolean;
   tier: SubscriptionTier;
+  appVersion: string;
   onLogin: () => void;
   onLogout: () => void;
 }) {
@@ -1041,7 +1050,7 @@ function AccountSection({
         <div className="pt-4 border-t border-edge/50">
           <div className="flex items-center justify-between text-xs text-fg-4">
             <span>Version</span>
-            <span className="font-mono">0.1.0</span>
+            <span className="font-mono">{appVersion}</span>
           </div>
           <div className="flex items-center justify-between text-xs text-fg-4 mt-1">
             <span>Runtime</span>

--- a/desktop/src/components/AppTaskbar.tsx
+++ b/desktop/src/components/AppTaskbar.tsx
@@ -137,6 +137,7 @@ export default function AppTaskbar({
         onClick={toggleTheme}
         className={btnIdle}
         title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+        aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
       >
         {isDark ? <Sun size={14} /> : <Moon size={14} />}
       </button>
@@ -145,6 +146,7 @@ export default function AppTaskbar({
         onClick={onToggleTicker}
         className={clsx(showTicker ? btnActive : btnIdle)}
         title={showTicker ? "Hide ticker preview" : "Show ticker preview"}
+        aria-label={showTicker ? "Hide ticker preview" : "Show ticker preview"}
       >
         {showTicker ? <TicketCheck size={14} /> : <TicketSlash size={14} />}
       </button>
@@ -153,6 +155,7 @@ export default function AppTaskbar({
         onClick={cycleRows}
         className={btnIdle}
         title={`Ticker rows: ${rows} (click to cycle)`}
+        aria-label={`Ticker rows: ${rows}`}
       >
         {rows <= 1 ? <Rows2 size={14} /> : <Rows3 size={14} />}
       </button>
@@ -161,6 +164,7 @@ export default function AppTaskbar({
         onClick={togglePin}
         className={clsx(isPinned ? btnActive : btnIdle)}
         title={isPinned ? "Unpin from top" : "Pin on top"}
+        aria-label={isPinned ? "Unpin from top" : "Pin on top"}
       >
         {isPinned ? <Pin size={14} /> : <PinOff size={14} />}
       </button>

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ interface SidebarProps {
   onToggleTicker: () => void;
   settingsTab: SettingsTab;
   onSettingsTabChange: (tab: SettingsTab) => void;
+  appVersion?: string;
 }
 
 const NAV_ITEMS: { id: Section; label: string; icon: typeof Activity }[] = [
@@ -46,6 +47,7 @@ export default function Sidebar({
   onToggleTicker,
   settingsTab,
   onSettingsTabChange,
+  appVersion,
 }: SidebarProps) {
   return (
     <aside className="flex flex-col w-[200px] shrink-0 border-r border-edge bg-surface-2 h-full">
@@ -170,7 +172,7 @@ export default function Sidebar({
 
       {/* Version */}
       <div className="px-4 py-3 border-t border-edge">
-        <span className="text-[10px] font-mono text-fg-4">v0.1.0</span>
+        <span className="text-[10px] font-mono text-fg-4">v{appVersion ?? "0.0.0"}</span>
       </div>
     </aside>
   );

--- a/desktop/src/components/TitleBar.tsx
+++ b/desktop/src/components/TitleBar.tsx
@@ -48,6 +48,7 @@ export default function TitleBar() {
           onClick={() => appWindow.minimize()}
           className={`${btnBase} text-fg-3 hover:text-fg hover:bg-surface-hover`}
           title="Minimize"
+          aria-label="Minimize"
           onMouseDown={(e) => e.stopPropagation()}
         >
           <svg width="10" height="1" viewBox="0 0 10 1">
@@ -60,6 +61,7 @@ export default function TitleBar() {
           onClick={() => appWindow.toggleMaximize()}
           className={`${btnBase} text-fg-3 hover:text-fg hover:bg-surface-hover`}
           title={maximized ? "Restore" : "Maximize"}
+          aria-label={maximized ? "Restore" : "Maximize"}
           onMouseDown={(e) => e.stopPropagation()}
         >
           {maximized ? (
@@ -101,6 +103,7 @@ export default function TitleBar() {
           onClick={() => appWindow.close()}
           className={`${btnBase} text-fg-3 hover:text-fg hover:bg-error/80 hover:text-white`}
           title="Close"
+          aria-label="Close"
           onMouseDown={(e) => e.stopPropagation()}
         >
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none">

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -315,22 +315,17 @@ body {
 }
 
 /* ── Custom title bar ─────────────────────────────────────────── */
+/* Drag is handled via JS (startDragging) — NOT CSS app-region.
+   CSS app-region: drag causes macOS WKWebView to swallow mouse
+   events before they reach JavaScript, breaking all buttons. */
 
 .titlebar {
   border-bottom: 1px solid var(--color-edge);
-  -webkit-app-region: drag;
-  app-region: drag;
 }
 
-/* Buttons must be non-draggable so they receive clicks */
-.titlebar button {
-  -webkit-app-region: no-drag;
-  app-region: no-drag;
-}
-
-/* Title bar rounds top corners when window is not maximized.
-   Tauri's borderless window has no rounding by default on Linux. */
-#app-shell {
+/* Rounded corners for custom-chrome windows (Linux/Windows).
+   macOS uses native decorations which handle rounding themselves. */
+#app-shell.custom-chrome {
   border-radius: 8px;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary

Patch release for the Scrollr desktop app (v0.2.1) fixing **broken mouse interactions on macOS** introduced by the v0.2.0 two-window architecture, plus cleanup and type safety improvements.

## Root Cause

`app-region: drag` in CSS combined with `decorations: false` caused WKWebView on macOS to intercept **all** mouse events at the native compositor layer before JavaScript could process them — making every button in the app unclickable.

## Changes

### macOS Fix
- **Native decorations on macOS** — `tauri.conf.json` sets `decorations: true`; Rust strips decorations at startup on Linux/Windows via `#[cfg(not(target_os = "macos"))]`
- **Removed `app-region: drag` entirely** from CSS — drag handled solely via JS `startDragging()` in TitleBar
- **Conditional TitleBar rendering** — custom chrome only on non-macOS (`navigator.platform` check)
- **Scoped `#app-shell` border-radius** to `.custom-chrome` class (macOS uses native window rounding)

### Polish
- **Dynamic version display** — reads from `tauri.conf.json` via `getVersion()` API, shown in Sidebar and Account section
- **Wired "Go to Channels" button** — was a no-op `() => {}`, now navigates correctly
- **Deduplicated `loadPref`/`savePref`** — removed local copies in App.tsx, imports from `preferences.ts`
- **Removed dead `DASHBOARD_KEY_MAP`** identity map — replaced with direct `activeTab` usage
- **Removed redundant `as HTMLElement` casts** in MainApp.tsx and App.tsx

### Type Safety
- **Fixed all 6 pre-existing TS errors** — handler params typed as `ChannelType`, proper casts at call sites where values come from untyped sources
- **Zero TypeScript errors** — `tsc --noEmit` passes clean

### Accessibility
- **`aria-label` on all icon-only buttons** — TitleBar (minimize, maximize, close) and AppTaskbar (4 action buttons)

## Files Changed
- `desktop/src-tauri/tauri.conf.json` — decorations + version bump
- `desktop/src-tauri/src/lib.rs` — conditional decoration stripping
- `desktop/src-tauri/Cargo.toml` — version 0.2.1
- `desktop/package.json` — version 0.2.1
- `desktop/src/MainApp.tsx` — macOS guard, version state, ChannelType fixes, cleanup
- `desktop/src/App.tsx` — deduped imports, ChannelType handler typing
- `desktop/src/style.css` — removed app-region, scoped border-radius
- `desktop/src/components/TitleBar.tsx` — aria-labels
- `desktop/src/components/AppTaskbar.tsx` — aria-labels
- `desktop/src/components/Sidebar.tsx` — dynamic version prop
- `.gitignore` — added sports binary and scaling-changes dir

## Testing
- `tsc --noEmit` — zero errors
- Rust `cargo build` — compiles clean
- Manual testing needed on macOS, Linux, and Windows