### PR TITLE
feat(desktop): v0.4.0 — ticker position toggle with full-width snap

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -12,15 +12,14 @@ use tokio::sync::watch;
 struct SseHandle(Mutex<Option<watch::Sender<bool>>>);
 
 /// Resize the window height, preserving current width.
-/// Anchors the bottom edge: when height changes, the top edge moves
-/// while the bottom stays fixed (natural for a bottom-docked window).
+/// The `anchor` parameter controls which edge stays fixed:
+///   - `"top"`: top edge stays fixed, height extends downward (no reposition)
+///   - `"bottom"` (or any other value): bottom edge stays fixed, top moves
 ///
 /// Reads current geometry once up-front, then applies size + position
-/// in a single pass to minimise visual tearing. Size is applied first
-/// so the brief intermediate state extends *downward* (usually off-screen
-/// for a bottom-docked window), then position corrects upward.
+/// in a single pass to minimise visual tearing.
 #[tauri::command]
-fn resize_window(window: tauri::Window, height: f64) {
+fn resize_window(window: tauri::Window, height: f64, anchor: Option<String>) {
     let (size, pos) = match (window.outer_size(), window.outer_position()) {
         (Ok(s), Ok(p)) => (s, p),
         _ => return,
@@ -34,15 +33,18 @@ fn resize_window(window: tauri::Window, height: f64) {
         return; // no meaningful change
     }
 
-    // 1. Resize first — window briefly extends downward
+    // 1. Resize — window extends downward from current position
     let _ = window.set_size(tauri::LogicalSize::new(current_width, height));
 
-    // 2. Shift upward so bottom edge returns to its original position
-    let current_y = pos.y as f64 / scale;
-    let _ = window.set_position(tauri::LogicalPosition::new(
-        pos.x as f64 / scale,
-        current_y - delta,
-    ));
+    // 2. If bottom-anchored, shift upward so bottom edge stays fixed
+    let is_top = anchor.as_deref() == Some("top");
+    if !is_top {
+        let current_y = pos.y as f64 / scale;
+        let _ = window.set_position(tauri::LogicalPosition::new(
+            pos.x as f64 / scale,
+            current_y - delta,
+        ));
+    }
 }
 
 /// Start a temporary HTTP server on 127.0.0.1:19284 to receive the OAuth
@@ -140,6 +142,217 @@ fn percent_decode(input: &str) -> String {
         }
     }
     out
+}
+
+/// Snap the ticker window to a screen edge and stretch it to full monitor width.
+/// Sets x = monitor left edge, width = monitor width, y = top or bottom edge.
+///
+/// Like `pin_window`, Wayland compositors ignore GTK's `set_position()` and
+/// may ignore `set_size()`. We detect the compositor and use native IPC:
+///   Hyprland → `hyprctl dispatch movewindowpixel` + `resizewindowpixel`
+///   Sway     → `swaymsg move absolute position` + `resize set`
+///   KDE/KWin → `qdbus6` D-Bus scripting API → frameGeometry
+///   Fallback → GTK set_size + set_position (works on macOS/Windows/X11)
+#[tauri::command]
+fn position_ticker(window: tauri::Window, position: String) -> Result<(), String> {
+    let monitor = window
+        .current_monitor()
+        .map_err(|e| format!("monitor query failed: {e}"))?
+        .ok_or("no monitor found")?;
+
+    let scale = monitor.scale_factor();
+    let screen_width = monitor.size().width as f64 / scale;
+    let screen_height = monitor.size().height as f64 / scale;
+    let monitor_x = monitor.position().x as f64 / scale;
+    let monitor_y = monitor.position().y as f64 / scale;
+
+    let size = window
+        .outer_size()
+        .map_err(|e| format!("outer_size failed: {e}"))?;
+    let win_height = size.height as f64 / scale;
+
+    let new_y = if position == "top" {
+        monitor_y
+    } else {
+        monitor_y + screen_height - win_height
+    };
+
+    // Wayland compositors ignore GTK set_position/set_size — use native IPC
+    if std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok() {
+        return position_hyprland(&window, monitor_x, new_y, screen_width);
+    }
+    if std::env::var("SWAYSOCK").is_ok() {
+        return position_sway(&window, monitor_x, new_y, screen_width);
+    }
+    if is_kde() {
+        if let Some(qdbus) = find_qdbus() {
+            return position_kwin(&window, monitor_x, new_y, screen_width, &qdbus);
+        }
+    }
+
+    // Fallback: GTK (macOS, Windows, X11, GNOME)
+    let _ = window.set_size(tauri::LogicalSize::new(screen_width, win_height));
+    window
+        .set_position(tauri::LogicalPosition::new(monitor_x, new_y))
+        .map_err(|e| format!("set_position failed: {e}"))?;
+    Ok(())
+}
+
+/// Hyprland: move + resize via `hyprctl dispatch`.
+fn position_hyprland(
+    window: &tauri::Window,
+    x: f64,
+    y: f64,
+    width: f64,
+) -> Result<(), String> {
+    let title = window.title().unwrap_or_default();
+
+    let output = std::process::Command::new("hyprctl")
+        .args(["clients", "-j"])
+        .output()
+        .map_err(|e| format!("hyprctl failed: {e}"))?;
+
+    let clients: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).map_err(|e| format!("parse error: {e}"))?;
+
+    for client in &clients {
+        if client["title"].as_str().unwrap_or("") == title {
+            let addr = client["address"].as_str().ok_or("no address field")?;
+            let current_h = client["size"]
+                .as_array()
+                .and_then(|a| a.get(1))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(44);
+
+            // Resize to full monitor width, keeping current height
+            std::process::Command::new("hyprctl")
+                .args([
+                    "dispatch",
+                    "resizewindowpixel",
+                    &format!("exact {} {},address:{addr}", width as i32, current_h),
+                ])
+                .output()
+                .map_err(|e| format!("hyprctl resize failed: {e}"))?;
+
+            // Move to target position
+            std::process::Command::new("hyprctl")
+                .args([
+                    "dispatch",
+                    "movewindowpixel",
+                    &format!("exact {} {},address:{addr}", x as i32, y as i32),
+                ])
+                .output()
+                .map_err(|e| format!("hyprctl move failed: {e}"))?;
+
+            return Ok(());
+        }
+    }
+
+    Err("window not found in hyprctl clients".into())
+}
+
+/// Sway: `move absolute position` + `resize set` for floating windows.
+fn position_sway(
+    window: &tauri::Window,
+    x: f64,
+    y: f64,
+    width: f64,
+) -> Result<(), String> {
+    let title = window.title().unwrap_or_default();
+
+    std::process::Command::new("swaymsg")
+        .arg(format!(
+            "[title=\"{title}\"] move absolute position {} {}, resize set {} 0",
+            x as i32, y as i32, width as i32,
+        ))
+        .output()
+        .map_err(|e| format!("swaymsg failed: {e}"))?;
+
+    Ok(())
+}
+
+/// KDE/KWin: inject a KWin script that sets the full `frameGeometry` via D-Bus.
+fn position_kwin(
+    window: &tauri::Window,
+    x: f64,
+    y: f64,
+    width: f64,
+    qdbus: &str,
+) -> Result<(), String> {
+    let title = window.title().unwrap_or_default();
+    let x_int = x as i32;
+    let y_int = y as i32;
+    let w_int = width as i32;
+
+    let script = format!(
+        r#"var wins = workspace.windowList();
+for (var i = 0; i < wins.length; i++) {{
+    if (wins[i].caption === "{title}") {{
+        var g = wins[i].frameGeometry;
+        wins[i].frameGeometry = {{x: {x_int}, y: {y_int}, width: {w_int}, height: g.height}};
+    }}
+}}"#
+    );
+
+    let tmp = std::env::temp_dir().join("scrollr_kwin_pos.js");
+    std::fs::write(&tmp, &script).map_err(|e| format!("write temp script: {e}"))?;
+    let tmp_path = tmp.to_str().ok_or("invalid temp path")?;
+
+    // Unload any previous instance (ignore errors — may not exist)
+    std::process::Command::new(qdbus)
+        .args([
+            "org.kde.KWin",
+            "/Scripting",
+            "org.kde.kwin.Scripting.unloadScript",
+            "scrollr_pos",
+        ])
+        .output()
+        .ok();
+
+    // Load the script → returns a numeric script ID
+    let load = std::process::Command::new(qdbus)
+        .args([
+            "org.kde.KWin",
+            "/Scripting",
+            "org.kde.kwin.Scripting.loadScript",
+            tmp_path,
+            "scrollr_pos",
+        ])
+        .output()
+        .map_err(|e| format!("{qdbus} loadScript failed: {e}"))?;
+
+    let script_id = String::from_utf8_lossy(&load.stdout).trim().to_string();
+    if script_id.is_empty() || !load.status.success() {
+        let stderr = String::from_utf8_lossy(&load.stderr);
+        std::fs::remove_file(&tmp).ok();
+        return Err(format!("loadScript failed: {stderr}"));
+    }
+
+    // Run the script
+    let run_path = format!("/Scripting/Script{script_id}");
+    std::process::Command::new(qdbus)
+        .args(["org.kde.KWin", &run_path, "org.kde.kwin.Script.run"])
+        .output()
+        .map_err(|e| format!("{qdbus} run failed: {e}"))?;
+
+    // Stop and unload — script is one-shot, clean up immediately
+    std::process::Command::new(qdbus)
+        .args(["org.kde.KWin", &run_path, "org.kde.kwin.Script.stop"])
+        .output()
+        .ok();
+
+    std::process::Command::new(qdbus)
+        .args([
+            "org.kde.KWin",
+            "/Scripting",
+            "org.kde.kwin.Scripting.unloadScript",
+            "scrollr_pos",
+        ])
+        .output()
+        .ok();
+
+    std::fs::remove_file(&tmp).ok();
+    Ok(())
 }
 
 // ── Pin (always-on-top) via compositor IPC ───────────────────────
@@ -515,6 +728,7 @@ pub fn run() {
         .manage(SseHandle(Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
             resize_window,
+            position_ticker,
             pin_window,
             start_auth_server,
             start_sse,

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
     "windows": [
       {
         "label": "ticker",
-        "title": "Scrollr",
+        "title": "Scrollr Ticker",
         "width": 1920,
         "height": 228,
         "decorations": false,

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -38,8 +38,7 @@
         "alwaysOnTop": true,
         "resizable": true,
         "skipTaskbar": true,
-        "visible": false,
-        "center": true
+        "visible": false
       },
       {
         "label": "app",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -9,6 +9,7 @@ import type {
   DeliveryMode,
 } from "~/utils/types";
 import ScrollrTicker from "./components/ScrollrTicker";
+import TickerToolbar from "./components/TickerToolbar";
 import {
   getValidToken,
   isAuthenticated as checkAuth,
@@ -25,7 +26,7 @@ import {
   TICKER_GAPS,
   TICKER_HEIGHTS,
 } from "./preferences";
-import type { AppPreferences } from "./preferences";
+import type { AppPreferences, TickerPosition } from "./preferences";
 
 // ── Constants ────────────────────────────────────────────────────
 
@@ -58,6 +59,14 @@ export default function App() {
 
   // Pin (always-on-top) state
   const [pinned, setPinned] = useState(() => loadPref("feedPinned", true));
+
+  // Ticker position state (top/bottom of screen)
+  const [tickerPosition, setTickerPosition] = useState<TickerPosition>(() =>
+    loadPref("tickerPosition", "top"),
+  );
+
+  // Hover state for toolbar visibility
+  const [hovered, setHovered] = useState(false);
 
   // Settings preferences
   const [prefs, setPrefs] = useState<AppPreferences>(loadPrefs);
@@ -336,6 +345,13 @@ export default function App() {
           invoke("pin_window", { pinned: next.window.pinned }).catch(() => {});
         }
 
+        // Side effects: ticker position
+        if (next.window.tickerPosition !== prev.window.tickerPosition) {
+          setTickerPosition(next.window.tickerPosition);
+          savePref("tickerPosition", next.window.tickerPosition);
+          invoke("position_ticker", { position: next.window.tickerPosition }).catch(() => {});
+        }
+
         // Side effects: ticker visibility
         const nextCollapsed = !next.ticker.showTicker;
         setTickerCollapsed(nextCollapsed);
@@ -405,7 +421,8 @@ export default function App() {
       ? 0
       : TICKER_HEIGHTS[prefs.ticker.tickerMode] * prefs.appearance.tickerRows;
     if (tickerH > 0) {
-      invoke("resize_window", { height: tickerH })
+      invoke("resize_window", { height: tickerH, anchor: tickerPosition })
+        .then(() => invoke("position_ticker", { position: tickerPosition }))
         .then(() => getCurrentWindow().show())
         .catch(() => {});
     }
@@ -420,12 +437,13 @@ export default function App() {
       ? 0
       : TICKER_HEIGHTS[prefs.ticker.tickerMode] * prefs.appearance.tickerRows;
     if (tickerH > 0) {
-      invoke("resize_window", { height: tickerH }).catch(() => {});
+      invoke("resize_window", { height: tickerH, anchor: tickerPosition }).catch(() => {});
     }
   }, [
     prefs.ticker.tickerMode,
     prefs.appearance.tickerRows,
     tickerCollapsed,
+    tickerPosition,
   ]);
 
   // ── Show/hide ticker window based on visibility ────────────────
@@ -469,6 +487,21 @@ export default function App() {
     },
     [fetchFeed],
   );
+
+  // ── Ticker position toggle ─────────────────────────────────────
+
+  const handleTogglePosition = useCallback(() => {
+    const next: TickerPosition = tickerPosition === "top" ? "bottom" : "top";
+    setTickerPosition(next);
+    savePref("tickerPosition", next);
+    const updated = {
+      ...prefsRef.current,
+      window: { ...prefsRef.current.window, tickerPosition: next },
+    };
+    setPrefs(updated);
+    savePrefs(updated);
+    invoke("position_ticker", { position: next }).catch(() => {});
+  }, [tickerPosition]);
 
   // ── Right-click → native context menu ──────────────────────────
 
@@ -572,25 +605,37 @@ export default function App() {
   const showTicker = !tickerCollapsed && prefs.ticker.showTicker;
 
   return (
-    <div id="desktop-shell">
-      {showTicker &&
-        Array.from({ length: prefs.appearance.tickerRows }, (_, i) => (
-          <ScrollrTicker
-            key={`row${i}-${prefs.ticker.tickerGap}-${prefs.ticker.tickerSpeed}-${prefs.ticker.hoverSpeed}-${prefs.ticker.tickerMode}-${prefs.ticker.mixMode}-${prefs.ticker.chipColors}-${prefs.appearance.tickerRows}`}
-            dashboard={dashboard}
-            activeTabs={activeTabs}
-            onChipClick={handleChipClick}
-            speed={prefs.ticker.tickerSpeed}
-            gap={TICKER_GAPS[prefs.ticker.tickerGap]}
-            pauseOnHover={prefs.ticker.pauseOnHover}
-            hoverSpeed={prefs.ticker.hoverSpeed}
-            mixMode={prefs.ticker.mixMode}
-            chipColorMode={prefs.ticker.chipColors}
-            comfort={prefs.ticker.tickerMode === "comfort"}
-            rowIndex={i}
-            totalRows={prefs.appearance.tickerRows}
+    <div
+      id="desktop-shell"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {showTicker && (
+        <>
+          <TickerToolbar
+            position={tickerPosition}
+            hovered={hovered}
+            onTogglePosition={handleTogglePosition}
           />
-        ))}
+          {Array.from({ length: prefs.appearance.tickerRows }, (_, i) => (
+            <ScrollrTicker
+              key={`row${i}-${prefs.ticker.tickerGap}-${prefs.ticker.tickerSpeed}-${prefs.ticker.hoverSpeed}-${prefs.ticker.tickerMode}-${prefs.ticker.mixMode}-${prefs.ticker.chipColors}-${prefs.appearance.tickerRows}`}
+              dashboard={dashboard}
+              activeTabs={activeTabs}
+              onChipClick={handleChipClick}
+              speed={prefs.ticker.tickerSpeed}
+              gap={TICKER_GAPS[prefs.ticker.tickerGap]}
+              pauseOnHover={prefs.ticker.pauseOnHover}
+              hoverSpeed={prefs.ticker.hoverSpeed}
+              mixMode={prefs.ticker.mixMode}
+              chipColorMode={prefs.ticker.chipColors}
+              comfort={prefs.ticker.tickerMode === "comfort"}
+              rowIndex={i}
+              totalRows={prefs.appearance.tickerRows}
+            />
+          ))}
+        </>
+      )}
     </div>
   );
 }

--- a/desktop/src/components/TickerToolbar.tsx
+++ b/desktop/src/components/TickerToolbar.tsx
@@ -1,0 +1,47 @@
+import { ChevronUp, ChevronDown } from "lucide-react";
+import clsx from "clsx";
+import type { TickerPosition } from "../preferences";
+
+interface TickerToolbarProps {
+  position: TickerPosition;
+  hovered: boolean;
+  onTogglePosition: () => void;
+}
+
+export default function TickerToolbar({
+  position,
+  hovered,
+  onTogglePosition,
+}: TickerToolbarProps) {
+  const Icon = position === "top" ? ChevronDown : ChevronUp;
+  const label = position === "top" ? "Move to bottom" : "Move to top";
+
+  return (
+    <div
+      className={clsx(
+        "absolute right-0 top-0 bottom-0 z-50 flex items-center",
+        "transition-opacity duration-200",
+        hovered ? "opacity-100" : "opacity-0 pointer-events-none",
+      )}
+    >
+      {/* Gradient fade from transparent to surface */}
+      <div className="w-8 h-full bg-gradient-to-r from-transparent to-surface/80" />
+
+      {/* Toolbar body */}
+      <div className="h-full flex items-center pr-2 bg-surface/80 backdrop-blur-sm">
+        <button
+          onClick={onTogglePosition}
+          aria-label={label}
+          title={label}
+          className={clsx(
+            "w-7 h-7 flex items-center justify-center rounded-md",
+            "text-fg-3 hover:text-fg hover:bg-surface-hover",
+            "transition-colors duration-150",
+          )}
+        >
+          <Icon size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -36,11 +36,14 @@ export interface StartupPrefs {
   autostart: boolean;
 }
 
+export type TickerPosition = "top" | "bottom";
+
 export interface WindowPrefs {
   pinned: boolean;
   defaultWidth: "full" | "narrow";
   narrowWidth: number;
   skipTaskbar: boolean;
+  tickerPosition: TickerPosition;
 }
 
 export interface TaskbarPrefs {
@@ -89,6 +92,7 @@ export const DEFAULT_WINDOW: WindowPrefs = {
   defaultWidth: "full",
   narrowWidth: 800,
   skipTaskbar: true,
+  tickerPosition: "top",
 };
 
 export const DEFAULT_TASKBAR: TaskbarPrefs = {

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -169,6 +169,7 @@ body {
 /* Shell wraps Ticker + FeedBar. Background and color are set here
    (not on body) so the data-theme light/dark overrides take effect. */
 #desktop-shell {
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;


### PR DESCRIPTION
## Summary

- **Ticker position toggle**: Hover toolbar appears at the right edge of the ticker with a chevron button to snap the ticker to the top or bottom edge of the screen
- **Full monitor width**: `position_ticker` also stretches the ticker to the full width of the current monitor on every snap (fixes Wayland `set_size` not working at startup)
- **Compositor-native positioning**: Wayland compositors ignore GTK `set_position`/`set_size`, so `position_ticker` uses native IPC — KWin D-Bus scripting (`qdbus6`), Hyprland (`hyprctl`), Sway (`swaymsg`) — with a GTK fallback for macOS/Windows/X11

## Changes

### New files
- `desktop/src/components/TickerToolbar.tsx` — Hover toolbar overlay with position chevron

### Modified
- **`lib.rs`** — New `position_ticker` command with compositor-specific helpers (`position_kwin`, `position_hyprland`, `position_sway`); `resize_window` now accepts `anchor` param (`"top"` keeps top edge fixed, `"bottom"` default keeps bottom edge fixed)
- **`App.tsx`** — `tickerPosition` and `hovered` state, position toggle handler, `position_ticker` called on mount, `resize_window` passes anchor, cross-window sync for position changes
- **`preferences.ts`** — `TickerPosition` type, `tickerPosition` field in `WindowPrefs` + default
- **`style.css`** — `position: relative` on `#desktop-shell` (fixes absolute toolbar positioning)
- **`tauri.conf.json`** — Version 0.4.0, removed `center: true` from ticker, unique ticker title (`"Scrollr Ticker"`) to prevent KWin scripts from matching both windows
- **`Cargo.toml`** / **`package.json`** — Version bump to 0.4.0

## KWin scripting notes
- `Qt.rect()` does not exist in KWin's QJSEngine (not QML) — `Qt is not defined`
- Mutating a QRect copy and reassigning doesn't trigger the property setter (same object reference)
- Fix: plain JS object literal `{x, y, width, height}` works as a QRectF value