### PR TITLE
feat(desktop): v0.5.0 — UX sweep with accessibility, polish, and robustness

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -154,7 +154,11 @@ fn percent_decode(input: &str) -> String {
 ///   KDE/KWin → `qdbus6` D-Bus scripting API → frameGeometry
 ///   Fallback → GTK set_size + set_position (works on macOS/Windows/X11)
 #[tauri::command]
-fn position_ticker(window: tauri::Window, position: String) -> Result<(), String> {
+fn position_ticker(
+    window: tauri::Window,
+    position: String,
+    height: Option<f64>,
+) -> Result<(), String> {
     let monitor = window
         .current_monitor()
         .map_err(|e| format!("monitor query failed: {e}"))?
@@ -166,10 +170,18 @@ fn position_ticker(window: tauri::Window, position: String) -> Result<(), String
     let monitor_x = monitor.position().x as f64 / scale;
     let monitor_y = monitor.position().y as f64 / scale;
 
-    let size = window
-        .outer_size()
-        .map_err(|e| format!("outer_size failed: {e}"))?;
-    let win_height = size.height as f64 / scale;
+    // Use explicit height if provided; otherwise read from window.
+    // On Wayland, a preceding set_size() may not have propagated yet,
+    // so callers should always pass the desired height.
+    let win_height = match height {
+        Some(h) => h,
+        None => {
+            let size = window
+                .outer_size()
+                .map_err(|e| format!("outer_size failed: {e}"))?;
+            size.height as f64 / scale
+        }
+    };
 
     let new_y = if position == "top" {
         monitor_y
@@ -177,16 +189,17 @@ fn position_ticker(window: tauri::Window, position: String) -> Result<(), String
         monitor_y + screen_height - win_height
     };
 
-    // Wayland compositors ignore GTK set_position/set_size — use native IPC
+    // Wayland compositors ignore GTK set_position/set_size — use native IPC.
+    // Pass height so compositor sets full geometry atomically.
     if std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok() {
-        return position_hyprland(&window, monitor_x, new_y, screen_width);
+        return position_hyprland(&window, monitor_x, new_y, screen_width, win_height);
     }
     if std::env::var("SWAYSOCK").is_ok() {
-        return position_sway(&window, monitor_x, new_y, screen_width);
+        return position_sway(&window, monitor_x, new_y, screen_width, win_height);
     }
     if is_kde() {
         if let Some(qdbus) = find_qdbus() {
-            return position_kwin(&window, monitor_x, new_y, screen_width, &qdbus);
+            return position_kwin(&window, monitor_x, new_y, screen_width, win_height, &qdbus);
         }
     }
 
@@ -204,6 +217,7 @@ fn position_hyprland(
     x: f64,
     y: f64,
     width: f64,
+    height: f64,
 ) -> Result<(), String> {
     let title = window.title().unwrap_or_default();
 
@@ -218,18 +232,13 @@ fn position_hyprland(
     for client in &clients {
         if client["title"].as_str().unwrap_or("") == title {
             let addr = client["address"].as_str().ok_or("no address field")?;
-            let current_h = client["size"]
-                .as_array()
-                .and_then(|a| a.get(1))
-                .and_then(|v| v.as_i64())
-                .unwrap_or(44);
 
-            // Resize to full monitor width, keeping current height
+            // Resize to full monitor width + desired height
             std::process::Command::new("hyprctl")
                 .args([
                     "dispatch",
                     "resizewindowpixel",
-                    &format!("exact {} {},address:{addr}", width as i32, current_h),
+                    &format!("exact {} {},address:{addr}", width as i32, height as i32),
                 ])
                 .output()
                 .map_err(|e| format!("hyprctl resize failed: {e}"))?;
@@ -257,13 +266,14 @@ fn position_sway(
     x: f64,
     y: f64,
     width: f64,
+    height: f64,
 ) -> Result<(), String> {
     let title = window.title().unwrap_or_default();
 
     std::process::Command::new("swaymsg")
         .arg(format!(
-            "[title=\"{title}\"] move absolute position {} {}, resize set {} 0",
-            x as i32, y as i32, width as i32,
+            "[title=\"{title}\"] move absolute position {} {}, resize set {} {}",
+            x as i32, y as i32, width as i32, height as i32,
         ))
         .output()
         .map_err(|e| format!("swaymsg failed: {e}"))?;
@@ -277,19 +287,20 @@ fn position_kwin(
     x: f64,
     y: f64,
     width: f64,
+    height: f64,
     qdbus: &str,
 ) -> Result<(), String> {
     let title = window.title().unwrap_or_default();
     let x_int = x as i32;
     let y_int = y as i32;
     let w_int = width as i32;
+    let h_int = height as i32;
 
     let script = format!(
         r#"var wins = workspace.windowList();
 for (var i = 0; i < wins.length; i++) {{
     if (wins[i].caption === "{title}") {{
-        var g = wins[i].frameGeometry;
-        wins[i].frameGeometry = {{x: {x_int}, y: {y_int}, width: {w_int}, height: g.height}};
+        wins[i].frameGeometry = {{x: {x_int}, y: {y_int}, width: {w_int}, height: {h_int}}};
     }}
 }}"#
     );

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -23,6 +23,7 @@ import {
   savePref,
   loadPrefs,
   savePrefs,
+  resolveTheme,
   TICKER_GAPS,
   TICKER_HEIGHTS,
 } from "./preferences";
@@ -349,7 +350,8 @@ export default function App() {
         if (next.window.tickerPosition !== prev.window.tickerPosition) {
           setTickerPosition(next.window.tickerPosition);
           savePref("tickerPosition", next.window.tickerPosition);
-          invoke("position_ticker", { position: next.window.tickerPosition }).catch(() => {});
+          const h = TICKER_HEIGHTS[next.ticker.tickerMode] * next.appearance.tickerRows;
+          invoke("position_ticker", { position: next.window.tickerPosition, height: h }).catch(() => {});
         }
 
         // Side effects: ticker visibility
@@ -368,12 +370,7 @@ export default function App() {
     const shell = document.getElementById("desktop-shell");
     if (!shell) return;
 
-    const resolved: "light" | "dark" =
-      prefs.appearance.theme === "system"
-        ? window.matchMedia("(prefers-color-scheme: dark)").matches
-          ? "dark"
-          : "light"
-        : prefs.appearance.theme as "light" | "dark";
+    const resolved = resolveTheme(prefs.appearance.theme);
 
     shell.classList.add("theme-transition");
     shell.dataset.theme = resolved;
@@ -421,8 +418,8 @@ export default function App() {
       ? 0
       : TICKER_HEIGHTS[prefs.ticker.tickerMode] * prefs.appearance.tickerRows;
     if (tickerH > 0) {
-      invoke("resize_window", { height: tickerH, anchor: tickerPosition })
-        .then(() => invoke("position_ticker", { position: tickerPosition }))
+      // position_ticker sets size + position atomically via compositor
+      invoke("position_ticker", { position: tickerPosition, height: tickerH })
         .then(() => getCurrentWindow().show())
         .catch(() => {});
     }
@@ -431,13 +428,17 @@ export default function App() {
   }, []);
 
   // ── Resize ticker when row/mode prefs change ───────────────────
+  // position_ticker sets the full geometry (x, y, width, height)
+  // atomically via compositor-specific commands. This avoids the
+  // race condition where set_size() hasn't propagated before the
+  // position calculation reads the old height.
 
   useEffect(() => {
     const tickerH = tickerCollapsed
       ? 0
       : TICKER_HEIGHTS[prefs.ticker.tickerMode] * prefs.appearance.tickerRows;
     if (tickerH > 0) {
-      invoke("resize_window", { height: tickerH, anchor: tickerPosition }).catch(() => {});
+      invoke("position_ticker", { position: tickerPosition, height: tickerH }).catch(() => {});
     }
   }, [
     prefs.ticker.tickerMode,
@@ -500,7 +501,8 @@ export default function App() {
     };
     setPrefs(updated);
     savePrefs(updated);
-    invoke("position_ticker", { position: next }).catch(() => {});
+    const h = TICKER_HEIGHTS[updated.ticker.tickerMode] * updated.appearance.tickerRows;
+    invoke("position_ticker", { position: next, height: h }).catch(() => {});
   }, [tickerPosition]);
 
   // ── Right-click → native context menu ──────────────────────────

--- a/desktop/src/MainApp.tsx
+++ b/desktop/src/MainApp.tsx
@@ -32,10 +32,11 @@ import {
   savePref,
   loadPrefs,
   savePrefs,
+  resolveTheme,
   TICKER_GAPS,
 } from "./preferences";
 import type { AppPreferences } from "./preferences";
-import type { FeedMode, DashboardResponse, DeliveryMode } from "~/utils/types";
+import type { DashboardResponse, DeliveryMode } from "~/utils/types";
 
 const API_URL = "https://api.myscrollr.relentnet.dev";
 
@@ -75,9 +76,6 @@ export default function MainApp() {
   const [activeTab, setActiveTab] = useState(
     () => loadPref("activeTab", "finance"),
   );
-  const [feedMode] = useState<FeedMode>(
-    () => loadPref<FeedMode>("feedMode", "comfort"),
-  );
 
   // App version (read from tauri.conf.json at runtime)
   const [appVersion, setAppVersion] = useState("");
@@ -97,9 +95,11 @@ export default function MainApp() {
     () => loadPref("showTaskbar", true),
   );
 
-  // Loading state
+  // Loading / error / notification state
   const [loading, setLoading] = useState(true);
   const [loggingIn, setLoggingIn] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [sessionExpired, setSessionExpired] = useState(false);
 
   // Data delivery mode (synced from ticker window)
   const [deliveryMode, setDeliveryMode] = useState<DeliveryMode>(
@@ -109,6 +109,7 @@ export default function MainApp() {
   // Refs for stable closures
   const authenticatedRef = useRef(authenticated);
   authenticatedRef.current = authenticated;
+  const lastFetchRef = useRef(0);
 
   // ── Theme & scale application ────────────────────────────────
   // Apply theme to the DOM and broadcast for cross-window sync.
@@ -117,13 +118,7 @@ export default function MainApp() {
     const shell = document.getElementById("app-shell");
     if (!shell) return;
 
-    // Resolve theme: "system" follows OS preference
-    const resolved: "light" | "dark" =
-      prefs.appearance.theme === "system"
-        ? window.matchMedia("(prefers-color-scheme: dark)").matches
-          ? "dark"
-          : "light"
-        : prefs.appearance.theme as "light" | "dark";
+    const resolved = resolveTheme(prefs.appearance.theme);
 
     shell.classList.add("theme-transition");
     shell.dataset.theme = resolved;
@@ -189,7 +184,9 @@ export default function MainApp() {
   // ── Data fetching ───────────────────────────────────────────
 
   const fetchDashboard = useCallback(async () => {
+    lastFetchRef.current = Date.now();
     try {
+      setFetchError(null);
       const isAuth = authenticatedRef.current;
       let url = `${API_URL}/public/feed`;
       const headers: Record<string, string> = {};
@@ -207,6 +204,7 @@ export default function MainApp() {
         // Token expired, fall back to anonymous
         setAuthenticated(false);
         setTier("free");
+        setSessionExpired(true);
         const anonRes = await fetch(`${API_URL}/public/feed`);
         if (anonRes.ok) {
           const data = await anonRes.json();
@@ -220,9 +218,12 @@ export default function MainApp() {
         const data = await res.json();
         setDashboard({ data: data.data });
         if (data.channels) setChannels(data.channels);
+      } else {
+        setFetchError(`Server returned ${res.status}`);
       }
     } catch (err) {
       console.error("[Scrollr] Dashboard fetch failed:", err);
+      setFetchError(err instanceof Error ? err.message : "Network error");
     } finally {
       setLoading(false);
     }
@@ -233,9 +234,10 @@ export default function MainApp() {
     fetchDashboard();
   }, [fetchDashboard, authenticated]);
 
-  // Re-fetch when window gains focus
+  // Re-fetch when window gains focus (throttled to 10s minimum gap)
   useEffect(() => {
     function onFocus() {
+      if (Date.now() - lastFetchRef.current < 10_000) return;
       fetchDashboard();
     }
     window.addEventListener("focus", onFocus);
@@ -246,6 +248,50 @@ export default function MainApp() {
   useEffect(() => {
     isAutostartEnabled().then(setAutostartOn).catch(() => {});
   }, []);
+
+  // ── Navigation ──────────────────────────────────────────────
+
+  const handleNavigate = useCallback((next: Section) => {
+    setSection(next);
+    savePref("appSection", next);
+  }, []);
+
+  const handleSettingsTab = useCallback((tab: SettingsTab) => {
+    setSettingsTab(tab);
+    savePref("settingsTab", tab);
+  }, []);
+
+  // ── Keyboard shortcuts ──────────────────────────────────────
+  // Cmd/Ctrl+1-5: navigate sections. Escape: dismiss overlays.
+
+  useEffect(() => {
+    const SECTION_MAP: Section[] = ["feed", "channels", "dashboard", "settings", "account"];
+    function onKeyDown(e: KeyboardEvent) {
+      const mod = IS_MACOS ? e.metaKey : e.ctrlKey;
+
+      // Cmd/Ctrl + 1-5 → navigate sections
+      if (mod && e.key >= "1" && e.key <= "5") {
+        e.preventDefault();
+        const idx = Number(e.key) - 1;
+        handleNavigate(SECTION_MAP[idx]);
+        return;
+      }
+
+      // Escape → dismiss login overlay or session banner
+      if (e.key === "Escape") {
+        if (loggingIn) {
+          setLoggingIn(false);
+          return;
+        }
+        if (sessionExpired) {
+          setSessionExpired(false);
+          return;
+        }
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [loggingIn, sessionExpired, handleNavigate]);
 
   // ── Auth handlers ───────────────────────────────────────────
 
@@ -365,18 +411,6 @@ export default function MainApp() {
     }
   }, []);
 
-  // ── Navigation ──────────────────────────────────────────────
-
-  function handleNavigate(next: Section) {
-    setSection(next);
-    savePref("appSection", next);
-  }
-
-  function handleSettingsTab(tab: SettingsTab) {
-    setSettingsTab(tab);
-    savePref("settingsTab", tab);
-  }
-
   // ── Stable getToken for DashboardTab components ─────────────
 
   const getToken = useCallback(() => getValidToken(), []);
@@ -426,7 +460,6 @@ export default function MainApp() {
         active={section}
         onNavigate={handleNavigate}
         tickerAlive={prefs.ticker.showTicker}
-        onToggleTicker={handleToggleStandaloneTicker}
         settingsTab={settingsTab}
         onSettingsTabChange={handleSettingsTab}
         appVersion={appVersion}
@@ -478,20 +511,45 @@ export default function MainApp() {
           )}
         </header>
 
+        {/* Session expired banner */}
+        {sessionExpired && (
+          <div className="flex items-center justify-between px-4 py-2 bg-warn/10 border-b border-warn/20 shrink-0">
+            <span className="text-xs text-warn">
+              Your session has expired. Sign in again to access your channels.
+            </span>
+            <div className="flex items-center gap-2 shrink-0 ml-4">
+              <button
+                onClick={handleLogin}
+                className="text-xs font-medium text-warn hover:text-fg transition-colors"
+              >
+                Sign in
+              </button>
+              <button
+                onClick={() => setSessionExpired(false)}
+                className="text-xs text-fg-4 hover:text-fg-3 transition-colors"
+                aria-label="Dismiss"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Content */}
         <div className="flex-1 overflow-y-auto scrollbar-thin">
           {section === "feed" && (
             <FeedSection
               authenticated={authenticated}
               loading={loading}
+              fetchError={fetchError}
               channels={channels}
               dashboard={dashboard}
-              feedMode={feedMode}
               activeTab={activeTab}
               onActiveTabChange={(tab) => {
                 setActiveTab(tab);
                 savePref("activeTab", tab);
               }}
+              onRetry={fetchDashboard}
               onLogin={handleLogin}
               onNavigateToChannels={() => handleNavigate("channels")}
             />
@@ -519,6 +577,7 @@ export default function MainApp() {
               }}
               getToken={getToken}
               tier={tier}
+              deliveryMode={deliveryMode}
               onToggle={() => {
                 const ch = channels.find((c) => c.channel_type === activeTab);
                 if (ch) handleToggleChannel(ch.channel_type, !ch.visible);
@@ -569,7 +628,12 @@ export default function MainApp() {
 
         {/* Login overlay */}
         {loggingIn && (
-          <div className="absolute inset-0 z-50 flex items-center justify-center bg-surface/80 backdrop-blur-sm">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Signing in"
+            className="absolute inset-0 z-50 flex items-center justify-center bg-surface/80 backdrop-blur-sm"
+          >
             <div className="text-center">
               <div className="w-6 h-6 border-2 border-accent/30 border-t-accent rounded-full animate-spin mx-auto mb-3" />
               <p className="text-sm font-medium text-fg-2">
@@ -578,6 +642,12 @@ export default function MainApp() {
               <p className="text-xs text-fg-3 mt-1">
                 Complete sign-in in your browser
               </p>
+              <button
+                onClick={() => setLoggingIn(false)}
+                className="mt-4 px-4 py-1.5 rounded-lg text-xs font-medium text-fg-3 hover:text-fg-2 hover:bg-surface-hover transition-colors"
+              >
+                Cancel
+              </button>
             </div>
           </div>
         )}
@@ -592,21 +662,23 @@ export default function MainApp() {
 function FeedSection({
   authenticated,
   loading,
+  fetchError,
   channels,
   dashboard,
-  feedMode,
   activeTab,
   onActiveTabChange,
+  onRetry,
   onLogin,
   onNavigateToChannels,
 }: {
   authenticated: boolean;
   loading: boolean;
+  fetchError: string | null;
   channels: Channel[];
   dashboard: DashboardResponse | null;
-  feedMode: FeedMode;
   activeTab: string;
   onActiveTabChange: (tab: string) => void;
+  onRetry: () => void;
   onLogin: () => void;
   onNavigateToChannels: () => void;
 }) {
@@ -640,7 +712,7 @@ function FeedSection({
     return (
       <div className="flex flex-col gap-3 p-6">
         {Array.from({ length: 6 }, (_, i) => (
-          <div key={i} className="flex items-center gap-3 animate-pulse">
+          <div key={i} className="flex items-center gap-3 motion-safe:animate-pulse">
             <div className="w-8 h-8 rounded-lg bg-surface-2" />
             <div className="flex-1 space-y-2">
               <div
@@ -658,6 +730,15 @@ function FeedSection({
     );
   }
 
+  if (fetchError) {
+    return (
+      <ErrorState
+        message={fetchError}
+        onRetry={onRetry}
+      />
+    );
+  }
+
   if (visibleChannels.length === 0) {
     return (
       <EmptyState
@@ -672,7 +753,7 @@ function FeedSection({
   return (
     <div className="flex flex-col h-full">
       {/* Channel tabs */}
-      <div className="flex gap-1 px-4 py-2 border-b border-edge/50 shrink-0">
+      <div role="tablist" aria-label="Feed channels" className="flex gap-1 px-4 py-2 border-b border-edge/50 shrink-0">
         {[...visibleChannels]
           .sort((a, b) =>
             CHANNEL_ORDER.indexOf(a.channel_type) -
@@ -680,15 +761,19 @@ function FeedSection({
           )
           .map((ch) => {
             const manifest = getChannel(ch.channel_type);
+            const selected = activeTab === ch.channel_type;
             return (
               <button
                 key={ch.channel_type}
+                role="tab"
+                aria-selected={selected}
                 onClick={() => onActiveTabChange(ch.channel_type)}
-                className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                  activeTab === ch.channel_type
+                className={clsx(
+                  "px-3 py-1.5 rounded-lg text-xs font-medium transition-colors",
+                  selected
                     ? "bg-accent/10 text-accent"
-                    : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover"
-                }`}
+                    : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
+                )}
               >
                 {manifest?.tabLabel ?? ch.channel_type}
               </button>
@@ -699,7 +784,7 @@ function FeedSection({
       {/* Feed content */}
       <div className="flex-1 overflow-y-auto scrollbar-thin">
         {FeedTabComponent ? (
-          <FeedTabComponent mode={feedMode} channelConfig={channelConfig} />
+          <FeedTabComponent mode="comfort" channelConfig={channelConfig} />
         ) : (
           <div className="flex items-center justify-center h-full">
             <p className="text-sm text-fg-3 font-mono">
@@ -886,6 +971,7 @@ function DashboardSection({
   onActiveTabChange,
   getToken,
   tier,
+  deliveryMode,
   onToggle,
   onDelete,
   onChannelUpdate,
@@ -897,6 +983,7 @@ function DashboardSection({
   onActiveTabChange: (tab: string) => void;
   getToken: () => Promise<string | null>;
   tier: SubscriptionTier;
+  deliveryMode: DeliveryMode;
   onToggle: () => void;
   onDelete: () => void;
   onChannelUpdate: (updated: Channel) => void;
@@ -928,7 +1015,7 @@ function DashboardSection({
   return (
     <div className="flex flex-col h-full">
       {/* Channel tabs */}
-      <div className="flex gap-1 px-4 py-2 border-b border-edge/50 shrink-0">
+      <div role="tablist" aria-label="Dashboard channels" className="flex gap-1 px-4 py-2 border-b border-edge/50 shrink-0">
         {[...channels]
           .sort((a, b) =>
             CHANNEL_ORDER.indexOf(a.channel_type) -
@@ -936,15 +1023,19 @@ function DashboardSection({
           )
           .map((ch) => {
             const manifest = getWebChannel(ch.channel_type);
+            const selected = activeTab === ch.channel_type;
             return (
               <button
                 key={ch.channel_type}
+                role="tab"
+                aria-selected={selected}
                 onClick={() => onActiveTabChange(ch.channel_type)}
-                className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                  activeTab === ch.channel_type
+                className={clsx(
+                  "px-3 py-1.5 rounded-lg text-xs font-medium transition-colors",
+                  selected
                     ? "bg-accent/10 text-accent"
-                    : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover"
-                }`}
+                    : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
+                )}
               >
                 {manifest?.tabLabel ?? ch.channel_type}
               </button>
@@ -961,7 +1052,7 @@ function DashboardSection({
             onToggle={onToggle}
             onDelete={onDelete}
             onChannelUpdate={onChannelUpdate}
-            connected={false}
+            connected={deliveryMode === "sse"}
             subscriptionTier={tier}
             hex={webChannel.hex}
           />
@@ -1060,6 +1151,32 @@ function AccountSection({
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+// ── Shared error state ───────────────────────────────────────────
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center max-w-sm mx-auto gap-3 p-6">
+      <div className="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center mb-1">
+        <span className="text-error text-lg font-bold">!</span>
+      </div>
+      <h2 className="text-base font-semibold text-fg">Something went wrong</h2>
+      <p className="text-sm text-fg-3 leading-relaxed">{message}</p>
+      <button
+        onClick={onRetry}
+        className="mt-2 px-4 py-2 rounded-xl text-sm font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
+      >
+        Try again
+      </button>
     </div>
   );
 }

--- a/desktop/src/auth.ts
+++ b/desktop/src/auth.ts
@@ -325,6 +325,21 @@ export function getAuth(): AuthState | null {
 }
 
 /**
+ * Extract user identity (email/name) from the stored access token JWT.
+ * Returns null fields if no auth or claims not present.
+ */
+export function getUserIdentity(): { email: string | null; name: string | null } {
+  const auth = loadAuth();
+  if (!auth) return { email: null, name: null };
+  const payload = decodeJwtPayload(auth.accessToken);
+  if (!payload) return { email: null, name: null };
+  return {
+    email: (payload.email as string) ?? null,
+    name: (payload.name as string) ?? null,
+  };
+}
+
+/**
  * Clear all auth state (logout).
  */
 export function logout(): void {

--- a/desktop/src/components/AppTaskbar.tsx
+++ b/desktop/src/components/AppTaskbar.tsx
@@ -5,13 +5,14 @@ import {
   Moon,
   Pin,
   PinOff,
-  Rows3,
   Rows2,
+  Rows3,
+  Rows4,
   TicketSlash,
   TicketCheck,
 } from "lucide-react";
 import type { AppPreferences, TickerRows } from "../preferences";
-import { savePrefs } from "../preferences";
+import { TASKBAR_HEIGHTS, resolveTheme } from "../preferences";
 import type { DeliveryMode } from "~/utils/types";
 
 // ── Props ───────────────────────────────────────────────────────
@@ -37,17 +38,16 @@ export default function AppTaskbar({
   onToggleStandaloneTicker,
   deliveryMode,
 }: AppTaskbarProps) {
-  const isDark =
-    prefs.appearance.theme === "dark" ||
-    (prefs.appearance.theme === "system" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches);
+  const isDark = resolveTheme(prefs.appearance.theme) === "dark";
 
   const isPinned = prefs.window.pinned;
   const rows = prefs.appearance.tickerRows;
+  const taskbarH = TASKBAR_HEIGHTS[prefs.taskbar.taskbarHeight];
+
+  const RowIcon = rows === 1 ? Rows2 : rows === 2 ? Rows3 : Rows4;
 
   function update(next: AppPreferences) {
     onPrefsChange(next);
-    savePrefs(next);
   }
 
   function toggleTheme() {
@@ -81,7 +81,10 @@ export default function AppTaskbar({
   const btnActive = `${btnBase} text-accent hover:text-accent hover:bg-accent/10`;
 
   return (
-    <div className="flex items-center gap-0.5 px-3 h-8 border-b border-edge/50 bg-surface-2/50 shrink-0">
+    <div
+      className="flex items-center gap-0.5 px-3 border-b border-edge/50 bg-surface-2/50 shrink-0"
+      style={{ height: `${taskbarH}px` }}
+    >
       {/* Left: status indicators */}
       <div className="flex items-center gap-3 mr-auto select-none">
         {/* Ticker toggle + status */}
@@ -103,7 +106,7 @@ export default function AppTaskbar({
             )}
           />
           <span className={clsx(
-            "text-[10px] font-mono uppercase tracking-widest transition-colors duration-300",
+            "text-[11px] font-mono uppercase tracking-widest transition-colors duration-300",
             tickerAlive ? "text-accent" : "text-fg-4",
           )}>
             {tickerAlive ? "Ticker" : "Off"}
@@ -119,12 +122,12 @@ export default function AppTaskbar({
             className={clsx(
               "w-1.5 h-1.5 rounded-full shrink-0",
               deliveryMode === "sse"
-                ? "bg-info animate-pulse"
-                : "bg-warn animate-pulse",
+                ? "bg-info motion-safe:animate-pulse"
+                : "bg-warn motion-safe:animate-pulse",
             )}
           />
           <span className={clsx(
-            "text-[10px] font-mono uppercase tracking-widest",
+            "text-[11px] font-mono uppercase tracking-widest",
             deliveryMode === "sse" ? "text-info" : "text-warn",
           )}>
             {deliveryMode === "sse" ? "SSE" : "Poll"}
@@ -153,11 +156,14 @@ export default function AppTaskbar({
 
       <button
         onClick={cycleRows}
-        className={btnIdle}
+        className={clsx(btnIdle, "relative")}
         title={`Ticker rows: ${rows} (click to cycle)`}
         aria-label={`Ticker rows: ${rows}`}
       >
-        {rows <= 1 ? <Rows2 size={14} /> : <Rows3 size={14} />}
+        <RowIcon size={14} />
+        <span className="absolute -top-0.5 -right-0.5 min-w-[12px] h-3 flex items-center justify-center rounded-full bg-accent/20 text-accent text-[8px] font-bold leading-none">
+          {rows}
+        </span>
       </button>
 
       <button

--- a/desktop/src/components/ConfirmDialog.tsx
+++ b/desktop/src/components/ConfirmDialog.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import clsx from "clsx";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the cancel button when the dialog opens
+  useEffect(() => {
+    if (open) cancelRef.current?.focus();
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-surface/60 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+
+      {/* Panel */}
+      <div className="relative w-full max-w-sm mx-4 p-5 rounded-xl bg-surface-2 border border-edge shadow-soft-md">
+        <h3 className="text-sm font-semibold text-fg">{title}</h3>
+        <p className="text-xs text-fg-3 mt-1.5 leading-relaxed">
+          {description}
+        </p>
+
+        <div className="flex items-center justify-end gap-2 mt-5">
+          <button
+            ref={cancelRef}
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded-lg text-xs font-medium text-fg-3 hover:text-fg-2 hover:bg-surface-hover transition-colors"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className={clsx(
+              "px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors",
+              destructive
+                ? "bg-error/10 text-error hover:bg-error/20"
+                : "bg-accent/10 text-accent hover:bg-accent/20",
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -52,6 +52,7 @@ function randomShuffle<T>(arr: T[]): T[] {
 /** Round-robin interleave across buckets:
  *  bucket0[0], bucket1[0], bucket2[0], bucket0[1], bucket1[1], ... */
 function weave<T>(buckets: T[][]): T[] {
+  if (buckets.length === 0) return [];
   const result: T[] = [];
   const maxLen = Math.max(...buckets.map((b) => b.length));
   for (let i = 0; i < maxLen; i++) {

--- a/desktop/src/components/SettingsPanel.tsx
+++ b/desktop/src/components/SettingsPanel.tsx
@@ -1,6 +1,7 @@
+import { AnimatePresence, motion } from "motion/react";
 import type { SubscriptionTier } from "../auth";
 import type { AppPreferences } from "../preferences";
-import { resetCategory, resetAll, savePrefs } from "../preferences";
+import { resetCategory, resetAll } from "../preferences";
 import type { SettingsTab } from "./Sidebar";
 import AppearanceSettings from "./settings/AppearanceSettings";
 import BehaviorSettings from "./settings/BehaviorSettings";
@@ -43,14 +44,9 @@ export default function SettingsPanel({
   onToggleTaskbar,
   appVersion,
 }: SettingsPanelProps) {
-  const updatePrefs = (next: AppPreferences) => {
-    onPrefsChange(next);
-    savePrefs(next);
-  };
-
   const handleResetCategory = (category: keyof AppPreferences) => {
     const next = resetCategory(prefs, category);
-    updatePrefs(next);
+    onPrefsChange(next);
   };
 
   const handleResetAll = () => {
@@ -59,46 +55,56 @@ export default function SettingsPanel({
   };
 
   return (
-    <div className="dashboard-content w-full max-w-2xl mx-auto">
-      {activeTab === "appearance" && (
-        <AppearanceSettings
-          appearance={prefs.appearance}
-          ticker={prefs.ticker}
-          onAppearanceChange={(appearance) =>
-            updatePrefs({ ...prefs, appearance })
-          }
-          onTickerChange={(ticker) => updatePrefs({ ...prefs, ticker })}
-          onResetAppearance={() => handleResetCategory("appearance")}
-          onResetTicker={() => handleResetCategory("ticker")}
-        />
-      )}
+    <div className="dashboard-content w-full max-w-2xl mx-auto relative">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeTab}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          {activeTab === "appearance" && (
+            <AppearanceSettings
+              appearance={prefs.appearance}
+              ticker={prefs.ticker}
+              onAppearanceChange={(appearance) =>
+                onPrefsChange({ ...prefs, appearance })
+              }
+              onTickerChange={(ticker) => onPrefsChange({ ...prefs, ticker })}
+              onResetAppearance={() => handleResetCategory("appearance")}
+              onResetTicker={() => handleResetCategory("ticker")}
+            />
+          )}
 
-      {activeTab === "behavior" && (
-        <BehaviorSettings
-          window_={prefs.window}
-          onWindowChange={(window_) =>
-            updatePrefs({ ...prefs, window: window_ })
-          }
-          onResetWindow={() => handleResetCategory("window")}
-          autostartEnabled={autostartEnabled}
-          onAutostartChange={onAutostartChange}
-          showAppTicker={showAppTicker}
-          onToggleAppTicker={onToggleAppTicker}
-          showTaskbar={showTaskbar}
-          onToggleTaskbar={onToggleTaskbar}
-        />
-      )}
+          {activeTab === "behavior" && (
+            <BehaviorSettings
+              window_={prefs.window}
+              onWindowChange={(window_) =>
+                onPrefsChange({ ...prefs, window: window_ })
+              }
+              onResetWindow={() => handleResetCategory("window")}
+              autostartEnabled={autostartEnabled}
+              onAutostartChange={onAutostartChange}
+              showAppTicker={showAppTicker}
+              onToggleAppTicker={onToggleAppTicker}
+              showTaskbar={showTaskbar}
+              onToggleTaskbar={onToggleTaskbar}
+            />
+          )}
 
-      {activeTab === "account" && (
-        <AccountSettings
-          authenticated={authenticated}
-          tier={tier}
-          onLogin={onLogin}
-          onLogout={onLogout}
-          onResetAll={handleResetAll}
-          appVersion={appVersion}
-        />
-      )}
+          {activeTab === "account" && (
+            <AccountSettings
+              authenticated={authenticated}
+              tier={tier}
+              onLogin={onLogin}
+              onLogout={onLogout}
+              onResetAll={handleResetAll}
+              appVersion={appVersion}
+            />
+          )}
+        </motion.div>
+      </AnimatePresence>
     </div>
   );
 }

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Activity,
   Layers,
@@ -7,8 +8,11 @@ import {
   Palette,
   SlidersHorizontal,
   UserCog,
+  PanelLeftClose,
+  PanelLeftOpen,
 } from "lucide-react";
 import clsx from "clsx";
+import { loadPref, savePref } from "../preferences";
 
 export type Section = "feed" | "channels" | "dashboard" | "settings" | "account";
 export type SettingsTab = "appearance" | "behavior" | "account";
@@ -17,7 +21,6 @@ interface SidebarProps {
   active: Section;
   onNavigate: (section: Section) => void;
   tickerAlive: boolean;
-  onToggleTicker: () => void;
   settingsTab: SettingsTab;
   onSettingsTabChange: (tab: SettingsTab) => void;
   appVersion?: string;
@@ -40,24 +43,47 @@ const SETTINGS_SUBS: { id: SettingsTab; label: string; icon: typeof Palette }[] 
 // EKG heartbeat path — exaggerated peaks for visual impact
 const EKG_PATH = "M0,8 L6,8 L9,2 L12,14 L15,4 L18,12 L21,8 L32,8";
 
+// Platform-aware modifier key for shortcut hints
+const MOD =
+  ((navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform === "macOS" ||
+  /Mac/.test(navigator.platform))
+    ? "\u2318"
+    : "Ctrl+";
+
 export default function Sidebar({
   active,
   onNavigate,
   tickerAlive,
-  onToggleTicker,
   settingsTab,
   onSettingsTabChange,
   appVersion,
 }: SidebarProps) {
+  const [collapsed, setCollapsed] = useState(
+    () => loadPref("sidebarCollapsed", false),
+  );
+
+  function toggleCollapsed() {
+    const next = !collapsed;
+    setCollapsed(next);
+    savePref("sidebarCollapsed", next);
+  }
+
   return (
-    <aside className="flex flex-col w-[200px] shrink-0 border-r border-edge bg-surface-2 h-full">
-      {/* Logo — clickable, toggles the standalone ticker */}
+    <aside
+      className={clsx(
+        "flex flex-col shrink-0 border-r border-edge bg-surface-2 h-full transition-[width] duration-200 ease-out overflow-hidden",
+        collapsed ? "w-[52px]" : "w-[200px]",
+      )}
+    >
+      {/* Logo — navigates to Feed */}
       <button
-        onClick={onToggleTicker}
-        aria-label="Toggle ticker widget"
+        onClick={() => onNavigate("feed")}
+        aria-label="Go to Feed"
+        title={collapsed ? "Scrollr — Go to Feed" : undefined}
         className={clsx(
           "relative flex items-center gap-3 px-4 h-14 shrink-0 overflow-hidden transition-all duration-500 w-full cursor-pointer",
           tickerAlive ? "border-b border-accent/15" : "border-b border-edge",
+          collapsed && "justify-center px-0",
         )}
       >
         {/* Ambient radial glow (only when live) */}
@@ -73,7 +99,12 @@ export default function Sidebar({
         />
 
         {/* EKG monitor */}
-        <svg viewBox="0 0 32 16" fill="none" className="relative w-10 h-6 shrink-0">
+        <svg
+          viewBox="0 0 32 16"
+          fill="none"
+          aria-hidden="true"
+          className="relative w-10 h-6 shrink-0"
+        >
           <defs>
             <linearGradient id="ekg-grad" x1="0" y1="0" x2="32" y2="0" gradientUnits="userSpaceOnUse">
               <stop offset="0%" stopColor="#34d399" />
@@ -118,36 +149,42 @@ export default function Sidebar({
           )}
         </svg>
 
-        {/* Brand */}
-        <span
-          className={clsx(
-            "font-mono text-[15px] font-bold tracking-[0.15em] uppercase select-none transition-colors duration-500",
-            tickerAlive ? "text-fg" : "text-fg-3",
-          )}
-        >
-          scrollr
-        </span>
+        {/* Brand (hidden when collapsed) */}
+        {!collapsed && (
+          <span
+            className={clsx(
+              "font-mono text-[15px] font-bold tracking-[0.15em] uppercase select-none transition-colors duration-500 whitespace-nowrap",
+              tickerAlive ? "text-fg" : "text-fg-3",
+            )}
+          >
+            scrollr
+          </span>
+        )}
       </button>
 
       {/* Navigation */}
-      <nav className="flex flex-col gap-1 p-2 flex-1">
-        {NAV_ITEMS.map(({ id, label, icon: Icon }) => (
+      <nav aria-label="Main navigation" className="flex flex-col gap-1 p-2 flex-1">
+        {NAV_ITEMS.map(({ id, label, icon: Icon }, idx) => {
+          const shortcut = `${MOD}${idx + 1}`;
+          return (
           <div key={id}>
             <button
               onClick={() => onNavigate(id)}
+              title={collapsed ? `${label}  (${shortcut})` : shortcut}
               className={clsx(
-                "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors w-full",
+                "flex items-center gap-3 rounded-lg text-sm font-medium transition-colors w-full",
+                collapsed ? "justify-center px-0 py-2" : "px-3 py-2",
                 active === id
                   ? "bg-accent/10 text-accent"
                   : "text-fg-2 hover:text-fg hover:bg-surface-hover",
               )}
             >
-              <Icon size={18} strokeWidth={1.75} />
-              {label}
+              <Icon size={18} strokeWidth={1.75} className="shrink-0" />
+              {!collapsed && label}
             </button>
 
-            {/* Settings sub-items — shown when Settings is active */}
-            {id === "settings" && active === "settings" && (
+            {/* Settings sub-items — shown when Settings is active and not collapsed */}
+            {!collapsed && id === "settings" && active === "settings" && (
               <div className="flex flex-col gap-0.5 mt-1 ml-4 pl-3 border-l border-edge/50">
                 {SETTINGS_SUBS.map((sub) => (
                   <button
@@ -167,15 +204,27 @@ export default function Sidebar({
               </div>
             )}
           </div>
-        ))}
+        );
+        })}
       </nav>
 
-      {/* Version */}
-      {appVersion && (
-        <div className="px-4 py-3 border-t border-edge">
-          <span className="text-[10px] font-mono text-fg-4">v{appVersion}</span>
-        </div>
-      )}
+      {/* Footer: collapse toggle + version */}
+      <div className={clsx(
+        "border-t border-edge shrink-0",
+        collapsed ? "flex flex-col items-center py-2 gap-1" : "flex items-center justify-between px-4 py-3",
+      )}>
+        {!collapsed && appVersion && (
+          <span className="text-[11px] font-mono text-fg-4">v{appVersion}</span>
+        )}
+        <button
+          onClick={toggleCollapsed}
+          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          className="flex items-center justify-center w-7 h-7 rounded-md text-fg-4 hover:text-fg-2 hover:bg-surface-hover transition-colors"
+        >
+          {collapsed ? <PanelLeftOpen size={14} /> : <PanelLeftClose size={14} />}
+        </button>
+      </div>
     </aside>
   );
 }

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -1,9 +1,10 @@
 import { useState, useCallback, useRef } from "react";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { TIER_LABELS } from "../../auth";
+import { TIER_LABELS, getUserIdentity } from "../../auth";
 import type { SubscriptionTier } from "../../auth";
 import { Section, DisplayRow, ActionRow, ResetButton } from "./SettingsControls";
+import ConfirmDialog from "../ConfirmDialog";
 import clsx from "clsx";
 
 // ── Update state machine ────────────────────────────────────────
@@ -38,6 +39,9 @@ export default function AccountSettings({
 }: AccountSettingsProps) {
   const [status, setStatus] = useState<UpdateStatus>({ step: "idle" });
   const pendingUpdate = useRef<Update | null>(null);
+  const [confirmReset, setConfirmReset] = useState(false);
+  const identity = authenticated ? getUserIdentity() : null;
+  const userLabel = identity?.email ?? identity?.name ?? null;
 
   const handleCheckForUpdates = useCallback(async () => {
     setStatus({ step: "checking" });
@@ -113,6 +117,13 @@ export default function AccountSettings({
       <Section title="Account">
         {authenticated ? (
           <>
+            {userLabel && (
+              <DisplayRow
+                label="Signed in as"
+                value={userLabel}
+                valueClass="text-[12px] text-fg-2 truncate max-w-[180px]"
+              />
+            )}
             <DisplayRow
               label="Plan"
               value={TIER_LABELS[tier]}
@@ -136,7 +147,7 @@ export default function AccountSettings({
       </Section>
 
       <Section title="About">
-        <DisplayRow label="Version" value={`v${appVersion}`} />
+        <DisplayRow label="Version" value={appVersion ? `v${appVersion}` : "\u2014"} />
         <DisplayRow label="Runtime" value="Tauri v2" />
       </Section>
 
@@ -155,13 +166,26 @@ export default function AccountSettings({
             <span className="text-[12px] text-fg-2 leading-tight">
               Reset all settings
             </span>
-            <span className="text-[10px] text-fg-4 leading-tight">
+            <span className="text-[11px] text-fg-4 leading-tight">
               Restore every setting to its factory default
             </span>
           </div>
-          <ResetButton label="Reset everything" onClick={onResetAll} />
+          <ResetButton label="Reset everything" onClick={() => setConfirmReset(true)} />
         </div>
       </Section>
+
+      <ConfirmDialog
+        open={confirmReset}
+        title="Reset all settings?"
+        description="This will restore every setting to its factory default. Your account and channels will not be affected."
+        confirmLabel="Reset everything"
+        destructive
+        onConfirm={() => {
+          setConfirmReset(false);
+          onResetAll();
+        }}
+        onCancel={() => setConfirmReset(false)}
+      />
     </div>
   );
 }
@@ -183,7 +207,7 @@ function UpdateRow({ status, onCheck, onDownload, onRelaunch }: UpdateRowProps) 
           <span className="text-[12px] text-fg-3">Check for new versions</span>
           <button
             onClick={onCheck}
-            className="text-[10px] font-medium px-2.5 py-1 rounded-md bg-base-250 text-fg-3 hover:text-fg-2 hover:bg-base-300 transition-colors cursor-pointer"
+            className="text-[11px] font-medium px-2.5 py-1 rounded-md bg-base-250 text-fg-3 hover:text-fg-2 hover:bg-base-300 transition-colors cursor-pointer"
           >
             Check for updates
           </button>
@@ -208,7 +232,7 @@ function UpdateRow({ status, onCheck, onDownload, onRelaunch }: UpdateRowProps) 
           </div>
           <button
             onClick={onCheck}
-            className="text-[10px] font-medium px-2.5 py-1 rounded-md text-fg-4 hover:text-fg-2 hover:bg-base-250/50 transition-colors cursor-pointer"
+            className="text-[11px] font-medium px-2.5 py-1 rounded-md text-fg-4 hover:text-fg-2 hover:bg-base-250/50 transition-colors cursor-pointer"
           >
             Check again
           </button>
@@ -223,19 +247,21 @@ function UpdateRow({ status, onCheck, onDownload, onRelaunch }: UpdateRowProps) 
               <span className="text-[12px] text-fg-2 leading-tight">
                 Update available: <span className="text-accent font-semibold">v{status.version}</span>
               </span>
-              {status.body && (
-                <span className="text-[10px] text-fg-4 leading-tight line-clamp-2">
-                  {status.body}
-                </span>
-              )}
             </div>
             <button
               onClick={onDownload}
-              className="text-[10px] font-semibold px-2.5 py-1 rounded-md bg-accent text-surface hover:bg-accent/90 transition-colors cursor-pointer shrink-0 ml-4"
+              className="text-[11px] font-semibold px-2.5 py-1 rounded-md bg-accent text-surface hover:bg-accent/90 transition-colors cursor-pointer shrink-0 ml-4"
             >
               Download & install
             </button>
           </div>
+          {status.body && (
+            <div className="max-h-32 overflow-y-auto scrollbar-thin rounded-md bg-base-200/50 px-2.5 py-2">
+              <p className="text-[11px] text-fg-4 leading-relaxed whitespace-pre-wrap">
+                {status.body}
+              </p>
+            </div>
+          )}
         </div>
       );
 
@@ -249,15 +275,22 @@ function UpdateRow({ status, onCheck, onDownload, onRelaunch }: UpdateRowProps) 
             <span className="text-[12px] text-fg-3 leading-tight">
               Downloading update...
             </span>
-            <span className="text-[10px] text-fg-4 tabular-nums">
+            <span className="text-[11px] text-fg-4 tabular-nums">
               {status.total > 0 ? `${pct}%` : "..."}
             </span>
           </div>
-          <div className="w-full h-1 rounded-full bg-base-300 overflow-hidden">
+          <div
+            role="progressbar"
+            aria-valuenow={pct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Download progress"
+            className="w-full h-1 rounded-full bg-base-300 overflow-hidden"
+          >
             <div
               className={clsx(
                 "h-full rounded-full transition-all duration-300",
-                status.total > 0 ? "bg-accent" : "bg-accent/50 animate-pulse",
+                status.total > 0 ? "bg-accent" : "bg-accent/50 motion-safe:animate-pulse",
               )}
               style={{ width: status.total > 0 ? `${pct}%` : "30%" }}
             />
@@ -273,13 +306,13 @@ function UpdateRow({ status, onCheck, onDownload, onRelaunch }: UpdateRowProps) 
             <span className="text-[12px] text-accent leading-tight">
               Update installed
             </span>
-            <span className="text-[10px] text-fg-4 leading-tight">
+            <span className="text-[11px] text-fg-4 leading-tight">
               Restart to apply the update
             </span>
           </div>
           <button
             onClick={onRelaunch}
-            className="text-[10px] font-semibold px-2.5 py-1 rounded-md bg-accent text-surface hover:bg-accent/90 transition-colors cursor-pointer"
+            className="text-[11px] font-semibold px-2.5 py-1 rounded-md bg-accent text-surface hover:bg-accent/90 transition-colors cursor-pointer"
           >
             Restart now
           </button>
@@ -293,13 +326,13 @@ function UpdateRow({ status, onCheck, onDownload, onRelaunch }: UpdateRowProps) 
             <span className="text-[12px] text-error leading-tight">
               Update check failed
             </span>
-            <span className="text-[10px] text-fg-4 leading-tight line-clamp-1">
+            <span className="text-[11px] text-fg-4 leading-tight line-clamp-1">
               {status.message}
             </span>
           </div>
           <button
             onClick={onCheck}
-            className="text-[10px] font-medium px-2.5 py-1 rounded-md text-fg-4 hover:text-fg-2 hover:bg-base-250/50 transition-colors cursor-pointer"
+            className="text-[11px] font-medium px-2.5 py-1 rounded-md text-fg-4 hover:text-fg-2 hover:bg-base-250/50 transition-colors cursor-pointer"
           >
             Retry
           </button>

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -11,7 +11,7 @@ interface SectionProps {
 export function Section({ title, children }: SectionProps) {
   return (
     <div className="mb-6 pb-5 border-b border-edge/30 last:border-b-0 last:mb-0 last:pb-0">
-      <h3 className="text-[10px] font-semibold uppercase tracking-[0.12em] text-fg-3 mb-3 px-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-[0.12em] text-fg-3 mb-3 px-3">
         {title}
       </h3>
       <div className="space-y-0.5">{children}</div>
@@ -37,6 +37,8 @@ export function ToggleRow({
   return (
     <button
       type="button"
+      role="switch"
+      aria-checked={checked}
       onClick={() => onChange(!checked)}
       className="flex items-center justify-between w-full px-3 py-2.5 rounded-lg hover:bg-base-250/50 transition-colors cursor-pointer group"
     >
@@ -45,7 +47,7 @@ export function ToggleRow({
           {label}
         </span>
         {description && (
-          <span className="text-[10px] text-fg-4 leading-tight">
+          <span className="text-[11px] text-fg-4 leading-tight">
             {description}
           </span>
         )}
@@ -91,18 +93,24 @@ export function SegmentedRow<T extends string>({
       <div className="flex flex-col gap-0.5">
         <span className="text-[12px] text-fg-2 leading-tight">{label}</span>
         {description && (
-          <span className="text-[10px] text-fg-4 leading-tight">
+          <span className="text-[11px] text-fg-4 leading-tight">
             {description}
           </span>
         )}
       </div>
-      <div className="inline-flex items-center rounded-lg bg-base-200 p-0.5 shrink-0 ml-4">
+      <div
+        role="radiogroup"
+        aria-label={label}
+        className="inline-flex items-center rounded-lg bg-base-200 p-0.5 shrink-0 ml-4"
+      >
         {options.map((opt) => (
           <button
             key={opt.value}
+            role="radio"
+            aria-checked={value === opt.value}
             onClick={() => onChange(opt.value)}
             className={clsx(
-              "px-2.5 py-1 text-[10px] font-medium rounded-md transition-all duration-200 cursor-pointer leading-none",
+              "px-2.5 py-1 text-[11px] font-medium rounded-md transition-all duration-200 cursor-pointer leading-none",
               value === opt.value
                 ? "bg-base-300 text-fg shadow-sm"
                 : "text-fg-3 hover:text-fg-2",
@@ -146,7 +154,7 @@ export function SliderRow({
       <div className="flex flex-col gap-0.5">
         <span className="text-[12px] text-fg-2 leading-tight">{label}</span>
         {description && (
-          <span className="text-[10px] text-fg-4 leading-tight">
+          <span className="text-[11px] text-fg-4 leading-tight">
             {description}
           </span>
         )}
@@ -162,6 +170,7 @@ export function SliderRow({
           />
           <input
             type="range"
+            aria-label={label}
             min={min}
             max={max}
             step={step}
@@ -175,7 +184,7 @@ export function SliderRow({
             style={{ left: `calc(${pct}% - 6px)` }}
           />
         </div>
-        <span className="text-[10px] text-fg-3 w-12 text-right tabular-nums font-medium">
+        <span className="text-[11px] text-fg-3 w-12 text-right tabular-nums font-medium">
           {displayValue ?? value}
         </span>
       </div>
@@ -214,7 +223,7 @@ export function ResetButton({
   return (
     <button
       onClick={onClick}
-      className="text-[10px] font-medium px-3 py-1.5 rounded-lg text-fg-4 hover:text-fg-2 hover:bg-base-250/50 transition-colors cursor-pointer"
+      className="text-[11px] font-medium px-3 py-1.5 rounded-lg text-fg-4 hover:text-fg-2 hover:bg-base-250/50 transition-colors cursor-pointer"
     >
       {label}
     </button>
@@ -243,7 +252,7 @@ export function ActionRow({
       <div className="flex flex-col gap-0.5">
         <span className="text-[12px] text-fg-2 leading-tight">{label}</span>
         {description && (
-          <span className="text-[10px] text-fg-4 leading-tight">
+          <span className="text-[11px] text-fg-4 leading-tight">
             {description}
           </span>
         )}
@@ -251,7 +260,7 @@ export function ActionRow({
       <button
         onClick={onClick}
         className={clsx(
-          "text-[10px] font-medium px-2.5 py-1 rounded-md transition-colors cursor-pointer",
+          "text-[11px] font-medium px-2.5 py-1 rounded-md transition-colors cursor-pointer",
           actionClass ??
             "bg-base-250 text-fg-3 hover:text-fg-2 hover:bg-base-300",
         )}

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -233,6 +233,19 @@ export function resetAll(): AppPreferences {
   return defaults;
 }
 
+// ── Theme resolution ────────────────────────────────────────
+
+/** Resolve the effective theme from a Theme preference value.
+ *  "system" follows the OS preference; otherwise returns as-is. */
+export function resolveTheme(theme: Theme): "light" | "dark" {
+  if (theme === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+  return theme;
+}
+
 // ── Derived values ──────────────────────────────────────────────
 
 export const TASKBAR_HEIGHTS: Record<TaskbarHeight, number> = {


### PR DESCRIPTION
## Summary

Comprehensive UX audit and sweep of the desktop app — 27 fixes across 12 files addressing accessibility, polish, robustness, and code quality.

## Changes

### Accessibility
- `role="tablist"` / `role="tab"` / `aria-selected` on Feed and Dashboard channel tabs
- `role="switch"` / `aria-checked` on toggle rows, `role="radiogroup"` / `role="radio"` on segmented controls
- `role="dialog"` / `aria-modal` on login overlay and new confirm dialog
- `aria-label` on nav, sliders, progress bar; `aria-hidden` on decorative EKG SVG
- `motion-safe:animate-pulse` on all pulsing indicators (respects reduced motion)
- Keyboard shortcuts: Cmd/Ctrl+1-5 for section nav, Escape to dismiss overlays

### UX Improvements
- Collapsible sidebar (52px/200px) with persisted state and keyboard shortcut hints
- Settings tab crossfade animation via `AnimatePresence`
- User identity (email) displayed in account settings
- Error state component with retry button
- Session expired banner with sign-in and dismiss actions
- Confirmation dialog for settings reset
- Login overlay cancel button
- Logo click navigates to Feed (was ticker toggle)
- Scrollable release notes container in updater
- Dynamic taskbar height, row count indicator badge with number

### Robustness
- `resolveTheme()` helper extracted to `preferences.ts` — was duplicated in MainApp, App, and AppTaskbar
- `handleNavigate` wrapped in `useCallback` with correct `useEffect` dependency
- Empty guard on `weave()` — `Math.max(...[])` returns `-Infinity`
- Focus refetch throttled to 10s minimum gap (was firing on every alt-tab)
- Stale `prefsRef` fix in `handleTogglePosition` — uses `updated` object directly
- `position_ticker` accepts explicit `height` param for atomic compositor geometry (KWin/Hyprland/Sway)
- Removed duplicate `savePrefs` calls from AppTaskbar and SettingsPanel
- Removed dead `feedMode` state variable
- `connected` prop now passes actual `deliveryMode === "sse"` (was hardcoded `false`)
- Version display shows "—" fallback when `appVersion` is empty

### Polish
- `text-[10px]` → `text-[11px]` across all controls for readability
- Template literal class strings → `clsx` for consistency

## Testing
- `tsc --noEmit` passes cleanly