### PR TITLE
feat(sports): game activity intelligence — ticker, dashboard, and feed enhancements

### DIFF
--- a/channels/sports/api/models.go
+++ b/channels/sports/api/models.go
@@ -25,13 +25,17 @@ type Game struct {
 	Season         string    `json:"season,omitempty"`
 }
 
-// TrackedLeague represents a league entry from the catalog.
+// TrackedLeague represents a league entry from the catalog, enriched with
+// current game activity counts for the dashboard league browser.
 type TrackedLeague struct {
-	Name     string `json:"name"`
-	SportAPI string `json:"sport_api"`
-	Category string `json:"category"`
-	Country  string `json:"country"`
-	LogoURL  string `json:"logo_url"`
+	Name      string     `json:"name"`
+	SportAPI  string     `json:"sport_api"`
+	Category  string     `json:"category"`
+	Country   string     `json:"country"`
+	LogoURL   string     `json:"logo_url"`
+	GameCount int        `json:"game_count"`
+	LiveCount int        `json:"live_count"`
+	NextGame  *time.Time `json:"next_game,omitempty"`
 }
 
 // CDCRecord represents a Change Data Capture record from Sequin.

--- a/channels/sports/api/sports.go
+++ b/channels/sports/api/sports.go
@@ -31,7 +31,8 @@ const (
 	SportsCacheTTL = 30 * time.Second
 
 	// SportsCatalogCacheTTL is how long the league catalog is cached.
-	SportsCatalogCacheTTL = 5 * time.Minute
+	// Reduced from 5min to 60s because game activity status changes frequently.
+	SportsCatalogCacheTTL = 60 * time.Second
 
 	// SportsLeagueSubscribersPrefix is the per-league subscriber set prefix.
 	// Keys: sports:subscribers:league:{NFL}, sports:subscribers:league:{NBA}, etc.
@@ -91,7 +92,7 @@ func (a *App) getSports(c *fiber.Ctx) error {
 }
 
 // getLeagueCatalog returns all enabled tracked leagues for the dashboard
-// league browser.
+// league browser, enriched with per-league game counts and activity status.
 func (a *App) getLeagueCatalog(c *fiber.Ctx) error {
 	var catalog []TrackedLeague
 	if GetCache(a.rdb, CacheKeySportsCatalog, &catalog) {
@@ -99,7 +100,9 @@ func (a *App) getLeagueCatalog(c *fiber.Ctx) error {
 		return c.JSON(catalog)
 	}
 
-	rows, err := a.db.Query(context.Background(),
+	ctx := context.Background()
+
+	rows, err := a.db.Query(ctx,
 		`SELECT name, COALESCE(sport_api, ''), COALESCE(category, 'Other'), COALESCE(country, ''), COALESCE(logo_url, '')
 		 FROM tracked_leagues WHERE is_enabled = true ORDER BY category, name`)
 	if err != nil {
@@ -119,6 +122,45 @@ func (a *App) getLeagueCatalog(c *fiber.Ctx) error {
 			continue
 		}
 		catalog = append(catalog, l)
+	}
+
+	// Enrich with per-league game activity counts.
+	type leagueStatus struct {
+		GameCount int
+		LiveCount int
+		NextGame  *time.Time
+	}
+	statusMap := make(map[string]leagueStatus)
+
+	statusRows, err := a.db.Query(ctx,
+		`SELECT league,
+		        COUNT(*) AS game_count,
+		        COUNT(*) FILTER (WHERE state = 'in') AS live_count,
+		        MIN(start_time) FILTER (WHERE state = 'pre') AS next_game
+		 FROM games
+		 GROUP BY league`)
+	if err != nil {
+		log.Printf("[Sports] League status query failed (non-fatal): %v", err)
+		// Continue without enrichment — the catalog is still useful.
+	} else {
+		defer statusRows.Close()
+		for statusRows.Next() {
+			var league string
+			var s leagueStatus
+			if err := statusRows.Scan(&league, &s.GameCount, &s.LiveCount, &s.NextGame); err != nil {
+				log.Printf("[Sports] League status scan error: %v", err)
+				continue
+			}
+			statusMap[league] = s
+		}
+	}
+
+	for i := range catalog {
+		if s, ok := statusMap[catalog[i].Name]; ok {
+			catalog[i].GameCount = s.GameCount
+			catalog[i].LiveCount = s.LiveCount
+			catalog[i].NextGame = s.NextGame
+		}
 	}
 
 	SetCache(a.rdb, CacheKeySportsCatalog, catalog, SportsCatalogCacheTTL)

--- a/channels/sports/extension/FeedTab.tsx
+++ b/channels/sports/extension/FeedTab.tsx
@@ -49,9 +49,11 @@ export default function SportsFeedTab({ mode, channelConfig }: FeedTabProps) {
     >
       {games.length === 0 && (
         <div className="col-span-full text-center py-8 text-fg-3 text-xs font-mono">
-          {channelConfig.__dashboardLoaded && initialItems.length === 0
-            ? "No leagues selected \u2014 configure on myscrollr.com"
-            : "Waiting for game data\u2026"}
+          {!channelConfig.__dashboardLoaded
+            ? "Waiting for game data\u2026"
+            : channelConfig.__hasConfig
+              ? "No active games for your selected leagues"
+              : "No leagues selected \u2014 configure on myscrollr.com"}
         </div>
       )}
       {games.map((game) => (

--- a/channels/sports/extension/GameItem.tsx
+++ b/channels/sports/extension/GameItem.tsx
@@ -1,5 +1,6 @@
-import { clsx } from 'clsx';
-import type { Game, FeedMode } from '~/utils/types';
+import { useState, useEffect, useRef } from "react";
+import { clsx } from "clsx";
+import type { Game, FeedMode } from "~/utils/types";
 
 interface GameItemProps {
   game: Game;
@@ -16,38 +17,81 @@ function statusLabel(game: Game): string {
     if (game.timer) return game.timer;
     if (game.status_long) return game.status_long;
     if (game.short_detail) return game.short_detail;
-    return 'Live';
+    return "Live";
   }
   // Finished games: prefer status_long (e.g. "Game Finished"), then short_detail
-  if (game.state === 'final' || game.state === 'post') {
+  if (game.state === "final" || game.state === "post") {
     if (game.status_long) return game.status_long;
     if (game.short_detail) return game.short_detail;
-    return 'Final';
+    return "Final";
   }
   // Upcoming: prefer status_long (e.g. "Not Started"), then short_detail
-  if (game.state === 'pre') {
+  if (game.state === "pre") {
     if (game.status_long) return game.status_long;
     if (game.short_detail) return game.short_detail;
-    return 'Upcoming';
+    return "Upcoming";
   }
   // Postponed/cancelled/other states
   if (game.status_long) return game.status_long;
   if (game.short_detail) return game.short_detail;
   if (game.status_short) return game.status_short;
-  return '';
+  return "";
 }
 
 function isLive(game: Game): boolean {
-  return game.state === 'in_progress' || game.state === 'in';
+  return game.state === "in_progress" || game.state === "in";
 }
+
+function getWinner(game: Game): "home" | "away" | null {
+  if (game.state !== "final") return null;
+  const a = Number(game.away_team_score);
+  const h = Number(game.home_team_score);
+  if (isNaN(a) || isNaN(h) || a === h) return null;
+  return h > a ? "home" : "away";
+}
+
+// ── Score flash hook ────────────────────────────────────────────
+
+function useScoreFlash(awayScore: number | string, homeScore: number | string) {
+  const prevRef = useRef({ away: awayScore, home: homeScore });
+  const [flash, setFlash] = useState(false);
+  const initialRender = useRef(true);
+
+  useEffect(() => {
+    if (initialRender.current) {
+      initialRender.current = false;
+      prevRef.current = { away: awayScore, home: homeScore };
+      return;
+    }
+
+    const prev = prevRef.current;
+    if (prev.away !== awayScore || prev.home !== homeScore) {
+      setFlash(true);
+      const t = setTimeout(() => setFlash(false), 800);
+      prevRef.current = { away: awayScore, home: homeScore };
+      return () => clearTimeout(t);
+    }
+  }, [awayScore, homeScore]);
+
+  return flash;
+}
+
+// ── Component ───────────────────────────────────────────────────
 
 export default function GameItem({ game, mode }: GameItemProps) {
   const live = isLive(game);
-  const final = game.state === 'final';
+  const isFinal = game.state === "final";
+  const winner = getWinner(game);
+  const flash = useScoreFlash(game.away_team_score, game.home_team_score);
 
-  if (mode === 'compact') {
+  if (mode === "compact") {
     return (
-      <div className="flex items-center gap-2 px-3 py-1.5 bg-surface text-xs">
+      <div
+        className={clsx(
+          "flex items-center gap-2 px-3 py-1.5 bg-surface text-xs transition-colors duration-700",
+          flash && "bg-live/10",
+        )}
+      >
         {game.away_team_logo && (
           <img
             src={game.away_team_logo}
@@ -55,17 +99,41 @@ export default function GameItem({ game, mode }: GameItemProps) {
             className="w-4 h-4 object-contain"
           />
         )}
-        <span className="font-mono font-medium text-fg min-w-[28px]">
+        <span
+          className={clsx(
+            "font-mono font-medium min-w-[28px]",
+            isFinal && winner === "home" ? "text-fg-3" : "text-fg",
+            winner === "away" && "font-bold",
+          )}
+        >
           {game.away_team_name.slice(0, 3).toUpperCase()}
         </span>
-        <span className="font-mono text-fg tabular-nums">
+        <span
+          className={clsx(
+            "font-mono tabular-nums",
+            isFinal && winner === "home" ? "text-fg-3" : "text-fg",
+            winner === "away" && "font-bold",
+          )}
+        >
           {formatScore(game.away_team_score)}
         </span>
         <span className="text-fg-4 font-mono">&ndash;</span>
-        <span className="font-mono text-fg tabular-nums">
+        <span
+          className={clsx(
+            "font-mono tabular-nums",
+            isFinal && winner === "away" ? "text-fg-3" : "text-fg",
+            winner === "home" && "font-bold",
+          )}
+        >
           {formatScore(game.home_team_score)}
         </span>
-        <span className="font-mono font-medium text-fg min-w-[28px]">
+        <span
+          className={clsx(
+            "font-mono font-medium min-w-[28px]",
+            isFinal && winner === "away" ? "text-fg-3" : "text-fg",
+            winner === "home" && "font-bold",
+          )}
+        >
           {game.home_team_name.slice(0, 3).toUpperCase()}
         </span>
         {game.home_team_logo && (
@@ -77,9 +145,9 @@ export default function GameItem({ game, mode }: GameItemProps) {
         )}
         <span
           className={clsx(
-            'ml-auto text-[9px] font-mono uppercase tracking-wider',
-            live && 'text-live font-bold',
-            !live && 'text-fg-3',
+            "ml-auto text-[9px] font-mono uppercase tracking-wider",
+            live && "text-live font-bold",
+            !live && "text-fg-3",
           )}
         >
           {live && (
@@ -93,10 +161,13 @@ export default function GameItem({ game, mode }: GameItemProps) {
 
   // Comfort mode
   return (
-    <div className={clsx(
-      'px-3 py-2 bg-surface border-l-2',
-      live ? 'border-l-live/40' : 'border-l-transparent',
-    )}>
+    <div
+      className={clsx(
+        "px-3 py-2 bg-surface border-l-2 transition-colors duration-700",
+        live ? "border-l-live/40" : "border-l-transparent",
+        flash && "bg-live/8",
+      )}
+    >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {game.away_team_logo && (
@@ -106,9 +177,22 @@ export default function GameItem({ game, mode }: GameItemProps) {
               className="w-5 h-5 object-contain"
             />
           )}
-          <span className="text-sm text-fg">{game.away_team_name}</span>
+          <span
+            className={clsx(
+              "text-sm",
+              isFinal && winner === "home" ? "text-fg-3" : "text-fg",
+              winner === "away" && "font-semibold",
+            )}
+          >
+            {game.away_team_name}
+          </span>
         </div>
-        <span className="text-sm font-mono font-bold text-fg tabular-nums">
+        <span
+          className={clsx(
+            "text-sm font-mono font-bold tabular-nums",
+            isFinal && winner === "home" ? "text-fg-3" : "text-fg",
+          )}
+        >
           {formatScore(game.away_team_score)}
         </span>
       </div>
@@ -122,9 +206,22 @@ export default function GameItem({ game, mode }: GameItemProps) {
               className="w-5 h-5 object-contain"
             />
           )}
-          <span className="text-sm text-fg">{game.home_team_name}</span>
+          <span
+            className={clsx(
+              "text-sm",
+              isFinal && winner === "away" ? "text-fg-3" : "text-fg",
+              winner === "home" && "font-semibold",
+            )}
+          >
+            {game.home_team_name}
+          </span>
         </div>
-        <span className="text-sm font-mono font-bold text-fg tabular-nums">
+        <span
+          className={clsx(
+            "text-sm font-mono font-bold tabular-nums",
+            isFinal && winner === "away" ? "text-fg-3" : "text-fg",
+          )}
+        >
           {formatScore(game.home_team_score)}
         </span>
       </div>
@@ -135,10 +232,9 @@ export default function GameItem({ game, mode }: GameItemProps) {
         )}
         <span
           className={clsx(
-            'text-[9px] font-mono uppercase tracking-wider',
-            live && 'text-live font-bold',
-            final && 'text-fg-3',
-            !live && !final && 'text-fg-3',
+            "text-[9px] font-mono uppercase tracking-wider",
+            live && "text-live font-bold",
+            !live && "text-fg-3",
           )}
         >
           {statusLabel(game)}

--- a/channels/sports/web/DashboardTab.tsx
+++ b/channels/sports/web/DashboardTab.tsx
@@ -13,6 +13,9 @@ interface TrackedLeague {
   category: string
   country: string
   logo_url: string
+  game_count: number
+  live_count: number
+  next_game: string | null
 }
 
 interface SportsChannelConfig {
@@ -31,6 +34,29 @@ async function fetchCatalog(): Promise<TrackedLeague[]> {
   const res = await fetch(`${API_BASE}/sports/leagues`)
   if (!res.ok) throw new Error('Failed to fetch league catalog')
   return res.json()
+}
+
+// ── League activity helpers ──────────────────────────────────────
+
+function leagueActivitySort(a: TrackedLeague, b: TrackedLeague): number {
+  // Live leagues first, then by game count desc, then alphabetical
+  if (a.live_count !== b.live_count) return b.live_count - a.live_count
+  if (a.game_count !== b.game_count) return b.game_count - a.game_count
+  return a.name.localeCompare(b.name)
+}
+
+function formatNextGame(dateStr: string | null): string | null {
+  if (!dateStr) return null
+  const d = new Date(dateStr)
+  const now = Date.now()
+  const diff = d.getTime() - now
+  if (diff <= 0) return 'Starting'
+  const h = Math.floor(diff / 3_600_000)
+  if (h < 24) {
+    const m = Math.floor((diff % 3_600_000) / 60_000)
+    return h > 0 ? `in ${h}h ${m}m` : `in ${m}m`
+  }
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }
 
 // ── Component ───────────────────────────────────────────────────
@@ -80,8 +106,10 @@ function SportsDashboardTab({
     ...Array.from(new Set(catalog.map((l) => l.category))),
   ]
 
-  // Filter by category and search
-  const filteredCatalog = catalog.filter((l) => {
+  // Sort by activity (live first, then game count, then alpha), then filter
+  const sortedCatalog = [...catalog].sort(leagueActivitySort)
+
+  const filteredCatalog = sortedCatalog.filter((l) => {
     const matchesCategory =
       activeCategory === 'All' || l.category === activeCategory
     const matchesSearch =
@@ -90,6 +118,14 @@ function SportsDashboardTab({
       l.category.toLowerCase().includes(searchQuery.toLowerCase())
     return matchesCategory && matchesSearch
   })
+
+  // Check if all selected leagues are off-season
+  const selectedAllOffSeason =
+    leagues.length > 0 &&
+    leagues.every((name) => {
+      const entry = catalog.find((l) => l.name === name)
+      return !entry || entry.game_count === 0
+    })
 
   const updateLeagues = async (nextLeagues: string[]) => {
     setSaving(true)
@@ -259,6 +295,19 @@ function SportsDashboardTab({
                         {entry.category}
                       </span>
                     )}
+                    {entry && entry.live_count > 0 && (
+                      <span className="text-[8px] text-live font-bold ml-1.5">
+                        <span className="inline-block w-1 h-1 rounded-full bg-live animate-pulse mr-0.5 align-middle" />
+                        {entry.live_count} Live
+                      </span>
+                    )}
+                    {entry &&
+                      entry.live_count === 0 &&
+                      entry.game_count === 0 && (
+                        <span className="text-[8px] text-base-content/20 ml-1.5">
+                          Off-season
+                        </span>
+                      )}
                   </div>
                   <button
                     onClick={() => removeLeague(name)}
@@ -276,6 +325,23 @@ function SportsDashboardTab({
             <Trophy size={28} className="mx-auto text-base-content/15 mb-2" />
             <p className="text-[10px] text-base-content/25 uppercase tracking-wide">
               No leagues selected — browse the catalog below
+            </p>
+          </div>
+        )}
+
+        {/* Off-season warning */}
+        {selectedAllOffSeason && (
+          <div
+            className="flex items-center gap-2 px-3 py-2.5 rounded-lg border text-[10px]"
+            style={{
+              background: `${hex}08`,
+              borderColor: `${hex}1A`,
+            }}
+          >
+            <Trophy size={14} className="text-base-content/20 shrink-0" />
+            <p className="text-base-content/40">
+              Your selected leagues are currently off-season. No game data will
+              appear in your feed until games are scheduled.
             </p>
           </div>
         )}
@@ -427,12 +493,30 @@ function SportsDashboardTab({
                     )}
                     <div className="min-w-0">
                       <div className="text-xs font-bold">{entry.name}</div>
-                      <div className="text-[9px] text-base-content/30 truncate">
-                        {entry.country}
+                      <div className="flex items-center gap-1.5 text-[9px] text-base-content/30 truncate">
+                        <span>{entry.country}</span>
+                        {entry.live_count > 0 && (
+                          <span className="inline-flex items-center gap-0.5 text-live font-bold">
+                            <span className="w-1 h-1 rounded-full bg-live animate-pulse" />
+                            {entry.live_count} Live
+                          </span>
+                        )}
+                        {entry.live_count === 0 && entry.game_count > 0 && (
+                          <span className="text-base-content/40">
+                            {entry.game_count} games
+                          </span>
+                        )}
+                        {entry.game_count === 0 && (
+                          <span className="text-base-content/20">
+                            {formatNextGame(entry.next_game)
+                              ? `Next: ${formatNextGame(entry.next_game)}`
+                              : 'Off-season'}
+                          </span>
+                        )}
                       </div>
                     </div>
                   </div>
-                  <div className="shrink-0">
+                  <div className="shrink-0 flex items-center gap-2">
                     {isAdded ? (
                       <span
                         className="text-[9px] font-bold uppercase tracking-widest px-2 py-1 rounded"

--- a/desktop/src/MainApp.tsx
+++ b/desktop/src/MainApp.tsx
@@ -680,11 +680,15 @@ function FeedSection({
   // Build channelConfig for the active FeedTab (same pattern as FeedBar)
   const channelConfig = useMemo(() => {
     const initialItems = dashboard?.data?.[activeTab] ?? [];
+    const hasChannel = channels.some(
+      (ch) => ch.channel_type === activeTab && ch.enabled,
+    );
     return {
       __initialItems: initialItems,
       __dashboardLoaded: dashboard !== null,
+      __hasConfig: hasChannel,
     };
-  }, [activeTab, dashboard]);
+  }, [activeTab, dashboard, channels]);
 
   // Look up the active channel's FeedTab component
   const channel = getChannel(activeTab);

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -4,9 +4,27 @@ import { useMotionValue, animate, AnimatePresence, motion } from "motion/react";
 import type { DashboardResponse, Trade, Game, RssItem } from "~/utils/types";
 import type { MixMode, ChipColorMode, TickerDirection, ScrollMode } from "../preferences";
 import TradeChip from "./chips/TradeChip";
-import GameChip from "./chips/GameChip";
+import GameChip, { isLive, isCloseGame } from "./chips/GameChip";
 import RssChip from "./chips/RssChip";
 import FantasyChip from "./chips/FantasyChip";
+
+// ── Sport engagement scoring (higher = more prominent in ticker) ─
+
+function gameEngagement(g: Game): number {
+  if (isLive(g)) return isCloseGame(g) ? 100 : 80;
+  if (g.state === "pre") {
+    const until = new Date(g.start_time).getTime() - Date.now();
+    if (until < 3_600_000) return 60;  // within 1 hour
+    if (until < 86_400_000) return 40; // within 24 hours
+    return 20;
+  }
+  if (g.state === "final") {
+    const ago = Date.now() - new Date(g.start_time).getTime();
+    if (ago < 7_200_000) return 30; // finished within 2 hours
+    return 10;
+  }
+  return 0;
+}
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -124,8 +142,10 @@ export default function ScrollrTicker({
           }
           break;
 
-        case "sports":
-          for (const game of data as Game[]) {
+        case "sports": {
+          // Sort by engagement: close live > live > starting soon > recent final > rest
+          const sorted = (data as Game[]).slice().sort((a, b) => gameEngagement(b) - gameEngagement(a));
+          for (const game of sorted) {
             bucket.push(
               wrap(`spo-${game.id}`,
                 <GameChip
@@ -138,6 +158,7 @@ export default function ScrollrTicker({
             );
           }
           break;
+        }
 
         case "rss":
           for (const item of data as RssItem[]) {

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -1,7 +1,10 @@
+import { useState, useEffect, useRef } from "react";
 import { clsx } from "clsx";
 import type { Game } from "~/utils/types";
 import type { ChipColorMode } from "../../preferences";
 import { getChipColors } from "./chipColors";
+
+// ── Props ───────────────────────────────────────────────────────
 
 interface GameChipProps {
   game: Game;
@@ -10,20 +13,114 @@ interface GameChipProps {
   onClick?: () => void;
 }
 
-function isLive(game: Game): boolean {
+// ── Sport utilities (exported for ScrollrTicker sorting) ────────
+
+/** Close-game threshold per sport — roughly "one score" in each sport. */
+const CLOSE_THRESHOLDS: Record<string, number> = {
+  "american-football": 8,
+  "basketball": 6,
+  "hockey": 1,
+  "baseball": 2,
+  "football": 1,
+};
+
+export function isLive(game: Game): boolean {
   return game.state === "in_progress" || game.state === "in";
 }
 
-function shortStatus(game: Game): string {
-  if (isLive(game)) return "LIVE";
-  if (game.state === "final") return "F";
+export function isCloseGame(game: Game): boolean {
+  if (!isLive(game)) return false;
+  const away = Number(game.away_team_score);
+  const home = Number(game.home_team_score);
+  if (isNaN(away) || isNaN(home)) return false;
+  return Math.abs(away - home) <= (CLOSE_THRESHOLDS[game.sport] ?? 3);
+}
+
+function getWinner(game: Game): "home" | "away" | null {
+  if (game.state !== "final") return null;
+  const a = Number(game.away_team_score);
+  const h = Number(game.home_team_score);
+  if (isNaN(a) || isNaN(h) || a === h) return null;
+  return h > a ? "home" : "away";
+}
+
+function formatCountdown(startTime: string): string {
+  const diff = new Date(startTime).getTime() - Date.now();
+  if (diff <= 0) return "Starting";
+  const h = Math.floor(diff / 3_600_000);
+  const m = Math.floor((diff % 3_600_000) / 60_000);
+  if (h >= 48) {
+    return new Date(startTime).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+  }
+  if (h >= 24) return "Tomorrow";
+  if (h > 0) return `in ${h}h ${m}m`;
+  if (m > 0) return `in ${m}m`;
+  return "Soon";
+}
+
+/** Rich status for the chip — game clock for live, countdown for pre. */
+function chipStatus(game: Game): string {
+  if (isLive(game)) return game.timer || game.status_short || "LIVE";
+  if (game.state === "final") return game.status_long || "Final";
+  if (game.state === "pre") return formatCountdown(game.start_time);
+  if (game.state === "postponed") return "PPD";
   return "";
 }
 
-export default function GameChip({ game, comfort, colorMode = "channel", onClick }: GameChipProps) {
+// ── Component ───────────────────────────────────────────────────
+
+export default function GameChip({
+  game,
+  comfort,
+  colorMode = "channel",
+  onClick,
+}: GameChipProps) {
   const c = getChipColors(colorMode, "sports");
   const live = isLive(game);
-  const status = shortStatus(game);
+  const close = isCloseGame(game);
+  const winner = getWinner(game);
+  const status = chipStatus(game);
+  const isFinal = game.state === "final";
+  const isPre = game.state === "pre";
+
+  // ── Score change flash ──────────────────────────────────────
+  const prevRef = useRef({
+    away: game.away_team_score,
+    home: game.home_team_score,
+  });
+  const [flash, setFlash] = useState(false);
+  const initialRender = useRef(true);
+
+  useEffect(() => {
+    // Skip flash on initial mount — only flash on updates.
+    if (initialRender.current) {
+      initialRender.current = false;
+      prevRef.current = {
+        away: game.away_team_score,
+        home: game.home_team_score,
+      };
+      return;
+    }
+
+    const prev = prevRef.current;
+    if (
+      prev.away !== game.away_team_score ||
+      prev.home !== game.home_team_score
+    ) {
+      setFlash(true);
+      const t = setTimeout(() => setFlash(false), 800);
+      prevRef.current = {
+        away: game.away_team_score,
+        home: game.home_team_score,
+      };
+      return () => clearTimeout(t);
+    }
+  }, [game.away_team_score, game.home_team_score]);
+
+  // ── Render ──────────────────────────────────────────────────
 
   return (
     <button
@@ -32,57 +129,130 @@ export default function GameChip({ game, comfort, colorMode = "channel", onClick
         "ticker-chip group",
         "px-3 rounded-sm border",
         "font-mono whitespace-nowrap",
-        "transition-colors cursor-pointer",
-        c.bg, c.border, c.hoverBorder,
-        comfort ? "flex flex-col items-start py-1.5 gap-0.5" : "flex items-center gap-2 py-1 text-[13px]",
+        "transition-colors duration-700 cursor-pointer",
+        flash ? "bg-live/15" : c.bg,
+        close ? "border-live/40" : c.border,
+        !close && c.hoverBorder,
+        comfort
+          ? "flex flex-col items-start py-1.5 gap-0.5"
+          : "flex items-center gap-2 py-1 text-[13px]",
       )}
     >
-      {/* Row 1: scores */}
-      <div className={clsx("flex items-center gap-2", comfort && "text-[13px]")}>
-        <span className={clsx("font-semibold", c.text)}>
+      {/* Row 1: logos + scores */}
+      <div
+        className={clsx("flex items-center gap-1.5", comfort && "text-[13px]")}
+      >
+        {/* Away team */}
+        {game.away_team_logo && (
+          <img
+            src={game.away_team_logo}
+            alt=""
+            className={clsx(
+              "object-contain shrink-0",
+              comfort ? "w-3.5 h-3.5" : "w-3 h-3",
+            )}
+          />
+        )}
+        <span
+          className={clsx(
+            c.text,
+            winner === "away" ? "font-bold" : "font-semibold",
+            isFinal && winner === "home" && "opacity-50",
+          )}
+        >
           {game.away_team_name.slice(0, 3).toUpperCase()}
         </span>
-        <span className={c.textDim}>{String(game.away_team_score)}</span>
+        <span
+          className={clsx(
+            "tabular-nums",
+            winner === "away" ? "font-bold " + c.text : c.textDim,
+            isFinal && winner === "home" && "opacity-50",
+            isPre && "opacity-30",
+          )}
+        >
+          {isPre ? "_" : String(game.away_team_score)}
+        </span>
+
         <span className="text-fg-4">-</span>
-        <span className={c.textDim}>{String(game.home_team_score)}</span>
-        <span className={clsx("font-semibold", c.text)}>
+
+        {/* Home team */}
+        <span
+          className={clsx(
+            "tabular-nums",
+            winner === "home" ? "font-bold " + c.text : c.textDim,
+            isFinal && winner === "away" && "opacity-50",
+            isPre && "opacity-30",
+          )}
+        >
+          {isPre ? "_" : String(game.home_team_score)}
+        </span>
+        <span
+          className={clsx(
+            c.text,
+            winner === "home" ? "font-bold" : "font-semibold",
+            isFinal && winner === "away" && "opacity-50",
+          )}
+        >
           {game.home_team_name.slice(0, 3).toUpperCase()}
         </span>
+        {game.home_team_logo && (
+          <img
+            src={game.home_team_logo}
+            alt=""
+            className={clsx(
+              "object-contain shrink-0",
+              comfort ? "w-3.5 h-3.5" : "w-3 h-3",
+            )}
+          />
+        )}
+
+        {/* Status (compact only) */}
         {!comfort && status && (
           <span
             className={clsx(
-              "flex items-center gap-1 text-[11px] uppercase tracking-wider",
-              live ? "text-live font-semibold" : "text-fg-3"
+              "flex items-center gap-1 text-[11px] uppercase tracking-wider ml-0.5",
+              live ? "text-live font-semibold" : "text-fg-3",
             )}
           >
             {live && (
-              <span className="w-1.5 h-1.5 rounded-full bg-live animate-pulse" />
+              <span className="w-1.5 h-1.5 rounded-full bg-live animate-pulse shrink-0" />
             )}
             {status}
           </span>
         )}
       </div>
-      {/* Row 2: league + detail (comfort only) */}
+
+      {/* Row 2: league + timer/status (comfort only) */}
       {comfort && (
-        <div className={clsx("flex items-center gap-1.5 text-[10px]", c.textFaint)}>
+        <div
+          className={clsx(
+            "flex items-center gap-1.5 text-[10px]",
+            c.textFaint,
+          )}
+        >
           {game.league && (
             <span className="uppercase font-semibold">{game.league}</span>
           )}
-          {game.short_detail && (
+          {status && (
             <>
               <span className="text-fg-4">&middot;</span>
-              <span>{game.short_detail}</span>
-            </>
-          )}
-          {!game.short_detail && status && (
-            <>
-              <span className="text-fg-4">&middot;</span>
-              <span className={clsx("flex items-center gap-1", live && "text-live")}>
+              <span
+                className={clsx(
+                  "flex items-center gap-1",
+                  live && "text-live font-semibold",
+                )}
+              >
                 {live && (
-                  <span className="w-1 h-1 rounded-full bg-live animate-pulse" />
+                  <span className="w-1 h-1 rounded-full bg-live animate-pulse shrink-0" />
                 )}
                 {status}
               </span>
+            </>
+          )}
+          {close && (
+            <>
+              <span className="text-fg-4">&middot;</span>
+              <span className="text-live/70 font-semibold">Close</span>
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary

- **Score change flash**: 800ms background pulse on GameChip and GameItem when scores update via CDC, matching finance's price flash pattern
- **Game clock in ticker**: Shows actual timer (Q3 5:42, 67', Inn 7) instead of generic "LIVE" text
- **Team logos**: 12-14px logos next to team abbreviations in ticker chips
- **Winner bold / loser dim**: Final games show winning team bolded and losing team dimmed
- **Close game highlighting**: Live games within one-score margin get accent border + "Close" label
- **Start countdown**: Upcoming games show "in 2h 15m" / "Tomorrow" / date instead of blank status
- **Smart engagement sort**: Ticker orders sports by priority — close live > live > starting soon > recent final > scheduled
- **League catalog enrichment**: Backend `/sports/leagues` now returns `game_count`, `live_count`, `next_game` per league (cache TTL reduced from 5min to 60s)
- **Dashboard status badges**: League cards show "X Live" (pulsing dot), "X games", "Next: Mar 15", or "Off-season"
- **Selected league indicators**: Chips show live count or "Off-season" tag
- **Off-season warning**: Banner when all selected leagues have zero games
- **Three-way feed empty state**: Distinguishes "waiting" / "no active games" / "no leagues selected"

## Files Changed (8)

| File | Change |
|------|--------|
| `channels/sports/api/models.go` | Add `game_count`, `live_count`, `next_game` to TrackedLeague |
| `channels/sports/api/sports.go` | Game count query in getLeagueCatalog, reduced cache TTL |
| `desktop/src/components/chips/GameChip.tsx` | Full rewrite: logos, timer, flash, close game, winner bold, countdown |
| `desktop/src/components/ScrollrTicker.tsx` | Engagement-priority sort for sports games |
| `channels/sports/extension/GameItem.tsx` | Score flash animation + winner bold |
| `channels/sports/extension/FeedTab.tsx` | Three-way empty state with `__hasConfig` |
| `channels/sports/web/DashboardTab.tsx` | Status badges, catalog sort, off-season warning |
| `desktop/src/MainApp.tsx` | Pass `__hasConfig` flag to FeedTab |

## Build Verification

- Desktop `tsc --noEmit` — clean
- Extension `tsc --noEmit` — clean
- Frontend `tsc --noEmit` — clean
- Desktop Vite build — clean (1.72s)