### PR TITLE
fix(desktop): eliminate sysmon polling lag

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tauri::{
     menu::{MenuBuilder, MenuItemBuilder},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
@@ -13,35 +13,54 @@ struct SseHandle(Mutex<Option<watch::Sender<bool>>>);
 
 /// Tracks whether the OAuth callback server is already running.
 #[derive(Clone)]
-struct AuthServerRunning(std::sync::Arc<Mutex<bool>>);
+struct AuthServerRunning(Arc<Mutex<bool>>);
 
 // ── System monitor state ─────────────────────────────────────────
 
-/// Persistent system info instances — refreshed on each poll,
-/// created once at startup to amortise the initial scan cost.
-struct SysInfoState {
-    sys: Mutex<sysinfo::System>,
-    components: Mutex<sysinfo::Components>,
-    networks: Mutex<sysinfo::Networks>,
+/// Data that never changes between polls — cached on first call.
+#[derive(Clone)]
+struct StaticSystemInfo {
+    cpu_name: String,
+    cpu_cores: usize,
+    os_name: String,
+    hostname: String,
+    gpu_name: Option<String>,
+    gpu_vram_total: Option<u64>,
+    /// Resolved GPU sysfs device path (AMD), if any.
+    gpu_sysfs_device: Option<std::path::PathBuf>,
+    /// Whether nvidia-smi is available (checked once).
+    has_nvidia_smi: bool,
 }
 
-/// Collected GPU snapshot from sysfs / nvidia-smi.
+/// Dynamic GPU values read each poll.
 #[derive(Default)]
-struct GpuInfo {
-    name: Option<String>,
+struct GpuDynamic {
     usage: Option<f64>,
-    vram_total: Option<u64>,
     vram_used: Option<u64>,
     power_watts: Option<f64>,
     power_cap_watts: Option<f64>,
     clock_mhz: Option<u64>,
 }
 
-/// Read GPU name, utilization, VRAM, power, and clock.
-/// Picks the discrete GPU over an idle iGPU (highest gpu_busy_percent).
-fn read_gpu_info() -> GpuInfo {
-    let mut best: Option<(std::path::PathBuf, f64)> = None;
+/// Persistent system info instances — refreshed on each poll.
+/// Wrapped in Arc so it can be sent into `spawn_blocking`.
+struct SysInfoInner {
+    sys: Mutex<sysinfo::System>,
+    components: Mutex<sysinfo::Components>,
+    networks: Mutex<sysinfo::Networks>,
+    /// Populated on first poll, then reused.
+    static_info: Mutex<Option<StaticSystemInfo>>,
+}
 
+#[derive(Clone)]
+struct SysInfoState(Arc<SysInfoInner>);
+
+/// Probe GPU once: find the sysfs device path, resolve the name and
+/// VRAM total, and check whether nvidia-smi is available.  Called only
+/// on the first poll; the results are cached in `StaticSystemInfo`.
+fn probe_gpu_static() -> (Option<std::path::PathBuf>, Option<String>, Option<u64>, bool) {
+    // Try AMD/Intel sysfs first
+    let mut best: Option<(std::path::PathBuf, f64)> = None;
     if let Ok(entries) = std::fs::read_dir("/sys/class/drm") {
         for entry in entries.flatten() {
             let fname = entry.file_name();
@@ -58,59 +77,73 @@ fn read_gpu_info() -> GpuInfo {
         }
     }
 
-    if let Some((dev, usage)) = best {
+    if let Some((dev, _)) = best {
         let name = std::fs::read_to_string(dev.join("product_name"))
             .ok()
             .map(|v| v.trim().to_string())
             .filter(|v| !v.is_empty())
             .or_else(|| gpu_name_from_lspci(&dev));
-
         let vram_total = read_sysfs_u64(&dev, "mem_info_vram_total");
-        let vram_used = read_sysfs_u64(&dev, "mem_info_vram_used");
-
-        // Power: hwmon exposes power1_average / power1_cap in microwatts
-        let (power_watts, power_cap_watts) = read_gpu_power(&dev);
-
-        // Clock: parse pp_dpm_sclk for the active state (marked with *)
-        let clock_mhz = read_gpu_clock(&dev);
-
-        return GpuInfo {
-            name,
-            usage: Some(usage),
-            vram_total,
-            vram_used,
-            power_watts,
-            power_cap_watts,
-            clock_mhz,
-        };
+        return (Some(dev), name, vram_total, false);
     }
 
-    // Fallback: nvidia-smi — query everything in one call
+    // Fallback: try nvidia-smi once for static values
+    let has_nvidia_smi = std::process::Command::new("nvidia-smi")
+        .args(["--query-gpu=name,memory.total", "--format=csv,noheader,nounits"])
+        .output()
+        .is_ok_and(|o| o.status.success());
+
+    if has_nvidia_smi {
+        if let Ok(out) = std::process::Command::new("nvidia-smi")
+            .args(["--query-gpu=name,memory.total", "--format=csv,noheader,nounits"])
+            .output()
+        {
+            if out.status.success() {
+                let line = String::from_utf8_lossy(&out.stdout);
+                let f: Vec<&str> = line.trim().splitn(2, ", ").collect();
+                let name = f.first().map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+                let vram = f.get(1).and_then(|s| s.trim().parse::<u64>().ok()).map(|m| m * 1024 * 1024);
+                return (None, name, vram, true);
+            }
+        }
+    }
+
+    (None, None, None, false)
+}
+
+/// Read dynamic GPU values from sysfs (AMD/Intel).
+fn read_gpu_dynamic_sysfs(dev: &std::path::Path) -> GpuDynamic {
+    GpuDynamic {
+        usage: read_sysfs_f64(dev, "gpu_busy_percent"),
+        vram_used: read_sysfs_u64(dev, "mem_info_vram_used"),
+        power_watts: read_gpu_power(dev).0,
+        power_cap_watts: read_gpu_power(dev).1,
+        clock_mhz: read_gpu_clock(dev),
+    }
+}
+
+/// Read dynamic GPU values from nvidia-smi.
+fn read_gpu_dynamic_nvidia() -> GpuDynamic {
     if let Ok(out) = std::process::Command::new("nvidia-smi")
         .args([
-            "--query-gpu=name,utilization.gpu,memory.total,memory.used,power.draw,power.limit,clocks.current.graphics",
+            "--query-gpu=utilization.gpu,memory.used,power.draw,power.limit,clocks.current.graphics",
             "--format=csv,noheader,nounits",
         ])
         .output()
     {
         if out.status.success() {
             let line = String::from_utf8_lossy(&out.stdout);
-            let f: Vec<&str> = line.trim().lines().next().unwrap_or("").splitn(7, ", ").collect();
-            return GpuInfo {
-                name: f.first().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
-                usage: f.get(1).and_then(|s| s.trim().parse().ok()),
-                // nvidia-smi reports MiB
-                vram_total: f.get(2).and_then(|s| s.trim().parse::<u64>().ok()).map(|m| m * 1024 * 1024),
-                vram_used: f.get(3).and_then(|s| s.trim().parse::<u64>().ok()).map(|m| m * 1024 * 1024),
-                // nvidia-smi reports watts directly
-                power_watts: f.get(4).and_then(|s| s.trim().parse().ok()),
-                power_cap_watts: f.get(5).and_then(|s| s.trim().parse().ok()),
-                clock_mhz: f.get(6).and_then(|s| s.trim().parse().ok()),
+            let f: Vec<&str> = line.trim().splitn(5, ", ").collect();
+            return GpuDynamic {
+                usage: f.first().and_then(|s| s.trim().parse().ok()),
+                vram_used: f.get(1).and_then(|s| s.trim().parse::<u64>().ok()).map(|m| m * 1024 * 1024),
+                power_watts: f.get(2).and_then(|s| s.trim().parse().ok()),
+                power_cap_watts: f.get(3).and_then(|s| s.trim().parse().ok()),
+                clock_mhz: f.get(4).and_then(|s| s.trim().parse().ok()),
             };
         }
     }
-
-    GpuInfo::default()
+    GpuDynamic::default()
 }
 
 /// Read GPU power from hwmon (microwatts → watts).
@@ -225,33 +258,76 @@ fn extract_lspci_field(text: &str, key: &str) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
-/// Return a snapshot of CPU, memory, GPU, temperatures, network, and system metadata.
-/// Refreshed in-place on each call (CPU + memory + components + networks).
+/// Return a snapshot of CPU, memory, GPU, temperatures, network, and
+/// system metadata.  Static values (names, totals, OS info) are cached
+/// on first call.  Runs on a blocking thread to keep the IPC loop free.
 #[tauri::command]
-fn get_system_info(state: tauri::State<SysInfoState>) -> Result<serde_json::Value, String> {
-    let mut sys = state.sys.lock().map_err(|e| format!("lock failed: {e}"))?;
-    let mut components = state.components.lock().map_err(|e| format!("lock failed: {e}"))?;
-    let mut networks = state.networks.lock().map_err(|e| format!("lock failed: {e}"))?;
+async fn get_system_info(
+    state: tauri::State<'_, SysInfoState>,
+) -> Result<serde_json::Value, String> {
+    let inner = state.0.clone();
+    tokio::task::spawn_blocking(move || get_system_info_blocking(&inner))
+        .await
+        .map_err(|e| format!("spawn_blocking: {e}"))?
+}
+
+/// All the actual work — runs inside `spawn_blocking`.
+fn get_system_info_blocking(inner: &SysInfoInner) -> Result<serde_json::Value, String> {
+    let mut sys = inner.sys.lock().map_err(|e| format!("lock: {e}"))?;
+    let mut components = inner.components.lock().map_err(|e| format!("lock: {e}"))?;
+    let mut networks = inner.networks.lock().map_err(|e| format!("lock: {e}"))?;
 
     sys.refresh_cpu_usage();
     sys.refresh_memory();
     components.refresh(false);
     networks.refresh(false);
 
-    let cpu_usage = if sys.cpus().is_empty() {
+    // ── Static info (cached after first poll) ────────────────────
+    let mut static_guard = inner.static_info.lock().map_err(|e| format!("lock: {e}"))?;
+    let cached = static_guard.get_or_insert_with(|| {
+        let cpu_name = sys.cpus().first().map(|c| c.brand().to_string()).unwrap_or_default();
+        let cpu_cores = sys.cpus().len();
+        let os_name = format!(
+            "{} {}",
+            sysinfo::System::name().unwrap_or_default(),
+            sysinfo::System::os_version().unwrap_or_default(),
+        );
+        let hostname = sysinfo::System::host_name().unwrap_or_default();
+        let (gpu_sysfs_device, gpu_name, gpu_vram_total, has_nvidia_smi) = probe_gpu_static();
+
+        StaticSystemInfo {
+            cpu_name,
+            cpu_cores,
+            os_name,
+            hostname,
+            gpu_name,
+            gpu_vram_total,
+            gpu_sysfs_device,
+            has_nvidia_smi,
+        }
+    });
+    let st = cached.clone();
+    drop(static_guard);
+
+    // ── Dynamic CPU ──────────────────────────────────────────────
+    let cpu_usage = if st.cpu_cores == 0 {
         0.0
     } else {
         let total: f32 = sys.cpus().iter().map(|c| c.cpu_usage()).sum();
-        (total / sys.cpus().len() as f32) as f64
+        (total / st.cpu_cores as f32) as f64
+    };
+    let cpu_freq_mhz = read_cpu_freq_mhz();
+
+    // ── Dynamic GPU ──────────────────────────────────────────────
+    let gpu = if let Some(ref dev) = st.gpu_sysfs_device {
+        read_gpu_dynamic_sysfs(dev)
+    } else if st.has_nvidia_smi {
+        read_gpu_dynamic_nvidia()
+    } else {
+        GpuDynamic::default()
     };
 
-    let cpu_name = sys
-        .cpus()
-        .first()
-        .map(|c| c.brand().to_string())
-        .unwrap_or_default();
-
-    // Component temperatures — skip sensors with no reading or reporting 0.
+    // ── Temperatures ─────────────────────────────────────────────
     let comp_info: Vec<serde_json::Value> = components
         .iter()
         .filter(|c| c.temperature().is_some_and(|t| t > 0.0))
@@ -265,14 +341,15 @@ fn get_system_info(state: tauri::State<SysInfoState>) -> Result<serde_json::Valu
         })
         .collect();
 
-    // Network info — bytes received/transmitted since last refresh (delta).
-    // Skip loopback, Docker/VM bridges, and zero-traffic interfaces.
+    // ── Memory (read before dropping sys lock) ─────────────────
+    let mem_total = sys.total_memory();
+    let mem_used = sys.used_memory();
+
+    // ── Network ──────────────────────────────────────────────────
     let net_info: Vec<serde_json::Value> = networks
         .iter()
         .filter(|(name, data)| {
-            // Skip loopback
             if name.starts_with("lo") { return false; }
-            // Skip Docker/VM/container interfaces
             if name.starts_with("docker")
                 || name.starts_with("veth")
                 || name.starts_with("br-")
@@ -280,7 +357,6 @@ fn get_system_info(state: tauri::State<SysInfoState>) -> Result<serde_json::Valu
             {
                 return false;
             }
-            // Must have some traffic
             data.received() > 0 || data.transmitted() > 0
                 || data.total_received() > 0
         })
@@ -293,29 +369,22 @@ fn get_system_info(state: tauri::State<SysInfoState>) -> Result<serde_json::Valu
         })
         .collect();
 
-    let gpu = read_gpu_info();
-    let cpu_freq_mhz = read_cpu_freq_mhz();
-
     Ok(serde_json::json!({
-        "cpuName": cpu_name,
-        "cpuCores": sys.cpus().len(),
+        "cpuName": st.cpu_name,
+        "cpuCores": st.cpu_cores,
         "cpuUsage": cpu_usage,
         "cpuFreqMhz": cpu_freq_mhz,
-        "gpuName": gpu.name,
+        "gpuName": st.gpu_name,
         "gpuUsage": gpu.usage,
-        "gpuVramTotal": gpu.vram_total,
+        "gpuVramTotal": st.gpu_vram_total,
         "gpuVramUsed": gpu.vram_used,
         "gpuPowerWatts": gpu.power_watts,
         "gpuPowerCapWatts": gpu.power_cap_watts,
         "gpuClockMhz": gpu.clock_mhz,
-        "memTotal": sys.total_memory(),
-        "memUsed": sys.used_memory(),
-        "osName": format!(
-            "{} {}",
-            sysinfo::System::name().unwrap_or_default(),
-            sysinfo::System::os_version().unwrap_or_default(),
-        ),
-        "hostname": sysinfo::System::host_name().unwrap_or_default(),
+        "memTotal": mem_total,
+        "memUsed": mem_used,
+        "osName": st.os_name,
+        "hostname": st.hostname,
         "uptime": sysinfo::System::uptime(),
         "components": comp_info,
         "network": net_info,
@@ -1066,7 +1135,8 @@ fn quit_app(app: tauri::AppHandle) {
 }
 
 pub fn run() {
-    let builder = tauri::Builder::default()
+    #[allow(unused_mut)]
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_autostart::init(
@@ -1083,12 +1153,13 @@ pub fn run() {
 
     builder
         .manage(SseHandle(Mutex::new(None)))
-        .manage(AuthServerRunning(std::sync::Arc::new(Mutex::new(false))))
-        .manage(SysInfoState {
-            sys: Mutex::new(sysinfo::System::new_all()),
+        .manage(AuthServerRunning(Arc::new(Mutex::new(false))))
+        .manage(SysInfoState(Arc::new(SysInfoInner {
+            sys: Mutex::new(sysinfo::System::new()),
             components: Mutex::new(sysinfo::Components::new_with_refreshed_list()),
             networks: Mutex::new(sysinfo::Networks::new_with_refreshed_list()),
-        })
+            static_info: Mutex::new(None),
+        })))
         .invoke_handler(tauri::generate_handler![
             resize_window,
             position_ticker,

--- a/desktop/src/components/AppTaskbar.tsx
+++ b/desktop/src/components/AppTaskbar.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import clsx from "clsx";
+import { useSysmonData } from "../hooks/useSysmonData";
 import {
   Sun,
   Moon,
@@ -207,62 +208,30 @@ function MiniWeatherChip({ onClick, taskbarCity }: { onClick: () => void; taskba
 
 // ── Mini System Monitor Chip ────────────────────────────────────
 
-interface SysInfo {
-  cpuUsage: number;
-  memTotal: number;
-  memUsed: number;
-  gpuUsage: number | null;
-}
-
 type SysMetric = "cpu" | "memory" | "gpu";
 
 function MiniSysmonChip({ onClick, metric = "cpu" }: { onClick: () => void; metric?: SysMetric }) {
-  const [display, setDisplay] = useState<string | null>(null);
-  const [hot, setHot] = useState(false);
-  const mountedRef = useRef(true);
+  const info = useSysmonData(3000);
 
-  useEffect(() => {
-    mountedRef.current = true;
-
-    async function poll() {
-      try {
-        const info = await invoke<SysInfo>("get_system_info");
-        if (!mountedRef.current) return;
-
-        let pct: number | null = null;
-        switch (metric) {
-          case "cpu":
-            pct = Math.round(info.cpuUsage);
-            break;
-          case "memory":
-            pct = info.memTotal > 0 ? Math.round((info.memUsed / info.memTotal) * 100) : null;
-            break;
-          case "gpu":
-            pct = info.gpuUsage != null ? Math.round(info.gpuUsage) : null;
-            break;
-        }
-
-        if (pct != null) {
-          setDisplay(`${pct}%`);
-          setHot(pct > 80);
-        } else {
-          setDisplay(null);
-        }
-      } catch {
-        if (mountedRef.current) setDisplay(null);
-      }
+  let pct: number | null = null;
+  if (info) {
+    switch (metric) {
+      case "cpu":
+        pct = Math.round(info.cpuUsage);
+        break;
+      case "memory":
+        pct = info.memTotal > 0 ? Math.round((info.memUsed / info.memTotal) * 100) : null;
+        break;
+      case "gpu":
+        pct = info.gpuUsage != null ? Math.round(info.gpuUsage) : null;
+        break;
     }
+  }
 
-    poll();
-    const id = setInterval(poll, 3000);
-    return () => {
-      mountedRef.current = false;
-      clearInterval(id);
-    };
-  }, [metric]);
+  if (pct == null) return null;
 
-  if (display === null) return null;
-
+  const display = `${pct}%`;
+  const hot = pct > 80;
   const labels: Record<SysMetric, string> = { cpu: "System Monitor", memory: "Memory", gpu: "GPU" };
 
   return (

--- a/desktop/src/hooks/useSysmonData.ts
+++ b/desktop/src/hooks/useSysmonData.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared sysmon data hook — deduplicates IPC calls across consumers.
+ *
+ * Multiple components (ticker, FeedTab, taskbar chip) all need the same
+ * system info.  Instead of each one running its own `invoke()` call,
+ * they share a single module-level fetch that caches the latest result
+ * for a short window (default 500 ms).  If two consumers poll within
+ * the same window, only one IPC round-trip happens.
+ */
+
+import { useState, useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+// ── Shared SystemInfo type ──────────────────────────────────────
+
+export interface SystemInfo {
+  cpuName: string;
+  cpuCores: number;
+  cpuUsage: number;
+  cpuFreqMhz: number | null;
+  gpuName: string | null;
+  gpuUsage: number | null;
+  gpuVramTotal: number | null;
+  gpuVramUsed: number | null;
+  gpuPowerWatts: number | null;
+  gpuPowerCapWatts: number | null;
+  gpuClockMhz: number | null;
+  memTotal: number;
+  memUsed: number;
+  osName: string;
+  hostname: string;
+  uptime: number;
+  components: { label: string; temp: number; max: number; critical: number | null }[];
+  network: { name: string; rxBytes: number; txBytes: number }[];
+}
+
+// ── Module-level cache ──────────────────────────────────────────
+
+/** How long a cached result is considered fresh (ms). */
+const CACHE_TTL = 500;
+
+let cachedData: SystemInfo | null = null;
+let cachedAt = 0;
+let inflight: Promise<SystemInfo> | null = null;
+
+/**
+ * Fetch system info, returning a cached value if one exists within
+ * the TTL window.  Concurrent callers share the same in-flight
+ * promise so only one IPC call happens at a time.
+ */
+export async function fetchSysmonData(): Promise<SystemInfo> {
+  const now = Date.now();
+  if (cachedData && now - cachedAt < CACHE_TTL) return cachedData;
+
+  if (!inflight) {
+    inflight = invoke<SystemInfo>("get_system_info")
+      .then((data) => {
+        cachedData = data;
+        cachedAt = Date.now();
+        return data;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+  }
+
+  return inflight;
+}
+
+// ── React hook ──────────────────────────────────────────────────
+
+/**
+ * Poll system info at `intervalMs` and return the latest snapshot.
+ * Multiple instances share the same underlying IPC call via the cache.
+ */
+export function useSysmonData(intervalMs: number): SystemInfo | null {
+  const [data, setData] = useState<SystemInfo | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    async function poll() {
+      try {
+        const info = await fetchSysmonData();
+        if (mountedRef.current) setData(info);
+      } catch {
+        /* ignore IPC failures */
+      }
+    }
+
+    poll();
+    const id = setInterval(poll, intervalMs);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(id);
+    };
+  }, [intervalMs]);
+
+  return data;
+}

--- a/desktop/src/hooks/useWidgetTickerData.ts
+++ b/desktop/src/hooks/useWidgetTickerData.ts
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import type { WidgetPrefs } from "../preferences";
 import type { ClockChipData } from "../components/chips/ClockTickerChip";
 import type { WeatherChipData } from "../components/chips/WeatherTickerChip";
 import type { SysmonChipData } from "../components/chips/SysmonTickerChip";
+import { fetchSysmonData } from "./useSysmonData";
+import type { SystemInfo } from "./useSysmonData";
 
 // ── localStorage keys (shared with widget FeedTabs) ─────────────
 const LS_TIMEZONES = "scrollr:widget:clock:timezones";
@@ -33,27 +34,6 @@ interface SavedCity {
     wind_direction?: number;
   };
   lastFetched?: number;
-}
-
-interface SystemInfo {
-  cpuName: string;
-  cpuCores: number;
-  cpuUsage: number;
-  cpuFreqMhz: number | null;
-  gpuName: string | null;
-  gpuUsage: number | null;
-  gpuVramTotal: number | null;
-  gpuVramUsed: number | null;
-  gpuPowerWatts: number | null;
-  gpuPowerCapWatts: number | null;
-  gpuClockMhz: number | null;
-  memTotal: number;
-  memUsed: number;
-  osName: string;
-  hostname: string;
-  uptime: number;
-  components: { label: string; temp: number; max: number; critical: number | null }[];
-  network: { name: string; rxBytes: number; txBytes: number }[];
 }
 
 // ── Result type ─────────────────────────────────────────────────
@@ -403,14 +383,14 @@ export function useWidgetTickerData(
     const sysmonMs = (widgetPrefs.sysmon.refreshInterval || 2) * 1000;
     const sysmonInterval = hasSysmon ? setInterval(async () => {
       try {
-        sysInfoRef.current = await invoke<SystemInfo>("get_system_info");
+        sysInfoRef.current = await fetchSysmonData();
         setData((prev) => ({ ...prev, sysmon: buildSysmonChips() }));
       } catch { /* ignore IPC failures */ }
     }, sysmonMs) : null;
 
     // Initial fetch for sysmon
     if (hasSysmon) {
-      invoke<SystemInfo>("get_system_info")
+      fetchSysmonData()
         .then((info) => { sysInfoRef.current = info; })
         .catch(() => {})
         .finally(refresh);

--- a/desktop/src/widgets/sysmon/FeedTab.tsx
+++ b/desktop/src/widgets/sysmon/FeedTab.tsx
@@ -1,43 +1,11 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import type { FeedTabProps } from "~/channels/types";
 import type { WidgetManifest } from "~/widgets/types";
+import { useSysmonData } from "../../hooks/useSysmonData";
+import type { SystemInfo } from "../../hooks/useSysmonData";
 
 // ── Types ───────────────────────────────────────────────────────
 
-interface ComponentTemp {
-  label: string;
-  temp: number;
-  max: number;
-  critical: number | null;
-}
-
-interface NetworkInfo {
-  name: string;
-  rxBytes: number;
-  txBytes: number;
-}
-
-interface SystemInfo {
-  cpuName: string;
-  cpuCores: number;
-  cpuUsage: number;
-  cpuFreqMhz: number | null;
-  gpuName: string | null;
-  gpuUsage: number | null;
-  gpuVramTotal: number | null;
-  gpuVramUsed: number | null;
-  gpuPowerWatts: number | null;
-  gpuPowerCapWatts: number | null;
-  gpuClockMhz: number | null;
-  memTotal: number;
-  memUsed: number;
-  osName: string;
-  hostname: string;
-  uptime: number;
-  components: ComponentTemp[];
-  network: NetworkInfo[];
-}
+type ComponentTemp = SystemInfo["components"][number];
 
 interface TempReading {
   temp: number;
@@ -150,45 +118,7 @@ function DetailLine({ items }: { items: (string | null | undefined)[] }) {
 
 function SysmonFeedTab({ mode: feedMode }: FeedTabProps) {
   const compact = feedMode === "compact";
-  const [info, setInfo] = useState<SystemInfo | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const poll = useCallback(async () => {
-    try {
-      const data = await invoke<SystemInfo>("get_system_info");
-      setInfo(data);
-      setError(null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      await poll();
-      if (!cancelled) {
-        intervalRef.current = setInterval(poll, POLL_INTERVAL);
-      }
-    })();
-    return () => {
-      cancelled = true;
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [poll]);
-
-  // ── Error state ─────────────────────────────────────────────
-  if (error && !info) {
-    return (
-      <div className="p-4 flex flex-col items-center justify-center gap-2">
-        <span className="text-xs font-mono text-error">{error}</span>
-        <span className="text-xs font-mono text-fg-3">
-          System monitor requires the desktop app
-        </span>
-      </div>
-    );
-  }
+  const info = useSysmonData(POLL_INTERVAL);
 
   // ── Loading state ───────────────────────────────────────────
   if (!info) {


### PR DESCRIPTION
## Summary

- **Rust backend**: Cache static system info (CPU name, OS, GPU name, VRAM total) at startup instead of re-reading every poll. Split GPU reads into one-time `probe_gpu_static()` and per-poll `read_gpu_dynamic_sysfs()`/`read_gpu_dynamic_nvidia()` to avoid spawning subprocesses every 2 seconds. Made `get_system_info` async with `spawn_blocking` so it doesn't block the Tauri IPC thread. Use `System::new()` with selective refresh instead of expensive `System::new_all()`.
- **Frontend**: Created shared `useSysmonData` hook with 500ms TTL cache and in-flight request deduplication. FeedTab, AppTaskbar, and ticker now share a single cached data source instead of each making independent IPC calls.
- **Net effect**: Eliminated per-poll subprocess spawns, reduced redundant system reads, and consolidated 3 independent pollers into 1 shared cache — resolving the UI jank that occurred every poll cycle.