### PR TITLE
feat(desktop): sidebar icons, header navigation, and ticker controls

### DIFF
--- a/channels/fantasy/web/DashboardTab.tsx
+++ b/channels/fantasy/web/DashboardTab.tsx
@@ -1744,5 +1744,15 @@ export const fantasyChannel: ChannelManifest = {
   description: 'Yahoo Fantasy Sports',
   hex: HEX,
   icon: Ghost,
+  info: {
+    about:
+      'The Fantasy channel connects to your Yahoo Fantasy Sports account and surfaces league activity on your ticker. See matchup scores, player updates, and standings across all your active leagues.',
+    usage: [
+      'Connect your Yahoo account in the Configuration tab to authorize access.',
+      'Your active leagues and matchups automatically appear on the ticker.',
+      'Ticker chips show matchup scores, opponent names, and win/loss records.',
+      'Disconnect or reconnect your Yahoo account at any time from the Configuration tab.',
+    ],
+  },
   DashboardTab: FantasyDashboardTab,
 }

--- a/channels/finance/web/DashboardTab.tsx
+++ b/channels/finance/web/DashboardTab.tsx
@@ -540,5 +540,15 @@ export const financeChannel: ChannelManifest = {
   description: "Real-time market data via TwelveData",
   hex: HEX,
   icon: TrendingUp,
+  info: {
+    about:
+      "The Finance channel streams real-time stock quotes, price changes, and market data directly to your ticker. Powered by TwelveData, it covers stocks, ETFs, forex pairs, and crypto across major global exchanges.",
+    usage: [
+      "Add ticker symbols (e.g. AAPL, TSLA, BTC/USD) in the Configuration tab to start tracking them.",
+      "Prices update in real time and appear as scrolling chips on the ticker.",
+      "Each chip shows the symbol, current price, and percentage change with color-coded gains/losses.",
+      "Remove symbols you no longer want to track from the Configuration tab.",
+    ],
+  },
   DashboardTab: FinanceDashboardTab,
 };

--- a/channels/rss/web/DashboardTab.tsx
+++ b/channels/rss/web/DashboardTab.tsx
@@ -513,5 +513,15 @@ export const rssChannel: ChannelManifest = {
   description: "Custom news streams",
   hex: HEX,
   icon: Rss,
+  info: {
+    about:
+      "The RSS channel lets you subscribe to any RSS or Atom feed and stream headlines directly to your ticker. Follow news sites, blogs, release notes, or any content source that publishes a feed.",
+    usage: [
+      "Add feed URLs in the Configuration tab to start subscribing.",
+      "Headlines appear as ticker chips with the article title and source name.",
+      "Click a chip to open the full article in your browser.",
+      "Remove feeds you no longer want from the Configuration tab.",
+    ],
+  },
   DashboardTab: RssDashboardTab,
 };

--- a/channels/sports/web/DashboardTab.tsx
+++ b/channels/sports/web/DashboardTab.tsx
@@ -575,5 +575,15 @@ export const sportsChannel: ChannelManifest = {
   description: 'Live scores via api-sports.io',
   hex: HEX,
   icon: Trophy,
+  info: {
+    about:
+      'The Sports channel delivers live scores and game updates straight to your ticker. Powered by api-sports.io, it covers major leagues including NFL, NBA, MLB, NHL, MLS, and international soccer.',
+    usage: [
+      'Select the leagues you want to follow in the Configuration tab.',
+      'Live games appear as ticker chips showing teams, scores, and game status (live, final, scheduled).',
+      'Scores update automatically as games progress — no manual refresh needed.',
+      'Toggle leagues on or off at any time to customize your feed.',
+    ],
+  },
   DashboardTab: SportsDashboardTab,
 }

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -517,13 +517,13 @@ export default function App() {
   const handleWidgetToggle = useCallback(
     (widgetId: string) => {
       setPrefs((prev) => {
-        const enabled = prev.widgets.enabledWidgets;
-        const next = enabled.includes(widgetId)
-          ? enabled.filter((id) => id !== widgetId)
-          : [...enabled, widgetId];
+        const onTicker = prev.widgets.widgetsOnTicker;
+        const next = onTicker.includes(widgetId)
+          ? onTicker.filter((id) => id !== widgetId)
+          : [...onTicker, widgetId];
         const updated = {
           ...prev,
-          widgets: { ...prev.widgets, enabledWidgets: next },
+          widgets: { ...prev.widgets, widgetsOnTicker: next },
         };
         savePrefs(updated);
         return updated;
@@ -615,7 +615,7 @@ export default function App() {
       const allWidgets = getAllWidgets();
       if (allWidgets.length > 0) {
         for (const widget of allWidgets) {
-          const isEnabled = prefsRef.current.widgets.enabledWidgets.includes(widget.id);
+          const isEnabled = prefsRef.current.widgets.widgetsOnTicker.includes(widget.id);
           const item = await CheckMenuItem.new({
             text: widget.name,
             checked: isEnabled,
@@ -698,7 +698,7 @@ export default function App() {
   }, [handleChannelToggle, handleWidgetToggle]);
 
   // ── Merge channel + widget tabs ──────────────────────────────
-  const activeTabs = [...channelTabs, ...prefs.widgets.enabledWidgets];
+  const activeTabs = [...channelTabs, ...prefs.widgets.widgetsOnTicker];
 
   // ── Widget ticker data (local polling for clock/weather/sysmon) ──
   const widgetData = useWidgetTickerData(prefs.widgets);

--- a/desktop/src/MainApp.tsx
+++ b/desktop/src/MainApp.tsx
@@ -888,29 +888,37 @@ export default function MainApp() {
         {/* Header */}
         <header className="flex items-center justify-between px-6 h-14 border-b border-edge shrink-0">
           <div className="flex items-center gap-3 min-w-0">
-            {/* Back arrow when configuring a channel or widget */}
-            {configuring && (isChannelActive || isWidgetActive) && (
-              <button
-                onClick={handleBackToFeed}
-                className="flex items-center gap-1.5 text-xs font-medium text-fg-3 hover:text-fg-2 transition-colors shrink-0"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M19 12H5M12 19l-7-7 7-7" />
-                </svg>
-                Feed
-              </button>
-            )}
             <h1 className="text-base font-semibold truncate">
               {activeItemName}
-              {configuring && (isChannelActive || isWidgetActive) && (
-                <span className="text-fg-3 font-normal ml-2 text-sm">
-                  Configuration
-                </span>
-              )}
             </h1>
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            {/* Settings tab switcher — only when viewing settings */}
+            {/* Feed / Configuration tabs — channels and widgets */}
+            {(isChannelActive || isWidgetActive) && (
+              <div className="flex gap-1">
+                {(["feed", "configuration"] as const).map((tab) => {
+                  const isActive =
+                    tab === "feed" ? !configuring : configuring;
+                  return (
+                    <button
+                      key={tab}
+                      onClick={() =>
+                        setConfiguring(tab === "configuration")
+                      }
+                      className={clsx(
+                        "px-3 py-1.5 rounded-lg text-xs font-medium transition-colors capitalize",
+                        isActive
+                          ? "bg-accent/10 text-accent"
+                          : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
+                      )}
+                    >
+                      {tab}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            {/* Settings tab switcher */}
             {isSettingsActive && (
               <div className="flex gap-1">
                 {(["general", "ticker", "account"] as SettingsTab[]).map(
@@ -931,7 +939,7 @@ export default function MainApp() {
                 )}
               </div>
             )}
-            {!authenticated && !isSettingsActive && (
+            {!authenticated && !isSettingsActive && !(isChannelActive || isWidgetActive) && (
               <button
                 onClick={handleLogin}
                 className="px-3 py-1.5 rounded-lg text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors"

--- a/desktop/src/MainApp.tsx
+++ b/desktop/src/MainApp.tsx
@@ -8,6 +8,8 @@ import {
 } from "@tauri-apps/plugin-autostart";
 
 import clsx from "clsx";
+import { Trash2 } from "lucide-react";
+import { motion } from "motion/react";
 import TitleBar from "./components/TitleBar";
 import Sidebar from "./components/Sidebar";
 import type { SettingsTab } from "./components/Sidebar";
@@ -96,6 +98,8 @@ export default function MainApp() {
   });
   const [sourceTab, setSourceTab] = useState<SourceTab>("feed");
   const configuring = sourceTab === "configuration";
+  const [deleteArmed, setDeleteArmed] = useState(false);
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [settingsTab, setSettingsTab] = useState<SettingsTab>(() => {
     const saved = loadPref<string>("settingsTab", "general");
@@ -356,6 +360,8 @@ export default function MainApp() {
 
   const handleSelectItem = useCallback((id: string) => {
     setActiveItem(id);
+    setDeleteArmed(false);
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
     savePref("activeItem", id);
   }, []);
 
@@ -435,13 +441,13 @@ export default function MainApp() {
       try {
         await channelsApi.update(
           channelType,
-          { enabled: visible, visible },
+          { enabled: true, visible },
           () => Promise.resolve(token),
         );
         setChannels((prev) =>
           prev.map((ch) =>
             ch.channel_type === channelType
-              ? { ...ch, enabled: visible, visible }
+              ? { ...ch, enabled: true, visible }
               : ch,
           ),
         );
@@ -516,18 +522,40 @@ export default function MainApp() {
     [fetchDashboard],
   );
 
-  // ── Widget toggle handler ───────────────────────────────────
+  // ── Widget handlers ─────────────────────────────────────────
 
+  /** Toggle widget on/off the ticker (keep it in sidebar). */
+  const handleToggleWidgetTicker = useCallback(
+    (widgetId: string) => {
+      const onTicker = prefs.widgets.widgetsOnTicker;
+      const nextOnTicker = onTicker.includes(widgetId)
+        ? onTicker.filter((id) => id !== widgetId)
+        : [...onTicker, widgetId];
+
+      const next: AppPreferences = {
+        ...prefs,
+        widgets: { ...prefs.widgets, widgetsOnTicker: nextOnTicker },
+      };
+      setPrefs(next);
+      savePrefs(next);
+    },
+    [prefs],
+  );
+
+  /** Remove widget from sidebar entirely (also removes from ticker). */
   const handleToggleWidget = useCallback(
     (widgetId: string) => {
       const isEnabled = enabledWidgets.includes(widgetId);
       const nextEnabled = isEnabled
         ? enabledWidgets.filter((id) => id !== widgetId)
         : [...enabledWidgets, widgetId];
+      const nextOnTicker = isEnabled
+        ? prefs.widgets.widgetsOnTicker.filter((id) => id !== widgetId)
+        : [...prefs.widgets.widgetsOnTicker, widgetId];
 
       const next: AppPreferences = {
         ...prefs,
-        widgets: { ...prefs.widgets, enabledWidgets: nextEnabled },
+        widgets: { ...prefs.widgets, enabledWidgets: nextEnabled, widgetsOnTicker: nextOnTicker },
       };
       setPrefs(next);
       savePrefs(next);
@@ -579,9 +607,9 @@ export default function MainApp() {
       ...channels
         .filter((ch) => ch.enabled && ch.visible)
         .map((ch) => ch.channel_type),
-      ...prefs.widgets.enabledWidgets,
+      ...prefs.widgets.widgetsOnTicker,
     ],
-    [channels, prefs.widgets.enabledWidgets],
+    [channels, prefs.widgets.widgetsOnTicker],
   );
 
   // ── Widget ticker data (local polling for clock/weather/sysmon) ──
@@ -956,9 +984,61 @@ export default function MainApp() {
             <h1 className="text-base font-semibold truncate">
               {activeItemName}
             </h1>
+
+            {/* Channel ticker toggle — compact switch only */}
+            {isChannelActive && (() => {
+              const ch = channels.find((c) => c.channel_type === activeItem);
+              const manifest = allChannelManifests.find((m) => m.id === activeItem);
+              const active = ch?.visible ?? false;
+              const hex = manifest?.hex ?? "var(--color-fg-3)";
+              return (
+                <button
+                  onClick={() => handleToggleChannel(activeItem as ChannelType, !active)}
+                  className="shrink-0"
+                  title={active ? "On Ticker" : "Off Ticker"}
+                >
+                  <span
+                    className="block h-4 w-7 rounded-full relative transition-colors"
+                    style={{ background: active ? hex : undefined }}
+                  >
+                    {!active && <span className="absolute inset-0 rounded-full bg-fg-4/25" />}
+                    <motion.span
+                      className="absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white"
+                      animate={{ x: active ? 12 : 0 }}
+                      transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                    />
+                  </span>
+                </button>
+              );
+            })()}
+
+            {/* Widget ticker toggle — compact switch only */}
+            {isWidgetActive && (() => {
+              const active = prefs.widgets.widgetsOnTicker.includes(activeItem);
+              const hex = activeWidget?.hex ?? "var(--color-fg-3)";
+              return (
+                <button
+                  onClick={() => handleToggleWidgetTicker(activeItem)}
+                  className="shrink-0"
+                  title={active ? "On Ticker" : "Off Ticker"}
+                >
+                  <span
+                    className="block h-4 w-7 rounded-full relative transition-colors"
+                    style={{ background: active ? hex : undefined }}
+                  >
+                    {!active && <span className="absolute inset-0 rounded-full bg-fg-4/25" />}
+                    <motion.span
+                      className="absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white"
+                      animate={{ x: active ? 12 : 0 }}
+                      transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                    />
+                  </span>
+                </button>
+              );
+            })()}
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            {/* Feed / Configuration tabs — channels and widgets */}
+            {/* Feed / Info / Configuration tabs — channels and widgets */}
             {(isChannelActive || isWidgetActive) && (
               <div className="flex gap-1">
                 {(["feed", "info", "configuration"] as const).map((tab) => (
@@ -1004,6 +1084,45 @@ export default function MainApp() {
                 className="px-3 py-1.5 rounded-lg text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
               >
                 Sign in
+              </button>
+            )}
+
+            {/* Delete — double-tap: first click arms (red), second click confirms */}
+            {(isChannelActive || isWidgetActive) && (
+              <button
+                onClick={() => {
+                  if (deleteArmed) {
+                    // Second click — execute
+                    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+                    if (isChannelActive) {
+                      handleDeleteChannel(activeItem as ChannelType);
+                    } else {
+                      handleToggleWidget(activeItem);
+                    }
+                    setDeleteArmed(false);
+                  } else {
+                    // First click — arm with 3s timeout
+                    setDeleteArmed(true);
+                    deleteTimerRef.current = setTimeout(() => {
+                      setDeleteArmed(false);
+                    }, 3000);
+                  }
+                }}
+                className={clsx(
+                  "p-2 rounded-lg transition-colors",
+                  deleteArmed
+                    ? "text-red-500 bg-red-500/10"
+                    : "text-fg-4/40 hover:text-red-500",
+                )}
+                title={
+                  deleteArmed
+                    ? "Click again to remove"
+                    : isChannelActive
+                      ? "Remove channel"
+                      : "Remove widget"
+                }
+              >
+                <Trash2 size={14} />
               </button>
             )}
           </div>

--- a/desktop/src/MainApp.tsx
+++ b/desktop/src/MainApp.tsx
@@ -82,7 +82,9 @@ function getActiveItemName(
 export default function MainApp() {
   // ── Navigation ──────────────────────────────────────────────
   // activeItem: channel ID, widget ID, or "settings"
-  // configuring: when true and activeItem is a channel, show DashboardTab
+  // sourceTab: which tab is active for channels/widgets
+  type SourceTab = "feed" | "info" | "configuration";
+
   const [activeItem, setActiveItem] = useState<string>(() => {
     const saved = loadPref<string>("activeItem", "");
     // Migration: old values "feed" / "channels" / "dashboard" / "account"
@@ -92,7 +94,8 @@ export default function MainApp() {
     }
     return saved;
   });
-  const [configuring, setConfiguring] = useState(false);
+  const [sourceTab, setSourceTab] = useState<SourceTab>("feed");
+  const configuring = sourceTab === "configuration";
 
   const [settingsTab, setSettingsTab] = useState<SettingsTab>(() => {
     const saved = loadPref<string>("settingsTab", "general");
@@ -353,24 +356,19 @@ export default function MainApp() {
 
   const handleSelectItem = useCallback((id: string) => {
     setActiveItem(id);
-    setConfiguring(false);
     savePref("activeItem", id);
   }, []);
 
   const handleConfigureChannel = useCallback((channelType: string) => {
     setActiveItem(channelType);
-    setConfiguring(true);
+    setSourceTab("configuration");
     savePref("activeItem", channelType);
   }, []);
 
   const handleConfigureWidget = useCallback((widgetId: string) => {
     setActiveItem(widgetId);
-    setConfiguring(true);
+    setSourceTab("configuration");
     savePref("activeItem", widgetId);
-  }, []);
-
-  const handleBackToFeed = useCallback(() => {
-    setConfiguring(false);
   }, []);
 
   const handleSettingsTab = useCallback((tab: SettingsTab) => {
@@ -393,8 +391,8 @@ export default function MainApp() {
           setSessionExpired(false);
           return;
         }
-        if (configuring) {
-          setConfiguring(false);
+        if (sourceTab !== "feed") {
+          setSourceTab("feed");
           return;
         }
       }
@@ -467,7 +465,7 @@ export default function MainApp() {
         setChannels((prev) => [...prev, created]);
         // Navigate to the new channel
         setActiveItem(channelType);
-        setConfiguring(false);
+        setSourceTab("feed");
         savePref("activeItem", channelType);
       } catch (err) {
         console.error("[Scrollr] Channel add failed:", err);
@@ -494,7 +492,7 @@ export default function MainApp() {
               enabledWidgets[0] ??
               "settings";
             setActiveItem(fallback);
-            setConfiguring(false);
+            setSourceTab("feed");
             savePref("activeItem", fallback);
           }
           return remaining;
@@ -537,7 +535,7 @@ export default function MainApp() {
       // If enabling, navigate to the widget
       if (!isEnabled) {
         setActiveItem(widgetId);
-        setConfiguring(false);
+        setSourceTab("feed");
         savePref("activeItem", widgetId);
       }
       // If disabling the active widget, navigate away
@@ -546,7 +544,7 @@ export default function MainApp() {
         const firstWidget = nextEnabled[0];
         const fallback = firstCh ?? firstWidget ?? "settings";
         setActiveItem(fallback);
-        setConfiguring(false);
+        setSourceTab("feed");
         savePref("activeItem", fallback);
       }
     },
@@ -699,6 +697,73 @@ export default function MainApp() {
     // Fetch error (only for channel content)
     if (fetchError && isChannelActive) {
       return <ErrorState message={fetchError} onRetry={fetchDashboard} />;
+    }
+
+    // Info tab — channels and widgets
+    if (sourceTab === "info" && (isChannelActive || isWidgetActive)) {
+      const manifest = isChannelActive
+        ? allChannelManifests.find((m) => m.id === activeItem)
+        : activeWidget;
+      const info = manifest?.info;
+      const Icon = manifest && "icon" in manifest ? manifest.icon : null;
+      const hex = manifest?.hex ?? "var(--color-fg-3)";
+
+      return (
+        <div className="p-6 max-w-xl">
+          {/* Header */}
+          <div className="flex items-center gap-3 mb-6">
+            {Icon && (
+              <span
+                className="flex items-center justify-center w-10 h-10 rounded-xl"
+                style={{ backgroundColor: `${hex}15`, color: hex }}
+              >
+                <Icon size={20} />
+              </span>
+            )}
+            <div>
+              <h2 className="text-lg font-semibold">{manifest?.name}</h2>
+              <p className="text-sm text-fg-3">
+                {"description" in (manifest ?? {})
+                  ? (manifest as { description: string }).description
+                  : ""}
+              </p>
+            </div>
+          </div>
+
+          {/* About */}
+          {info && (
+            <div className="space-y-4">
+              <section>
+                <h3 className="text-xs font-mono font-bold text-fg-3 uppercase tracking-wider mb-2">
+                  About
+                </h3>
+                <p className="text-sm text-fg-2 leading-relaxed">
+                  {info.about}
+                </p>
+              </section>
+
+              <section>
+                <h3 className="text-xs font-mono font-bold text-fg-3 uppercase tracking-wider mb-2">
+                  How to use
+                </h3>
+                <ul className="space-y-2">
+                  {info.usage.map((step, i) => (
+                    <li key={i} className="flex gap-2.5 text-sm text-fg-2">
+                      <span
+                        className="flex items-center justify-center w-5 h-5 rounded-md text-[10px] font-bold shrink-0 mt-0.5"
+                        style={{ backgroundColor: `${hex}15`, color: hex }}
+                      >
+                        {i + 1}
+                      </span>
+                      <span className="leading-relaxed">{step}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            </div>
+          )}
+        </div>
+      );
     }
 
     // Channel — configure mode (DashboardTab)
@@ -896,26 +961,20 @@ export default function MainApp() {
             {/* Feed / Configuration tabs — channels and widgets */}
             {(isChannelActive || isWidgetActive) && (
               <div className="flex gap-1">
-                {(["feed", "configuration"] as const).map((tab) => {
-                  const isActive =
-                    tab === "feed" ? !configuring : configuring;
-                  return (
-                    <button
-                      key={tab}
-                      onClick={() =>
-                        setConfiguring(tab === "configuration")
-                      }
-                      className={clsx(
-                        "px-3 py-1.5 rounded-lg text-xs font-medium transition-colors capitalize",
-                        isActive
-                          ? "bg-accent/10 text-accent"
-                          : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
-                      )}
-                    >
-                      {tab}
-                    </button>
-                  );
-                })}
+                {(["feed", "info", "configuration"] as const).map((tab) => (
+                  <button
+                    key={tab}
+                    onClick={() => setSourceTab(tab)}
+                    className={clsx(
+                      "px-3 py-1.5 rounded-lg text-xs font-medium transition-colors capitalize",
+                      sourceTab === tab
+                        ? "bg-accent/10 text-accent"
+                        : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
+                    )}
+                  >
+                    {tab}
+                  </button>
+                ))}
               </div>
             )}
             {/* Settings tab switcher */}

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -260,6 +260,7 @@ export default function Sidebar({
               (m) => m.id === ch.channel_type,
             );
             const isActive = activeItem === ch.channel_type;
+            const Icon = manifest?.icon;
             return (
               <button
                 key={ch.channel_type}
@@ -270,10 +271,16 @@ export default function Sidebar({
                   isActive ? "bg-accent/10" : "hover:bg-surface-hover",
                 )}
               >
-                <div
-                  className="w-2.5 h-2.5 rounded-full"
-                  style={{ background: manifest?.hex ?? "var(--color-fg-4)" }}
-                />
+                {Icon ? (
+                  <span style={{ color: manifest!.hex }}>
+                    <Icon size={14} />
+                  </span>
+                ) : (
+                  <div
+                    className="w-2.5 h-2.5 rounded-full"
+                    style={{ background: "var(--color-fg-4)" }}
+                  />
+                )}
               </button>
             );
           })}
@@ -296,10 +303,9 @@ export default function Sidebar({
                   isActive ? "bg-accent/10" : "hover:bg-surface-hover",
                 )}
               >
-                <div
-                  className="w-2.5 h-2.5 rounded-full"
-                  style={{ background: widget.hex }}
-                />
+                <span style={{ color: widget.hex }}>
+                  <widget.icon size={14} />
+                </span>
               </button>
             );
           })}
@@ -432,15 +438,27 @@ export default function Sidebar({
                           : "text-fg-2 hover:text-fg hover:bg-surface-hover",
                       )}
                     >
-                      <div
-                        className={clsx(
-                          "w-2 h-2 rounded-full shrink-0 transition-opacity",
-                          isActive ? "opacity-100" : "opacity-60",
-                        )}
-                        style={{
-                          background: manifest?.hex ?? "var(--color-fg-4)",
-                        }}
-                      />
+                      {manifest?.icon ? (
+                        <span
+                          className={clsx(
+                            "shrink-0 transition-opacity",
+                            isActive ? "opacity-100" : "opacity-60",
+                          )}
+                          style={{ color: manifest.hex }}
+                        >
+                          <manifest.icon size={14} />
+                        </span>
+                      ) : (
+                        <div
+                          className={clsx(
+                            "w-2 h-2 rounded-full shrink-0 transition-opacity",
+                            isActive ? "opacity-100" : "opacity-60",
+                          )}
+                          style={{
+                            background: "var(--color-fg-4)",
+                          }}
+                        />
+                      )}
                       <span className="truncate">
                         {manifest?.name ?? ch.channel_type}
                       </span>
@@ -527,13 +545,15 @@ export default function Sidebar({
                           : "text-fg-2 hover:text-fg hover:bg-surface-hover",
                       )}
                     >
-                      <div
+                      <span
                         className={clsx(
-                          "w-2 h-2 rounded-full shrink-0 transition-opacity",
+                          "shrink-0 transition-opacity",
                           isActive ? "opacity-100" : "opacity-60",
                         )}
-                        style={{ background: widget.hex }}
-                      />
+                        style={{ color: widget.hex }}
+                      >
+                        <widget.icon size={14} />
+                      </span>
                       <span className="truncate">{widget.name}</span>
                       {isConfiguring && (
                         <span className="text-[8px] text-accent/50 ml-auto shrink-0">
@@ -620,10 +640,9 @@ export default function Sidebar({
               }}
               className="flex items-center gap-3 w-full px-3 py-2.5 text-left hover:bg-surface-hover transition-colors"
             >
-              <div
-                className="w-2.5 h-2.5 rounded-full shrink-0"
-                style={{ background: manifest.hex }}
-              />
+              <span className="shrink-0" style={{ color: manifest.hex }}>
+                <manifest.icon size={14} />
+              </span>
               <div className="min-w-0">
                 <p className="text-[12px] font-medium text-fg-2 truncate">
                   {manifest.name}
@@ -658,10 +677,9 @@ export default function Sidebar({
               }}
               className="flex items-center gap-3 w-full px-3 py-2.5 text-left hover:bg-surface-hover transition-colors"
             >
-              <div
-                className="w-2.5 h-2.5 rounded-full shrink-0"
-                style={{ background: widget.hex }}
-              />
+              <span className="shrink-0" style={{ color: widget.hex }}>
+                <widget.icon size={14} />
+              </span>
               <div className="min-w-0 flex-1">
                 <p className="text-[12px] font-medium text-fg-2 truncate">
                   {widget.name}

--- a/desktop/src/hooks/useWidgetTickerData.ts
+++ b/desktop/src/hooks/useWidgetTickerData.ts
@@ -193,7 +193,7 @@ export function useWidgetTickerData(
 ): WidgetTickerData {
   const [data, setData] = useState<WidgetTickerData>(EMPTY);
   const sysInfoRef = useRef<SystemInfo | null>(null);
-  const enabledSet = new Set(widgetPrefs.enabledWidgets);
+  const enabledSet = new Set(widgetPrefs.widgetsOnTicker);
 
   // ── Build clock + timer chips ─────────────────────────────────
   const buildClockChips = useCallback((): ClockChipData[] => {
@@ -246,7 +246,7 @@ export function useWidgetTickerData(
 
     return chips;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [widgetPrefs.clock, widgetPrefs.enabledWidgets]);
+  }, [widgetPrefs.clock, widgetPrefs.widgetsOnTicker]);
 
   // ── Build weather chips ───────────────────────────────────────
   const buildWeatherChips = useCallback((): WeatherChipData[] => {
@@ -281,7 +281,7 @@ export function useWidgetTickerData(
 
     return chips;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [widgetPrefs.weather, widgetPrefs.enabledWidgets]);
+  }, [widgetPrefs.weather, widgetPrefs.widgetsOnTicker]);
 
   // ── Build sysmon chips ────────────────────────────────────────
   const buildSysmonChips = useCallback((): SysmonChipData[] => {
@@ -346,7 +346,7 @@ export function useWidgetTickerData(
 
     return chips;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [widgetPrefs.sysmon, widgetPrefs.enabledWidgets]);
+  }, [widgetPrefs.sysmon, widgetPrefs.widgetsOnTicker]);
 
   // ── Polling intervals ─────────────────────────────────────────
 
@@ -405,7 +405,7 @@ export function useWidgetTickerData(
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    widgetPrefs.enabledWidgets.join(","),
+    widgetPrefs.widgetsOnTicker.join(","),
     widgetPrefs.sysmon.refreshInterval,
     buildClockChips,
     buildWeatherChips,

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -116,8 +116,10 @@ export interface WidgetPinConfig {
 }
 
 export interface WidgetPrefs {
-  /** Widget IDs that are enabled (shown in feed tabs and ticker). */
+  /** Widget IDs that are enabled (shown in sidebar and feed tabs). */
   enabledWidgets: string[];
+  /** Widget IDs whose data appears on the ticker. Subset of enabledWidgets. */
+  widgetsOnTicker: string[];
   /** Per-widget pin state: removes the chip from the scrolling ticker and
    *  places it as a static element on the chosen side. Keyed by widget ID. */
   pinnedWidgets: Record<string, WidgetPinConfig>;
@@ -206,6 +208,7 @@ export const DEFAULT_SYSMON_TICKER: SysmonTickerConfig = {
 
 export const DEFAULT_WIDGETS: WidgetPrefs = {
   enabledWidgets: [],
+  widgetsOnTicker: [],
   pinnedWidgets: {},
   clock: {
     ticker: { ...DEFAULT_CLOCK_TICKER },
@@ -312,8 +315,12 @@ function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
   const wth = obj(saved.weather);
   const sys = obj(saved.sysmon);
 
+  const enabledWidgets = Array.isArray(saved.enabledWidgets) ? saved.enabledWidgets : DEFAULT_WIDGETS.enabledWidgets;
+
   return {
-    enabledWidgets: Array.isArray(saved.enabledWidgets) ? saved.enabledWidgets : DEFAULT_WIDGETS.enabledWidgets,
+    enabledWidgets,
+    // Migration: if widgetsOnTicker doesn't exist, default to enabledWidgets
+    widgetsOnTicker: Array.isArray(saved.widgetsOnTicker) ? saved.widgetsOnTicker : enabledWidgets,
     pinnedWidgets: (saved.pinnedWidgets != null && typeof saved.pinnedWidgets === "object" && !Array.isArray(saved.pinnedWidgets))
       ? saved.pinnedWidgets as Record<string, WidgetPinConfig>
       : {},

--- a/desktop/src/widgets/sysmon/FeedTab.tsx
+++ b/desktop/src/widgets/sysmon/FeedTab.tsx
@@ -1,3 +1,4 @@
+import { Activity } from "lucide-react";
 import type { FeedTabProps } from "~/channels/types";
 import type { WidgetManifest } from "~/widgets/types";
 import { useSysmonData } from "../../hooks/useSysmonData";
@@ -393,6 +394,7 @@ export const sysmonWidget: WidgetManifest = {
   name: "System Monitor",
   tabLabel: "System",
   hex: "#06b6d4",
+  icon: Activity,
   desktopOnly: true,
   FeedTab: SysmonFeedTab,
 };

--- a/desktop/src/widgets/sysmon/FeedTab.tsx
+++ b/desktop/src/widgets/sysmon/FeedTab.tsx
@@ -393,8 +393,19 @@ export const sysmonWidget: WidgetManifest = {
   id: "sysmon",
   name: "System Monitor",
   tabLabel: "System",
+  description: "Live CPU, memory, and GPU stats",
   hex: "#06b6d4",
   icon: Activity,
+  info: {
+    about:
+      "The System Monitor widget displays live hardware metrics on your ticker, including CPU usage, memory consumption, and GPU stats. Available on the desktop app only.",
+    usage: [
+      "CPU, memory, and GPU usage appear as a consolidated chip on the ticker.",
+      "Toggle individual metrics (CPU, memory, GPU, GPU power) in the Configuration tab.",
+      "The feed view shows detailed real-time stats including temperatures and per-component breakdowns.",
+      "Pin the system monitor chip to keep it stationary on one side of the ticker.",
+    ],
+  },
   desktopOnly: true,
   FeedTab: SysmonFeedTab,
 };

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "clsx": "^2.1.1",
+        "lucide-react": "^0.577.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -163,6 +164,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1800,6 +1802,7 @@
       "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1810,6 +1813,7 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2219,6 +2223,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4463,6 +4468,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4479,6 +4493,7 @@
       "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
@@ -5320,6 +5335,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5466,6 +5482,7 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6186,6 +6203,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6423,6 +6441,7 @@
       "integrity": "sha512-FwQEk+0a4/pYha6rTKGl5iicU6kRYDBDiElJf55CFEfoJKqvGzBTZpphafurQfqU1X0hvAm9w5GEWC0thXI6wQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@1natsu/wait-element": "^4.1.2",
         "@aklinker1/rollup-plugin-visualizer": "5.12.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/extension/widgets/clock/FeedTab.tsx
+++ b/extension/widgets/clock/FeedTab.tsx
@@ -630,8 +630,19 @@ export const clockWidget: WidgetManifest = {
   id: "clock",
   name: "Clock",
   tabLabel: "Clock",
+  description: "Local time, world clocks, and timers",
   hex: "#6366f1",
   icon: Clock,
+  info: {
+    about:
+      "The Clock widget displays your local time on the ticker and provides world clocks for tracking multiple time zones. It also includes a countdown and stopwatch timer.",
+    usage: [
+      "Your local time appears on the ticker by default.",
+      "Enable world clocks in the Configuration tab to add additional time zones.",
+      "Use the timer tab in the feed view to set countdowns or run a stopwatch.",
+      "Exclude specific time zones from the ticker in the Configuration tab.",
+    ],
+  },
   FeedTab: ClockFeedTab,
 };
 

--- a/extension/widgets/clock/FeedTab.tsx
+++ b/extension/widgets/clock/FeedTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { Clock } from "lucide-react";
 import type { FeedTabProps } from "~/channels/types";
 import type { WidgetManifest } from "../types";
 
@@ -630,6 +631,7 @@ export const clockWidget: WidgetManifest = {
   name: "Clock",
   tabLabel: "Clock",
   hex: "#6366f1",
+  icon: Clock,
   FeedTab: ClockFeedTab,
 };
 

--- a/extension/widgets/types.ts
+++ b/extension/widgets/types.ts
@@ -14,6 +14,8 @@ export interface WidgetManifest {
   tabLabel: string;
   /** Brand hex color for the widget. */
   hex: string;
+  /** Lucide icon component for sidebar and header display. */
+  icon: React.ComponentType<{ size?: number; className?: string }>;
   /** When true, this widget only works in the desktop app (e.g. system monitor). */
   desktopOnly?: boolean;
   /** The React component rendered inside the feed bar for this widget. */

--- a/extension/widgets/types.ts
+++ b/extension/widgets/types.ts
@@ -5,6 +5,14 @@ import type { FeedTabProps } from "~/channels/types";
 // with no backend. They share the feed tab UI surface with channels
 // but have zero API/CDC involvement.
 
+/** Structured info content for the Info tab */
+export interface SourceInfo {
+  /** What this source is and what it does */
+  about: string;
+  /** How to use it (rendered as bullet points) */
+  usage: string[];
+}
+
 export interface WidgetManifest {
   /** Unique identifier (e.g. "clock", "weather"). Must not collide with channel IDs. */
   id: string;
@@ -12,10 +20,14 @@ export interface WidgetManifest {
   name: string;
   /** Short label shown on the feed bar tab. */
   tabLabel: string;
+  /** Brief description of the widget. */
+  description: string;
   /** Brand hex color for the widget. */
   hex: string;
   /** Lucide icon component for sidebar and header display. */
   icon: React.ComponentType<{ size?: number; className?: string }>;
+  /** Info tab content — what this widget is and how to use it */
+  info: SourceInfo;
   /** When true, this widget only works in the desktop app (e.g. system monitor). */
   desktopOnly?: boolean;
   /** The React component rendered inside the feed bar for this widget. */

--- a/extension/widgets/weather/FeedTab.tsx
+++ b/extension/widgets/weather/FeedTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { CloudSun } from "lucide-react";
 import type { FeedTabProps } from "~/channels/types";
 import type { WidgetManifest } from "../types";
 
@@ -706,6 +707,7 @@ export const weatherWidget: WidgetManifest = {
   name: "Weather",
   tabLabel: "Weather",
   hex: "#0ea5e9",
+  icon: CloudSun,
   FeedTab: WeatherFeedTab,
 };
 

--- a/extension/widgets/weather/FeedTab.tsx
+++ b/extension/widgets/weather/FeedTab.tsx
@@ -706,8 +706,19 @@ export const weatherWidget: WidgetManifest = {
   id: "weather",
   name: "Weather",
   tabLabel: "Weather",
+  description: "Current conditions for your locations",
   hex: "#0ea5e9",
   icon: CloudSun,
+  info: {
+    about:
+      "The Weather widget shows current weather conditions for one or more locations on your ticker. Data is fetched from the Open-Meteo API with no API key required.",
+    usage: [
+      "Search for a city in the feed view to add it to your weather locations.",
+      "Each location appears as a ticker chip with temperature, conditions, and an icon.",
+      "Add multiple cities to track weather across different locations.",
+      "Exclude specific cities from the ticker in the Configuration tab.",
+    ],
+  },
   FeedTab: WeatherFeedTab,
 };
 

--- a/myscrollr.com/src/channels/types.ts
+++ b/myscrollr.com/src/channels/types.ts
@@ -15,6 +15,14 @@ export interface DashboardTabProps {
   hex: string
 }
 
+/** Structured info content for the Info tab */
+export interface SourceInfo {
+  /** What this source is and what it does */
+  about: string
+  /** How to use it (rendered as bullet points) */
+  usage: string[]
+}
+
 /** Manifest describing a single channel */
 export interface ChannelManifest {
   /** Unique channel identifier (matches channel_type) */
@@ -29,6 +37,8 @@ export interface ChannelManifest {
   hex: string
   /** Lucide icon component rendered at size 14 for sidebar, 20 for header */
   icon: React.ComponentType<{ size?: number; className?: string }>
+  /** Info tab content — what this channel is and how to use it */
+  info: SourceInfo
   /** Dashboard configuration panel component */
   DashboardTab: React.ComponentType<DashboardTabProps>
 }


### PR DESCRIPTION
## Summary

- **Sidebar icons**: Replace colored dots with Lucide icons (TrendingUp, Trophy, Rss, Ghost for channels; Clock, CloudSun, Activity for widgets) in both expanded and collapsed sidebar modes. Add `icon` field to `WidgetManifest` type and `lucide-react` to extension dependencies.
- **Header navigation tabs**: Add Feed / Info / Configuration pill tabs to channel and widget page headers, matching the existing settings tab pattern. Active tab persists when switching between channels/widgets.
- **Info tab**: New tab showing an about paragraph and numbered usage steps for each channel and widget. Add `SourceInfo` type and `info` content to all 4 channel and 3 widget manifests.
- **Ticker toggle**: Compact animated switch in the header controls ticker visibility only — channels stay in sidebar/feed, widgets stay enabled. Decouples `visible` from `enabled` for channels. New `widgetsOnTicker` preference decouples widget ticker visibility from sidebar presence.
- **Double-tap trash**: Trash icon in header for both channels and widgets. First click arms it (turns red, 3s auto-reset), second click confirms removal. Zero layout shift.