### PR TITLE
refactor(desktop): native channel config panels — v0.7.8

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.6.0",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "0.6.0",
+      "version": "0.7.7",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.5.1",
@@ -64,7 +64,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1767,7 +1766,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1836,7 +1834,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2554,7 +2551,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2596,7 +2592,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2606,7 +2601,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2790,7 +2784,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/MainApp.tsx
+++ b/desktop/src/MainApp.tsx
@@ -20,6 +20,7 @@ import { getWebChannel, getAllWebChannels } from "./channels/webRegistry";
 import { getChannel } from "~/channels/registry";
 import { getWidget, getAllWidgets } from "./widgets/registry";
 import WidgetConfigPanel from "./widgets/WidgetConfigPanel";
+import ChannelConfigPanel from "./channels/ChannelConfigPanel";
 import { useWidgetTickerData } from "./hooks/useWidgetTickerData";
 import {
   login as authLogin,
@@ -794,27 +795,22 @@ export default function MainApp() {
       );
     }
 
-    // Channel — configure mode (DashboardTab)
+    // Channel — configure mode (desktop-native ConfigPanel)
     if (isChannelActive && configuring) {
       const channel = channels.find((c) => c.channel_type === activeItem);
       const webChannel = getWebChannel(activeItem);
 
-      if (channel && webChannel) {
+      if (channel) {
         return (
-          <div className="flex-1 overflow-y-auto p-4 scrollbar-thin dashboard-content">
-            <webChannel.DashboardTab
+          <div className="flex-1 overflow-y-auto p-4 scrollbar-thin">
+            <ChannelConfigPanel
+              channelType={activeItem}
               channel={channel}
               getToken={getToken}
-              onToggle={() =>
-                handleToggleChannel(channel.channel_type, !channel.visible)
-              }
-              onDelete={() =>
-                handleDeleteChannel(activeItem as ChannelType)
-              }
               onChannelUpdate={handleChannelUpdate}
-              connected={deliveryMode === "sse"}
               subscriptionTier={tier}
-              hex={webChannel.hex}
+              connected={deliveryMode === "sse"}
+              hex={webChannel?.hex ?? "var(--color-accent)"}
             />
           </div>
         );
@@ -858,7 +854,7 @@ export default function MainApp() {
     // Widget — configure mode
     if (isWidgetActive && configuring) {
       return (
-        <div className="flex-1 overflow-y-auto p-4 scrollbar-thin dashboard-content">
+        <div className="flex-1 overflow-y-auto p-4 scrollbar-thin">
           <WidgetConfigPanel
             widgetId={activeItem}
             prefs={prefs}

--- a/desktop/src/channels/ChannelConfigPanel.tsx
+++ b/desktop/src/channels/ChannelConfigPanel.tsx
@@ -1,0 +1,86 @@
+import type { Channel } from "../api/client";
+import FinanceConfigPanel from "./FinanceConfigPanel";
+import SportsConfigPanel from "./SportsConfigPanel";
+import RssConfigPanel from "./RssConfigPanel";
+import FantasyConfigPanel from "./FantasyConfigPanel";
+
+// ── Props ────────────────────────────────────────────────────────
+
+interface ChannelConfigPanelProps {
+  channelType: string;
+  channel: Channel;
+  getToken: () => Promise<string | null>;
+  onChannelUpdate: (updated: Channel) => void;
+  subscriptionTier: string;
+  /** SSE delivery mode active */
+  connected: boolean;
+  /** Channel accent hex color */
+  hex: string;
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export default function ChannelConfigPanel({
+  channelType,
+  channel,
+  getToken,
+  onChannelUpdate,
+  subscriptionTier,
+  connected,
+  hex,
+}: ChannelConfigPanelProps) {
+  switch (channelType) {
+    case "finance":
+      return (
+        <FinanceConfigPanel
+          channel={channel}
+          getToken={getToken}
+          onChannelUpdate={onChannelUpdate}
+          subscriptionTier={subscriptionTier}
+          connected={connected}
+          hex={hex}
+        />
+      );
+    case "sports":
+      return (
+        <SportsConfigPanel
+          channel={channel}
+          getToken={getToken}
+          onChannelUpdate={onChannelUpdate}
+          subscriptionTier={subscriptionTier}
+          connected={connected}
+          hex={hex}
+        />
+      );
+    case "rss":
+      return (
+        <RssConfigPanel
+          channel={channel}
+          getToken={getToken}
+          onChannelUpdate={onChannelUpdate}
+          hex={hex}
+        />
+      );
+    case "fantasy":
+      return (
+        <FantasyConfigPanel
+          channel={channel}
+          getToken={getToken}
+          subscriptionTier={subscriptionTier}
+          connected={connected}
+          hex={hex}
+        />
+      );
+    default:
+      return (
+        <div className="flex flex-col items-center justify-center h-full text-center max-w-sm mx-auto gap-3 p-6">
+          <h2 className="text-base font-semibold text-fg">
+            Configuration unavailable
+          </h2>
+          <p className="text-sm text-fg-3 leading-relaxed">
+            This channel does not have a configuration panel.
+          </p>
+        </div>
+      );
+  }
+}

--- a/desktop/src/channels/FantasyConfigPanel.tsx
+++ b/desktop/src/channels/FantasyConfigPanel.tsx
@@ -1,0 +1,1582 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  Ghost,
+  Link2,
+  Loader2,
+  Plus,
+  Shield,
+  Unlink,
+} from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { clsx } from "clsx";
+import {
+  Section,
+  DisplayRow,
+  ActionRow,
+  SegmentedRow,
+} from "../components/settings/SettingsControls";
+import { authenticatedFetch, API_BASE } from "../api/client";
+import type { Channel } from "../api/client";
+
+// ── Data Types ───────────────────────────────────────────────────
+
+interface StandingsEntry {
+  team_key: string;
+  team_id: number;
+  name: string;
+  url: string;
+  team_logo: string;
+  manager_name: string;
+  rank: number | null;
+  wins: number;
+  losses: number;
+  ties: number;
+  percentage: string;
+  games_back: string;
+  points_for: string;
+  points_against: string;
+  streak_type: string;
+  streak_value: number;
+  playoff_seed: number | null;
+  clinched_playoffs: boolean;
+  waiver_priority: number | null;
+}
+
+interface MatchupTeam {
+  team_key: string;
+  team_id: number;
+  name: string;
+  team_logo: string;
+  manager_name: string;
+  points: number | null;
+  projected_points: number | null;
+}
+
+interface Matchup {
+  week: number;
+  week_start: string;
+  week_end: string;
+  status: string;
+  is_playoffs: boolean;
+  is_consolation: boolean;
+  is_tied: boolean;
+  winner_team_key: string | null;
+  teams: MatchupTeam[];
+}
+
+interface RosterPlayer {
+  player_key: string;
+  player_id: number;
+  name: { full: string; first: string; last: string };
+  editorial_team_abbr: string;
+  display_position: string;
+  selected_position: string;
+  image_url: string;
+  status: string | null;
+  status_full: string | null;
+  injury_note: string | null;
+  player_points: number | null;
+}
+
+interface RosterEntry {
+  team_key: string;
+  data: {
+    team_key: string;
+    team_name: string;
+    players: RosterPlayer[];
+  };
+}
+
+interface LeagueData {
+  league_key: string;
+  name: string;
+  game_code: string;
+  season: string;
+  team_key: string | null;
+  team_name: string | null;
+  data: {
+    num_teams: number;
+    is_finished: boolean;
+    current_week: number | null;
+    scoring_type: string;
+    [k: string]: unknown;
+  };
+  standings: StandingsEntry[] | null;
+  matchups: Matchup[] | null;
+  rosters: RosterEntry[] | null;
+}
+
+interface MyLeaguesResponse {
+  leagues: LeagueData[];
+}
+
+interface DiscoveredLeague {
+  league_key: string;
+  name: string;
+  game_code: string;
+  season: number;
+  num_teams: number;
+  is_finished: boolean;
+  logo_url?: string;
+  url?: string;
+}
+
+type Phase =
+  | "disconnected"
+  | "discovering"
+  | "picking"
+  | "importing"
+  | "connected";
+
+type ImportStatus = "pending" | "importing" | "done" | "error";
+
+// ── Constants ────────────────────────────────────────────────────
+
+const GAME_CODE_LABELS: Record<string, string> = {
+  nfl: "Football",
+  nba: "Basketball",
+  nhl: "Hockey",
+  mlb: "Baseball",
+};
+
+const GAME_CODE_EMOJI: Record<string, string> = {
+  nfl: "\uD83C\uDFC8",
+  nba: "\uD83C\uDFC0",
+  nhl: "\uD83C\uDFD2",
+  mlb: "\u26BE",
+};
+
+const INJURY_COLORS: Record<string, string> = {
+  O: "#ef4444",
+  IR: "#ef4444",
+  SUSP: "#ef4444",
+  D: "#f97316",
+  Q: "#eab308",
+  P: "#eab308",
+  DTD: "#f97316",
+  DL: "#ef4444",
+  NA: "#a3a3a3",
+};
+
+const LEAGUES_PER_PAGE = 5;
+
+// ── Props ────────────────────────────────────────────────────────
+
+interface FantasyConfigPanelProps {
+  channel: Channel;
+  getToken: () => Promise<string | null>;
+  subscriptionTier: string;
+  connected: boolean;
+  hex: string;
+}
+
+// ── Main Component ───────────────────────────────────────────────
+
+export default function FantasyConfigPanel({
+  channel: _channel,
+  getToken,
+  subscriptionTier,
+  connected,
+  hex,
+}: FantasyConfigPanelProps) {
+  const isUnlimited = subscriptionTier === "uplink_unlimited";
+  const isUplink = subscriptionTier === "uplink" || isUnlimited;
+
+  const [leagues, setLeagues] = useState<LeagueData[]>([]);
+  const [yahooConnected, setYahooConnected] = useState(false);
+  const [phase, setPhase] = useState<Phase>("disconnected");
+  const [discoveredLeagues, setDiscoveredLeagues] = useState<
+    DiscoveredLeague[]
+  >([]);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [importStatuses, setImportStatuses] = useState<
+    Record<string, ImportStatus>
+  >({});
+  const [discoverError, setDiscoverError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<"active" | "finished">("active");
+  const [leagueVisibleCount, setLeagueVisibleCount] =
+    useState(LEAGUES_PER_PAGE);
+
+  const initialLoadDone = useRef(false);
+
+  // ── Fetch existing Yahoo data ──────────────────────────────────
+
+  const fetchYahooData = useCallback(async () => {
+    try {
+      const [statusData, leaguesData] = await Promise.all([
+        authenticatedFetch<{ connected: boolean; synced: boolean }>(
+          "/users/me/yahoo-status",
+          {},
+          getToken,
+        ).catch(() => null),
+        authenticatedFetch<MyLeaguesResponse>(
+          "/users/me/yahoo-leagues",
+          {},
+          getToken,
+        ).catch(() => null),
+      ]);
+
+      const isConn = statusData?.connected ?? false;
+      setYahooConnected(isConn);
+      setLeagues(leaguesData?.leagues ?? []);
+
+      if (!initialLoadDone.current) {
+        initialLoadDone.current = true;
+        if (isConn && (leaguesData?.leagues?.length ?? 0) > 0) {
+          setPhase("connected");
+        } else if (isConn) {
+          setPhase("connected");
+        } else {
+          setPhase("disconnected");
+        }
+      }
+    } catch (err) {
+      console.error("[Fantasy] fetchYahooData error:", err);
+      if (!initialLoadDone.current) {
+        initialLoadDone.current = true;
+        setPhase("disconnected");
+      }
+    }
+  }, [getToken]);
+
+  useEffect(() => {
+    fetchYahooData();
+  }, [fetchYahooData]);
+
+  // ── League discovery ───────────────────────────────────────────
+
+  const startDiscovery = useCallback(async () => {
+    setPhase("discovering");
+    setDiscoverError(null);
+    setDiscoveredLeagues([]);
+
+    try {
+      const result = await authenticatedFetch<{
+        leagues: DiscoveredLeague[];
+        error?: string;
+      }>("/users/me/yahoo-leagues/discover", { method: "POST" }, getToken);
+
+      if (result.error) {
+        setDiscoverError(result.error);
+        setPhase(leagues.length > 0 ? "connected" : "disconnected");
+        return;
+      }
+
+      const discovered = result.leagues || [];
+      setDiscoveredLeagues(discovered);
+
+      const alreadyImported = new Set(leagues.map((l) => l.league_key));
+      const newLeagues = discovered.filter(
+        (l) => !alreadyImported.has(l.league_key),
+      );
+
+      if (newLeagues.length === 0) {
+        setPhase("connected");
+        return;
+      }
+
+      const preSelected = new Set(
+        newLeagues.filter((l) => !l.is_finished).map((l) => l.league_key),
+      );
+      setSelectedKeys(preSelected);
+      setPhase("picking");
+    } catch (err: unknown) {
+      console.error("[Fantasy] discover failed:", err);
+      setDiscoverError(
+        err instanceof Error ? err.message : "Discovery failed",
+      );
+      setPhase(leagues.length > 0 ? "connected" : "disconnected");
+    }
+  }, [getToken, leagues]);
+
+  // ── Import selected leagues ────────────────────────────────────
+
+  const importSelected = useCallback(async () => {
+    const keys = Array.from(selectedKeys);
+    if (keys.length === 0) return;
+
+    setPhase("importing");
+
+    const statuses: Record<string, ImportStatus> = {};
+    for (const key of keys) statuses[key] = "pending";
+    setImportStatuses({ ...statuses });
+
+    for (const key of keys) {
+      const league = discoveredLeagues.find((l) => l.league_key === key);
+      if (!league) continue;
+
+      statuses[key] = "importing";
+      setImportStatuses({ ...statuses });
+
+      try {
+        const result = await authenticatedFetch<{
+          status: string;
+          error?: string;
+        }>(
+          "/users/me/yahoo-leagues/import",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              league_key: league.league_key,
+              game_code: league.game_code,
+              season: league.season,
+            }),
+          },
+          getToken,
+        );
+        statuses[key] = result.error ? "error" : "done";
+      } catch {
+        statuses[key] = "error";
+      }
+      setImportStatuses({ ...statuses });
+    }
+
+    await fetchYahooData();
+    setPhase("connected");
+  }, [selectedKeys, discoveredLeagues, getToken, fetchYahooData]);
+
+  // ── Listen for Yahoo auth popup completion ─────────────────────
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === "yahoo-auth-complete") {
+        setYahooConnected(true);
+        startDiscovery();
+      }
+    };
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [startDiscovery]);
+
+  // ── Yahoo connect / disconnect ─────────────────────────────────
+
+  const handleYahooConnect = useCallback(async () => {
+    const token = await getToken();
+    if (!token) return;
+
+    let sub: string | undefined;
+    try {
+      const payload = JSON.parse(atob(token.split(".")[1]));
+      sub = payload.sub;
+    } catch {
+      /* ignore */
+    }
+    if (!sub) return;
+
+    const popupUrl = `${API_BASE}/yahoo/start?logto_sub=${sub}`;
+    window.open(popupUrl, "yahoo-auth", "width=600,height=700");
+  }, [getToken]);
+
+  const handleYahooDisconnect = useCallback(async () => {
+    try {
+      await authenticatedFetch(
+        "/users/me/yahoo",
+        { method: "DELETE" },
+        getToken,
+      );
+      setYahooConnected(false);
+      setLeagues([]);
+      setPhase("disconnected");
+      initialLoadDone.current = false;
+    } catch (err) {
+      console.error("[Fantasy] disconnect failed:", err);
+    }
+  }, [getToken]);
+
+  // ── Derived data ───────────────────────────────────────────────
+
+  const sortedLeagues = [...leagues].sort(
+    (a, b) => Number(b.season) - Number(a.season),
+  );
+  const activeLeagues = sortedLeagues.filter((l) => !l.data?.is_finished);
+  const finishedLeagues = sortedLeagues.filter((l) => l.data?.is_finished);
+  const filteredLeagues =
+    filter === "active" ? activeLeagues : finishedLeagues;
+  const visibleLeagues = filteredLeagues.slice(0, leagueVisibleCount);
+  const hasMore = leagueVisibleCount < filteredLeagues.length;
+  const remaining = filteredLeagues.length - leagueVisibleCount;
+
+  const handleFilterChange = (newFilter: string) => {
+    setFilter(newFilter as "active" | "finished");
+    setLeagueVisibleCount(LEAGUES_PER_PAGE);
+  };
+
+  // ── Picking helpers ────────────────────────────────────────────
+
+  const alreadyImported = new Set(leagues.map((l) => l.league_key));
+  const pickableLeagues = discoveredLeagues.filter(
+    (l) => !alreadyImported.has(l.league_key),
+  );
+  const pickableActive = pickableLeagues.filter((l) => !l.is_finished);
+  const pickableFinished = pickableLeagues.filter((l) => l.is_finished);
+
+  const toggleLeague = (key: string) => {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+  const selectAll = () =>
+    setSelectedKeys(new Set(pickableLeagues.map((l) => l.league_key)));
+  const deselectAll = () => setSelectedKeys(new Set());
+
+  const totalLeagues = leagues.length;
+  const totalActiveMatchups = activeLeagues.reduce(
+    (n, l) => n + (l.matchups?.length ?? 0),
+    0,
+  );
+
+  const delivery = isUnlimited
+    ? "Real-time SSE"
+    : isUplink
+      ? "Poll 30s"
+      : "Poll 60s";
+
+  // ── Render ─────────────────────────────────────────────────────
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6 px-3">
+        <div
+          className="w-8 h-8 rounded-lg flex items-center justify-center"
+          style={{
+            background: `${hex}15`,
+            boxShadow: `0 0 15px ${hex}15, 0 0 0 1px ${hex}20`,
+          }}
+        >
+          <Ghost size={16} style={{ color: hex }} />
+        </div>
+        <div>
+          <h2 className="text-sm font-bold text-fg">Fantasy</h2>
+          <p className="text-[11px] text-fg-4">Yahoo Fantasy Sports</p>
+        </div>
+      </div>
+
+      {/* ── DISCONNECTED ──────────────────────────────────────── */}
+      {phase === "disconnected" && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center py-10 space-y-4 px-3"
+        >
+          <Ghost size={40} className="mx-auto text-fg-4/30" />
+          <div className="space-y-2">
+            <p className="text-sm font-bold text-fg-2">No Fantasy Data</p>
+            <p className="text-[12px] text-fg-3 max-w-xs mx-auto">
+              Connect your Yahoo account to see your fantasy leagues, matchup
+              scores, standings, and rosters.
+            </p>
+          </div>
+          {discoverError && (
+            <p className="text-[12px] text-error max-w-xs mx-auto">
+              {discoverError}
+            </p>
+          )}
+          <button
+            onClick={handleYahooConnect}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-[12px] font-medium text-white transition-colors cursor-pointer"
+            style={{ background: hex }}
+          >
+            <Link2 size={14} />
+            Connect Yahoo Account
+          </button>
+        </motion.div>
+      )}
+
+      {/* ── DISCOVERING ───────────────────────────────────────── */}
+      {phase === "discovering" && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center py-10 space-y-4 px-3"
+        >
+          <div className="flex items-center justify-center gap-1.5 h-6">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <motion.div
+                key={i}
+                className="w-1.5 rounded-full origin-center"
+                style={{ height: 8, background: hex }}
+                animate={{
+                  scaleY: [1, 3, 1],
+                  opacity: [0.3, 1, 0.3],
+                }}
+                transition={{
+                  duration: 1,
+                  repeat: Infinity,
+                  delay: i * 0.12,
+                  ease: "easeInOut",
+                }}
+              />
+            ))}
+          </div>
+          <div className="space-y-2">
+            <p
+              className="text-sm font-bold"
+              style={{ color: `${hex}B3` }}
+            >
+              Discovering Leagues
+            </p>
+            <p className="text-[12px] text-fg-3 max-w-xs mx-auto">
+              Scanning your Yahoo Fantasy account for leagues across all
+              sports.
+            </p>
+          </div>
+        </motion.div>
+      )}
+
+      {/* ── PICKING ───────────────────────────────────────────── */}
+      {phase === "picking" && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <Section title={`Select Leagues (${pickableLeagues.length} found)`}>
+            <div className="px-3 space-y-3">
+              <div className="flex items-center justify-end gap-3">
+                <button
+                  onClick={selectAll}
+                  className="text-[11px] text-fg-3 hover:text-fg-2 transition-colors cursor-pointer"
+                >
+                  Select All
+                </button>
+                <span className="text-fg-4">|</span>
+                <button
+                  onClick={deselectAll}
+                  className="text-[11px] text-fg-3 hover:text-fg-2 transition-colors cursor-pointer"
+                >
+                  Deselect All
+                </button>
+              </div>
+
+              {pickableActive.length > 0 && (
+                <div className="space-y-1">
+                  <p className="text-[11px] font-semibold text-success/80 flex items-center gap-1.5 mb-1.5">
+                    <span className="h-1.5 w-1.5 rounded-full bg-success animate-pulse" />
+                    Active Leagues
+                  </p>
+                  {pickableActive.map((league) => (
+                    <LeaguePickerRow
+                      key={league.league_key}
+                      league={league}
+                      selected={selectedKeys.has(league.league_key)}
+                      onToggle={() => toggleLeague(league.league_key)}
+                      hex={hex}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {pickableFinished.length > 0 && (
+                <div className="space-y-1">
+                  <p className="text-[11px] font-semibold text-fg-4 mb-1.5">
+                    Past Leagues
+                  </p>
+                  {pickableFinished.map((league) => (
+                    <LeaguePickerRow
+                      key={league.league_key}
+                      league={league}
+                      selected={selectedKeys.has(league.league_key)}
+                      onToggle={() => toggleLeague(league.league_key)}
+                      hex={hex}
+                    />
+                  ))}
+                </div>
+              )}
+
+              <div className="flex gap-2 pt-2">
+                <button
+                  onClick={importSelected}
+                  disabled={selectedKeys.size === 0}
+                  className="flex-1 px-4 py-2 rounded-lg text-[12px] font-medium text-white transition-colors disabled:opacity-30 cursor-pointer"
+                  style={{
+                    background:
+                      selectedKeys.size > 0 ? hex : "var(--color-base-300)",
+                  }}
+                >
+                  Import Selected ({selectedKeys.size})
+                </button>
+                <button
+                  onClick={() =>
+                    setPhase(
+                      leagues.length > 0 ? "connected" : "disconnected",
+                    )
+                  }
+                  className="px-4 py-2 rounded-lg text-[12px] font-medium text-fg-3 hover:text-fg-2 hover:bg-base-250/50 transition-colors cursor-pointer"
+                >
+                  Skip
+                </button>
+              </div>
+            </div>
+          </Section>
+        </motion.div>
+      )}
+
+      {/* ── IMPORTING ─────────────────────────────────────────── */}
+      {phase === "importing" && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <Section title="Importing Leagues">
+            <div className="px-3 space-y-1.5">
+              {Array.from(selectedKeys).map((key) => {
+                const league = discoveredLeagues.find(
+                  (l) => l.league_key === key,
+                );
+                const status = importStatuses[key] || "pending";
+                const sportLabel =
+                  GAME_CODE_LABELS[league?.game_code || ""] ||
+                  league?.game_code ||
+                  "Fantasy";
+
+                return (
+                  <motion.div
+                    key={key}
+                    initial={{ opacity: 0, x: -8 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    className="flex items-center gap-3 p-2.5 rounded-lg border border-edge/20 bg-base-250/30"
+                  >
+                    <div className="w-5 h-5 flex items-center justify-center shrink-0">
+                      {status === "done" && (
+                        <Check size={14} className="text-success" />
+                      )}
+                      {status === "importing" && (
+                        <Loader2
+                          size={14}
+                          className="animate-spin"
+                          style={{ color: hex }}
+                        />
+                      )}
+                      {status === "pending" && (
+                        <span className="h-2 w-2 rounded-full bg-fg-4/30" />
+                      )}
+                      {status === "error" && (
+                        <span className="text-error text-[12px] font-bold">
+                          !
+                        </span>
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-[12px] font-bold text-fg-2 truncate">
+                        {league?.name || key}
+                      </p>
+                      <p className="text-[11px] text-fg-4">
+                        {sportLabel} &middot; {league?.season}
+                      </p>
+                    </div>
+                    <span
+                      className="text-[10px] font-mono"
+                      style={{
+                        color:
+                          status === "done"
+                            ? "var(--color-success)"
+                            : status === "importing"
+                              ? hex
+                              : status === "error"
+                                ? "var(--color-error)"
+                                : "var(--color-fg-4)",
+                      }}
+                    >
+                      {status}
+                    </span>
+                  </motion.div>
+                );
+              })}
+            </div>
+          </Section>
+        </motion.div>
+      )}
+
+      {/* ── CONNECTED — Status ────────────────────────────────── */}
+      {phase === "connected" && leagues.length > 0 && (
+        <Section title="Status">
+          <DisplayRow label="Leagues" value={String(totalLeagues)} />
+          <DisplayRow
+            label="Active Matchups"
+            value={String(totalActiveMatchups)}
+          />
+          <DisplayRow label="Delivery" value={delivery} />
+          <DisplayRow
+            label="Connection"
+            value={
+              isUnlimited ? (connected ? "Live" : "Offline") : "Polling"
+            }
+          />
+        </Section>
+      )}
+
+      {/* ── CONNECTED — Filter toggle ─────────────────────────── */}
+      {phase === "connected" && leagues.length > 0 && (
+        <Section title="Your Leagues">
+          <div className="px-3">
+            <SegmentedRow
+              label="Filter"
+              value={filter}
+              options={[
+                {
+                  value: "active",
+                  label: `Active (${activeLeagues.length})`,
+                },
+                {
+                  value: "finished",
+                  label: `Past (${finishedLeagues.length})`,
+                },
+              ]}
+              onChange={handleFilterChange}
+            />
+          </div>
+
+          {/* League cards */}
+          <div className="px-3 space-y-2 mt-2">
+            <AnimatePresence mode="popLayout">
+              {visibleLeagues.map((league, i) => (
+                <motion.div
+                  key={league.league_key}
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -6 }}
+                  transition={{
+                    type: "spring",
+                    stiffness: 400,
+                    damping: 30,
+                    delay: i < LEAGUES_PER_PAGE ? i * 0.04 : 0,
+                  }}
+                  layout
+                >
+                  <LeagueCard league={league} hex={hex} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+
+            {/* Empty filter state */}
+            {filteredLeagues.length === 0 && (
+              <p className="text-center text-[11px] text-fg-4 py-6">
+                {filter === "active"
+                  ? "No active leagues right now"
+                  : "No past leagues found"}
+              </p>
+            )}
+
+            {/* Load more */}
+            {hasMore && (
+              <button
+                onClick={() =>
+                  setLeagueVisibleCount((prev) => prev + LEAGUES_PER_PAGE)
+                }
+                className="w-full p-3 rounded-lg bg-base-250/30 border border-edge/20 text-fg-3 hover:text-fg-2 hover:border-edge/40 transition-all flex items-center justify-center gap-2 cursor-pointer"
+              >
+                <ChevronDown size={14} />
+                <span className="text-[11px] font-medium">
+                  Show {Math.min(remaining, LEAGUES_PER_PAGE)} more ({remaining}{" "}
+                  remaining)
+                </span>
+              </button>
+            )}
+          </div>
+        </Section>
+      )}
+
+      {/* Connected but no leagues at all */}
+      {phase === "connected" && yahooConnected && leagues.length === 0 && (
+        <div className="text-center py-8 space-y-3 px-3">
+          <p className="text-[12px] text-fg-3">
+            Yahoo account connected — no leagues imported yet
+          </p>
+          <button
+            onClick={startDiscovery}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-[12px] font-medium text-white transition-colors cursor-pointer"
+            style={{ background: hex }}
+          >
+            <Plus size={14} />
+            Import Leagues
+          </button>
+        </div>
+      )}
+
+      {/* ── Account actions ───────────────────────────────────── */}
+      {phase === "connected" && yahooConnected && (
+        <Section title="Account">
+          <ActionRow
+            label="Add more leagues"
+            description="Discover and import new Yahoo Fantasy leagues"
+            action="Discover"
+            onClick={startDiscovery}
+          />
+          <ActionRow
+            label="Disconnect Yahoo"
+            description="Remove your Yahoo account connection"
+            action="Disconnect"
+            actionClass="bg-error/10 text-error hover:bg-error/20"
+            onClick={handleYahooDisconnect}
+          />
+        </Section>
+      )}
+    </div>
+  );
+}
+
+// ── League Picker Row ────────────────────────────────────────────
+
+function LeaguePickerRow({
+  league,
+  selected,
+  onToggle,
+  hex,
+}: {
+  league: DiscoveredLeague;
+  selected: boolean;
+  onToggle: () => void;
+  hex: string;
+}) {
+  const sportLabel =
+    GAME_CODE_LABELS[league.game_code] || league.game_code || "Fantasy";
+
+  return (
+    <button
+      onClick={onToggle}
+      className={clsx(
+        "w-full flex items-center gap-3 p-2.5 rounded-lg border transition-all text-left cursor-pointer",
+        selected
+          ? "bg-base-250/40 border-edge/30"
+          : "bg-base-250/15 border-edge/15 opacity-60",
+      )}
+      style={
+        selected ? { borderColor: `${hex}30`, background: `${hex}08` } : {}
+      }
+    >
+      <div
+        className="h-4 w-4 rounded border flex items-center justify-center shrink-0 transition-all"
+        style={
+          selected
+            ? { background: hex, borderColor: hex }
+            : { borderColor: "var(--color-fg-4)" }
+        }
+      >
+        {selected && <Check size={10} className="text-white" />}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-[12px] font-bold text-fg-2 truncate">
+          {league.name}
+        </p>
+        <p className="text-[11px] text-fg-4">
+          {sportLabel} &middot; {league.num_teams} Teams &middot;{" "}
+          {league.season}
+        </p>
+      </div>
+
+      {!league.is_finished ? (
+        <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-success/10 border border-success/20">
+          <span className="h-1 w-1 rounded-full bg-success animate-pulse" />
+          <span className="text-[10px] font-bold text-success">Active</span>
+        </span>
+      ) : (
+        <span className="text-[10px] font-mono text-fg-4">
+          {league.season}
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ── League Card ──────────────────────────────────────────────────
+
+function LeagueCard({
+  league,
+  hex,
+}: {
+  league: LeagueData;
+  hex: string;
+}) {
+  const [openSection, setOpenSection] = useState<
+    "matchups" | "standings" | "roster" | null
+  >(null);
+
+  const isActive = !league.data?.is_finished;
+  const sportLabel =
+    GAME_CODE_LABELS[league.game_code] || league.game_code || "Fantasy";
+  const sportEmoji = GAME_CODE_EMOJI[league.game_code] || "";
+  const numTeams = league.data?.num_teams || 0;
+  const currentWeek = league.data?.current_week;
+
+  const userMatchup = league.matchups?.find((m) =>
+    m.teams.some((t) => t.team_key === league.team_key),
+  );
+  const standings = league.standings ?? [];
+  const userStanding = standings.find(
+    (s) => s.team_key === league.team_key,
+  );
+  const userRoster = league.rosters?.find(
+    (r) => r.team_key === league.team_key,
+  );
+  const injuredPlayers =
+    userRoster?.data?.players?.filter((p) => p.status) ?? [];
+
+  const toggleSection = (section: "matchups" | "standings" | "roster") =>
+    setOpenSection((prev) => (prev === section ? null : section));
+
+  return (
+    <div
+      className={clsx(
+        "border rounded-lg overflow-hidden transition-colors relative",
+        isActive
+          ? "bg-base-250/30 border-edge/25"
+          : "bg-base-250/15 border-edge/15",
+      )}
+    >
+      {/* Accent top line */}
+      {isActive && (
+        <div
+          className="absolute top-0 left-0 right-0 h-px"
+          style={{
+            background: `linear-gradient(90deg, transparent, ${hex} 50%, transparent)`,
+          }}
+        />
+      )}
+
+      {/* Header */}
+      <div className="p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div
+              className="h-9 w-9 rounded-lg flex items-center justify-center shrink-0 text-base"
+              style={
+                isActive
+                  ? {
+                      background: `${hex}15`,
+                      boxShadow: `0 0 0 1px ${hex}20`,
+                    }
+                  : {
+                      background: "var(--color-base-300)",
+                      boxShadow: "0 0 0 1px var(--color-edge)",
+                    }
+              }
+            >
+              {sportEmoji || (
+                <span
+                  className="text-sm font-bold"
+                  style={isActive ? { color: hex } : { color: "var(--color-fg-3)" }}
+                >
+                  Y!
+                </span>
+              )}
+            </div>
+            <div className="min-w-0">
+              <h3
+                className={clsx(
+                  "text-[13px] font-bold truncate",
+                  isActive ? "text-fg" : "text-fg-3",
+                )}
+              >
+                {league.name}
+              </h3>
+              <p className="text-[11px] text-fg-4">
+                {sportLabel} &middot; {numTeams} Teams
+                {league.season ? ` \u00b7 ${league.season}` : ""}
+                {currentWeek && isActive ? ` \u00b7 Week ${currentWeek}` : ""}
+              </p>
+            </div>
+          </div>
+          {isActive ? (
+            <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-success/10 border border-success/20">
+              <span className="h-1 w-1 rounded-full bg-success animate-pulse" />
+              <span className="text-[10px] font-bold text-success">
+                Active
+              </span>
+            </span>
+          ) : (
+            <span className="text-[10px] font-mono text-fg-4">
+              {league.season}
+            </span>
+          )}
+        </div>
+
+        {/* User's matchup score */}
+        {userMatchup && (
+          <MatchupScoreCard
+            matchup={userMatchup}
+            userTeamKey={league.team_key}
+            hex={hex}
+          />
+        )}
+
+        {/* Quick stats */}
+        {league.team_key && (
+          <div className="flex items-center gap-4 mt-2">
+            {userStanding && (
+              <span className="text-[11px] text-fg-3">
+                <span className="font-bold" style={{ color: hex }}>
+                  #{userStanding.rank ?? "?"}
+                </span>{" "}
+                in standings &middot;{" "}
+                <span className="font-mono">
+                  {userStanding.wins}-{userStanding.losses}
+                  {userStanding.ties > 0 ? `-${userStanding.ties}` : ""}
+                </span>
+                {userStanding.streak_value > 0 && (
+                  <span className="ml-1">
+                    ({userStanding.streak_type?.[0]?.toUpperCase()}
+                    {userStanding.streak_value})
+                  </span>
+                )}
+              </span>
+            )}
+            {injuredPlayers.length > 0 && (
+              <span className="flex items-center gap-1 text-[11px] text-warn">
+                <AlertTriangle size={11} />
+                {injuredPlayers.length} injured
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Section toggles */}
+      <div className="px-4 pb-2">
+        <div className="h-px bg-edge/20 mb-2" />
+        <div className="flex gap-1">
+          {(league.matchups?.length ?? 0) > 0 && (
+            <SectionToggle
+              label="Matchups"
+              isOpen={openSection === "matchups"}
+              onClick={() => toggleSection("matchups")}
+              hex={hex}
+            />
+          )}
+          {standings.length > 0 && (
+            <SectionToggle
+              label="Standings"
+              isOpen={openSection === "standings"}
+              onClick={() => toggleSection("standings")}
+              hex={hex}
+            />
+          )}
+          {(league.rosters?.length ?? 0) > 0 && (
+            <SectionToggle
+              label="Rosters"
+              isOpen={openSection === "roster"}
+              onClick={() => toggleSection("roster")}
+              hex={hex}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Expandable sections */}
+      <AnimatePresence initial={false}>
+        {openSection === "matchups" && league.matchups && (
+          <ExpandableSection key="matchups">
+            <MatchupsSection
+              matchups={league.matchups}
+              userTeamKey={league.team_key}
+              hex={hex}
+            />
+          </ExpandableSection>
+        )}
+        {openSection === "standings" && standings.length > 0 && (
+          <ExpandableSection key="standings">
+            <StandingsSection
+              standings={standings}
+              userTeamKey={league.team_key}
+              hex={hex}
+            />
+          </ExpandableSection>
+        )}
+        {openSection === "roster" && league.rosters && (
+          <ExpandableSection key="roster">
+            <RosterSection
+              rosters={league.rosters}
+              userTeamKey={league.team_key}
+            />
+          </ExpandableSection>
+        )}
+      </AnimatePresence>
+
+      {/* No data fallback */}
+      {!userMatchup &&
+        standings.length === 0 &&
+        (league.rosters?.length ?? 0) === 0 && (
+          <div className="px-4 pb-3">
+            <div className="h-px bg-edge/20 mb-2" />
+            <p className="text-[11px] text-fg-4 text-center">
+              Data not yet available — syncing soon
+            </p>
+          </div>
+        )}
+    </div>
+  );
+}
+
+// ── Section Toggle ───────────────────────────────────────────────
+
+function SectionToggle({
+  label,
+  isOpen,
+  onClick,
+  hex,
+}: {
+  label: string;
+  isOpen: boolean;
+  onClick: () => void;
+  hex: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        "flex items-center gap-1.5 px-2.5 py-1.5 rounded text-[10px] font-medium transition-all cursor-pointer",
+        isOpen ? "" : "text-fg-3 hover:text-fg-2",
+      )}
+      style={
+        isOpen
+          ? {
+              color: hex,
+              background: `${hex}10`,
+            }
+          : undefined
+      }
+    >
+      {label}
+      <motion.div
+        animate={{ rotate: isOpen ? 180 : 0 }}
+        transition={{ type: "spring", stiffness: 400, damping: 25 }}
+      >
+        <ChevronDown size={10} />
+      </motion.div>
+    </button>
+  );
+}
+
+// ── Expandable Wrapper ───────────────────────────────────────────
+
+function ExpandableSection({ children }: { children: React.ReactNode }) {
+  return (
+    <motion.div
+      initial={{ height: 0, opacity: 0 }}
+      animate={{ height: "auto", opacity: 1 }}
+      exit={{ height: 0, opacity: 0 }}
+      transition={{ type: "spring", stiffness: 400, damping: 30 }}
+      className="overflow-hidden"
+    >
+      <div className="px-4 pb-4">{children}</div>
+    </motion.div>
+  );
+}
+
+// ── Matchup Score Card ───────────────────────────────────────────
+
+function MatchupScoreCard({
+  matchup,
+  userTeamKey,
+  hex,
+}: {
+  matchup: Matchup;
+  userTeamKey: string | null;
+  hex: string;
+}) {
+  const userTeam = matchup.teams.find((t) => t.team_key === userTeamKey);
+  const opponentTeam = matchup.teams.find(
+    (t) => t.team_key !== userTeamKey,
+  );
+
+  if (!userTeam || !opponentTeam) return null;
+
+  const userPoints = userTeam.points ?? 0;
+  const opponentPoints = opponentTeam.points ?? 0;
+  const isWinning = userPoints > opponentPoints;
+  const isLosing = userPoints < opponentPoints;
+  const isLive = matchup.status === "midevent";
+  const isDone = matchup.status === "postevent";
+
+  return (
+    <div
+      className="rounded-lg border p-3"
+      style={{
+        background: `${hex}08`,
+        borderColor: `${hex}15`,
+      }}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[10px] font-medium text-fg-4">
+          {isLive
+            ? "Live Matchup"
+            : isDone
+              ? `Week ${matchup.week} Final`
+              : `Week ${matchup.week}`}
+        </span>
+        {isLive && (
+          <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-error/10 border border-error/20">
+            <span className="h-1 w-1 rounded-full bg-error animate-pulse" />
+            <span className="text-[9px] font-bold text-error">Live</span>
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          {userTeam.team_logo && (
+            <img
+              src={userTeam.team_logo}
+              alt=""
+              className="h-7 w-7 rounded object-cover shrink-0"
+            />
+          )}
+          <div className="min-w-0">
+            <p className="text-[12px] font-bold text-fg-2 truncate">
+              {userTeam.name}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <span
+            className={clsx(
+              "text-base font-bold font-mono tabular-nums",
+              isWinning ? "" : isLosing ? "text-fg-4" : "text-fg-2",
+            )}
+            style={isWinning ? { color: hex } : undefined}
+          >
+            {userPoints.toFixed(1)}
+          </span>
+          <span className="text-[10px] text-fg-4 font-bold">-</span>
+          <span
+            className={clsx(
+              "text-base font-bold font-mono tabular-nums",
+              isLosing ? "text-error" : isWinning ? "text-fg-4" : "text-fg-2",
+            )}
+          >
+            {opponentPoints.toFixed(1)}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 min-w-0 flex-1 justify-end text-right">
+          <div className="min-w-0">
+            <p className="text-[12px] font-bold text-fg-2 truncate">
+              {opponentTeam.name}
+            </p>
+          </div>
+          {opponentTeam.team_logo && (
+            <img
+              src={opponentTeam.team_logo}
+              alt=""
+              className="h-7 w-7 rounded object-cover shrink-0"
+            />
+          )}
+        </div>
+      </div>
+
+      {(userTeam.projected_points || opponentTeam.projected_points) &&
+        !isDone && (
+          <div className="flex justify-between mt-1.5 text-[10px] text-fg-4 font-mono">
+            <span>
+              Proj: {userTeam.projected_points?.toFixed(1) ?? "---"}
+            </span>
+            <span>
+              Proj: {opponentTeam.projected_points?.toFixed(1) ?? "---"}
+            </span>
+          </div>
+        )}
+    </div>
+  );
+}
+
+// ── Matchups Section ─────────────────────────────────────────────
+
+function MatchupsSection({
+  matchups,
+  userTeamKey,
+  hex,
+}: {
+  matchups: Matchup[];
+  userTeamKey: string | null;
+  hex: string;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[11px] font-semibold text-fg-3 mb-2">
+        All Matchups &middot; Week {matchups[0]?.week}
+      </p>
+      {matchups.map((matchup, i) => {
+        const isUserMatchup = matchup.teams.some(
+          (t) => t.team_key === userTeamKey,
+        );
+        const teamA = matchup.teams[0];
+        const teamB = matchup.teams[1];
+        if (!teamA || !teamB) return null;
+
+        return (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, x: -6 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: i * 0.03 }}
+            className={clsx(
+              "flex items-center justify-between p-2 rounded-lg border",
+              isUserMatchup
+                ? "border-edge/25"
+                : "border-edge/15 bg-base-250/15",
+            )}
+            style={
+              isUserMatchup
+                ? {
+                    borderColor: `${hex}25`,
+                    background: `${hex}06`,
+                  }
+                : undefined
+            }
+          >
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              {teamA.team_logo && (
+                <img
+                  src={teamA.team_logo}
+                  alt=""
+                  className="h-4 w-4 rounded object-cover shrink-0"
+                />
+              )}
+              <span
+                className={clsx(
+                  "text-[11px] font-bold truncate",
+                  isUserMatchup && teamA.team_key === userTeamKey
+                    ? ""
+                    : "text-fg-3",
+                )}
+                style={
+                  isUserMatchup && teamA.team_key === userTeamKey
+                    ? { color: hex }
+                    : undefined
+                }
+              >
+                {teamA.name}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 shrink-0 mx-2">
+              <span className="text-[11px] font-mono font-bold tabular-nums text-fg-2">
+                {teamA.points?.toFixed(1) ?? "--"}
+              </span>
+              <span className="text-[10px] text-fg-4">vs</span>
+              <span className="text-[11px] font-mono font-bold tabular-nums text-fg-2">
+                {teamB.points?.toFixed(1) ?? "--"}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 min-w-0 flex-1 justify-end">
+              <span
+                className={clsx(
+                  "text-[11px] font-bold truncate",
+                  isUserMatchup && teamB.team_key === userTeamKey
+                    ? ""
+                    : "text-fg-3",
+                )}
+                style={
+                  isUserMatchup && teamB.team_key === userTeamKey
+                    ? { color: hex }
+                    : undefined
+                }
+              >
+                {teamB.name}
+              </span>
+              {teamB.team_logo && (
+                <img
+                  src={teamB.team_logo}
+                  alt=""
+                  className="h-4 w-4 rounded object-cover shrink-0"
+                />
+              )}
+            </div>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Standings Section ────────────────────────────────────────────
+
+function StandingsSection({
+  standings,
+  userTeamKey,
+  hex,
+}: {
+  standings: StandingsEntry[];
+  userTeamKey: string | null;
+  hex: string;
+}) {
+  const sorted = [...standings].sort(
+    (a, b) => (a.rank ?? 99) - (b.rank ?? 99),
+  );
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[11px] font-semibold text-fg-3 mb-2">Standings</p>
+      {sorted.map((team, i) => {
+        const isUser = team.team_key === userTeamKey;
+        return (
+          <motion.div
+            key={team.team_key}
+            initial={{ opacity: 0, x: -6 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: i * 0.02 }}
+            className={clsx(
+              "flex items-center justify-between p-2 rounded-lg border",
+              isUser ? "border-edge/25" : "border-edge/15 bg-base-250/15",
+            )}
+            style={
+              isUser
+                ? { borderColor: `${hex}25`, background: `${hex}06` }
+                : undefined
+            }
+          >
+            <div className="flex items-center gap-2.5">
+              <span
+                className="text-[11px] font-mono w-4 text-right"
+                style={isUser ? { color: hex } : undefined}
+              >
+                {team.rank ?? i + 1}
+              </span>
+              {team.team_logo && (
+                <img
+                  src={team.team_logo}
+                  alt=""
+                  className="h-5 w-5 rounded object-cover"
+                />
+              )}
+              <div className="min-w-0">
+                <span
+                  className={clsx(
+                    "text-[12px] font-bold truncate block max-w-[140px]",
+                    isUser ? "" : "text-fg-2",
+                  )}
+                  style={isUser ? { color: hex } : undefined}
+                >
+                  {team.name}
+                </span>
+                {team.manager_name && (
+                  <span className="text-[10px] text-fg-4 block truncate max-w-[120px]">
+                    {team.manager_name}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-3 shrink-0">
+              {team.clinched_playoffs && (
+                <Shield size={10} className="text-success" />
+              )}
+              <span className="text-[11px] font-mono text-fg-3 tabular-nums">
+                {team.wins}-{team.losses}
+                {team.ties > 0 ? `-${team.ties}` : ""}
+              </span>
+              <span className="text-[11px] font-mono text-fg-4 tabular-nums w-16 text-right">
+                {team.points_for} PF
+              </span>
+            </div>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Roster Section ───────────────────────────────────────────────
+
+function RosterSection({
+  rosters,
+  userTeamKey,
+}: {
+  rosters: RosterEntry[];
+  userTeamKey: string | null;
+}) {
+  const [selectedTeam, setSelectedTeam] = useState<string>(
+    userTeamKey ?? rosters[0]?.team_key ?? "",
+  );
+
+  const currentRoster = rosters.find((r) => r.team_key === selectedTeam);
+  const players = currentRoster?.data?.players ?? [];
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-[11px] font-semibold text-fg-3">Roster</p>
+        {rosters.length > 1 && (
+          <select
+            value={selectedTeam}
+            onChange={(e) => setSelectedTeam(e.target.value)}
+            className="text-[11px] bg-base-200 border border-edge/30 rounded-lg px-2 py-1 text-fg-2 focus:outline-none cursor-pointer"
+          >
+            {rosters.map((r) => (
+              <option key={r.team_key} value={r.team_key}>
+                {r.data?.team_name || r.team_key}
+                {r.team_key === userTeamKey ? " (You)" : ""}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div className="space-y-0.5">
+        {players.map((player) => {
+          const hasInjury = !!player.status;
+          const injuryColor =
+            INJURY_COLORS[player.status ?? ""] ?? "#a3a3a3";
+
+          return (
+            <div
+              key={player.player_key}
+              className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-base-250/30 transition-colors"
+            >
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                <span className="text-[10px] font-mono text-fg-4 w-6 text-center shrink-0">
+                  {player.selected_position}
+                </span>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[12px] font-bold text-fg-2 truncate max-w-[120px]">
+                      {player.name.full || player.name.last}
+                    </span>
+                    {hasInjury && (
+                      <span
+                        className="text-[9px] font-bold px-1 rounded"
+                        style={{
+                          color: injuryColor,
+                          background: `${injuryColor}15`,
+                        }}
+                      >
+                        {player.status}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-[10px] text-fg-4">
+                    {player.editorial_team_abbr}
+                    {player.display_position
+                      ? ` - ${player.display_position}`
+                      : ""}
+                    {hasInjury && player.injury_note
+                      ? ` \u00b7 ${player.injury_note}`
+                      : ""}
+                  </span>
+                </div>
+              </div>
+              {player.player_points !== null &&
+                player.player_points !== undefined && (
+                  <span className="text-[11px] font-mono font-bold tabular-nums text-fg-3 shrink-0">
+                    {player.player_points.toFixed(1)}
+                  </span>
+                )}
+            </div>
+          );
+        })}
+
+        {players.length === 0 && (
+          <p className="text-[11px] text-fg-4 text-center py-3">
+            No roster data available
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/channels/FinanceConfigPanel.tsx
+++ b/desktop/src/channels/FinanceConfigPanel.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState, useCallback } from "react";
+import { TrendingUp } from "lucide-react";
+import { Section, DisplayRow } from "../components/settings/SettingsControls";
+import { CatalogBrowser } from "../components/settings/CatalogBrowser";
+import { SelectedItems } from "../components/settings/SelectedItems";
+import { fetch } from "@tauri-apps/plugin-http";
+import { channelsApi, API_BASE } from "../api/client";
+import type { Channel } from "../api/client";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface TrackedSymbol {
+  symbol: string;
+  name: string;
+  category: string;
+}
+
+interface FinanceChannelConfig {
+  symbols?: string[];
+}
+
+interface FinanceConfigPanelProps {
+  channel: Channel;
+  getToken: () => Promise<string | null>;
+  onChannelUpdate: (updated: Channel) => void;
+  subscriptionTier: string;
+  connected: boolean;
+  hex: string;
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export default function FinanceConfigPanel({
+  channel,
+  getToken,
+  onChannelUpdate,
+  subscriptionTier,
+  connected,
+  hex,
+}: FinanceConfigPanelProps) {
+  const isUnlimited = subscriptionTier === "uplink_unlimited";
+  const isUplink = subscriptionTier === "uplink" || isUnlimited;
+
+  const [catalog, setCatalog] = useState<TrackedSymbol[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [catalogError, setCatalogError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const config = channel.config as FinanceChannelConfig;
+  const symbols = Array.isArray(config?.symbols) ? config.symbols : [];
+  const symbolSet = new Set(symbols);
+
+  // Auto-dismiss errors
+  useEffect(() => {
+    if (!error) return;
+    const t = setTimeout(() => setError(null), 4000);
+    return () => clearTimeout(t);
+  }, [error]);
+
+  // Fetch catalog
+  useEffect(() => {
+    fetch(`${API_BASE}/finance/symbols`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed");
+        return r.json() as Promise<TrackedSymbol[]>;
+      })
+      .then(setCatalog)
+      .catch(() => setCatalogError(true))
+      .finally(() => setCatalogLoading(false));
+  }, []);
+
+  const nameMap = new Map(catalog.map((s) => [s.symbol, s.name]));
+
+  const updateSymbols = useCallback(
+    async (next: string[]) => {
+      setSaving(true);
+      try {
+        const updated = await channelsApi.update(
+          "finance",
+          { config: { symbols: next } },
+          getToken,
+        );
+        onChannelUpdate(updated);
+      } catch {
+        setError("Failed to save symbol changes");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [getToken, onChannelUpdate],
+  );
+
+  const addSymbol = useCallback(
+    (sym: string) => {
+      if (symbolSet.has(sym)) return;
+      updateSymbols([...symbols, sym]);
+    },
+    [symbols, symbolSet, updateSymbols],
+  );
+
+  const removeSymbol = useCallback(
+    (sym: string) => {
+      updateSymbols(symbols.filter((s) => s !== sym));
+    },
+    [symbols, updateSymbols],
+  );
+
+  const delivery = isUnlimited
+    ? "Real-time SSE"
+    : isUplink
+      ? "Poll 30s"
+      : "Poll 60s";
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6 px-3">
+        <div
+          className="w-8 h-8 rounded-lg flex items-center justify-center"
+          style={{
+            background: `${hex}15`,
+            boxShadow: `0 0 15px ${hex}15, 0 0 0 1px ${hex}20`,
+          }}
+        >
+          <TrendingUp size={16} style={{ color: hex }} />
+        </div>
+        <div>
+          <h2 className="text-sm font-bold text-fg">Finance</h2>
+          <p className="text-[11px] text-fg-4">
+            Real-time market data via TwelveData
+          </p>
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="mx-3 mb-4 flex items-center justify-between px-3 py-2 rounded-lg bg-error/10 border border-error/20 text-error text-[12px]">
+          <span>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            className="p-0.5 hover:bg-error/10 rounded cursor-pointer"
+          >
+            <TrendingUp size={12} />
+          </button>
+        </div>
+      )}
+
+      {/* Status */}
+      <Section title="Status">
+        <DisplayRow label="Your Symbols" value={String(symbols.length)} />
+        <DisplayRow label="Available" value={String(catalog.length)} />
+        <DisplayRow label="Delivery" value={delivery} />
+        <DisplayRow
+          label="Connection"
+          value={isUnlimited ? (connected ? "Live" : "Offline") : "Polling"}
+        />
+      </Section>
+
+      {/* Selected symbols */}
+      <SelectedItems
+        title={`Your Symbols`}
+        items={symbols}
+        getKey={(s) => s}
+        renderChip={(sym) => (
+          <div className="min-w-0">
+            <span className="text-[12px] font-bold font-mono text-fg-2">
+              {sym}
+            </span>
+            {nameMap.has(sym) && (
+              <span className="text-[11px] text-fg-4 ml-1.5">
+                {nameMap.get(sym)}
+              </span>
+            )}
+          </div>
+        )}
+        onRemove={removeSymbol}
+        onClearAll={() => updateSymbols([])}
+        hex={hex}
+        emptyIcon={<TrendingUp size={24} />}
+        emptyMessage="No symbols selected — browse the catalog below"
+        saving={saving}
+      />
+
+      {/* Catalog browser */}
+      <CatalogBrowser
+        title="Symbol Catalog"
+        items={catalog}
+        getKey={(s) => s.symbol}
+        selectedKeys={symbolSet}
+        getCategory={(s) => s.category}
+        matchesSearch={(s, q) => {
+          const lower = q.toLowerCase();
+          return (
+            s.symbol.toLowerCase().includes(lower) ||
+            s.name.toLowerCase().includes(lower)
+          );
+        }}
+        renderItem={(item, isAdded) => (
+          <>
+            <div className="min-w-0 mr-2">
+              <div className="text-[12px] font-bold font-mono text-fg-2">
+                {item.symbol}
+              </div>
+              <div className="text-[11px] text-fg-4 truncate">{item.name}</div>
+            </div>
+            <span
+              className="text-[10px] font-medium shrink-0"
+              style={isAdded ? { color: hex } : undefined}
+            >
+              {isAdded ? "Added" : "+ Add"}
+            </span>
+          </>
+        )}
+        hex={hex}
+        searchPlaceholder="Search by ticker or company name..."
+        saving={saving}
+        loading={catalogLoading}
+        error={catalogError}
+        onAdd={addSymbol}
+        onRemove={removeSymbol}
+        onBulkAdd={(keys) => updateSymbols([...symbols, ...keys])}
+        onBulkRemove={(keys) => {
+          const toRemove = new Set(keys);
+          updateSymbols(symbols.filter((s) => !toRemove.has(s)));
+        }}
+      />
+    </div>
+  );
+}

--- a/desktop/src/channels/RssConfigPanel.tsx
+++ b/desktop/src/channels/RssConfigPanel.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useState, useCallback } from "react";
+import { Plus, Rss, Trash2 } from "lucide-react";
+import { motion } from "motion/react";
+import { Section, DisplayRow } from "../components/settings/SettingsControls";
+import { CatalogBrowser } from "../components/settings/CatalogBrowser";
+import { channelsApi, rssApi } from "../api/client";
+import type { Channel, TrackedFeed, RssChannelConfig } from "../api/client";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface RssConfigPanelProps {
+  channel: Channel;
+  getToken: () => Promise<string | null>;
+  onChannelUpdate: (updated: Channel) => void;
+  hex: string;
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export default function RssConfigPanel({
+  channel,
+  getToken,
+  onChannelUpdate,
+  hex,
+}: RssConfigPanelProps) {
+  const [catalog, setCatalog] = useState<TrackedFeed[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [catalogError, setCatalogError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [newFeedName, setNewFeedName] = useState("");
+  const [newFeedUrl, setNewFeedUrl] = useState("");
+  const [urlError, setUrlError] = useState<string | null>(null);
+
+  const rssConfig = channel.config as RssChannelConfig;
+  const feeds = Array.isArray(rssConfig?.feeds) ? rssConfig.feeds : [];
+  const feedUrlSet = new Set(feeds.map((f) => f.url));
+
+  useEffect(() => {
+    if (!error) return;
+    const t = setTimeout(() => setError(null), 4000);
+    return () => clearTimeout(t);
+  }, [error]);
+
+  useEffect(() => {
+    rssApi
+      .getCatalog()
+      .then(setCatalog)
+      .catch(() => setCatalogError(true))
+      .finally(() => setCatalogLoading(false));
+  }, []);
+
+  const updateFeeds = useCallback(
+    async (next: Array<{ name: string; url: string }>) => {
+      setSaving(true);
+      try {
+        const updated = await channelsApi.update(
+          "rss",
+          { config: { feeds: next } },
+          getToken,
+        );
+        onChannelUpdate(updated);
+      } catch {
+        setError("Failed to save feed changes");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [getToken, onChannelUpdate],
+  );
+
+  const addCatalogFeed = useCallback(
+    (url: string) => {
+      const feed = catalog.find((f) => f.url === url);
+      if (!feed || feedUrlSet.has(url)) return;
+      updateFeeds([...feeds, { name: feed.name, url: feed.url }]);
+    },
+    [catalog, feeds, feedUrlSet, updateFeeds],
+  );
+
+  const removeFeed = useCallback(
+    (url: string) => {
+      updateFeeds(feeds.filter((f) => f.url !== url));
+    },
+    [feeds, updateFeeds],
+  );
+
+  const deleteCatalogFeed = useCallback(
+    async (feed: TrackedFeed) => {
+      if (feed.is_default) return;
+      try {
+        await rssApi.deleteFeed(feed.url, getToken);
+        setCatalog((prev) => prev.filter((f) => f.url !== feed.url));
+        if (feedUrlSet.has(feed.url)) {
+          updateFeeds(feeds.filter((f) => f.url !== feed.url));
+        }
+      } catch {
+        setError("Failed to delete feed from catalog");
+      }
+    },
+    [getToken, feedUrlSet, feeds, updateFeeds],
+  );
+
+  const addCustomFeed = useCallback(() => {
+    const name = newFeedName.trim();
+    const url = newFeedUrl.trim();
+    if (!name || !url) return;
+    if (!/^https?:\/\/.+/.test(url)) {
+      setUrlError("URL must start with http:// or https://");
+      return;
+    }
+    setUrlError(null);
+    if (feedUrlSet.has(url)) return;
+    updateFeeds([...feeds, { name, url }]);
+    setNewFeedName("");
+    setNewFeedUrl("");
+  }, [newFeedName, newFeedUrl, feeds, feedUrlSet, updateFeeds]);
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6 px-3">
+        <div
+          className="w-8 h-8 rounded-lg flex items-center justify-center"
+          style={{
+            background: `${hex}15`,
+            boxShadow: `0 0 15px ${hex}15, 0 0 0 1px ${hex}20`,
+          }}
+        >
+          <Rss size={16} style={{ color: hex }} />
+        </div>
+        <div>
+          <h2 className="text-sm font-bold text-fg">RSS Feeds</h2>
+          <p className="text-[11px] text-fg-4">
+            Custom news feeds on your ticker
+          </p>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="mx-3 mb-4 flex items-center justify-between px-3 py-2 rounded-lg bg-error/10 border border-error/20 text-error text-[12px]">
+          <span>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            className="p-0.5 hover:bg-error/10 rounded cursor-pointer"
+          >
+            <Rss size={12} />
+          </button>
+        </div>
+      )}
+
+      {/* Status */}
+      <Section title="Status">
+        <DisplayRow label="Your Feeds" value={String(feeds.length)} />
+        <DisplayRow label="Catalog Size" value={String(catalog.length)} />
+        <DisplayRow label="Poll Interval" value="5 min" />
+      </Section>
+
+      {/* Your feeds */}
+      <Section title="Your Feeds">
+        <div className="px-3 space-y-1.5">
+          {feeds.length > 0 ? (
+            feeds.map((feed, i) => (
+              <motion.div
+                key={feed.url}
+                initial={{ opacity: 0, x: -8 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: i * 0.02 }}
+                className="flex items-center justify-between p-2.5 rounded-lg bg-base-250/30 border border-edge/20 group"
+              >
+                <div className="flex items-center gap-2.5 min-w-0">
+                  <div
+                    className="w-7 h-7 rounded-md flex items-center justify-center shrink-0"
+                    style={{
+                      background: `${hex}15`,
+                      boxShadow: `0 0 0 1px ${hex}20`,
+                    }}
+                  >
+                    <Rss size={11} style={{ color: hex }} />
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-[12px] font-bold text-fg-2 truncate">
+                      {feed.name}
+                    </div>
+                    <div className="text-[11px] text-fg-4 font-mono truncate max-w-[280px]">
+                      {feed.url}
+                    </div>
+                  </div>
+                </div>
+                <button
+                  onClick={() => removeFeed(feed.url)}
+                  disabled={saving}
+                  className="p-1.5 rounded-md hover:bg-error/10 text-fg-4 hover:text-error transition-colors shrink-0 opacity-0 group-hover:opacity-100 disabled:opacity-30 cursor-pointer"
+                >
+                  <Trash2 size={13} />
+                </button>
+              </motion.div>
+            ))
+          ) : (
+            <div className="text-center py-5">
+              <Rss size={24} className="mx-auto text-fg-4/40 mb-2" />
+              <p className="text-[11px] text-fg-4">
+                No feeds yet — browse the catalog or add a custom feed
+              </p>
+            </div>
+          )}
+        </div>
+      </Section>
+
+      {/* Add custom feed */}
+      <Section title="Add Custom Feed">
+        <div className="px-3 space-y-2">
+          <div className="flex flex-col sm:flex-row gap-2">
+            <input
+              type="text"
+              value={newFeedName}
+              onChange={(e) => setNewFeedName(e.target.value)}
+              placeholder="Feed name"
+              className="flex-1 px-3 py-2 rounded-lg bg-base-200 border border-edge/30 text-[12px] font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/40 transition-colors"
+            />
+            <input
+              type="url"
+              value={newFeedUrl}
+              onChange={(e) => setNewFeedUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") addCustomFeed();
+              }}
+              placeholder="https://example.com/feed.xml"
+              className="flex-[2] px-3 py-2 rounded-lg bg-base-200 border border-edge/30 text-[12px] font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/40 transition-colors"
+            />
+            <button
+              onClick={addCustomFeed}
+              disabled={saving || !newFeedName.trim() || !newFeedUrl.trim()}
+              className="px-3 py-2 rounded-lg bg-base-250 border border-edge/30 text-fg-3 hover:text-accent hover:border-accent/30 transition-colors flex items-center gap-1.5 disabled:opacity-30 cursor-pointer"
+            >
+              <Plus size={13} />
+              <span className="text-[11px] font-medium">Add</span>
+            </button>
+          </div>
+          {urlError && (
+            <p className="text-[11px] text-error/70">{urlError}</p>
+          )}
+        </div>
+      </Section>
+
+      {/* Catalog browser */}
+      <CatalogBrowser
+        title="Feed Catalog"
+        items={catalog}
+        getKey={(f) => f.url}
+        selectedKeys={feedUrlSet}
+        getCategory={(f) => f.category}
+        matchesSearch={(f, q) => {
+          const lower = q.toLowerCase();
+          return (
+            f.name.toLowerCase().includes(lower) ||
+            f.url.toLowerCase().includes(lower)
+          );
+        }}
+        renderItem={(item, isAdded) => (
+          <>
+            <div className="min-w-0 mr-2">
+              <div className="text-[12px] font-bold text-fg-2 truncate">
+                {item.name}
+              </div>
+              <div className="text-[10px] text-fg-4">
+                {item.category}
+                {!item.is_default && (
+                  <span className="ml-1 text-fg-4/50">(custom)</span>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              <span
+                className="text-[10px] font-medium"
+                style={isAdded ? { color: hex } : undefined}
+              >
+                {isAdded ? "Added" : "+ Add"}
+              </span>
+              {!item.is_default && !isAdded && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    deleteCatalogFeed(item);
+                  }}
+                  title="Remove custom feed from catalog"
+                  className="p-0.5 rounded hover:bg-error/10 text-fg-4 hover:text-error transition-colors cursor-pointer"
+                >
+                  <Trash2 size={11} />
+                </button>
+              )}
+            </div>
+          </>
+        )}
+        hex={hex}
+        searchPlaceholder="Search by feed name or URL..."
+        saving={saving}
+        loading={catalogLoading}
+        error={catalogError}
+        onAdd={addCatalogFeed}
+        onRemove={removeFeed}
+      />
+    </div>
+  );
+}

--- a/desktop/src/channels/SportsConfigPanel.tsx
+++ b/desktop/src/channels/SportsConfigPanel.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useState, useCallback } from "react";
+import { Trophy } from "lucide-react";
+import { Section, DisplayRow } from "../components/settings/SettingsControls";
+import { CatalogBrowser } from "../components/settings/CatalogBrowser";
+import { SelectedItems } from "../components/settings/SelectedItems";
+import { fetch } from "@tauri-apps/plugin-http";
+import { channelsApi, API_BASE } from "../api/client";
+import type { Channel } from "../api/client";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface TrackedLeague {
+  name: string;
+  sport_api: string;
+  category: string;
+  country: string;
+  logo_url: string;
+  game_count: number;
+  live_count: number;
+  next_game: string | null;
+}
+
+interface SportsChannelConfig {
+  leagues?: string[];
+}
+
+interface SportsConfigPanelProps {
+  channel: Channel;
+  getToken: () => Promise<string | null>;
+  onChannelUpdate: (updated: Channel) => void;
+  subscriptionTier: string;
+  connected: boolean;
+  hex: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function formatNextGame(dateStr: string | null): string | null {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  const diff = d.getTime() - Date.now();
+  if (diff <= 0) return "Starting";
+  const h = Math.floor(diff / 3_600_000);
+  if (h < 24) {
+    const m = Math.floor((diff % 3_600_000) / 60_000);
+    return h > 0 ? `in ${h}h ${m}m` : `in ${m}m`;
+  }
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export default function SportsConfigPanel({
+  channel,
+  getToken,
+  onChannelUpdate,
+  subscriptionTier,
+  connected,
+  hex,
+}: SportsConfigPanelProps) {
+  const isUnlimited = subscriptionTier === "uplink_unlimited";
+  const isUplink = subscriptionTier === "uplink" || isUnlimited;
+
+  const [catalog, setCatalog] = useState<TrackedLeague[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [catalogError, setCatalogError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const config = channel.config as SportsChannelConfig;
+  const leagues = Array.isArray(config?.leagues) ? config.leagues : [];
+  const leagueSet = new Set(leagues);
+
+  useEffect(() => {
+    if (!error) return;
+    const t = setTimeout(() => setError(null), 4000);
+    return () => clearTimeout(t);
+  }, [error]);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/sports/leagues`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed");
+        return r.json() as Promise<TrackedLeague[]>;
+      })
+      .then(setCatalog)
+      .catch(() => setCatalogError(true))
+      .finally(() => setCatalogLoading(false));
+  }, []);
+
+  // Sort catalog: live first, then by game count, then alpha
+  const sortedCatalog = [...catalog].sort((a, b) => {
+    if (a.live_count !== b.live_count) return b.live_count - a.live_count;
+    if (a.game_count !== b.game_count) return b.game_count - a.game_count;
+    return a.name.localeCompare(b.name);
+  });
+
+  const updateLeagues = useCallback(
+    async (next: string[]) => {
+      setSaving(true);
+      try {
+        const updated = await channelsApi.update(
+          "sports",
+          { config: { leagues: next } },
+          getToken,
+        );
+        onChannelUpdate(updated);
+      } catch {
+        setError("Failed to save league changes");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [getToken, onChannelUpdate],
+  );
+
+  const addLeague = useCallback(
+    (name: string) => {
+      if (leagueSet.has(name)) return;
+      updateLeagues([...leagues, name]);
+    },
+    [leagues, leagueSet, updateLeagues],
+  );
+
+  const removeLeague = useCallback(
+    (name: string) => {
+      updateLeagues(leagues.filter((l) => l !== name));
+    },
+    [leagues, updateLeagues],
+  );
+
+  const delivery = isUnlimited
+    ? "Real-time SSE"
+    : isUplink
+      ? "Poll 30s"
+      : "Poll 60s";
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6 px-3">
+        <div
+          className="w-8 h-8 rounded-lg flex items-center justify-center"
+          style={{
+            background: `${hex}15`,
+            boxShadow: `0 0 15px ${hex}15, 0 0 0 1px ${hex}20`,
+          }}
+        >
+          <Trophy size={16} style={{ color: hex }} />
+        </div>
+        <div>
+          <h2 className="text-sm font-bold text-fg">Sports</h2>
+          <p className="text-[11px] text-fg-4">
+            Live scores via api-sports.io
+          </p>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="mx-3 mb-4 flex items-center justify-between px-3 py-2 rounded-lg bg-error/10 border border-error/20 text-error text-[12px]">
+          <span>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            className="p-0.5 hover:bg-error/10 rounded cursor-pointer"
+          >
+            <Trophy size={12} />
+          </button>
+        </div>
+      )}
+
+      {/* Status */}
+      <Section title="Status">
+        <DisplayRow label="Your Leagues" value={String(leagues.length)} />
+        <DisplayRow label="Available" value={String(catalog.length)} />
+        <DisplayRow label="Delivery" value={delivery} />
+        <DisplayRow
+          label="Connection"
+          value={isUnlimited ? (connected ? "Live" : "Offline") : "Polling"}
+        />
+      </Section>
+
+      {/* Selected leagues */}
+      <SelectedItems
+        title="Your Leagues"
+        items={leagues.map((name) => ({
+          name,
+          entry: catalog.find((l) => l.name === name),
+        }))}
+        getKey={(item) => item.name}
+        renderChip={(item) => (
+          <div className="flex items-center gap-2 min-w-0">
+            {item.entry?.logo_url && (
+              <img
+                src={item.entry.logo_url}
+                alt=""
+                className="w-4 h-4 object-contain shrink-0"
+              />
+            )}
+            <span className="text-[12px] font-bold text-fg-2">
+              {item.name}
+            </span>
+            {item.entry && item.entry.live_count > 0 && (
+              <span className="text-[10px] text-live font-bold flex items-center gap-0.5">
+                <span className="inline-block w-1 h-1 rounded-full bg-live animate-pulse" />
+                {item.entry.live_count} Live
+              </span>
+            )}
+            {item.entry &&
+              item.entry.live_count === 0 &&
+              item.entry.game_count === 0 && (
+                <span className="text-[10px] text-fg-4">Off-season</span>
+              )}
+          </div>
+        )}
+        onRemove={removeLeague}
+        onClearAll={() => updateLeagues([])}
+        hex={hex}
+        emptyIcon={<Trophy size={24} />}
+        emptyMessage="No leagues selected — browse the catalog below"
+        saving={saving}
+      />
+
+      {/* Catalog */}
+      <CatalogBrowser
+        title="League Catalog"
+        items={sortedCatalog}
+        getKey={(l) => l.name}
+        selectedKeys={leagueSet}
+        getCategory={(l) => l.category}
+        matchesSearch={(l, q) => {
+          const lower = q.toLowerCase();
+          return (
+            l.name.toLowerCase().includes(lower) ||
+            l.category.toLowerCase().includes(lower)
+          );
+        }}
+        renderItem={(item, isAdded) => (
+          <>
+            <div className="flex items-center gap-2 min-w-0 mr-2">
+              {item.logo_url && (
+                <img
+                  src={item.logo_url}
+                  alt=""
+                  className="w-5 h-5 object-contain shrink-0"
+                />
+              )}
+              <div className="min-w-0">
+                <div className="text-[12px] font-bold text-fg-2">
+                  {item.name}
+                </div>
+                <div className="flex items-center gap-1.5 text-[10px] text-fg-4 truncate">
+                  <span>{item.country}</span>
+                  {item.live_count > 0 && (
+                    <span className="flex items-center gap-0.5 text-live font-bold">
+                      <span className="w-1 h-1 rounded-full bg-live animate-pulse" />
+                      {item.live_count} Live
+                    </span>
+                  )}
+                  {item.live_count === 0 && item.game_count > 0 && (
+                    <span>{item.game_count} games</span>
+                  )}
+                  {item.game_count === 0 && (
+                    <span className="text-fg-4/60">
+                      {formatNextGame(item.next_game)
+                        ? `Next: ${formatNextGame(item.next_game)}`
+                        : "Off-season"}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+            <span
+              className="text-[10px] font-medium shrink-0"
+              style={isAdded ? { color: hex } : undefined}
+            >
+              {isAdded ? "Added" : "+ Add"}
+            </span>
+          </>
+        )}
+        hex={hex}
+        searchPlaceholder="Search by league name..."
+        saving={saving}
+        loading={catalogLoading}
+        error={catalogError}
+        onAdd={addLeague}
+        onRemove={removeLeague}
+        onBulkAdd={(keys) => updateLeagues([...leagues, ...keys])}
+        onBulkRemove={(keys) => {
+          const toRemove = new Set(keys);
+          updateLeagues(leagues.filter((l) => !toRemove.has(l)));
+        }}
+      />
+    </div>
+  );
+}

--- a/desktop/src/components/SettingsPanel.tsx
+++ b/desktop/src/components/SettingsPanel.tsx
@@ -55,7 +55,7 @@ export default function SettingsPanel({
   };
 
   return (
-    <div className="dashboard-content w-full max-w-2xl mx-auto relative">
+    <div className="w-full max-w-2xl mx-auto relative">
       <AnimatePresence mode="wait">
         <motion.div
           key={activeTab}

--- a/desktop/src/components/settings/CatalogBrowser.tsx
+++ b/desktop/src/components/settings/CatalogBrowser.tsx
@@ -1,0 +1,276 @@
+import { useState } from "react";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+import { motion } from "motion/react";
+import { clsx } from "clsx";
+import { Section } from "./SettingsControls";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface CatalogBrowserProps<T> {
+  /** Section heading */
+  title: string;
+  /** Catalog items to browse */
+  items: T[];
+  /** Unique key extractor */
+  getKey: (item: T) => string;
+  /** Set of selected item keys */
+  selectedKeys: Set<string>;
+  /** Category extractor — return the category string for an item */
+  getCategory: (item: T) => string;
+  /** Whether item matches a search query */
+  matchesSearch: (item: T, query: string) => boolean;
+  /** Render a single catalog grid item */
+  renderItem: (item: T, isAdded: boolean) => React.ReactNode;
+  /** Channel accent hex */
+  hex: string;
+  /** Search input placeholder */
+  searchPlaceholder?: string;
+  /** Items per page */
+  pageSize?: number;
+  /** Whether save is in progress */
+  saving?: boolean;
+  /** Loading state */
+  loading?: boolean;
+  /** Error state */
+  error?: boolean;
+  /** Callbacks */
+  onAdd: (key: string) => void;
+  onRemove: (key: string) => void;
+  onBulkAdd?: (keys: string[]) => void;
+  onBulkRemove?: (keys: string[]) => void;
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export function CatalogBrowser<T>({
+  title,
+  items,
+  getKey,
+  selectedKeys,
+  getCategory,
+  matchesSearch,
+  renderItem,
+  hex,
+  searchPlaceholder = "Search...",
+  pageSize = 24,
+  saving = false,
+  loading = false,
+  error = false,
+  onAdd,
+  onRemove,
+  onBulkAdd,
+  onBulkRemove,
+}: CatalogBrowserProps<T>) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeCategory, setActiveCategory] = useState("All");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Derive categories
+  const categories = [
+    "All",
+    ...Array.from(new Set(items.map(getCategory))).sort(),
+  ];
+
+  // Filter
+  const filtered = items.filter((item) => {
+    const matchesCat =
+      activeCategory === "All" || getCategory(item) === activeCategory;
+    const matchesQ = !searchQuery || matchesSearch(item, searchQuery);
+    return matchesCat && matchesQ;
+  });
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const paginated = filtered.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize,
+  );
+
+  // Bulk counts for active category
+  const catItems = items
+    .filter((i) => activeCategory === "All" || getCategory(i) === activeCategory)
+    .map(getKey);
+  const catAdded = catItems.filter((k) => selectedKeys.has(k)).length;
+  const catAvailable = catItems.length - catAdded;
+
+  return (
+    <Section title={title}>
+      <div className="space-y-3 px-3">
+        {/* Search */}
+        <div className="relative">
+          <Search
+            size={14}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-fg-4"
+          />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setCurrentPage(1);
+            }}
+            placeholder={searchPlaceholder}
+            className="w-full pl-9 pr-3 py-2 rounded-lg bg-base-200 border border-edge/30 text-[12px] font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/40 transition-colors"
+          />
+        </div>
+
+        {/* Category tabs */}
+        {categories.length > 2 && (
+          <div className="flex flex-wrap gap-0.5 p-0.5 rounded-lg bg-base-200 border border-edge/30">
+            {categories.map((cat) => {
+              const isActive = activeCategory === cat;
+              const catTotal = items.filter(
+                (i) => cat === "All" || getCategory(i) === cat,
+              ).length;
+              const catSelected = items.filter(
+                (i) =>
+                  (cat === "All" || getCategory(i) === cat) &&
+                  selectedKeys.has(getKey(i)),
+              ).length;
+              return (
+                <button
+                  key={cat}
+                  onClick={() => {
+                    setActiveCategory(cat);
+                    setCurrentPage(1);
+                  }}
+                  className={clsx(
+                    "relative px-2.5 py-1.5 rounded-md text-[11px] font-medium transition-colors cursor-pointer",
+                    isActive
+                      ? "bg-base-300 text-fg shadow-sm"
+                      : "text-fg-3 hover:text-fg-2",
+                  )}
+                >
+                  {cat}
+                  <span className="ml-1 text-[10px] opacity-50">
+                    {catSelected}/{catTotal}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Bulk actions */}
+        {(onBulkAdd || onBulkRemove) && (catAvailable > 0 || catAdded > 0) && (
+          <div className="flex items-center gap-2">
+            {onBulkAdd && catAvailable > 0 && (
+              <button
+                onClick={() => {
+                  const toAdd = catItems.filter((k) => !selectedKeys.has(k));
+                  onBulkAdd(toAdd);
+                }}
+                disabled={saving}
+                className="text-[11px] font-medium text-fg-3 hover:text-accent px-2 py-1 rounded-md hover:bg-base-250/50 transition-colors disabled:opacity-30 cursor-pointer"
+              >
+                + Add all ({catAvailable})
+              </button>
+            )}
+            {onBulkRemove && catAdded > 0 && (
+              <button
+                onClick={() => {
+                  const toRemove = catItems.filter((k) => selectedKeys.has(k));
+                  onBulkRemove(toRemove);
+                }}
+                disabled={saving}
+                className="text-[11px] font-medium text-fg-3 hover:text-error px-2 py-1 rounded-md hover:bg-base-250/50 transition-colors disabled:opacity-30 cursor-pointer"
+              >
+                Remove all ({catAdded})
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Loading */}
+        {loading && (
+          <div className="text-center py-8">
+            <motion.span
+              animate={{ opacity: [0.3, 0.7, 0.3] }}
+              transition={{ duration: 1.5, repeat: Infinity }}
+              className="text-[11px] font-mono text-fg-4"
+            >
+              Loading catalog...
+            </motion.span>
+          </div>
+        )}
+
+        {/* Error */}
+        {!loading && error && items.length === 0 && (
+          <p className="text-center text-[11px] text-error/60 py-4">
+            Failed to load catalog
+          </p>
+        )}
+
+        {/* Grid */}
+        {!loading && (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-1.5">
+              {paginated.map((item) => {
+                const key = getKey(item);
+                const isAdded = selectedKeys.has(key);
+                return (
+                  <motion.div
+                    key={key}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                  >
+                    <button
+                      type="button"
+                      onClick={() =>
+                        isAdded ? onRemove(key) : onAdd(key)
+                      }
+                      disabled={saving}
+                      className={clsx(
+                        "w-full flex items-center justify-between p-2.5 rounded-lg border transition-colors text-left cursor-pointer disabled:opacity-30",
+                        isAdded
+                          ? "border-accent/25 bg-accent/5"
+                          : "bg-base-250/30 border-edge/20 hover:border-edge/40 hover:bg-base-250/50",
+                      )}
+                    >
+                      {renderItem(item, isAdded)}
+                    </button>
+                  </motion.div>
+                );
+              })}
+            </div>
+
+            {/* Empty filtered */}
+            {!error && filtered.length === 0 && (
+              <p className="text-center text-[11px] text-fg-4 py-4">
+                {searchQuery
+                  ? "No results match your search"
+                  : "No items in this category"}
+              </p>
+            )}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between pt-1">
+                <button
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium text-fg-3 hover:text-fg-2 hover:bg-base-250/50 transition-colors disabled:opacity-20 disabled:pointer-events-none cursor-pointer"
+                >
+                  <ChevronLeft size={12} />
+                  Prev
+                </button>
+                <span className="text-[11px] font-mono text-fg-4">
+                  {currentPage} / {totalPages}
+                </span>
+                <button
+                  onClick={() =>
+                    setCurrentPage((p) => Math.min(totalPages, p + 1))
+                  }
+                  disabled={currentPage === totalPages}
+                  className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium text-fg-3 hover:text-fg-2 hover:bg-base-250/50 transition-colors disabled:opacity-20 disabled:pointer-events-none cursor-pointer"
+                >
+                  Next
+                  <ChevronRight size={12} />
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Section>
+  );
+}

--- a/desktop/src/components/settings/SelectedItems.tsx
+++ b/desktop/src/components/settings/SelectedItems.tsx
@@ -1,0 +1,105 @@
+import { motion } from "motion/react";
+import { X } from "lucide-react";
+import { Section } from "./SettingsControls";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface SelectedItemsProps<T> {
+  /** Section heading */
+  title: string;
+  /** Selected items */
+  items: T[];
+  /** Unique key extractor */
+  getKey: (item: T) => string;
+  /** Render a single chip's content (label area only — remove button is handled) */
+  renderChip: (item: T) => React.ReactNode;
+  /** Remove an item by key */
+  onRemove: (key: string) => void;
+  /** Clear all items */
+  onClearAll?: () => void;
+  /** Channel accent hex */
+  hex: string;
+  /** Icon shown in empty state */
+  emptyIcon?: React.ReactNode;
+  /** Message shown in empty state */
+  emptyMessage?: string;
+  /** Whether save is in progress */
+  saving?: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export function SelectedItems<T>({
+  title,
+  items,
+  getKey,
+  renderChip,
+  onRemove,
+  onClearAll,
+  hex,
+  emptyIcon,
+  emptyMessage = "No items selected",
+  saving = false,
+}: SelectedItemsProps<T>) {
+  return (
+    <Section title={title}>
+      <div className="px-3 space-y-2">
+        {/* Header row with count + clear */}
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] text-fg-3">
+            {items.length} selected
+          </span>
+          {items.length > 0 && onClearAll && (
+            <button
+              onClick={onClearAll}
+              disabled={saving}
+              className="text-[11px] font-medium text-fg-4 hover:text-error px-2 py-0.5 rounded-md hover:bg-base-250/50 transition-colors disabled:opacity-30 cursor-pointer"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+
+        {/* Chips */}
+        {items.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {items.map((item, i) => {
+              const key = getKey(item);
+              return (
+                <motion.div
+                  key={key}
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ delay: i * 0.015 }}
+                  className="flex items-center gap-1.5 pl-2.5 pr-1 py-1.5 rounded-lg border transition-colors group"
+                  style={{
+                    background: `${hex}0D`,
+                    borderColor: `${hex}25`,
+                  }}
+                >
+                  {renderChip(item)}
+                  <button
+                    onClick={() => onRemove(key)}
+                    disabled={saving}
+                    className="p-0.5 rounded hover:bg-error/10 text-fg-4 hover:text-error transition-colors shrink-0 opacity-0 group-hover:opacity-100 disabled:opacity-30 cursor-pointer"
+                  >
+                    <X size={12} />
+                  </button>
+                </motion.div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-center py-5">
+            {emptyIcon && (
+              <div className="flex justify-center mb-2 text-fg-4/40">
+                {emptyIcon}
+              </div>
+            )}
+            <p className="text-[11px] text-fg-4">{emptyMessage}</p>
+          </div>
+        )}
+      </div>
+    </Section>
+  );
+}

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -360,32 +360,6 @@ body {
   cursor: pointer;
 }
 
-/* ── Dashboard content scaling ──────────────────────────────────── */
-/* DashboardTab components use compact 8–10px text designed for the
-   website layout. Desktop displays need larger text for readability.
-   The .dashboard-content class is applied by App.tsx's overrideContent. */
-
-/* Tiny labels & metadata: 8–9px → 11px */
-.dashboard-content .text-\[8px\],
-.dashboard-content .text-\[9px\] {
-  font-size: 11px !important;
-}
-
-/* Small labels: 10px → 12px */
-.dashboard-content .text-\[10px\] {
-  font-size: 12px !important;
-}
-
-/* Body text: xs (12px) → 13px */
-.dashboard-content .text-xs {
-  font-size: 13px !important;
-}
-
-/* Sub-body text: sm (14px) → 15px */
-.dashboard-content .text-sm {
-  font-size: 15px !important;
-}
-
 /* ── EKG animated trace ──────────────────────────────────────────
    A bright segment sweeps along the heartbeat path like a real
    cardiac monitor. Uses pathLength normalisation + stroke-dashoffset.

--- a/myscrollr.com/src/channels/shared.tsx
+++ b/myscrollr.com/src/channels/shared.tsx
@@ -41,8 +41,8 @@ export function ChannelHeader({
   connected?: boolean
   subscriptionTier?: string
   hex: string
-  onToggle: () => void
-  onDelete: () => void
+  onToggle?: () => void
+  onDelete?: () => void
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const active = channel.visible
@@ -136,65 +136,71 @@ export function ChannelHeader({
         )}
       </div>
 
-      {/* Toggle + Delete */}
-      <div className="flex flex-wrap gap-3">
-        <button
-          onClick={onToggle}
-          className={`flex items-center gap-2 px-4 py-2.5 rounded-lg border transition-colors ${
-            !active
-              ? 'bg-base-200/40 border-base-300/25 text-base-content/40'
-              : ''
-          }`}
-          style={
-            active
-              ? {
-                  background: `${hex}14`,
-                  borderColor: `${hex}33`,
-                  color: hex,
-                }
-              : undefined
-          }
-        >
-          {active ? <Eye size={12} /> : <EyeOff size={12} />}
-          <span className="text-[10px] font-bold uppercase tracking-widest">
-            {active ? 'On Ticker' : 'Off'}
-          </span>
-          <ToggleSwitch active={active} hex={hex} />
-        </button>
-
-        <div className="ml-auto">
-          {confirmDelete ? (
-            <div className="flex items-center gap-2">
-              <span className="text-[10px] text-base-content/40 uppercase">
-                Remove?
-              </span>
-              <button
-                onClick={() => {
-                  onDelete()
-                  setConfirmDelete(false)
-                }}
-                className="px-3 py-2 rounded-lg border border-error/30 text-error text-[10px] font-bold uppercase tracking-widest hover:bg-error/10 transition-colors"
-              >
-                Confirm
-              </button>
-              <button
-                onClick={() => setConfirmDelete(false)}
-                className="p-2 rounded-lg border border-base-300/25 text-base-content/30 hover:text-base-content/50 transition-colors"
-              >
-                <X size={12} />
-              </button>
-            </div>
-          ) : (
+      {/* Toggle + Delete — hidden when callbacks are omitted (e.g. desktop) */}
+      {(onToggle || onDelete) && (
+        <div className="flex flex-wrap gap-3">
+          {onToggle && (
             <button
-              onClick={() => setConfirmDelete(true)}
-              className="p-2.5 rounded-lg border border-base-300/25 text-base-content/20 hover:text-error hover:border-error/30 transition-colors"
-              title="Remove channel"
+              onClick={onToggle}
+              className={`flex items-center gap-2 px-4 py-2.5 rounded-lg border transition-colors ${
+                !active
+                  ? 'bg-base-200/40 border-base-300/25 text-base-content/40'
+                  : ''
+              }`}
+              style={
+                active
+                  ? {
+                      background: `${hex}14`,
+                      borderColor: `${hex}33`,
+                      color: hex,
+                    }
+                  : undefined
+              }
             >
-              <Trash2 size={14} />
+              {active ? <Eye size={12} /> : <EyeOff size={12} />}
+              <span className="text-[10px] font-bold uppercase tracking-widest">
+                {active ? 'On Ticker' : 'Off'}
+              </span>
+              <ToggleSwitch active={active} hex={hex} />
             </button>
           )}
+
+          {onDelete && (
+            <div className="ml-auto">
+              {confirmDelete ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-[10px] text-base-content/40 uppercase">
+                    Remove?
+                  </span>
+                  <button
+                    onClick={() => {
+                      onDelete()
+                      setConfirmDelete(false)
+                    }}
+                    className="px-3 py-2 rounded-lg border border-error/30 text-error text-[10px] font-bold uppercase tracking-widest hover:bg-error/10 transition-colors"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setConfirmDelete(false)}
+                    className="p-2 rounded-lg border border-base-300/25 text-base-content/30 hover:text-base-content/50 transition-colors"
+                  >
+                    <X size={12} />
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setConfirmDelete(true)}
+                  className="p-2.5 rounded-lg border border-base-300/25 text-base-content/20 hover:text-error hover:border-error/30 transition-colors"
+                  title="Remove channel"
+                >
+                  <Trash2 size={14} />
+                </button>
+              )}
+            </div>
+          )}
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/myscrollr.com/src/channels/types.ts
+++ b/myscrollr.com/src/channels/types.ts
@@ -4,8 +4,10 @@ import type { Channel } from '@/api/client'
 export interface DashboardTabProps {
   channel: Channel
   getToken: () => Promise<string | null>
-  onToggle: () => void
-  onDelete: () => void
+  /** Toggle channel on/off ticker. Omit to hide the toggle control. */
+  onToggle?: () => void
+  /** Delete channel. Omit to hide the delete control. */
+  onDelete?: () => void
   onChannelUpdate: (updated: Channel) => void
   /** SSE connection status */
   connected: boolean


### PR DESCRIPTION
## Summary

Reworks all channel configuration panels in the desktop app to use the native `SettingsControls` design system instead of rendering the frontend website's `DashboardTab` components. This aligns the channel config UI with the rest of the desktop settings (widgets, preferences, account).

## Changes

- **New reusable components**: `CatalogBrowser` (search, category tabs, item grid, bulk actions, pagination) and `SelectedItems` (chip list with animated entrance, remove/clear)
- **New channel ConfigPanels**: `FinanceConfigPanel`, `SportsConfigPanel`, `RssConfigPanel`, `FantasyConfigPanel` (all phases: connect, discover, pick, import, connected with league cards/matchups/standings/rosters)
- **`ChannelConfigPanel` router**: Switches to the correct panel by channel type
- **`MainApp.tsx`**: Renders `ChannelConfigPanel` instead of `DashboardTab`; removed redundant `onToggle`/`onDelete` passing
- **CSS cleanup**: Removed `.dashboard-content` font-size overrides from `style.css`
- **Tauri fetch fix**: Finance and Sports catalog calls now use `@tauri-apps/plugin-http` fetch to bypass CORS
- **Backward-compatible shared type changes**: `onToggle`/`onDelete` made optional in `DashboardTabProps` and `ChannelHeader` so the frontend website continues working unchanged
- **Version bump**: 0.7.7 → 0.7.8