### PR TITLE
fix(desktop): resolve Windows COM threading crash on startup — v0.8.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -29,7 +29,10 @@ tauri-plugin-log = "2"
 log = "0.4"
 sysinfo = "0.33"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_Com"] }
+
 [profile.release]
 lto = true
-strip = true
+strip = "debuginfo"
 codegen-units = 1

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1144,7 +1144,7 @@ pub fn run() {
     {
         use windows_sys::Win32::System::Com::{CoInitializeEx, COINIT_APARTMENTTHREADED};
         unsafe {
-            CoInitializeEx(std::ptr::null(), COINIT_APARTMENTTHREADED);
+            CoInitializeEx(std::ptr::null(), COINIT_APARTMENTTHREADED as u32);
         }
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1135,6 +1135,19 @@ fn quit_app(app: tauri::AppHandle) {
 }
 
 pub fn run() {
+    // Windows: claim the main thread for STA (Single-Threaded Apartment)
+    // mode before any plugin can initialize COM in MTA mode. Plugins like
+    // tauri-plugin-http (via native-tls/WinHTTP) and tauri-plugin-mcp-bridge
+    // (via WebSocket server) can trigger MTA initialization, which conflicts
+    // with tao's OleInitialize requirement for drag-and-drop support.
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::System::Com::{CoInitializeEx, COINIT_APARTMENTTHREADED};
+        unsafe {
+            CoInitializeEx(std::ptr::null(), COINIT_APARTMENTTHREADED);
+        }
+    }
+
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -1161,7 +1174,9 @@ pub fn run() {
             }
         }));
 
-    #[cfg(debug_assertions)]
+    // MCP bridge is dev-only and excluded on Windows — its WebSocket
+    // server is architecturally incompatible with Windows COM threading.
+    #[cfg(all(debug_assertions, not(target_os = "windows")))]
     {
         builder = builder.plugin(tauri_plugin_mcp_bridge::init());
     }
@@ -1200,16 +1215,18 @@ pub fn run() {
         })
         .setup(|app| {
             // ── Ticker window setup ──────────────────────────────
-            let ticker = app.get_webview_window("ticker").unwrap();
+            if let Some(ticker) = app.get_webview_window("ticker") {
+                // Set initial ticker width to fill screen
+                if let Ok(Some(monitor)) = ticker.current_monitor() {
+                    let scale = monitor.scale_factor();
+                    let screen_width = monitor.size().width as f64 / scale;
+                    let _ = ticker.set_size(tauri::LogicalSize::new(screen_width, 200.0));
+                }
 
-            // Set initial ticker width to fill screen
-            if let Ok(Some(monitor)) = ticker.current_monitor() {
-                let scale = monitor.scale_factor();
-                let screen_width = monitor.size().width as f64 / scale;
-                let _ = ticker.set_size(tauri::LogicalSize::new(screen_width, 200.0));
+                let _ = ticker.show();
+            } else {
+                log::error!("Failed to create ticker window — continuing without it");
             }
-
-            let _ = ticker.show();
 
             // ── App window: strip native chrome on Linux/Windows ─
             // macOS keeps native decorations (traffic lights). On

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Fixes the app immediately crashing on Windows with:
```
OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`
```

The root cause is plugins initializing COM in MTA (Multi-Threaded Apartment) mode before `tao` can call `OleInitialize`, which requires STA (Single-Threaded Apartment) mode for GUI drag-and-drop support.

## Changes

- **Force STA COM init** — Call `CoInitializeEx(COINIT_APARTMENTTHREADED)` at the top of `run()` on Windows before any plugins load, claiming the main thread for STA mode
- **Gate MCP bridge to non-Windows** — The WebSocket server is architecturally incompatible with Windows COM threading; exclude it even in debug builds on Windows
- **Replace ticker `unwrap()` with graceful handling** — If the ticker window fails to create, log an error and continue instead of panicking
- **Change `strip = true` to `strip = "debuginfo"`** — Preserve panic messages in release builds so future Windows crashes produce useful output instead of silent exits

## Testing

- Rust compiles clean on macOS (`cargo check`)
- Frontend builds clean (`vite build`, 2431 modules, 0 errors)
- `windows-sys` is a Windows-only dependency (`[target.'cfg(windows)'.dependencies]`) — zero impact on macOS/Linux builds
- Needs Windows testing by friend to confirm the fix