### PR TITLE
refactor(desktop): migrate data fetching to TanStack Query

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -75,12 +75,17 @@ export default function App() {
     if (channels.length === 0) {
       return loadPref("activeFeedTabs", ["finance", "sports"]);
     }
-    const visible = channels
+    return channels
       .filter((ch) => ch.enabled && ch.visible)
       .map((ch) => ch.channel_type);
-    savePref("activeFeedTabs", visible);
-    return visible;
   }, [channels]);
+
+  // Persist active tabs when they change (side effect, not in useMemo)
+  useEffect(() => {
+    if (channels.length > 0) {
+      savePref("activeFeedTabs", channelTabs);
+    }
+  }, [channelTabs, channels.length]);
 
   const channelsRef = useRef(channels);
   channelsRef.current = channels;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,13 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { invoke } from "@tauri-apps/api/core";
-import { fetch } from "@tauri-apps/plugin-http";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTauriListener } from "./hooks/useTauriListener";
 import { Menu, CheckMenuItem, MenuItem, PredefinedMenuItem } from "@tauri-apps/api/menu";
-import type {
-  DashboardResponse,
-  DeliveryMode,
-} from "./types";
+import { dashboardQueryOptions, queryKeys } from "./api/queries";
 import ScrollrTicker from "./components/ScrollrTicker";
 import TickerToolbar from "./components/TickerToolbar";
 import {
@@ -15,8 +12,6 @@ import {
   isAuthenticated as checkAuth,
   getTier,
 } from "./auth";
-import type { SubscriptionTier } from "./auth";
-import type { Channel, ChannelType } from "./api/client";
 import { channelsApi } from "./api/client";
 import {
   loadPref,
@@ -26,6 +21,9 @@ import {
   TICKER_GAPS,
   TICKER_HEIGHTS,
 } from "./preferences";
+import type { SubscriptionTier } from "./auth";
+import type { ChannelType } from "./api/client";
+import type { DeliveryMode } from "./types";
 import type { AppPreferences, TickerPosition } from "./preferences";
 import { getAllWidgets } from "./widgets/registry";
 import { useWidgetTickerData } from "./hooks/useWidgetTickerData";
@@ -46,15 +44,44 @@ const SSE_REFETCH_DELAY_MS = 500;
 // ── App (Ticker Window) ─────────────────────────────────────────
 
 export default function App() {
-  // Data state
-  const [dashboard, setDashboard] = useState<DashboardResponse | null>(null);
+  const queryClient = useQueryClient();
+
+  // Auth + tier state (drives refetchInterval)
+  const [authenticated, setAuthenticated] = useState(() => checkAuth());
+  const [tier, setTier] = useState<SubscriptionTier>(() =>
+    checkAuth() ? getTier() : "free",
+  );
+
+  // Delivery mode
   const [deliveryMode, setDeliveryMode] = useState<DeliveryMode>("polling");
 
-  // Channel state
-  const [channels, setChannels] = useState<Channel[]>([]);
-  const [channelTabs, setChannelTabs] = useState<string[]>(() =>
-    loadPref("activeFeedTabs", ["finance", "sports"]),
+  // ── Dashboard data via TanStack Query ──────────────────────────
+  // refetchInterval replaces the manual setInterval polling lifecycle.
+  // TanStack Query also handles refetchOnWindowFocus (configured in
+  // the QueryClient defaults).
+
+  const { data: dashboard } = useQuery({
+    ...dashboardQueryOptions(),
+    refetchInterval: POLL_INTERVALS[tier],
+  });
+
+  // Derive channels and active tabs from query data
+  const channels = useMemo(
+    () => dashboard?.channels ?? [],
+    [dashboard?.channels],
   );
+
+  const channelTabs = useMemo(() => {
+    if (channels.length === 0) {
+      return loadPref("activeFeedTabs", ["finance", "sports"]);
+    }
+    const visible = channels
+      .filter((ch) => ch.enabled && ch.visible)
+      .map((ch) => ch.channel_type);
+    savePref("activeFeedTabs", visible);
+    return visible;
+  }, [channels]);
+
   const channelsRef = useRef(channels);
   channelsRef.current = channels;
 
@@ -79,84 +106,11 @@ export default function App() {
   const prefsRef = useRef(prefs);
   prefsRef.current = prefs;
 
-  // Auth state
-  const [authenticated, setAuthenticated] = useState(() => checkAuth());
-
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const authenticatedRef = useRef(authenticated);
   authenticatedRef.current = authenticated;
-  const tierRef = useRef<SubscriptionTier>("free");
+  const tierRef = useRef<SubscriptionTier>(tier);
+  tierRef.current = tier;
   const sseActiveRef = useRef(false);
-
-  // ── Fetch feed data ───────────────────────────────────────────
-
-  const fetchFeed = useCallback(async () => {
-    try {
-      // Always attempt to get a valid token — handles silent refresh
-      // even when the access token has expired but a refresh token exists.
-      const token = await getValidToken();
-      let res: Response;
-
-      if (token) {
-        // Sync auth state (covers silent refresh from expired state)
-        if (!authenticatedRef.current) {
-          setAuthenticated(true);
-          const currentTier = getTier();
-          tierRef.current = currentTier;
-        }
-        res = await fetch(`${API_URL}/dashboard`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (res.status === 401) {
-          setAuthenticated(false);
-          tierRef.current = "free";
-          res = await fetch(`${API_URL}/public/feed`);
-        }
-      } else {
-        if (authenticatedRef.current) {
-          setAuthenticated(false);
-          tierRef.current = "free";
-        }
-        res = await fetch(`${API_URL}/public/feed`);
-      }
-
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      setDashboard({ data: data.data });
-
-      // Sync channels and active tabs from server config
-      if (Array.isArray(data.channels)) {
-        const channelList = data.channels as Channel[];
-        setChannels(channelList);
-        const visible = channelList
-          .filter((ch) => ch.enabled && ch.visible)
-          .map((ch) => ch.channel_type);
-        setChannelTabs(visible);
-        savePref("activeFeedTabs", visible);
-      }
-    } catch {
-      // Silently fail — ticker just shows stale data
-    }
-  }, []);
-
-  // ── Polling lifecycle ─────────────────────────────────────────
-
-  const startPolling = useCallback(
-    (tier: SubscriptionTier) => {
-      if (pollRef.current) clearInterval(pollRef.current);
-      const interval = POLL_INTERVALS[tier];
-      fetchFeed();
-      pollRef.current = setInterval(fetchFeed, interval);
-    },
-    [fetchFeed],
-  );
-
-  const stopPolling = useCallback(() => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-  }, []);
 
   // ── SSE lifecycle ───────────────────────────────────────────
 
@@ -168,9 +122,8 @@ export default function App() {
     await invoke("start_sse", { token, apiBase: API_URL }).catch(() => {
       sseActiveRef.current = false;
       setDeliveryMode("polling");
-      startPolling(tierRef.current);
     });
-  }, [startPolling]);
+  }, []);
 
   const stopSSE = useCallback(async () => {
     sseActiveRef.current = false;
@@ -211,6 +164,14 @@ export default function App() {
   );
 
   // ── Channel config sync via CDC ────────────────────────────────
+  // CDC events for user_channels come via SSE. We update the local
+  // channelTabs optimistically and then invalidate the dashboard
+  // query so TanStack Query re-fetches the full dashboard.
+  //
+  // Note: channelTabs is now derived from the query cache, so the
+  // invalidation will cause it to update automatically. But the SSE
+  // event gives us immediate CDC data to update tabs without waiting
+  // for the re-fetch round-trip.
 
   useTauriListener<{
     data?: {
@@ -229,86 +190,65 @@ export default function App() {
       );
       if (channelRecords.length === 0) return;
 
-      setChannelTabs((prev) => {
-        let next = [...prev];
+      // Optimistically update the dashboard cache with CDC channel changes
+      queryClient.setQueryData(queryKeys.dashboard, (old: typeof dashboard) => {
+        if (!old?.channels) return old;
 
+        const updatedChannels = [...old.channels];
         for (const cdc of channelRecords) {
           const type = cdc.record.channel_type as string | undefined;
           if (!type) continue;
 
-          if (
-            cdc.action === "delete" ||
-            !cdc.record.enabled ||
-            !cdc.record.visible
-          ) {
-            next = next.filter((t) => t !== type);
-          } else if (!next.includes(type)) {
-            next.push(type);
+          const idx = updatedChannels.findIndex(
+            (ch) => ch.channel_type === type,
+          );
+
+          if (cdc.action === "delete") {
+            if (idx !== -1) updatedChannels.splice(idx, 1);
+          } else if (idx !== -1) {
+            updatedChannels[idx] = {
+              ...updatedChannels[idx],
+              enabled: cdc.record.enabled as boolean,
+              visible: cdc.record.visible as boolean,
+            };
           }
         }
 
-        savePref("activeFeedTabs", next);
-        return next;
+        return { ...old, channels: updatedChannels };
       });
 
-      setTimeout(() => fetchFeed(), SSE_REFETCH_DELAY_MS);
+      // Re-fetch full dashboard after a delay to pick up data changes
+      setTimeout(
+        () =>
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard }),
+        SSE_REFETCH_DELAY_MS,
+      );
     },
-    [fetchFeed],
+    [queryClient],
   );
 
-  // ── Initial data fetch + delivery start ────────────────────────
+  // ── Initial SSE start for unlimited tier ──────────────────────
 
   useEffect(() => {
     async function init() {
-      // Attempt silent token refresh to determine the real tier,
-      // even if checkAuth() returned false due to an expired access token.
+      // Attempt silent token refresh to determine the real tier
       const token = await getValidToken();
-      const tier = token ? getTier() : "free";
-      tierRef.current = tier;
+      const resolvedTier = token ? getTier() : "free";
+      setTier(resolvedTier);
+      tierRef.current = resolvedTier;
 
       if (token && !authenticatedRef.current) {
         setAuthenticated(true);
       }
 
-      startPolling(tier);
-
-      if (tier === "uplink_unlimited") {
+      if (resolvedTier === "uplink_unlimited") {
         startSSE();
       }
     }
 
     init();
-
-    return () => {
-      stopPolling();
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // ── Window focus refetch ────────────────────────────────────────
-
-  useEffect(() => {
-    let cancelled = false;
-    let unlisten: (() => void) | null = null;
-
-    const appWindow = getCurrentWindow();
-    appWindow.onFocusChanged(({ payload: focused }) => {
-      if (focused && authenticatedRef.current) {
-        fetchFeed();
-      }
-    }).then((fn) => {
-      if (cancelled) {
-        fn();
-      } else {
-        unlisten = fn;
-      }
-    });
-
-    return () => {
-      cancelled = true;
-      unlisten?.();
-    };
-  }, [fetchFeed]);
 
   // ── Auth sync from app window ──────────────────────────────────
   // When the user logs in/out via the app window, auth tokens change
@@ -323,24 +263,24 @@ export default function App() {
         setAuthenticated(isAuth);
 
         if (isAuth && !wasAuth) {
-          // Just logged in — restart with proper tier
-          const tier = getTier();
-          tierRef.current = tier;
-          stopPolling();
-          startPolling(tier);
-          if (tier === "uplink_unlimited") startSSE();
+          // Just logged in — update tier (drives refetchInterval)
+          const newTier = getTier();
+          setTier(newTier);
+          tierRef.current = newTier;
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+          if (newTier === "uplink_unlimited") startSSE();
         } else if (!isAuth && wasAuth) {
-          // Just logged out — tear down SSE, restart as anonymous
+          // Just logged out — tear down SSE, reset to free tier
           if (sseActiveRef.current) stopSSE();
-          stopPolling();
-          startPolling("free");
+          setTier("free");
           tierRef.current = "free";
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
         }
       }
     }
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
-  }, [startPolling, stopPolling, startSSE, stopSSE]);
+  }, [startSSE, stopSSE, queryClient]);
 
   // ── Cross-window prefs sync ─────────────────────────────────
 
@@ -452,20 +392,14 @@ export default function App() {
 
   const handleChannelToggle = useCallback(
     async (channelType: ChannelType, visible: boolean) => {
-      const token = await getValidToken();
-      if (!token) return;
       try {
-        await channelsApi.update(
-          channelType,
-          { visible },
-          () => Promise.resolve(token),
-        );
-        fetchFeed();
+        await channelsApi.update(channelType, { visible });
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
       } catch {
         // Silently fail — will sync on next poll
       }
     },
-    [fetchFeed],
+    [queryClient],
   );
 
   // ── Widget quick-toggle (for context menu) ─────────────────────
@@ -680,7 +614,7 @@ export default function App() {
           {Array.from({ length: prefs.appearance.tickerRows }, (_, i) => (
             <ScrollrTicker
               key={`row${i}-${prefs.ticker.tickerGap}-${prefs.ticker.tickerSpeed}-${prefs.ticker.hoverSpeed}-${prefs.ticker.tickerMode}-${prefs.ticker.mixMode}-${prefs.ticker.chipColors}-${prefs.ticker.tickerDirection}-${prefs.ticker.scrollMode}-${prefs.ticker.stepPause}-${prefs.appearance.tickerRows}`}
-              dashboard={dashboard}
+              dashboard={dashboard ?? null}
               activeTabs={activeTabs}
               widgetData={widgetData}
               onChipClick={handleChipClick}

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -1,12 +1,13 @@
 /**
- * Desktop API client — mirrors myscrollr.com/src/api/client.ts but uses
- * `fetch` from `@tauri-apps/plugin-http` to bypass browser CORS.
+ * Desktop API client — uses `fetch` from `@tauri-apps/plugin-http`
+ * to bypass browser CORS (Rust reqwest under the hood).
  *
- * DashboardTab components import from `@/api/client`. The Vite alias
- * resolves `@/api/client` to this file (desktop override), so all API
- * calls route through Tauri's reqwest-backed fetch automatically.
+ * Two request helpers:
+ *   - `request<T>()` — unauthenticated (public endpoints)
+ *   - `authFetch<T>()` — automatically attaches Bearer token via getValidToken()
  */
 import { fetch } from "@tauri-apps/plugin-http";
+import { getValidToken } from "../auth";
 
 // ── Constants ────────────────────────────────────────────────────
 
@@ -15,21 +16,14 @@ export { API_BASE };
 
 // ── Request helpers ─────────────────────────────────────────────
 
-type RequestOptions = RequestInit;
-
-async function request<T>(
+/** Unauthenticated request — use for public endpoints. */
+export async function request<T>(
   path: string,
-  options: RequestOptions = {},
+  options: RequestInit = {},
 ): Promise<T> {
-  const { ...fetchOptions } = options;
-
-  const headers: HeadersInit = {
-    ...options.headers,
-  };
-
   const response = await fetch(`${API_BASE}${path}`, {
-    ...fetchOptions,
-    headers,
+    ...options,
+    headers: { ...options.headers },
   });
 
   if (!response.ok) {
@@ -44,15 +38,16 @@ async function request<T>(
   return response.json() as Promise<T>;
 }
 
-export async function authenticatedFetch<T>(
+/**
+ * Authenticated request — resolves a valid token via getValidToken()
+ * (handles silent refresh) and attaches it as a Bearer header.
+ */
+export async function authFetch<T>(
   path: string,
   options: RequestInit = {},
-  getToken: () => Promise<string | null>,
 ): Promise<T> {
-  const token = await getToken();
-  const headers: HeadersInit = {
-    ...options.headers,
-  };
+  const token = await getValidToken();
+  const headers: HeadersInit = { ...options.headers };
 
   if (token) {
     (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
@@ -96,27 +91,15 @@ export interface RssChannelConfig {
 // ── Channels API ────────────────────────────────────────────────
 
 export const channelsApi = {
-  getAll: (getToken: () => Promise<string | null>) =>
-    authenticatedFetch<{ channels: Array<Channel> }>(
-      "/users/me/channels",
-      {},
-      getToken,
-    ),
+  getAll: () =>
+    authFetch<{ channels: Array<Channel> }>("/users/me/channels"),
 
-  create: (
-    channelType: ChannelType,
-    config: Record<string, unknown>,
-    getToken: () => Promise<string | null>,
-  ) =>
-    authenticatedFetch<Channel>(
-      "/users/me/channels",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ channel_type: channelType, config }),
-      },
-      getToken,
-    ),
+  create: (channelType: ChannelType, config: Record<string, unknown> = {}) =>
+    authFetch<Channel>("/users/me/channels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel_type: channelType, config }),
+    }),
 
   update: (
     channelType: ChannelType,
@@ -125,26 +108,18 @@ export const channelsApi = {
       visible?: boolean;
       config?: Record<string, unknown>;
     },
-    getToken: () => Promise<string | null>,
   ) =>
-    authenticatedFetch<Channel>(
-      `/users/me/channels/${channelType}`,
-      {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
-      },
-      getToken,
-    ),
+    authFetch<Channel>(`/users/me/channels/${channelType}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    }),
 
-  delete: (
-    channelType: ChannelType,
-    getToken: () => Promise<string | null>,
-  ) =>
-    authenticatedFetch<{
-      status: string;
-      message: string;
-    }>(`/users/me/channels/${channelType}`, { method: "DELETE" }, getToken),
+  delete: (channelType: ChannelType) =>
+    authFetch<{ status: string; message: string }>(
+      `/users/me/channels/${channelType}`,
+      { method: "DELETE" },
+    ),
 };
 
 // ── RSS Types & API ─────────────────────────────────────────────
@@ -161,16 +136,12 @@ export const rssApi = {
   getCatalog: () => request<Array<TrackedFeed>>("/rss/feeds"),
 
   /** Delete a custom (non-default) feed from the catalog */
-  deleteFeed: (url: string, getToken: () => Promise<string | null>) =>
-    authenticatedFetch<{ status: string; message: string }>(
-      "/rss/feeds",
-      {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url }),
-      },
-      getToken,
-    ),
+  deleteFeed: (url: string) =>
+    authFetch<{ status: string; message: string }>("/rss/feeds", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url }),
+    }),
 };
 
 

--- a/desktop/src/api/queries.ts
+++ b/desktop/src/api/queries.ts
@@ -9,6 +9,7 @@ import { fetch } from "@tauri-apps/plugin-http";
 import { API_BASE } from "../config";
 import { getValidToken } from "../auth";
 import { request } from "./client";
+import type { TrackedFeed } from "./client";
 import type { DashboardResponse } from "../types";
 
 // ── Query Keys ───────────────────────────────────────────────────
@@ -107,7 +108,7 @@ export function financeCatalogOptions() {
 export function rssCatalogOptions() {
   return queryOptions({
     queryKey: queryKeys.catalogs.rss,
-    queryFn: () => request<Array<import("./client").TrackedFeed>>("/rss/feeds"),
+    queryFn: () => request<Array<TrackedFeed>>("/rss/feeds"),
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/desktop/src/api/queries.ts
+++ b/desktop/src/api/queries.ts
@@ -1,19 +1,29 @@
 /**
  * TanStack Query hooks for the desktop API layer.
  *
- * These replace the manual fetch + useState + useEffect patterns
- * that were previously spread across MainApp.tsx.
+ * Centralizes all query keys, query options, and mutation helpers.
+ * Every remote data fetch uses this layer — no manual fetch + useState.
  */
 import { queryOptions } from "@tanstack/react-query";
 import { fetch } from "@tauri-apps/plugin-http";
 import { API_BASE } from "../config";
 import { getValidToken } from "../auth";
+import { request } from "./client";
 import type { DashboardResponse } from "../types";
 
 // ── Query Keys ───────────────────────────────────────────────────
 
 export const queryKeys = {
   dashboard: ["dashboard"] as const,
+  catalogs: {
+    sports: ["catalogs", "sports"] as const,
+    finance: ["catalogs", "finance"] as const,
+    rss: ["catalogs", "rss"] as const,
+  },
+  fantasy: {
+    status: ["fantasy", "status"] as const,
+    leagues: ["fantasy", "leagues"] as const,
+  },
 };
 
 // ── Dashboard Query ──────────────────────────────────────────────
@@ -59,5 +69,45 @@ export function dashboardQueryOptions() {
   });
 }
 
+// ── Catalog Queries ──────────────────────────────────────────────
 
+export interface TrackedLeague {
+  name: string;
+  sport_api: string;
+  category: string;
+  country: string;
+  logo_url: string;
+  game_count: number;
+  live_count: number;
+  next_game: string | null;
+}
 
+export interface TrackedSymbol {
+  symbol: string;
+  name: string;
+  category: string;
+}
+
+export function sportsCatalogOptions() {
+  return queryOptions({
+    queryKey: queryKeys.catalogs.sports,
+    queryFn: () => request<TrackedLeague[]>("/sports/leagues"),
+    staleTime: 5 * 60 * 1000, // 5 min — catalogs change infrequently
+  });
+}
+
+export function financeCatalogOptions() {
+  return queryOptions({
+    queryKey: queryKeys.catalogs.finance,
+    queryFn: () => request<TrackedSymbol[]>("/finance/symbols"),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function rssCatalogOptions() {
+  return queryOptions({
+    queryKey: queryKeys.catalogs.rss,
+    queryFn: () => request<Array<import("./client").TrackedFeed>>("/rss/feeds"),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/desktop/src/channels/ChannelConfigPanel.tsx
+++ b/desktop/src/channels/ChannelConfigPanel.tsx
@@ -9,8 +9,6 @@ import FantasyConfigPanel from "./FantasyConfigPanel";
 interface ChannelConfigPanelProps {
   channelType: string;
   channel: Channel;
-  getToken: () => Promise<string | null>;
-  onChannelUpdate: (updated: Channel) => void;
   subscriptionTier: string;
   /** SSE delivery mode active */
   connected: boolean;
@@ -23,8 +21,6 @@ interface ChannelConfigPanelProps {
 export default function ChannelConfigPanel({
   channelType,
   channel,
-  getToken,
-  onChannelUpdate,
   subscriptionTier,
   connected,
   hex,
@@ -34,8 +30,6 @@ export default function ChannelConfigPanel({
       return (
         <FinanceConfigPanel
           channel={channel}
-          getToken={getToken}
-          onChannelUpdate={onChannelUpdate}
           subscriptionTier={subscriptionTier}
           connected={connected}
           hex={hex}
@@ -45,8 +39,6 @@ export default function ChannelConfigPanel({
       return (
         <SportsConfigPanel
           channel={channel}
-          getToken={getToken}
-          onChannelUpdate={onChannelUpdate}
           subscriptionTier={subscriptionTier}
           connected={connected}
           hex={hex}
@@ -56,8 +48,6 @@ export default function ChannelConfigPanel({
       return (
         <RssConfigPanel
           channel={channel}
-          getToken={getToken}
-          onChannelUpdate={onChannelUpdate}
           hex={hex}
         />
       );
@@ -65,7 +55,6 @@ export default function ChannelConfigPanel({
       return (
         <FantasyConfigPanel
           channel={channel}
-          getToken={getToken}
           subscriptionTier={subscriptionTier}
           connected={connected}
           hex={hex}

--- a/desktop/src/channels/FantasyConfigPanel.tsx
+++ b/desktop/src/channels/FantasyConfigPanel.tsx
@@ -18,7 +18,8 @@ import {
   ActionRow,
   SegmentedRow,
 } from "../components/settings/SettingsControls";
-import { authenticatedFetch, API_BASE } from "../api/client";
+import { authFetch, API_BASE } from "../api/client";
+import { getValidToken } from "../auth";
 import type { Channel } from "../api/client";
 
 // ── Data Types ───────────────────────────────────────────────────
@@ -167,7 +168,6 @@ const LEAGUES_PER_PAGE = 5;
 
 interface FantasyConfigPanelProps {
   channel: Channel;
-  getToken: () => Promise<string | null>;
   subscriptionTier: string;
   connected: boolean;
   hex: string;
@@ -177,7 +177,6 @@ interface FantasyConfigPanelProps {
 
 export default function FantasyConfigPanel({
   channel: _channel,
-  getToken,
   hex,
 }: FantasyConfigPanelProps) {
 
@@ -203,15 +202,11 @@ export default function FantasyConfigPanel({
   const fetchYahooData = useCallback(async () => {
     try {
       const [statusData, leaguesData] = await Promise.all([
-        authenticatedFetch<{ connected: boolean; synced: boolean }>(
+        authFetch<{ connected: boolean; synced: boolean }>(
           "/users/me/yahoo-status",
-          {},
-          getToken,
         ).catch(() => null),
-        authenticatedFetch<MyLeaguesResponse>(
+        authFetch<MyLeaguesResponse>(
           "/users/me/yahoo-leagues",
-          {},
-          getToken,
         ).catch(() => null),
       ]);
 
@@ -236,7 +231,7 @@ export default function FantasyConfigPanel({
         setPhase("disconnected");
       }
     }
-  }, [getToken]);
+  }, []);
 
   useEffect(() => {
     fetchYahooData();
@@ -250,10 +245,10 @@ export default function FantasyConfigPanel({
     setDiscoveredLeagues([]);
 
     try {
-      const result = await authenticatedFetch<{
+      const result = await authFetch<{
         leagues: DiscoveredLeague[];
         error?: string;
-      }>("/users/me/yahoo-leagues/discover", { method: "POST" }, getToken);
+      }>("/users/me/yahoo-leagues/discover", { method: "POST" });
 
       if (result.error) {
         setDiscoverError(result.error);
@@ -286,7 +281,7 @@ export default function FantasyConfigPanel({
       );
       setPhase(leagues.length > 0 ? "connected" : "disconnected");
     }
-  }, [getToken, leagues]);
+  }, [leagues]);
 
   // ── Import selected leagues ────────────────────────────────────
 
@@ -308,7 +303,7 @@ export default function FantasyConfigPanel({
       setImportStatuses({ ...statuses });
 
       try {
-        const result = await authenticatedFetch<{
+        const result = await authFetch<{
           status: string;
           error?: string;
         }>(
@@ -322,7 +317,6 @@ export default function FantasyConfigPanel({
               season: league.season,
             }),
           },
-          getToken,
         );
         statuses[key] = result.error ? "error" : "done";
       } catch {
@@ -333,7 +327,7 @@ export default function FantasyConfigPanel({
 
     await fetchYahooData();
     setPhase("connected");
-  }, [selectedKeys, discoveredLeagues, getToken, fetchYahooData]);
+  }, [selectedKeys, discoveredLeagues, fetchYahooData]);
 
   // ── Listen for Yahoo auth popup completion ─────────────────────
 
@@ -351,7 +345,7 @@ export default function FantasyConfigPanel({
   // ── Yahoo connect / disconnect ─────────────────────────────────
 
   const handleYahooConnect = useCallback(async () => {
-    const token = await getToken();
+    const token = await getValidToken();
     if (!token) return;
 
     let sub: string | undefined;
@@ -365,15 +359,11 @@ export default function FantasyConfigPanel({
 
     const popupUrl = `${API_BASE}/yahoo/start?logto_sub=${sub}`;
     window.open(popupUrl, "yahoo-auth", "width=600,height=700");
-  }, [getToken]);
+  }, []);
 
   const handleYahooDisconnect = useCallback(async () => {
     try {
-      await authenticatedFetch(
-        "/users/me/yahoo",
-        { method: "DELETE" },
-        getToken,
-      );
+      await authFetch("/users/me/yahoo", { method: "DELETE" });
       setYahooConnected(false);
       setLeagues([]);
       setPhase("disconnected");
@@ -381,7 +371,7 @@ export default function FantasyConfigPanel({
     } catch (err) {
       console.error("[Fantasy] disconnect failed:", err);
     }
-  }, [getToken]);
+  }, []);
 
   // ── Derived data ───────────────────────────────────────────────
 

--- a/desktop/src/channels/FinanceConfigPanel.tsx
+++ b/desktop/src/channels/FinanceConfigPanel.tsx
@@ -1,18 +1,14 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { TrendingUp } from "lucide-react";
 import { clsx } from "clsx";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
-import { fetch } from "@tauri-apps/plugin-http";
-import { channelsApi, API_BASE } from "../api/client";
+import { channelsApi } from "../api/client";
+import { financeCatalogOptions, queryKeys } from "../api/queries";
+import type { TrackedSymbol } from "../api/queries";
 import type { Channel } from "../api/client";
 
 // ── Types ────────────────────────────────────────────────────────
-
-interface TrackedSymbol {
-  symbol: string;
-  name: string;
-  category: string;
-}
 
 interface FinanceChannelConfig {
   symbols?: string[];
@@ -20,8 +16,6 @@ interface FinanceChannelConfig {
 
 interface FinanceConfigPanelProps {
   channel: Channel;
-  getToken: () => Promise<string | null>;
-  onChannelUpdate: (updated: Channel) => void;
   subscriptionTier: string;
   connected: boolean;
   hex: string;
@@ -48,14 +42,9 @@ const POPULAR_SYMBOLS = [
 
 export default function FinanceConfigPanel({
   channel,
-  getToken,
-  onChannelUpdate,
   hex,
 }: FinanceConfigPanelProps) {
-  const [catalog, setCatalog] = useState<TrackedSymbol[]>([]);
-  const [catalogLoading, setCatalogLoading] = useState(true);
-  const [catalogError, setCatalogError] = useState(false);
-  const [saving, setSaving] = useState(false);
+  const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
   const [hidePopular, setHidePopular] = useState(
     () => localStorage.getItem("scrollr:hidePopular") === "1",
@@ -65,47 +54,40 @@ export default function FinanceConfigPanel({
   const symbols = Array.isArray(config?.symbols) ? config.symbols : [];
   const symbolSet = useMemo(() => new Set(symbols), [symbols]);
 
+  // ── Catalog query ──────────────────────────────────────────────
+  const {
+    data: catalog = [],
+    isLoading: catalogLoading,
+    isError: catalogError,
+  } = useQuery(financeCatalogOptions());
+
   const nameMap = useMemo(
     () => new Map(catalog.map((s) => [s.symbol, s.name])),
     [catalog],
   );
 
   // Auto-dismiss errors
-  useEffect(() => {
+  useState(() => {
     if (!error) return;
     const t = setTimeout(() => setError(null), 4000);
     return () => clearTimeout(t);
-  }, [error]);
+  });
 
-  // Fetch catalog
-  useEffect(() => {
-    fetch(`${API_BASE}/finance/symbols`)
-      .then((r) => {
-        if (!r.ok) throw new Error("Failed");
-        return r.json() as Promise<TrackedSymbol[]>;
-      })
-      .then(setCatalog)
-      .catch(() => setCatalogError(true))
-      .finally(() => setCatalogLoading(false));
-  }, []);
+  // ── Update mutation ────────────────────────────────────────────
+  const updateMutation = useMutation({
+    mutationFn: (nextSymbols: string[]) =>
+      channelsApi.update("finance", { config: { symbols: nextSymbols } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+    },
+    onError: () => {
+      setError("Failed to save — try again");
+    },
+  });
 
   const updateSymbols = useCallback(
-    async (next: string[]) => {
-      setSaving(true);
-      try {
-        const updated = await channelsApi.update(
-          "finance",
-          { config: { symbols: next } },
-          getToken,
-        );
-        onChannelUpdate(updated);
-      } catch {
-        setError("Failed to save — try again");
-      } finally {
-        setSaving(false);
-      }
-    },
-    [getToken, onChannelUpdate],
+    (next: string[]) => updateMutation.mutate(next),
+    [updateMutation],
   );
 
   const addSymbol = useCallback(
@@ -139,16 +121,16 @@ export default function FinanceConfigPanel({
         hex={hex}
         items={catalog}
         selectedKeys={symbolSet}
-        getKey={(s) => s.symbol}
-        getCategory={(s) => s.category}
-        matchesSearch={(s, q) => {
+        getKey={(s: TrackedSymbol) => s.symbol}
+        getCategory={(s: TrackedSymbol) => s.category}
+        matchesSearch={(s: TrackedSymbol, q: string) => {
           const lower = q.toLowerCase();
           return (
             s.symbol.toLowerCase().includes(lower) ||
             s.name.toLowerCase().includes(lower)
           );
         }}
-        renderItem={(item, isSelected) => (
+        renderItem={(item: TrackedSymbol, isSelected: boolean) => (
           <>
             <div className="min-w-0 mr-2">
               <span className="text-[12px] font-bold font-mono text-fg-2">
@@ -175,7 +157,7 @@ export default function FinanceConfigPanel({
             hex={hex}
             onAdd={addSymbol}
             onRemove={removeSymbol}
-            saving={saving}
+            saving={updateMutation.isPending}
             hidden={hidePopular}
             onToggleHidden={(hidden) => {
               setHidePopular(hidden);
@@ -187,11 +169,11 @@ export default function FinanceConfigPanel({
         onDismissError={() => setError(null)}
         loading={catalogLoading}
         catalogError={catalogError}
-        saving={saving}
+        saving={updateMutation.isPending}
         onAdd={addSymbol}
         onRemove={removeSymbol}
-        onBulkAdd={(keys) => updateSymbols([...symbols, ...keys])}
-        onBulkRemove={(keys) => {
+        onBulkAdd={(keys: string[]) => updateSymbols([...symbols, ...keys])}
+        onBulkRemove={(keys: string[]) => {
           const toRemove = new Set(keys);
           updateSymbols(symbols.filter((s) => !toRemove.has(s)));
         }}

--- a/desktop/src/channels/FinanceConfigPanel.tsx
+++ b/desktop/src/channels/FinanceConfigPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { TrendingUp } from "lucide-react";
 import { clsx } from "clsx";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -67,11 +67,11 @@ export default function FinanceConfigPanel({
   );
 
   // Auto-dismiss errors
-  useState(() => {
+  useEffect(() => {
     if (!error) return;
     const t = setTimeout(() => setError(null), 4000);
     return () => clearTimeout(t);
-  });
+  }, [error]);
 
   // ── Update mutation ────────────────────────────────────────────
   const updateMutation = useMutation({

--- a/desktop/src/channels/RssConfigPanel.tsx
+++ b/desktop/src/channels/RssConfigPanel.tsx
@@ -1,15 +1,15 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { Plus, Rss, Trash2 } from "lucide-react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
 import { channelsApi, rssApi } from "../api/client";
+import { rssCatalogOptions, queryKeys } from "../api/queries";
 import type { Channel, TrackedFeed, RssChannelConfig } from "../api/client";
 
 // ── Types ────────────────────────────────────────────────────────
 
 interface RssConfigPanelProps {
   channel: Channel;
-  getToken: () => Promise<string | null>;
-  onChannelUpdate: (updated: Channel) => void;
   hex: string;
 }
 
@@ -17,14 +17,9 @@ interface RssConfigPanelProps {
 
 export default function RssConfigPanel({
   channel,
-  getToken,
-  onChannelUpdate,
   hex,
 }: RssConfigPanelProps) {
-  const [catalog, setCatalog] = useState<TrackedFeed[]>([]);
-  const [catalogLoading, setCatalogLoading] = useState(true);
-  const [catalogError, setCatalogError] = useState(false);
-  const [saving, setSaving] = useState(false);
+  const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
   const [newFeedName, setNewFeedName] = useState("");
   const [newFeedUrl, setNewFeedUrl] = useState("");
@@ -34,38 +29,50 @@ export default function RssConfigPanel({
   const feeds = Array.isArray(rssConfig?.feeds) ? rssConfig.feeds : [];
   const feedUrlSet = useMemo(() => new Set(feeds.map((f) => f.url)), [feeds]);
 
-  useEffect(() => {
+  // Auto-dismiss errors
+  useState(() => {
     if (!error) return;
     const t = setTimeout(() => setError(null), 4000);
     return () => clearTimeout(t);
-  }, [error]);
+  });
 
-  useEffect(() => {
-    rssApi
-      .getCatalog()
-      .then(setCatalog)
-      .catch(() => setCatalogError(true))
-      .finally(() => setCatalogLoading(false));
-  }, []);
+  // ── Catalog query ──────────────────────────────────────────────
+  const {
+    data: catalog = [],
+    isLoading: catalogLoading,
+    isError: catalogError,
+  } = useQuery(rssCatalogOptions());
+
+  // ── Update feeds mutation ──────────────────────────────────────
+  const updateMutation = useMutation({
+    mutationFn: (nextFeeds: Array<{ name: string; url: string }>) =>
+      channelsApi.update("rss", { config: { feeds: nextFeeds } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+    },
+    onError: () => {
+      setError("Failed to save — try again");
+    },
+  });
 
   const updateFeeds = useCallback(
-    async (next: Array<{ name: string; url: string }>) => {
-      setSaving(true);
-      try {
-        const updated = await channelsApi.update(
-          "rss",
-          { config: { feeds: next } },
-          getToken,
-        );
-        onChannelUpdate(updated);
-      } catch {
-        setError("Failed to save — try again");
-      } finally {
-        setSaving(false);
+    (next: Array<{ name: string; url: string }>) => updateMutation.mutate(next),
+    [updateMutation],
+  );
+
+  // ── Delete catalog feed mutation ───────────────────────────────
+  const deleteCatalogMutation = useMutation({
+    mutationFn: (url: string) => rssApi.deleteFeed(url),
+    onSuccess: (_data, url) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.catalogs.rss });
+      if (feedUrlSet.has(url)) {
+        updateFeeds(feeds.filter((f) => f.url !== url));
       }
     },
-    [getToken, onChannelUpdate],
-  );
+    onError: () => {
+      setError("Failed to remove feed from catalog");
+    },
+  });
 
   const addCatalogFeed = useCallback(
     (url: string) => {
@@ -84,19 +91,11 @@ export default function RssConfigPanel({
   );
 
   const deleteCatalogFeed = useCallback(
-    async (feed: TrackedFeed) => {
+    (feed: TrackedFeed) => {
       if (feed.is_default) return;
-      try {
-        await rssApi.deleteFeed(feed.url, getToken);
-        setCatalog((prev) => prev.filter((f) => f.url !== feed.url));
-        if (feedUrlSet.has(feed.url)) {
-          updateFeeds(feeds.filter((f) => f.url !== feed.url));
-        }
-      } catch {
-        setError("Failed to remove feed from catalog");
-      }
+      deleteCatalogMutation.mutate(feed.url);
     },
-    [getToken, feedUrlSet, feeds, updateFeeds],
+    [deleteCatalogMutation],
   );
 
   const addCustomFeed = useCallback(() => {
@@ -123,16 +122,16 @@ export default function RssConfigPanel({
         hex={hex}
         items={catalog}
         selectedKeys={feedUrlSet}
-        getKey={(f) => f.url}
-        getCategory={(f) => f.category}
-        matchesSearch={(f, q) => {
+        getKey={(f: TrackedFeed) => f.url}
+        getCategory={(f: TrackedFeed) => f.category}
+        matchesSearch={(f: TrackedFeed, q: string) => {
           const lower = q.toLowerCase();
           return (
             f.name.toLowerCase().includes(lower) ||
             f.url.toLowerCase().includes(lower)
           );
         }}
-        renderItem={(item, isSelected) => (
+        renderItem={(item: TrackedFeed, isSelected: boolean) => (
           <>
             <div className="min-w-0 mr-2">
               <div className="text-[12px] font-bold text-fg-2 truncate">
@@ -173,7 +172,7 @@ export default function RssConfigPanel({
             name={newFeedName}
             url={newFeedUrl}
             urlError={urlError}
-            saving={saving}
+            saving={updateMutation.isPending}
             onNameChange={setNewFeedName}
             onUrlChange={setNewFeedUrl}
             onSubmit={addCustomFeed}
@@ -183,7 +182,7 @@ export default function RssConfigPanel({
         onDismissError={() => setError(null)}
         loading={catalogLoading}
         catalogError={catalogError}
-        saving={saving}
+        saving={updateMutation.isPending}
         onAdd={addCatalogFeed}
         onRemove={removeFeed}
         onClearAll={() => updateFeeds([])}

--- a/desktop/src/channels/RssConfigPanel.tsx
+++ b/desktop/src/channels/RssConfigPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Plus, Rss, Trash2 } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
@@ -30,11 +30,11 @@ export default function RssConfigPanel({
   const feedUrlSet = useMemo(() => new Set(feeds.map((f) => f.url)), [feeds]);
 
   // Auto-dismiss errors
-  useState(() => {
+  useEffect(() => {
     if (!error) return;
     const t = setTimeout(() => setError(null), 4000);
     return () => clearTimeout(t);
-  });
+  }, [error]);
 
   // ── Catalog query ──────────────────────────────────────────────
   const {
@@ -63,12 +63,6 @@ export default function RssConfigPanel({
   // ── Delete catalog feed mutation ───────────────────────────────
   const deleteCatalogMutation = useMutation({
     mutationFn: (url: string) => rssApi.deleteFeed(url),
-    onSuccess: (_data, url) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.catalogs.rss });
-      if (feedUrlSet.has(url)) {
-        updateFeeds(feeds.filter((f) => f.url !== url));
-      }
-    },
     onError: () => {
       setError("Failed to remove feed from catalog");
     },
@@ -91,11 +85,20 @@ export default function RssConfigPanel({
   );
 
   const deleteCatalogFeed = useCallback(
-    (feed: TrackedFeed) => {
+    async (feed: TrackedFeed) => {
       if (feed.is_default) return;
-      deleteCatalogMutation.mutate(feed.url);
+      try {
+        await deleteCatalogMutation.mutateAsync(feed.url);
+        queryClient.invalidateQueries({ queryKey: queryKeys.catalogs.rss });
+        // Also remove from user's feed list if subscribed
+        if (feedUrlSet.has(feed.url)) {
+          updateFeeds(feeds.filter((f) => f.url !== feed.url));
+        }
+      } catch {
+        // onError in mutation config handles the UI
+      }
     },
-    [deleteCatalogMutation],
+    [deleteCatalogMutation, queryClient, feedUrlSet, feeds, updateFeeds],
   );
 
   const addCustomFeed = useCallback(() => {

--- a/desktop/src/channels/SportsConfigPanel.tsx
+++ b/desktop/src/channels/SportsConfigPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Trophy } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
@@ -49,11 +49,11 @@ export default function SportsConfigPanel({
   const leagueSet = useMemo(() => new Set(leagues), [leagues]);
 
   // Auto-dismiss errors
-  useState(() => {
+  useEffect(() => {
     if (!error) return;
     const t = setTimeout(() => setError(null), 4000);
     return () => clearTimeout(t);
-  });
+  }, [error]);
 
   // ── Catalog query ──────────────────────────────────────────────
   const {

--- a/desktop/src/channels/SportsConfigPanel.tsx
+++ b/desktop/src/channels/SportsConfigPanel.tsx
@@ -1,22 +1,13 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { Trophy } from "lucide-react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
-import { fetch } from "@tauri-apps/plugin-http";
-import { channelsApi, API_BASE } from "../api/client";
+import { channelsApi } from "../api/client";
+import { sportsCatalogOptions, queryKeys } from "../api/queries";
+import type { TrackedLeague } from "../api/queries";
 import type { Channel } from "../api/client";
 
 // ── Types ────────────────────────────────────────────────────────
-
-interface TrackedLeague {
-  name: string;
-  sport_api: string;
-  category: string;
-  country: string;
-  logo_url: string;
-  game_count: number;
-  live_count: number;
-  next_game: string | null;
-}
 
 interface SportsChannelConfig {
   leagues?: string[];
@@ -24,8 +15,6 @@ interface SportsChannelConfig {
 
 interface SportsConfigPanelProps {
   channel: Channel;
-  getToken: () => Promise<string | null>;
-  onChannelUpdate: (updated: Channel) => void;
   subscriptionTier: string;
   connected: boolean;
   hex: string;
@@ -50,36 +39,28 @@ function formatNextGame(dateStr: string | null): string | null {
 
 export default function SportsConfigPanel({
   channel,
-  getToken,
-  onChannelUpdate,
   hex,
 }: SportsConfigPanelProps) {
-  const [catalog, setCatalog] = useState<TrackedLeague[]>([]);
-  const [catalogLoading, setCatalogLoading] = useState(true);
-  const [catalogError, setCatalogError] = useState(false);
-  const [saving, setSaving] = useState(false);
+  const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
 
   const config = channel.config as SportsChannelConfig;
   const leagues = Array.isArray(config?.leagues) ? config.leagues : [];
   const leagueSet = useMemo(() => new Set(leagues), [leagues]);
 
-  useEffect(() => {
+  // Auto-dismiss errors
+  useState(() => {
     if (!error) return;
     const t = setTimeout(() => setError(null), 4000);
     return () => clearTimeout(t);
-  }, [error]);
+  });
 
-  useEffect(() => {
-    fetch(`${API_BASE}/sports/leagues`)
-      .then((r) => {
-        if (!r.ok) throw new Error("Failed");
-        return r.json() as Promise<TrackedLeague[]>;
-      })
-      .then(setCatalog)
-      .catch(() => setCatalogError(true))
-      .finally(() => setCatalogLoading(false));
-  }, []);
+  // ── Catalog query ──────────────────────────────────────────────
+  const {
+    data: catalog = [],
+    isLoading: catalogLoading,
+    isError: catalogError,
+  } = useQuery(sportsCatalogOptions());
 
   // Sort catalog: live first, then by game count, then alpha
   const sortedCatalog = useMemo(
@@ -92,23 +73,21 @@ export default function SportsConfigPanel({
     [catalog],
   );
 
-  const updateLeagues = useCallback(
-    async (next: string[]) => {
-      setSaving(true);
-      try {
-        const updated = await channelsApi.update(
-          "sports",
-          { config: { leagues: next } },
-          getToken,
-        );
-        onChannelUpdate(updated);
-      } catch {
-        setError("Failed to save — try again");
-      } finally {
-        setSaving(false);
-      }
+  // ── Update mutation ────────────────────────────────────────────
+  const updateMutation = useMutation({
+    mutationFn: (nextLeagues: string[]) =>
+      channelsApi.update("sports", { config: { leagues: nextLeagues } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
     },
-    [getToken, onChannelUpdate],
+    onError: () => {
+      setError("Failed to save — try again");
+    },
+  });
+
+  const updateLeagues = useCallback(
+    (next: string[]) => updateMutation.mutate(next),
+    [updateMutation],
   );
 
   const addLeague = useCallback(
@@ -135,16 +114,16 @@ export default function SportsConfigPanel({
         hex={hex}
         items={sortedCatalog}
         selectedKeys={leagueSet}
-        getKey={(l) => l.name}
-        getCategory={(l) => l.category}
-        matchesSearch={(l, q) => {
+        getKey={(l: TrackedLeague) => l.name}
+        getCategory={(l: TrackedLeague) => l.category}
+        matchesSearch={(l: TrackedLeague, q: string) => {
           const lower = q.toLowerCase();
           return (
             l.name.toLowerCase().includes(lower) ||
             l.category.toLowerCase().includes(lower)
           );
         }}
-        renderItem={(item, isSelected) => (
+        renderItem={(item: TrackedLeague, isSelected: boolean) => (
           <>
             <div className="flex items-center gap-2 min-w-0 mr-2">
               {item.logo_url && (
@@ -192,11 +171,11 @@ export default function SportsConfigPanel({
         onDismissError={() => setError(null)}
         loading={catalogLoading}
         catalogError={catalogError}
-        saving={saving}
+        saving={updateMutation.isPending}
         onAdd={addLeague}
         onRemove={removeLeague}
-        onBulkAdd={(keys) => updateLeagues([...leagues, ...keys])}
-        onBulkRemove={(keys) => {
+        onBulkAdd={(keys: string[]) => updateLeagues([...leagues, ...keys])}
+        onBulkRemove={(keys: string[]) => {
           const toRemove = new Set(keys);
           updateLeagues(leagues.filter((l) => !toRemove.has(l)));
         }}

--- a/desktop/src/channels/fantasy/FeedTab.tsx
+++ b/desktop/src/channels/fantasy/FeedTab.tsx
@@ -8,7 +8,9 @@
  */
 import { useMemo } from "react";
 import { Swords } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { LeagueCard } from "./LeagueCard";
+import { dashboardQueryOptions } from "../../api/queries";
 import type { FeedTabProps, ChannelManifest } from "../../types";
 import type { LeagueResponse, MyLeaguesResponse } from "./types";
 
@@ -36,20 +38,21 @@ export const fantasyChannel: ChannelManifest = {
 
 // ── Helpers ──────────────────────────────────────────────────────
 
-function getLeagues(config: Record<string, unknown>): LeagueResponse[] {
-  const items = config.__initialItems;
-  if (items && typeof items === "object" && !Array.isArray(items)) {
-    const resp = items as MyLeaguesResponse;
+function extractLeagues(data: unknown): LeagueResponse[] {
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const resp = data as MyLeaguesResponse;
     return resp.leagues ?? [];
   }
-  if (Array.isArray(items)) return items as LeagueResponse[];
+  if (Array.isArray(data)) return data as LeagueResponse[];
   return [];
 }
 
 // ── FeedTab ──────────────────────────────────────────────────────
 
 function FantasyFeedTab({ mode, channelConfig }: FeedTabProps) {
-  const leagues = useMemo(() => getLeagues(channelConfig), [channelConfig]);
+  const { data: dashboard } = useQuery(dashboardQueryOptions());
+  const fantasyData = dashboard?.data?.fantasy;
+  const leagues = useMemo(() => extractLeagues(fantasyData), [fantasyData]);
   const dashboardLoaded = channelConfig.__dashboardLoaded as
     | boolean
     | undefined;

--- a/desktop/src/channels/finance/FeedTab.tsx
+++ b/desktop/src/channels/finance/FeedTab.tsx
@@ -36,11 +36,6 @@ export const financeChannel: ChannelManifest = {
 // ── FeedTab ──────────────────────────────────────────────────────
 
 function FinanceFeedTab({ mode, channelConfig }: FeedTabProps) {
-  const initialItems = useMemo(() => {
-    const items = channelConfig.__initialItems as Trade[] | undefined;
-    return items ?? [];
-  }, [channelConfig]);
-
   const keyOf = useCallback((t: Trade) => t.symbol, []);
   const validate = useCallback(
     (record: Record<string, unknown>) => typeof record.symbol === "string",
@@ -54,7 +49,7 @@ function FinanceFeedTab({ mode, channelConfig }: FeedTabProps) {
 
   const { items: trades } = useScrollrCDC<Trade>({
     table: "trades",
-    initialItems,
+    dataKey: "finance",
     keyOf,
     validate,
     sort,
@@ -72,7 +67,7 @@ function FinanceFeedTab({ mode, channelConfig }: FeedTabProps) {
       {trades.length === 0 && (
         <div className="col-span-full flex flex-col items-center justify-center gap-2 py-12 bg-surface">
           <TrendingUp size={28} className="text-fg-4/40" />
-          {channelConfig.__dashboardLoaded && initialItems.length === 0 ? (
+          {channelConfig.__dashboardLoaded && !channelConfig.__hasConfig ? (
             <>
               <p className="text-sm font-medium text-fg-3">
                 No stocks or crypto picked yet

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -41,11 +41,6 @@ export const rssChannel: ChannelManifest = {
 // ── FeedTab ──────────────────────────────────────────────────────
 
 function RssFeedTab({ mode, channelConfig }: FeedTabProps) {
-  const initialItems = useMemo(() => {
-    const items = channelConfig.__initialItems as RssItemType[] | undefined;
-    return items ?? [];
-  }, [channelConfig]);
-
   const dashboardLoaded = channelConfig.__dashboardLoaded as
     | boolean
     | undefined;
@@ -67,7 +62,7 @@ function RssFeedTab({ mode, channelConfig }: FeedTabProps) {
 
   const { items: rssItems } = useScrollrCDC<RssItemType>({
     table: "rss_items",
-    initialItems,
+    dataKey: "rss",
     keyOf,
     validate,
     sort,
@@ -85,7 +80,7 @@ function RssFeedTab({ mode, channelConfig }: FeedTabProps) {
       {rssItems.length === 0 && (
         <div className="col-span-full flex flex-col items-center justify-center gap-2 py-12 bg-surface">
           <Rss size={28} className="text-fg-4/40" />
-          {dashboardLoaded && initialItems.length === 0 ? (
+          {dashboardLoaded && !channelConfig.__hasConfig ? (
             <>
               <p className="text-sm font-medium text-fg-3">
                 No feeds added yet

--- a/desktop/src/channels/sports/FeedTab.tsx
+++ b/desktop/src/channels/sports/FeedTab.tsx
@@ -37,11 +37,6 @@ export const sportsChannel: ChannelManifest = {
 // ── FeedTab ──────────────────────────────────────────────────────
 
 function SportsFeedTab({ mode, channelConfig }: FeedTabProps) {
-  const initialItems = useMemo(() => {
-    const items = channelConfig.__initialItems as Game[] | undefined;
-    return items ?? [];
-  }, [channelConfig]);
-
   const keyOf = useCallback((g: Game) => String(g.id), []);
   const validate = useCallback(
     (record: Record<string, unknown>) => record.id != null,
@@ -50,7 +45,7 @@ function SportsFeedTab({ mode, channelConfig }: FeedTabProps) {
 
   const { items: games } = useScrollrCDC<Game>({
     table: "games",
-    initialItems,
+    dataKey: "sports",
     keyOf,
     validate,
   });

--- a/desktop/src/components/dashboard/FantasySummary.tsx
+++ b/desktop/src/components/dashboard/FantasySummary.tsx
@@ -51,8 +51,7 @@ const SPORT_EMOJI: Record<string, string> = {
 };
 
 export default function FantasySummary({ dashboard, prefs, onConfigure }: FantasySummaryProps) {
-  // Fantasy data comes via channelConfig.__initialItems (not CDC)
-  // On the dashboard, we read from the dashboard response directly
+  // Fantasy data is stored in channel config (not CDC like other channels)
   const channelData = (dashboard?.channels ?? []).find(
     (ch) => ch.channel_type === "fantasy",
   );

--- a/desktop/src/components/dashboard/FinanceSummary.tsx
+++ b/desktop/src/components/dashboard/FinanceSummary.tsx
@@ -179,10 +179,9 @@ interface FinanceSummaryProps {
 }
 
 export default function FinanceSummary({ dashboard, prefs, onConfigure }: FinanceSummaryProps) {
-  const initialItems = (dashboard?.data?.finance ?? []) as Trade[];
   const { items } = useScrollrCDC<Trade>({
     table: "trades",
-    initialItems,
+    dataKey: "finance",
     keyOf: (t) => t.symbol,
     maxItems: 50,
   });

--- a/desktop/src/components/dashboard/RssSummary.tsx
+++ b/desktop/src/components/dashboard/RssSummary.tsx
@@ -164,10 +164,9 @@ interface RssSummaryProps {
 }
 
 export default function RssSummary({ dashboard, prefs, onConfigure }: RssSummaryProps) {
-  const initialItems = (dashboard?.data?.rss ?? []) as RssItem[];
   const { items } = useScrollrCDC<RssItem>({
     table: "rss_items",
-    initialItems,
+    dataKey: "rss",
     keyOf: (r) => `${r.feed_url}::${r.guid}`,
     sort: (a, b) => {
       const aTime = a.published_at ? new Date(a.published_at).getTime() : 0;

--- a/desktop/src/components/dashboard/SportsSummary.tsx
+++ b/desktop/src/components/dashboard/SportsSummary.tsx
@@ -381,10 +381,9 @@ interface SportsSummaryProps {
 }
 
 export default function SportsSummary({ dashboard, prefs, onConfigure }: SportsSummaryProps) {
-  const initialItems = (dashboard?.data?.sports ?? []) as Game[];
   const { items } = useScrollrCDC<Game>({
     table: "games",
-    initialItems,
+    dataKey: "sports",
     keyOf: (g) => String(g.id),
     maxItems: 200,
   });

--- a/desktop/src/hooks/useAuthState.ts
+++ b/desktop/src/hooks/useAuthState.ts
@@ -6,12 +6,14 @@
  */
 import { useState, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   login as authLogin,
   logout as authLogout,
   isAuthenticated as checkAuth,
   getTier,
 } from "../auth";
+import { queryKeys } from "../api/queries";
 import type { SubscriptionTier } from "../auth";
 import type { DashboardResponse } from "../types";
 
@@ -27,9 +29,8 @@ interface AuthState {
   syncAuthFromDashboard: (dashboard: DashboardResponse | undefined) => void;
 }
 
-export function useAuthState(
-  fetchDashboard: () => void,
-): AuthState {
+export function useAuthState(): AuthState {
+  const queryClient = useQueryClient();
   const [authenticated, setAuthenticated] = useState(() => checkAuth());
   const [tier, setTier] = useState<SubscriptionTier>(() =>
     checkAuth() ? getTier() : "free",
@@ -47,20 +48,20 @@ export function useAuthState(
       if (result) {
         setAuthenticated(true);
         setTier(getTier());
-        fetchDashboard();
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
       }
     } finally {
       setLoggingIn(false);
     }
-  }, [fetchDashboard]);
+  }, [queryClient]);
 
   const handleLogout = useCallback(async () => {
     await invoke("stop_sse").catch(() => {});
     authLogout();
     setAuthenticated(false);
     setTier("free");
-    fetchDashboard();
-  }, [fetchDashboard]);
+    queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+  }, [queryClient]);
 
   const syncAuthFromDashboard = useCallback(
     (dashboard: DashboardResponse | undefined) => {

--- a/desktop/src/hooks/useChannelActions.ts
+++ b/desktop/src/hooks/useChannelActions.ts
@@ -1,13 +1,14 @@
 /**
  * Channel CRUD actions for the app window.
  *
- * Handles toggling channel visibility, adding new channels,
- * and deleting channels via the API.
+ * Uses TanStack Query mutations with automatic dashboard cache
+ * invalidation — no manual fetchDashboard() threading required.
  */
 import { useCallback } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { getValidToken } from "../auth";
+import { useQueryClient } from "@tanstack/react-query";
 import { channelsApi } from "../api/client";
+import { queryKeys } from "../api/queries";
 import type { ChannelType } from "../api/client";
 
 interface ChannelActions {
@@ -16,40 +17,27 @@ interface ChannelActions {
   handleDeleteChannel: (channelType: ChannelType) => Promise<void>;
 }
 
-export function useChannelActions(
-  fetchDashboard: () => void,
-): ChannelActions {
+export function useChannelActions(): ChannelActions {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const handleToggleChannel = useCallback(
     async (channelType: ChannelType, visible: boolean) => {
-      const token = await getValidToken();
-      if (!token) return;
       try {
-        await channelsApi.update(
-          channelType,
-          { enabled: true, visible },
-          () => Promise.resolve(token),
-        );
-        fetchDashboard();
+        await channelsApi.update(channelType, { enabled: true, visible });
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
       } catch (err) {
         console.error("[Scrollr] Channel toggle failed:", err);
       }
     },
-    [fetchDashboard],
+    [queryClient],
   );
 
   const handleAddChannel = useCallback(
     async (channelType: ChannelType) => {
-      const token = await getValidToken();
-      if (!token) return;
       try {
-        await channelsApi.create(
-          channelType,
-          {},
-          () => Promise.resolve(token),
-        );
-        fetchDashboard();
+        await channelsApi.create(channelType);
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
         navigate({
           to: "/channel/$type/$tab",
           params: { type: channelType, tab: "feed" },
@@ -58,22 +46,20 @@ export function useChannelActions(
         console.error("[Scrollr] Channel add failed:", err);
       }
     },
-    [fetchDashboard, navigate],
+    [queryClient, navigate],
   );
 
   const handleDeleteChannel = useCallback(
     async (channelType: ChannelType) => {
-      const token = await getValidToken();
-      if (!token) return;
       try {
-        await channelsApi.delete(channelType, () => Promise.resolve(token));
-        await fetchDashboard();
+        await channelsApi.delete(channelType);
+        await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
         navigate({ to: "/feed" });
       } catch (err) {
         console.error("[Scrollr] Channel delete failed:", err);
       }
     },
-    [fetchDashboard, navigate],
+    [queryClient, navigate],
   );
 
   return { handleToggleChannel, handleAddChannel, handleDeleteChannel };

--- a/desktop/src/hooks/useScrollrCDC.ts
+++ b/desktop/src/hooks/useScrollrCDC.ts
@@ -1,5 +1,8 @@
-import { useState, useEffect, useRef } from "react";
+import { useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTauriListener } from "./useTauriListener";
+import { dashboardQueryOptions, queryKeys } from "../api/queries";
+import type { DashboardResponse } from "../types";
 
 /**
  * Uniqueness key extractor — given a record, returns a string key
@@ -16,8 +19,8 @@ type ItemComparator<T> = (a: T, b: T) => number;
 interface UseScrollrCDCOptions<T> {
   /** CDC table name to subscribe to (e.g. 'trades', 'games', 'rss_items'). */
   table: string;
-  /** Initial items from the dashboard snapshot. */
-  initialItems: T[];
+  /** Dashboard data key to read initial items from (e.g. 'finance', 'sports', 'rss'). */
+  dataKey: string;
   /** Extract a unique key from a record for upsert/dedup. */
   keyOf: KeyExtractor<T>;
   /** Optional sort comparator applied after every upsert. */
@@ -49,35 +52,35 @@ interface SSEPayload {
 }
 
 /**
- * Desktop CDC hook — manages an in-memory array of items with
- * real-time upsert/delete from the Rust SSE client.
+ * Desktop CDC hook — merges real-time SSE mutations directly into
+ * the TanStack Query dashboard cache.
  *
- * In polling mode (no SSE connection), items are driven entirely
- * by the dashboard snapshot that App.tsx fetches on interval.
+ * In polling mode (no SSE connection), items come from the dashboard
+ * query snapshot that TanStack Query manages automatically.
  *
- * In SSE mode, the hook listens for `sse-event` Tauri events,
- * filters by table name, and applies CDC mutations to the array.
+ * In SSE mode, CDC events update the dashboard cache in-place via
+ * queryClient.setQueryData, so there is no parallel state and no
+ * visual flash on refetch.
  */
 export function useScrollrCDC<T>({
   table,
-  initialItems,
+  dataKey,
   keyOf,
   sort,
   maxItems = 50,
   validate,
 }: UseScrollrCDCOptions<T>): UseScrollrCDCResult<T> {
-  const [items, setItems] = useState<T[]>(initialItems);
+  const queryClient = useQueryClient();
   const initializedRef = useRef(false);
 
-  // Sync when initialItems changes (e.g., polling refresh arrives)
-  useEffect(() => {
-    // Skip the very first empty array (dashboard hasn't loaded yet)
-    if (!initializedRef.current && initialItems.length === 0) return;
-    initializedRef.current = true;
-    setItems(initialItems);
-  }, [initialItems]);
+  // Read items from the dashboard query cache
+  const { data: dashboard } = useQuery(dashboardQueryOptions());
+  const items = ((dashboard?.data?.[dataKey] as T[] | undefined) ?? []);
 
-  // Listen for CDC events from the Rust SSE client
+  // Track initialization
+  if (items.length > 0) initializedRef.current = true;
+
+  // Listen for CDC events from the Rust SSE client and merge into cache
   useTauriListener<SSEPayload>(
     "sse-event",
     (event) => {
@@ -90,39 +93,52 @@ export function useScrollrCDC<T>({
       );
       if (relevant.length === 0) return;
 
-      setItems((prev) => {
-        let next = [...prev];
+      // Update the dashboard cache in-place
+      queryClient.setQueryData<DashboardResponse>(
+        queryKeys.dashboard,
+        (old) => {
+          if (!old) return old;
 
-        for (const cdc of relevant) {
-          const record = cdc.record as unknown as T;
+          let currentItems = ((old.data?.[dataKey] as T[] | undefined) ?? []);
+          let next = [...currentItems];
 
-          if (cdc.action === "delete") {
-            const key = keyOf(record);
-            next = next.filter((item) => keyOf(item) !== key);
-          } else {
-            // insert or update — validate first
-            if (validate && !validate(cdc.record)) continue;
+          for (const cdc of relevant) {
+            const record = cdc.record as unknown as T;
 
-            const key = keyOf(record);
-            const idx = next.findIndex((item) => keyOf(item) === key);
-            if (idx >= 0) {
-              next[idx] = record;
+            if (cdc.action === "delete") {
+              const key = keyOf(record);
+              next = next.filter((item) => keyOf(item) !== key);
             } else {
-              next.push(record);
-              if (next.length > maxItems) next.shift();
+              // insert or update — validate first
+              if (validate && !validate(cdc.record)) continue;
+
+              const key = keyOf(record);
+              const idx = next.findIndex((item) => keyOf(item) === key);
+              if (idx >= 0) {
+                next[idx] = record;
+              } else {
+                next.push(record);
+                if (next.length > maxItems) next.shift();
+              }
             }
           }
-        }
 
-        // Apply sort if provided
-        if (sort) {
-          next.sort(sort);
-        }
+          // Apply sort if provided
+          if (sort) {
+            next.sort(sort);
+          }
 
-        return next;
-      });
+          return {
+            ...old,
+            data: {
+              ...old.data,
+              [dataKey]: next,
+            },
+          };
+        },
+      );
     },
-    [table, keyOf, sort, maxItems, validate],
+    [table, dataKey, keyOf, sort, maxItems, validate, queryClient],
   );
 
   return { items };

--- a/desktop/src/hooks/useScrollrCDC.ts
+++ b/desktop/src/hooks/useScrollrCDC.ts
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTauriListener } from "./useTauriListener";
 import { dashboardQueryOptions, queryKeys } from "../api/queries";
@@ -71,14 +70,10 @@ export function useScrollrCDC<T>({
   validate,
 }: UseScrollrCDCOptions<T>): UseScrollrCDCResult<T> {
   const queryClient = useQueryClient();
-  const initializedRef = useRef(false);
 
   // Read items from the dashboard query cache
   const { data: dashboard } = useQuery(dashboardQueryOptions());
   const items = ((dashboard?.data?.[dataKey] as T[] | undefined) ?? []);
-
-  // Track initialization
-  if (items.length > 0) initializedRef.current = true;
 
   // Listen for CDC events from the Rust SSE client and merge into cache
   useTauriListener<SSEPayload>(

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,11 +1,17 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 import "./api/fetchOverride";
+import { createQueryClient } from "./query";
 import App from "./App";
 import "./style.css";
 
+const queryClient = createQueryClient();
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -151,7 +151,6 @@ function RootLayout() {
   const {
     data: dashboard,
     isLoading: loading,
-    refetch: fetchDashboard,
   } = useQuery(dashboardQueryOptions());
 
   const channels: Channel[] = useMemo(() => dashboard?.channels ?? [], [dashboard]);

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -35,7 +35,6 @@ import { getAllWidgets, getWidget } from "../widgets/registry";
 
 // Data
 import { dashboardQueryOptions } from "../api/queries";
-import { getValidToken } from "../auth";
 
 // Preferences
 import {
@@ -194,10 +193,8 @@ function RootLayout() {
 
   // ── Extracted hooks ─────────────────────────────────────────
 
-  const refetchDashboard = useCallback(() => { fetchDashboard(); }, [fetchDashboard]);
-
-  const auth = useAuthState(refetchDashboard);
-  const channelActions = useChannelActions(refetchDashboard);
+  const auth = useAuthState();
+  const channelActions = useChannelActions();
   const widgetActions = useWidgetActions(prefs, setPrefs, route.activeItem);
 
   // Apply theme + UI scale
@@ -305,8 +302,6 @@ function RootLayout() {
     }
   }, []);
 
-  const getToken = useCallback(() => getValidToken(), []);
-
   // ── Ticker data ─────────────────────────────────────────────
 
   const activeTabs = useMemo(
@@ -361,7 +356,6 @@ function RootLayout() {
         savePref("showTaskbar", v);
       },
       appVersion,
-      getToken,
       channels,
       dashboard,
       allChannelManifests,
@@ -371,17 +365,16 @@ function RootLayout() {
       onAddChannel: channelActions.handleAddChannel,
       onDeleteChannel: channelActions.handleDeleteChannel,
       onToggleWidget: widgetActions.handleToggleWidget,
-      fetchDashboard: refetchDashboard,
       onSelectItem: handleSelectItem,
     }),
     [
       prefs, handlePrefsChange, auth.authenticated, auth.tier,
       auth.handleLogin, auth.handleLogout, autostartOn, handleAutostartChange,
-      showAppTicker, showTaskbar, appVersion, getToken,
+      showAppTicker, showTaskbar, appVersion,
       channels, dashboard, allChannelManifests, allWidgets,
       channelActions.handleToggleChannel, widgetActions.handleToggleWidgetTicker,
       channelActions.handleAddChannel, channelActions.handleDeleteChannel,
-      widgetActions.handleToggleWidget, refetchDashboard, handleSelectItem,
+      widgetActions.handleToggleWidget, handleSelectItem,
     ],
   );
 

--- a/desktop/src/routes/channel.$type.$tab.tsx
+++ b/desktop/src/routes/channel.$type.$tab.tsx
@@ -7,11 +7,9 @@
  */
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import RouteError from "../components/RouteError";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getChannel } from "../channels/registry";
-import { getAllChannels } from "../channels/registry";
-import { dashboardQueryOptions, queryKeys } from "../api/queries";
-import { getValidToken } from "../auth";
+import { useQuery } from "@tanstack/react-query";
+import { getChannel, getAllChannels } from "../channels/registry";
+import { dashboardQueryOptions } from "../api/queries";
 import { getTier } from "../auth";
 import ChannelConfigPanel from "../channels/ChannelConfigPanel";
 import ContentHeader from "../components/ContentHeader";
@@ -97,9 +95,7 @@ function ChannelFeedTab({
   dashboard: DashboardResponse | undefined;
   channel: NonNullable<ReturnType<typeof getChannel>>;
 }) {
-  const initialItems = dashboard?.data?.[type] ?? [];
   const channelConfig = {
-    __initialItems: initialItems,
     __dashboardLoaded: dashboard !== undefined,
     __hasConfig: (dashboard?.channels ?? []).some(
       (ch) => ch.channel_type === type && ch.enabled,
@@ -166,7 +162,6 @@ function ChannelInfoTab({
   );
 }
 
-/** Extracted so useQueryClient() is called unconditionally. */
 function ChannelConfigTab({
   type,
   dashboard,
@@ -174,7 +169,6 @@ function ChannelConfigTab({
   type: string;
   dashboard: DashboardResponse | undefined;
 }) {
-  const queryClient = useQueryClient();
   const channelData = (dashboard?.channels ?? []).find(
     (ch) => ch.channel_type === type,
   );
@@ -200,10 +194,6 @@ function ChannelConfigTab({
       <ChannelConfigPanel
         channelType={type}
         channel={channelData as unknown as Channel}
-        getToken={() => getValidToken().then((t) => t ?? null)}
-        onChannelUpdate={() => {
-          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
-        }}
         subscriptionTier={getTier()}
         connected={deliveryMode === "sse"}
         hex={manifest?.hex ?? "var(--color-accent)"}

--- a/desktop/src/routes/widget.$id.$tab.tsx
+++ b/desktop/src/routes/widget.$id.$tab.tsx
@@ -77,7 +77,6 @@ function WidgetFeedTab({
   widget: NonNullable<ReturnType<typeof getWidget>>;
 }) {
   const channelConfig = {
-    __initialItems: [],
     __dashboardLoaded: true,
   };
   return <widget.FeedTab mode="comfort" channelConfig={channelConfig} />;

--- a/desktop/src/shell-context.ts
+++ b/desktop/src/shell-context.ts
@@ -25,7 +25,6 @@ export interface ShellState {
   showTaskbar: boolean;
   onToggleTaskbar: (enabled: boolean) => void;
   appVersion: string;
-  getToken: () => Promise<string | null>;
 
   // ── Navigation overhaul additions ──────────────────────────────
   /** User's channel records from the dashboard API. */
@@ -46,8 +45,6 @@ export interface ShellState {
   onDeleteChannel: (channelType: ChannelType) => void;
   /** Toggle a widget on/off entirely. */
   onToggleWidget: (widgetId: string) => void;
-  /** Refetch the dashboard data. */
-  fetchDashboard: () => void;
   /** Navigate to a source by ID. */
   onSelectItem: (id: string) => void;
 }


### PR DESCRIPTION
## Summary

Migrates the entire desktop app from manual `fetch + useState + useEffect` patterns to TanStack Query, eliminating prop-threaded `getToken` callbacks, manual polling lifecycle code, and disconnected CDC state.

- **24 files changed**, net **-135 lines** removed
- Build passes clean (`vite build && tsc --noEmit`)

## What Changed

### New API layer (`client.ts`, `queries.ts`)
- `authFetch<T>()` helper that resolves tokens internally via `getValidToken()`, replacing the `getToken` callback prop chain
- Query option factories for dashboard, sports/finance/RSS catalogs with appropriate `staleTime`
- Centralized `queryKeys` factory for cache key consistency

### Config panels (Sports, Finance, RSS)
- Catalog fetches converted from `useState + useEffect` to `useQuery` with 5-min staleTime
- Save operations converted from fire-and-forget `fetch` to `useMutation` with `onSuccess` cache invalidation
- `getToken` prop removed from all config panels and `ChannelConfigPanel` wrapper

### CDC integration (`useScrollrCDC`)
- Rewritten to read initial data from the query cache via `useQuery(dashboardQueryOptions())`
- CDC events now update the dashboard cache in-place via `queryClient.setQueryData()`, fixing a visual flash where feed tabs briefly showed stale data on dashboard refetch
- Interface changed from `initialItems` prop to `dataKey` (e.g., `"finance"`, `"sports"`, `"rss"`)

### Ticker window (`App.tsx`, `main.tsx`)
- Added `QueryClientProvider` to ticker window entry point
- Replaced ~60 lines of manual `setInterval` polling (`fetchFeed`, `startPolling`, `stopPolling`, `pollRef`) with `useQuery` + `refetchInterval` driven by reactive tier state
- Channels and active tabs derived from query data instead of parallel `useState`
- CDC channel config sync uses `queryClient.setQueryData()` for optimistic updates + `invalidateQueries()` for full re-fetch

### Shell context cleanup
- Removed `getToken` and `fetchDashboard` from `ShellState` interface
- `useAuthState` and `useChannelActions` use `queryClient.invalidateQueries()` internally

### Intentionally unchanged
- **SSE lifecycle** — start/stop SSE, status listener, delivery mode tracking all stay as-is
- **`FantasyConfigPanel`** — Yahoo OAuth multi-step flow uses `authFetch()` correctly; not a simple query pattern
- **`useSysmonData`** — module-level cache with 500ms TTL is optimal for cross-window sharing
- **Weather/clock widgets** — local-only state, no server data