### PR TITLE
refactor(desktop): split ShellContext and add React.memo to prevent cascading re-renders

### DIFF
--- a/desktop/src/channels/finance/FeedTab.tsx
+++ b/desktop/src/channels/finance/FeedTab.tsx
@@ -5,7 +5,7 @@
  * via the desktop CDC/SSE pipeline. Supports compact and comfort
  * display modes with price flash animations on change.
  */
-import { useMemo, useCallback, useRef, useEffect, useState } from "react";
+import { memo, useMemo, useCallback, useRef, useEffect, useState } from "react";
 import { clsx } from "clsx";
 import { TrendingUp } from "lucide-react";
 import { useScrollrCDC } from "../../hooks/useScrollrCDC";
@@ -130,7 +130,7 @@ function timeAgo(dateStr: string | undefined): string {
   return `${days}d`;
 }
 
-function TradeItem({ trade, mode }: TradeItemProps) {
+const TradeItem = memo(function TradeItem({ trade, mode }: TradeItemProps) {
   const isUp = trade.direction === "up";
   const isDown = trade.direction === "down";
 
@@ -238,4 +238,12 @@ function TradeItem({ trade, mode }: TradeItemProps) {
       </div>
     </a>
   );
-}
+}, (prev, next) =>
+  prev.mode === next.mode &&
+  prev.trade.symbol === next.trade.symbol &&
+  prev.trade.price === next.trade.price &&
+  prev.trade.percentage_change === next.trade.percentage_change &&
+  prev.trade.direction === next.trade.direction &&
+  prev.trade.previous_close === next.trade.previous_close &&
+  prev.trade.last_updated === next.trade.last_updated
+);

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -5,7 +5,7 @@
  * real-time updates via the desktop CDC/SSE pipeline. Shows source
  * name, title, description, and relative timestamps.
  */
-import { useMemo, useCallback } from "react";
+import { memo, useMemo, useCallback } from "react";
 import { Rss } from "lucide-react";
 import { clsx } from "clsx";
 import { useScrollrCDC } from "../../hooks/useScrollrCDC";
@@ -141,7 +141,7 @@ function truncate(text: string, maxLen: number): string {
   return text.slice(0, maxLen).trimEnd() + "\u2026";
 }
 
-function RssArticle({ item, mode }: RssArticleProps) {
+const RssArticle = memo(function RssArticle({ item, mode }: RssArticleProps) {
   const ago = timeAgo(item.published_at);
 
   if (mode === "compact") {
@@ -193,4 +193,10 @@ function RssArticle({ item, mode }: RssArticleProps) {
       </div>
     </a>
   );
-}
+}, (prev, next) =>
+  prev.mode === next.mode &&
+  prev.item.guid === next.item.guid &&
+  prev.item.feed_url === next.item.feed_url &&
+  prev.item.title === next.item.title &&
+  prev.item.published_at === next.item.published_at
+);

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -198,5 +198,8 @@ const RssArticle = memo(function RssArticle({ item, mode }: RssArticleProps) {
   prev.item.guid === next.item.guid &&
   prev.item.feed_url === next.item.feed_url &&
   prev.item.title === next.item.title &&
+  prev.item.description === next.item.description &&
+  prev.item.link === next.item.link &&
+  prev.item.source_name === next.item.source_name &&
   prev.item.published_at === next.item.published_at
 );

--- a/desktop/src/channels/sports/GameItem.tsx
+++ b/desktop/src/channels/sports/GameItem.tsx
@@ -250,7 +250,11 @@ export const GameItem = memo(function GameItem({ game, mode }: GameItemProps) {
 }, (prev, next) =>
   prev.mode === next.mode &&
   prev.game.id === next.game.id &&
+  prev.game.away_team_name === next.game.away_team_name &&
+  prev.game.away_team_logo === next.game.away_team_logo &&
   prev.game.away_team_score === next.game.away_team_score &&
+  prev.game.home_team_name === next.game.home_team_name &&
+  prev.game.home_team_logo === next.game.home_team_logo &&
   prev.game.home_team_score === next.game.home_team_score &&
   prev.game.state === next.game.state &&
   prev.game.timer === next.game.timer &&

--- a/desktop/src/channels/sports/GameItem.tsx
+++ b/desktop/src/channels/sports/GameItem.tsx
@@ -4,7 +4,7 @@
  * Supports compact (single-row) and comfort (two-row with team logos)
  * display modes. Flashes briefly when scores update via CDC.
  */
-import { useState, useEffect, useRef } from "react";
+import { memo, useState, useEffect, useRef } from "react";
 import { clsx } from "clsx";
 import type { Game, FeedMode } from "../../types";
 
@@ -83,7 +83,7 @@ function useScoreFlash(
 
 // ── Component ───────────────────────────────────────────────────
 
-export function GameItem({ game, mode }: GameItemProps) {
+export const GameItem = memo(function GameItem({ game, mode }: GameItemProps) {
   const live = isLive(game);
   const isFinal = game.state === "final";
   const winner = getWinner(game);
@@ -247,4 +247,14 @@ export function GameItem({ game, mode }: GameItemProps) {
       </div>
     </div>
   );
-}
+}, (prev, next) =>
+  prev.mode === next.mode &&
+  prev.game.id === next.game.id &&
+  prev.game.away_team_score === next.game.away_team_score &&
+  prev.game.home_team_score === next.game.home_team_score &&
+  prev.game.state === next.game.state &&
+  prev.game.timer === next.game.timer &&
+  prev.game.status_long === next.game.status_long &&
+  prev.game.status_short === next.game.status_short &&
+  prev.game.short_detail === next.game.short_detail
+);

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -264,7 +264,13 @@ const GameChip = memo(function GameChip({
   prev.colorMode === next.colorMode &&
   prev.onClick === next.onClick &&
   prev.game.id === next.game.id &&
+  prev.game.sport === next.game.sport &&
+  prev.game.league === next.game.league &&
+  prev.game.away_team_name === next.game.away_team_name &&
+  prev.game.away_team_logo === next.game.away_team_logo &&
   prev.game.away_team_score === next.game.away_team_score &&
+  prev.game.home_team_name === next.game.home_team_name &&
+  prev.game.home_team_logo === next.game.home_team_logo &&
   prev.game.home_team_score === next.game.home_team_score &&
   prev.game.state === next.game.state &&
   prev.game.timer === next.game.timer &&

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { memo, useState, useEffect, useRef } from "react";
 import { clsx } from "clsx";
 import type { Game } from "../../types";
 import type { ChipColorMode } from "../../preferences";
@@ -72,7 +72,7 @@ function chipStatus(game: Game): string {
 
 // ── Component ───────────────────────────────────────────────────
 
-export default function GameChip({
+const GameChip = memo(function GameChip({
   game,
   comfort,
   colorMode = "channel",
@@ -259,4 +259,18 @@ export default function GameChip({
       )}
     </button>
   );
-}
+}, (prev, next) =>
+  prev.comfort === next.comfort &&
+  prev.colorMode === next.colorMode &&
+  prev.onClick === next.onClick &&
+  prev.game.id === next.game.id &&
+  prev.game.away_team_score === next.game.away_team_score &&
+  prev.game.home_team_score === next.game.home_team_score &&
+  prev.game.state === next.game.state &&
+  prev.game.timer === next.game.timer &&
+  prev.game.status_short === next.game.status_short &&
+  prev.game.status_long === next.game.status_long &&
+  prev.game.start_time === next.game.start_time
+);
+
+export default GameChip;

--- a/desktop/src/components/chips/RssChip.tsx
+++ b/desktop/src/components/chips/RssChip.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { clsx } from "clsx";
 import type { RssItem } from "../../types";
 import type { ChipColorMode } from "../../preferences";
@@ -22,7 +23,7 @@ function timeAgo(dateStr: string | null): string {
   return `${days}d ago`;
 }
 
-export default function RssChip({ item, comfort, colorMode = "channel", onClick }: RssChipProps) {
+const RssChip = memo(function RssChip({ item, comfort, colorMode = "channel", onClick }: RssChipProps) {
   const c = getChipColors(colorMode, "rss");
   const maxLen = comfort ? 60 : 40;
   const headline =
@@ -65,4 +66,15 @@ export default function RssChip({ item, comfort, colorMode = "channel", onClick 
       )}
     </button>
   );
-}
+}, (prev, next) =>
+  prev.comfort === next.comfort &&
+  prev.colorMode === next.colorMode &&
+  prev.onClick === next.onClick &&
+  prev.item.guid === next.item.guid &&
+  prev.item.feed_url === next.item.feed_url &&
+  prev.item.title === next.item.title &&
+  prev.item.source_name === next.item.source_name &&
+  prev.item.published_at === next.item.published_at
+);
+
+export default RssChip;

--- a/desktop/src/components/chips/TradeChip.tsx
+++ b/desktop/src/components/chips/TradeChip.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { clsx } from "clsx";
 import type { Trade } from "../../types";
 import type { ChipColorMode } from "../../preferences";
@@ -31,7 +32,7 @@ function formatPriceChange(change: number | string | undefined): string {
   return `${sign}$${Math.abs(num).toFixed(2)}`;
 }
 
-export default function TradeChip({ trade, comfort, colorMode = "channel", onClick }: TradeChipProps) {
+const TradeChip = memo(function TradeChip({ trade, comfort, colorMode = "channel", onClick }: TradeChipProps) {
   const c = getChipColors(colorMode, "finance");
   const isUp = trade.direction === "up";
   const changeStr = formatChange(trade.percentage_change);
@@ -82,4 +83,16 @@ export default function TradeChip({ trade, comfort, colorMode = "channel", onCli
       )}
     </button>
   );
-}
+}, (prev, next) =>
+  prev.comfort === next.comfort &&
+  prev.colorMode === next.colorMode &&
+  prev.onClick === next.onClick &&
+  prev.trade.symbol === next.trade.symbol &&
+  prev.trade.price === next.trade.price &&
+  prev.trade.percentage_change === next.trade.percentage_change &&
+  prev.trade.direction === next.trade.direction &&
+  prev.trade.previous_close === next.trade.previous_close &&
+  prev.trade.price_change === next.trade.price_change
+);
+
+export default TradeChip;

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -58,7 +58,7 @@ import { useChannelActions } from "../hooks/useChannelActions";
 import { useWidgetActions } from "../hooks/useWidgetActions";
 
 // Shell context
-import { ShellContext } from "../shell-context";
+import { ShellContext, ShellDataContext } from "../shell-context";
 
 // ── Route context ────────────────────────────────────────────────
 
@@ -332,9 +332,21 @@ function RootLayout() {
     savePrefs(next);
   }
 
-  // ── Shell context value ─────────────────────────────────────
+  // ── Stable callbacks for context ─────────────────────────────
 
-  const shellValue = useMemo(
+  const handleToggleAppTickerPref = useCallback((v: boolean) => {
+    setShowAppTicker(v);
+    savePref("showAppTicker", v);
+  }, []);
+
+  const handleToggleTaskbarPref = useCallback((v: boolean) => {
+    setShowTaskbar(v);
+    savePref("showTaskbar", v);
+  }, []);
+
+  // ── Shell context values (split: stable + volatile) ────────
+
+  const shellStableValue = useMemo(
     () => ({
       prefs,
       onPrefsChange: handlePrefsChange,
@@ -345,18 +357,10 @@ function RootLayout() {
       autostartEnabled: autostartOn,
       onAutostartChange: handleAutostartChange,
       showAppTicker,
-      onToggleAppTicker: (v: boolean) => {
-        setShowAppTicker(v);
-        savePref("showAppTicker", v);
-      },
+      onToggleAppTicker: handleToggleAppTickerPref,
       showTaskbar,
-      onToggleTaskbar: (v: boolean) => {
-        setShowTaskbar(v);
-        savePref("showTaskbar", v);
-      },
+      onToggleTaskbar: handleToggleTaskbarPref,
       appVersion,
-      channels,
-      dashboard,
       allChannelManifests,
       allWidgets,
       onToggleChannelTicker: channelActions.handleToggleChannel,
@@ -369,12 +373,18 @@ function RootLayout() {
     [
       prefs, handlePrefsChange, auth.authenticated, auth.tier,
       auth.handleLogin, auth.handleLogout, autostartOn, handleAutostartChange,
-      showAppTicker, showTaskbar, appVersion,
-      channels, dashboard, allChannelManifests, allWidgets,
+      showAppTicker, handleToggleAppTickerPref,
+      showTaskbar, handleToggleTaskbarPref,
+      appVersion, allChannelManifests, allWidgets,
       channelActions.handleToggleChannel, widgetActions.handleToggleWidgetTicker,
       channelActions.handleAddChannel, channelActions.handleDeleteChannel,
       widgetActions.handleToggleWidget, handleSelectItem,
     ],
+  );
+
+  const shellDataValue = useMemo(
+    () => ({ channels, dashboard }),
+    [channels, dashboard],
   );
 
   // ── Render ──────────────────────────────────────────────────
@@ -478,8 +488,10 @@ function RootLayout() {
           )}
 
           <div className="flex-1 overflow-y-auto scrollbar-thin">
-            <ShellContext.Provider value={shellValue}>
-              <Outlet />
+            <ShellContext.Provider value={shellStableValue}>
+              <ShellDataContext.Provider value={shellDataValue}>
+                <Outlet />
+              </ShellDataContext.Provider>
             </ShellContext.Provider>
           </div>
 

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -13,7 +13,7 @@ import {
 } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import {
   enable as enableAutostart,
   disable as disableAutostart,
@@ -235,13 +235,18 @@ function RootLayout() {
 
   // ── Navigation handlers ─────────────────────────────────────
 
+  // Keep a ref to channels so handleSelectItem doesn't depend on
+  // the volatile `channels` array, which changes every dashboard refetch.
+  const channelsRef = useRef(channels);
+  channelsRef.current = channels;
+
   const handleSelectItem = useCallback(
     (id: string) => {
       if (id === "settings") {
         navigate({ to: "/settings" });
         return;
       }
-      if (channels.some((ch) => ch.channel_type === id)) {
+      if (channelsRef.current.some((ch) => ch.channel_type === id)) {
         navigate({ to: "/channel/$type/$tab", params: { type: id, tab: "feed" } });
         return;
       }
@@ -251,7 +256,7 @@ function RootLayout() {
       }
       navigate({ to: "/feed" });
     },
-    [channels, navigate],
+    [navigate],
   );
 
   const handleNavigateToFeed = useCallback(() => navigate({ to: "/feed" }), [navigate]);

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -11,7 +11,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import RouteError from "../components/RouteError";
 import { Pencil, Check, ChevronDown, ChevronRight } from "lucide-react";
 import clsx from "clsx";
-import { useShell } from "../shell-context";
+import { useShell, useShellData } from "../shell-context";
 import DashboardCard, { GhostCard } from "../components/dashboard/DashboardCard";
 import FinanceSummary from "../components/dashboard/FinanceSummary";
 import SportsSummary from "../components/dashboard/SportsSummary";
@@ -101,9 +101,8 @@ export const Route = createFileRoute("/feed")({
 function FeedDashboard() {
   const navigate = useNavigate();
   const shell = useShell();
+  const { channels, dashboard } = useShellData();
   const {
-    channels,
-    dashboard,
     allChannelManifests,
     allWidgets,
     authenticated,

--- a/desktop/src/routes/ticker.tsx
+++ b/desktop/src/routes/ticker.tsx
@@ -6,7 +6,7 @@
  */
 import { createFileRoute } from "@tanstack/react-router";
 import RouteError from "../components/RouteError";
-import { useShell } from "../shell-context";
+import { useShell, useShellData } from "../shell-context";
 import type { ChannelType } from "../api/client";
 import type {
   AppearancePrefs,
@@ -91,7 +91,8 @@ function speedLabel(speed: number): string {
 
 function TickerRoute() {
   const shell = useShell();
-  const { prefs, onPrefsChange, channels, allChannelManifests, allWidgets } = shell;
+  const { channels } = useShellData();
+  const { prefs, onPrefsChange, allChannelManifests, allWidgets } = shell;
   const { appearance, ticker } = prefs;
   const enabledWidgets = prefs.widgets.enabledWidgets;
 

--- a/desktop/src/shell-context.ts
+++ b/desktop/src/shell-context.ts
@@ -1,8 +1,16 @@
 /**
  * Shell context — shared state between the root layout and child routes.
  *
+ * Split into two contexts for render performance:
+ *   - ShellContext  (stable)  — prefs, auth, callbacks, manifests. Changes
+ *     only on explicit user action. Consumed by all routes.
+ *   - ShellDataContext (volatile) — channels and dashboard data. Changes on
+ *     every TanStack Query refetch / CDC event. Only consumed by routes
+ *     that actually need live data (feed, ticker).
+ *
  * Routes that need preferences, auth state, or shell handlers consume
- * this context via useShell(). The root layout provides it.
+ * this context via useShell(). Routes that also need live dashboard data
+ * additionally call useShellData().
  */
 import { createContext, useContext } from "react";
 import type { AppPreferences } from "./preferences";
@@ -10,6 +18,8 @@ import type { SubscriptionTier } from "./auth";
 import type { ChannelType, Channel } from "./api/client";
 import type { DashboardResponse } from "./types";
 import type { ChannelManifest, WidgetManifest } from "./types";
+
+// ── Stable context (prefs, auth, callbacks, manifests) ──────────
 
 export interface ShellState {
   prefs: AppPreferences;
@@ -26,11 +36,6 @@ export interface ShellState {
   onToggleTaskbar: (enabled: boolean) => void;
   appVersion: string;
 
-  // ── Navigation overhaul additions ──────────────────────────────
-  /** User's channel records from the dashboard API. */
-  channels: Channel[];
-  /** Dashboard query response (for initial data snapshots). */
-  dashboard: DashboardResponse | undefined;
   /** All registered channel manifests (static). */
   allChannelManifests: ChannelManifest[];
   /** All registered widget manifests (static). */
@@ -54,5 +59,22 @@ export const ShellContext = createContext<ShellState | null>(null);
 export function useShell(): ShellState {
   const ctx = useContext(ShellContext);
   if (!ctx) throw new Error("useShell must be used within RootLayout");
+  return ctx;
+}
+
+// ── Volatile data context (channels + dashboard) ────────────────
+
+export interface ShellDataState {
+  /** User's channel records from the dashboard API. */
+  channels: Channel[];
+  /** Dashboard query response (for initial data snapshots). */
+  dashboard: DashboardResponse | undefined;
+}
+
+export const ShellDataContext = createContext<ShellDataState | null>(null);
+
+export function useShellData(): ShellDataState {
+  const ctx = useContext(ShellDataContext);
+  if (!ctx) throw new Error("useShellData must be used within RootLayout");
   return ctx;
 }


### PR DESCRIPTION
## Summary

- **Split `ShellContext` into two contexts** — a stable context (prefs, auth, callbacks, manifests) and a volatile data context (channels, dashboard) — so that 4 of 6 consumer routes (`settings`, `account`, `channel.$type.$tab`, `widget.$id.$tab`) stop re-rendering on every 10-second dashboard refetch cycle.
- **Added `React.memo` with field-level comparators** to 6 high-traffic list/chip components (`TradeItem`, `GameItem`, `RssArticle`, `GameChip`, `TradeChip`, `RssChip`) so that CDC/SSE updates to one item no longer force re-renders of all siblings.
- **Extracted 2 inline arrow callbacks** in `__root.tsx` to proper `useCallback` hooks to maintain referential stability in the stable context value.

## What this eliminates

| Before | After |
|--------|-------|
| All 6 routes re-render every 10s on dashboard refetch | Only `feed` and `ticker` re-render (they actually need the data) |
| Every trade/game/article re-renders when any sibling updates via CDC | Only the specific item whose data changed re-renders |
| Inline callbacks in `useMemo` recreated on every context change | Stable `useCallback` refs that never change |

## Files changed (10)

| File | Change |
|------|--------|
| `shell-context.ts` | Added `ShellDataState`, `ShellDataContext`, `useShellData()` |
| `routes/__root.tsx` | Split `useMemo` into stable + volatile, nested two providers, extracted callbacks |
| `routes/feed.tsx` | Uses `useShellData()` for `channels`/`dashboard` |
| `routes/ticker.tsx` | Uses `useShellData()` for `channels` |
| `channels/finance/FeedTab.tsx` | `TradeItem` wrapped with `memo` + comparator |
| `channels/sports/GameItem.tsx` | `GameItem` wrapped with `memo` + comparator |
| `channels/rss/FeedTab.tsx` | `RssArticle` wrapped with `memo` + comparator |
| `components/chips/GameChip.tsx` | Wrapped with `memo` + comparator |
| `components/chips/TradeChip.tsx` | Wrapped with `memo` + comparator |
| `components/chips/RssChip.tsx` | Wrapped with `memo` + comparator |

## Verification

- `npm run build` passes (vite build + tsc --noEmit) with zero errors