### PR TITLE
fix(desktop): dashboard card layout and custom tooltip system

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@tanstack/react-query": "^5.90.21",
@@ -1474,6 +1474,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.7.8",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "0.7.8",
+      "version": "0.9.2",
       "dependencies": {
+        "@floating-ui/react": "^0.27.19",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-router": "^1.166.7",
         "@tauri-apps/api": "^2.0.0",
@@ -17,7 +18,6 @@
         "@tauri-apps/plugin-shell": "^2.0.0",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "clsx": "^2.1.1",
-        "lenis": "^1.3.18",
         "lucide-react": "^0.577.0",
         "motion": "^12.35.1",
         "motion-plus": "https://api.motion.dev/registry.tgz?package=motion-plus&version=2.11.0&token=032997dbced0702754906e3f43111740b10beaa970fd6d26423e34e43a46acfe",
@@ -791,6 +791,59 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -2629,32 +2682,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/lenis": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.18.tgz",
-      "integrity": "sha512-7KBl3V7vx5y1h05pu9fNFZS66I0+1eZ+zUGNNNBKtEn3BONZy+nkHWvdEe2b+zKT+6WX1x7zyOb1zbYYOs6tcg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/darkroomengineering"
-      },
-      "peerDependencies": {
-        "@nuxt/kit": ">=3.0.0",
-        "react": ">=17.0.0",
-        "vue": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@nuxt/kit": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/lightningcss": {
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
@@ -3331,6 +3358,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,6 +11,7 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@floating-ui/react": "^0.27.19",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.166.7",
     "@tauri-apps/api": "^2.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 
 [lib]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/channels/RssConfigPanel.tsx
+++ b/desktop/src/channels/RssConfigPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Plus, Rss, Trash2 } from "lucide-react";
+import Tooltip from "../components/Tooltip";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
 import { channelsApi, rssApi } from "../api/client";
@@ -155,16 +156,17 @@ export default function RssConfigPanel({
                 {isSelected ? "✓ Added" : "+ Add"}
               </span>
               {!item.is_default && !isSelected && (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    deleteCatalogFeed(item);
-                  }}
-                  title="Delete this feed"
-                  className="p-0.5 rounded hover:bg-error/10 text-fg-4 hover:text-error transition-colors cursor-pointer"
-                >
-                  <Trash2 size={11} />
-                </button>
+                <Tooltip content="Delete this feed">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      deleteCatalogFeed(item);
+                    }}
+                    className="p-0.5 rounded hover:bg-error/10 text-fg-4 hover:text-error transition-colors cursor-pointer"
+                  >
+                    <Trash2 size={11} />
+                  </button>
+                </Tooltip>
               )}
             </div>
           </>

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@
 import { useState, useMemo } from "react";
 import { LayoutDashboard, Settings, User, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import clsx from "clsx";
+import Tooltip from "./Tooltip";
 import type { ChannelManifest, WidgetManifest, DeliveryMode } from "../types";
 import type { Channel } from "../api/client";
 import { CHANNEL_ORDER } from "../channels/registry";
@@ -164,10 +165,10 @@ export default function Sidebar({
       )}
     >
       {/* App header — logo + name */}
+      <Tooltip content={collapsed ? "Dashboard" : undefined} side="right">
       <button
         onClick={onNavigateToFeed}
         aria-label="Scrollr — go to dashboard"
-        title={collapsed ? "Dashboard" : undefined}
         className={clsx(
           "flex items-center w-full h-12 shrink-0 transition-colors",
           collapsed ? "justify-center px-0" : "gap-2.5 px-4",
@@ -183,6 +184,7 @@ export default function Sidebar({
           <span className="text-sm font-semibold text-fg tracking-tight">Scrollr</span>
         )}
       </button>
+      </Tooltip>
 
       {/* Navigation items */}
       <nav
@@ -288,10 +290,10 @@ export default function Sidebar({
         />
 
         {/* Collapse toggle */}
+        <Tooltip content={collapsed ? "Expand sidebar" : "Collapse sidebar"} side="right">
         <button
           onClick={toggleCollapsed}
           aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
           className={clsx(
             "flex items-center w-full rounded-lg text-fg-4 hover:text-fg-2 hover:bg-surface-hover transition-colors",
             collapsed
@@ -306,6 +308,7 @@ export default function Sidebar({
             <span className="text-[12px] font-medium">Collapse</span>
           )}
         </button>
+        </Tooltip>
 
         {/* Status footer — informational only */}
         <div
@@ -314,9 +317,9 @@ export default function Sidebar({
             collapsed ? "flex-col gap-1.5 px-0 justify-center" : "gap-3 px-2.5",
           )}
         >
+          <Tooltip content={deliveryMode === "sse" ? "Receiving updates live" : "Polling for updates"} side="right">
           <div
             className="flex items-center gap-1.5"
-            title={deliveryMode === "sse" ? "Receiving updates live" : "Polling for updates"}
           >
             <div
               className={clsx(
@@ -332,9 +335,10 @@ export default function Sidebar({
               </span>
             )}
           </div>
+          </Tooltip>
+          <Tooltip content={tickerAlive ? "Ticker is running" : "Ticker is off"} side="right">
           <div
             className="flex items-center gap-1.5"
-            title={tickerAlive ? "Ticker is running" : "Ticker is off"}
           >
             <div
               className={clsx(
@@ -350,6 +354,7 @@ export default function Sidebar({
               </span>
             )}
           </div>
+          </Tooltip>
         </div>
       </div>
     </aside>
@@ -390,11 +395,11 @@ function NavItem({
   onClick: () => void;
 }) {
   return (
+    <Tooltip content={collapsed ? label : undefined} side="right">
     <button
       onClick={onClick}
       aria-current={active ? "page" : undefined}
       aria-label={collapsed ? label : undefined}
-      title={collapsed ? label : undefined}
       className={clsx(
         "relative flex items-center w-full rounded-lg font-medium transition-colors",
         collapsed
@@ -417,5 +422,6 @@ function NavItem({
       </span>
       {!collapsed && <span className="truncate">{label}</span>}
     </button>
+    </Tooltip>
   );
 }

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -166,24 +166,24 @@ export default function Sidebar({
     >
       {/* App header — logo + name */}
       <Tooltip content={collapsed ? "Dashboard" : undefined} side="right">
-      <button
-        onClick={onNavigateToFeed}
-        aria-label="Scrollr — go to dashboard"
-        className={clsx(
-          "flex items-center w-full h-12 shrink-0 transition-colors",
-          collapsed ? "justify-center px-0" : "gap-2.5 px-4",
-          isFeed
-            ? "border-b border-accent/30 bg-accent/5"
-            : tickerAlive
-              ? "border-b border-accent/15"
-              : "border-b border-edge",
-        )}
-      >
-        <EkgLogo alive={tickerAlive} />
-        {!collapsed && (
-          <span className="text-sm font-semibold text-fg tracking-tight">Scrollr</span>
-        )}
-      </button>
+        <button
+          onClick={onNavigateToFeed}
+          aria-label="Scrollr — go to dashboard"
+          className={clsx(
+            "flex items-center w-full h-12 shrink-0 transition-colors",
+            collapsed ? "justify-center px-0" : "gap-2.5 px-4",
+            isFeed
+              ? "border-b border-accent/30 bg-accent/5"
+              : tickerAlive
+                ? "border-b border-accent/15"
+                : "border-b border-edge",
+          )}
+        >
+          <EkgLogo alive={tickerAlive} />
+          {!collapsed && (
+            <span className="text-sm font-semibold text-fg tracking-tight">Scrollr</span>
+          )}
+        </button>
       </Tooltip>
 
       {/* Navigation items */}
@@ -291,23 +291,23 @@ export default function Sidebar({
 
         {/* Collapse toggle */}
         <Tooltip content={collapsed ? "Expand sidebar" : "Collapse sidebar"} side="right">
-        <button
-          onClick={toggleCollapsed}
-          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          className={clsx(
-            "flex items-center w-full rounded-lg text-fg-4 hover:text-fg-2 hover:bg-surface-hover transition-colors",
-            collapsed
-              ? "justify-center py-1.5"
-              : "gap-2.5 px-2.5 py-1.5",
-          )}
-        >
-          <span className="shrink-0 flex items-center justify-center w-5 h-5">
-            {collapsed ? <PanelLeftOpen size={14} /> : <PanelLeftClose size={14} />}
-          </span>
-          {!collapsed && (
-            <span className="text-[12px] font-medium">Collapse</span>
-          )}
-        </button>
+          <button
+            onClick={toggleCollapsed}
+            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            className={clsx(
+              "flex items-center w-full rounded-lg text-fg-4 hover:text-fg-2 hover:bg-surface-hover transition-colors",
+              collapsed
+                ? "justify-center py-1.5"
+                : "gap-2.5 px-2.5 py-1.5",
+            )}
+          >
+            <span className="shrink-0 flex items-center justify-center w-5 h-5">
+              {collapsed ? <PanelLeftOpen size={14} /> : <PanelLeftClose size={14} />}
+            </span>
+            {!collapsed && (
+              <span className="text-[12px] font-medium">Collapse</span>
+            )}
+          </button>
         </Tooltip>
 
         {/* Status footer — informational only */}
@@ -318,42 +318,38 @@ export default function Sidebar({
           )}
         >
           <Tooltip content={deliveryMode === "sse" ? "Receiving updates live" : "Polling for updates"} side="right">
-          <div
-            className="flex items-center gap-1.5"
-          >
-            <div
-              className={clsx(
-                "w-1.5 h-1.5 rounded-full shrink-0",
-                deliveryMode === "sse"
-                  ? "bg-info"
-                  : "bg-warn",
+            <div className="flex items-center gap-1.5">
+              <div
+                className={clsx(
+                  "w-1.5 h-1.5 rounded-full shrink-0",
+                  deliveryMode === "sse"
+                    ? "bg-info"
+                    : "bg-warn",
+                )}
+              />
+              {!collapsed && (
+                <span className="text-[10px] font-mono uppercase tracking-wider text-fg-4">
+                  {deliveryMode === "sse" ? "Live" : "Polling"}
+                </span>
               )}
-            />
-            {!collapsed && (
-              <span className="text-[10px] font-mono uppercase tracking-wider text-fg-4">
-                {deliveryMode === "sse" ? "Live" : "Polling"}
-              </span>
-            )}
-          </div>
+            </div>
           </Tooltip>
           <Tooltip content={tickerAlive ? "Ticker is running" : "Ticker is off"} side="right">
-          <div
-            className="flex items-center gap-1.5"
-          >
-            <div
-              className={clsx(
-                "w-1.5 h-1.5 rounded-full shrink-0 transition-all duration-500",
-                tickerAlive
-                  ? "bg-accent"
-                  : "bg-fg-4/30",
+            <div className="flex items-center gap-1.5">
+              <div
+                className={clsx(
+                  "w-1.5 h-1.5 rounded-full shrink-0 transition-all duration-500",
+                  tickerAlive
+                    ? "bg-accent"
+                    : "bg-fg-4/30",
+                )}
+              />
+              {!collapsed && (
+                <span className="text-[10px] font-mono uppercase tracking-wider text-fg-4">
+                  {tickerAlive ? "Ticker" : "Off"}
+                </span>
               )}
-            />
-            {!collapsed && (
-              <span className="text-[10px] font-mono uppercase tracking-wider text-fg-4">
-                {tickerAlive ? "Ticker" : "Off"}
-              </span>
-            )}
-          </div>
+            </div>
           </Tooltip>
         </div>
       </div>
@@ -396,32 +392,32 @@ function NavItem({
 }) {
   return (
     <Tooltip content={collapsed ? label : undefined} side="right">
-    <button
-      onClick={onClick}
-      aria-current={active ? "page" : undefined}
-      aria-label={collapsed ? label : undefined}
-      className={clsx(
-        "relative flex items-center w-full rounded-lg font-medium transition-colors",
-        collapsed
-          ? "justify-center py-1.5 px-0"
-          : "gap-2.5 px-2.5 py-1.5 text-[13px]",
-        active
-          ? "bg-accent/10 text-fg"
-          : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
-      )}
-    >
-      {/* Active indicator — left accent bar */}
-      {active && (
-        <span
-          className="absolute left-0 top-1.5 bottom-1.5 w-[2.5px] rounded-full"
-          style={{ background: accentColor ?? "var(--color-accent)" }}
-        />
-      )}
-      <span className="shrink-0 flex items-center justify-center w-5 h-5">
-        {icon}
-      </span>
-      {!collapsed && <span className="truncate">{label}</span>}
-    </button>
+      <button
+        onClick={onClick}
+        aria-current={active ? "page" : undefined}
+        aria-label={collapsed ? label : undefined}
+        className={clsx(
+          "relative flex items-center w-full rounded-lg font-medium transition-colors",
+          collapsed
+            ? "justify-center py-1.5 px-0"
+            : "gap-2.5 px-2.5 py-1.5 text-[13px]",
+          active
+            ? "bg-accent/10 text-fg"
+            : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
+        )}
+      >
+        {/* Active indicator — left accent bar */}
+        {active && (
+          <span
+            className="absolute left-0 top-1.5 bottom-1.5 w-[2.5px] rounded-full"
+            style={{ background: accentColor ?? "var(--color-accent)" }}
+          />
+        )}
+        <span className="shrink-0 flex items-center justify-center w-5 h-5">
+          {icon}
+        </span>
+        {!collapsed && <span className="truncate">{label}</span>}
+      </button>
     </Tooltip>
   );
 }

--- a/desktop/src/components/TickerToolbar.tsx
+++ b/desktop/src/components/TickerToolbar.tsx
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { ChevronUp, ChevronDown, AppWindow, EyeOff } from "lucide-react";
 import clsx from "clsx";
+import Tooltip from "./Tooltip";
 import type { TickerPosition } from "../preferences";
 
 interface TickerToolbarProps {
@@ -42,32 +43,35 @@ export default function TickerToolbar({
 
       {/* Toolbar body */}
       <div className="h-full flex items-center gap-0.5 pr-2 bg-surface/80 backdrop-blur-sm">
-        <button
-          onClick={openApp}
-          aria-label="Open Scrollr"
-          title="Open Scrollr"
-          className={btn}
-        >
-          <AppWindow size={14} />
-        </button>
+        <Tooltip content="Open Scrollr" side="bottom">
+          <button
+            onClick={openApp}
+            aria-label="Open Scrollr"
+            className={btn}
+          >
+            <AppWindow size={14} />
+          </button>
+        </Tooltip>
 
-        <button
-          onClick={onTogglePosition}
-          aria-label={posLabel}
-          title={posLabel}
-          className={btn}
-        >
-          <PosIcon size={16} />
-        </button>
+        <Tooltip content={posLabel} side="bottom">
+          <button
+            onClick={onTogglePosition}
+            aria-label={posLabel}
+            className={btn}
+          >
+            <PosIcon size={16} />
+          </button>
+        </Tooltip>
 
-        <button
-          onClick={onHideTicker}
-          aria-label="Hide Ticker"
-          title="Hide Ticker"
-          className={btn}
-        >
-          <EyeOff size={14} />
-        </button>
+        <Tooltip content="Hide Ticker" side="bottom">
+          <button
+            onClick={onHideTicker}
+            aria-label="Hide Ticker"
+            className={btn}
+          >
+            <EyeOff size={14} />
+          </button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/desktop/src/components/TitleBar.tsx
+++ b/desktop/src/components/TitleBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import Tooltip from "./Tooltip";
 
 const appWindow = getCurrentWindow();
 
@@ -44,26 +45,27 @@ export default function TitleBar() {
       {/* Window controls — right side */}
       <div className="flex items-center h-full">
         {/* Minimize */}
-        <button
-          onClick={() => appWindow.minimize()}
-          className={`${btnBase} text-fg-3 hover:text-fg hover:bg-surface-hover`}
-          title="Minimize"
-          aria-label="Minimize"
-          onMouseDown={(e) => e.stopPropagation()}
-        >
-          <svg width="10" height="1" viewBox="0 0 10 1">
-            <rect fill="currentColor" width="10" height="1" rx="0.5" />
-          </svg>
-        </button>
+        <Tooltip content="Minimize" side="bottom">
+          <button
+            onClick={() => appWindow.minimize()}
+            className={`${btnBase} text-fg-3 hover:text-fg hover:bg-surface-hover`}
+            aria-label="Minimize"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <svg width="10" height="1" viewBox="0 0 10 1">
+              <rect fill="currentColor" width="10" height="1" rx="0.5" />
+            </svg>
+          </button>
+        </Tooltip>
 
         {/* Maximize / Restore */}
-        <button
-          onClick={() => appWindow.toggleMaximize()}
-          className={`${btnBase} text-fg-3 hover:text-fg hover:bg-surface-hover`}
-          title={maximized ? "Restore" : "Maximize"}
-          aria-label={maximized ? "Restore" : "Maximize"}
-          onMouseDown={(e) => e.stopPropagation()}
-        >
+        <Tooltip content={maximized ? "Restore" : "Maximize"} side="bottom">
+          <button
+            onClick={() => appWindow.toggleMaximize()}
+            className={`${btnBase} text-fg-3 hover:text-fg hover:bg-surface-hover`}
+            aria-label={maximized ? "Restore" : "Maximize"}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
           {maximized ? (
             // Restore icon — two overlapping rectangles
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
@@ -97,24 +99,26 @@ export default function TitleBar() {
             </svg>
           )}
         </button>
+        </Tooltip>
 
         {/* Close */}
-        <button
-          onClick={() => appWindow.close()}
-          className={`${btnBase} text-fg-3 hover:text-fg hover:bg-error/80 hover:text-white`}
-          title="Close"
-          aria-label="Close"
-          onMouseDown={(e) => e.stopPropagation()}
-        >
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-            <path
-              d="M1 1l8 8M9 1l-8 8"
-              stroke="currentColor"
-              strokeWidth="1.3"
-              strokeLinecap="round"
-            />
-          </svg>
-        </button>
+        <Tooltip content="Close" side="bottom">
+          <button
+            onClick={() => appWindow.close()}
+            className={`${btnBase} text-fg-3 hover:text-fg hover:bg-error/80 hover:text-white`}
+            aria-label="Close"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+              <path
+                d="M1 1l8 8M9 1l-8 8"
+                stroke="currentColor"
+                strokeWidth="1.3"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/desktop/src/components/Tooltip.tsx
+++ b/desktop/src/components/Tooltip.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tooltip — themed tooltip with fast appearance and viewport-aware positioning.
+ *
+ * Uses Floating UI for positioning (flip/shift at viewport edges) and
+ * portal rendering (avoids overflow:hidden clipping). Appears after a
+ * short hover delay (150ms default, vs native title ~500-1000ms).
+ *
+ * When `content` is undefined, renders children as a passthrough with
+ * zero overhead — useful for conditional tooltips (e.g. sidebar collapsed state).
+ */
+import { useState, cloneElement } from "react";
+import type { ReactElement, Ref } from "react";
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  useHover,
+  useFocus,
+  useDismiss,
+  useRole,
+  useInteractions,
+  useTransitionStyles,
+  FloatingPortal,
+} from "@floating-ui/react";
+import type { Placement, Side } from "@floating-ui/react";
+
+interface TooltipProps {
+  /** Tooltip text. When undefined, renders children without tooltip. */
+  content: string | undefined;
+  /** Preferred placement. Auto-flips if near viewport edge. Default "top". */
+  side?: Placement;
+  /** Hover delay in ms. Default 150. */
+  delay?: number;
+  /** The trigger element. Must be a single React element. */
+  children: ReactElement<{ ref?: Ref<HTMLElement> }>;
+}
+
+/** Slide-in transform per placement side. */
+const SLIDE: Record<Side, string> = {
+  top: "translateY(4px)",
+  bottom: "translateY(-4px)",
+  left: "translateX(4px)",
+  right: "translateX(-4px)",
+};
+
+export default function Tooltip({
+  content,
+  side = "top",
+  delay = 150,
+  children,
+}: TooltipProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: side,
+    // Use top/left positioning instead of transform so that
+    // useTransitionStyles can own the transform property for
+    // enter/exit animations without overwriting the position.
+    transform: false,
+    middleware: [
+      offset(6),
+      flip({ fallbackAxisSideDirection: "start" }),
+      shift({ padding: 5 }),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const hover = useHover(context, { move: false, delay: { open: delay } });
+  const focus = useFocus(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: "tooltip" });
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    hover,
+    focus,
+    dismiss,
+    role,
+  ]);
+
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(
+    context,
+    {
+      duration: 100,
+      initial: ({ side: s }) => ({
+        opacity: 0,
+        transform: SLIDE[s],
+      }),
+    },
+  );
+
+  // Passthrough when no content — hooks above are called unconditionally
+  if (!content) return children;
+
+  return (
+    <>
+      {cloneElement(children, {
+        ref: refs.setReference,
+        ...getReferenceProps(),
+      })}
+      <FloatingPortal>
+        {isMounted && (
+          <div
+            ref={refs.setFloating}
+            style={{ ...floatingStyles, ...transitionStyles }}
+            className="z-50 px-2.5 py-1 text-xs text-fg-2 bg-surface-2 border border-edge rounded-md shadow-soft-sm pointer-events-none select-none whitespace-nowrap"
+            {...getFloatingProps()}
+          >
+            {content}
+          </div>
+        )}
+      </FloatingPortal>
+    </>
+  );
+}

--- a/desktop/src/components/dashboard/DashboardCard.tsx
+++ b/desktop/src/components/dashboard/DashboardCard.tsx
@@ -140,7 +140,7 @@ export default function DashboardCard({
             "absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-0.5 rounded-lg px-1 py-0.5 transition-opacity",
             deleteArmed || customizing
               ? "opacity-100 bg-surface-2"
-              : "opacity-0 pointer-events-none group-hover/card:opacity-100 group-hover/card:pointer-events-auto bg-surface-2",
+              : "opacity-0 pointer-events-none group-hover/card:opacity-100 group-hover/card:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto bg-surface-2",
           )}
         >
           {/* Ticker visibility toggle (hover-revealed) */}

--- a/desktop/src/components/dashboard/DashboardCard.tsx
+++ b/desktop/src/components/dashboard/DashboardCard.tsx
@@ -13,6 +13,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Settings, SlidersHorizontal, ChevronUp, ChevronDown, ArrowRight, X, Eye, EyeOff } from "lucide-react";
 import clsx from "clsx";
+import Tooltip from "../Tooltip";
 import CardEditor from "./CardEditor";
 import type { EditorField } from "./dashboardPrefs";
 
@@ -139,118 +140,124 @@ export default function DashboardCard({
             "absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-0.5 rounded-lg px-1 py-0.5 transition-opacity",
             deleteArmed || customizing
               ? "opacity-100 bg-surface-2"
-              : "opacity-0 group-hover/card:opacity-100 bg-surface-2",
+              : "opacity-0 pointer-events-none group-hover/card:opacity-100 group-hover/card:pointer-events-auto bg-surface-2",
           )}
         >
           {/* Ticker visibility toggle (hover-revealed) */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleTicker();
-            }}
-            aria-label={tickerEnabled ? `Hide ${name} from ticker` : `Show ${name} on ticker`}
-            title={tickerEnabled ? "Visible on ticker" : "Hidden from ticker"}
-            className={clsx(
-              "w-6 h-6 flex items-center justify-center rounded-md transition-all shrink-0",
-              tickerEnabled
-                ? "text-fg-3 hover:text-fg hover:bg-surface-hover"
-                : "text-fg-4/60 hover:text-fg-2 hover:bg-surface-hover",
-              "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40",
-            )}
-          >
-            {tickerEnabled ? <Eye size={12} /> : <EyeOff size={12} />}
-          </button>
-
-          {/* Customize card display (hover-revealed, toggles inline editor) */}
-          {hasEditor && (
+          <Tooltip content={tickerEnabled ? "Visible on ticker" : "Hidden from ticker"}>
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                setCustomizing((p) => !p);
+                onToggleTicker();
               }}
-              aria-label={customizing ? "Close card customization" : "Customize card display"}
-              title={customizing ? "Done customizing" : "Customize card"}
+              aria-label={tickerEnabled ? `Hide ${name} from ticker` : `Show ${name} on ticker`}
               className={clsx(
                 "w-6 h-6 flex items-center justify-center rounded-md transition-all shrink-0",
-                customizing
-                  ? "text-accent bg-accent/10"
-                  : "text-fg-4 hover:text-fg-2 hover:bg-surface-hover",
+                tickerEnabled
+                  ? "text-fg-3 hover:text-fg hover:bg-surface-hover"
+                  : "text-fg-4/60 hover:text-fg-2 hover:bg-surface-hover",
                 "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40",
               )}
             >
-              <SlidersHorizontal size={12} />
+              {tickerEnabled ? <Eye size={12} /> : <EyeOff size={12} />}
             </button>
+          </Tooltip>
+
+          {/* Customize card display (hover-revealed, toggles inline editor) */}
+          {hasEditor && (
+            <Tooltip content={customizing ? "Done customizing" : "Customize card"}>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setCustomizing((p) => !p);
+                }}
+                aria-label={customizing ? "Close card customization" : "Customize card display"}
+                className={clsx(
+                  "w-6 h-6 flex items-center justify-center rounded-md transition-all shrink-0",
+                  customizing
+                    ? "text-accent bg-accent/10"
+                    : "text-fg-4 hover:text-fg-2 hover:bg-surface-hover",
+                  "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40",
+                )}
+              >
+                <SlidersHorizontal size={12} />
+              </button>
+            </Tooltip>
           )}
 
           {/* Gear — configure source (hover-revealed) */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onConfigure();
-            }}
-            aria-label={`Configure ${name}`}
-            title="Configure"
-            className="w-6 h-6 flex items-center justify-center rounded-md text-fg-4 hover:text-fg-2 hover:bg-surface-hover focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 transition-all shrink-0"
-          >
-            <Settings size={12} />
-          </button>
+          <Tooltip content="Configure">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onConfigure();
+              }}
+              aria-label={`Configure ${name}`}
+              className="w-6 h-6 flex items-center justify-center rounded-md text-fg-4 hover:text-fg-2 hover:bg-surface-hover focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 transition-all shrink-0"
+            >
+              <Settings size={12} />
+            </button>
+          </Tooltip>
 
           {/* Reorder arrows (hover-revealed) */}
           <div className="flex items-center">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onMoveUp?.();
-              }}
-              disabled={!onMoveUp}
-              className={clsx(
-                "w-5 h-5 flex items-center justify-center rounded transition-colors",
-                onMoveUp
-                  ? "text-fg-4 hover:text-fg-2 hover:bg-surface-hover"
-                  : "text-fg-4/20 cursor-default",
-              )}
-              aria-label={`Move ${name} up`}
-              title="Move up"
-            >
-              <ChevronUp size={13} />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onMoveDown?.();
-              }}
-              disabled={!onMoveDown}
-              className={clsx(
-                "w-5 h-5 flex items-center justify-center rounded transition-colors",
-                onMoveDown
-                  ? "text-fg-4 hover:text-fg-2 hover:bg-surface-hover"
-                  : "text-fg-4/20 cursor-default",
-              )}
-              aria-label={`Move ${name} down`}
-              title="Move down"
-            >
-              <ChevronDown size={13} />
-            </button>
+            <Tooltip content="Move up">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMoveUp?.();
+                }}
+                disabled={!onMoveUp}
+                className={clsx(
+                  "w-5 h-5 flex items-center justify-center rounded transition-colors",
+                  onMoveUp
+                    ? "text-fg-4 hover:text-fg-2 hover:bg-surface-hover"
+                    : "text-fg-4/20 cursor-default",
+                )}
+                aria-label={`Move ${name} up`}
+              >
+                <ChevronUp size={13} />
+              </button>
+            </Tooltip>
+            <Tooltip content="Move down">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMoveDown?.();
+                }}
+                disabled={!onMoveDown}
+                className={clsx(
+                  "w-5 h-5 flex items-center justify-center rounded transition-colors",
+                  onMoveDown
+                    ? "text-fg-4 hover:text-fg-2 hover:bg-surface-hover"
+                    : "text-fg-4/20 cursor-default",
+                )}
+                aria-label={`Move ${name} down`}
+              >
+                <ChevronDown size={13} />
+              </button>
+            </Tooltip>
           </div>
 
           {/* Remove (hover-revealed, two-click confirm) */}
-          <button
-            onClick={handleDeleteClick}
-            aria-label={deleteArmed ? `Confirm removal of ${name}` : `Remove ${name}`}
-            title={deleteArmed ? "Click again to confirm" : "Remove"}
-            className={clsx(
-              "flex items-center gap-1 rounded-md transition-all shrink-0",
-              deleteArmed
-                ? "px-2 py-0.5 text-red-500 bg-red-500/10"
-                : "w-6 h-6 justify-center text-fg-4 hover:text-red-400 hover:bg-red-500/10",
-              "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500/40",
-            )}
-          >
-            <X size={12} />
-            {deleteArmed && (
-              <span className="text-[10px] font-medium">Remove?</span>
-            )}
-          </button>
+          <Tooltip content={deleteArmed ? "Click again to confirm" : "Remove"}>
+            <button
+              onClick={handleDeleteClick}
+              aria-label={deleteArmed ? `Confirm removal of ${name}` : `Remove ${name}`}
+              className={clsx(
+                "flex items-center gap-1 rounded-md transition-all shrink-0",
+                deleteArmed
+                  ? "px-2 py-0.5 text-red-500 bg-red-500/10"
+                  : "w-6 h-6 justify-center text-fg-4 hover:text-red-400 hover:bg-red-500/10",
+                "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500/40",
+              )}
+            >
+              <X size={12} />
+              {deleteArmed && (
+                <span className="text-[10px] font-medium">Remove?</span>
+              )}
+            </button>
+          </Tooltip>
         </div>
       </div>
 

--- a/desktop/src/components/dashboard/DashboardCard.tsx
+++ b/desktop/src/components/dashboard/DashboardCard.tsx
@@ -11,7 +11,7 @@
  * All cards use header-click navigation (click name → source feed).
  */
 import { useState, useRef, useEffect } from "react";
-import { Settings, SlidersHorizontal, ChevronUp, ChevronDown, ArrowRight, X } from "lucide-react";
+import { Settings, SlidersHorizontal, ChevronUp, ChevronDown, ArrowRight, X, Eye, EyeOff } from "lucide-react";
 import clsx from "clsx";
 import CardEditor from "./CardEditor";
 import type { EditorField } from "./dashboardPrefs";
@@ -99,14 +99,17 @@ export default function DashboardCard({
         customizing && "ring-1 ring-accent/15",
       )}
     >
-      {/* Left accent bar */}
+      {/* Left accent bar — reflects ticker state */}
       <div
-        className="absolute left-0 top-0 bottom-0 w-[3px] rounded-l-xl"
+        className={clsx(
+          "absolute left-0 top-0 bottom-0 w-[3px] rounded-l-xl transition-opacity duration-300",
+          tickerEnabled ? "opacity-100" : "opacity-20",
+        )}
         style={{ background: hex }}
       />
 
       {/* Header */}
-      <div className="flex items-center justify-between px-4 pt-3.5 pb-2">
+      <div className="relative flex items-center px-4 pt-3.5 pb-2">
         {/* Title area — clickable to navigate to feed */}
         <button
           onClick={(e) => {
@@ -130,9 +133,16 @@ export default function DashboardCard({
           />
         </button>
 
-        {/* Action controls */}
-        <div className="flex items-center gap-0.5 shrink-0">
-          {/* Ticker status dot — always visible */}
+        {/* Action controls — absolutely positioned, hover-revealed */}
+        <div
+          className={clsx(
+            "absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-0.5 rounded-lg px-1 py-0.5 transition-opacity",
+            deleteArmed || customizing
+              ? "opacity-100 bg-surface-2"
+              : "opacity-0 group-hover/card:opacity-100 bg-surface-2",
+          )}
+        >
+          {/* Ticker visibility toggle (hover-revealed) */}
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -140,20 +150,15 @@ export default function DashboardCard({
             }}
             aria-label={tickerEnabled ? `Hide ${name} from ticker` : `Show ${name} on ticker`}
             title={tickerEnabled ? "Visible on ticker" : "Hidden from ticker"}
-            className="w-6 h-6 flex items-center justify-center rounded-md hover:bg-surface-hover transition-colors"
+            className={clsx(
+              "w-6 h-6 flex items-center justify-center rounded-md transition-all shrink-0",
+              tickerEnabled
+                ? "text-fg-3 hover:text-fg hover:bg-surface-hover"
+                : "text-fg-4/60 hover:text-fg-2 hover:bg-surface-hover",
+              "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40",
+            )}
           >
-            <div
-              className={clsx(
-                "w-[7px] h-[7px] rounded-full transition-all duration-300",
-                tickerEnabled
-                  ? "shadow-[0_0_4px_var(--glow-color)]"
-                  : "opacity-40",
-              )}
-              style={{
-                background: tickerEnabled ? hex : "var(--color-fg-4)",
-                "--glow-color": `${hex}60`,
-              } as React.CSSProperties}
-            />
+            {tickerEnabled ? <Eye size={12} /> : <EyeOff size={12} />}
           </button>
 
           {/* Customize card display (hover-revealed, toggles inline editor) */}
@@ -168,8 +173,8 @@ export default function DashboardCard({
               className={clsx(
                 "w-6 h-6 flex items-center justify-center rounded-md transition-all shrink-0",
                 customizing
-                  ? "opacity-100 text-accent bg-accent/10"
-                  : "text-fg-4 opacity-0 group-hover/card:opacity-60 hover:!opacity-100 hover:text-fg-2 hover:bg-surface-hover",
+                  ? "text-accent bg-accent/10"
+                  : "text-fg-4 hover:text-fg-2 hover:bg-surface-hover",
                 "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40",
               )}
             >
@@ -185,13 +190,13 @@ export default function DashboardCard({
             }}
             aria-label={`Configure ${name}`}
             title="Configure"
-            className="w-6 h-6 flex items-center justify-center rounded-md text-fg-4 opacity-0 group-hover/card:opacity-60 hover:!opacity-100 hover:text-fg-2 hover:bg-surface-hover focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 transition-all shrink-0"
+            className="w-6 h-6 flex items-center justify-center rounded-md text-fg-4 hover:text-fg-2 hover:bg-surface-hover focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 transition-all shrink-0"
           >
             <Settings size={12} />
           </button>
 
           {/* Reorder arrows (hover-revealed) */}
-          <div className="flex items-center opacity-0 group-hover/card:opacity-100 focus-within:opacity-100 transition-opacity">
+          <div className="flex items-center">
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -236,8 +241,8 @@ export default function DashboardCard({
             className={clsx(
               "flex items-center gap-1 rounded-md transition-all shrink-0",
               deleteArmed
-                ? "opacity-100 px-2 py-0.5 text-red-500 bg-red-500/10"
-                : "opacity-0 group-hover/card:opacity-60 hover:!opacity-100 w-6 h-6 justify-center text-fg-4 hover:text-red-400 hover:bg-red-500/10",
+                ? "px-2 py-0.5 text-red-500 bg-red-500/10"
+                : "w-6 h-6 justify-center text-fg-4 hover:text-red-400 hover:bg-red-500/10",
               "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500/40",
             )}
           >

--- a/desktop/src/components/dashboard/FinanceSummary.tsx
+++ b/desktop/src/components/dashboard/FinanceSummary.tsx
@@ -13,6 +13,7 @@ import { useState, useMemo, useCallback } from "react";
 import { useScrollrCDC } from "../../hooks/useScrollrCDC";
 import { loadPref, savePref } from "../../preferences";
 import clsx from "clsx";
+import Tooltip from "../Tooltip";
 import { formatPrice, formatChange } from "../../utils/format";
 import type { Trade, DashboardResponse } from "../../types";
 import type { FinanceCardPrefs } from "./dashboardPrefs";
@@ -95,20 +96,21 @@ function PrimaryStock({ trade, pinned, prefs, onUnpin }: PrimaryStockProps) {
           </span>
         )}
         {pinned && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onUnpin();
-            }}
-            className={clsx(
-              "w-4 h-4 flex items-center justify-center rounded-sm",
-              "text-[10px] text-fg-4 opacity-0 group-hover:opacity-100",
-              "hover:text-fg-2 hover:bg-surface-3/80 transition-all",
-            )}
-            title="Unpin"
-          >
-            &#x2715;
-          </button>
+          <Tooltip content="Unpin">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onUnpin();
+              }}
+              className={clsx(
+                "w-4 h-4 flex items-center justify-center rounded-sm",
+                "text-[10px] text-fg-4 opacity-0 group-hover:opacity-100",
+                "hover:text-fg-2 hover:bg-surface-3/80 transition-all",
+              )}
+            >
+              &#x2715;
+            </button>
+          </Tooltip>
         )}
       </div>
     </div>
@@ -127,27 +129,28 @@ function CompactBadge({ trade, onPromote }: CompactBadgeProps) {
   const pct = Number(trade.percentage_change) || 0;
 
   return (
-    <button
-      onClick={(e) => {
-        e.stopPropagation();
-        onPromote();
-      }}
-      className={clsx(
-        "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono",
-        "transition-colors shrink-0 cursor-pointer",
-        "bg-surface-3/40 hover:bg-surface-3/70 text-fg-3",
-      )}
-      title="Click to pin this stock"
-    >
-      <span className="font-semibold">{trade.symbol}</span>
-      {pct !== 0 && (
-        <span
-          className={clsx("tabular-nums", up ? "text-up" : "text-down")}
-        >
-          {formatChange(trade.percentage_change)}
-        </span>
-      )}
-    </button>
+    <Tooltip content="Click to pin this stock">
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onPromote();
+        }}
+        className={clsx(
+          "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono",
+          "transition-colors shrink-0 cursor-pointer",
+          "bg-surface-3/40 hover:bg-surface-3/70 text-fg-3",
+        )}
+      >
+        <span className="font-semibold">{trade.symbol}</span>
+        {pct !== 0 && (
+          <span
+            className={clsx("tabular-nums", up ? "text-up" : "text-down")}
+          >
+            {formatChange(trade.percentage_change)}
+          </span>
+        )}
+      </button>
+    </Tooltip>
   );
 }
 

--- a/desktop/src/components/dashboard/RssSummary.tsx
+++ b/desktop/src/components/dashboard/RssSummary.tsx
@@ -13,6 +13,7 @@ import { useState, useMemo, useCallback } from "react";
 import { useScrollrCDC } from "../../hooks/useScrollrCDC";
 import { loadPref, savePref } from "../../preferences";
 import clsx from "clsx";
+import Tooltip from "../Tooltip";
 import { timeAgo, truncate } from "../../utils/format";
 import type { RssItem, DashboardResponse } from "../../types";
 import type { RssCardPrefs } from "./dashboardPrefs";
@@ -106,13 +107,13 @@ function CompactHeadline({ article, prefs, onPromote }: CompactHeadlineProps) {
   const ago = timeAgo(article.published_at);
 
   return (
+    <Tooltip content="Click to feature this article">
     <button
       onClick={(e) => {
         e.stopPropagation();
         onPromote();
       }}
       className="flex items-center gap-1.5 w-full text-left px-1 py-1 rounded hover:bg-surface-3/40 transition-colors cursor-pointer group/headline"
-      title="Click to feature this article"
     >
       {fresh && (
         <span className="w-1 h-1 rounded-full bg-accent shrink-0 animate-pulse" />
@@ -131,6 +132,7 @@ function CompactHeadline({ article, prefs, onPromote }: CompactHeadlineProps) {
         </span>
       )}
     </button>
+    </Tooltip>
   );
 }
 

--- a/desktop/src/components/dashboard/RssSummary.tsx
+++ b/desktop/src/components/dashboard/RssSummary.tsx
@@ -108,30 +108,30 @@ function CompactHeadline({ article, prefs, onPromote }: CompactHeadlineProps) {
 
   return (
     <Tooltip content="Click to feature this article">
-    <button
-      onClick={(e) => {
-        e.stopPropagation();
-        onPromote();
-      }}
-      className="flex items-center gap-1.5 w-full text-left px-1 py-1 rounded hover:bg-surface-3/40 transition-colors cursor-pointer group/headline"
-    >
-      {fresh && (
-        <span className="w-1 h-1 rounded-full bg-accent shrink-0 animate-pulse" />
-      )}
-      {prefs.showSource && (
-        <span className="text-[9px] font-mono font-bold text-accent-purple uppercase tracking-wider shrink-0 max-w-[64px] truncate">
-          {article.source_name}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onPromote();
+        }}
+        className="flex items-center gap-1.5 w-full text-left px-1 py-1 rounded hover:bg-surface-3/40 transition-colors cursor-pointer group/headline"
+      >
+        {fresh && (
+          <span className="w-1 h-1 rounded-full bg-accent shrink-0 animate-pulse" />
+        )}
+        {prefs.showSource && (
+          <span className="text-[9px] font-mono font-bold text-accent-purple uppercase tracking-wider shrink-0 max-w-[64px] truncate">
+            {article.source_name}
+          </span>
+        )}
+        <span className="text-[11px] text-fg-3 group-hover/headline:text-fg-2 truncate flex-1 transition-colors">
+          {article.title}
         </span>
-      )}
-      <span className="text-[11px] text-fg-3 group-hover/headline:text-fg-2 truncate flex-1 transition-colors">
-        {article.title}
-      </span>
-      {prefs.showTime && ago && (
-        <span className="text-[9px] font-mono text-fg-4 tabular-nums shrink-0">
-          {ago}
-        </span>
-      )}
-    </button>
+        {prefs.showTime && ago && (
+          <span className="text-[9px] font-mono text-fg-4 tabular-nums shrink-0">
+            {ago}
+          </span>
+        )}
+      </button>
     </Tooltip>
   );
 }

--- a/desktop/src/components/dashboard/SportsSummary.tsx
+++ b/desktop/src/components/dashboard/SportsSummary.tsx
@@ -14,6 +14,7 @@ import { useScrollrCDC } from "../../hooks/useScrollrCDC";
 import { isCloseGame } from "../chips/GameChip";
 import { loadPref, savePref } from "../../preferences";
 import clsx from "clsx";
+import Tooltip from "../Tooltip";
 import type { Game, DashboardResponse } from "../../types";
 import type { SportsCardPrefs } from "./dashboardPrefs";
 
@@ -276,41 +277,42 @@ function CompactChip({ game, onPromote, showFinals, showUpcoming }: CompactChipP
   if (pre && !showUpcoming) return null;
 
   return (
-    <button
-      onClick={(e) => {
-        e.stopPropagation();
-        onPromote();
-      }}
-      className={clsx(
-        "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono",
-        "transition-colors cursor-pointer shrink-0",
-        live
-          ? "bg-live/8 hover:bg-live/15 text-fg-2"
-          : "bg-surface-3/40 hover:bg-surface-3/70 text-fg-3",
-      )}
-      title="Click to feature this game"
-    >
-      {live && (
-        <span className="w-1 h-1 rounded-full bg-live shrink-0 animate-pulse" />
-      )}
-      <span className={live ? "font-semibold" : ""}>
-        {abbreviate(game.away_team_name)}
-      </span>
-      {pre ? (
-        <span className="text-fg-4">vs</span>
-      ) : (
-        <>
-          <span className="tabular-nums">
-            {game.away_team_score}-{game.home_team_score}
-          </span>
-        </>
-      )}
-      <span className={live ? "font-semibold" : ""}>
-        {abbreviate(game.home_team_name)}
-      </span>
-      {final && <span className="text-fg-4 text-[9px]">F</span>}
-      {pre && <span className="text-fg-4 text-[9px]">{formatCountdown(game.start_time)}</span>}
-    </button>
+    <Tooltip content="Click to feature this game">
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onPromote();
+        }}
+        className={clsx(
+          "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono",
+          "transition-colors cursor-pointer shrink-0",
+          live
+            ? "bg-live/8 hover:bg-live/15 text-fg-2"
+            : "bg-surface-3/40 hover:bg-surface-3/70 text-fg-3",
+        )}
+      >
+        {live && (
+          <span className="w-1 h-1 rounded-full bg-live shrink-0 animate-pulse" />
+        )}
+        <span className={live ? "font-semibold" : ""}>
+          {abbreviate(game.away_team_name)}
+        </span>
+        {pre ? (
+          <span className="text-fg-4">vs</span>
+        ) : (
+          <>
+            <span className="tabular-nums">
+              {game.away_team_score}-{game.home_team_score}
+            </span>
+          </>
+        )}
+        <span className={live ? "font-semibold" : ""}>
+          {abbreviate(game.home_team_name)}
+        </span>
+        {final && <span className="text-fg-4 text-[9px]">F</span>}
+        {pre && <span className="text-fg-4 text-[9px]">{formatCountdown(game.start_time)}</span>}
+      </button>
+    </Tooltip>
   );
 }
 

--- a/desktop/src/widgets/clock/WorldClock.tsx
+++ b/desktop/src/widgets/clock/WorldClock.tsx
@@ -5,6 +5,7 @@
  * TODO: Phase E — migrate to Tauri store plugin.
  */
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import Tooltip from "../../components/Tooltip";
 import type { TimeFormat, TimezoneEntry } from "./types";
 
 // ── Timezone presets ────────────────────────────────────────────
@@ -223,13 +224,14 @@ function ClockCard({
         <div className="flex items-center gap-2">
           <span className="text-[11px] font-mono text-fg-2">{offset}</span>
           {!isLocal && onRemove && (
-            <button
-              onClick={onRemove}
-              className="text-fg-3 hover:text-error opacity-0 group-hover:opacity-100 transition-all"
-              title="Remove timezone"
-            >
-              <CloseIcon size={11} />
-            </button>
+            <Tooltip content="Remove timezone">
+              <button
+                onClick={onRemove}
+                className="text-fg-3 hover:text-error opacity-0 group-hover:opacity-100 transition-all"
+              >
+                <CloseIcon size={11} />
+              </button>
+            </Tooltip>
           )}
         </div>
       </div>
@@ -251,13 +253,14 @@ function ClockCard({
       }
     >
       {!isLocal && onRemove && (
-        <button
-          onClick={onRemove}
-          className="absolute top-2.5 right-2.5 w-5 h-5 flex items-center justify-center rounded text-fg-3 hover:text-error hover:bg-error/10 opacity-0 group-hover:opacity-100 transition-all"
-          title="Remove timezone"
-        >
-          <CloseIcon size={11} />
-        </button>
+        <Tooltip content="Remove timezone">
+          <button
+            onClick={onRemove}
+            className="absolute top-2.5 right-2.5 w-5 h-5 flex items-center justify-center rounded text-fg-3 hover:text-error hover:bg-error/10 opacity-0 group-hover:opacity-100 transition-all"
+          >
+            <CloseIcon size={11} />
+          </button>
+        </Tooltip>
       )}
       <div className="flex items-center gap-2 mb-1">
         <span className="text-xs font-mono text-widget-clock/80 uppercase tracking-wider">
@@ -354,17 +357,14 @@ export function WorldClock({ compact }: WorldClockProps) {
       {/* Controls */}
       <div className="flex items-center justify-between px-1 mb-1">
         <div className="flex items-center gap-2">
+          <Tooltip content={fmt === "12h" ? "Switch to 24-hour format" : "Switch to 12-hour format"}>
           <button
             onClick={toggleFormat}
             className="text-xs font-mono px-1.5 py-0.5 rounded border transition-colors text-widget-clock/70 border-widget-clock/20 hover:text-widget-clock hover:border-widget-clock/30"
-            title={
-              fmt === "12h"
-                ? "Switch to 24-hour format"
-                : "Switch to 12-hour format"
-            }
           >
             {fmt === "12h" ? "12h" : "24h"}
           </button>
+          </Tooltip>
         </div>
         <button
           onClick={() => setShowAdd(!showAdd)}

--- a/desktop/src/widgets/clock/WorldClock.tsx
+++ b/desktop/src/widgets/clock/WorldClock.tsx
@@ -358,12 +358,12 @@ export function WorldClock({ compact }: WorldClockProps) {
       <div className="flex items-center justify-between px-1 mb-1">
         <div className="flex items-center gap-2">
           <Tooltip content={fmt === "12h" ? "Switch to 24-hour format" : "Switch to 12-hour format"}>
-          <button
-            onClick={toggleFormat}
-            className="text-xs font-mono px-1.5 py-0.5 rounded border transition-colors text-widget-clock/70 border-widget-clock/20 hover:text-widget-clock hover:border-widget-clock/30"
-          >
-            {fmt === "12h" ? "12h" : "24h"}
-          </button>
+            <button
+              onClick={toggleFormat}
+              className="text-xs font-mono px-1.5 py-0.5 rounded border transition-colors text-widget-clock/70 border-widget-clock/20 hover:text-widget-clock hover:border-widget-clock/30"
+            >
+              {fmt === "12h" ? "12h" : "24h"}
+            </button>
           </Tooltip>
         </div>
         <button

--- a/desktop/src/widgets/weather/FeedTab.tsx
+++ b/desktop/src/widgets/weather/FeedTab.tsx
@@ -12,6 +12,7 @@
  * TODO: Phase E — migrate to Tauri store plugin.
  */
 import { useState, useEffect, useCallback } from "react";
+import Tooltip from "../../components/Tooltip";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { CloudSun } from "lucide-react";
 import { WeatherCard } from "./WeatherCard";
@@ -221,13 +222,14 @@ function WeatherFeedTab({ mode: feedMode }: FeedTabProps) {
           </button>
         </div>
         <div className="flex items-center gap-2">
+          <Tooltip content="Use my location">
           <button
             onClick={detectLocation}
             className="text-xs font-mono text-widget-weather/70 hover:text-widget-weather transition-colors"
-            title="Use my location"
           >
             {"\u{1F4CD}"}
           </button>
+          </Tooltip>
           <button
             onClick={() => {
               setShowSearch(!showSearch);

--- a/desktop/src/widgets/weather/FeedTab.tsx
+++ b/desktop/src/widgets/weather/FeedTab.tsx
@@ -223,12 +223,12 @@ function WeatherFeedTab({ mode: feedMode }: FeedTabProps) {
         </div>
         <div className="flex items-center gap-2">
           <Tooltip content="Use my location">
-          <button
-            onClick={detectLocation}
-            className="text-xs font-mono text-widget-weather/70 hover:text-widget-weather transition-colors"
-          >
-            {"\u{1F4CD}"}
-          </button>
+            <button
+              onClick={detectLocation}
+              className="text-xs font-mono text-widget-weather/70 hover:text-widget-weather transition-colors"
+            >
+              {"\u{1F4CD}"}
+            </button>
           </Tooltip>
           <button
             onClick={() => {

--- a/desktop/src/widgets/weather/WeatherCard.tsx
+++ b/desktop/src/widgets/weather/WeatherCard.tsx
@@ -12,6 +12,7 @@ import {
   formatTemp,
   formatWind,
 } from "./types";
+import Tooltip from "../../components/Tooltip";
 
 // ── Inline SVG Icons ────────────────────────────────────────────
 
@@ -104,20 +105,22 @@ export function WeatherCard({
           )}
         </div>
         <div className="flex items-center gap-1">
-          <button
-            onClick={onRefresh}
-            className="text-fg-3 hover:text-widget-weather opacity-0 group-hover:opacity-100 transition-opacity"
-            title="Refresh"
-          >
-            <RefreshIcon />
-          </button>
-          <button
-            onClick={onRemove}
-            className="text-fg-3 hover:text-error opacity-0 group-hover:opacity-100 transition-opacity"
-            title="Remove city"
-          >
-            <CloseIcon />
-          </button>
+          <Tooltip content="Refresh">
+            <button
+              onClick={onRefresh}
+              className="text-fg-3 hover:text-widget-weather opacity-0 group-hover:opacity-100 transition-opacity"
+            >
+              <RefreshIcon />
+            </button>
+          </Tooltip>
+          <Tooltip content="Remove city">
+            <button
+              onClick={onRemove}
+              className="text-fg-3 hover:text-error opacity-0 group-hover:opacity-100 transition-opacity"
+            >
+              <CloseIcon />
+            </button>
+          </Tooltip>
         </div>
       </div>
     );
@@ -129,20 +132,22 @@ export function WeatherCard({
       style={{ animation: "widget-card-enter 0.25s ease-out both" }}
     >
       <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button
-          onClick={onRefresh}
-          className="text-fg-3 hover:text-widget-weather p-0.5"
-          title="Refresh"
-        >
-          <RefreshIcon />
-        </button>
-        <button
-          onClick={onRemove}
-          className="text-fg-3 hover:text-error p-0.5"
-          title="Remove city"
-        >
-          <CloseIcon />
-        </button>
+        <Tooltip content="Refresh">
+          <button
+            onClick={onRefresh}
+            className="text-fg-3 hover:text-widget-weather p-0.5"
+          >
+            <RefreshIcon />
+          </button>
+        </Tooltip>
+        <Tooltip content="Remove city">
+          <button
+            onClick={onRemove}
+            className="text-fg-3 hover:text-error p-0.5"
+          >
+            <CloseIcon />
+          </button>
+        </Tooltip>
       </div>
 
       <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary

- **Dashboard card header layout**: Moved action controls to absolute positioning so they overlay on hover instead of consuming layout space. Fixes widget title truncation on the narrow 240px panel. Replaced the always-visible ticker status dot with a hover-revealed Eye/EyeOff toggle, and made the left accent bar opacity reflect ticker state at a glance.
- **Custom Tooltip component**: Added a themed `Tooltip` component using `@floating-ui/react` for viewport-aware positioning with 150ms hover delay, direction-aware slide-in animation, and portal rendering. Styled with existing design tokens (`bg-surface-2`, `border-edge`, `shadow-soft-sm`).
- **Full migration**: Replaced all 31 native `title=` attributes across 11 files with the new `Tooltip` component for consistent in-theme tooltips throughout the app.

## New dependency

`@floating-ui/react` (~4KB gzipped) — positioning, flip/shift middleware, hover/focus/dismiss interactions, portal rendering.