### PR TITLE
feature(desktop): add GitHub Actions CI status widget

### DIFF
--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -209,6 +209,25 @@ export default function ScrollrTicker({
         continue;
       }
 
+      if (tab === "github" && widgetData?.github.length) {
+        if (!pinnedWidgets.github) {
+          bucket.push(
+            wrap("ghb-consolidated",
+              <ConsolidatedChip
+                type="github"
+                items={widgetData.github}
+                comfort={comfort}
+                colorMode={chipColorMode}
+                onTogglePin={onTogglePin ? () => onTogglePin("github") : undefined}
+                onClick={() => onChipClick?.("github", "github")}
+              />
+            )
+          );
+          buckets.push(bucket);
+        }
+        continue;
+      }
+
       // ── Channel tabs: use dashboard.data ──────────────────────
       const data = dashboard?.data?.[tab];
       if (!Array.isArray(data) || data.length === 0) continue;
@@ -470,6 +489,20 @@ export default function ScrollrTicker({
           pinned
           onTogglePin={onTogglePin ? () => onTogglePin("uptime") : undefined}
           onClick={() => onChipClick?.("uptime", "uptime")}
+        />
+      );
+    }
+    if (tab === "github" && widgetData?.github.length) {
+      target.push(
+        <ConsolidatedChip
+          key="pinned-github"
+          type="github"
+          items={widgetData.github}
+          comfort={comfort}
+          colorMode={chipColorMode}
+          pinned
+          onTogglePin={onTogglePin ? () => onTogglePin("github") : undefined}
+          onClick={() => onChipClick?.("github", "github")}
         />
       );
     }

--- a/desktop/src/components/chips/ConsolidatedChip.tsx
+++ b/desktop/src/components/chips/ConsolidatedChip.tsx
@@ -1,5 +1,5 @@
 /**
- * ConsolidatedChip — generic ticker chip for clock, weather, sysmon, and uptime widgets.
+ * ConsolidatedChip — generic ticker chip for clock, weather, sysmon, uptime, and github widgets.
  *
  * Replaces the three nearly-identical ClockConsolidatedChip,
  * WeatherConsolidatedChip, and SysmonConsolidatedChip components.
@@ -13,11 +13,12 @@ import type {
   WeatherChipData,
   SysmonChipData,
   UptimeChipData,
+  GitHubChipData,
 } from "../../types";
 
 // ── Item shape union ────────────────────────────────────────────
 
-type ChipItem = ClockChipData | WeatherChipData | SysmonChipData | UptimeChipData;
+type ChipItem = ClockChipData | WeatherChipData | SysmonChipData | UptimeChipData | GitHubChipData;
 
 // ── Type guards ─────────────────────────────────────────────────
 
@@ -33,6 +34,10 @@ function isUptime(item: ChipItem): item is UptimeChipData {
   return "status" in item && "uptime" in item;
 }
 
+function isGithub(item: ChipItem): item is GitHubChipData {
+  return "workflowName" in item;
+}
+
 // ── Uptime status dot color ─────────────────────────────────────
 
 const UPTIME_DOT_COLORS: Record<string, string> = {
@@ -40,6 +45,15 @@ const UPTIME_DOT_COLORS: Record<string, string> = {
   down: "bg-down",
   pending: "bg-warning",
   maintenance: "bg-info",
+};
+
+// ── GitHub CI status dot color ───────────────────────────────────
+
+const CI_DOT_COLORS: Record<string, string> = {
+  success: "bg-up",
+  failure: "bg-down",
+  in_progress: "bg-warning",
+  unavailable: "bg-fg-4",
 };
 
 // ── Heartbeat mini bar ──────────────────────────────────────────
@@ -67,7 +81,7 @@ function HeartbeatBar({ heartbeats }: { heartbeats: number[] }) {
 // ── Props ───────────────────────────────────────────────────────
 
 interface ConsolidatedChipProps {
-  type: "clock" | "weather" | "sysmon" | "uptime";
+  type: "clock" | "weather" | "sysmon" | "uptime" | "github";
   items: ChipItem[];
   comfort?: boolean;
   colorMode?: ChipColorMode;
@@ -93,6 +107,7 @@ export default function ConsolidatedChip({
   const PinIcon = pinned ? PinOff : Pin;
   const anyHot = type === "sysmon" && items.some((item) => isSysmon(item) && item.hot);
   const anyDown = type === "uptime" && items.some((item) => isUptime(item) && item.status === "down");
+  const anyFailing = type === "github" && items.some((item) => isGithub(item) && item.status === "failure");
 
   return (
     <button
@@ -105,6 +120,7 @@ export default function ConsolidatedChip({
         c.bg, c.border, c.hoverBorder,
         anyHot && "border-error/30",
         anyDown && "border-down/30",
+        anyFailing && "border-down/30",
         comfort ? "flex flex-col items-start py-1.5 gap-0.5" : "flex items-center gap-2 py-1 text-[13px]",
       )}
     >
@@ -134,7 +150,12 @@ export default function ConsolidatedChip({
             <span className={clsx("font-semibold text-[11px] uppercase tracking-wider mr-1.5", c.textDim)}>
               {"label" in item ? item.label : ""}
             </span>
-            {isUptime(item) ? (
+            {isGithub(item) ? (
+              <>
+                <span className={clsx("w-1.5 h-1.5 rounded-full inline-block mr-1", CI_DOT_COLORS[item.status] ?? "bg-fg-4")} />
+                <span className={c.text}>{item.workflowName}</span>
+              </>
+            ) : isUptime(item) ? (
               <>
                 <span className={clsx("w-1.5 h-1.5 rounded-full inline-block mr-1", UPTIME_DOT_COLORS[item.status] ?? "bg-fg-4")} />
                 <span className={c.text}>{item.uptime}</span>

--- a/desktop/src/components/chips/chipColors.ts
+++ b/desktop/src/components/chips/chipColors.ts
@@ -105,6 +105,15 @@ const WIDGET_UPTIME: ChipColors = {
   textFaint: "text-widget-uptime/40",
 };
 
+const WIDGET_GITHUB: ChipColors = {
+  bg: "bg-widget-github/[0.06]",
+  border: "border-widget-github/25",
+  hoverBorder: "hover:border-widget-github/40",
+  text: "text-widget-github",
+  textDim: "text-widget-github/60",
+  textFaint: "text-widget-github/40",
+};
+
 // ── Channel + widget → color mapping ────────────────────────────
 
 const CHANNEL_MAP: Record<string, ChipColors> = {
@@ -117,6 +126,7 @@ const CHANNEL_MAP: Record<string, ChipColors> = {
   weather: WIDGET_WEATHER,
   sysmon: WIDGET_SYSMON,
   uptime: WIDGET_UPTIME,
+  github: WIDGET_GITHUB,
 };
 
 // ── Resolver ────────────────────────────────────────────────────

--- a/desktop/src/components/dashboard/GitHubSummary.tsx
+++ b/desktop/src/components/dashboard/GitHubSummary.tsx
@@ -1,0 +1,87 @@
+/**
+ * GitHubSummary — dashboard card content for the GitHub widget.
+ *
+ * Shows CI/Actions status summary: passing/failing counts and
+ * per-repo status dots. Reads from localStorage.
+ */
+import { useState, useEffect } from "react";
+import { loadRepoData } from "../../widgets/github/types";
+import { LS_GITHUB_REPOS } from "../../constants";
+import type { GitHubCardPrefs } from "./dashboardPrefs";
+
+interface GitHubSummaryProps {
+  prefs: GitHubCardPrefs;
+}
+
+const STATUS_DOTS: Record<string, string> = {
+  success: "bg-up",
+  failure: "bg-down",
+  in_progress: "bg-warning",
+  unavailable: "bg-fg-4",
+};
+
+export default function GitHubSummary({ prefs }: GitHubSummaryProps) {
+  const [repos, setRepos] = useState(loadRepoData);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === LS_GITHUB_REPOS) setRepos(loadRepoData());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  if (repos.length === 0) {
+    return (
+      <p className="text-[11px] text-fg-4 italic py-1">
+        No repos configured
+      </p>
+    );
+  }
+
+  const passCount = repos.filter((r) => r.status === "success").length;
+  const failCount = repos.filter((r) => r.status === "failure").length;
+  const allPassing = failCount === 0 && passCount > 0;
+
+  return (
+    <div className="space-y-1.5">
+      {/* Overall status */}
+      {prefs.status && (
+        <div className="flex items-center gap-2">
+          <span className={`w-2 h-2 rounded-full ${allPassing ? "bg-up" : failCount > 0 ? "bg-down" : "bg-fg-4"}`} />
+          <span className="text-xs font-mono text-fg">
+            {allPassing ? "All Passing" : failCount > 0 ? `${failCount} failing` : "No data"}
+          </span>
+        </div>
+      )}
+
+      {/* Counts */}
+      {prefs.counts && (
+        <div className="flex items-center gap-3 text-[11px] font-mono text-fg-3">
+          {passCount > 0 && <span className="text-up">{passCount} passing</span>}
+          {failCount > 0 && <span className="text-down">{failCount} failing</span>}
+          <span className="text-fg-4">{repos.length} total</span>
+        </div>
+      )}
+
+      {/* Repos */}
+      {prefs.repos && (
+        <div className="flex flex-wrap gap-x-3 gap-y-1">
+          {repos.slice(0, 6).map((r) => (
+            <div key={`${r.owner}/${r.repo}`} className="flex items-center gap-1.5">
+              <span className={`w-1.5 h-1.5 rounded-full ${STATUS_DOTS[r.status] ?? "bg-fg-4"}`} />
+              <span className="text-[10px] font-mono text-fg-3 truncate max-w-[120px]">
+                {r.repo}
+              </span>
+            </div>
+          ))}
+          {repos.length > 6 && (
+            <span className="text-[10px] font-mono text-fg-4">
+              +{repos.length - 6} more
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/dashboard/dashboardPrefs.ts
+++ b/desktop/src/components/dashboard/dashboardPrefs.ts
@@ -65,6 +65,12 @@ export interface UptimeCardPrefs {
   monitors: boolean;
 }
 
+export interface GitHubCardPrefs {
+  status: boolean;
+  counts: boolean;
+  repos: boolean;
+}
+
 export interface DashboardCardPrefs {
   finance: FinanceCardPrefs;
   sports: SportsCardPrefs;
@@ -74,6 +80,7 @@ export interface DashboardCardPrefs {
   weather: WeatherCardPrefs;
   sysmon: SysmonCardPrefs;
   uptime: UptimeCardPrefs;
+  github: GitHubCardPrefs;
 }
 
 // ── Defaults ────────────────────────────────────────────────────
@@ -87,6 +94,7 @@ export const DEFAULT_CARD_PREFS: DashboardCardPrefs = {
   weather: { condition: true, feelsLike: true, cityCount: true },
   sysmon: { cpu: true, ram: true, gpu: true, uptime: true },
   uptime: { health: true, monitorCount: true, monitors: true },
+  github: { status: true, counts: true, repos: true },
 };
 
 // ── Storage ─────────────────────────────────────────────────────
@@ -106,6 +114,7 @@ export function loadCardPrefs(): DashboardCardPrefs {
     weather: { ...DEFAULT_CARD_PREFS.weather, ...saved.weather },
     sysmon: { ...DEFAULT_CARD_PREFS.sysmon, ...saved.sysmon },
     uptime: { ...DEFAULT_CARD_PREFS.uptime, ...saved.uptime },
+    github: { ...DEFAULT_CARD_PREFS.github, ...saved.github },
   };
 }
 
@@ -244,4 +253,10 @@ export const UPTIME_SCHEMA: EditorField[] = [
   { type: "toggle", key: "health", label: "Health Status" },
   { type: "toggle", key: "monitorCount", label: "Monitor Count" },
   { type: "toggle", key: "monitors", label: "Monitor List" },
+];
+
+export const GITHUB_SCHEMA: EditorField[] = [
+  { type: "toggle", key: "status", label: "Overall Status" },
+  { type: "toggle", key: "counts", label: "Pass/Fail Counts" },
+  { type: "toggle", key: "repos", label: "Repo List" },
 ];

--- a/desktop/src/constants.ts
+++ b/desktop/src/constants.ts
@@ -13,6 +13,7 @@ export const LS_TIMER_STATE = "scrollr:widget:timer:state";
 export const LS_WEATHER_CITIES = "scrollr:widget:weather:cities";
 export const LS_WEATHER_UNIT = "scrollr:widget:weather:unit";
 export const LS_UPTIME_MONITORS = "scrollr:widget:uptime:monitors";
+export const LS_GITHUB_REPOS = "scrollr:widget:github:repos";
 
 // ── Widget pin options ──────────────────────────────────────────
 

--- a/desktop/src/hooks/useWidgetTickerData.ts
+++ b/desktop/src/hooks/useWidgetTickerData.ts
@@ -7,12 +7,13 @@ import { LS_CLOCK_TIMEZONES, LS_CLOCK_FORMAT, LS_TIMER_STATE, LS_WEATHER_CITIES,
 import { formatBytes, timeAgo } from "../utils/format";
 import { weatherCodeToIcon, weatherCodeToLabel, formatTemp } from "../widgets/weather/types";
 import { findCpuTemp, findGpuTemp, formatComponentTemp } from "../widgets/sysmon/utils";
-import type { ClockChipData, WeatherChipData, SysmonChipData, UptimeChipData, WidgetTickerData } from "../types";
+import type { ClockChipData, WeatherChipData, SysmonChipData, UptimeChipData, GitHubChipData, WidgetTickerData } from "../types";
 import type { TimerState } from "../widgets/clock/types";
 import type { SavedCity } from "../widgets/weather/types";
 import { loadMonitors } from "../widgets/uptime/types";
+import { loadRepoData, repoKey } from "../widgets/github/types";
 
-const EMPTY: WidgetTickerData = { clock: [], weather: [], sysmon: [], uptime: [] };
+const EMPTY: WidgetTickerData = { clock: [], weather: [], sysmon: [], uptime: [], github: [] };
 
 // ── Time formatting helpers ─────────────────────────────────────
 
@@ -283,6 +284,40 @@ export function useWidgetTickerData(
     return chips;
   }, [widgetPrefs.uptime, enabledWidgets]);
 
+  // ── Build github chips ────────────────────────────────────────
+  const buildGithubChips = useCallback((): GitHubChipData[] => {
+    if (!enabledWidgets.has("github")) return [];
+    const repos = loadRepoData();
+    if (repos.length === 0) return [];
+
+    const cfg = widgetPrefs.github;
+    const chips: GitHubChipData[] = [];
+
+    for (const repo of repos) {
+      const key = repoKey(repo);
+      if (cfg.ticker.excludedRepos.includes(key)) continue;
+
+      const repoLabel = repo.repo.length > 20 ? repo.repo.slice(0, 18) + "\u2026" : repo.repo;
+      const workflow = repo.workflowName ?? "CI";
+
+      // Comfort detail: first line of commit message + time ago
+      const firstLine = repo.commitMessage?.split("\n")[0] ?? "";
+      const commit = firstLine.length > 30 ? firstLine.slice(0, 28) + "\u2026" : firstLine;
+      const checked = timeAgo(repo.updatedAt, { suffix: true });
+      const detail = [commit, checked].filter(Boolean).join(" \u00B7 ");
+
+      chips.push({
+        id: `github-${key}`,
+        label: repoLabel,
+        status: repo.status,
+        workflowName: workflow,
+        detail: detail || undefined,
+      });
+    }
+
+    return chips;
+  }, [widgetPrefs.github, enabledWidgets]);
+
   // ── Polling intervals ─────────────────────────────────────────
 
   useEffect(() => {
@@ -290,8 +325,9 @@ export function useWidgetTickerData(
     const hasWeather = enabledWidgets.has("weather");
     const hasSysmon = enabledWidgets.has("sysmon");
     const hasUptime = enabledWidgets.has("uptime");
+    const hasGithub = enabledWidgets.has("github");
 
-    if (!hasClock && !hasWeather && !hasSysmon && !hasUptime) {
+    if (!hasClock && !hasWeather && !hasSysmon && !hasUptime && !hasGithub) {
       setData(EMPTY);
       return;
     }
@@ -303,6 +339,7 @@ export function useWidgetTickerData(
         weather: buildWeatherChips(),
         sysmon: buildSysmonChips(),
         uptime: buildUptimeChips(),
+        github: buildGithubChips(),
       });
     };
 
@@ -331,6 +368,12 @@ export function useWidgetTickerData(
       setData((prev) => ({ ...prev, uptime: buildUptimeChips() }));
     }, uptimeMs) : null;
 
+    // GitHub: re-read cached localStorage data at poll cadence (FeedTab does the actual fetching)
+    const githubMs = (widgetPrefs.github.pollInterval || 120) * 1000;
+    const githubInterval = hasGithub ? setInterval(() => {
+      setData((prev) => ({ ...prev, github: buildGithubChips() }));
+    }, githubMs) : null;
+
     // Initial fetch for sysmon (only widget that needs async init)
     if (hasSysmon) {
       fetchSysmonData()
@@ -346,6 +389,7 @@ export function useWidgetTickerData(
       if (weatherInterval) clearInterval(weatherInterval);
       if (sysmonInterval) clearInterval(sysmonInterval);
       if (uptimeInterval) clearInterval(uptimeInterval);
+      if (githubInterval) clearInterval(githubInterval);
     };
   // Suppressed: JSON.stringify stabilizes the dep by value instead of reference,
   // so the effect only re-runs when the array contents actually change.
@@ -354,10 +398,12 @@ export function useWidgetTickerData(
     JSON.stringify(widgetPrefs.widgetsOnTicker),
     widgetPrefs.sysmon.refreshInterval,
     widgetPrefs.uptime.pollInterval,
+    widgetPrefs.github.pollInterval,
     buildClockChips,
     buildWeatherChips,
     buildSysmonChips,
     buildUptimeChips,
+    buildGithubChips,
   ]);
 
   return data;

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -392,7 +392,14 @@ function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
       ticker: { ...DEFAULT_UPTIME_TICKER, ...obj(upt?.ticker) },
     },
     github: {
-      repos: Array.isArray(ghb?.repos) ? ghb.repos as Array<{ owner: string; repo: string }> : DEFAULT_WIDGETS.github.repos,
+      repos: Array.isArray(ghb?.repos)
+        ? (ghb.repos as unknown[]).filter(
+            (r): r is { owner: string; repo: string } =>
+              r != null && typeof r === "object" &&
+              typeof (r as Record<string, unknown>).owner === "string" &&
+              typeof (r as Record<string, unknown>).repo === "string",
+          )
+        : DEFAULT_WIDGETS.github.repos,
       pollInterval: typeof ghb?.pollInterval === "number" ? ghb.pollInterval : DEFAULT_WIDGETS.github.pollInterval,
       ticker: { ...DEFAULT_GITHUB_TICKER, ...obj(ghb?.ticker) },
     },

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -124,6 +124,19 @@ export interface UptimeWidgetConfig {
   ticker: UptimeTickerConfig;
 }
 
+export interface GitHubTickerConfig {
+  /** Repo keys ("owner/repo") excluded from the ticker. */
+  excludedRepos: string[];
+}
+
+export interface GitHubWidgetConfig {
+  /** Configured repos to track. */
+  repos: Array<{ owner: string; repo: string }>;
+  /** Poll interval in seconds (default 120). */
+  pollInterval: number;
+  ticker: GitHubTickerConfig;
+}
+
 export interface WidgetPinConfig {
   side: PinSide;
 }
@@ -140,6 +153,7 @@ export interface WidgetPrefs {
   weather: WeatherWidgetConfig;
   sysmon: SysmonWidgetConfig;
   uptime: UptimeWidgetConfig;
+  github: GitHubWidgetConfig;
 }
 
 export interface AppPreferences {
@@ -224,6 +238,10 @@ export const DEFAULT_UPTIME_TICKER: UptimeTickerConfig = {
   excludedMonitors: [],
 };
 
+export const DEFAULT_GITHUB_TICKER: GitHubTickerConfig = {
+  excludedRepos: [],
+};
+
 const DEFAULT_WIDGETS: WidgetPrefs = {
   enabledWidgets: [],
   widgetsOnTicker: [],
@@ -246,6 +264,11 @@ const DEFAULT_WIDGETS: WidgetPrefs = {
     url: "",
     pollInterval: 60,
     ticker: { ...DEFAULT_UPTIME_TICKER },
+  },
+  github: {
+    repos: [],
+    pollInterval: 120,
+    ticker: { ...DEFAULT_GITHUB_TICKER },
   },
 };
 
@@ -338,6 +361,7 @@ function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
   const wth = obj(saved.weather);
   const sys = obj(saved.sysmon);
   const upt = obj(saved.uptime);
+  const ghb = obj(saved.github);
 
   const enabledWidgets = Array.isArray(saved.enabledWidgets) ? saved.enabledWidgets : DEFAULT_WIDGETS.enabledWidgets;
 
@@ -366,6 +390,11 @@ function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
       url: typeof upt?.url === "string" ? upt.url : DEFAULT_WIDGETS.uptime.url,
       pollInterval: typeof upt?.pollInterval === "number" ? upt.pollInterval : DEFAULT_WIDGETS.uptime.pollInterval,
       ticker: { ...DEFAULT_UPTIME_TICKER, ...obj(upt?.ticker) },
+    },
+    github: {
+      repos: Array.isArray(ghb?.repos) ? ghb.repos as Array<{ owner: string; repo: string }> : DEFAULT_WIDGETS.github.repos,
+      pollInterval: typeof ghb?.pollInterval === "number" ? ghb.pollInterval : DEFAULT_WIDGETS.github.pollInterval,
+      ticker: { ...DEFAULT_GITHUB_TICKER, ...obj(ghb?.ticker) },
     },
   };
 }

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -19,6 +19,7 @@ import ClockSummary from "../components/dashboard/ClockSummary";
 import WeatherSummary from "../components/dashboard/WeatherSummary";
 import SysmonSummary from "../components/dashboard/SysmonSummary";
 import UptimeSummary from "../components/dashboard/UptimeSummary";
+import GitHubSummary from "../components/dashboard/GitHubSummary";
 import {
   loadCardPrefs,
   saveCardPrefs,
@@ -34,6 +35,7 @@ import {
   WEATHER_SCHEMA,
   SYSMON_SCHEMA,
   UPTIME_SCHEMA,
+  GITHUB_SCHEMA,
 } from "../components/dashboard/dashboardPrefs";
 import type { ChannelType } from "../api/client";
 import type { ChannelManifest, WidgetManifest, DashboardResponse } from "../types";
@@ -74,6 +76,8 @@ function renderWidgetSummary(
       return <SysmonSummary prefs={cardPrefs.sysmon} />;
     case "uptime":
       return <UptimeSummary prefs={cardPrefs.uptime} />;
+    case "github":
+      return <GitHubSummary prefs={cardPrefs.github} />;
     default:
       return null;
   }
@@ -93,6 +97,7 @@ const WIDGET_SCHEMAS: Record<string, EditorField[]> = {
   weather: WEATHER_SCHEMA,
   sysmon: SYSMON_SCHEMA,
   uptime: UPTIME_SCHEMA,
+  github: GITHUB_SCHEMA,
 };
 
 const CHANNEL_PREFS_KEY: Record<string, keyof DashboardCardPrefs> = {
@@ -107,6 +112,7 @@ const WIDGET_PREFS_KEY: Record<string, keyof DashboardCardPrefs> = {
   weather: "weather",
   sysmon: "sysmon",
   uptime: "uptime",
+  github: "github",
 };
 
 // ── Route ───────────────────────────────────────────────────────

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -40,6 +40,7 @@
   --color-widget-weather: #0ea5e9;
   --color-widget-sysmon: #06b6d4;
   --color-widget-uptime: #10b981;
+  --color-widget-github: #f97316;
 
   /* ── Text hierarchy ───────────────────────────────────────── */
   --color-fg: #e2e2ec;

--- a/desktop/src/types/index.ts
+++ b/desktop/src/types/index.ts
@@ -196,9 +196,18 @@ export interface UptimeChipData {
   heartbeats?: number[];
 }
 
+export interface GitHubChipData {
+  id: string;
+  label: string;
+  status: "success" | "failure" | "in_progress" | "unavailable";
+  workflowName: string;
+  detail?: string;
+}
+
 export interface WidgetTickerData {
   clock: ClockChipData[];
   weather: WeatherChipData[];
   sysmon: SysmonChipData[];
   uptime: UptimeChipData[];
+  github: GitHubChipData[];
 }

--- a/desktop/src/widgets/WidgetConfigPanel.tsx
+++ b/desktop/src/widgets/WidgetConfigPanel.tsx
@@ -3,6 +3,7 @@ import ClockConfigPanel from "./clock/ConfigPanel";
 import WeatherConfigPanel from "./weather/ConfigPanel";
 import SysmonConfigPanel from "./sysmon/ConfigPanel";
 import UptimeConfigPanel from "./uptime/ConfigPanel";
+import GitHubConfigPanel from "./github/ConfigPanel";
 
 interface WidgetConfigPanelProps {
   widgetId: string;
@@ -32,6 +33,10 @@ export default function WidgetConfigPanel({
     case "uptime":
       return (
         <UptimeConfigPanel prefs={prefs} onPrefsChange={onPrefsChange} />
+      );
+    case "github":
+      return (
+        <GitHubConfigPanel prefs={prefs} onPrefsChange={onPrefsChange} />
       );
     default:
       return (

--- a/desktop/src/widgets/github/ConfigPanel.tsx
+++ b/desktop/src/widgets/github/ConfigPanel.tsx
@@ -1,0 +1,194 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SliderRow,
+  SegmentedRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+import type {
+  AppPreferences,
+  GitHubWidgetConfig,
+  GitHubTickerConfig,
+} from "../../preferences";
+import { DEFAULT_GITHUB_TICKER, savePrefs } from "../../preferences";
+import { useWidgetPin } from "../../hooks/useWidgetPin";
+import { LS_GITHUB_REPOS, PIN_SIDE_OPTIONS } from "../../constants";
+import { loadRepoData, repoKey } from "./types";
+import type { GitHubRepo } from "./types";
+
+interface GitHubConfigPanelProps {
+  prefs: AppPreferences;
+  onPrefsChange: (prefs: AppPreferences) => void;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  success: "Passing",
+  failure: "Failing",
+  in_progress: "Running",
+  unavailable: "Unavailable",
+};
+
+export default function GitHubConfigPanel({
+  prefs,
+  onPrefsChange,
+}: GitHubConfigPanelProps) {
+  const config = prefs.widgets.github;
+  const [repoData, setRepoData] = useState<GitHubRepo[]>(loadRepoData);
+
+  const { isPinned, pinSide, togglePin, setPinSide } = useWidgetPin("github", prefs, onPrefsChange);
+
+  // Re-read when localStorage changes (FeedTab refreshes data)
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === LS_GITHUB_REPOS) setRepoData(loadRepoData());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const update = useCallback(
+    (patch: Partial<GitHubWidgetConfig>) => {
+      const next: AppPreferences = {
+        ...prefs,
+        widgets: {
+          ...prefs.widgets,
+          github: { ...config, ...patch },
+        },
+      };
+      onPrefsChange(next);
+      savePrefs(next);
+    },
+    [prefs, config, onPrefsChange],
+  );
+
+  const setTicker = useCallback(
+    (patch: Partial<GitHubTickerConfig>) => {
+      update({ ticker: { ...config.ticker, ...patch } });
+    },
+    [update, config.ticker],
+  );
+
+  const isRepoExcluded = (key: string) =>
+    config.ticker.excludedRepos.includes(key);
+
+  const toggleRepo = useCallback(
+    (key: string) => {
+      const excluded = config.ticker.excludedRepos;
+      const next = excluded.includes(key)
+        ? excluded.filter((r) => r !== key)
+        : [...excluded, key];
+      setTicker({ excludedRepos: next });
+    },
+    [config.ticker.excludedRepos, setTicker],
+  );
+
+  const resetAll = useCallback(() => {
+    update({
+      pollInterval: 120,
+      ticker: { ...DEFAULT_GITHUB_TICKER },
+    });
+  }, [update]);
+
+  // Status summary
+  const passCount = repoData.filter((r) => r.status === "success").length;
+  const failCount = repoData.filter((r) => r.status === "failure").length;
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6 px-3">
+        <div
+          className="w-8 h-8 rounded-lg flex items-center justify-center"
+          style={{ background: "color-mix(in srgb, var(--color-widget-github) 15%, transparent)" }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-github)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+            <path d="M9 18c-4.51 2-5-2-7-2" />
+          </svg>
+        </div>
+        <div>
+          <h2 className="text-sm font-bold text-fg">GitHub Settings</h2>
+          <p className="text-[11px] text-fg-4">CI/Actions status for your repos</p>
+        </div>
+      </div>
+
+      {/* Toolbar Preview */}
+      <Section title="Toolbar Preview">
+        {repoData.length > 0 ? (
+          <div className="px-3 py-2.5 text-[11px] text-fg-3 font-mono">
+            {repoData.length} repo{repoData.length !== 1 ? "s" : ""}
+            {" \u2014 "}
+            {passCount > 0 && <span className="text-up">{passCount} passing</span>}
+            {passCount > 0 && failCount > 0 && ", "}
+            {failCount > 0 && <span className="text-down">{failCount} failing</span>}
+            {passCount === 0 && failCount === 0 && <span className="text-fg-4">no data yet</span>}
+          </div>
+        ) : (
+          <div className="px-3 py-2.5 text-[11px] text-fg-4">
+            Add repos in the GitHub tab to see CI status.
+          </div>
+        )}
+      </Section>
+
+      {/* Ticker */}
+      <Section title="Ticker">
+        {config.repos.map((r) => {
+          const key = repoKey(r);
+          const rd = repoData.find((d) => repoKey(d) === key);
+          const statusLabel = rd ? STATUS_LABELS[rd.status] ?? "Unknown" : "Loading";
+          const workflow = rd?.workflowName ? ` \u00B7 ${rd.workflowName}` : "";
+          return (
+            <ToggleRow
+              key={key}
+              label={key}
+              description={`${statusLabel}${workflow}`}
+              checked={!isRepoExcluded(key)}
+              onChange={() => toggleRepo(key)}
+            />
+          );
+        })}
+        {config.repos.length === 0 && (
+          <div className="px-3 py-2.5 text-[11px] text-fg-4">
+            Add repos in the GitHub tab to choose what shows on the ticker.
+          </div>
+        )}
+        <ToggleRow
+          label="Keep in a fixed spot"
+          description="Stay on one side instead of scrolling across"
+          checked={isPinned}
+          onChange={togglePin}
+        />
+        {isPinned && (
+          <SegmentedRow
+            label="Which side"
+            value={pinSide}
+            options={PIN_SIDE_OPTIONS}
+            onChange={setPinSide}
+          />
+        )}
+      </Section>
+
+      {/* Polling */}
+      <Section title="Polling">
+        <SliderRow
+          label="Refresh interval"
+          description="How often to check workflow status"
+          value={config.pollInterval}
+          min={60}
+          max={300}
+          step={30}
+          displayValue={config.pollInterval >= 60
+            ? `${Math.floor(config.pollInterval / 60)}m${config.pollInterval % 60 ? ` ${config.pollInterval % 60}s` : ""}`
+            : `${config.pollInterval}s`}
+          onChange={(v) => update({ pollInterval: v })}
+        />
+      </Section>
+
+      {/* Reset */}
+      <div className="flex items-center justify-end pt-2 px-3">
+        <ResetButton onClick={resetAll} />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/widgets/github/FeedTab.tsx
+++ b/desktop/src/widgets/github/FeedTab.tsx
@@ -1,0 +1,350 @@
+/**
+ * GitHub Actions widget FeedTab.
+ *
+ * Tracks CI/Actions workflow run status for user-configured public
+ * GitHub repos. Repos are added individually via URL input. Data is
+ * cached in localStorage for cross-window ticker sync.
+ */
+import { useState, useEffect, useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Github, Plus, Trash2, ExternalLink, Loader2 } from "lucide-react";
+import type { FeedTabProps, WidgetManifest } from "../../types";
+import type { GitHubRepo, CIStatus } from "./types";
+import {
+  parseRepoUrl,
+  repoKey,
+  fetchAllRepos,
+  loadRepoData,
+  saveRepoData,
+} from "./types";
+import { useShell } from "../../shell-context";
+import { savePrefs } from "../../preferences";
+import type { AppPreferences } from "../../preferences";
+import { LS_GITHUB_REPOS } from "../../constants";
+
+// ── Widget manifest ─────────────────────────────────────────────
+
+export const githubWidget: WidgetManifest = {
+  id: "github",
+  name: "GitHub",
+  tabLabel: "GitHub",
+  description: "CI/Actions status for your repos",
+  hex: "#f97316",
+  icon: Github,
+  info: {
+    about:
+      "The GitHub widget tracks the latest workflow run status for " +
+      "your public GitHub repositories.",
+    usage: [
+      "Paste a GitHub repo URL to add it (e.g. https://github.com/org/repo).",
+      "Each repo shows its latest GitHub Actions workflow run status.",
+      "Click a repo row to open the workflow run on GitHub.",
+      "Hide specific repos from the ticker in the Settings tab.",
+    ],
+  },
+  FeedTab: GitHubFeedTab,
+};
+
+// ── Status helpers ──────────────────────────────────────────────
+
+const STATUS_LABELS: Record<CIStatus, string> = {
+  success: "Passing",
+  failure: "Failing",
+  in_progress: "Running",
+  unavailable: "Unavailable",
+};
+
+const STATUS_COLORS: Record<CIStatus, string> = {
+  success: "bg-up",
+  failure: "bg-down",
+  in_progress: "bg-warning",
+  unavailable: "bg-fg-4",
+};
+
+const STATUS_TEXT_COLORS: Record<CIStatus, string> = {
+  success: "text-up",
+  failure: "text-down",
+  in_progress: "text-warning",
+  unavailable: "text-fg-4",
+};
+
+// ── FeedTab ─────────────────────────────────────────────────────
+
+function GitHubFeedTab({ mode: feedMode }: FeedTabProps) {
+  const compact = feedMode === "compact";
+  const shell = useShell();
+  const configRepos = shell.prefs.widgets.github.repos;
+  const pollInterval = shell.prefs.widgets.github.pollInterval;
+
+  const [inputUrl, setInputUrl] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+
+  // Load cached repo data for initial display
+  const [repoData, setRepoData] = useState<GitHubRepo[]>(loadRepoData);
+
+  // Listen for localStorage changes from the ticker window
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === LS_GITHUB_REPOS) setRepoData(loadRepoData());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  // Auto-refresh when repos are configured via TanStack Query
+  const { data, error } = useQuery({
+    queryKey: ["github-actions", configRepos.map(repoKey).join(",")],
+    queryFn: () => fetchAllRepos(configRepos),
+    enabled: configRepos.length > 0,
+    refetchInterval: pollInterval * 1000,
+    staleTime: (pollInterval * 1000) / 2,
+    retry: 1,
+  });
+
+  // Sync query results to localStorage + local state
+  useEffect(() => {
+    if (data) {
+      setRepoData(data);
+      saveRepoData(data);
+    }
+  }, [data]);
+
+  // ── Add repo handler ──────────────────────────────────────────
+
+  const handleAddRepo = useCallback(() => {
+    const parsed = parseRepoUrl(inputUrl);
+    if (!parsed) {
+      setInputError("Invalid GitHub URL. Expected: https://github.com/owner/repo");
+      return;
+    }
+
+    // Check for duplicates
+    const key = repoKey(parsed);
+    if (configRepos.some((r) => repoKey(r) === key)) {
+      setInputError("This repo is already added.");
+      return;
+    }
+
+    // Save to prefs
+    const nextRepos = [...configRepos, parsed];
+    const next: AppPreferences = {
+      ...shell.prefs,
+      widgets: {
+        ...shell.prefs.widgets,
+        github: { ...shell.prefs.widgets.github, repos: nextRepos },
+      },
+    };
+    shell.onPrefsChange(next);
+    savePrefs(next);
+
+    setInputUrl("");
+    setInputError(null);
+  }, [inputUrl, configRepos, shell]);
+
+  // ── Remove repo handler ───────────────────────────────────────
+
+  const removeRepo = useCallback(
+    (owner: string, repo: string) => {
+      const key = repoKey({ owner, repo });
+      const nextRepos = configRepos.filter((r) => repoKey(r) !== key);
+      const next: AppPreferences = {
+        ...shell.prefs,
+        widgets: {
+          ...shell.prefs.widgets,
+          github: { ...shell.prefs.widgets.github, repos: nextRepos },
+        },
+      };
+      shell.onPrefsChange(next);
+      savePrefs(next);
+
+      // Also remove from cached data
+      const nextData = repoData.filter((r) => repoKey(r) !== key);
+      setRepoData(nextData);
+      saveRepoData(nextData);
+    },
+    [configRepos, repoData, shell],
+  );
+
+  // ── Empty state ───────────────────────────────────────────────
+
+  if (configRepos.length === 0) {
+    return (
+      <div className="p-4 flex flex-col items-center justify-center gap-3">
+        <Github size={24} className="text-widget-github/60" />
+        <span className="text-xs font-mono text-fg-2 text-center">
+          Add a GitHub repo to track CI status
+        </span>
+
+        <div className="w-full max-w-sm space-y-2">
+          <input
+            type="url"
+            value={inputUrl}
+            onChange={(e) => { setInputUrl(e.target.value); setInputError(null); }}
+            onKeyDown={(e) => { if (e.key === "Enter") handleAddRepo(); }}
+            placeholder="https://github.com/owner/repo"
+            className="w-full text-xs font-mono px-3 py-2 rounded-lg bg-surface-2 border border-edge text-fg placeholder:text-fg-4 focus:border-widget-github/50 focus:outline-none transition-colors"
+          />
+          <button
+            onClick={handleAddRepo}
+            disabled={!inputUrl.trim()}
+            className="w-full text-xs font-mono font-semibold text-widget-github px-3 py-2 rounded-lg bg-widget-github/10 border border-widget-github/25 hover:bg-widget-github/15 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            <Plus size={12} />
+            Add Repo
+          </button>
+        </div>
+
+        {inputError && (
+          <p className="text-[11px] font-mono text-error text-center max-w-sm">
+            {inputError}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // ── Connected state ───────────────────────────────────────────
+
+  const passCount = repoData.filter((r) => r.status === "success").length;
+  const failCount = repoData.filter((r) => r.status === "failure").length;
+
+  return (
+    <div className="p-3 space-y-2">
+      {/* Header */}
+      <div className="flex items-center justify-between px-1 mb-1">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-mono font-semibold text-widget-github/80 uppercase tracking-wider">
+            GitHub
+          </span>
+          <span className="text-[10px] font-mono text-fg-4">
+            {configRepos.length} repo{configRepos.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Status summary */}
+      <div className="flex items-center gap-3 px-1 text-[11px] font-mono text-fg-3">
+        {passCount > 0 && <span className="text-up">{passCount} passing</span>}
+        {failCount > 0 && <span className="text-down">{failCount} failing</span>}
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="px-2 py-1.5 text-[11px] font-mono text-error/80 bg-error/5 border border-error/15 rounded">
+          Failed to refresh: {error.message}
+        </div>
+      )}
+
+      {/* Add repo input */}
+      <div className="flex gap-1.5 px-1">
+        <input
+          type="url"
+          value={inputUrl}
+          onChange={(e) => { setInputUrl(e.target.value); setInputError(null); }}
+          onKeyDown={(e) => { if (e.key === "Enter") handleAddRepo(); }}
+          placeholder="Add another repo..."
+          className="flex-1 text-[11px] font-mono px-2.5 py-1.5 rounded-md bg-surface-2 border border-edge text-fg placeholder:text-fg-4 focus:border-widget-github/50 focus:outline-none transition-colors"
+        />
+        <button
+          onClick={handleAddRepo}
+          disabled={!inputUrl.trim()}
+          className="text-[11px] font-mono font-semibold text-widget-github px-2.5 py-1.5 rounded-md bg-widget-github/10 border border-widget-github/25 hover:bg-widget-github/15 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <Plus size={11} />
+        </button>
+      </div>
+      {inputError && (
+        <p className="text-[10px] font-mono text-error px-1">
+          {inputError}
+        </p>
+      )}
+
+      {/* Repo list */}
+      <div className={compact ? "space-y-1" : "space-y-1.5"}>
+        {configRepos.map((configRepo) => {
+          const rd = repoData.find((r) => repoKey(r) === repoKey(configRepo));
+          return (
+            <RepoRow
+              key={repoKey(configRepo)}
+              owner={configRepo.owner}
+              repo={configRepo.repo}
+              data={rd ?? null}
+              compact={compact}
+              onRemove={() => removeRepo(configRepo.owner, configRepo.repo)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── RepoRow ─────────────────────────────────────────────────────
+
+function RepoRow({
+  owner,
+  repo,
+  data,
+  compact,
+  onRemove,
+}: {
+  owner: string;
+  repo: string;
+  data: GitHubRepo | null;
+  compact: boolean;
+  onRemove: () => void;
+}) {
+  const status = data?.status ?? "unavailable";
+  const isLoading = !data;
+
+  return (
+    <div
+      className={`flex items-center gap-2 px-2 rounded-md border border-edge/50 bg-surface-2/30 ${compact ? "py-1.5" : "py-2"}`}
+    >
+      {/* Status dot */}
+      {isLoading ? (
+        <Loader2 size={10} className="animate-spin text-fg-4 shrink-0" />
+      ) : (
+        <span className={`w-2 h-2 rounded-full shrink-0 ${STATUS_COLORS[status]}${status === "failure" ? " animate-pulse" : ""}`} />
+      )}
+
+      {/* Repo name + workflow */}
+      <div className="flex-1 min-w-0">
+        {data?.runUrl ? (
+          <a
+            href={data.runUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-mono text-fg hover:text-widget-github transition-colors truncate block"
+          >
+            {owner}/{repo}
+            <ExternalLink size={9} className="inline ml-1 opacity-40" />
+          </a>
+        ) : (
+          <span className="text-xs font-mono text-fg truncate block">
+            {owner}/{repo}
+          </span>
+        )}
+        {!compact && data?.workflowName && (
+          <span className="text-[10px] font-mono text-fg-4 truncate block">
+            {data.workflowName}
+          </span>
+        )}
+      </div>
+
+      {/* Status label */}
+      <span className={`text-[10px] font-mono font-semibold uppercase tracking-wider shrink-0 ${STATUS_TEXT_COLORS[status]}`}>
+        {isLoading ? "" : STATUS_LABELS[status]}
+      </span>
+
+      {/* Remove */}
+      <button
+        onClick={onRemove}
+        className="text-fg-4 hover:text-error transition-colors shrink-0"
+        title="Remove repo"
+      >
+        <Trash2 size={11} />
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/widgets/github/FeedTab.tsx
+++ b/desktop/src/widgets/github/FeedTab.tsx
@@ -93,7 +93,7 @@ function GitHubFeedTab({ mode: feedMode }: FeedTabProps) {
 
   // Auto-refresh when repos are configured via TanStack Query
   const { data, error } = useQuery({
-    queryKey: ["github-actions", configRepos.map(repoKey).join(",")],
+    queryKey: ["github-actions", configRepos.map(repoKey)],
     queryFn: () => fetchAllRepos(configRepos),
     enabled: configRepos.length > 0,
     refetchInterval: pollInterval * 1000,
@@ -226,6 +226,9 @@ function GitHubFeedTab({ mode: feedMode }: FeedTabProps) {
       <div className="flex items-center gap-3 px-1 text-[11px] font-mono text-fg-3">
         {passCount > 0 && <span className="text-up">{passCount} passing</span>}
         {failCount > 0 && <span className="text-down">{failCount} failing</span>}
+        {passCount === 0 && failCount === 0 && repoData.length > 0 && (
+          <span className="text-fg-4">checking...</span>
+        )}
       </div>
 
       {/* Error banner */}

--- a/desktop/src/widgets/github/types.ts
+++ b/desktop/src/widgets/github/types.ts
@@ -59,13 +59,19 @@ function toCIStatus(status: string, conclusion: string | null): CIStatus {
  *   https://github.com/owner/repo/anything/else
  *   github.com/owner/repo
  */
+/** Valid GitHub owner/repo name: alphanumeric, hyphens, dots, underscores. */
+const GITHUB_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
+
 export function parseRepoUrl(url: string): { owner: string; repo: string } | null {
   const trimmed = url.trim().replace(/\/+$/, "");
   const match = trimmed.match(/(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)/i);
-  if (match) {
-    return { owner: match[1], repo: match[2] };
-  }
-  return null;
+  if (!match) return null;
+
+  const owner = match[1];
+  const repo = match[2];
+  if (!GITHUB_NAME_RE.test(owner) || !GITHUB_NAME_RE.test(repo)) return null;
+
+  return { owner, repo };
 }
 
 /** Format owner/repo as a stable key for exclusion lists. */
@@ -108,7 +114,7 @@ export async function fetchRepoStatus(
 
     const data = (await res.json()) as GitHubActionsResponse;
     const run = data.workflow_runs?.[0];
-    if (!run) return { ...unavailable, status: "unavailable" };
+    if (!run) return unavailable;
 
     return {
       owner,

--- a/desktop/src/widgets/github/types.ts
+++ b/desktop/src/widgets/github/types.ts
@@ -1,0 +1,166 @@
+/**
+ * GitHub Actions widget types, fetch logic, and localStorage helpers.
+ *
+ * Fetches the latest workflow run status for user-configured public
+ * GitHub repos. Uses @tauri-apps/plugin-http to bypass CORS.
+ * Each repo is fetched independently so a single failure doesn't
+ * break the entire widget.
+ */
+import { fetch } from "@tauri-apps/plugin-http";
+import { LS_GITHUB_REPOS } from "../../constants";
+
+// ── GitHub Actions API response ────────────────────────────────
+
+interface GitHubWorkflowRun {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  html_url: string;
+  head_commit: { message: string } | null;
+  updated_at: string;
+}
+
+interface GitHubActionsResponse {
+  total_count: number;
+  workflow_runs: GitHubWorkflowRun[];
+}
+
+// ── Internal model ─────────────────────────────────────────────
+
+export type CIStatus = "success" | "failure" | "in_progress" | "unavailable";
+
+export interface GitHubRepo {
+  owner: string;
+  repo: string;
+  status: CIStatus;
+  workflowName: string | null;
+  runUrl: string | null;
+  commitMessage: string | null;
+  updatedAt: string | null;
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+/** Map GitHub API status/conclusion to our CIStatus. */
+function toCIStatus(status: string, conclusion: string | null): CIStatus {
+  if (status === "in_progress" || status === "queued") return "in_progress";
+  if (conclusion === "success") return "success";
+  if (conclusion === "failure" || conclusion === "timed_out") return "failure";
+  // cancelled, skipped, action_required, stale, etc.
+  return "unavailable";
+}
+
+/**
+ * Parse a GitHub repo URL into owner/repo.
+ *
+ * Accepts:
+ *   https://github.com/owner/repo
+ *   https://github.com/owner/repo/anything/else
+ *   github.com/owner/repo
+ */
+export function parseRepoUrl(url: string): { owner: string; repo: string } | null {
+  const trimmed = url.trim().replace(/\/+$/, "");
+  const match = trimmed.match(/(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)/i);
+  if (match) {
+    return { owner: match[1], repo: match[2] };
+  }
+  return null;
+}
+
+/** Format owner/repo as a stable key for exclusion lists. */
+export function repoKey(r: { owner: string; repo: string }): string {
+  return `${r.owner}/${r.repo}`;
+}
+
+// ── Fetch ──────────────────────────────────────────────────────
+
+/**
+ * Fetch the latest workflow run for a single repo.
+ * Returns a GitHubRepo with status "unavailable" on any error
+ * (404, rate limit, network failure) rather than throwing.
+ */
+export async function fetchRepoStatus(
+  owner: string,
+  repo: string,
+): Promise<GitHubRepo> {
+  const unavailable: GitHubRepo = {
+    owner,
+    repo,
+    status: "unavailable",
+    workflowName: null,
+    runUrl: null,
+    commitMessage: null,
+    updatedAt: null,
+  };
+
+  try {
+    const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs?per_page=1`;
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "Scrollr/1.0",
+      },
+    });
+
+    if (!res.ok) return unavailable;
+
+    const data = (await res.json()) as GitHubActionsResponse;
+    const run = data.workflow_runs?.[0];
+    if (!run) return { ...unavailable, status: "unavailable" };
+
+    return {
+      owner,
+      repo,
+      status: toCIStatus(run.status, run.conclusion),
+      workflowName: run.name,
+      runUrl: run.html_url,
+      commitMessage: run.head_commit?.message ?? null,
+      updatedAt: run.updated_at,
+    };
+  } catch {
+    return unavailable;
+  }
+}
+
+/**
+ * Fetch status for all configured repos in parallel.
+ * Uses Promise.allSettled so one failure doesn't break others.
+ */
+export async function fetchAllRepos(
+  repos: Array<{ owner: string; repo: string }>,
+): Promise<GitHubRepo[]> {
+  const results = await Promise.allSettled(
+    repos.map((r) => fetchRepoStatus(r.owner, r.repo)),
+  );
+
+  return results.map((r, i) =>
+    r.status === "fulfilled"
+      ? r.value
+      : {
+          owner: repos[i].owner,
+          repo: repos[i].repo,
+          status: "unavailable" as CIStatus,
+          workflowName: null,
+          runUrl: null,
+          commitMessage: null,
+          updatedAt: null,
+        },
+  );
+}
+
+// ── localStorage persistence ───────────────────────────────────
+
+export function loadRepoData(): GitHubRepo[] {
+  try {
+    const raw = localStorage.getItem(LS_GITHUB_REPOS);
+    return raw ? (JSON.parse(raw) as GitHubRepo[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveRepoData(repos: GitHubRepo[]): void {
+  localStorage.setItem(LS_GITHUB_REPOS, JSON.stringify(repos));
+}

--- a/desktop/src/widgets/registry.ts
+++ b/desktop/src/widgets/registry.ts
@@ -18,7 +18,7 @@ const modules = import.meta.glob<Record<string, WidgetManifest>>(
 const widgets = new Map<string, WidgetManifest>();
 
 /** Canonical display order for widget tabs. */
-export const WIDGET_ORDER: readonly string[] = ["clock", "weather", "sysmon", "uptime"];
+export const WIDGET_ORDER: readonly string[] = ["clock", "weather", "sysmon", "uptime", "github"];
 
 // Auto-register all discovered widgets.
 for (const [, mod] of Object.entries(modules)) {


### PR DESCRIPTION
## Summary

- Add a new **GitHub Actions** widget that tracks the latest workflow run status for user-configured public repos
- Each repo is fetched independently with graceful error handling — a broken or private repo shows "unavailable" instead of crashing the widget
- Polls at a configurable interval (default 120s to respect GitHub's unauthenticated rate limit of 60 req/hour)
- Comfort mode shows first-line-only commit messages (`.split('\n')[0]`) + relative timestamps; compact mode shows just repo name + status dot + workflow name

## New Files

| File | Purpose |
|------|---------|
| `widgets/github/types.ts` | GitHub Actions API types, `fetchRepoStatus` with per-repo error isolation, `Promise.allSettled` batch fetch, URL parser, localStorage helpers |
| `widgets/github/FeedTab.tsx` | Widget manifest + FeedTab with multi-repo add/remove flow, TanStack Query polling, clickable `<a href target="_blank">` links to workflow runs |
| `widgets/github/ConfigPanel.tsx` | Per-repo ticker toggles, poll interval slider (60s–300s), pin toggle |
| `dashboard/GitHubSummary.tsx` | Dashboard card with pass/fail counts and per-repo status dots |

## Modified Files (12)

Standard widget registration footprint — same files every widget touches:

- **types/index.ts** — `GitHubChipData` type + `WidgetTickerData.github`
- **preferences.ts** — `GitHubWidgetConfig`, defaults, merge logic
- **constants.ts** — `LS_GITHUB_REPOS` localStorage key
- **style.css** — `--color-widget-github: #f97316` (orange)
- **chipColors.ts** — `WIDGET_GITHUB` palette
- **ConsolidatedChip.tsx** — GitHub type with CI status dots + failure border highlight
- **ScrollrTicker.tsx** — GitHub chip in scrolling + pinned zones
- **useWidgetTickerData.ts** — `buildGithubChips()` reading from localStorage (no duplicate fetching)
- **WidgetConfigPanel.tsx** — `case "github"` dispatch
- **registry.ts** — Added to `WIDGET_ORDER`
- **dashboardPrefs.ts** — `GitHubCardPrefs`, `GITHUB_SCHEMA`
- **feed.tsx** — Dashboard summary + schema/prefs wiring

## Design Decisions

- **No duplicate polling** — FeedTab is the sole fetcher via TanStack Query; ticker reads cached localStorage only (lesson from uptime review)
- **Per-repo error isolation** — `fetchRepoStatus` catches errors per-repo and returns `status: "unavailable"`; `fetchAllRepos` uses `Promise.allSettled`
- **ConsolidatedChip** — matches existing widget pattern (clock, weather, sysmon, uptime)
- **No new dependencies** — uses existing `@tauri-apps/plugin-http`, `@tanstack/react-query`, `clsx`, `lucide-react`