### PR TITLE
fix(sports): stop polling yesterday's games and tighten cleanup to 12h

### DIFF
--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -281,11 +281,11 @@ pub async fn truncate_games(pool: &Arc<PgPool>) -> Result<()> {
     Ok(())
 }
 
-/// Delete finished games older than 24 hours. Returns the number of rows deleted.
+/// Delete finished games older than 12 hours. Returns the number of rows deleted.
 pub async fn cleanup_old_games(pool: &Arc<PgPool>) -> Result<u64> {
     let mut connection = pool.acquire().await?;
     let result = query(
-        "DELETE FROM games WHERE state IN ('final', 'post') AND start_time < NOW() - INTERVAL '24 hours'"
+        "DELETE FROM games WHERE state IN ('final', 'post') AND start_time < NOW() - INTERVAL '12 hours'"
     )
     .execute(&mut *connection)
     .await?;

--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -8,7 +8,7 @@ use crate::database::{
     get_tracked_leagues, seed_tracked_leagues, disable_stale_leagues,
     cleanup_old_games, LeagueConfig, TrackedLeague, upsert_game, CleanedData, Team,
 };
-pub use crate::types::{SportsHealth, RateLimitTracker};
+pub use crate::types::{SportsHealth, RateLimiter};
 
 pub mod log;
 pub mod database;
@@ -104,7 +104,7 @@ pub async fn poll_live(
     client: &Client,
     leagues: &[TrackedLeague],
     health_state: &Arc<Mutex<SportsHealth>>,
-    rate_limiter: &Arc<RateLimitTracker>,
+    rate_limiter: &Arc<RateLimiter>,
 ) {
     let today = Utc::now().format("%Y-%m-%d").to_string();
 
@@ -113,8 +113,9 @@ pub async fn poll_live(
     let mut leagues_with_live = 0u32;
 
     for league in leagues {
-        if !rate_limiter.has_budget() {
-            warn!("[{}] Skipping live poll — rate limit budget low ({})", league.name, rate_limiter.remaining());
+        if !rate_limiter.has_budget(&league.sport_api) {
+            warn!("[{}] Skipping live poll — rate limit budget low for {} ({})",
+                league.name, league.sport_api, rate_limiter.remaining(&league.sport_api));
             continue;
         }
 
@@ -136,7 +137,7 @@ pub async fn poll_live(
 
     let mut health = health_state.lock().await;
     health.record_success(leagues.len() as u32, leagues_with_live);
-    health.set_rate_limit(rate_limiter.remaining());
+    health.set_rate_limits(rate_limiter.all_remaining());
 
     if total_failed > 0 {
         info!("Live poll complete: {} upserted, {} failed across {} leagues", total_upserted, total_failed, leagues.len());
@@ -144,22 +145,21 @@ pub async fn poll_live(
 }
 
 // =============================================================================
-// Schedule polling (slow — yesterday + today + 7 days ahead, every 30 min)
+// Schedule polling (slow — today + 7 days ahead, every 30 min)
 // =============================================================================
 
-/// Poll yesterday through 7 days ahead to populate the upcoming schedule.
-/// Also cleans up finished games older than 24 hours.
+/// Poll today through 7 days ahead to populate the upcoming schedule.
+/// Also cleans up finished games older than 12 hours.
 pub async fn poll_schedule(
     pool: &Arc<PgPool>,
     client: &Client,
     leagues: &[TrackedLeague],
-    rate_limiter: &Arc<RateLimitTracker>,
+    rate_limiter: &Arc<RateLimiter>,
 ) {
     let now = Utc::now();
-    let yesterday = (now - Duration::days(1)).format("%Y-%m-%d").to_string();
 
-    // Build list of dates: yesterday, today, +1 ... +7
-    let mut dates = vec![yesterday];
+    // Build list of dates: today, +1 ... +7
+    let mut dates = Vec::with_capacity((SCHEDULE_DAYS_AHEAD + 1) as usize);
     for offset in 0..=SCHEDULE_DAYS_AHEAD {
         dates.push((now + Duration::days(offset)).format("%Y-%m-%d").to_string());
     }
@@ -177,8 +177,9 @@ pub async fn poll_schedule(
         }
 
         for date in &dates {
-            if !rate_limiter.has_budget() {
-                warn!("[{}] Skipping schedule poll — rate limit budget low ({})", league.name, rate_limiter.remaining());
+            if !rate_limiter.has_budget(&league.sport_api) {
+                warn!("[{}] Skipping schedule poll — rate limit budget low for {} ({})",
+                    league.name, league.sport_api, rate_limiter.remaining(&league.sport_api));
                 break;
             }
 
@@ -267,19 +268,19 @@ async fn poll_league(
     client: &Client,
     league: &TrackedLeague,
     date: &str,
-    rate_limiter: &RateLimitTracker,
+    rate_limiter: &RateLimiter,
 ) -> anyhow::Result<Vec<CleanedData>> {
     let url = build_api_url(league, date);
 
     let resp = client.get(&url).send().await?;
 
-    // Extract rate limit info from headers
+    // Extract rate limit info from headers — update only this sport's bucket
     if let Some(remaining) = resp.headers()
         .get("x-ratelimit-requests-remaining")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.parse::<u32>().ok())
     {
-        rate_limiter.update(remaining);
+        rate_limiter.update(&league.sport_api, remaining);
     }
 
     let status = resp.status();
@@ -722,7 +723,7 @@ fn parse_f1_race(item: &serde_json::Value, league: &TrackedLeague) -> Option<Cle
     };
 
     // Skip old completed races — they'd be cleaned up anyway and waste DB writes
-    if state == "final" && start_time < Utc::now() - Duration::hours(24) {
+    if state == "final" && start_time < Utc::now() - Duration::hours(12) {
         return None;
     }
 

--- a/channels/sports/service/src/main.rs
+++ b/channels/sports/service/src/main.rs
@@ -5,7 +5,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use sports_service::{
     init_sports_service, poll_live, poll_schedule,
-    SportsHealth, RateLimitTracker,
+    SportsHealth, RateLimiter,
     log::init_async_logger, database::initialize_pool,
 };
 
@@ -38,9 +38,6 @@ async fn main() {
     };
     let health = Arc::new(Mutex::new(SportsHealth::new()));
 
-    // Pro plan: 7,500 requests/day per sport API. Start with that as the initial budget.
-    let rate_limiter = Arc::new(RateLimitTracker::new(7500));
-
     // Cancellation token for coordinated shutdown
     let cancel = CancellationToken::new();
 
@@ -61,6 +58,16 @@ async fn main() {
             return;
         }
     };
+
+    // Pro plan: 7,500 requests/day per sport API. Each sport host
+    // (basketball, football, hockey, etc.) has its own independent budget.
+    let sports: Vec<String> = leagues
+        .iter()
+        .map(|l| l.sport_api.clone())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    let rate_limiter = Arc::new(RateLimiter::new(&sports, 7500));
 
     let client = Arc::new(client);
     let leagues = Arc::new(leagues);
@@ -99,7 +106,7 @@ async fn main() {
         }
     });
 
-    // ── Slow poll: schedule + cleanup (yesterday + 7 days, every 30 min) ──
+    // ── Slow poll: schedule + cleanup (today + 7 days, every 30 min) ──
     let pool_sched = pool.clone();
     let client_sched = client.clone();
     let leagues_sched = leagues.clone();

--- a/channels/sports/service/src/types.rs
+++ b/channels/sports/service/src/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 #[derive(Serialize, Clone)]
@@ -8,7 +9,7 @@ pub struct SportsHealth {
     pub last_poll: Option<DateTime<Utc>>,
     pub leagues_active: u32,
     pub leagues_live: u32,
-    pub rate_limit_remaining: Option<u32>,
+    pub rate_limits: Option<HashMap<String, u32>>,
     pub error_count: u64,
     pub last_error: Option<String>,
 }
@@ -20,7 +21,7 @@ impl SportsHealth {
             last_poll: None,
             leagues_active: 0,
             leagues_live: 0,
-            rate_limit_remaining: None,
+            rate_limits: None,
             error_count: 0,
             last_error: None,
         }
@@ -39,8 +40,8 @@ impl SportsHealth {
         self.status = String::from("degraded");
     }
 
-    pub fn set_rate_limit(&mut self, remaining: u32) {
-        self.rate_limit_remaining = Some(remaining);
+    pub fn set_rate_limits(&mut self, limits: HashMap<String, u32>) {
+        self.rate_limits = Some(limits);
     }
 
     pub fn get_health(&self) -> Self {
@@ -48,30 +49,52 @@ impl SportsHealth {
     }
 }
 
-/// Shared atomic counter for tracking remaining API requests across tasks.
-/// Updated from response headers after each api-sports.io call.
-pub struct RateLimitTracker {
-    remaining: AtomicU32,
+/// Per-sport rate limit tracker. Each sport API (basketball, football, etc.)
+/// has its own daily budget on api-sports.io, so we track them independently.
+/// The map keys are `sport_api` values (e.g. "basketball", "hockey").
+/// The map is built once at startup and never resized — only the atomic
+/// counters inside are updated from response headers.
+pub struct RateLimiter {
+    budgets: HashMap<String, AtomicU32>,
 }
 
-impl RateLimitTracker {
-    pub fn new(initial: u32) -> Self {
-        Self {
-            remaining: AtomicU32::new(initial),
+impl RateLimiter {
+    /// Create a rate limiter with one bucket per sport, each initialized
+    /// to `initial` remaining requests (typically 7,500 for Pro plan).
+    pub fn new(sports: &[String], initial: u32) -> Self {
+        let mut budgets = HashMap::new();
+        for sport in sports {
+            budgets.insert(sport.clone(), AtomicU32::new(initial));
+        }
+        Self { budgets }
+    }
+
+    /// Update the remaining count for a specific sport from an API response header.
+    pub fn update(&self, sport: &str, remaining: u32) {
+        if let Some(counter) = self.budgets.get(sport) {
+            counter.store(remaining, Ordering::Relaxed);
         }
     }
 
-    pub fn update(&self, remaining: u32) {
-        self.remaining.store(remaining, Ordering::Relaxed);
+    /// Get the remaining request count for a specific sport.
+    pub fn remaining(&self, sport: &str) -> u32 {
+        self.budgets
+            .get(sport)
+            .map(|c| c.load(Ordering::Relaxed))
+            .unwrap_or(0)
     }
 
-    pub fn remaining(&self) -> u32 {
-        self.remaining.load(Ordering::Relaxed)
-    }
-
-    /// Returns true if we have enough budget to make a request.
+    /// Returns true if the given sport has enough budget to make a request.
     /// Reserves a conservative buffer of 100 requests.
-    pub fn has_budget(&self) -> bool {
-        self.remaining() > 100
+    pub fn has_budget(&self, sport: &str) -> bool {
+        self.remaining(sport) > 100
+    }
+
+    /// Snapshot of all sport budgets for the health endpoint.
+    pub fn all_remaining(&self) -> HashMap<String, u32> {
+        self.budgets
+            .iter()
+            .map(|(k, v)| (k.clone(), v.load(Ordering::Relaxed)))
+            .collect()
     }
 }


### PR DESCRIPTION
Schedule poll now fetches today + 7 days ahead instead of yesterday + 7, reducing unnecessary API calls. Cleanup threshold for finished games reduced from 24h to 12h. F1 completed race skip aligned to 12h. Rate limiter refactored to track budgets per sport independently.