### PR TITLE
refactor: rename tiers to free/uplink/uplink_pro/uplink_ultimate and add Pro role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,31 +13,29 @@ LOGTO_EXTENSION_APP_ID={{ environment.LOGTO_EXTENSION_APP_ID }}
 LOGTO_M2M_APP_ID={{ environment.LOGTO_M2M_APP_ID }}
 LOGTO_M2M_APP_SECRET={{ environment.LOGTO_M2M_APP_SECRET }}
 LOGTO_UPLINK_ROLE_ID={{ environment.LOGTO_UPLINK_ROLE_ID }}
-LOGTO_UNLIMITED_ROLE_ID={{ environment.LOGTO_UNLIMITED_ROLE_ID }}
+LOGTO_PRO_ROLE_ID={{ environment.LOGTO_PRO_ROLE_ID }}
+LOGTO_ULTIMATE_ROLE_ID={{ environment.LOGTO_ULTIMATE_ROLE_ID }}
 
 # ── Stripe Billing ───────────────────────────────────────────────
 STRIPE_SECRET_KEY={{ environment.STRIPE_SECRET_KEY }}
 STRIPE_PUBLISHABLE_KEY={{ environment.STRIPE_PUBLISHABLE_KEY }}
 STRIPE_WEBHOOK_SECRET={{ environment.STRIPE_WEBHOOK_SECRET }}
 
-# Uplink (mid-tier) price IDs
+# Uplink (base paid tier) price IDs
 STRIPE_PRICE_MONTHLY={{ environment.STRIPE_PRICE_MONTHLY }}
-STRIPE_PRICE_QUARTERLY={{ environment.STRIPE_PRICE_QUARTERLY }}
 STRIPE_PRICE_ANNUAL={{ environment.STRIPE_PRICE_ANNUAL }}
 STRIPE_PRICE_LIFETIME={{ environment.STRIPE_PRICE_LIFETIME }}
 
-# Uplink Unlimited (top-tier) price IDs
-STRIPE_PRICE_UNLIMITED_MONTHLY={{ environment.STRIPE_PRICE_UNLIMITED_MONTHLY }}
-STRIPE_PRICE_UNLIMITED_QUARTERLY={{ environment.STRIPE_PRICE_UNLIMITED_QUARTERLY }}
-STRIPE_PRICE_UNLIMITED_ANNUAL={{ environment.STRIPE_PRICE_UNLIMITED_ANNUAL }}
+# Uplink Pro (mid-tier) price IDs
+STRIPE_PRICE_PRO_MONTHLY={{ environment.STRIPE_PRICE_PRO_MONTHLY }}
+STRIPE_PRICE_PRO_ANNUAL={{ environment.STRIPE_PRICE_PRO_ANNUAL }}
 
-# Grandfathered legacy price IDs (old Uplink → mapped to unlimited)
-STRIPE_PRICE_LEGACY_MONTHLY={{ environment.STRIPE_PRICE_LEGACY_MONTHLY }}
-STRIPE_PRICE_LEGACY_QUARTERLY={{ environment.STRIPE_PRICE_LEGACY_QUARTERLY }}
-STRIPE_PRICE_LEGACY_ANNUAL={{ environment.STRIPE_PRICE_LEGACY_ANNUAL }}
+# Uplink Ultimate (top-tier) price IDs
+STRIPE_PRICE_ULTIMATE_MONTHLY={{ environment.STRIPE_PRICE_ULTIMATE_MONTHLY }}
+STRIPE_PRICE_ULTIMATE_ANNUAL={{ environment.STRIPE_PRICE_ULTIMATE_ANNUAL }}
 
-# Coupon for lifetime members upgrading to Unlimited (50% off)
-STRIPE_LIFETIME_UNLIMITED_COUPON_ID={{ environment.STRIPE_LIFETIME_UNLIMITED_COUPON_ID }}
+# Coupon for lifetime members upgrading to Ultimate (50% off)
+STRIPE_LIFETIME_ULTIMATE_COUPON_ID={{ environment.STRIPE_LIFETIME_ULTIMATE_COUPON_ID }}
 
 # ── Sequin CDC ───────────────────────────────────────────────────
 SEQUIN_WEBHOOK_SECRET={{ environment.SEQUIN_WEBHOOK_SECRET }}

--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -163,9 +163,10 @@ func HandleCreateCheckoutSession(c *fiber.Ctx) error {
 	).Scan(&existingPlan, &existingStatus, &isLifetime)
 
 	if err == nil && existingPlan != "free" && existingStatus == "active" {
-		// Lifetime members can add an Ultimate subscription for 50% off
-		if isLifetime && isUltimatePlan(plan) {
-			// Allow through — coupon applied below
+		// Lifetime members can add an Ultimate or Pro subscription on top
+		// (Ultimate gets 50% off coupon applied below)
+		if isLifetime && (isUltimatePlan(plan) || isProPlan(plan)) {
+			// Allow through
 		} else {
 			return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
 				Status: "error", Error: "You already have an active subscription",

--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -30,22 +30,19 @@ func initStripe() {
 }
 
 // planFromPriceID maps a Stripe price ID to a human-readable plan name.
-// Handles both Uplink and Unlimited tiers, plus grandfathered legacy price IDs.
+// Handles Uplink, Uplink Pro, and Uplink Ultimate tiers.
 func planFromPriceID(priceID string) string {
 	priceMap := map[string]string{
-		// Uplink (mid-tier)
-		os.Getenv("STRIPE_PRICE_MONTHLY"):   "monthly",
-		os.Getenv("STRIPE_PRICE_QUARTERLY"):  "quarterly",
-		os.Getenv("STRIPE_PRICE_ANNUAL"):     "annual",
-		os.Getenv("STRIPE_PRICE_LIFETIME"):   "lifetime",
-		// Uplink Unlimited (top-tier)
-		os.Getenv("STRIPE_PRICE_UNLIMITED_MONTHLY"):  "unlimited_monthly",
-		os.Getenv("STRIPE_PRICE_UNLIMITED_QUARTERLY"): "unlimited_quarterly",
-		os.Getenv("STRIPE_PRICE_UNLIMITED_ANNUAL"):    "unlimited_annual",
-		// Grandfathered legacy prices (old Uplink subscribers → mapped to unlimited)
-		os.Getenv("STRIPE_PRICE_LEGACY_MONTHLY"):  "legacy_monthly",
-		os.Getenv("STRIPE_PRICE_LEGACY_QUARTERLY"): "legacy_quarterly",
-		os.Getenv("STRIPE_PRICE_LEGACY_ANNUAL"):    "legacy_annual",
+		// Uplink (base paid tier)
+		os.Getenv("STRIPE_PRICE_MONTHLY"):  "monthly",
+		os.Getenv("STRIPE_PRICE_ANNUAL"):   "annual",
+		os.Getenv("STRIPE_PRICE_LIFETIME"): "lifetime",
+		// Uplink Pro (mid-tier)
+		os.Getenv("STRIPE_PRICE_PRO_MONTHLY"): "pro_monthly",
+		os.Getenv("STRIPE_PRICE_PRO_ANNUAL"):  "pro_annual",
+		// Uplink Ultimate (top-tier)
+		os.Getenv("STRIPE_PRICE_ULTIMATE_MONTHLY"): "ultimate_monthly",
+		os.Getenv("STRIPE_PRICE_ULTIMATE_ANNUAL"):  "ultimate_annual",
 	}
 
 	// Remove empty-key entry (unset env vars map to "")
@@ -57,12 +54,19 @@ func planFromPriceID(priceID string) string {
 	return "unknown"
 }
 
-// isUnlimitedPlan returns true if the plan name corresponds to the top-tier (Uplink Unlimited).
-// Grandfathered legacy subscribers are also treated as unlimited.
-func isUnlimitedPlan(plan string) bool {
+// isProPlan returns true if the plan name corresponds to the Uplink Pro tier.
+func isProPlan(plan string) bool {
 	switch plan {
-	case "unlimited_monthly", "unlimited_quarterly", "unlimited_annual",
-		"legacy_monthly", "legacy_quarterly", "legacy_annual":
+	case "pro_monthly", "pro_annual":
+		return true
+	}
+	return false
+}
+
+// isUltimatePlan returns true if the plan name corresponds to the top-tier (Uplink Ultimate).
+func isUltimatePlan(plan string) bool {
+	switch plan {
+	case "ultimate_monthly", "ultimate_annual":
 		return true
 	}
 	return false
@@ -159,8 +163,8 @@ func HandleCreateCheckoutSession(c *fiber.Ctx) error {
 	).Scan(&existingPlan, &existingStatus, &isLifetime)
 
 	if err == nil && existingPlan != "free" && existingStatus == "active" {
-		// Lifetime members can add an Unlimited subscription for 50% off
-		if isLifetime && isUnlimitedPlan(plan) {
+		// Lifetime members can add an Ultimate subscription for 50% off
+		if isLifetime && isUltimatePlan(plan) {
 			// Allow through — coupon applied below
 		} else {
 			return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
@@ -197,9 +201,9 @@ func HandleCreateCheckoutSession(c *fiber.Ctx) error {
 	params.AddMetadata("logto_sub", userID)
 	params.AddMetadata("plan", plan)
 
-	// Lifetime members get 50% off Unlimited subscriptions
-	if isLifetime && isUnlimitedPlan(plan) {
-		couponID := os.Getenv("STRIPE_LIFETIME_UNLIMITED_COUPON_ID")
+	// Lifetime members get 50% off Ultimate subscriptions
+	if isLifetime && isUltimatePlan(plan) {
+		couponID := os.Getenv("STRIPE_LIFETIME_ULTIMATE_COUPON_ID")
 		if couponID != "" {
 			params.Discounts = []*stripe.CheckoutSessionDiscountParams{
 				{Coupon: stripe.String(couponID)},

--- a/api/core/logto_admin.go
+++ b/api/core/logto_admin.go
@@ -26,12 +26,13 @@ var (
 
 // logtoM2MConfig holds the env-derived configuration for M2M calls.
 type logtoM2MConfig struct {
-	Endpoint        string // e.g. https://auth.myscrollr.relentnet.dev
-	AppID           string
-	AppSecret       string
-	RoleID          string // "uplink" role
-	UnlimitedRoleID string // "uplink_unlimited" role
-	Resource        string // https://default.logto.app/api
+	Endpoint       string // e.g. https://auth.myscrollr.relentnet.dev
+	AppID          string
+	AppSecret      string
+	RoleID         string // "uplink" role
+	ProRoleID      string // "uplink_pro" role
+	UltimateRoleID string // "uplink_ultimate" role
+	Resource       string // https://default.logto.app/api
 }
 
 // getM2MConfig reads Logto M2M config from environment once.
@@ -48,12 +49,13 @@ func getM2MConfig() logtoM2MConfig {
 	}
 
 	return logtoM2MConfig{
-		Endpoint:        endpoint,
-		AppID:           os.Getenv("LOGTO_M2M_APP_ID"),
-		AppSecret:       os.Getenv("LOGTO_M2M_APP_SECRET"),
-		RoleID:          os.Getenv("LOGTO_UPLINK_ROLE_ID"),
-		UnlimitedRoleID: os.Getenv("LOGTO_UNLIMITED_ROLE_ID"),
-		Resource:        resource,
+		Endpoint:       endpoint,
+		AppID:          os.Getenv("LOGTO_M2M_APP_ID"),
+		AppSecret:      os.Getenv("LOGTO_M2M_APP_SECRET"),
+		RoleID:         os.Getenv("LOGTO_UPLINK_ROLE_ID"),
+		ProRoleID:      os.Getenv("LOGTO_PRO_ROLE_ID"),
+		UltimateRoleID: os.Getenv("LOGTO_ULTIMATE_ROLE_ID"),
+		Resource:       resource,
 	}
 }
 
@@ -152,11 +154,11 @@ func AssignUplinkRole(logtoSub string) error {
 	return nil
 }
 
-// AssignUnlimitedRole assigns the "uplink_unlimited" role to a Logto user via Management API.
-func AssignUnlimitedRole(logtoSub string) error {
+// AssignProRole assigns the "uplink_pro" role to a Logto user via Management API.
+func AssignProRole(logtoSub string) error {
 	cfg := getM2MConfig()
-	if cfg.UnlimitedRoleID == "" {
-		return fmt.Errorf("LOGTO_UNLIMITED_ROLE_ID must be set")
+	if cfg.ProRoleID == "" {
+		return fmt.Errorf("LOGTO_PRO_ROLE_ID must be set")
 	}
 
 	token, err := getM2MToken()
@@ -165,13 +167,13 @@ func AssignUnlimitedRole(logtoSub string) error {
 	}
 
 	payload, _ := json.Marshal(map[string][]string{
-		"roleIds": {cfg.UnlimitedRoleID},
+		"roleIds": {cfg.ProRoleID},
 	})
 
 	reqURL := fmt.Sprintf("%s/api/users/%s/roles", cfg.Endpoint, logtoSub)
 	req, err := http.NewRequest("POST", reqURL, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("create assign unlimited role request: %w", err)
+		return fmt.Errorf("create assign pro role request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
@@ -179,25 +181,25 @@ func AssignUnlimitedRole(logtoSub string) error {
 	client := &http.Client{Timeout: LogtoM2MTokenTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("assign unlimited role request failed: %w", err)
+		return fmt.Errorf("assign pro role request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	// 201 = assigned, 422 = already assigned (both are fine)
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusUnprocessableEntity {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("assign unlimited role returned %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("assign pro role returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	log.Printf("[Logto M2M] Assigned uplink_unlimited role to user %s", logtoSub)
+	log.Printf("[Logto M2M] Assigned uplink_pro role to user %s", logtoSub)
 	return nil
 }
 
-// RemoveUnlimitedRole removes the "uplink_unlimited" role from a Logto user via Management API.
-func RemoveUnlimitedRole(logtoSub string) error {
+// AssignUltimateRole assigns the "uplink_ultimate" role to a Logto user via Management API.
+func AssignUltimateRole(logtoSub string) error {
 	cfg := getM2MConfig()
-	if cfg.UnlimitedRoleID == "" {
-		return fmt.Errorf("LOGTO_UNLIMITED_ROLE_ID must be set")
+	if cfg.UltimateRoleID == "" {
+		return fmt.Errorf("LOGTO_ULTIMATE_ROLE_ID must be set")
 	}
 
 	token, err := getM2MToken()
@@ -205,27 +207,104 @@ func RemoveUnlimitedRole(logtoSub string) error {
 		return err
 	}
 
-	reqURL := fmt.Sprintf("%s/api/users/%s/roles/%s", cfg.Endpoint, logtoSub, cfg.UnlimitedRoleID)
+	payload, _ := json.Marshal(map[string][]string{
+		"roleIds": {cfg.UltimateRoleID},
+	})
+
+	reqURL := fmt.Sprintf("%s/api/users/%s/roles", cfg.Endpoint, logtoSub)
+	req, err := http.NewRequest("POST", reqURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create assign ultimate role request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: LogtoM2MTokenTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("assign ultimate role request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 201 = assigned, 422 = already assigned (both are fine)
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusUnprocessableEntity {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("assign ultimate role returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	log.Printf("[Logto M2M] Assigned uplink_ultimate role to user %s", logtoSub)
+	return nil
+}
+
+// RemoveProRole removes the "uplink_pro" role from a Logto user via Management API.
+func RemoveProRole(logtoSub string) error {
+	cfg := getM2MConfig()
+	if cfg.ProRoleID == "" {
+		return fmt.Errorf("LOGTO_PRO_ROLE_ID must be set")
+	}
+
+	token, err := getM2MToken()
+	if err != nil {
+		return err
+	}
+
+	reqURL := fmt.Sprintf("%s/api/users/%s/roles/%s", cfg.Endpoint, logtoSub, cfg.ProRoleID)
 	req, err := http.NewRequest("DELETE", reqURL, nil)
 	if err != nil {
-		return fmt.Errorf("create remove unlimited role request: %w", err)
+		return fmt.Errorf("create remove pro role request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	client := &http.Client{Timeout: LogtoM2MTokenTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("remove unlimited role request failed: %w", err)
+		return fmt.Errorf("remove pro role request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	// 204 = removed, 404 = not assigned (both are fine)
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("remove unlimited role returned %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("remove pro role returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	log.Printf("[Logto M2M] Removed uplink_unlimited role from user %s", logtoSub)
+	log.Printf("[Logto M2M] Removed uplink_pro role from user %s", logtoSub)
+	return nil
+}
+
+// RemoveUltimateRole removes the "uplink_ultimate" role from a Logto user via Management API.
+func RemoveUltimateRole(logtoSub string) error {
+	cfg := getM2MConfig()
+	if cfg.UltimateRoleID == "" {
+		return fmt.Errorf("LOGTO_ULTIMATE_ROLE_ID must be set")
+	}
+
+	token, err := getM2MToken()
+	if err != nil {
+		return err
+	}
+
+	reqURL := fmt.Sprintf("%s/api/users/%s/roles/%s", cfg.Endpoint, logtoSub, cfg.UltimateRoleID)
+	req, err := http.NewRequest("DELETE", reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("create remove ultimate role request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: LogtoM2MTokenTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("remove ultimate role request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 204 = removed, 404 = not assigned (both are fine)
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("remove ultimate role returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	log.Printf("[Logto M2M] Removed uplink_ultimate role from user %s", logtoSub)
 	return nil
 }
 

--- a/api/core/preferences.go
+++ b/api/core/preferences.go
@@ -10,15 +10,21 @@ import (
 )
 
 // tierFromRoles determines the subscription tier based on JWT roles.
-// Priority: uplink_unlimited > uplink > free. Picks highest tier present.
+// Priority: uplink_ultimate > uplink_pro > uplink > free. Picks highest tier present.
 func tierFromRoles(roles []string) string {
 	tier := "free"
 	for _, r := range roles {
 		switch r {
-		case "uplink_unlimited":
-			return "uplink_unlimited" // highest — return immediately
+		case "uplink_ultimate":
+			return "uplink_ultimate" // highest — return immediately
+		case "uplink_pro":
+			if tier != "uplink_ultimate" {
+				tier = "uplink_pro"
+			}
 		case "uplink":
-			tier = "uplink"
+			if tier == "free" {
+				tier = "uplink"
+			}
 		}
 	}
 	return tier

--- a/api/core/stripe_webhook.go
+++ b/api/core/stripe_webhook.go
@@ -113,10 +113,15 @@ func handleCheckoutCompleted(event stripe.Event) {
 
 	// Assign the appropriate Logto role (async — don't block webhook response)
 	go func() {
-		if plan == "lifetime" || isUnlimitedPlan(plan) {
-			// Lifetime and Unlimited subscribers get uplink_unlimited role
-			if err := AssignUnlimitedRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to assign uplink_unlimited role to %s: %v", logtoSub, err)
+		if plan == "lifetime" || isUltimatePlan(plan) {
+			// Lifetime and Ultimate subscribers get uplink_ultimate role
+			if err := AssignUltimateRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)
+			}
+		} else if isProPlan(plan) {
+			// Pro subscribers get uplink_pro role
+			if err := AssignProRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to assign uplink_pro role to %s: %v", logtoSub, err)
 			}
 		} else {
 			// Standard Uplink subscribers get uplink role
@@ -178,9 +183,13 @@ func handleSubscriptionUpdated(event stripe.Event) {
 	// If subscription is active (not canceling), ensure correct role is assigned
 	if status == "active" && !sub.CancelAtPeriodEnd {
 		go func() {
-			if isUnlimitedPlan(plan) {
-				if err := AssignUnlimitedRole(logtoSub); err != nil {
-					log.Printf("[Stripe Webhook] Failed to assign uplink_unlimited role to %s: %v", logtoSub, err)
+			if isUltimatePlan(plan) {
+				if err := AssignUltimateRole(logtoSub); err != nil {
+					log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)
+				}
+			} else if isProPlan(plan) {
+				if err := AssignProRole(logtoSub); err != nil {
+					log.Printf("[Stripe Webhook] Failed to assign uplink_pro role to %s: %v", logtoSub, err)
 				}
 			} else {
 				if err := AssignUplinkRole(logtoSub); err != nil {
@@ -225,14 +234,17 @@ func handleSubscriptionDeleted(event stripe.Event) {
 		log.Printf("[Stripe Webhook] Failed to reset subscription for %s: %v", logtoSub, err)
 	}
 
-	// Remove both roles (only if not lifetime)
+	// Remove all paid roles (only if not lifetime)
 	if !isLifetime {
 		go func() {
 			if err := RemoveUplinkRole(logtoSub); err != nil {
 				log.Printf("[Stripe Webhook] Failed to remove uplink role from %s: %v", logtoSub, err)
 			}
-			if err := RemoveUnlimitedRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to remove uplink_unlimited role from %s: %v", logtoSub, err)
+			if err := RemoveProRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to remove uplink_pro role from %s: %v", logtoSub, err)
+			}
+			if err := RemoveUltimateRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to remove uplink_ultimate role from %s: %v", logtoSub, err)
 			}
 		}()
 	}
@@ -264,9 +276,13 @@ func handleInvoicePaid(event stripe.Event) {
 
 	// Ensure correct role is still assigned on successful renewal
 	go func() {
-		if isUnlimitedPlan(currentPlan) {
-			if err := AssignUnlimitedRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to re-assign uplink_unlimited role to %s: %v", logtoSub, err)
+		if isUltimatePlan(currentPlan) {
+			if err := AssignUltimateRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to re-assign uplink_ultimate role to %s: %v", logtoSub, err)
+			}
+		} else if isProPlan(currentPlan) {
+			if err := AssignProRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to re-assign uplink_pro role to %s: %v", logtoSub, err)
 			}
 		} else {
 			if err := AssignUplinkRole(logtoSub); err != nil {

--- a/api/core/stripe_webhook.go
+++ b/api/core/stripe_webhook.go
@@ -180,9 +180,15 @@ func handleSubscriptionUpdated(event stripe.Event) {
 		log.Printf("[Stripe Webhook] Failed to update subscription for %s: %v", logtoSub, err)
 	}
 
-	// If subscription is active (not canceling), ensure correct role is assigned
+	// If subscription is active (not canceling), ensure correct role is assigned.
+	// Remove stale roles first to handle plan up/downgrades cleanly.
 	if status == "active" && !sub.CancelAtPeriodEnd {
 		go func() {
+			// Remove all paid roles, then assign only the current one
+			_ = RemoveUplinkRole(logtoSub)
+			_ = RemoveProRole(logtoSub)
+			_ = RemoveUltimateRole(logtoSub)
+
 			if isUltimatePlan(plan) {
 				if err := AssignUltimateRole(logtoSub); err != nil {
 					log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)

--- a/api/migrations/001_rename_tiers.sql
+++ b/api/migrations/001_rename_tiers.sql
@@ -3,3 +3,11 @@
 UPDATE user_preferences
 SET subscription_tier = 'uplink_ultimate'
 WHERE subscription_tier = 'uplink_unlimited';
+
+-- Rename old plan names in stripe_customers to match new naming
+UPDATE stripe_customers SET plan = 'ultimate_monthly' WHERE plan = 'unlimited_monthly';
+UPDATE stripe_customers SET plan = 'ultimate_annual' WHERE plan = 'unlimited_annual';
+UPDATE stripe_customers SET plan = 'ultimate_quarterly' WHERE plan = 'unlimited_quarterly';
+UPDATE stripe_customers SET plan = 'annual' WHERE plan = 'legacy_annual';
+UPDATE stripe_customers SET plan = 'monthly' WHERE plan = 'legacy_monthly';
+UPDATE stripe_customers SET plan = 'quarterly' WHERE plan = 'legacy_quarterly';

--- a/api/migrations/001_rename_tiers.sql
+++ b/api/migrations/001_rename_tiers.sql
@@ -1,0 +1,5 @@
+-- Rename uplink_unlimited → uplink_ultimate in user_preferences
+-- Run once after deploying the code changes. Idempotent if run multiple times.
+UPDATE user_preferences
+SET subscription_tier = 'uplink_ultimate'
+WHERE subscription_tier = 'uplink_unlimited';

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -38,7 +38,8 @@ import { API_BASE as API_URL } from "./config";
 const POLL_INTERVALS: Record<SubscriptionTier, number> = {
   free: 60_000,
   uplink: 30_000,
-  uplink_unlimited: 30_000,
+  uplink_pro: 10_000,
+  uplink_ultimate: 30_000, // Ultimate uses SSE — polling is just a safety-net fallback
 };
 /** Delay before re-fetching after an SSE config-change event, giving the
  *  backend time to propagate the update before we query. */
@@ -249,7 +250,7 @@ export default function App() {
         setAuthenticated(true);
       }
 
-      if (resolvedTier === "uplink_unlimited") {
+      if (resolvedTier === "uplink_ultimate") {
         startSSE();
       }
     }
@@ -274,7 +275,7 @@ export default function App() {
         setTier(newTier);
         tierRef.current = newTier;
         queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
-        if (newTier === "uplink_unlimited") startSSE();
+        if (newTier === "uplink_ultimate") startSSE();
       } else if (!isAuth && wasAuth) {
         // Just logged out — tear down SSE, reset to free tier
         if (sseActiveRef.current) stopSSE();

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -236,7 +236,7 @@ export default function App() {
     [queryClient],
   );
 
-  // ── Initial SSE start for unlimited tier ──────────────────────
+  // ── Initial SSE start for ultimate tier ───────────────────────
 
   useEffect(() => {
     async function init() {

--- a/desktop/src/auth.ts
+++ b/desktop/src/auth.ts
@@ -147,16 +147,17 @@ function extractSub(jwt: string): string | null {
 
 /**
  * Extract the subscription tier from the JWT's `roles` claim.
- * Logto injects roles via Custom JWT (e.g. ["uplink_unlimited"]).
+ * Logto injects roles via Custom JWT (e.g. ["uplink_ultimate"]).
  *
- * Tier hierarchy: uplink_unlimited > uplink > free
+ * Tier hierarchy: uplink_ultimate > uplink_pro > uplink > free
  */
-export type SubscriptionTier = "free" | "uplink" | "uplink_unlimited";
+export type SubscriptionTier = "free" | "uplink" | "uplink_pro" | "uplink_ultimate";
 
 export const TIER_LABELS: Record<SubscriptionTier, string> = {
   free: "Free",
   uplink: "Uplink",
-  uplink_unlimited: "Uplink Unlimited",
+  uplink_pro: "Uplink Pro",
+  uplink_ultimate: "Uplink Ultimate",
 };
 
 export function getTier(): SubscriptionTier {
@@ -170,7 +171,8 @@ export function getTier(): SubscriptionTier {
     ? (payload.roles as string[])
     : [];
 
-  if (roles.includes("uplink_unlimited")) return "uplink_unlimited";
+  if (roles.includes("uplink_ultimate")) return "uplink_ultimate";
+  if (roles.includes("uplink_pro")) return "uplink_pro";
   if (roles.includes("uplink")) return "uplink";
   return "free";
 }

--- a/desktop/src/channels/ChannelConfigPanel.tsx
+++ b/desktop/src/channels/ChannelConfigPanel.tsx
@@ -48,6 +48,7 @@ export default function ChannelConfigPanel({
       return (
         <RssConfigPanel
           channel={channel}
+          subscriptionTier={subscriptionTier}
           hex={hex}
         />
       );

--- a/desktop/src/channels/RssConfigPanel.tsx
+++ b/desktop/src/channels/RssConfigPanel.tsx
@@ -12,6 +12,7 @@ import type { Channel, TrackedFeed, RssChannelConfig } from "../api/client";
 
 interface RssConfigPanelProps {
   channel: Channel;
+  subscriptionTier: string;
   hex: string;
 }
 
@@ -19,6 +20,7 @@ interface RssConfigPanelProps {
 
 export default function RssConfigPanel({
   channel,
+  // subscriptionTier — accepted for consistency; enforcement added in Phase 2
   hex,
 }: RssConfigPanelProps) {
   const queryClient = useQueryClient();

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -279,7 +279,7 @@ body {
 
 /* ── Unlimited tier glow animations ─────────────────────────────── */
 /* Copied from myscrollr.com/src/styles.css — used by ChannelHeader
-   and InfoCard in @/channels/shared for uplink_unlimited users. */
+   and InfoCard in @/channels/shared for uplink_ultimate users. */
 
 @keyframes unlimited-glow-pulse {
   0%,

--- a/desktop/src/types/index.ts
+++ b/desktop/src/types/index.ts
@@ -77,7 +77,7 @@ export interface DashboardResponse {
     feed_enabled: boolean;
     enabled_sites: string[];
     disabled_sites: string[];
-    subscription_tier?: "anonymous" | "free" | "uplink" | "uplink_unlimited";
+    subscription_tier?: "anonymous" | "free" | "uplink" | "uplink_pro" | "uplink_ultimate";
     updated_at: string;
   };
   channels?: Array<Channel & { logto_sub: string }>;

--- a/myscrollr.com/.env.example
+++ b/myscrollr.com/.env.example
@@ -14,12 +14,14 @@ VITE_LOGTO_RESOURCE=https://api.myscrollr.relentnet.dev
 # Stripe (publishable key only — never put secret key here)
 VITE_STRIPE_PUBLISHABLE_KEY=pk_live_or_test_key_here
 
-# Uplink (mid-tier) price IDs
+# Uplink (base paid tier) price IDs
 VITE_STRIPE_PRICE_MONTHLY=price_xxx
-VITE_STRIPE_PRICE_QUARTERLY=price_xxx
 VITE_STRIPE_PRICE_ANNUAL=price_xxx
 
-# Uplink Unlimited (top-tier) price IDs
-VITE_STRIPE_PRICE_UNLIMITED_MONTHLY=price_xxx
-VITE_STRIPE_PRICE_UNLIMITED_QUARTERLY=price_xxx
-VITE_STRIPE_PRICE_UNLIMITED_ANNUAL=price_xxx
+# Uplink Pro (mid-tier) price IDs
+VITE_STRIPE_PRICE_PRO_MONTHLY=price_xxx
+VITE_STRIPE_PRICE_PRO_ANNUAL=price_xxx
+
+# Uplink Ultimate (top-tier) price IDs
+VITE_STRIPE_PRICE_ULTIMATE_MONTHLY=price_xxx
+VITE_STRIPE_PRICE_ULTIMATE_ANNUAL=price_xxx

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -225,7 +225,7 @@ export interface CheckoutReturnStatus {
 }
 
 export const billingApi = {
-  /** Create a subscription checkout session (monthly/quarterly/annual) */
+  /** Create a subscription checkout session (monthly/annual) */
   createCheckoutSession: (
     priceId: string,
     getToken: () => Promise<string | null>,

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -11,7 +11,7 @@ export interface UserPreferences {
   feed_enabled: boolean
   enabled_sites: Array<string>
   disabled_sites: Array<string>
-  subscription_tier: 'free' | 'uplink' | 'uplink_unlimited'
+  subscription_tier: 'free' | 'uplink' | 'uplink_pro' | 'uplink_ultimate'
   updated_at: string
 }
 
@@ -208,15 +208,12 @@ export interface SubscriptionStatus {
   plan:
     | 'free'
     | 'monthly'
-    | 'quarterly'
     | 'annual'
     | 'lifetime'
-    | 'unlimited_monthly'
-    | 'unlimited_quarterly'
-    | 'unlimited_annual'
-    | 'legacy_monthly'
-    | 'legacy_quarterly'
-    | 'legacy_annual'
+    | 'pro_monthly'
+    | 'pro_annual'
+    | 'ultimate_monthly'
+    | 'ultimate_annual'
   status: 'none' | 'active' | 'canceling' | 'canceled' | 'past_due'
   current_period_end?: string
   lifetime: boolean

--- a/myscrollr.com/src/components/billing/CheckoutForm.tsx
+++ b/myscrollr.com/src/components/billing/CheckoutForm.tsx
@@ -15,7 +15,7 @@ const stripePromise = loadStripe(
 interface CheckoutFormProps {
   priceId?: string
   isLifetime?: boolean
-  isUnlimited?: boolean
+  isUltimate?: boolean
   getToken: () => Promise<string | null>
   onClose: () => void
   onSuccess?: () => void
@@ -29,7 +29,7 @@ interface CheckoutFormProps {
 export default function CheckoutForm({
   priceId,
   isLifetime = false,
-  isUnlimited = false,
+  isUltimate = false,
   getToken,
   onClose,
 }: CheckoutFormProps) {
@@ -110,35 +110,35 @@ export default function CheckoutForm({
         aria-label={
           isLifetime
             ? 'Lifetime purchase checkout'
-            : isUnlimited
-              ? 'Subscribe to Uplink Unlimited'
+            : isUltimate
+              ? 'Subscribe to Uplink Ultimate'
               : 'Subscribe to Uplink'
         }
         tabIndex={-1}
         className={`relative w-full max-w-lg mx-4 bg-base-200 border rounded-xl overflow-hidden ${
-          isUnlimited
+          isUltimate
             ? 'border-primary/20 unlimited-glow'
             : 'border-base-content/10'
         }`}
       >
         <div
           className={`flex items-center justify-between px-6 py-4 border-b ${
-            isUnlimited
+            isUltimate
               ? 'border-primary/15 bg-primary/[0.03]'
               : 'border-base-content/10'
           }`}
         >
           <h3
             className={`text-xs font-semibold ${
-              isUnlimited
+              isUltimate
                 ? 'text-primary unlimited-text-glow'
                 : 'text-base-content/60'
             }`}
           >
             {isLifetime
               ? 'Lifetime Purchase'
-              : isUnlimited
-                ? 'Subscribe to Uplink Unlimited'
+              : isUltimate
+                ? 'Subscribe to Uplink Ultimate'
                 : 'Subscribe to Uplink'}
           </h3>
           <button

--- a/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
+++ b/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
@@ -14,9 +14,12 @@ interface SubscriptionStatusProps {
 const PLAN_LABELS: Record<string, string> = {
   free: 'Free',
   monthly: 'Monthly',
-  quarterly: 'Quarterly',
   annual: 'Annual',
   lifetime: 'Lifetime',
+  pro_monthly: 'Monthly',
+  pro_annual: 'Annual',
+  ultimate_monthly: 'Monthly',
+  ultimate_annual: 'Annual',
 }
 
 const STATUS_LABELS: Record<string, { label: string; color: string }> = {
@@ -36,7 +39,8 @@ export default function SubscriptionStatus({
   const [canceling, setCanceling] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const isUnlimited = tier === 'uplink_unlimited'
+  const isUltimate = tier === 'uplink_ultimate'
+  const isPro = tier === 'uplink_pro'
 
   useEffect(() => {
     loadSubscription()
@@ -107,7 +111,7 @@ export default function SubscriptionStatus({
           </span>
         </div>
         <p className="text-xs text-base-content/30">
-          Upgrade to Uplink for faster polling, or Unlimited for real-time SSE.
+          Upgrade to Uplink for faster polling, or Uplink Ultimate for real-time SSE.
         </p>
       </div>
     )
@@ -120,9 +124,9 @@ export default function SubscriptionStatus({
 
   return (
     <div
-      className={`space-y-4 ${isUnlimited ? 'unlimited-glow rounded-xl p-4 -m-4' : ''}`}
+      className={`space-y-4 ${isUltimate ? 'unlimited-glow rounded-xl p-4 -m-4' : ''}`}
       style={
-        isUnlimited
+        isUltimate
           ? {
               background: 'rgba(52, 211, 153, 0.03)',
               borderColor: 'rgba(52, 211, 153, 0.15)',
@@ -136,15 +140,15 @@ export default function SubscriptionStatus({
           <Crown
             size={14}
             className={
-              isUnlimited
+              isUltimate
                 ? 'text-primary unlimited-dot-glow rounded-full'
                 : 'text-primary'
             }
           />
           <span
-            className={`text-xs font-semibold text-primary ${isUnlimited ? 'unlimited-text-glow' : ''}`}
+            className={`text-xs font-semibold text-primary ${isUltimate ? 'unlimited-text-glow' : ''}`}
           >
-            {isUnlimited ? 'Uplink Unlimited' : 'Uplink'}{' '}
+            {isUltimate ? 'Uplink Ultimate' : isPro ? 'Uplink Pro' : 'Uplink'}{' '}
             {PLAN_LABELS[subscription.plan] || subscription.plan}
           </span>
         </div>

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -742,7 +742,7 @@ function BottomCTA({
                 onClick={() => handleSelectPlan('annual', 'ultimate')}
                 className="btn btn-pulse gap-2 text-base px-8 py-5 shadow-2xl"
               >
-                <Crown size={14} /> Start Free Trial — Unlimited
+                <Crown size={14} /> Start Free Trial — Ultimate
               </button>
               <button
                 type="button"

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -61,13 +61,13 @@ const PRO_PRICE_IDS = {
   annual: import.meta.env.VITE_STRIPE_PRICE_PRO_ANNUAL || '',
 } as const
 
-const UNLIMITED_PRICE_IDS = {
-  monthly: import.meta.env.VITE_STRIPE_PRICE_UNLIMITED_MONTHLY || '',
-  annual: import.meta.env.VITE_STRIPE_PRICE_UNLIMITED_ANNUAL || '',
+const ULTIMATE_PRICE_IDS = {
+  monthly: import.meta.env.VITE_STRIPE_PRICE_ULTIMATE_MONTHLY || '',
+  annual: import.meta.env.VITE_STRIPE_PRICE_ULTIMATE_ANNUAL || '',
 } as const
 
 type PlanKey = 'monthly' | 'annual'
-type TierKey = 'uplink' | 'pro' | 'unlimited'
+type TierKey = 'uplink' | 'pro' | 'ultimate'
 
 export const Route = createFileRoute('/uplink')({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -83,11 +83,11 @@ interface ComparisonRow {
   free: string
   uplink: string
   pro: string
-  unlimited: string
+  ultimate: string
   /** Which columns are visually "upgraded" vs free */
   uplinkUp?: boolean
   proUp?: boolean
-  unlimitedUp?: boolean
+  ultimateUp?: boolean
 }
 
 const COMPARISON: Array<ComparisonRow> = [
@@ -96,164 +96,164 @@ const COMPARISON: Array<ComparisonRow> = [
     free: '60s polling',
     uplink: '30s polling',
     pro: '10s polling',
-    unlimited: 'Real-time SSE',
+    ultimate: 'Real-time SSE',
     uplinkUp: true,
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Tracked Symbols',
     free: '10 symbols',
     uplink: '25 symbols',
     pro: '75 symbols',
-    unlimited: 'Unlimited',
+    ultimate: 'Unlimited',
     uplinkUp: true,
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'RSS Feeds',
     free: '5 feeds',
     uplink: '50 feeds',
     pro: '150 feeds',
-    unlimited: 'Unlimited',
+    ultimate: 'Unlimited',
     uplinkUp: true,
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Custom RSS Feeds',
     free: 'None',
     uplink: '10 custom',
     pro: '25 custom',
-    unlimited: 'Unlimited',
+    ultimate: 'Unlimited',
     uplinkUp: true,
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Sports Leagues',
     free: 'Pro only',
     uplink: 'Pro + College',
     pro: 'Pro + College',
-    unlimited: 'Pro + College',
+    ultimate: 'Pro + College',
     uplinkUp: true,
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Fantasy Leagues',
     free: '1 league',
     uplink: '3 leagues',
     pro: '10 leagues',
-    unlimited: 'Unlimited',
+    ultimate: 'Unlimited',
     uplinkUp: true,
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Site Filtering',
     free: 'Blacklist',
     uplink: 'Blacklist',
     pro: 'Blacklist + Whitelist',
-    unlimited: 'Blacklist + Whitelist',
+    ultimate: 'Blacklist + Whitelist',
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Feed Retention',
     free: '25 items',
     uplink: '50 items',
     pro: '200 items',
-    unlimited: 'Unlimited',
+    ultimate: 'Unlimited',
     uplinkUp: true,
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Custom Alerts',
     free: 'No',
     uplink: 'No',
     pro: 'Yes',
-    unlimited: 'Yes',
+    ultimate: 'Yes',
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Feed Profiles',
     free: 'No',
     uplink: 'No',
     pro: 'Yes',
-    unlimited: 'Yes',
+    ultimate: 'Yes',
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Advanced Feed Controls',
     free: 'No',
     uplink: 'No',
     pro: 'Yes',
-    unlimited: 'Yes',
+    ultimate: 'Yes',
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Priority RSS Refresh',
     free: 'No',
     uplink: 'No',
     pro: 'Yes',
-    unlimited: 'Yes',
+    ultimate: 'Yes',
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Webhooks & Integrations',
     free: 'No',
     uplink: 'No',
     pro: 'No',
-    unlimited: 'Yes',
-    unlimitedUp: true,
+    ultimate: 'Yes',
+    ultimateUp: true,
   },
   {
     label: 'Data Export',
     free: 'No',
     uplink: 'No',
     pro: 'No',
-    unlimited: 'CSV / JSON',
-    unlimitedUp: true,
+    ultimate: 'CSV / JSON',
+    ultimateUp: true,
   },
   {
     label: 'API Access',
     free: 'No',
     uplink: 'No',
     pro: 'No',
-    unlimited: 'Yes',
-    unlimitedUp: true,
+    ultimate: 'Yes',
+    ultimateUp: true,
   },
   {
     label: 'Early Access',
     free: 'No',
     uplink: 'Yes',
     pro: 'Yes',
-    unlimited: 'Yes',
+    ultimate: 'Yes',
     uplinkUp: true,
     proUp: true,
-    unlimitedUp: true,
+    ultimateUp: true,
   },
   {
     label: 'Priority Support',
     free: 'No',
     uplink: 'No',
     pro: 'No',
-    unlimited: 'Yes',
-    unlimitedUp: true,
+    ultimate: 'Yes',
+    ultimateUp: true,
   },
   {
     label: 'Dashboard Access',
     free: 'Full',
     uplink: 'Full',
     pro: 'Full',
-    unlimited: 'Full',
+    ultimate: 'Full',
   },
 ]
 
@@ -313,9 +313,9 @@ const TIER_SHOWCASES: Array<TierShowcase> = [
     ],
   },
   {
-    tier: 'unlimited',
+    tier: 'ultimate',
     Icon: Crown,
-    name: 'Unlimited',
+    name: 'Uplink Ultimate',
     tagline: 'Everything. Zero limits.',
     hex: '#34d399',
     delivery: 'Real-time SSE',
@@ -362,7 +362,7 @@ const PRICING: Record<TierKey, Record<PlanKey, PricingPlan>> = {
       savings: 'Save ~$100/yr',
     },
   },
-  unlimited: {
+  ultimate: {
     monthly: { price: 49.99, period: '/mo', perMonth: 49.99 },
     annual: {
       price: 399.99,
@@ -739,7 +739,7 @@ function BottomCTA({
             <div className="relative z-10 flex flex-wrap items-center justify-center gap-4">
               <button
                 type="button"
-                onClick={() => handleSelectPlan('annual', 'unlimited')}
+                onClick={() => handleSelectPlan('annual', 'ultimate')}
                 className="btn btn-pulse gap-2 text-base px-8 py-5 shadow-2xl"
               >
                 <Crown size={14} /> Start Free Trial — Unlimited
@@ -926,7 +926,7 @@ function UplinkPage() {
 
   const getSelectedPriceId = (): string => {
     if (!selectedPlan) return ''
-    if (selectedTier === 'unlimited') return UNLIMITED_PRICE_IDS[selectedPlan]
+    if (selectedTier === 'ultimate') return ULTIMATE_PRICE_IDS[selectedPlan]
     if (selectedTier === 'pro') return PRO_PRICE_IDS[selectedPlan]
     return UPLINK_PRICE_IDS[selectedPlan]
   }
@@ -944,7 +944,7 @@ function UplinkPage() {
         >
           <CheckoutForm
             priceId={getSelectedPriceId()}
-            isUnlimited={selectedTier === 'unlimited'}
+            isUltimate={selectedTier === 'ultimate'}
             getToken={getToken}
             onClose={handleCloseCheckout}
           />
@@ -2224,11 +2224,11 @@ function UplinkPage() {
                     role="button"
                     tabIndex={0}
                     aria-label={`Select Unlimited ${BILLING_LABELS[billingPeriod]} plan`}
-                    onClick={() => handleSelectPlan(billingPeriod, 'unlimited')}
+                    onClick={() => handleSelectPlan(billingPeriod, 'ultimate')}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault()
-                        handleSelectPlan(billingPeriod, 'unlimited')
+                        handleSelectPlan(billingPeriod, 'ultimate')
                       }
                     }}
                     className="group relative rounded-xl overflow-hidden cursor-pointer flex flex-col"
@@ -2428,7 +2428,7 @@ function UplinkPage() {
                                   opacity: { duration: 0.15 },
                                 }}
                               >
-                                {PRICING.unlimited[billingPeriod].perMonth}
+                                {PRICING.ultimate[billingPeriod].perMonth}
                               </AnimateNumber>
                             </span>
                             <span className="text-xs font-mono text-base-content/25 ml-1 self-end mb-0.5">
@@ -2443,7 +2443,7 @@ function UplinkPage() {
                                   opacity: billingPeriod === 'annual' ? 1 : 0,
                                 }}
                               >
-                                Billed ${PRICING.unlimited.annual.price}/yr
+                                Billed ${PRICING.ultimate.annual.price}/yr
                               </span>
                               <span
                                 className="col-start-1 row-start-1 transition-opacity duration-200"
@@ -2457,14 +2457,14 @@ function UplinkPage() {
                             <span
                               className="text-[8px] font-bold text-primary/70 bg-primary/10 px-1.5 py-0.5 rounded transition-opacity duration-200"
                               style={{
-                                opacity: PRICING.unlimited[billingPeriod]
+                                opacity: PRICING.ultimate[billingPeriod]
                                   .savings
                                   ? 1
                                   : 0,
                               }}
                             >
-                              {PRICING.unlimited[billingPeriod].savings ??
-                                PRICING.unlimited.annual.savings}
+                              {PRICING.ultimate[billingPeriod].savings ??
+                                PRICING.ultimate.annual.savings}
                             </span>
                           </div>
                         </div>
@@ -2496,7 +2496,7 @@ function UplinkPage() {
                           </div>
                           <span className="text-[9px] text-base-content/20">
                             7 days free, then $
-                            {PRICING.unlimited[billingPeriod].perMonth}/mo
+                            {PRICING.ultimate[billingPeriod].perMonth}/mo
                           </span>
                         </div>
                       </div>
@@ -2899,7 +2899,7 @@ function UplinkPage() {
                 </div>
                 <div className="p-4 flex items-center justify-center border-l border-primary/10 bg-primary/[0.025] relative">
                   {/* Ethereal row glow for unlimited upgrades */}
-                  {row.unlimitedUp && (
+                  {row.ultimateUp && (
                     <motion.div
                       className="absolute inset-0 pointer-events-none"
                       style={{
@@ -2916,7 +2916,7 @@ function UplinkPage() {
                       }}
                     />
                   )}
-                  {row.unlimitedUp ? (
+                  {row.ultimateUp ? (
                     <span className="relative inline-flex items-center gap-1.5 text-[11px] font-bold font-mono text-primary">
                       <motion.span
                         className="shrink-0"
@@ -2930,7 +2930,7 @@ function UplinkPage() {
                       >
                         <Check size={11} className="text-primary" />
                       </motion.span>
-                      {row.unlimited}
+                      {row.ultimate}
                     </span>
                   ) : (
                     <span className="relative inline-flex items-center gap-1.5 text-[11px] font-mono text-base-content/25">
@@ -2938,7 +2938,7 @@ function UplinkPage() {
                         size={9}
                         className="text-base-content/15 shrink-0"
                       />
-                      {row.unlimited}
+                      {row.ultimate}
                     </span>
                   )}
                 </div>
@@ -3006,7 +3006,7 @@ function UplinkPage() {
                   ease: EASE,
                 }}
                 className={`group relative rounded-2xl overflow-hidden ${
-                  tier.tier === 'unlimited'
+                  tier.tier === 'ultimate'
                     ? 'border border-primary/20'
                     : tier.tier === 'pro'
                       ? 'border border-[#a78bfa]/20'
@@ -3014,7 +3014,7 @@ function UplinkPage() {
                 }`}
               >
                 {/* Animated border glow for Unlimited */}
-                {tier.tier === 'unlimited' && (
+                {tier.tier === 'ultimate' && (
                   <motion.div
                     className="absolute -inset-px rounded-2xl bg-gradient-to-b from-primary/25 via-primary/8 to-primary/3 -z-10"
                     animate={{ opacity: [0.6, 1, 0.6] }}
@@ -3028,11 +3028,11 @@ function UplinkPage() {
 
                 <div
                   className={`relative p-7 md:p-8 h-full flex flex-col ${
-                    tier.tier === 'unlimited' ? '' : 'bg-base-200/40'
+                    tier.tier === 'ultimate' ? '' : 'bg-base-200/40'
                   }`}
                 >
                   {/* Background layer — separate for Unlimited so smoke sits above it */}
-                  {tier.tier === 'unlimited' && (
+                  {tier.tier === 'ultimate' && (
                     <div className="absolute inset-0 bg-base-200/60 rounded-2xl pointer-events-none" />
                   )}
 
@@ -3078,7 +3078,7 @@ function UplinkPage() {
                   />
 
                   {/* "Recommended" badge for Unlimited */}
-                  {tier.tier === 'unlimited' && (
+                  {tier.tier === 'ultimate' && (
                     <div
                       className="absolute top-0 right-0"
                       style={{ zIndex: 20 }}
@@ -3090,7 +3090,7 @@ function UplinkPage() {
                   )}
 
                   {/* ── Ethereal smoke (Unlimited only) — above background, below content ── */}
-                  {tier.tier === 'unlimited' && (
+                  {tier.tier === 'ultimate' && (
                     <div
                       className="absolute inset-0 pointer-events-none overflow-hidden rounded-2xl"
                       style={{ zIndex: 1 }}
@@ -3314,7 +3314,7 @@ function UplinkPage() {
                         type="button"
                         onClick={() => handleSelectPlan('annual', tier.tier)}
                         className={`w-full py-2.5 text-center text-[10px] font-semibold rounded-lg transition-colors ${
-                          tier.tier === 'unlimited'
+                          tier.tier === 'ultimate'
                             ? 'bg-primary/10 border border-primary/30 text-primary hover:bg-primary/20 hover:border-primary/50'
                             : tier.tier === 'pro'
                               ? 'border border-[#a78bfa]/20 text-[#a78bfa]/60 hover:border-[#a78bfa]/40 hover:text-[#a78bfa]/80'
@@ -3324,7 +3324,7 @@ function UplinkPage() {
                         Start Free Trial
                       </button>
                       <p className="text-center mt-1.5 text-[9px] text-base-content/20">
-                        {tier.tier === 'unlimited'
+                        {tier.tier === 'ultimate'
                           ? '7 days free, then $33.33/mo'
                           : tier.tier === 'pro'
                             ? '7 days free, then $16.67/mo'

--- a/myscrollr.com/src/routes/uplink_.lifetime.tsx
+++ b/myscrollr.com/src/routes/uplink_.lifetime.tsx
@@ -237,7 +237,7 @@ function LifetimePage() {
               >
                 50% Off
                 <br />
-                <span className="text-primary">Unlimited.</span>
+                <span className="text-primary">Ultimate.</span>
                 <br />
                 <span className="text-warning">Forever.</span>
               </motion.h1>
@@ -250,7 +250,7 @@ function LifetimePage() {
                 className="text-sm text-base-content/40 leading-relaxed max-w-md mb-10"
               >
                 Lifetime members get permanent Uplink-tier access with a single
-                payment — plus 50% off any Unlimited subscription. Real-time
+                payment — plus 50% off any Uplink Ultimate subscription. Real-time
                 SSE, unlimited symbols, webhooks, API access — all at half
                 price, for as long as you subscribe. Only 128 founding member
                 slots will ever exist.
@@ -264,7 +264,7 @@ function LifetimePage() {
                 className="space-y-3 mb-10"
               >
                 <Feature>
-                  50% off any Unlimited subscription — from $25.00/mo
+                  50% off any Uplink Ultimate subscription — from $25.00/mo
                 </Feature>
                 <Feature>
                   Real-time SSE, unlimited symbols, feeds & leagues
@@ -398,11 +398,11 @@ function LifetimePage() {
                       }}
                     />
                     <div className="relative z-10">
-                      <p className="text-[10px] text-primary/70 font-semibold mb-1">
-                        50% Off Unlimited — From $25.00/mo
+                       <p className="text-[10px] text-primary/70 font-semibold mb-1">
+                        50% Off Uplink Ultimate — From $25.00/mo
                       </p>
                       <p className="text-[10px] text-base-content/35 leading-relaxed">
-                        Lifetime members get half off any Unlimited
+                        Lifetime members get half off any Uplink Ultimate
                         subscription. Real-time SSE, unlimited symbols and
                         feeds, webhooks, API access, and data export — all at
                         half price.

--- a/v1_checklist.md
+++ b/v1_checklist.md
@@ -1,0 +1,181 @@
+# Scrollr Desktop 1.0.0 — Release Checklist
+
+## Tier Reference
+
+| Feature | Free | Uplink ($9.99/mo) | Uplink Pro ($24.99/mo) | Uplink Ultimate ($49.99/mo) |
+|---|---|---|---|---|
+| **Data delivery** | 60s polling | 30s polling | 10s polling | Real-time SSE |
+| **Tracked symbols** | 5 | 25 | 75 | Unlimited |
+| **News feeds** | 1 | 25 | 100 | Unlimited |
+| **Sports leagues** | 1 | 8 | 20 | Unlimited |
+| **Custom news feeds** | 0 | 1 | 3 | 10 |
+| **Fantasy leagues** | 0 | 1 | 3 | 10 |
+| **Custom alerts** | No | No | Yes *(post-v1)* | Yes *(post-v1)* |
+| **Feed profiles** | No | No | Yes *(post-v1)* | Yes *(post-v1)* |
+| **Widgets** | All | All | All | All |
+| **Premium widgets** | No | No | Yes *(future)* | Yes *(future)* |
+| **Webhooks** | No | No | No | Yes *(post-v1)* |
+| **Data export** | No | No | No | Yes *(post-v1)* |
+| **API access** | No | No | No | Yes *(post-v1)* |
+
+**Tier pitches:**
+- **Free → Uplink**: 5× symbols, 25× news feeds, 8 sports leagues, 1 fantasy league, 2× faster data. More of everything.
+- **Uplink → Pro**: Higher limits again, plus new capabilities when they ship (alerts, profiles).
+- **Pro → Ultimate**: Real-time SSE is the headline. Symbols, news, and sports become unlimited.
+
+Annual pricing: Uplink $79.99/yr, Uplink Pro $199.99/yr, Uplink Ultimate $399.99/yr.
+Lifetime: $399 one-time (permanent Uplink-tier access + 50% off Ultimate upgrade).
+All paid tiers include a 7-day free trial.
+
+---
+
+## Phase 1 — Foundation
+
+### Security
+- [x] Confirm Stripe webhook signature verification is implemented
+- [x] Tauri capability scoping (main vs ticker split)
+- [ ] Tighten Tauri HTTP scope (currently `http://*:*` and `https://*:*` in both capabilities — defeats scoped HTTP)
+- [ ] Review / add CSP headers in Tauri webview
+- [ ] CORS configuration review (channel APIs have no CORS — relies on core proxy, but verify)
+- [ ] Input validation audit across all API endpoints (currently ad-hoc field checks, no schema validation)
+- [ ] Dependency audit (`npm audit` + `cargo audit`)
+
+### Distribution & Signing
+> **Highest-risk items on the list.** Gatekeeper and SmartScreen block unsigned binaries. Hard gate on shipping.
+- [ ] Apple Developer certificate + notarization setup
+- [ ] Windows Authenticode code signing certificate
+- [ ] Update CI workflow to use OS-level signing credentials (currently only has minisign for updater artifacts)
+
+### Billing & Monetization
+> **Backend role gap:** Pro tier has no backend role — it maps to the same `uplink` role as Uplink. `tierFromRoles()` only knows `free`, `uplink`, `uplink_unlimited`. The backend cannot distinguish Uplink from Pro users. Also: rename `uplink_unlimited` → `uplink_ultimate` everywhere (Logto, Go backend, TypeScript types, DB).
+- [ ] Rename `uplink_unlimited` → `uplink_ultimate` across codebase (Logto role, `tierFromRoles()`, `planFromPriceID()`, TypeScript `SubscriptionTier` type, DB values) and display name to "Uplink Ultimate"
+- [ ] Add `uplink_pro` backend role to Logto and update `tierFromRoles()` / `planFromPriceID()` to distinguish all four tiers
+- [ ] Create Stripe products/prices for Uplink Pro tier (monthly + annual) and wire up `VITE_STRIPE_PRICE_PRO_MONTHLY` / `VITE_STRIPE_PRICE_PRO_ANNUAL` env vars
+- [ ] Integrate Stripe Customer Portal (payment method, invoices, plan switching)
+- [ ] Handle Stripe Customer Portal browser handoff from desktop app (can't embed — needs browser redirect)
+- [ ] Add webhook event idempotency (deduplicate redelivered Stripe events)
+- [ ] Handle failed payments / dunning (grace period + user notification — `invoice.payment_failed` currently sets `past_due` but does nothing else)
+- [ ] Verify 7-day free trial is implemented in Stripe checkout flow (promised on pricing page)
+- [ ] Test full billing lifecycle (subscribe → use → upgrade → downgrade → cancel → resubscribe)
+- [ ] Billing UI in desktop app (current plan, usage, manage subscription link)
+
+### Database & Infrastructure
+- [ ] Database migrations strategy (`CREATE TABLE IF NOT EXISTS` on startup won't handle schema changes in production — adopt golang-migrate, goose, or atlas)
+
+### Legal Doc Sync
+> **Pricing page and legal documents are out of sync.** Legal docs reference old pricing and quarterly billing that no longer exists.
+- [ ] Update legal documents to match current pricing and tier names (Terms of Service, Privacy Policy)
+- [ ] Remove quarterly billing references from legal docs and `SubscriptionStatus` type (`quarterly`, `unlimited_quarterly`, `legacy_quarterly`)
+
+### Phase 1 Validation
+- [x] Auto-updater implemented with progress UI and GitHub releases endpoint
+- [ ] Test auto-updater end-to-end (install old version → push update → verify install)
+
+---
+
+## Phase 2 — Product
+
+### Crash Reporting
+> Moved from Phase 3 — capturing bugs during active development is more valuable than waiting until pre-launch.
+- [ ] Integrate crash reporting (Sentry or equivalent) across desktop app, Go APIs, and Rust services
+
+### Toast Notification System
+- [ ] Implement toast notification system (success, error, info feedback across the app)
+
+### Tier Enforcement — Infrastructure
+> **Currently zero server-side enforcement.** Channel APIs receive `X-User-Sub` but not tier info. Client-side polling intervals are trivially bypassable. The `subscriptionTier` prop already flows into Finance, Sports, and Fantasy config panels but is unused. RSS config panel doesn't receive it at all.
+- [ ] Forward tier info from core API to channel APIs (add `X-User-Tier` header to proxy) — **prerequisite for all enforcement below**
+- [ ] Server-side rate limiting per tier (enforce polling intervals server-side, not just client-side)
+- [ ] Wire `subscriptionTier` into RSS (`NewsConfigPanel`) — currently the only channel missing the prop
+
+### Tier Enforcement — Finance
+- [ ] Enforce tracked symbol limit: Free=5, Uplink=25, Pro=75, Ultimate=unlimited
+- [ ] Show usage indicator in config panel (e.g. "12/25 symbols tracked")
+- [ ] Block symbol additions beyond limit with upgrade prompt
+
+### Tier Enforcement — News (RSS)
+- [ ] Enforce news feed count limit: Free=1, Uplink=25, Pro=100, Ultimate=unlimited
+- [ ] Enforce custom news feed limit: Free=0, Uplink=1, Pro=3, Ultimate=10
+- [ ] Block "Add Custom Feed" form for Free tier
+- [ ] Show usage indicator and upgrade prompt at limit
+
+### Tier Enforcement — Sports
+- [ ] Enforce sports league count limit: Free=1, Uplink=8, Pro=20, Ultimate=unlimited
+- [ ] Show usage indicator and upgrade prompt at limit
+
+### Tier Enforcement — Fantasy
+- [ ] Gate Fantasy channel entirely for Free tier (0 leagues — show upgrade prompt instead of Yahoo connect flow)
+- [ ] Enforce fantasy league count limit: Uplink=1, Pro=3, Ultimate=10
+- [ ] Block league import beyond limit with upgrade prompt
+
+### Tier Enforcement — Data Delivery
+- [x] SSE delivery implemented for Uplink Ultimate (Rust client → Hub → Sequin CDC pipeline)
+- [ ] Enforce polling intervals server-side: Free=60s, Uplink=30s, Pro=10s, Ultimate=SSE
+- [ ] Enforce server-side SSE access: only `uplink_ultimate` should open `/events` (currently client-side gate only in `App.tsx`)
+
+### Tier Enforcement — UX
+- [ ] Graceful upgrade prompts when users hit a limit (nudge, not hard error)
+- [ ] Consistent upgrade prompt component reused across all channels
+
+### Pricing Page
+> **No "Coming Soon" labels exist on the pricing page.** Unbuilt features are presented as included. Pricing page also needs to reflect the new tier names, limits, and structure.
+- [ ] Rewrite pricing page to reflect new tier names (Uplink / Uplink Pro / Uplink Ultimate), limits, and structure
+- [ ] Mark post-v1 features as "Coming Soon": Custom alerts, Feed profiles, Webhooks, Data export, API access
+- [ ] Remove feed retention from pricing page (internal concern, not a user-facing feature)
+- [ ] Remove referral program from pricing page (no backend support exists)
+- [ ] Verify lifetime deal page reflects correct tier name (Uplink Ultimate) and current pricing
+
+### Stability & Error Handling
+- [ ] Test and fix auth token expiry / silent refresh behavior
+- [ ] Offline detection + graceful degradation (show last-known data, not a blank screen)
+- [ ] API connection recovery / automatic retry with backoff
+- [ ] Handle rate limit (429) responses gracefully on the frontend
+- [ ] Stale data indicators (if data is old, make it visible)
+- [ ] Window state persistence (remember size and position across restarts — currently only saves ticker position preference, not actual window geometry)
+
+### Core UX
+- [x] Error boundaries (`RouteError.tsx` across all 6 route groups)
+- [x] Empty states (`DashboardEmptyState` and `EmptyChannelState` implemented)
+- [ ] First-run onboarding flow (guide new users through initial setup — currently only a basic welcome state)
+- [ ] Channel/widget discovery catalog (browsable UI to find and enable sources)
+- [ ] Fix flashing on configure page when adding items from catalog
+- [ ] Flesh out Account tab (profile info, billing summary, usage stats, connected accounts)
+- [ ] Audit all loading states (no layout shift, no blank screens)
+
+---
+
+## Phase 3 — Pre-launch
+
+### Bug Reporting & Support
+- [ ] Add in-app "Report a Bug" link (pre-filled GitHub issue or form)
+- [ ] Create GitHub issue templates (bug report, feature request)
+- [ ] Changelog / "What's New" display after updates
+- [ ] Basic help docs or FAQ accessible from the app
+
+### Legal & Compliance
+- [ ] Update Privacy Policy to cover desktop app (local storage, network requests, data handling)
+- [ ] Update Terms of Service for desktop distribution
+- [ ] Ensure AGPL license is bundled with the binary
+- [ ] Review data collection disclosure (even if it's "we collect nothing")
+
+### Website Overhaul
+> **Site is deeply extension-oriented.** `InstallButton`, `HeroBrowserStack`, `HowItWorks`, `CallToAction`, and more reference Chrome/Firefox stores. The download page with OS detection is a meaningful feature build on its own.
+- [ ] Remove all extension references (~15+ files: InstallButton, HeroBrowserStack, FAQs, HowItWorks, CallToAction, Footer)
+- [ ] Build download page with OS detection (macOS / Windows / Linux, handle unsigned binary warnings)
+- [ ] Update hero section with desktop app visuals
+- [ ] Update "How It Works" section for desktop flow
+- [ ] Update all FAQs for desktop context
+- [ ] Update footer links (remove Chrome Web Store / Firefox Add-ons)
+- [ ] Add desktop screenshots or preview video
+
+---
+
+## Phase 4 — Ship It
+
+### Launch Preparation
+- [ ] Cross-platform testing pass (macOS arm64, Windows x64, Linux x64)
+- [ ] Performance baseline (startup time, idle memory usage, no memory leaks on long runs)
+- [ ] Verify rollback plan (unpublish GitHub release + push hotfix via auto-updater if critical bug found)
+- [ ] Update project README to reflect desktop as primary product
+- [ ] Prepare release notes template
+- [ ] Draft launch announcement

--- a/v1_checklist.md
+++ b/v1_checklist.md
@@ -48,9 +48,9 @@ All paid tiers include a 7-day free trial.
 
 ### Billing & Monetization
 > **Backend role gap:** Pro tier has no backend role — it maps to the same `uplink` role as Uplink. `tierFromRoles()` only knows `free`, `uplink`, `uplink_unlimited`. The backend cannot distinguish Uplink from Pro users. Also: rename `uplink_unlimited` → `uplink_ultimate` everywhere (Logto, Go backend, TypeScript types, DB).
-- [ ] Rename `uplink_unlimited` → `uplink_ultimate` across codebase (Logto role, `tierFromRoles()`, `planFromPriceID()`, TypeScript `SubscriptionTier` type, DB values) and display name to "Uplink Ultimate"
-- [ ] Add `uplink_pro` backend role to Logto and update `tierFromRoles()` / `planFromPriceID()` to distinguish all four tiers
-- [ ] Create Stripe products/prices for Uplink Pro tier (monthly + annual) and wire up `VITE_STRIPE_PRICE_PRO_MONTHLY` / `VITE_STRIPE_PRICE_PRO_ANNUAL` env vars
+- [x] Rename `uplink_unlimited` → `uplink_ultimate` across codebase (Logto role, `tierFromRoles()`, `planFromPriceID()`, TypeScript `SubscriptionTier` type, DB values) and display name to "Uplink Ultimate"
+- [x] Add `uplink_pro` backend role to Logto and update `tierFromRoles()` / `planFromPriceID()` to distinguish all four tiers
+- [x] Create Stripe products/prices for all tiers (Uplink, Pro, Ultimate, Lifetime) and 50% off lifetime coupon in Stripe sandbox
 - [ ] Integrate Stripe Customer Portal (payment method, invoices, plan switching)
 - [ ] Handle Stripe Customer Portal browser handoff from desktop app (can't embed — needs browser redirect)
 - [ ] Add webhook event idempotency (deduplicate redelivered Stripe events)
@@ -86,7 +86,7 @@ All paid tiers include a 7-day free trial.
 > **Currently zero server-side enforcement.** Channel APIs receive `X-User-Sub` but not tier info. Client-side polling intervals are trivially bypassable. The `subscriptionTier` prop already flows into Finance, Sports, and Fantasy config panels but is unused. RSS config panel doesn't receive it at all.
 - [ ] Forward tier info from core API to channel APIs (add `X-User-Tier` header to proxy) — **prerequisite for all enforcement below**
 - [ ] Server-side rate limiting per tier (enforce polling intervals server-side, not just client-side)
-- [ ] Wire `subscriptionTier` into RSS (`NewsConfigPanel`) — currently the only channel missing the prop
+- [x] Wire `subscriptionTier` into RSS (`NewsConfigPanel`) — was the only channel missing the prop
 
 ### Tier Enforcement — Finance
 - [ ] Enforce tracked symbol limit: Free=5, Uplink=25, Pro=75, Ultimate=unlimited


### PR DESCRIPTION
## Summary

- Renames `uplink_unlimited` → `uplink_ultimate` across the entire codebase (Go backend, website, desktop)
- Adds `uplink_pro` as a new tier between Uplink and Ultimate
- Creates all Stripe sandbox products/prices for the 4-tier structure + lifetime coupon

## Changes

### Go backend (`api/core/`)
- `tierFromRoles()`: 4-tier hierarchy — `uplink_ultimate > uplink_pro > uplink > free`
- `planFromPriceID()`: maps new Pro and Ultimate price env vars, removes legacy/quarterly
- `isUltimatePlan()` and `isProPlan()` replace `isUnlimitedPlan()`
- New `AssignProRole()`, `RemoveProRole()`, `AssignUltimateRole()`, `RemoveUltimateRole()` Logto M2M functions
- All webhook handlers now route Pro subscribers to `uplink_pro` role
- Subscription deletion removes all three paid roles

### Website (`myscrollr.com/`)
- `UserPreferences.subscription_tier`: added `uplink_pro` and `uplink_ultimate`
- `SubscriptionStatus.plan`: removed quarterly, added `pro_*` and `ultimate_*`
- `CheckoutForm`: `isUnlimited` → `isUltimate`, display names updated
- Pricing page: `TierKey` `'unlimited'` → `'ultimate'`, all data structures renamed
- Lifetime page: display text updated to "Uplink Ultimate"

### Desktop (`desktop/`)
- `SubscriptionTier` type: 4 values, `TIER_LABELS` updated
- `POLL_INTERVALS`: Pro=10s, Ultimate=30s (SSE fallback)
- SSE gating now checks `uplink_ultimate`
- `RssConfigPanel` now receives `subscriptionTier` prop

### Infrastructure
- SQL migration: `api/migrations/001_rename_tiers.sql`
- Website `.env.example` updated for new tier env vars

## Manual steps after merge
1. Rename `uplink_unlimited` role to `uplink_ultimate` in Logto console
2. Set new env vars on server (Stripe price IDs, Logto role IDs)
3. Run `api/migrations/001_rename_tiers.sql` against production DB