### PR TITLE
fix: Yahoo OAuth connect flow for Tauri desktop app

### DIFF
--- a/desktop/src/channels/FantasyConfigPanel.tsx
+++ b/desktop/src/channels/FantasyConfigPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { AnimatePresence, motion } from "motion/react";
 import { clsx } from "clsx";
 import { toast } from "sonner";
+import { open } from "@tauri-apps/plugin-shell";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Section,
@@ -81,9 +82,13 @@ export default function FantasyConfigPanel({
 }: FantasyConfigPanelProps) {
 
   const queryClient = useQueryClient();
+  const [phase, setPhase] = useState<Phase>("disconnected");
+  const [awaitingYahoo, setAwaitingYahoo] = useState(false);
+  const phaseInitRef = useRef(false);
 
   const { data: statusData } = useQuery({
     ...fantasyStatusOptions(),
+    refetchInterval: awaitingYahoo ? 2000 : false,
   });
 
   const { data: leaguesData } = useQuery({
@@ -98,9 +103,6 @@ export default function FantasyConfigPanel({
     (): Phase => (statusData && yahooConnected ? "connected" : "disconnected"),
     [statusData, yahooConnected],
   );
-
-  const [phase, setPhase] = useState<Phase>("disconnected");
-  const phaseInitRef = useRef(false);
 
   // Sync phase from query data on initial load
   useEffect(() => {
@@ -226,33 +228,51 @@ export default function FantasyConfigPanel({
     setPhase("connected");
   }, [selectedKeys, discoveredLeagues, queryClient, importLeagueMutation]);
 
-  // ── Listen for Yahoo auth popup completion ─────────────────────
+  // ── Detect Yahoo connection via polling ─────────────────────────
 
   useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data?.type === "yahoo-auth-complete") {
-        queryClient.invalidateQueries({ queryKey: queryKeys.fantasy.status });
-        queryClient.invalidateQueries({ queryKey: queryKeys.fantasy.leagues });
-        startDiscovery();
-      }
-    };
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, [queryClient, startDiscovery]);
+    if (awaitingYahoo && statusData?.connected) {
+      setAwaitingYahoo(false);
+      toast.success("Yahoo account connected");
+      queryClient.invalidateQueries({ queryKey: queryKeys.fantasy.leagues });
+      startDiscovery();
+    }
+  }, [awaitingYahoo, statusData, queryClient, startDiscovery]);
+
+  // ── Timeout if Yahoo sign-in takes too long ───────────────────
+
+  useEffect(() => {
+    if (!awaitingYahoo) return;
+    const timeout = setTimeout(() => {
+      setAwaitingYahoo(false);
+      toast.error("Yahoo sign-in timed out — try again");
+    }, 5 * 60 * 1000);
+    return () => clearTimeout(timeout);
+  }, [awaitingYahoo]);
 
   // ── Yahoo connect / disconnect ─────────────────────────────────
 
   const handleYahooConnect = useCallback(async () => {
     const token = await getValidToken();
-    if (!token) return;
+    if (!token) {
+      toast.error("Sign in to your account first");
+      return;
+    }
 
-    let sub: string | undefined;
     const payload = decodeJwtPayload(token);
-    sub = payload?.sub as string | undefined;
-    if (!sub) return;
+    const sub = payload?.sub as string | undefined;
+    if (!sub) {
+      toast.error("Couldn't verify your identity — try signing in again");
+      return;
+    }
 
     const popupUrl = `${API_BASE}/yahoo/start?logto_sub=${sub}`;
-    window.open(popupUrl, "yahoo-auth", "width=600,height=700");
+    try {
+      await open(popupUrl);
+      setAwaitingYahoo(true);
+    } catch {
+      toast.error("Couldn't open Yahoo sign-in");
+    }
   }, []);
 
   const disconnectMutation = useMutation({
@@ -365,11 +385,21 @@ export default function FantasyConfigPanel({
           )}
           <button
             onClick={handleYahooConnect}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-[12px] font-medium text-white transition-colors cursor-pointer"
+            disabled={awaitingYahoo}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-[12px] font-medium text-white transition-colors cursor-pointer disabled:opacity-60"
             style={{ background: hex }}
           >
-            <Link2 size={14} />
-            Connect Yahoo Account
+            {awaitingYahoo ? (
+              <>
+                <Loader2 size={14} className="animate-spin" />
+                Waiting for Yahoo sign-in…
+              </>
+            ) : (
+              <>
+                <Link2 size={14} />
+                Connect Yahoo Account
+              </>
+            )}
           </button>
         </motion.div>
       )}


### PR DESCRIPTION
## Summary

- Replace broken `window.open()` with `@tauri-apps/plugin-shell` `open()` so Yahoo sign-in launches in the system browser instead of failing silently in the Tauri webview
- Replace dead `window.opener.postMessage` listener with status endpoint polling (2s interval) to detect when Yahoo account is linked
- Add 5-minute timeout safety valve for the polling
- Add toast error feedback for auth failures that previously returned silently (no token, no sub claim, shell open failure)
- Update button to show spinner + "Waiting for Yahoo sign-in…" while awaiting completion

## Root Cause

`FantasyConfigPanel.tsx` used `window.open(url, "yahoo-auth", ...)` which does not open an external browser in Tauri's webview. The callback HTML from the Go API used `window.opener.postMessage()` which cannot reach the Tauri webview since the system browser has no `window.opener` reference. The working Logto login flow correctly uses `open()` from `@tauri-apps/plugin-shell`.

## Changes

Single file: `desktop/src/channels/FantasyConfigPanel.tsx` (+52/-22)