### PR TITLE
fix: sports scores — yesterday polling, CDC cache bust, null score rendering

### DIFF
--- a/channels/sports/api/sports.go
+++ b/channels/sports/api/sports.go
@@ -229,6 +229,13 @@ func (a *App) handleInternalCDC(c *fiber.Ctx) error {
 		}
 	}
 
+	// Bust caches so the next request serves fresh data instead of stale scores.
+	// Without this, CDC notifies clients of changes but re-fetches return cached data.
+	DeleteCache(a.rdb, CacheKeySports) // public cache
+	for sub := range userSet {
+		DeleteCache(a.rdb, CacheKeySportsPrefix+sub) // per-user cache
+	}
+
 	users := make([]string, 0, len(userSet))
 	for sub := range userSet {
 		users = append(users, sub)

--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -196,6 +196,35 @@ pub async fn truncate_games(pool: &Arc<PgPool>) -> Result<()> {
     Ok(())
 }
 
+/// Return distinct league names that have live games from yesterday (UTC).
+/// Used by poll_live to decide whether to also query yesterday's date.
+pub async fn get_live_yesterday_leagues(pool: &Arc<PgPool>) -> Vec<String> {
+    let today_start = Utc::now()
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .expect("valid midnight timestamp");
+    let today_utc = today_start.and_utc();
+
+    let result: Result<Vec<(String,)>, sqlx::Error> = async {
+        let mut conn = pool.acquire().await?;
+        let rows = sqlx::query_as(
+            "SELECT DISTINCT league FROM games WHERE state = 'in' AND start_time < $1"
+        )
+        .bind(today_utc)
+        .fetch_all(&mut *conn)
+        .await?;
+        Ok(rows)
+    }.await;
+
+    match result {
+        Ok(rows) => rows.into_iter().map(|(league,)| league).collect(),
+        Err(e) => {
+            log::warn!("Failed to query live-yesterday leagues, skipping yesterday poll: {}", e);
+            Vec::new()
+        }
+    }
+}
+
 /// Delete stale games. Final/postponed/pre games older than 12h past start time,
 /// and live games not seen in 4h (API stopped returning them).
 pub async fn cleanup_old_games(pool: &Arc<PgPool>) -> Result<u64> {

--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -6,7 +6,8 @@ use crate::log::{error, info, warn};
 use crate::database::{
     PgPool, truncate_games,
     get_tracked_leagues, seed_tracked_leagues, disable_stale_leagues,
-    cleanup_old_games, LeagueConfig, TrackedLeague, upsert_game, CleanedData, Team,
+    cleanup_old_games, get_live_yesterday_leagues,
+    LeagueConfig, TrackedLeague, upsert_game, CleanedData, Team,
 };
 pub use crate::types::{SportsHealth, RateLimiter};
 
@@ -86,10 +87,13 @@ pub async fn init_sports_service(pool: &Arc<PgPool>) -> Option<(Client, Vec<Trac
 }
 
 // =============================================================================
-// Live polling (fast — today only, every 30s-3min)
+// Live polling (fast — today + yesterday when needed, every 30s-1min)
 // =============================================================================
 
 /// Poll today's games for live score updates. Called on the fast interval.
+/// Also polls yesterday's date for leagues that still have live games from
+/// yesterday (handles UTC midnight boundary — US evening games that started
+/// on the previous UTC date).
 pub async fn poll_live(
     pool: &Arc<PgPool>,
     client: &Client,
@@ -97,7 +101,21 @@ pub async fn poll_live(
     health_state: &Arc<Mutex<SportsHealth>>,
     rate_limiter: &Arc<RateLimiter>,
 ) {
-    let today = Utc::now().format("%Y-%m-%d").to_string();
+    let now = Utc::now();
+    let today = now.format("%Y-%m-%d").to_string();
+    let yesterday = (now - Duration::days(1)).format("%Y-%m-%d").to_string();
+
+    // Check which leagues still have live games from yesterday's UTC date.
+    // On DB error this returns empty — we only poll today (fail safe).
+    let yesterday_leagues = get_live_yesterday_leagues(pool).await;
+    let has_yesterday = !yesterday_leagues.is_empty();
+    let yesterday_set: std::collections::HashSet<&str> =
+        yesterday_leagues.iter().map(|s| s.as_str()).collect();
+
+    if has_yesterday {
+        info!("Yesterday live games detected for {} league(s): {}",
+            yesterday_leagues.len(), yesterday_leagues.join(", "));
+    }
 
     let mut total_upserted = 0u32;
     let mut total_failed = 0u32;
@@ -110,6 +128,7 @@ pub async fn poll_live(
             continue;
         }
 
+        // Always poll today
         match poll_league(client, league, &today, rate_limiter).await {
             Ok(games) => {
                 let (upserted, failed, has_live) = upsert_games(pool, league, games).await;
@@ -122,6 +141,28 @@ pub async fn poll_live(
             Err(e) => {
                 error!("[{}] Live poll error: {}", league.name, e);
                 health_state.lock().await.record_error(e.to_string());
+            }
+        }
+
+        // Also poll yesterday if this league has live games from yesterday
+        if yesterday_set.contains(league.name.as_str()) {
+            if !rate_limiter.has_budget(&league.sport_api) {
+                warn!("[{}] Skipping yesterday poll — rate limit budget low", league.name);
+                continue;
+            }
+            match poll_league(client, league, &yesterday, rate_limiter).await {
+                Ok(games) => {
+                    let (upserted, failed, has_live) = upsert_games(pool, league, games).await;
+                    if has_live {
+                        leagues_with_live += 1;
+                    }
+                    total_upserted += upserted;
+                    total_failed += failed;
+                }
+                Err(e) => {
+                    error!("[{}] Yesterday poll error: {}", league.name, e);
+                    health_state.lock().await.record_error(e.to_string());
+                }
             }
         }
     }

--- a/desktop/src/channels/sports/GameItem.tsx
+++ b/desktop/src/channels/sports/GameItem.tsx
@@ -15,7 +15,8 @@ interface GameItemProps {
   mode: FeedMode;
 }
 
-function formatScore(score: number | string): string {
+function formatScore(score: number | string | null | undefined): string {
+  if (score == null || score === "") return "-";
   return String(score);
 }
 

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -82,7 +82,7 @@ const GameChip = memo(function GameChip({
             pre_ && "opacity-30",
           )}
         >
-          {pre_ ? "_" : String(game.away_team_score)}
+          {pre_ ? "_" : (game.away_team_score == null || game.away_team_score === "" ? "-" : String(game.away_team_score))}
         </span>
 
         <span className="text-fg-4">-</span>
@@ -96,7 +96,7 @@ const GameChip = memo(function GameChip({
             pre_ && "opacity-30",
           )}
         >
-          {pre_ ? "_" : String(game.home_team_score)}
+          {pre_ ? "_" : (game.home_team_score == null || game.home_team_score === "" ? "-" : String(game.home_team_score))}
         </span>
         <span
           className={clsx(

--- a/desktop/src/components/dashboard/SportsSummary.tsx
+++ b/desktop/src/components/dashboard/SportsSummary.tsx
@@ -25,8 +25,12 @@ type PinnedMap = Record<string, string>;
 
 
 
-/** Score difference — lower = closer = more exciting. */
+/** Score difference — lower = closer = more exciting. Returns Infinity for games without valid scores. */
 function scoreDiff(g: Game): number {
+  if (g.away_team_score == null || g.away_team_score === "" ||
+      g.home_team_score == null || g.home_team_score === "") {
+    return Infinity;
+  }
   return Math.abs(Number(g.away_team_score) - Number(g.home_team_score));
 }
 
@@ -119,7 +123,7 @@ function PrimaryGame({ game, prefs }: PrimaryGameProps) {
               winner === "home" ? "text-fg-4" : "text-fg",
             )}
           >
-            {game.away_team_score}
+            {game.away_team_score == null || game.away_team_score === "" ? "-" : game.away_team_score}
           </span>
         )}
       </div>
@@ -147,7 +151,7 @@ function PrimaryGame({ game, prefs }: PrimaryGameProps) {
               winner === "away" ? "text-fg-4" : "text-fg",
             )}
           >
-            {game.home_team_score}
+            {game.home_team_score == null || game.home_team_score === "" ? "-" : game.home_team_score}
           </span>
         )}
       </div>
@@ -245,7 +249,9 @@ function CompactChip({ game, onPromote, showFinals, showUpcoming }: CompactChipP
         ) : (
           <>
             <span className="tabular-nums">
-              {game.away_team_score}-{game.home_team_score}
+              {game.away_team_score == null || game.away_team_score === "" ? "-" : game.away_team_score}
+              -
+              {game.home_team_score == null || game.home_team_score === "" ? "-" : game.home_team_score}
             </span>
           </>
         )}

--- a/desktop/src/utils/gameHelpers.ts
+++ b/desktop/src/utils/gameHelpers.ts
@@ -32,8 +32,14 @@ const CLOSE_THRESHOLDS: Record<string, number> = {
   "football": 1,
 };
 
+/** Check if a score value is present and numeric (not null, undefined, or empty). */
+function hasScore(score: number | string | null | undefined): boolean {
+  return score != null && score !== "";
+}
+
 export function isCloseGame(game: Game): boolean {
   if (!isLive(game)) return false;
+  if (!hasScore(game.away_team_score) || !hasScore(game.home_team_score)) return false;
   const away = Number(game.away_team_score);
   const home = Number(game.home_team_score);
   if (isNaN(away) || isNaN(home)) return false;
@@ -42,6 +48,7 @@ export function isCloseGame(game: Game): boolean {
 
 export function getWinner(game: Game): "home" | "away" | null {
   if (!isFinal(game)) return null;
+  if (!hasScore(game.away_team_score) || !hasScore(game.home_team_score)) return null;
   const a = Number(game.away_team_score);
   const h = Number(game.home_team_score);
   if (isNaN(a) || isNaN(h) || a === h) return null;


### PR DESCRIPTION
## Summary

Fixes three root causes behind stale/incorrect sports scores:

1. **UTC midnight boundary** — Live games that started on the previous UTC date (US evening games) stopped receiving score updates after midnight UTC. The live poll now queries yesterday's date for leagues with active live games in the database.

2. **CDC cache race** — When CDC events notified clients of score changes, re-fetches returned stale Redis-cached data. The CDC handler now invalidates both public and per-user caches immediately.

3. **Null score rendering** — Pre-game records and CDC-delivered NULLs rendered as literal "null" text. All score display paths now normalize null/empty to "-".

## Changes

| File | Change |
|------|--------|
| `channels/sports/service/src/database.rs` | New `get_live_yesterday_leagues()` query |
| `channels/sports/service/src/lib.rs` | `poll_live()` queries yesterday for leagues with live games |
| `channels/sports/api/sports.go` | `handleInternalCDC()` busts public + per-user caches |
| `desktop/src/channels/sports/GameItem.tsx` | `formatScore()` handles null/empty → "-" |
| `desktop/src/components/chips/GameChip.tsx` | Ticker score null safety |
| `desktop/src/components/dashboard/SportsSummary.tsx` | `scoreDiff()` returns Infinity for null scores, display null safety |
| `desktop/src/utils/gameHelpers.ts` | `getWinner()` and `isCloseGame()` guard against null scores |

## Testing

- [x] TypeScript: `tsc --noEmit` — zero errors
- [x] Rust: `cargo check` — compiles clean
- [ ] Go: not locally verifiable (no Go installed) — follows existing patterns exactly