### PR TITLE
fix: CSP img-src for external logos, onError fallbacks, baseball innings scoring

### DIFF
--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -726,13 +726,15 @@ fn parse_baseball_game(item: &serde_json::Value, league: &TrackedLeague) -> Opti
     let home = teams.get("home")?;
     let away = teams.get("away")?;
 
-    // Baseball scores: scores.home.total / scores.away.total or top-level integer
+    // Baseball scores: sum per-inning runs for real-time accuracy (total lags behind)
     let home_score = scores.get("home")
-        .and_then(|s| s.get("total").and_then(|t| t.as_i64()).or_else(|| s.as_i64()))
-        .map(|s| s as i32);
+        .and_then(|s| s.get("innings"))
+        .and_then(|inn| inn.as_object())
+        .map(|obj| obj.values().filter_map(|v| v.as_i64()).sum::<i64>() as i32);
     let away_score = scores.get("away")
-        .and_then(|s| s.get("total").and_then(|t| t.as_i64()).or_else(|| s.as_i64()))
-        .map(|s| s as i32);
+        .and_then(|s| s.get("innings"))
+        .and_then(|inn| inn.as_object())
+        .map(|obj| obj.values().filter_map(|v| v.as_i64()).sum::<i64>() as i32);
 
     // Baseball uses inning info in status
     let inning = status.get("inning").and_then(|i| i.as_i64());

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*; img-src 'self' data: blob:; worker-src 'self' blob:",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*; img-src 'self' data: blob: https://*; worker-src 'self' blob:",
       "capabilities": ["main-capability", "ticker-capability"]
     }
   }

--- a/desktop/src/channels/sports/GameItem.tsx
+++ b/desktop/src/channels/sports/GameItem.tsx
@@ -4,7 +4,7 @@
  * Supports compact (single-row) and comfort (two-row with team logos)
  * display modes. Flashes briefly when scores update via CDC.
  */
-import { memo } from "react";
+import { memo, useState } from "react";
 import { clsx } from "clsx";
 import { isLive, isFinal, getWinner, gameStatusLabel, abbreviateTeam } from "../../utils/gameHelpers";
 import { useScoreFlash } from "../../hooks/useScoreFlash";
@@ -18,6 +18,19 @@ interface GameItemProps {
 function formatScore(score: number | string | null | undefined): string {
   if (score == null || score === "") return "-";
   return String(score);
+}
+
+function TeamLogo({ src, alt, size = "w-4 h-4" }: { src: string; alt: string; size?: string }) {
+  const [err, setErr] = useState(false);
+  if (err || !src) return null;
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={`${size} object-contain`}
+      onError={() => setErr(true)}
+    />
+  );
 }
 
 // ── Component ───────────────────────────────────────────────────
@@ -36,13 +49,7 @@ export const GameItem = memo(function GameItem({ game, mode }: GameItemProps) {
           flash && "bg-live/10",
         )}
       >
-        {game.away_team_logo && (
-          <img
-            src={game.away_team_logo}
-            alt={game.away_team_name}
-            className="w-4 h-4 object-contain"
-          />
-        )}
+        <TeamLogo src={game.away_team_logo} alt={game.away_team_name} />
         <span
           className={clsx(
             "font-mono font-medium min-w-[28px]",
@@ -80,13 +87,7 @@ export const GameItem = memo(function GameItem({ game, mode }: GameItemProps) {
         >
           {abbreviateTeam(game.home_team_name)}
         </span>
-        {game.home_team_logo && (
-          <img
-            src={game.home_team_logo}
-            alt={game.home_team_name}
-            className="w-4 h-4 object-contain"
-          />
-        )}
+        <TeamLogo src={game.home_team_logo} alt={game.home_team_name} />
         <span
           className={clsx(
             "ml-auto text-[9px] font-mono uppercase tracking-wider",
@@ -114,13 +115,7 @@ export const GameItem = memo(function GameItem({ game, mode }: GameItemProps) {
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          {game.away_team_logo && (
-            <img
-              src={game.away_team_logo}
-              alt={game.away_team_name}
-              className="w-5 h-5 object-contain"
-            />
-          )}
+          <TeamLogo src={game.away_team_logo} alt={game.away_team_name} size="w-5 h-5" />
           <span
             className={clsx(
               "text-sm",
@@ -143,13 +138,7 @@ export const GameItem = memo(function GameItem({ game, mode }: GameItemProps) {
 
       <div className="flex items-center justify-between mt-0.5">
         <div className="flex items-center gap-2">
-          {game.home_team_logo && (
-            <img
-              src={game.home_team_logo}
-              alt={game.home_team_name}
-              className="w-5 h-5 object-contain"
-            />
-          )}
+          <TeamLogo src={game.home_team_logo} alt={game.home_team_name} size="w-5 h-5" />
           <span
             className={clsx(
               "text-sm",

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -1,10 +1,23 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { clsx } from "clsx";
 import { isLive, isFinal, isPre, isCloseGame, getWinner, gameStatusLabel, abbreviateTeam } from "../../utils/gameHelpers";
 import { useScoreFlash } from "../../hooks/useScoreFlash";
 import { getChipColors } from "./chipColors";
 import type { Game } from "../../types";
 import type { ChipColorMode } from "../../preferences";
+
+function ChipLogo({ src, alt, size }: { src: string; alt: string; size: string }) {
+  const [err, setErr] = useState(false);
+  if (err || !src) return null;
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={`${size} object-contain shrink-0`}
+      onError={() => setErr(true)}
+    />
+  );
+}
 
 // ── Props ───────────────────────────────────────────────────────
 
@@ -55,16 +68,11 @@ const GameChip = memo(function GameChip({
         className={clsx("flex items-center gap-1.5", comfort && "text-[13px]")}
       >
         {/* Away team */}
-        {game.away_team_logo && (
-          <img
-            src={game.away_team_logo}
-            alt={game.away_team_name}
-            className={clsx(
-              "object-contain shrink-0",
-              comfort ? "w-3.5 h-3.5" : "w-3 h-3",
-            )}
-          />
-        )}
+        <ChipLogo
+          src={game.away_team_logo}
+          alt={game.away_team_name}
+          size={comfort ? "w-3.5 h-3.5" : "w-3 h-3"}
+        />
         <span
           className={clsx(
             c.text,
@@ -107,16 +115,11 @@ const GameChip = memo(function GameChip({
         >
           {abbreviateTeam(game.home_team_name)}
         </span>
-        {game.home_team_logo && (
-          <img
-            src={game.home_team_logo}
-            alt={game.home_team_name}
-            className={clsx(
-              "object-contain shrink-0",
-              comfort ? "w-3.5 h-3.5" : "w-3 h-3",
-            )}
-          />
-        )}
+        <ChipLogo
+          src={game.home_team_logo}
+          alt={game.home_team_name}
+          size={comfort ? "w-3.5 h-3.5" : "w-3 h-3"}
+        />
 
         {/* Status (compact only) */}
         {!comfort && status && (


### PR DESCRIPTION
## Summary

- **CSP fix**: Added `https://*` to the `img-src` CSP directive in `tauri.conf.json` — the recently-added CSP was blocking all external images (team logos from `media.api-sports.io`, league logos, etc.)
- **Image error handling**: Added `onError` fallback to `GameItem.tsx` and `GameChip.tsx` so broken images hide gracefully instead of showing white empty boxes (matching `SportsSummary.tsx` pattern)
- **Baseball scoring**: Switched MLB score parsing from reading the `total` field (which only updates once per half-inning) to summing per-inning runs from the `innings` object for real-time accuracy

## Files Changed (4)

| File | Change |
|------|--------|
| `desktop/src-tauri/tauri.conf.json` | `img-src 'self' data: blob:` → `img-src 'self' data: blob: https://*` |
| `desktop/src/channels/sports/GameItem.tsx` | Added `TeamLogo` component with `onError` + `useState` fallback |
| `desktop/src/components/chips/GameChip.tsx` | Added `ChipLogo` component with same pattern |
| `channels/sports/service/src/lib.rs` | `parse_baseball_game()` now sums `scores.home.innings` values instead of reading `scores.home.total` |