### PR TITLE
feat(desktop): client-side tier enforcement for all channel config panels

### DIFF
--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -83,7 +83,7 @@ export interface Channel {
 }
 
 export interface RssChannelConfig {
-  feeds?: Array<{ name: string; url: string }>;
+  feeds?: Array<{ name: string; url: string; is_custom?: boolean }>;
 }
 
 // ── Channels API ────────────────────────────────────────────────

--- a/desktop/src/channels/ChannelConfigPanel.tsx
+++ b/desktop/src/channels/ChannelConfigPanel.tsx
@@ -1,4 +1,5 @@
 import type { Channel } from "../api/client";
+import type { SubscriptionTier } from "../auth";
 import FinanceConfigPanel from "./FinanceConfigPanel";
 import SportsConfigPanel from "./SportsConfigPanel";
 import RssConfigPanel from "./RssConfigPanel";
@@ -9,7 +10,7 @@ import FantasyConfigPanel from "./FantasyConfigPanel";
 interface ChannelConfigPanelProps {
   channelType: string;
   channel: Channel;
-  subscriptionTier: string;
+  subscriptionTier: SubscriptionTier;
   /** SSE delivery mode active */
   connected: boolean;
   /** Channel accent hex color */

--- a/desktop/src/channels/FantasyConfigPanel.tsx
+++ b/desktop/src/channels/FantasyConfigPanel.tsx
@@ -21,6 +21,7 @@ import {
   ActionRow,
   SegmentedRow,
 } from "../components/settings/SettingsControls";
+import UpgradePrompt from "../components/UpgradePrompt";
 import { authFetch, API_BASE } from "../api/client";
 import {
   fantasyStatusOptions,
@@ -28,8 +29,10 @@ import {
   queryKeys,
 } from "../api/queries";
 import { getValidToken, decodeJwtPayload } from "../auth";
+import { getLimit } from "../tierLimits";
 import { sportLabel, SPORT_EMOJI, isMatchupLive, isMatchupFinal } from "./fantasy/types";
 import type { Channel } from "../api/client";
+import type { SubscriptionTier } from "../auth";
 import type {
   LeagueResponse,
   MyLeaguesResponse,
@@ -69,7 +72,7 @@ const LEAGUES_PER_PAGE = 5;
 
 interface FantasyConfigPanelProps {
   channel: Channel;
-  subscriptionTier: string;
+  subscriptionTier: SubscriptionTier;
   connected: boolean;
   hex: string;
 }
@@ -78,6 +81,7 @@ interface FantasyConfigPanelProps {
 
 export default function FantasyConfigPanel({
   channel: _channel,
+  subscriptionTier,
   hex,
 }: FantasyConfigPanelProps) {
 
@@ -97,6 +101,10 @@ export default function FantasyConfigPanel({
 
   const yahooConnected = statusData?.connected ?? false;
   const leagues: LeagueResponse[] = (leaguesData?.leagues ?? []) as LeagueResponse[];
+
+  const maxFantasy = getLimit(subscriptionTier, "fantasy");
+  const remainingCapacity = Math.max(0, maxFantasy - leagues.length);
+  const atLeagueLimit = leagues.length >= maxFantasy;
 
   // Determine initial phase from query data
   const initialPhase = useMemo(
@@ -149,7 +157,10 @@ export default function FantasyConfigPanel({
         return;
       }
       const preSelected = new Set(
-        newLeagues.filter((l) => !l.is_finished).map((l) => l.league_key),
+        newLeagues
+          .filter((l) => !l.is_finished)
+          .map((l) => l.league_key)
+          .slice(0, remainingCapacity),
       );
       setSelectedKeys(preSelected);
       setPhase("picking");
@@ -188,7 +199,7 @@ export default function FantasyConfigPanel({
   });
 
   const importSelected = useCallback(async () => {
-    const keys = Array.from(selectedKeys);
+    const keys = Array.from(selectedKeys).slice(0, remainingCapacity);
     if (keys.length === 0) return;
 
     setPhase("importing");
@@ -226,7 +237,7 @@ export default function FantasyConfigPanel({
     await queryClient.invalidateQueries({ queryKey: queryKeys.fantasy.leagues });
     await queryClient.invalidateQueries({ queryKey: queryKeys.fantasy.status });
     setPhase("connected");
-  }, [selectedKeys, discoveredLeagues, queryClient, importLeagueMutation]);
+  }, [selectedKeys, discoveredLeagues, queryClient, importLeagueMutation, remainingCapacity]);
 
   // ── Detect Yahoo connection via polling ─────────────────────────
 
@@ -325,13 +336,22 @@ export default function FantasyConfigPanel({
   const toggleLeague = (key: string) => {
     setSelectedKeys((prev) => {
       const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
+      if (next.has(key)) {
+        next.delete(key);
+      } else if (next.size < remainingCapacity) {
+        next.add(key);
+      }
       return next;
     });
   };
   const selectAll = () =>
-    setSelectedKeys(new Set(pickableLeagues.map((l) => l.league_key)));
+    setSelectedKeys(
+      new Set(
+        pickableLeagues
+          .map((l) => l.league_key)
+          .slice(0, remainingCapacity),
+      ),
+    );
   const deselectAll = () => setSelectedKeys(new Set());
 
   const totalLeagues = leagues.length;
@@ -363,8 +383,31 @@ export default function FantasyConfigPanel({
         </div>
       </div>
 
+      {/* ── FREE TIER GATE ────────────────────────────────────── */}
+      {maxFantasy === 0 && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center py-10 space-y-4 px-3"
+        >
+          <Ghost size={40} className="mx-auto text-fg-4/30" />
+          <div className="space-y-2">
+            <p className="text-sm font-bold text-fg-2">Fantasy Sports</p>
+            <p className="text-[12px] text-fg-3 max-w-xs mx-auto">
+              Track your Yahoo Fantasy leagues with live scores, standings,
+              and rosters.
+            </p>
+          </div>
+          <UpgradePrompt
+            max={0}
+            noun="Fantasy leagues"
+            tier={subscriptionTier}
+          />
+        </motion.div>
+      )}
+
       {/* ── DISCONNECTED ──────────────────────────────────────── */}
-      {phase === "disconnected" && (
+      {maxFantasy > 0 && phase === "disconnected" && (
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -453,6 +496,20 @@ export default function FantasyConfigPanel({
         >
           <Section title={`Select Leagues (${pickableLeagues.length} found)`}>
             <div className="px-3 space-y-3">
+              {atLeagueLimit ? (
+                <UpgradePrompt
+                  current={leagues.length}
+                  max={maxFantasy}
+                  noun="Fantasy leagues"
+                  tier={subscriptionTier}
+                />
+              ) : maxFantasy < Infinity ? (
+                <p className="text-[11px] text-fg-4">
+                  {leagues.length}/{maxFantasy} leagues used
+                  {" · "}
+                  {remainingCapacity} remaining
+                </p>
+              ) : null}
               <div className="flex items-center justify-end gap-3">
                 <button
                   onClick={selectAll}
@@ -507,7 +564,7 @@ export default function FantasyConfigPanel({
               <div className="flex gap-2 pt-2">
                 <button
                   onClick={importSelected}
-                  disabled={selectedKeys.size === 0}
+                  disabled={selectedKeys.size === 0 || atLeagueLimit}
                   className="flex-1 px-4 py-2 rounded-lg text-[12px] font-medium text-white transition-colors disabled:opacity-30 cursor-pointer"
                   style={{
                     background:
@@ -620,6 +677,17 @@ export default function FantasyConfigPanel({
             value={String(totalActiveMatchups)}
           />
         </Section>
+      )}
+
+      {phase === "connected" && atLeagueLimit && (
+        <div className="px-3 mb-4">
+          <UpgradePrompt
+            current={leagues.length}
+            max={maxFantasy}
+            noun="Fantasy leagues"
+            tier={subscriptionTier}
+          />
+        </div>
       )}
 
       {/* ── CONNECTED — Filter toggle ─────────────────────────── */}

--- a/desktop/src/channels/FinanceConfigPanel.tsx
+++ b/desktop/src/channels/FinanceConfigPanel.tsx
@@ -4,10 +4,13 @@ import { clsx } from "clsx";
 import { getStore, setStore } from "../lib/store";
 import { useQuery } from "@tanstack/react-query";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
+import UpgradePrompt from "../components/UpgradePrompt";
 import { useChannelConfig } from "../hooks/useChannelConfig";
 import { financeCatalogOptions } from "../api/queries";
+import { getLimit, maxItemsForBrowser } from "../tierLimits";
 import type { TrackedSymbol } from "../api/queries";
 import type { Channel } from "../api/client";
+import type { SubscriptionTier } from "../auth";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -17,7 +20,7 @@ interface FinanceChannelConfig {
 
 interface FinanceConfigPanelProps {
   channel: Channel;
-  subscriptionTier: string;
+  subscriptionTier: SubscriptionTier;
   connected: boolean;
   hex: string;
 }
@@ -43,6 +46,7 @@ const POPULAR_SYMBOLS = [
 
 export default function FinanceConfigPanel({
   channel,
+  subscriptionTier,
   hex,
 }: FinanceConfigPanelProps) {
   const { error, setError, saving, updateItems } = useChannelConfig<string[]>("finance", "symbols");
@@ -53,6 +57,9 @@ export default function FinanceConfigPanel({
   const config = channel.config as FinanceChannelConfig;
   const symbols = Array.isArray(config?.symbols) ? config.symbols : [];
   const symbolSet = useMemo(() => new Set(symbols), [symbols]);
+
+  const maxSymbols = getLimit(subscriptionTier, "symbols");
+  const atLimit = symbols.length >= maxSymbols;
 
   // ── Catalog query ──────────────────────────────────────────────
   const {
@@ -69,9 +76,10 @@ export default function FinanceConfigPanel({
   const addSymbol = useCallback(
     (sym: string) => {
       if (symbolSet.has(sym)) return;
+      if (symbols.length >= maxSymbols) return;
       updateItems([...symbols, sym]);
     },
-    [symbols, symbolSet, updateItems],
+    [symbols, symbolSet, updateItems, maxSymbols],
   );
 
   const removeSymbol = useCallback(
@@ -90,6 +98,16 @@ export default function FinanceConfigPanel({
 
   return (
     <div className="w-full max-w-2xl mx-auto">
+      {atLimit && (
+        <div className="mb-4 px-3">
+          <UpgradePrompt
+            current={symbols.length}
+            max={maxSymbols}
+            noun="symbols"
+            tier={subscriptionTier}
+          />
+        </div>
+      )}
       <SetupBrowser
         title="Finance"
         subtitle="Stocks, ETFs, and crypto prices"
@@ -146,9 +164,14 @@ export default function FinanceConfigPanel({
         loading={catalogLoading}
         catalogError={catalogError}
         saving={saving}
+        maxItems={maxItemsForBrowser(subscriptionTier, "symbols")}
         onAdd={addSymbol}
         onRemove={removeSymbol}
-        onBulkAdd={(keys: string[]) => updateItems([...symbols, ...keys])}
+        onBulkAdd={(keys: string[]) => {
+          const capacity = maxSymbols - symbols.length;
+          if (capacity <= 0) return;
+          updateItems([...symbols, ...keys.slice(0, capacity)]);
+        }}
         onBulkRemove={(keys: string[]) => {
           const toRemove = new Set(keys);
           updateItems(symbols.filter((s) => !toRemove.has(s)));

--- a/desktop/src/channels/RssConfigPanel.tsx
+++ b/desktop/src/channels/RssConfigPanel.tsx
@@ -1,19 +1,22 @@
 import { useState, useCallback, useMemo } from "react";
 import { Plus, Rss, Trash2 } from "lucide-react";
 import Tooltip from "../components/Tooltip";
+import UpgradePrompt from "../components/UpgradePrompt";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
 import { rssApi } from "../api/client";
 import { toast } from "sonner";
 import { useChannelConfig } from "../hooks/useChannelConfig";
 import { rssCatalogOptions, queryKeys } from "../api/queries";
+import { getLimit, maxItemsForBrowser } from "../tierLimits";
 import type { Channel, TrackedFeed, RssChannelConfig } from "../api/client";
+import type { SubscriptionTier } from "../auth";
 
 // ── Types ────────────────────────────────────────────────────────
 
 interface RssConfigPanelProps {
   channel: Channel;
-  subscriptionTier: string;
+  subscriptionTier: SubscriptionTier;
   hex: string;
 }
 
@@ -21,11 +24,11 @@ interface RssConfigPanelProps {
 
 export default function RssConfigPanel({
   channel,
-  // subscriptionTier — accepted for consistency; enforcement added in Phase 2
+  subscriptionTier,
   hex,
 }: RssConfigPanelProps) {
   const queryClient = useQueryClient();
-  const { error, setError, saving, updateItems } = useChannelConfig<Array<{ name: string; url: string }>>("rss", "feeds");
+  const { error, setError, saving, updateItems } = useChannelConfig<Array<{ name: string; url: string; is_custom?: boolean }>>("rss", "feeds");
   const [newFeedName, setNewFeedName] = useState("");
   const [newFeedUrl, setNewFeedUrl] = useState("");
   const [urlError, setUrlError] = useState<string | null>(null);
@@ -33,6 +36,12 @@ export default function RssConfigPanel({
   const rssConfig = channel.config as RssChannelConfig;
   const feeds = Array.isArray(rssConfig?.feeds) ? rssConfig.feeds : [];
   const feedUrlSet = useMemo(() => new Set(feeds.map((f) => f.url)), [feeds]);
+
+  const maxFeeds = getLimit(subscriptionTier, "feeds");
+  const maxCustomFeeds = getLimit(subscriptionTier, "customFeeds");
+  const customFeedCount = useMemo(() => feeds.filter((f) => f.is_custom).length, [feeds]);
+  const atFeedLimit = feeds.length >= maxFeeds;
+  const atCustomLimit = customFeedCount >= maxCustomFeeds;
 
   // ── Catalog query ──────────────────────────────────────────────
   const {
@@ -51,11 +60,12 @@ export default function RssConfigPanel({
 
   const addCatalogFeed = useCallback(
     (url: string) => {
+      if (feeds.length >= maxFeeds) return;
       const feed = catalog.find((f) => f.url === url);
       if (!feed || feedUrlSet.has(url)) return;
       updateItems([...feeds, { name: feed.name, url: feed.url }]);
     },
-    [catalog, feeds, feedUrlSet, updateItems],
+    [catalog, feeds, feedUrlSet, updateItems, maxFeeds],
   );
 
   const removeFeed = useCallback(
@@ -87,19 +97,31 @@ export default function RssConfigPanel({
     const name = newFeedName.trim();
     const url = newFeedUrl.trim();
     if (!name || !url) return;
+    if (feeds.length >= maxFeeds) return;
+    if (feeds.filter((f) => f.is_custom).length >= maxCustomFeeds) return;
     if (!/^https?:\/\/.+/.test(url)) {
       setUrlError("Please enter a full web address (starting with http:// or https://)");
       return;
     }
     setUrlError(null);
     if (feedUrlSet.has(url)) return;
-    updateItems([...feeds, { name, url }]);
+    updateItems([...feeds, { name, url, is_custom: true }]);
     setNewFeedName("");
     setNewFeedUrl("");
-  }, [newFeedName, newFeedUrl, feeds, feedUrlSet, updateItems]);
+  }, [newFeedName, newFeedUrl, feeds, feedUrlSet, updateItems, maxFeeds, maxCustomFeeds]);
 
   return (
     <div className="w-full max-w-2xl mx-auto">
+      {atFeedLimit && (
+        <div className="mb-4 px-3">
+          <UpgradePrompt
+            current={feeds.length}
+            max={maxFeeds}
+            noun="feeds"
+            tier={subscriptionTier}
+          />
+        </div>
+      )}
       <SetupBrowser
         title="News"
         subtitle="News and articles from your favorite sites"
@@ -153,12 +175,17 @@ export default function RssConfigPanel({
           </>
         )}
         searchPlaceholder="Search feeds..."
+        maxItems={maxItemsForBrowser(subscriptionTier, "feeds")}
         renderBeforeList={() => (
           <AddCustomFeed
             name={newFeedName}
             url={newFeedUrl}
             urlError={urlError}
             saving={saving}
+            disabled={atCustomLimit || atFeedLimit}
+            customCount={customFeedCount}
+            maxCustom={maxCustomFeeds}
+            tier={subscriptionTier}
             onNameChange={setNewFeedName}
             onUrlChange={setNewFeedUrl}
             onSubmit={addCustomFeed}
@@ -184,6 +211,10 @@ interface AddCustomFeedProps {
   url: string;
   urlError: string | null;
   saving: boolean;
+  disabled: boolean;
+  customCount: number;
+  maxCustom: number;
+  tier: SubscriptionTier;
   onNameChange: (v: string) => void;
   onUrlChange: (v: string) => void;
   onSubmit: () => void;
@@ -194,44 +225,66 @@ function AddCustomFeed({
   url,
   urlError,
   saving,
+  disabled,
+  customCount,
+  maxCustom,
+  tier,
   onNameChange,
   onUrlChange,
   onSubmit,
 }: AddCustomFeedProps) {
   return (
     <div className="space-y-2">
-      <h3 className="text-[10px] uppercase tracking-wider font-bold text-fg-4">
-        Add your own feed
-      </h3>
-      <div className="flex flex-col sm:flex-row gap-2">
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => onNameChange(e.target.value)}
-          placeholder="Feed name"
-          className="flex-1 px-3 py-2 rounded-lg bg-base-200 border border-edge/30 text-[12px] font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/40 transition-colors"
-        />
-        <input
-          type="url"
-          value={url}
-          onChange={(e) => onUrlChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") onSubmit();
-          }}
-          placeholder="https://..."
-          className="flex-[2] px-3 py-2 rounded-lg bg-base-200 border border-edge/30 text-[12px] font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/40 transition-colors"
-        />
-        <button
-          onClick={onSubmit}
-          disabled={saving || !name.trim() || !url.trim()}
-          className="px-3 py-2 rounded-lg bg-base-250 border border-edge/30 text-fg-3 hover:text-accent hover:border-accent/30 transition-colors flex items-center gap-1.5 disabled:opacity-30 cursor-pointer"
-        >
-          <Plus size={13} />
-          <span className="text-[11px] font-medium">Add</span>
-        </button>
+      <div className="flex items-center justify-between">
+        <h3 className="text-[10px] uppercase tracking-wider font-bold text-fg-4">
+          Add your own feed
+        </h3>
+        {maxCustom > 0 && maxCustom !== Infinity && (
+          <span className="text-[10px] text-fg-4 tabular-nums">
+            {customCount}/{maxCustom} custom
+          </span>
+        )}
       </div>
-      {urlError && (
-        <p className="text-[11px] text-error/70">{urlError}</p>
+      {disabled ? (
+        <UpgradePrompt
+          current={customCount}
+          max={maxCustom}
+          noun="custom feeds"
+          tier={tier}
+        />
+      ) : (
+        <>
+          <div className="flex flex-col sm:flex-row gap-2">
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => onNameChange(e.target.value)}
+              placeholder="Feed name"
+              className="flex-1 px-3 py-2 rounded-lg bg-base-200 border border-edge/30 text-[12px] font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/40 transition-colors"
+            />
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => onUrlChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onSubmit();
+              }}
+              placeholder="https://..."
+              className="flex-[2] px-3 py-2 rounded-lg bg-base-200 border border-edge/30 text-[12px] font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/40 transition-colors"
+            />
+            <button
+              onClick={onSubmit}
+              disabled={saving || !name.trim() || !url.trim()}
+              className="px-3 py-2 rounded-lg bg-base-250 border border-edge/30 text-fg-3 hover:text-accent hover:border-accent/30 transition-colors flex items-center gap-1.5 disabled:opacity-30 cursor-pointer"
+            >
+              <Plus size={13} />
+              <span className="text-[11px] font-medium">Add</span>
+            </button>
+          </div>
+          {urlError && (
+            <p className="text-[11px] text-error/70">{urlError}</p>
+          )}
+        </>
       )}
     </div>
   );

--- a/desktop/src/channels/SportsConfigPanel.tsx
+++ b/desktop/src/channels/SportsConfigPanel.tsx
@@ -3,17 +3,20 @@ import { Trophy } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
 import { SetupBrowser } from "../components/settings/SetupBrowser";
+import UpgradePrompt from "../components/UpgradePrompt";
 import { useSportsConfig } from "../hooks/useSportsConfig";
 import { formatCountdown } from "../utils/gameHelpers";
 import { sportsCatalogOptions } from "../api/queries";
+import { getLimit, maxItemsForBrowser } from "../tierLimits";
 import type { TrackedLeague } from "../api/queries";
 import type { Channel } from "../api/client";
+import type { SubscriptionTier } from "../auth";
 
 // ── Types ────────────────────────────────────────────────────────
 
 interface SportsConfigPanelProps {
   channel: Channel;
-  subscriptionTier: string;
+  subscriptionTier: SubscriptionTier;
   connected: boolean;
   hex: string;
 }
@@ -21,6 +24,7 @@ interface SportsConfigPanelProps {
 // ── Component ────────────────────────────────────────────────────
 
 export default function SportsConfigPanel({
+  subscriptionTier,
   hex,
 }: SportsConfigPanelProps) {
   const { leagues, display, setLeagues, setDisplay, saving } =
@@ -28,6 +32,9 @@ export default function SportsConfigPanel({
   const [error, setError] = useState<string | null>(null);
 
   const leagueSet = useMemo(() => new Set(leagues), [leagues]);
+
+  const maxLeagues = getLimit(subscriptionTier, "leagues");
+  const atLimit = leagues.length >= maxLeagues;
 
   // ── Catalog query ──────────────────────────────────────────────
   const {
@@ -50,9 +57,10 @@ export default function SportsConfigPanel({
   const addLeague = useCallback(
     (name: string) => {
       if (leagueSet.has(name)) return;
+      if (leagues.length >= maxLeagues) return;
       setLeagues([...leagues, name]);
     },
-    [leagues, leagueSet, setLeagues],
+    [leagues, leagueSet, setLeagues, maxLeagues],
   );
 
   const removeLeague = useCallback(
@@ -64,6 +72,16 @@ export default function SportsConfigPanel({
 
   return (
     <div className="w-full max-w-2xl mx-auto">
+      {atLimit && (
+        <div className="mb-4 px-3">
+          <UpgradePrompt
+            current={leagues.length}
+            max={maxLeagues}
+            noun="leagues"
+            tier={subscriptionTier}
+          />
+        </div>
+      )}
       <SetupBrowser
         title="Sports"
         subtitle="Live scores from your favorite leagues"
@@ -131,9 +149,14 @@ export default function SportsConfigPanel({
         loading={catalogLoading}
         catalogError={catalogError}
         saving={saving}
+        maxItems={maxItemsForBrowser(subscriptionTier, "leagues")}
         onAdd={addLeague}
         onRemove={removeLeague}
-        onBulkAdd={(keys: string[]) => setLeagues([...leagues, ...keys])}
+        onBulkAdd={(keys: string[]) => {
+          const capacity = maxLeagues - leagues.length;
+          if (capacity <= 0) return;
+          setLeagues([...leagues, ...keys.slice(0, capacity)]);
+        }}
         onBulkRemove={(keys: string[]) => {
           const toRemove = new Set(keys);
           setLeagues(leagues.filter((l) => !toRemove.has(l)));

--- a/desktop/src/components/UpgradePrompt.tsx
+++ b/desktop/src/components/UpgradePrompt.tsx
@@ -1,0 +1,44 @@
+import { ArrowUpRight } from "lucide-react";
+import { open } from "@tauri-apps/plugin-shell";
+import { TIER_LABELS } from "../auth";
+import type { SubscriptionTier } from "../auth";
+
+interface UpgradePromptProps {
+  /** Current item count (e.g. 5). Omit for features gated entirely (fantasy on free). */
+  current?: number;
+  /** Maximum allowed by the tier (e.g. 5). 0 means the feature is unavailable. */
+  max: number;
+  /** Plural noun for the feature ("symbols", "feeds", "leagues"). */
+  noun: string;
+  /** User's current tier, used for the label in the gated message. */
+  tier: SubscriptionTier;
+}
+
+const UPGRADE_URL = "https://myscrollr.com/uplink";
+
+export default function UpgradePrompt({
+  current,
+  max,
+  noun,
+  tier,
+}: UpgradePromptProps) {
+  const gated = max === 0;
+  const tierLabel = TIER_LABELS[tier];
+
+  const message = gated
+    ? `${noun.charAt(0).toUpperCase() + noun.slice(1)} requires an Uplink subscription.`
+    : `You've reached ${current ?? max}/${max} ${noun}. Upgrade for more.`;
+
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg bg-warn/10 border border-warn/20">
+      <span className="text-xs text-warn leading-snug">{message}</span>
+      <button
+        onClick={() => open(UPGRADE_URL)}
+        className="shrink-0 inline-flex items-center gap-1 text-xs font-medium text-warn hover:text-fg transition-colors"
+      >
+        {gated ? `See plans` : `Upgrade from ${tierLabel}`}
+        <ArrowUpRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/components/settings/SetupBrowser.tsx
+++ b/desktop/src/components/settings/SetupBrowser.tsx
@@ -67,6 +67,8 @@ interface SetupBrowserProps<T> {
   onBulkRemove?: (keys: string[]) => void;
   /** Clear all selections */
   onClearAll?: () => void;
+  /** When set, caps selections and shows "N/max" in header instead of "N selected" */
+  maxItems?: number;
 }
 
 // ── Tabs ─────────────────────────────────────────────────────────
@@ -101,6 +103,7 @@ export function SetupBrowser<T>({
   onBulkAdd,
   onBulkRemove,
   onClearAll,
+  maxItems,
 }: SetupBrowserProps<T>) {
   const [searchQuery, setSearchQuery] = useState("");
   const [activeTab, setActiveTab] = useState(ALL);
@@ -149,6 +152,8 @@ export function SetupBrowser<T>({
     [tabItemKeys, selectedKeys],
   );
   const tabAvailableCount = tabItemKeys.length - tabAddedCount;
+  const atLimit = maxItems != null && selectedKeys.size >= maxItems;
+  const remaining_capacity = maxItems != null ? maxItems - selectedKeys.size : Infinity;
 
   // Reset visible count when switching tabs or searching
   const handleTabChange = (tab: string) => {
@@ -185,7 +190,9 @@ export function SetupBrowser<T>({
           )}
         </div>
         <span className="text-[11px] text-fg-3 tabular-nums shrink-0">
-          {selectedKeys.size} selected
+          {maxItems != null
+            ? `${selectedKeys.size}/${maxItems}`
+            : `${selectedKeys.size} selected`}
         </span>
       </div>
 
@@ -309,16 +316,18 @@ export function SetupBrowser<T>({
       {/* ── Bulk actions ────────────────────────────────────── */}
       {activeTab !== MY_PICKS && (onBulkAdd || onBulkRemove) && (
         <div className="flex items-center justify-end gap-2 px-3">
-          {onBulkAdd && tabAvailableCount > 0 && (
+          {onBulkAdd && tabAvailableCount > 0 && !atLimit && (
             <button
               onClick={() => {
-                const toAdd = tabItemKeys.filter((k) => !selectedKeys.has(k));
+                const toAdd = tabItemKeys
+                  .filter((k) => !selectedKeys.has(k))
+                  .slice(0, remaining_capacity);
                 onBulkAdd(toAdd);
               }}
               disabled={saving}
               className="text-[11px] font-medium text-fg-3 hover:text-accent px-2 py-1 rounded-md hover:bg-base-250/50 transition-colors disabled:opacity-30 cursor-pointer"
             >
-              + Add all ({tabAvailableCount})
+              + Add all ({Math.min(tabAvailableCount, remaining_capacity)})
             </button>
           )}
           {onBulkRemove && tabAddedCount > 0 && (
@@ -385,7 +394,7 @@ export function SetupBrowser<T>({
                 <button
                   type="button"
                   onClick={() => (isSelected ? onRemove(key) : onAdd(key))}
-                  disabled={saving}
+                  disabled={saving || (!isSelected && atLimit)}
                   className={clsx(
                     "w-full flex items-center justify-between p-2.5 rounded-lg border transition-colors text-left cursor-pointer disabled:opacity-30",
                     isSelected

--- a/desktop/src/tierLimits.ts
+++ b/desktop/src/tierLimits.ts
@@ -1,0 +1,50 @@
+import type { SubscriptionTier } from "./auth";
+
+// =====================================================================
+// Tier Limits
+// =====================================================================
+
+interface ChannelLimits {
+  symbols: number;
+  feeds: number;
+  customFeeds: number;
+  leagues: number;
+  fantasy: number;
+}
+
+export const TIER_LIMITS: Record<SubscriptionTier, ChannelLimits> = {
+  free: { symbols: 5, feeds: 1, customFeeds: 0, leagues: 1, fantasy: 0 },
+  uplink: { symbols: 25, feeds: 25, customFeeds: 1, leagues: 8, fantasy: 1 },
+  uplink_pro: { symbols: 75, feeds: 100, customFeeds: 3, leagues: 20, fantasy: 3 },
+  uplink_ultimate: {
+    symbols: Infinity,
+    feeds: Infinity,
+    customFeeds: 10,
+    leagues: Infinity,
+    fantasy: 10,
+  },
+};
+
+type LimitKey = keyof ChannelLimits;
+
+/** Get the numeric limit for a tier + channel feature. */
+export function getLimit(tier: SubscriptionTier, key: LimitKey): number {
+  return TIER_LIMITS[tier][key];
+}
+
+/** True when the tier has no cap (Infinity) for the given feature. */
+export function isUnlimited(tier: SubscriptionTier, key: LimitKey): boolean {
+  return TIER_LIMITS[tier][key] === Infinity;
+}
+
+/**
+ * Returns `maxItems` for SetupBrowser: a finite number or undefined (unlimited).
+ * Passing undefined means SetupBrowser won't enforce any cap.
+ */
+export function maxItemsForBrowser(
+  tier: SubscriptionTier,
+  key: LimitKey
+): number | undefined {
+  const limit = TIER_LIMITS[tier][key];
+  return limit === Infinity ? undefined : limit;
+}


### PR DESCRIPTION
## Summary
- Enforce subscription tier limits (Free/Uplink/Pro/Ultimate) across all 4 channel config panels in the desktop app
- Users at their tier limit see an inline UpgradePrompt banner with a CTA linking to the pricing page via system browser

## Changes
| File | Change |
|------|--------|
| `desktop/src/tierLimits.ts` | New — per-tier limit constants and helpers |
| `desktop/src/components/UpgradePrompt.tsx` | New — shared upgrade banner component |
| `desktop/src/components/settings/SetupBrowser.tsx` | Add `maxItems` prop for N/M display + add-gating |
| `desktop/src/channels/FinanceConfigPanel.tsx` | Symbol count enforcement |
| `desktop/src/channels/SportsConfigPanel.tsx` | League count enforcement |
| `desktop/src/channels/RssConfigPanel.tsx` | Dual limits: total feeds + custom feeds (`is_custom` flag) |
| `desktop/src/channels/FantasyConfigPanel.tsx` | Free-tier gate + league import cap |
| `desktop/src/channels/ChannelConfigPanel.tsx` | Type `subscriptionTier` as `SubscriptionTier` |
| `desktop/src/api/client.ts` | Add `is_custom?: boolean` to RSS feed type |

## Tier Limits
| Feature | Free | Uplink | Pro | Ultimate |
|---------|------|--------|-----|----------|
| Symbols | 5 | 25 | 75 | Unlimited |
| News feeds | 1 | 25 | 100 | Unlimited |
| Custom feeds | 0 | 1 | 3 | 10 |
| Sports leagues | 1 | 8 | 20 | Unlimited |
| Fantasy leagues | 0 | 1 | 3 | 10 |

Build verified: `npm run build` passes with zero type errors.