### PR TITLE
feat(website): pivot landing page from browser extension to desktop app

### DIFF
--- a/myscrollr.com/src/components/DownloadButton.tsx
+++ b/myscrollr.com/src/components/DownloadButton.tsx
@@ -1,14 +1,19 @@
 import { Download } from 'lucide-react'
 
-function getOS(): 'macOS' | 'Windows' | 'Linux' {
+type PlatformInfo = {
+  label: string
+  arch: string
+}
+
+function getPlatform(): PlatformInfo {
   const ua = navigator.userAgent.toLowerCase()
-  if (ua.includes('mac')) return 'macOS'
-  if (ua.includes('win')) return 'Windows'
-  return 'Linux'
+  if (ua.includes('mac')) return { label: 'macOS', arch: 'Apple Silicon' }
+  if (ua.includes('win')) return { label: 'Windows', arch: 'x64' }
+  return { label: 'Linux', arch: 'x64' }
 }
 
 export function DownloadButton() {
-  const os = getOS()
+  const { label } = getPlatform()
 
   return (
     <a
@@ -18,7 +23,7 @@ export function DownloadButton() {
       className="group relative inline-flex items-center gap-3 rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-content! shadow-lg transition-all duration-200 hover:brightness-110 hover:shadow-xl active:scale-[0.98]"
     >
       <Download className="h-4 w-4 transition-transform duration-200 group-hover:-translate-y-0.5" />
-      Download for {os}
+      Download for {label}
     </a>
   )
 }

--- a/myscrollr.com/src/components/Footer.tsx
+++ b/myscrollr.com/src/components/Footer.tsx
@@ -16,10 +16,7 @@ export default function Footer() {
   const links = {
     product: [
       { label: 'Channels', href: '/channels' },
-      {
-        label: 'Download',
-        href: 'https://github.com/brandon-relentnet/myscrollr/releases/latest',
-      },
+      { label: 'Download', href: '/download' },
       { label: 'Uplink', href: '/uplink' },
     ],
     resources: [

--- a/myscrollr.com/src/components/Header.tsx
+++ b/myscrollr.com/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from '@tanstack/react-router'
 import {
   ChevronRight,
+  Download,
   House,
   LogOut,
   Menu,
@@ -69,7 +70,7 @@ export default function Header() {
 
   return (
     <>
-      <header className="fixed top-0 left-0 right-0 z-50 px-6 flex items-center bg-base-100/80 backdrop-blur-2xl border-b border-base-300/50 h-20 will-change-transform">
+      <header className="fixed top-0 left-0 right-0 z-50 px-6 flex items-center bg-base-100/80 backdrop-blur-2xl will-change-transform border-b border-base-300/50 h-20">
         {/* Brand */}
         <div className="flex-1 flex items-center gap-4">
           <Link to="/" className="flex items-center gap-3 group">
@@ -106,6 +107,11 @@ export default function Header() {
             <NavLink to="/uplink" activeOn="/uplink">
               <Satellite size={14} />
               Uplink
+            </NavLink>
+
+            <NavLink to="/download" activeOn="/download">
+              <Download size={14} />
+              Download
             </NavLink>
 
             {isAuthenticated && (
@@ -248,6 +254,14 @@ export default function Header() {
                   onClick={() => setIsOpen(false)}
                 >
                   Uplink
+                </MobileNavLink>
+
+                <MobileNavLink
+                  to="/download"
+                  icon={<ChevronRight size={18} />}
+                  onClick={() => setIsOpen(false)}
+                >
+                  Download
                 </MobileNavLink>
 
                 {isAuthenticated && (

--- a/myscrollr.com/src/components/landing/BenefitsSection.tsx
+++ b/myscrollr.com/src/components/landing/BenefitsSection.tsx
@@ -50,7 +50,7 @@ const BENEFITS: Array<Benefit> = [
     icon: SlidersHorizontal,
     title: 'It Gets Out of the Way',
     headline: 'Quiet when you need quiet',
-    body: "Resize it, reposition it, hide it on specific sites, or collapse it entirely. When you need deep focus, one click and it's gone.",
+    body: "Resize it, reposition it, minimize it, or collapse it entirely. When you need deep focus, one click and it's gone.",
     accent: 'text-accent',
     accentBg: 'bg-accent/8',
     accentBorder: 'border-accent/15',
@@ -474,10 +474,7 @@ function IllustrationOutOfWay() {
 
       {/* Ticker bar — animates from expanded to collapsed */}
       <motion.g
-        animate={{
-          scaleY: [1, 1, 0.15, 0.15, 1],
-          opacity: [1, 1, 0.5, 0.5, 1],
-        }}
+        animate={{ scaleY: [1, 1, 0.15, 0.15, 1], opacity: [1, 1, 0.5, 0.5, 1] }}
         transition={{
           duration: 5,
           repeat: Infinity,
@@ -518,10 +515,7 @@ function IllustrationOutOfWay() {
 
       {/* Collapse/expand arrow indicator */}
       <motion.g
-        animate={{
-          y: [0, 0, -3, -3, 0],
-          rotate: [0, 0, 180, 180, 0],
-        }}
+        animate={{ y: [0, 0, -3, -3, 0], rotate: [0, 0, 180, 180, 0] }}
         transition={{
           duration: 5,
           repeat: Infinity,
@@ -676,9 +670,9 @@ export function BenefitsSection() {
         style={{
           width: 500,
           height: 500,
-          right: 0,
-          top: '25%',
-          opacity: 0.07,
+          right: -100,
+          top: '20%',
+          opacity: 0.1,
           backgroundColor: `var(--color-${BENEFITS[activeIndex].accentRaw})`,
         }}
       />

--- a/myscrollr.com/src/components/landing/CallToAction.tsx
+++ b/myscrollr.com/src/components/landing/CallToAction.tsx
@@ -191,7 +191,7 @@ export function CallToAction() {
 
       {/* Ambient gradient orb — follows mouse */}
       <motion.div
-        className="absolute pointer-events-none"
+        className="absolute rounded-full pointer-events-none"
         style={{
           width: 600,
           height: 600,
@@ -292,7 +292,7 @@ export function CallToAction() {
           >
             <span className="block">Stop</span>
             <span className="block mt-2 text-gradient-primary">
-              Tab-Switching.
+              Context-Switching.
             </span>
           </motion.h2>
 
@@ -309,7 +309,7 @@ export function CallToAction() {
             }}
             className="block mt-6 text-lg sm:text-xl text-base-content/50 max-w-lg leading-relaxed"
           >
-            Install once. Open a tab. That's it — updates are already rolling.
+            Download once. It runs quietly at the edge of your screen.
           </motion.span>
 
           {/* ── CTA button area with orbiting icons ─────────────────────── */}
@@ -340,7 +340,7 @@ export function CallToAction() {
             <DownloadButton />
           </motion.div>
 
-          {/* Browser support line */}
+          {/* Platform support line */}
           <motion.div
             style={{ opacity: 0 }}
             initial={{ opacity: 0 }}
@@ -349,10 +349,10 @@ export function CallToAction() {
             transition={{ delay: 0.6, duration: 0.5, ease: EASE }}
             className="mt-6 flex items-center gap-4 text-xs text-base-content/30"
           >
-            {['Chrome', 'Firefox', 'Edge', 'Brave', 'Safari'].map((browser) => (
-              <span key={browser} className="flex items-center gap-1.5">
+            {['macOS', 'Windows', 'Linux'].map((platform) => (
+              <span key={platform} className="flex items-center gap-1.5">
                 <span className="w-1.5 h-1.5 rounded-full bg-primary/40" />
-                {browser}
+                {platform}
               </span>
             ))}
           </motion.div>

--- a/myscrollr.com/src/components/landing/FAQSection.tsx
+++ b/myscrollr.com/src/components/landing/FAQSection.tsx
@@ -33,43 +33,43 @@ export interface FAQItem {
 const FAQ_ITEMS: Array<FAQItem> = [
   {
     icon: Gift,
-    question: 'Is Scrollr really free?',
-    highlight: 'Completely free with no trials, ads, or paywalls. Ever.',
+    question: 'Is Scrollr free?',
+    highlight: 'A generous free tier with no ads or tracking. Upgrade anytime.',
     answer:
-      'Completely free, no strings attached. There are no trials, no premium gates on core features, and no ads. The entire codebase is open source under the AGPL-3.0 license, so you can inspect every line.',
+      'The free tier gives you real-time data across all four channels with no ads or tracking. Uplink plans unlock higher limits, faster polling, custom RSS feeds, and fantasy league tracking. The entire codebase is open source under the AGPL-3.0 license.',
     accent: 'emerald',
   },
   {
     icon: Zap,
-    question: 'Does it slow down my browser?',
+    question: 'Does it affect performance?',
     highlight:
       'A single background connection handles everything. Lightweight by design.',
     answer:
-      'Not noticeably. All data flows through a single connection in the background, not one per tab. The feed bar runs in an isolated Shadow DOM with at most 50 items in memory, and nothing gets written to disk.',
+      'Not noticeably. All data flows through a single connection in the background. The ticker overlay is hardware-accelerated with minimal CPU and memory usage, and it never interferes with your other applications.',
     accent: 'amber',
   },
   {
     icon: ShieldCheck,
-    question: 'Is my browsing data private?',
+    question: 'Is my data private?',
     highlight: 'No analytics, no tracking pixels, and no telemetry. Period.',
     answer:
-      "The extension contains zero analytics, zero tracking pixels, and zero telemetry. Your preferences are stored in your browser's local extension storage and never transmitted anywhere. The only network requests go to the Scrollr API to fetch your feed data.",
+      'Scrollr contains zero analytics, zero tracking pixels, and zero telemetry. Your preferences are stored locally on your device and never transmitted anywhere. The only network requests go to the Scrollr API to fetch your feed data.',
     accent: 'sky',
   },
   {
     icon: Globe,
-    question: 'What browsers are supported?',
-    highlight: 'Works on every major browser right out of the box.',
+    question: 'What platforms are supported?',
+    highlight: 'Runs natively on macOS, Windows, and Linux.',
     answer:
-      'Any Chromium-based browser works out of the box. Scrollr is available on the Chrome Web Store and Firefox Add-ons, covering virtually every modern desktop browser.',
+      'Scrollr runs natively on macOS (Apple Silicon), Windows (x64), and Linux (x64). Download the app for your platform from our download page.',
     accent: 'violet',
   },
   {
     icon: UserX,
     question: 'Do I need an account?',
-    highlight: 'Just install and go. No sign-up required to start.',
+    highlight: 'Just download and go. No sign-up required to start.',
     answer:
-      "Install the extension and you'll immediately receive live stock and sports data with no sign-up. Creating a free account unlocks all four channels (finance, sports, news, and fantasy), the web dashboard, and cross-device preference sync.",
+      "Download the app and you'll immediately receive live stock and sports data with no sign-up. Creating a free account unlocks all four channels (finance, sports, news, and fantasy), the web dashboard, and preference sync across devices.",
     accent: 'rose',
   },
   {
@@ -85,9 +85,9 @@ const FAQ_ITEMS: Array<FAQItem> = [
     icon: SlidersHorizontal,
     question: 'Can I customize the feed?',
     highlight:
-      'Adjust everything from position and size to per-site visibility.',
+      'Adjust everything from position and size to display behavior.',
     answer:
-      'Position the bar at the top or bottom of your screen, drag to resize the height, switch between comfort and compact modes, choose overlay or push behavior, pick which channels appear as tabs, and choose which websites show or hide the feed.',
+      'Position the ticker at the top or bottom of your screen, drag to resize, switch between comfort and compact modes, choose overlay or push behavior, and pick which channels appear as tabs.',
     accent: 'orange',
   },
   {
@@ -95,7 +95,7 @@ const FAQ_ITEMS: Array<FAQItem> = [
     question: 'Is Scrollr open source?',
     highlight: 'Every line of code is public. Inspect, fork, or contribute.',
     answer:
-      'Every component, from the browser extension and web app to the API and integration services, is publicly available on GitHub under the GNU Affero General Public License v3.0. You can inspect, fork, or contribute to any part of it.',
+      'Every component, from the desktop application and web dashboard to the API and integration services, is publicly available on GitHub under the GNU Affero General Public License v3.0. You can inspect, fork, or contribute to any part of it.',
     accent: 'fuchsia',
   },
 ]
@@ -430,7 +430,7 @@ interface FAQSectionProps {
 export function FAQSection({
   items = FAQ_ITEMS,
   title = 'Before You',
-  titleHighlight = 'Install',
+  titleHighlight = 'Download',
   subtitle = 'Quick answers, no fluff.',
 }: FAQSectionProps = {}) {
   const [activeIndex, setActiveIndex] = useState(0)

--- a/myscrollr.com/src/components/landing/HeroBrowserStack.tsx
+++ b/myscrollr.com/src/components/landing/HeroBrowserStack.tsx
@@ -71,10 +71,9 @@ type Accent = keyof typeof accentMap
 
 interface MockupConfig {
   word: string
-  url: string
-  tabTitle: string
-  tabIconBg: string
-  tabIconDot: string
+  appTitle: string
+  appIconBg: string
+  appIconDot: string
   accent: Accent
   tickerChips: Array<{ label: string; value: string }>
 }
@@ -82,10 +81,9 @@ interface MockupConfig {
 const MOCKUPS: Array<MockupConfig> = [
   {
     word: 'Scores',
-    url: 'youtube.com/watch?v=dQw4w9W',
-    tabTitle: 'lofi hip hop radio ☕ - YouTube',
-    tabIconBg: 'bg-secondary/15',
-    tabIconDot: 'bg-secondary',
+    appTitle: 'Music — Chill Mix',
+    appIconBg: 'bg-secondary/15',
+    appIconDot: 'bg-secondary',
     accent: 'secondary',
     tickerChips: [
       { label: 'LAL 112', value: 'BOS 108' },
@@ -95,10 +93,9 @@ const MOCKUPS: Array<MockupConfig> = [
   },
   {
     word: 'Markets',
-    url: 'github.com/acme/app/pull/412',
-    tabTitle: 'fix: auth token · PR #412',
-    tabIconBg: 'bg-base-content/8',
-    tabIconDot: 'bg-base-content/50',
+    appTitle: 'Code — acme-project',
+    appIconBg: 'bg-base-content/8',
+    appIconDot: 'bg-base-content/50',
     accent: 'primary',
     tickerChips: [
       { label: 'BTC', value: '+2.47%' },
@@ -108,10 +105,9 @@ const MOCKUPS: Array<MockupConfig> = [
   },
   {
     word: 'Headlines',
-    url: 'docs.google.com/document/d/1xQ...',
-    tabTitle: 'Q4 Planning Notes - Google Docs',
-    tabIconBg: 'bg-info/15',
-    tabIconDot: 'bg-info',
+    appTitle: 'Notes — Q4 Planning',
+    appIconBg: 'bg-info/15',
+    appIconDot: 'bg-info',
     accent: 'info',
     tickerChips: [
       { label: 'Fed holds rates', value: 'Reuters' },
@@ -121,10 +117,9 @@ const MOCKUPS: Array<MockupConfig> = [
   },
   {
     word: 'Leagues',
-    url: 'x.com/home',
-    tabTitle: 'Home / X',
-    tabIconBg: 'bg-base-content/8',
-    tabIconDot: 'bg-base-content/50',
+    appTitle: 'Chat — #general',
+    appIconBg: 'bg-base-content/8',
+    appIconDot: 'bg-base-content/50',
     accent: 'accent',
     tickerChips: [
       { label: 'P. Mahomes', value: '28.4 pts' },
@@ -134,96 +129,124 @@ const MOCKUPS: Array<MockupConfig> = [
   },
 ]
 
-// ── Fake page content — each is an unrelated site ────────────────
-// The ticker shows integration data (scores, markets, etc.)
-// while the PAGE shows a totally different website — proving
-// that Scrollr works on any tab.
+// ── Desktop app content ──────────────────────────────────────────
+// Each shows a different desktop app the user might be working in.
+// The ticker at the bottom shows live data (scores, markets, etc.)
+// regardless of which app is in focus — proving Scrollr works
+// across your entire desktop.
 
-function YouTubePageContent() {
+function MusicPlayerContent() {
   return (
     <div className="space-y-2">
-      {/* Video player */}
+      {/* Album art */}
       <div className="h-16 rounded-sm bg-base-300/30 flex items-center justify-center relative overflow-hidden">
-        {/* Fake video gradient */}
-        <div className="absolute inset-0 bg-gradient-to-br from-base-content/4 to-base-content/8" />
-        {/* Play button */}
-        <div className="relative w-8 h-5.5 rounded bg-secondary/90 flex items-center justify-center">
-          <span className="text-white text-[8px] ml-0.5">▶</span>
+        <div className="absolute inset-0 bg-gradient-to-br from-secondary/8 to-secondary/15" />
+        <div className="relative flex flex-col items-center">
+          <span className="text-[16px]">&#9835;</span>
+          <span className="text-[7px] text-base-content/30 mt-0.5">
+            Now Playing
+          </span>
         </div>
-        {/* Timestamp */}
-        <span className="absolute bottom-1 right-1.5 text-[7px] font-mono bg-base-content/60 text-white px-1 rounded-sm">
-          2:34:17
-        </span>
       </div>
-      {/* Title + channel */}
-      <div className="px-0.5">
+      {/* Track info */}
+      <div className="px-0.5 text-center">
         <p className="text-[11px] font-semibold text-base-content/65 leading-snug">
-          lofi hip hop radio ☕ beats to relax/study to
+          Midnight Drift
         </p>
-        <div className="flex items-center gap-1 mt-0.5">
-          <div className="w-3.5 h-3.5 rounded-full bg-base-300/30 shrink-0" />
-          <span className="text-[9px] text-base-content/30">
-            Lofi Girl · 42M views
-          </span>
-        </div>
+        <p className="text-[9px] text-base-content/30 mt-0.5">
+          Chillhop Essentials
+        </p>
       </div>
-      {/* Top comment — the hint */}
-      <div className="flex items-start gap-2 px-0.5 pt-1.5 border-t border-base-300/10">
-        <div className="w-4 h-4 rounded-full bg-base-300/20 shrink-0 mt-0.5" />
-        <div>
-          <span className="text-[8px] font-medium text-base-content/35">
-            @chillvibes42
-          </span>
-          <p className="text-[9px] text-base-content/30 leading-snug">
-            finally watching this without checking ESPN every 5 min 😌🏀
-          </p>
+      {/* Progress bar */}
+      <div className="flex items-center gap-2 px-0.5">
+        <span className="text-[7px] font-mono text-base-content/20">2:34</span>
+        <div className="flex-1 h-1 rounded-full bg-base-300/20 relative overflow-hidden">
+          <div className="absolute inset-y-0 left-0 w-3/5 rounded-full bg-secondary/40" />
         </div>
+        <span className="text-[7px] font-mono text-base-content/20">4:12</span>
+      </div>
+      {/* Playback controls */}
+      <div className="flex items-center justify-center gap-4">
+        <span className="text-[10px] text-base-content/20">&#9198;</span>
+        <div className="w-6 h-6 rounded-full bg-base-content/8 flex items-center justify-center">
+          <span className="text-[10px] text-base-content/40 ml-0.5">
+            &#9654;
+          </span>
+        </div>
+        <span className="text-[10px] text-base-content/20">&#9197;</span>
+      </div>
+      {/* Up Next — the hint */}
+      <div className="px-0.5 pt-1 border-t border-base-300/10">
+        <span className="text-[8px] text-base-content/20 uppercase tracking-wider">
+          Up Next
+        </span>
+        <p className="text-[9px] text-base-content/30 leading-snug mt-0.5">
+          game day focus — scores live at the bottom &#127936;
+        </p>
       </div>
     </div>
   )
 }
 
-function GitHubPageContent() {
+function CodeEditorContent() {
+  const lines = [
+    { num: 1, code: "import { fetchData } from", cls: 'text-info/50' },
+    { num: 2, code: "  './api'", cls: 'text-primary/50' },
+    { num: 3, code: '', cls: '' },
+    {
+      num: 4,
+      code: '// prices in the ticker — focus here',
+      cls: 'text-base-content/20',
+    },
+    {
+      num: 5,
+      code: 'async function syncPortfolio() {',
+      cls: 'text-accent/50',
+    },
+    {
+      num: 6,
+      code: '  const data = await fetchData()',
+      cls: 'text-base-content/40',
+    },
+    {
+      num: 7,
+      code: '  return data.filter(active)',
+      cls: 'text-base-content/40',
+    },
+    { num: 8, code: '}', cls: 'text-accent/50' },
+  ]
+
   return (
-    <div className="space-y-2">
-      {/* PR header */}
-      <div className="flex items-center gap-2">
-        <span className="text-[8px] px-1.5 py-0.5 rounded-full bg-primary/15 text-primary font-semibold">
-          Open
-        </span>
-        <span className="text-[11px] font-semibold text-base-content/60 truncate">
-          fix: auth token refresh flow
-        </span>
-      </div>
-      <div className="text-[8px] text-base-content/25">
-        acme/app #412 · opened 2h ago · 3 files changed
-      </div>
-      {/* Diff — the hint is the deleted TODO */}
-      <div className="rounded-sm border border-base-300/10 overflow-hidden font-mono text-[9px] leading-relaxed">
-        <div className="bg-secondary/5 px-2 py-1 text-secondary/50 border-b border-base-300/6">
-          <span className="text-secondary/30 select-none mr-1">−</span>
-          {'// TODO: stop alt-tabbing to check AAPL'}
+    <div className="space-y-0">
+      {/* File tabs */}
+      <div className="flex items-center gap-0 mb-2">
+        <div className="px-2.5 py-1 rounded-t-sm bg-base-100/50 border border-b-0 border-base-300/10 text-[9px] text-base-content/40">
+          app.ts
         </div>
-        <div className="bg-primary/5 px-2 py-1 text-primary/50 border-b border-base-300/6">
-          <span className="text-primary/30 select-none mr-1">+</span>
-          {'const token = await refreshAuth()'}
-        </div>
-        <div className="bg-primary/5 px-2 py-1 text-primary/50">
-          <span className="text-primary/30 select-none mr-1">+</span>
-          {'// no need — prices live in toolbar 📈'}
+        <div className="px-2.5 py-1 text-[9px] text-base-content/20">
+          utils.ts
         </div>
       </div>
-      {/* Merge button */}
-      <div className="flex justify-end pt-0.5">
-        <div className="text-[9px] px-3 py-1 rounded-md bg-primary/80 text-white font-medium">
-          Merge pull request
-        </div>
+      {/* Code lines */}
+      <div className="font-mono text-[9px] leading-relaxed">
+        {lines.map((line) => (
+          <div key={line.num} className="flex">
+            <span className="w-5 text-right pr-2 text-base-content/15 select-none shrink-0">
+              {line.num}
+            </span>
+            <span className={line.cls}>{line.code}</span>
+          </div>
+        ))}
+      </div>
+      {/* Cursor */}
+      <div className="pl-5 mt-0.5">
+        <span className="inline-block w-0.5 h-3 bg-primary/40 animate-pulse" />
       </div>
     </div>
   )
 }
 
-function DocsPageContent() {
+function NotesContent() {
   return (
     <div className="space-y-2">
       {/* Mini toolbar */}
@@ -232,8 +255,8 @@ function DocsPageContent() {
         <span className="text-[10px] italic text-base-content/25">I</span>
         <span className="text-[10px] underline text-base-content/25">U</span>
         <span className="text-base-content/10">|</span>
-        <span className="text-[10px] text-base-content/20">≡</span>
-        <span className="text-[10px] text-base-content/20">⋮≡</span>
+        <span className="text-[10px] text-base-content/20">&equiv;</span>
+        <span className="text-[10px] text-base-content/20">&#8942;&equiv;</span>
       </div>
       {/* Document content */}
       <div className="px-1">
@@ -241,11 +264,13 @@ function DocsPageContent() {
           Q4 Planning Notes
         </p>
         <div className="space-y-1.5 text-[10px] text-base-content/35 leading-relaxed">
-          <p>• Review product launch timeline</p>
-          <p>• Finalize Q1 budget allocation</p>
+          <p>&bull; Review product launch timeline</p>
+          <p>&bull; Finalize Q1 budget allocation</p>
           {/* The hint — natural meeting note */}
-          <p>• No more tab-switching for news — feed is live below ↓</p>
-          <p className="text-base-content/15">• Assign design review owners</p>
+          <p>&bull; Headlines streaming in the ticker &mdash; stay in flow ↓</p>
+          <p className="text-base-content/15">
+            &bull; Assign design review owners
+          </p>
         </div>
       </div>
       {/* Cursor blink */}
@@ -256,59 +281,46 @@ function DocsPageContent() {
   )
 }
 
-function XPageContent() {
-  const tweets = [
+function ChatContent() {
+  const messages = [
     {
-      handle: '@devjordan',
-      time: '24m',
-      text: 'just mass-deployed to prod on a Friday. pray for me 🫡',
-      likes: '2.4k',
-      retweets: '891',
-    },
-    {
-      handle: '@ballerSZN',
+      name: 'Alex',
       time: '12m',
-      // The hint — natural sports-fan tweet
-      text: 'Mahomes is going OFF and I don\u2019t even have to leave this timeline to check 🏆🔥',
-      likes: '892',
-      retweets: '214',
+      text: 'standup notes pushed — reviews welcome',
     },
     {
-      handle: '@designr_',
-      time: '1h',
-      text: 'new portfolio just dropped. roast me.',
-      likes: '1.2k',
-      retweets: '445',
+      name: 'Jordan',
+      time: '8m',
+      // The hint — natural chat about fantasy scores
+      text: 'Mahomes going OFF today \u{1F3C6} can see it right in the ticker',
+    },
+    {
+      name: 'Sam',
+      time: '3m',
+      text: 'merging the auth PR now, looks good',
     },
   ]
+
   return (
     <div className="space-y-0">
-      {tweets.map((t) => (
+      {messages.map((m) => (
         <div
-          key={t.handle}
+          key={m.name}
           className="flex items-start gap-2 px-3 py-2 border-b border-base-300/10"
         >
           <div className="w-5 h-5 rounded-full bg-base-300/25 shrink-0 mt-0.5" />
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-1.5">
               <span className="text-[10px] font-bold text-base-content/50">
-                {t.handle}
+                {m.name}
               </span>
               <span className="text-[8px] text-base-content/20">
-                · {t.time}
+                &middot; {m.time} ago
               </span>
             </div>
             <p className="text-[10px] text-base-content/45 leading-snug mt-0.5">
-              {t.text}
+              {m.text}
             </p>
-            <div className="flex items-center gap-4 mt-1">
-              <span className="text-[8px] text-base-content/20">
-                ♡ {t.likes}
-              </span>
-              <span className="text-[8px] text-base-content/20">
-                ↻ {t.retweets}
-              </span>
-            </div>
           </div>
         </div>
       ))}
@@ -317,13 +329,13 @@ function XPageContent() {
 }
 
 const CONTENT_RENDERERS: Record<string, React.FC> = {
-  Scores: YouTubePageContent,
-  Markets: GitHubPageContent,
-  Headlines: DocsPageContent,
-  Leagues: XPageContent,
+  Scores: MusicPlayerContent,
+  Markets: CodeEditorContent,
+  Headlines: NotesContent,
+  Leagues: ChatContent,
 }
 
-// ── Content carousel (FAQ-style spring + motion blur) ────────────
+// ── Content carousel (spring + motion blur) ──────────────────────
 
 function calculateViewX(difference: number, containerWidth: number) {
   return difference * containerWidth * 0.75 * -1
@@ -382,15 +394,15 @@ function ContentView({
 
 // ── Main Component ───────────────────────────────────────────────
 
-interface HeroBrowserStackProps {
+interface HeroDesktopPreviewProps {
   activeIndex: number
   onSelect?: (index: number) => void
 }
 
-export function HeroBrowserStack({
+export function HeroDesktopPreview({
   activeIndex,
   onSelect,
-}: HeroBrowserStackProps) {
+}: HeroDesktopPreviewProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const [contentWidth, setContentWidth] = useState(0)
   const [isMounted, setIsMounted] = useState(false)
@@ -427,7 +439,7 @@ export function HeroBrowserStack({
         style={{ backgroundColor: styles.glow }}
       />
 
-      {/* ── Single browser frame ── */}
+      {/* ── Desktop window frame ── */}
       <div
         className="relative h-full rounded-xl overflow-hidden flex flex-col border bg-base-200/80 backdrop-blur-sm transition-[border-color,box-shadow] duration-500"
         style={{
@@ -435,11 +447,19 @@ export function HeroBrowserStack({
           boxShadow: styles.shadow,
         }}
       >
-        {/* ── Tab strip — all 4 tabs visible ── */}
+        {/* ── Title bar — traffic lights + app tabs ── */}
         <div
           className="shrink-0 flex items-end px-2 pt-2 bg-base-200/95 border-b border-base-300/20"
           role="tablist"
         >
+          {/* macOS traffic lights */}
+          <div className="flex items-center gap-1.5 pl-1 pr-2 pb-2 shrink-0">
+            <div className="w-2.5 h-2.5 rounded-full bg-[#FF5F57]/80" />
+            <div className="w-2.5 h-2.5 rounded-full bg-[#FEBC2E]/80" />
+            <div className="w-2.5 h-2.5 rounded-full bg-[#28C840]/80" />
+          </div>
+
+          {/* App tabs — each represents a different desktop app */}
           {MOCKUPS.map((mockup, i) => {
             const isActive = i === activeIndex
 
@@ -469,77 +489,28 @@ export function HeroBrowserStack({
                 {/* Tab content */}
                 <div className="relative z-10 flex items-center gap-1 sm:gap-1.5 px-1.5 sm:px-3 py-1.5">
                   <div
-                    className={`w-3 h-3 rounded-sm ${mockup.tabIconBg} flex items-center justify-center shrink-0`}
+                    className={`w-3 h-3 rounded-sm ${mockup.appIconBg} flex items-center justify-center shrink-0`}
                   >
                     <div
-                      className={`w-1.5 h-1.5 rounded-full ${mockup.tabIconDot}`}
+                      className={`w-1.5 h-1.5 rounded-full ${mockup.appIconDot}`}
                     />
                   </div>
                   <span
                     className={`text-[10px] truncate transition-colors duration-300 ${
-                      isActive ? 'text-base-content/50' : 'text-base-content/25'
+                      isActive
+                        ? 'text-base-content/50'
+                        : 'text-base-content/25'
                     }`}
                   >
-                    {mockup.tabTitle}
+                    {mockup.appTitle}
                   </span>
-                  {isActive && (
-                    <span className="text-[9px] text-base-content/20 ml-auto shrink-0 hidden sm:inline">
-                      ×
-                    </span>
-                  )}
                 </div>
               </button>
             )
           })}
-
-          {/* New tab button */}
-          <div className="flex items-center justify-center w-6 h-6 mb-0.5 ml-1 shrink-0 rounded-sm text-base-content/20">
-            <span className="text-[11px] leading-none">+</span>
-          </div>
         </div>
 
-        {/* ── Toolbar ── */}
-        <div className="shrink-0 flex items-center gap-2 px-3 py-1.5 bg-base-200/90">
-          {/* Nav buttons */}
-          <div className="flex items-center gap-1 shrink-0">
-            <span className="text-[10px] text-base-content/15 w-4 text-center">
-              ←
-            </span>
-            <span className="text-[10px] text-base-content/15 w-4 text-center">
-              →
-            </span>
-            <span className="text-[10px] text-base-content/15 w-4 text-center">
-              ↻
-            </span>
-          </div>
-
-          {/* URL bar — crossfades between URLs */}
-          <div className="flex-1 flex items-center gap-2 px-2.5 py-1 rounded-full bg-base-100/50 border border-base-300/15 overflow-hidden">
-            <div className="w-2.5 h-2.5 rounded-full bg-success/25 shrink-0" />
-            <AnimatePresence mode="wait">
-              <motion.span
-                key={activeMockup.url}
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -6 }}
-                transition={{ duration: 0.15 }}
-                className="text-[10px] font-mono text-base-content/25 truncate"
-              >
-                {activeMockup.url}
-              </motion.span>
-            </AnimatePresence>
-          </div>
-
-          {/* Scrollr extension icon — always primary/green */}
-          <div className="flex items-center justify-center w-6 h-6 rounded-sm bg-primary/8 shrink-0">
-            <span className="relative flex h-1.5 w-1.5">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
-              <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary" />
-            </span>
-          </div>
-        </div>
-
-        {/* ── Page content — spring-animated vertical carousel ── */}
+        {/* ── App content — spring-animated carousel ── */}
         <div
           ref={contentRef}
           className="relative flex-1 min-h-0 overflow-hidden bg-base-100/30"
@@ -580,7 +551,7 @@ export function HeroBrowserStack({
             </span>
           </div>
 
-          {/* Ticker chips — crossfade per active tab */}
+          {/* Ticker chips — crossfade per active app */}
           <AnimatePresence mode="wait">
             <motion.div
               key={activeMockup.word}

--- a/myscrollr.com/src/components/landing/HeroSection.tsx
+++ b/myscrollr.com/src/components/landing/HeroSection.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { motion } from 'motion/react'
 import { wrap } from 'motion'
 import HeroTextSwap, { WORDS } from '@/components/Typewriter'
-import { HeroBrowserStack } from '@/components/landing/HeroBrowserStack'
+import { HeroDesktopPreview } from '@/components/landing/HeroBrowserStack'
 import { DownloadButton } from '@/components/DownloadButton'
 
 const CYCLE_MS = 4000
@@ -76,9 +76,9 @@ export function HeroSection() {
     <section className="relative min-h-dvh flex items-center overflow-hidden">
       <div className="container relative">
         <div className="flex lg:flex-row flex-col justify-center items-center gap-12 lg:gap-12 xl:gap-16">
-          {/* Stacked Browser Mockups */}
+          {/* Desktop App Preview */}
           <div className="relative order-2 lg:order-1">
-            <HeroBrowserStack
+            <HeroDesktopPreview
               activeIndex={activeWordIndex}
               onSelect={handleSelect}
             />
@@ -140,9 +140,9 @@ export function HeroSection() {
               transition={{ duration: 0.5, delay: 1 }}
               className="text-base text-base-content/50 max-w-md leading-relaxed"
             >
-              A quiet ticker at the bottom of your browser. Scores update,
-              prices move, headlines arrive &mdash; all while you stay on the
-              page you&rsquo;re already on.
+              A quiet ticker at the edge of your screen. Scores update,
+              prices move, headlines arrive &mdash; all while you stay
+              focused on whatever you&rsquo;re working on.
             </motion.p>
 
             <motion.div

--- a/myscrollr.com/src/components/landing/HowItWorks.tsx
+++ b/myscrollr.com/src/components/landing/HowItWorks.tsx
@@ -19,10 +19,10 @@ const CYCLE_MS = 5000
 
 const STEPS = [
   {
-    id: 'install',
-    title: 'Add to Chrome',
+    id: 'download',
+    title: 'Download the App',
     description:
-      'One click from the Chrome Web Store. No sign-up, no account, nothing else.',
+      'Grab the installer for macOS, Windows, or Linux. No sign-up, no account, nothing else.',
   },
   {
     id: 'choose',
@@ -31,10 +31,10 @@ const STEPS = [
       'Toggle on sports, markets, news, or fantasy. Whatever matters to you.',
   },
   {
-    id: 'browse',
-    title: 'Browse as Usual',
+    id: 'work',
+    title: 'Work as Usual',
     description:
-      'A quiet ticker at the bottom of every tab. Always there, never in the way.',
+      'A quiet ticker at the edge of your screen. Always there, never in the way.',
   },
 ]
 
@@ -106,9 +106,9 @@ const chipStyle: Record<
 
 const VISUAL_EASE = [0.22, 1, 0.36, 1] as const
 
-// ── Step 1 Visual: Install ───────────────────────────────────────
+// ── Step 1 Visual: Download ──────────────────────────────────────
 
-function InstallVisual() {
+function DownloadVisual() {
   return (
     <motion.div
       initial={{ opacity: 0, scale: 0.97 }}
@@ -117,16 +117,16 @@ function InstallVisual() {
       transition={{ duration: 0.35, ease: VISUAL_EASE }}
       className="flex flex-col h-full"
     >
-      {/* Store-style listing card */}
+      {/* App listing card */}
       <div className="flex-1 flex flex-col justify-center px-6 sm:px-10 py-8 sm:py-10">
-        {/* Top: Extension info row */}
+        {/* Top: App info row */}
         <motion.div
           initial={{ opacity: 0, y: 15 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.1, duration: 0.45, ease: VISUAL_EASE }}
           className="flex items-start gap-4 sm:gap-5 mb-6 sm:mb-8"
         >
-          {/* Extension icon */}
+          {/* App icon */}
           <motion.div
             initial={{ scale: 0, rotate: -10 }}
             animate={{ scale: 1, rotate: 0 }}
@@ -149,7 +149,7 @@ function InstallVisual() {
               Scrollr
             </h4>
             <p className="text-xs sm:text-sm text-base-content/40 leading-relaxed mb-2.5">
-              Live finance, sports &amp; news in a quiet ticker on every tab.
+              Live finance, sports &amp; news in a quiet desktop ticker.
             </p>
 
             {/* Rating + meta row */}
@@ -182,7 +182,7 @@ function InstallVisual() {
               <div className="flex items-center gap-1.5">
                 <span className="inline-flex items-center gap-1 text-[10px] font-semibold text-primary/70 bg-primary/[0.07] border border-primary/10 rounded-md px-1.5 py-0.5">
                   <Zap size={9} />
-                  Free
+                  Free tier
                 </span>
                 <span className="inline-flex items-center gap-1 text-[10px] font-semibold text-base-content/30 bg-base-300/10 border border-base-300/15 rounded-md px-1.5 py-0.5">
                   <Shield size={9} />
@@ -201,9 +201,9 @@ function InstallVisual() {
           className="grid grid-cols-3 gap-3 mb-7 sm:mb-8"
         >
           {[
-            { icon: Zap, label: 'Lightweight', sub: '<1MB' },
+            { icon: Zap, label: 'Native app', sub: 'Fast & light' },
             { icon: Shield, label: 'No tracking', sub: 'Zero analytics' },
-            { icon: Download, label: 'Instant setup', sub: 'No account' },
+            { icon: Download, label: 'Instant setup', sub: 'No sign-up' },
           ].map((feat, i) => (
             <motion.div
               key={feat.label}
@@ -227,7 +227,7 @@ function InstallVisual() {
           ))}
         </motion.div>
 
-        {/* Actual install button */}
+        {/* Download button */}
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -325,16 +325,16 @@ function ChooseVisual() {
           transition={{ delay: 1.2, duration: 0.5, ease: VISUAL_EASE }}
           className="text-[11px] text-base-content/25 text-center pt-2"
         >
-          Change anytime from the extension popup
+          Change anytime from the app settings
         </motion.p>
       </div>
     </motion.div>
   )
 }
 
-// ── Step 3 Visual: Browse ────────────────────────────────────────
+// ── Step 3 Visual: Work ──────────────────────────────────────────
 
-function BrowseVisual() {
+function WorkVisual() {
   return (
     <motion.div
       initial={{ opacity: 0, scale: 0.97 }}
@@ -343,26 +343,26 @@ function BrowseVisual() {
       transition={{ duration: 0.35, ease: VISUAL_EASE }}
       className="flex flex-col h-full"
     >
-      {/* Browser frame — full bleed within container */}
+      {/* Desktop workspace — app window with Scrollr ticker */}
       <div className="flex-1 flex flex-col bg-base-100/40">
-        {/* Tab / URL bar */}
+        {/* Application title bar */}
         <div className="flex items-center gap-2.5 px-4 py-2.5 border-b border-base-300/20 bg-base-200/50">
           <div className="flex gap-1.5">
             <div className="w-2 h-2 rounded-full bg-error/25" />
             <div className="w-2 h-2 rounded-full bg-warning/25" />
             <div className="w-2 h-2 rounded-full bg-success/25" />
           </div>
-          <div className="flex-1 mx-2 px-3 py-1 rounded-md bg-base-100/50 border border-base-300/20">
+          <div className="flex-1 mx-2">
             <span className="text-[10px] text-base-content/20">
-              reddit.com/r/nba
+              Your workspace
             </span>
           </div>
         </div>
 
-        {/* Content skeleton — fills remaining space */}
+        {/* Content skeleton — represents any application */}
         <div className="flex-1 p-5 space-y-3">
           <div className="flex items-center gap-3">
-            <div className="w-7 h-7 rounded-full bg-base-300/12 shrink-0" />
+            <div className="w-7 h-7 rounded bg-base-300/12 shrink-0" />
             <div className="space-y-1.5 flex-1">
               <div className="h-2 bg-base-300/10 rounded w-3/4" />
               <div className="h-1.5 bg-base-300/7 rounded w-1/2" />
@@ -374,9 +374,8 @@ function BrowseVisual() {
             <div className="h-1.5 bg-base-300/6 rounded w-5/6" />
             <div className="h-1.5 bg-base-300/5 rounded w-2/3" />
           </div>
-          {/* Extra skeleton rows to fill taller containers */}
           <div className="flex items-center gap-3 pt-2">
-            <div className="w-7 h-7 rounded-full bg-base-300/8 shrink-0" />
+            <div className="w-7 h-7 rounded bg-base-300/8 shrink-0" />
             <div className="space-y-1.5 flex-1">
               <div className="h-2 bg-base-300/7 rounded w-2/3" />
               <div className="h-1.5 bg-base-300/5 rounded w-2/5" />
@@ -385,7 +384,7 @@ function BrowseVisual() {
           <div className="h-10 bg-base-300/4 rounded-lg border border-base-300/6" />
         </div>
 
-        {/* Ticker bar — pinned to bottom, slides up */}
+        {/* Scrollr ticker — pinned to bottom edge, slides up */}
         <motion.div
           initial={{ y: 40, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
@@ -393,7 +392,7 @@ function BrowseVisual() {
           className="mt-auto border-t border-primary/15 bg-base-100/95 px-3 py-2"
         >
           <div className="flex items-center gap-2 overflow-hidden">
-            {/* Scrollr badge */}
+            {/* Scrollr live indicator */}
             <div className="flex items-center gap-1.5 pr-2 border-r border-base-300/20 shrink-0">
               <span className="relative flex h-1.5 w-1.5">
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
@@ -434,7 +433,7 @@ function BrowseVisual() {
 
 // ── Visual lookup ────────────────────────────────────────────────
 
-const VISUALS = [InstallVisual, ChooseVisual, BrowseVisual]
+const VISUALS = [DownloadVisual, ChooseVisual, WorkVisual]
 
 // ── Main Component ───────────────────────────────────────────────
 
@@ -529,7 +528,7 @@ export function HowItWorks() {
             <span className="text-gradient-primary">Under a Minute</span>
           </h2>
           <p className="text-base text-base-content/50 leading-relaxed text-center max-w-lg">
-            Three steps between you and live data in your browser.
+            Three steps between you and live data on your desktop.
           </p>
         </motion.div>
 

--- a/myscrollr.com/src/components/legal/documents.ts
+++ b/myscrollr.com/src/components/legal/documents.ts
@@ -7,6 +7,7 @@ import {
   GitPullRequest,
   Link2,
   Lock,
+  Monitor,
   RotateCcw,
   Scale,
   Shield,
@@ -219,6 +220,73 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
   },
 
   // ─────────────────────────────────────────────────────────────
+  // 2b. DESKTOP APPLICATION PRIVACY
+  // ─────────────────────────────────────────────────────────────
+  {
+    slug: 'desktop-privacy',
+    title: 'Desktop Application Privacy',
+    shortTitle: 'Desktop Privacy',
+    icon: Monitor,
+    category: 'data',
+    lastUpdated: 'March 2026',
+    effectiveDate: 'March 30, 2026',
+    badge: 'New',
+    sections: [
+      {
+        heading: 'Overview',
+        content: [
+          'This document describes the privacy practices specific to the Scrollr desktop application. It supplements our general Privacy Policy with details about what the desktop app stores on your device, what it transmits, and what it does not access.',
+        ],
+      },
+      {
+        heading: 'Data Stored Locally',
+        content: [
+          'The Scrollr desktop application stores the following data on your device:',
+          'Authentication tokens: Your access token and refresh token for authenticating with our API servers. These are stored in the application data directory and are not shared with any third party.',
+          'Channel and widget configurations: Your selected data sources (stock symbols, RSS feeds, sports leagues, fantasy leagues), ticker layout preferences, and per-channel display settings.',
+          'Feed preferences: Display settings including ticker position, mode, behavior, visibility, scroll speed, and appearance customizations.',
+          'Dashboard state: Cached dashboard data for faster loading between sessions.',
+          'Application logs: Diagnostic log files are written to a local logs directory within the application data folder. These logs contain operational information (connection status, errors, data sync events) and do not contain personal data, browsing activity, or content from other applications.',
+          'Window state: Window position, size, and display information used to restore your ticker and main window layout between sessions.',
+        ],
+      },
+      {
+        heading: 'Network Communication',
+        content: [
+          'The desktop application communicates exclusively with Scrollr API servers (api.myscrollr.relentnet.dev) to retrieve real-time data via Server-Sent Events (SSE) and to synchronize your configuration.',
+          'All network communication uses HTTPS encryption. The application sends your authentication token and subscription tier with each request. It does not transmit any data about other applications, files, or activity on your device.',
+        ],
+      },
+      {
+        heading: 'What the Application Does Not Access',
+        content: [
+          'The Scrollr desktop application does not read, collect, or transmit: the content of other applications or windows on your screen; your browsing history, bookmarks, or browser data; files, documents, or media on your device; clipboard contents; keystrokes or input to other applications; your location, contacts, calendar, or other personal data; or screenshots or screen recordings.',
+          'The application renders its own ticker window as a native overlay. It does not inject code into, modify, or interact with any other application.',
+        ],
+      },
+      {
+        heading: 'Automatic Updates',
+        content: [
+          'The application checks for updates by downloading a manifest file (latest.json) from our GitHub releases. Update checks transmit only the request for the manifest file. If an update is available, you are prompted before downloading. Update artifacts are cryptographically signed to ensure integrity.',
+        ],
+      },
+      {
+        heading: 'Third-Party Services',
+        content: [
+          'Yahoo Fantasy Sports: If you connect your Yahoo account, the desktop application opens your default browser for the OAuth authorization flow. The application stores an encrypted refresh token locally and on our servers to maintain the connection. See our Privacy Policy for details on Yahoo data handling.',
+          'The application does not include any analytics SDKs, telemetry services, crash reporters, or advertising frameworks.',
+        ],
+      },
+      {
+        heading: 'Data Deletion',
+        content: [
+          'You can delete all locally stored data by uninstalling the application or by using the "Reset all settings" option on the Account page. Server-side data (channel configurations, account preferences) can be deleted by contacting us through our GitHub repository or community Discord.',
+        ],
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────
   // 3. COOKIE & STORAGE POLICY
   // ─────────────────────────────────────────────────────────────
   {
@@ -247,7 +315,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         heading: 'Desktop Application Storage',
         content: [
           'The Scrollr desktop application uses local storage to store the following data on your device:',
-          'Authentication tokens: Your access token and refresh token for communicating with our API. Feed preferences: Your display settings (position, mode, behavior, visibility). Dashboard state: Cached dashboard data for faster loading. Connection state: SSE connection status and subscription information.',
+          'Authentication tokens: Your access token and refresh token for communicating with our API. Feed preferences: Your display settings (position, mode, behavior, visibility). Channel and widget configurations: Your selected data sources, ticker layout, and per-channel settings. Dashboard state: Cached dashboard data for faster loading. Connection state: SSE connection status and subscription information. Application logs: Diagnostic log files written locally for troubleshooting. Window state: Window position, size, and display information used to manage the ticker and main windows.',
           "This data is stored locally on your device and is not transmitted to third parties. It is only sent to Scrollr's API servers to authenticate requests and retrieve your personalized data.",
         ],
       },
@@ -262,7 +330,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         heading: 'Managing Storage',
         content: [
           'Website cookies: You can clear cookies through your browser settings. Note that clearing authentication cookies will sign you out of the Platform.',
-          "Extension storage: You can clear extension data by removing and re-installing the extension, or through your browser's extension management page. You can also manage your preferences through the extension's settings panel or the web dashboard.",
+          'Desktop application: You can clear application data by uninstalling and re-installing the app, or by using the "Reset all settings" option in the Account page. You can also manage your preferences through the app settings.',
           'Disabling cookies entirely may prevent you from using authenticated features of the Platform.',
         ],
       },
@@ -647,9 +715,9 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         ],
       },
       {
-        heading: 'Extension Modifications',
+        heading: 'Application Modifications',
         content: [
-          'You may modify the Scrollr extension source code under the terms of the AGPL-3.0 license. However, modified extensions that connect to our hosted infrastructure must comply with this AUP. We reserve the right to block connections from modified clients that abuse our services.',
+          'You may modify the Scrollr source code under the terms of the AGPL-3.0 license. However, modified applications that connect to our hosted infrastructure must comply with this AUP. We reserve the right to block connections from modified clients that abuse our services.',
         ],
       },
       {

--- a/myscrollr.com/src/routeTree.gen.ts
+++ b/myscrollr.com/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as UplinkRouteImport } from './routes/uplink'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as LegalRouteImport } from './routes/legal'
+import { Route as DownloadRouteImport } from './routes/download'
 import { Route as ChannelsRouteImport } from './routes/channels'
 import { Route as CallbackRouteImport } from './routes/callback'
 import { Route as ArchitectureRouteImport } from './routes/architecture'
@@ -33,6 +34,11 @@ const StatusRoute = StatusRouteImport.update({
 const LegalRoute = LegalRouteImport.update({
   id: '/legal',
   path: '/legal',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DownloadRoute = DownloadRouteImport.update({
+  id: '/download',
+  path: '/download',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChannelsRoute = ChannelsRouteImport.update({
@@ -77,6 +83,7 @@ export interface FileRoutesByFullPath {
   '/architecture': typeof ArchitectureRoute
   '/callback': typeof CallbackRoute
   '/channels': typeof ChannelsRoute
+  '/download': typeof DownloadRoute
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
   '/uplink': typeof UplinkRoute
@@ -89,6 +96,7 @@ export interface FileRoutesByTo {
   '/architecture': typeof ArchitectureRoute
   '/callback': typeof CallbackRoute
   '/channels': typeof ChannelsRoute
+  '/download': typeof DownloadRoute
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
   '/uplink': typeof UplinkRoute
@@ -102,6 +110,7 @@ export interface FileRoutesById {
   '/architecture': typeof ArchitectureRoute
   '/callback': typeof CallbackRoute
   '/channels': typeof ChannelsRoute
+  '/download': typeof DownloadRoute
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
   '/uplink': typeof UplinkRoute
@@ -116,6 +125,7 @@ export interface FileRouteTypes {
     | '/architecture'
     | '/callback'
     | '/channels'
+    | '/download'
     | '/legal'
     | '/status'
     | '/uplink'
@@ -128,6 +138,7 @@ export interface FileRouteTypes {
     | '/architecture'
     | '/callback'
     | '/channels'
+    | '/download'
     | '/legal'
     | '/status'
     | '/uplink'
@@ -140,6 +151,7 @@ export interface FileRouteTypes {
     | '/architecture'
     | '/callback'
     | '/channels'
+    | '/download'
     | '/legal'
     | '/status'
     | '/uplink'
@@ -153,6 +165,7 @@ export interface RootRouteChildren {
   ArchitectureRoute: typeof ArchitectureRoute
   CallbackRoute: typeof CallbackRoute
   ChannelsRoute: typeof ChannelsRoute
+  DownloadRoute: typeof DownloadRoute
   LegalRoute: typeof LegalRoute
   StatusRoute: typeof StatusRoute
   UplinkRoute: typeof UplinkRoute
@@ -181,6 +194,13 @@ declare module '@tanstack/react-router' {
       path: '/legal'
       fullPath: '/legal'
       preLoaderRoute: typeof LegalRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/download': {
+      id: '/download'
+      path: '/download'
+      fullPath: '/download'
+      preLoaderRoute: typeof DownloadRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/channels': {
@@ -241,6 +261,7 @@ const rootRouteChildren: RootRouteChildren = {
   ArchitectureRoute: ArchitectureRoute,
   CallbackRoute: CallbackRoute,
   ChannelsRoute: ChannelsRoute,
+  DownloadRoute: DownloadRoute,
   LegalRoute: LegalRoute,
   StatusRoute: StatusRoute,
   UplinkRoute: UplinkRoute,

--- a/myscrollr.com/src/routes/download.tsx
+++ b/myscrollr.com/src/routes/download.tsx
@@ -1,0 +1,284 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import {
+  Apple,
+  Check,
+  Download,
+  ExternalLink,
+  Monitor,
+} from 'lucide-react'
+import { motion } from 'motion/react'
+import { usePageMeta } from '@/lib/usePageMeta'
+
+export const Route = createFileRoute('/download')({
+  component: DownloadPage,
+})
+
+// ── Constants ──────────────────────────────────────────────────
+
+const REPO = 'https://github.com/brandon-relentnet/myscrollr'
+const RELEASES_URL = `${REPO}/releases/latest`
+
+const EASE = [0.22, 1, 0.36, 1] as const
+
+type Platform = {
+  id: 'macos' | 'windows' | 'linux'
+  name: string
+  arch: string
+  icon: React.ReactNode
+  requirements: string[]
+  note?: string
+}
+
+const PLATFORMS: Platform[] = [
+  {
+    id: 'macos',
+    name: 'macOS',
+    arch: 'Apple Silicon (arm64)',
+    icon: <Apple className="h-6 w-6" />,
+    requirements: ['macOS 11 Big Sur or later', 'Apple Silicon (M1/M2/M3/M4)'],
+    note: 'Intel Macs are not currently supported.',
+  },
+  {
+    id: 'windows',
+    name: 'Windows',
+    arch: 'x64',
+    icon: <Monitor className="h-6 w-6" />,
+    requirements: ['Windows 10 (1803) or later', '64-bit processor'],
+  },
+  {
+    id: 'linux',
+    name: 'Linux',
+    arch: 'x64',
+    icon: (
+      <svg className="h-6 w-6" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12.5 2c-1.7 0-3 2.3-3 5.2 0 1.5.3 2.8.8 3.9-.8.4-1.5.9-2 1.5C7 14 6.3 16.2 6.3 18.5c0 .3 0 .6.1.9-1 .4-1.7 1-1.7 1.7 0 .5.4.9 1 1.2.7.3 1.6.5 2.6.5 1.2 0 2.3-.3 3-.7.4.1.8.2 1.2.2s.8-.1 1.2-.2c.7.4 1.8.7 3 .7 1 0 1.9-.2 2.6-.5.6-.3 1-.7 1-1.2 0-.7-.7-1.3-1.7-1.7 0-.3.1-.6.1-.9 0-2.3-.7-4.5-2-5.9-.5-.6-1.2-1.1-2-1.5.5-1.1.8-2.4.8-3.9C15.5 4.3 14.2 2 12.5 2z" />
+      </svg>
+    ),
+    requirements: ['Ubuntu 22.04+ or equivalent', '64-bit processor'],
+    note: 'AppImage format — works on most distributions.',
+  },
+]
+
+// ── OS detection ───────────────────────────────────────────────
+
+function detectPlatform(): Platform['id'] {
+  const ua = navigator.userAgent.toLowerCase()
+  if (ua.includes('mac')) return 'macos'
+  if (ua.includes('win')) return 'windows'
+  return 'linux'
+}
+
+// ── Component ──────────────────────────────────────────────────
+
+function DownloadPage() {
+  usePageMeta({
+    title: 'Download Scrollr — Free Desktop App',
+    description:
+      'Download Scrollr for macOS, Windows, or Linux. A quiet ticker at the edge of your screen with live sports, markets, news, and fantasy data.',
+    canonicalUrl: 'https://myscrollr.com/download',
+  })
+
+  const detected = detectPlatform()
+  const recommended = PLATFORMS.find((p) => p.id === detected) ?? PLATFORMS[0]
+
+  return (
+    <div className="min-h-screen bg-base-100">
+      {/* ── Hero ─────────────────────────────────────────────── */}
+      <section className="relative overflow-hidden py-24 sm:py-32">
+        <div className="mx-auto max-w-4xl px-6 text-center">
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, ease: EASE }}
+            className="text-4xl font-bold tracking-tight text-base-content sm:text-5xl"
+          >
+            Download Scrollr
+          </motion.h1>
+
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, ease: EASE, delay: 0.1 }}
+            className="mx-auto mt-6 max-w-2xl text-lg text-base-content/60"
+          >
+            A quiet ticker at the edge of your screen. Live scores, prices,
+            headlines, and fantasy data &mdash; always visible, never in the
+            way.
+          </motion.p>
+
+          {/* ── Recommended download ───────────────────────── */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, ease: EASE, delay: 0.2 }}
+            className="mt-10"
+          >
+            <a
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-center gap-3 rounded-2xl bg-primary px-8 py-4 text-lg font-semibold text-primary-content! shadow-lg transition-all duration-200 hover:brightness-110 hover:shadow-xl active:scale-[0.98]"
+            >
+              <Download className="h-5 w-5 transition-transform duration-200 group-hover:-translate-y-0.5" />
+              Download for {recommended.name}
+            </a>
+            <p className="mt-3 text-sm text-base-content/40">
+              {recommended.arch} &middot; Free &middot; Open source
+            </p>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* ── All platforms ────────────────────────────────────── */}
+      <section className="border-t border-base-content/5 py-16 sm:py-24">
+        <div className="mx-auto max-w-4xl px-6">
+          <h2 className="text-center text-2xl font-bold text-base-content sm:text-3xl">
+            All Platforms
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-center text-base-content/50">
+            Scrollr runs natively on macOS, Windows, and Linux. Pick your
+            platform below.
+          </p>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-3">
+            {PLATFORMS.map((platform, i) => (
+              <motion.a
+                key={platform.id}
+                href={RELEASES_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{
+                  duration: 0.4,
+                  ease: EASE,
+                  delay: i * 0.1,
+                }}
+                className={`group relative flex flex-col rounded-2xl border p-6 transition-all duration-200 hover:shadow-lg ${
+                  platform.id === detected
+                    ? 'border-primary/30 bg-primary/5'
+                    : 'border-base-content/10 bg-base-200/30 hover:border-base-content/20'
+                }`}
+              >
+                {platform.id === detected && (
+                  <span className="absolute -top-3 right-4 rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-content!">
+                    Recommended
+                  </span>
+                )}
+
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-base-content/5 text-base-content/60">
+                    {platform.icon}
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-base-content">
+                      {platform.name}
+                    </h3>
+                    <p className="text-sm text-base-content/40">
+                      {platform.arch}
+                    </p>
+                  </div>
+                </div>
+
+                <ul className="mt-4 flex-1 space-y-1.5">
+                  {platform.requirements.map((req) => (
+                    <li
+                      key={req}
+                      className="flex items-start gap-2 text-sm text-base-content/50"
+                    >
+                      <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary/60" />
+                      {req}
+                    </li>
+                  ))}
+                </ul>
+
+                {platform.note && (
+                  <p className="mt-3 text-xs text-base-content/35 italic">
+                    {platform.note}
+                  </p>
+                )}
+
+                <div className="mt-4 flex items-center gap-2 text-sm font-medium text-primary transition-colors group-hover:text-primary/80">
+                  <Download className="h-4 w-4" />
+                  Download
+                  <ExternalLink className="h-3 w-3 opacity-50" />
+                </div>
+              </motion.a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Details ──────────────────────────────────────────── */}
+      <section className="border-t border-base-content/5 py-16 sm:py-24">
+        <div className="mx-auto max-w-4xl px-6">
+          <div className="grid gap-12 sm:grid-cols-2">
+            <div>
+              <h3 className="text-lg font-semibold text-base-content">
+                What you get
+              </h3>
+              <ul className="mt-4 space-y-2.5">
+                {[
+                  'Real-time stock prices and crypto markets',
+                  'Live sports scores across major leagues',
+                  'RSS news feeds from your favorite sources',
+                  'Yahoo Fantasy Sports league tracking',
+                  'Automatic updates — always the latest version',
+                ].map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-start gap-2.5 text-sm text-base-content/60"
+                  >
+                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary/50" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-semibold text-base-content">
+                Privacy first
+              </h3>
+              <p className="mt-4 text-sm leading-relaxed text-base-content/60">
+                Scrollr stores your preferences locally on your device.
+                No browsing data, no analytics, no tracking. The app
+                communicates only with Scrollr&rsquo;s API servers to deliver
+                live data via Server-Sent Events.
+              </p>
+              <Link
+                to="/legal"
+                search={{ doc: 'privacy' }}
+                className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-primary/80"
+              >
+                Read our privacy policy
+                <ExternalLink className="h-3 w-3" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── GitHub CTA ───────────────────────────────────────── */}
+      <section className="border-t border-base-content/5 py-16">
+        <div className="mx-auto max-w-4xl px-6 text-center">
+          <p className="text-sm text-base-content/40">
+            Scrollr is open source under the AGPL-3.0 license.
+          </p>
+          <a
+            href={REPO}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-base-content/50 transition-colors hover:text-base-content/70"
+          >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+            </svg>
+            View on GitHub
+          </a>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/myscrollr.com/src/styles.css
+++ b/myscrollr.com/src/styles.css
@@ -593,7 +593,7 @@ pre,
      ========================================================================== */
 
   .input {
-    @apply h-10 w-full rounded-lg border border-base-300 bg-base-200/50 backdrop-blur-md px-4 py-2 text-sm transition-colors duration-200;
+    @apply h-10 w-full rounded-lg border border-base-300 bg-base-200/80 backdrop-blur-md px-4 py-2 text-sm transition-colors duration-200;
     font-family: var(--font-display);
   }
 
@@ -616,7 +616,7 @@ pre,
 
   /* Select */
   .select {
-    @apply h-10 w-full rounded-lg border border-base-300 bg-base-200/50 backdrop-blur-md px-4 py-2 text-sm transition-colors duration-200 appearance-none cursor-pointer;
+    @apply h-10 w-full rounded-lg border border-base-300 bg-base-200/80 backdrop-blur-md px-4 py-2 text-sm transition-colors duration-200 appearance-none cursor-pointer;
     font-family: var(--font-display);
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239598a8' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
     background-repeat: no-repeat;


### PR DESCRIPTION
## Summary

Rewrites the entire marketing website to reflect the desktop application product instead of the legacy browser extension.

### Landing Page Copy Rewrites
- **HeroSection**: "bottom of your browser" → "edge of your screen"
- **HowItWorks**: "Add to Chrome → Pick Channels → Browse as Usual" → "Download the App → Choose Your Data → Work as Usual"
- **FAQSection**: All 8 FAQ answers rewritten (Shadow DOM → hardware-accelerated overlay, Chrome Web Store → macOS/Windows/Linux, etc.)
- **CallToAction**: "Stop Tab-Switching" → "Stop Context-Switching", browser list → platform list
- **BenefitsSection**: "hide it on specific sites" → "minimize it"

### Visual Overhaul
- **HeroBrowserStack → HeroDesktopPreview**: Browser mockup (tabs, URL bar, extension icon) replaced with desktop workspace visual (macOS traffic lights, app title bar, 4 desktop app contexts: Music, Code, Notes, Chat)

### New Features
- **`/download` route**: OS auto-detection, 3 platform cards (macOS arm64, Windows x64, Linux x64), system requirements, Intel Mac note
- **DownloadButton**: Updated with architecture detection
- **Navigation**: Download link added to Header + Footer

### Legal Updates
- New "Desktop Application Privacy" document (7 sections)
- Updated desktop local data disclosure (added logs, widget configs, window state)
- Removed stale extension references from Cookie Policy and Acceptable Use Policy

### Files Changed
- 13 files changed, 630 insertions, 277 deletions
- 1 new file: `src/routes/download.tsx`