### PR TITLE
fix(desktop): proactive token refresh to prevent hourly sign-outs

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 
 [lib]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -46,6 +46,8 @@ export async function request<T>(
 /**
  * Authenticated request — resolves a valid token via getValidToken()
  * (handles silent refresh) and attaches it as a Bearer header.
+ *
+ * On 401, forces a token refresh and retries the request once.
  */
 export async function authFetch<T>(
   path: string,
@@ -64,6 +66,18 @@ export async function authFetch<T>(
     ...options,
     headers,
   });
+
+  // 401 retry: force a token refresh and retry the request once
+  if (response.status === 401 && token) {
+    const newToken = await getValidToken(true);
+    if (newToken && newToken !== token) {
+      const retryResponse = await fetch(`${API_BASE}${path}`, {
+        ...options,
+        headers: { ...options.headers, Authorization: `Bearer ${newToken}` },
+      });
+      return handleResponse<T>(retryResponse);
+    }
+  }
 
   return handleResponse<T>(response);
 }

--- a/desktop/src/api/queries.ts
+++ b/desktop/src/api/queries.ts
@@ -5,7 +5,7 @@
  * Every remote data fetch uses this layer — no manual fetch + useState.
  */
 import { queryOptions } from "@tanstack/react-query";
-import { isAuthenticated } from "../auth";
+import { isAuthenticated, hasRefreshToken } from "../auth";
 import { authFetch, request, rssApi } from "./client";
 import type { TrackedFeed } from "./client";
 import type { DashboardResponse } from "../types";
@@ -29,7 +29,10 @@ export const queryKeys = {
 // ── Dashboard Query ──────────────────────────────────────────────
 
 async function fetchDashboard(): Promise<DashboardResponse> {
-  if (isAuthenticated()) {
+  // Try authenticated path if token is valid OR a refresh token can restore the session.
+  // This prevents the deadlock where an expired access token blocked the only code path
+  // that could trigger a refresh via getValidToken().
+  if (isAuthenticated() || hasRefreshToken()) {
     try {
       const data = await authFetch<{
         data: DashboardResponse["data"];

--- a/desktop/src/auth.ts
+++ b/desktop/src/auth.ts
@@ -58,9 +58,14 @@ function loadAuth(): AuthState | null {
 
 function saveAuth(state: AuthState): void {
   setStore(STORAGE_KEY, state);
+  scheduleRefresh();
 }
 
 function clearAuth(): void {
+  if (refreshTimer !== null) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
   removeStore(STORAGE_KEY);
 }
 
@@ -180,6 +185,40 @@ export function getTier(): SubscriptionTier {
 // ── Concurrency guard ────────────────────────────────────────────
 
 let refreshPromise: Promise<string | null> | null = null;
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Proactively refresh the access token before it expires.
+ * Self-sustaining: on success, saveAuth() re-schedules the next refresh.
+ * On network failure, retries every 30s until auth is cleared or refresh succeeds.
+ */
+function scheduleRefresh(): void {
+  if (refreshTimer !== null) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+
+  const auth = loadAuth();
+  if (!auth || !auth.refreshToken) return;
+
+  const msUntilRefresh = auth.expiresAt - Date.now() - REFRESH_BUFFER_MS;
+
+  const performRefresh = async () => {
+    const token = await getValidToken();
+    // If refresh failed but we still have a refresh token (network error), retry in 30s
+    if (!token && loadAuth()?.refreshToken) {
+      refreshTimer = setTimeout(performRefresh, 30_000);
+    }
+    // If succeeded, saveAuth() → scheduleRefresh() was already called with new expiry
+  };
+
+  if (msUntilRefresh <= 0) {
+    // Already past the refresh point — refresh immediately
+    performRefresh();
+  } else {
+    refreshTimer = setTimeout(performRefresh, msUntilRefresh);
+  }
+}
 
 // ── Public API ───────────────────────────────────────────────────
 
@@ -277,12 +316,12 @@ export async function login(): Promise<AuthState | null> {
  * Get a valid access token, refreshing silently if near expiry.
  * Returns null if not authenticated or refresh fails.
  */
-export async function getValidToken(): Promise<string | null> {
+export async function getValidToken(forceRefresh = false): Promise<string | null> {
   const auth = loadAuth();
   if (!auth) return null;
 
-  // Token still valid (with buffer)
-  if (auth.expiresAt - Date.now() > REFRESH_BUFFER_MS) {
+  // Token still valid (with buffer) — skip if forced
+  if (!forceRefresh && auth.expiresAt - Date.now() > REFRESH_BUFFER_MS) {
     return auth.accessToken;
   }
 
@@ -314,8 +353,13 @@ async function doRefresh(refreshToken: string): Promise<string | null> {
 
     saveAuth(authState);
     return authState.accessToken;
-  } catch {
-    clearAuth();
+  } catch (err) {
+    // Only clear auth if the refresh token was explicitly rejected (4xx).
+    // Network errors preserve state so the proactive timer can retry.
+    const message = (err as Error).message ?? "";
+    if (/Token refresh failed: 4\d\d/.test(message)) {
+      clearAuth();
+    }
     return null;
   }
 }
@@ -349,3 +393,18 @@ export function getUserIdentity(): { email: string | null; name: string | null }
 export function logout(): void {
   clearAuth();
 }
+
+/**
+ * Check if a refresh token exists (even if access token is expired).
+ * Used by fetchDashboard to try the authenticated path when a refresh
+ * could restore the session.
+ */
+export function hasRefreshToken(): boolean {
+  const auth = loadAuth();
+  return auth !== null && auth.refreshToken !== null;
+}
+
+// ── Initialize proactive refresh on module load ──────────────────
+// If the app restarts with existing auth, this ensures the refresh
+// timer is set up immediately rather than waiting for the first API call.
+scheduleRefresh();

--- a/desktop/src/hooks/useAuthState.ts
+++ b/desktop/src/hooks/useAuthState.ts
@@ -70,7 +70,13 @@ export function useAuthState(): UseAuthStateReturn {
     (dashboard: DashboardResponse | undefined) => {
       if (dashboard) {
         const isAuth = checkAuth();
-        if (isAuth !== authenticatedRef.current) setAuthenticated(isAuth);
+        if (isAuth !== authenticatedRef.current) {
+          // Was authenticated and now isn't — show session expired banner
+          if (authenticatedRef.current && !isAuth) {
+            setSessionExpired(true);
+          }
+          setAuthenticated(isAuth);
+        }
         if (isAuth) setTier(getTier());
       }
     },


### PR DESCRIPTION
## Summary

- Adds a proactive refresh timer that fires before access token expiry, creating a self-sustaining refresh cycle
- Adds 401 retry logic in `authFetch` — force-refreshes the token and retries the request once
- Wires the existing session-expired banner (was dead code — `sessionExpired` was never set to `true`)
- Breaks the `fetchDashboard` deadlock where an expired access token blocked the only code path that could trigger a refresh
- Makes `doRefresh` resilient to network errors — only clears auth on 4xx (token rejected), preserves state on network failures so the timer can retry
- Bumps version to 0.9.5