### PR TITLE
fix(desktop): weather widget stays fresh regardless of page visibility

### DIFF
--- a/desktop/src/api/queries.ts
+++ b/desktop/src/api/queries.ts
@@ -182,20 +182,7 @@ export function fantasyLeaguesOptions() {
 
 // ── Weather Queries ──────────────────────────────────────────────
 
-import { searchCities, fetchWeather } from "../widgets/weather/types";
-import type { WeatherLocation, CurrentWeather } from "../widgets/weather/types";
-
-export type { WeatherLocation, CurrentWeather };
-
-export function weatherQueryOptions(lat: number, lon: number) {
-  return queryOptions({
-    queryKey: ["weather", lat, lon] as const,
-    queryFn: () => fetchWeather(lat, lon),
-    staleTime: 10 * 60 * 1000, // 10 min
-    gcTime: 30 * 60 * 1000,
-    refetchInterval: 10 * 60 * 1000, // auto-refetch every 10 min
-  });
-}
+import { searchCities } from "../widgets/weather/types";
 
 export function citySearchOptions(query: string) {
   return queryOptions({

--- a/desktop/src/hooks/useWeatherData.ts
+++ b/desktop/src/hooks/useWeatherData.ts
@@ -1,0 +1,152 @@
+/**
+ * Shell-level weather polling hook.
+ *
+ * Runs at the __root level so weather data stays fresh regardless of
+ * which page the user is viewing. Fetches from Open-Meteo every 10
+ * minutes and writes results to the Tauri store. Both the main window
+ * (WeatherFeedTab) and the ticker window (useWidgetTickerData) read
+ * from the store.
+ *
+ * Follows the same pattern as useSysmonData: module-level fetch →
+ * store write → store subscription in consumers.
+ */
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { getStore, setStore, onStoreChange } from "../lib/store";
+import { LS_WEATHER_CITIES } from "../constants";
+import type { SavedCity, CurrentWeather } from "../widgets/weather/types";
+import { fetchWeather } from "../widgets/weather/types";
+
+/** How often to poll the Open-Meteo API (ms). */
+const POLL_INTERVAL = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Fetch fresh weather for every city and write results to the store.
+ * Returns the updated city list.
+ */
+async function fetchAllWeather(cities: SavedCity[]): Promise<SavedCity[]> {
+  if (cities.length === 0) return cities;
+
+  const results = await Promise.allSettled(
+    cities.map((city) => fetchWeather(city.location.lat, city.location.lon)),
+  );
+
+  let hasChanges = false;
+  const updated = cities.map((city, i) => {
+    const result = results[i];
+    if (result.status === "fulfilled") {
+      hasChanges = true;
+      return {
+        ...city,
+        weather: result.value,
+        lastFetched: Date.now(),
+        error: undefined,
+      };
+    }
+    // On failure, keep existing weather data (don't nuke it)
+    return city;
+  });
+
+  if (hasChanges) {
+    setStore(LS_WEATHER_CITIES, updated);
+  }
+
+  return updated;
+}
+
+/**
+ * Shell-level hook that keeps weather data fresh.
+ * Call this in __root.tsx — it runs as long as weather cities exist.
+ *
+ * @param enabled - Only poll when weather widget is enabled.
+ */
+export function useWeatherData(enabled: boolean): SavedCity[] {
+  const [cities, setCities] = useState<SavedCity[]>(() =>
+    enabled ? (getStore<SavedCity[]>(LS_WEATHER_CITIES, []) ?? []) : [],
+  );
+  const mountedRef = useRef(true);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const poll = useCallback(async () => {
+    const current = getStore<SavedCity[]>(LS_WEATHER_CITIES, []) ?? [];
+    if (current.length === 0) return;
+
+    const updated = await fetchAllWeather(current);
+    if (mountedRef.current) {
+      setCities(updated);
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!enabled) {
+      setCities([]);
+      return;
+    }
+
+    // Load initial data from store
+    const initial = getStore<SavedCity[]>(LS_WEATHER_CITIES, []) ?? [];
+    setCities(initial);
+
+    // Fetch immediately if any city has stale or missing weather
+    const needsFetch = initial.some(
+      (c) => !c.weather || Date.now() - c.lastFetched > POLL_INTERVAL,
+    );
+    if (needsFetch && initial.length > 0) {
+      poll();
+    }
+
+    // Set up recurring poll
+    intervalRef.current = setInterval(poll, POLL_INTERVAL);
+
+    // Listen for store changes from FeedTab (city add/remove/manual refresh)
+    const unsubscribe = onStoreChange<SavedCity[]>(LS_WEATHER_CITIES, (next) => {
+      if (mountedRef.current) {
+        const arr = Array.isArray(next) ? next : [];
+        setCities(arr);
+      }
+    });
+
+    return () => {
+      mountedRef.current = false;
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      unsubscribe();
+    };
+  }, [enabled, poll]);
+
+  return cities;
+}
+
+/**
+ * Force an immediate weather refresh. Called by FeedTab's refresh button.
+ */
+export async function refreshWeather(): Promise<void> {
+  const cities = getStore<SavedCity[]>(LS_WEATHER_CITIES, []) ?? [];
+  await fetchAllWeather(cities);
+}
+
+/**
+ * Refresh weather for a single city by coordinates.
+ */
+export async function refreshCityWeather(lat: number, lon: number): Promise<void> {
+  const cities = getStore<SavedCity[]>(LS_WEATHER_CITIES, []) ?? [];
+  const idx = cities.findIndex(
+    (c) => c.location.lat === lat && c.location.lon === lon,
+  );
+  if (idx === -1) return;
+
+  try {
+    const weather: CurrentWeather = await fetchWeather(lat, lon);
+    const updated = [...cities];
+    updated[idx] = {
+      ...updated[idx],
+      weather,
+      lastFetched: Date.now(),
+      error: undefined,
+    };
+    setStore(LS_WEATHER_CITIES, updated);
+  } catch {
+    // Keep existing data on failure
+  }
+}

--- a/desktop/src/hooks/useWidgetTickerData.ts
+++ b/desktop/src/hooks/useWidgetTickerData.ts
@@ -4,7 +4,7 @@ import type { TempUnit } from "../preferences";
 import { fetchSysmonData } from "./useSysmonData";
 import type { SystemInfo } from "./useSysmonData";
 import { LS_CLOCK_TIMEZONES, LS_CLOCK_FORMAT, LS_TIMER_STATE, LS_WEATHER_CITIES, LS_WEATHER_UNIT, LS_UPTIME_MONITORS } from "../constants";
-import { getStore } from "../lib/store";
+import { getStore, onStoreChange } from "../lib/store";
 import { formatBytes, timeAgo } from "../utils/format";
 import { weatherCodeToIcon, weatherCodeToLabel, formatTemp } from "../widgets/weather/types";
 import { findCpuTemp, findGpuTemp } from "../widgets/sysmon/utils";
@@ -341,10 +341,18 @@ export function useWidgetTickerData(
       setData((prev) => ({ ...prev, clock: buildClockChips() }));
     }, 1000) : null;
 
-     // Weather: update every 30s (reads cached store data)
-    const weatherInterval = hasWeather ? setInterval(() => {
-      setData((prev) => ({ ...prev, weather: buildWeatherChips() }));
-    }, 30_000) : null;
+    // Weather: listen for store changes instead of polling
+    // (useWeatherData in __root.tsx writes to LS_WEATHER_CITIES on every fetch)
+    const unsubWeatherCities = hasWeather
+      ? onStoreChange<SavedCity[]>(LS_WEATHER_CITIES, () => {
+          setData((prev) => ({ ...prev, weather: buildWeatherChips() }));
+        })
+      : null;
+    const unsubWeatherUnit = hasWeather
+      ? onStoreChange<string>(LS_WEATHER_UNIT, () => {
+          setData((prev) => ({ ...prev, weather: buildWeatherChips() }));
+        })
+      : null;
 
     // Sysmon: poll Tauri IPC at the configured interval
     const sysmonMs = (widgetPrefs.sysmon.refreshInterval || 2) * 1000;
@@ -379,7 +387,8 @@ export function useWidgetTickerData(
 
     return () => {
       if (clockInterval) clearInterval(clockInterval);
-      if (weatherInterval) clearInterval(weatherInterval);
+      unsubWeatherCities?.();
+      unsubWeatherUnit?.();
       if (sysmonInterval) clearInterval(sysmonInterval);
       if (uptimeInterval) clearInterval(uptimeInterval);
       if (githubInterval) clearInterval(githubInterval);

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -50,6 +50,7 @@ import { useTheme } from "../hooks/useTheme";
 import { useAuthState } from "../hooks/useAuthState";
 import { useChannelActions } from "../hooks/useChannelActions";
 import { useWidgetActions } from "../hooks/useWidgetActions";
+import { useWeatherData } from "../hooks/useWeatherData";
 
 // Shell context
 import { ShellContext, ShellDataContext } from "../shell-context";
@@ -165,6 +166,9 @@ function RootLayout() {
   const auth = useAuthState();
   const channelActions = useChannelActions();
   const widgetActions = useWidgetActions(prefs, setPrefs, route.activeItem);
+
+  // Shell-level weather polling — keeps data fresh regardless of which page is visible
+  useWeatherData(enabledWidgets.includes("weather"));
 
   // Apply theme + UI scale
   useTheme("app-shell", prefs.appearance.theme, prefs.appearance.uiScale);

--- a/desktop/src/widgets/weather/FeedTab.tsx
+++ b/desktop/src/widgets/weather/FeedTab.tsx
@@ -1,24 +1,24 @@
 /**
  * Weather widget FeedTab — desktop-native.
  *
- * Shows current weather for user-selected cities using the
- * Open-Meteo API (free, no API key required). Cities and unit
- * preference are persisted to the Tauri store.
- *
- * Weather fetching is managed by TanStack Query (useQueries).
- * Query results are synced back to the store so the ticker
- * window can read them via cross-window sync.
+ * Pure display consumer: reads weather data from the Tauri store
+ * (kept fresh by useWeatherData in __root.tsx). City management
+ * (add/remove) writes to the store; the shell-level hook picks up
+ * changes and fetches weather for new cities automatically.
  */
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import Tooltip from "../../components/Tooltip";
-import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { CloudSun } from "lucide-react";
 import { WeatherCard } from "./WeatherCard";
 import { CitySearch } from "./CitySearch";
 import type { FeedTabProps, WidgetManifest } from "../../types";
-import type { WeatherLocation } from "./types";
+import type { WeatherLocation, SavedCity } from "./types";
 import { loadCities, saveCities, loadUnit, saveUnit } from "./types";
-import { weatherQueryOptions } from "../../api/queries";
+import { refreshCityWeather } from "../../hooks/useWeatherData";
+import { getStore } from "../../lib/store";
+import { onStoreChange } from "../../lib/store";
+import { LS_WEATHER_CITIES } from "../../constants";
+import { useEffect } from "react";
 
 // ── Widget manifest ─────────────────────────────────────────────
 
@@ -47,79 +47,60 @@ export const weatherWidget: WidgetManifest = {
 
 function WeatherFeedTab({ mode: feedMode }: FeedTabProps) {
   const compact = feedMode === "compact";
-  const queryClient = useQueryClient();
 
-   // City list is local state backed by Tauri store
-  const [cities, setCities] = useState(loadCities);
+  // City list — read from store, subscribe to cross-window updates
+  const [cities, setCities] = useState<SavedCity[]>(loadCities);
   const [unit, setUnit] = useState(loadUnit);
   const [showSearch, setShowSearch] = useState(false);
 
-  // Persist cities on change
+  // Subscribe to store changes (from useWeatherData shell hook or other window)
   useEffect(() => {
-    saveCities(cities);
-  }, [cities]);
-
-  // Fetch weather for each city using TanStack Query
-  const weatherQueries = useQueries({
-    queries: cities.map((city) => ({
-      ...weatherQueryOptions(city.location.lat, city.location.lon),
-      // Use existing weather as initial data if available and non-null
-      ...(city.weather ? { initialData: city.weather } : {}),
-    })),
-  });
-
-   // Sync query results back to cities (for store persistence)
-  useEffect(() => {
-    let hasUpdates = false;
-    const updated = cities.map((city, i) => {
-      const query = weatherQueries[i];
-      if (query?.data && query.data !== city.weather) {
-        hasUpdates = true;
-        return { ...city, weather: query.data, lastFetched: Date.now(), error: undefined };
-      }
-      if (query?.error && !city.error) {
-        hasUpdates = true;
-        return { ...city, error: "Couldn't get weather data", lastFetched: Date.now() };
-      }
-      return city;
+    const unsubscribe = onStoreChange<SavedCity[]>(LS_WEATHER_CITIES, (next) => {
+      const arr = Array.isArray(next) ? next : [];
+      setCities(arr);
     });
-    if (hasUpdates) {
-      setCities(updated);
-    }
-    // Only sync when query data actually changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [weatherQueries.map((q) => q.dataUpdatedAt).join(",")]);
+    return unsubscribe;
+  }, []);
 
-  // Add city
+  // Also refresh from store on mount (in case shell hook updated since last render)
+  useEffect(() => {
+    setCities(loadCities());
+  }, []);
+
+  // Add city — writes to store, shell hook picks up and fetches weather
   const addCity = useCallback((location: WeatherLocation) => {
     setCities((prev) => {
       const exists = prev.some(
         (c) => c.location.lat === location.lat && c.location.lon === location.lon,
       );
       if (exists) return prev;
-      return [...prev, { location, weather: null, lastFetched: 0 }];
+      const next = [...prev, { location, weather: null, lastFetched: 0 }];
+      saveCities(next);
+      return next;
     });
     setShowSearch(false);
   }, []);
 
-  // Remove city
+  // Remove city — writes to store
   const removeCity = useCallback(
     (lat: number, lon: number) => {
-      setCities((prev) =>
-        prev.filter((c) => c.location.lat !== lat || c.location.lon !== lon),
-      );
-      // Also remove from query cache
-      queryClient.removeQueries({ queryKey: ["weather", lat, lon] });
+      setCities((prev) => {
+        const next = prev.filter(
+          (c) => c.location.lat !== lat || c.location.lon !== lon,
+        );
+        saveCities(next);
+        return next;
+      });
     },
-    [queryClient],
+    [],
   );
 
-  // Refresh single city
+  // Refresh single city — fetches directly and writes to store
   const refreshCity = useCallback(
     (lat: number, lon: number) => {
-      queryClient.invalidateQueries({ queryKey: ["weather", lat, lon] });
+      refreshCityWeather(lat, lon);
     },
-    [queryClient],
+    [],
   );
 
   // Toggle unit

--- a/desktop/src/widgets/weather/types.ts
+++ b/desktop/src/widgets/weather/types.ts
@@ -92,8 +92,6 @@ export function formatWind(kmh: number, unit: TempUnit): string {
 
 // ── Storage ─────────────────────────────────────────────────────
 
-export const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
-
 export function loadCities(): SavedCity[] {
   const cities = getStore<SavedCity[]>(LS_WEATHER_CITIES, []);
   return Array.isArray(cities) && cities.length > 0 ? cities : [];


### PR DESCRIPTION
## Summary

- Weather data was only fetched when the Weather FeedTab was mounted. Navigating away stopped all fetching indefinitely.
- Extracted weather polling into a shell-level hook (`useWeatherData`) that runs in `__root.tsx` as long as the weather widget is enabled
- FeedTab is now a pure display consumer — reads from the Tauri store instead of managing TanStack Query
- Ticker window now uses `onStoreChange` listeners for `LS_WEATHER_CITIES` and `LS_WEATHER_UNIT` instead of a 30-second polling interval
- City add/remove/unit changes propagate to the ticker window immediately
- Removed dead `weatherQueryOptions` and unused `CACHE_TTL` constant

## Root Cause

Weather fetching was coupled to `useQueries` inside `WeatherFeedTab`. TanStack Query's `refetchInterval` only fires while there are active observers. When the user navigated to any other page, observer count dropped to zero, fetching stopped, and the store never updated. The ticker window read the same stale cached data forever.