### PR TITLE
fix(api): pre-fill Stripe checkout with customer email

### DIFF
--- a/api/core/auth.go
+++ b/api/core/auth.go
@@ -155,6 +155,11 @@ func ValidateAuth(c *fiber.Ctx) error {
 	}
 	c.Locals("user_roles", roles)
 
+	// Extract email from JWT claims (Logto includes it when "email" scope is requested)
+	if email, ok := claims["email"].(string); ok {
+		c.Locals("user_email", email)
+	}
+
 	return nil
 }
 

--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -114,6 +114,12 @@ func getOrCreateStripeCustomer(logtoSub, email string) (string, error) {
 		// Verify the cached customer still exists in Stripe and isn't deleted
 		c, stripeErr := stripecustomer.Get(customerID, nil)
 		if stripeErr == nil && !c.Deleted {
+			// Backfill email if the Stripe customer was created without one
+			if c.Email == "" && email != "" {
+				stripecustomer.Update(customerID, &stripe.CustomerParams{
+					Email: stripe.String(email),
+				})
+			}
 			return customerID, nil
 		}
 		// Stale, deleted, or invalid customer — purge and recreate


### PR DESCRIPTION
## Summary

- Extract `email` claim from JWT in auth middleware and set as `user_email` Fiber local
- Backfill email on existing Stripe Customers that were created without one
- Stripe embedded checkout now auto-fills the email field for logged-in users

## Problem

The auth middleware extracted `user_id` and `user_roles` from the JWT but never extracted `email`. The billing handlers read `c.Locals("user_email")` which was always empty, so Stripe Customers were created without an email. The checkout form couldn't pre-fill it.

## Changes

- `api/core/auth.go`: 3 lines — extract email from JWT `claims["email"]`, set as local
- `api/core/billing.go`: 5 lines — when returning a cached Stripe Customer, update their email if it was previously empty (backfills existing customers on next checkout)