### PR TITLE
fix(api): harden billing — trial loophole, role races, portal URL, trialing status

### DIFF
--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -156,7 +156,11 @@ func getOrCreateStripeCustomer(logtoSub, email string) (string, error) {
 // Prefers the request's Origin header so redirects always match the caller.
 func getFrontendURL(c *fiber.Ctx) string {
 	if origin := c.Get("Origin"); origin != "" {
-		return strings.TrimSuffix(origin, "/")
+		// Desktop app sends "tauri://localhost" which isn't a valid browser URL.
+		// Only use the Origin if it's an HTTP(S) URL.
+		if strings.HasPrefix(origin, "http://") || strings.HasPrefix(origin, "https://") {
+			return strings.TrimSuffix(origin, "/")
+		}
 	}
 	if url := os.Getenv("FRONTEND_URL"); url != "" {
 		return url
@@ -197,7 +201,7 @@ func HandleCreateCheckoutSession(c *fiber.Ctx) error {
 		`SELECT plan, status, lifetime FROM stripe_customers WHERE logto_sub = $1`, userID,
 	).Scan(&existingPlan, &existingStatus, &isLifetime)
 
-	if err == nil && existingPlan != "free" && existingStatus == "active" {
+	if err == nil && existingPlan != "free" && (existingStatus == "active" || existingStatus == "trialing") {
 		// Lifetime members can add an Ultimate or Pro subscription on top
 		// (Ultimate gets 50% off coupon applied below)
 		if isLifetime && (isUltimatePlan(plan) || isProPlan(plan)) {
@@ -222,6 +226,14 @@ func HandleCreateCheckoutSession(c *fiber.Ctx) error {
 
 	frontendURL := getFrontendURL(c)
 
+	// Only offer a 7-day trial to first-time subscribers.
+	// Users who have had any prior paid plan (active, canceled, or past_due) skip the trial.
+	var hadPriorSub bool
+	_ = DBPool.QueryRow(context.Background(),
+		`SELECT EXISTS(SELECT 1 FROM stripe_customers WHERE logto_sub = $1 AND plan != 'free')`,
+		userID,
+	).Scan(&hadPriorSub)
+
 	params := &stripe.CheckoutSessionParams{
 		Customer: stripe.String(customerID),
 		Mode:     stripe.String(string(stripe.CheckoutSessionModeSubscription)),
@@ -233,9 +245,11 @@ func HandleCreateCheckoutSession(c *fiber.Ctx) error {
 			},
 		},
 		ReturnURL: stripe.String(frontendURL + "/uplink?session_id={CHECKOUT_SESSION_ID}"),
-		SubscriptionData: &stripe.CheckoutSessionSubscriptionDataParams{
+	}
+	if !hadPriorSub {
+		params.SubscriptionData = &stripe.CheckoutSessionSubscriptionDataParams{
 			TrialPeriodDays: stripe.Int64(7),
-		},
+		}
 	}
 	params.AddMetadata("logto_sub", userID)
 	params.AddMetadata("plan", plan)

--- a/api/core/models.go
+++ b/api/core/models.go
@@ -101,7 +101,6 @@ type SubscriptionResponse struct {
 	Status               string     `json:"status"`
 	CurrentPeriodEnd     *time.Time `json:"current_period_end,omitempty"`
 	Lifetime             bool       `json:"lifetime"`
-	CancelURL            string     `json:"cancel_url,omitempty"`
 	PendingDowngradePlan string     `json:"pending_downgrade_plan,omitempty"`
 	ScheduledChangeAt    *time.Time `json:"scheduled_change_at,omitempty"`
 }

--- a/api/core/stripe_webhook.go
+++ b/api/core/stripe_webhook.go
@@ -28,8 +28,7 @@ func HandleStripeWebhook(c *fiber.Ctx) error {
 	payload := c.Body()
 	sigHeader := c.Get("Stripe-Signature")
 
-	event, err := webhook.ConstructEventWithOptions(payload, sigHeader, webhookSecret,
-		webhook.ConstructEventOptions{IgnoreAPIVersionMismatch: true})
+	event, err := webhook.ConstructEvent(payload, sigHeader, webhookSecret)
 	if err != nil {
 		log.Printf("[Stripe Webhook] Signature verification failed: %v", err)
 		return c.SendStatus(fiber.StatusBadRequest)
@@ -61,6 +60,8 @@ func HandleStripeWebhook(c *fiber.Ctx) error {
 		handleInvoicePaid(event)
 	case "invoice.payment_failed":
 		handleInvoicePaymentFailed(event)
+	case "customer.subscription.trial_will_end":
+		handleTrialWillEnd(event)
 	default:
 		log.Printf("[Stripe Webhook] Unhandled event type: %s", event.Type)
 	}
@@ -134,25 +135,21 @@ func handleCheckoutCompleted(event stripe.Event) {
 		}
 	}
 
-	// Assign the appropriate Logto role (async — don't block webhook response)
-	go func() {
-		if plan == "lifetime" || isUltimatePlan(plan) {
-			// Lifetime and Ultimate subscribers get uplink_ultimate role
-			if err := AssignUltimateRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)
-			}
-		} else if isProPlan(plan) {
-			// Pro subscribers get uplink_pro role
-			if err := AssignProRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to assign uplink_pro role to %s: %v", logtoSub, err)
-			}
-		} else {
-			// Standard Uplink subscribers get uplink role
-			if err := AssignUplinkRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to assign uplink role to %s: %v", logtoSub, err)
-			}
+	// Assign the appropriate Logto role synchronously to avoid race conditions
+	// with subscription.updated events that fire near-simultaneously.
+	if plan == "lifetime" || isUltimatePlan(plan) {
+		if err := AssignUltimateRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)
 		}
-	}()
+	} else if isProPlan(plan) {
+		if err := AssignProRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to assign uplink_pro role to %s: %v", logtoSub, err)
+		}
+	} else {
+		if err := AssignUplinkRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to assign uplink role to %s: %v", logtoSub, err)
+		}
+	}
 }
 
 // handleSubscriptionUpdated handles subscription changes (renewals, plan changes, cancellations).
@@ -205,27 +202,25 @@ func handleSubscriptionUpdated(event stripe.Event) {
 
 	// If subscription is active (not canceling), ensure correct role is assigned.
 	// Remove stale roles first to handle plan up/downgrades cleanly.
-	if status == "active" && !sub.CancelAtPeriodEnd {
-		go func() {
-			// Remove all paid roles, then assign only the current one
-			_ = RemoveUplinkRole(logtoSub)
-			_ = RemoveProRole(logtoSub)
-			_ = RemoveUltimateRole(logtoSub)
+	if (status == "active" || status == "trialing") && !sub.CancelAtPeriodEnd {
+		// Remove all paid roles, then assign only the current one
+		_ = RemoveUplinkRole(logtoSub)
+		_ = RemoveProRole(logtoSub)
+		_ = RemoveUltimateRole(logtoSub)
 
-			if isUltimatePlan(plan) {
-				if err := AssignUltimateRole(logtoSub); err != nil {
-					log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)
-				}
-			} else if isProPlan(plan) {
-				if err := AssignProRole(logtoSub); err != nil {
-					log.Printf("[Stripe Webhook] Failed to assign uplink_pro role to %s: %v", logtoSub, err)
-				}
-			} else {
-				if err := AssignUplinkRole(logtoSub); err != nil {
-					log.Printf("[Stripe Webhook] Failed to assign uplink role to %s: %v", logtoSub, err)
-				}
+		if isUltimatePlan(plan) {
+			if err := AssignUltimateRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)
 			}
-		}()
+		} else if isProPlan(plan) {
+			if err := AssignProRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to assign uplink_pro role to %s: %v", logtoSub, err)
+			}
+		} else {
+			if err := AssignUplinkRole(logtoSub); err != nil {
+				log.Printf("[Stripe Webhook] Failed to assign uplink role to %s: %v", logtoSub, err)
+			}
+		}
 	}
 }
 
@@ -265,17 +260,15 @@ func handleSubscriptionDeleted(event stripe.Event) {
 
 	// Remove all paid roles (only if not lifetime)
 	if !isLifetime {
-		go func() {
-			if err := RemoveUplinkRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to remove uplink role from %s: %v", logtoSub, err)
-			}
-			if err := RemoveProRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to remove uplink_pro role from %s: %v", logtoSub, err)
-			}
-			if err := RemoveUltimateRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to remove uplink_ultimate role from %s: %v", logtoSub, err)
-			}
-		}()
+		if err := RemoveUplinkRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to remove uplink role from %s: %v", logtoSub, err)
+		}
+		if err := RemoveProRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to remove uplink_pro role from %s: %v", logtoSub, err)
+		}
+		if err := RemoveUltimateRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to remove uplink_ultimate role from %s: %v", logtoSub, err)
+		}
 	}
 }
 
@@ -303,22 +296,27 @@ func handleInvoicePaid(event stripe.Event) {
 		`SELECT plan FROM stripe_customers WHERE logto_sub = $1`, logtoSub,
 	).Scan(&currentPlan)
 
-	// Ensure correct role is still assigned on successful renewal
-	go func() {
-		if isUltimatePlan(currentPlan) {
-			if err := AssignUltimateRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to re-assign uplink_ultimate role to %s: %v", logtoSub, err)
-			}
-		} else if isProPlan(currentPlan) {
-			if err := AssignProRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to re-assign uplink_pro role to %s: %v", logtoSub, err)
-			}
-		} else {
-			if err := AssignUplinkRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to re-assign uplink role to %s: %v", logtoSub, err)
-			}
+	// Ensure correct role is still assigned on successful renewal.
+	// Also reset past_due status back to active on successful payment.
+	_, _ = DBPool.Exec(context.Background(),
+		`UPDATE stripe_customers SET status = 'active', updated_at = now()
+		 WHERE logto_sub = $1 AND status = 'past_due'`,
+		logtoSub,
+	)
+
+	if isUltimatePlan(currentPlan) {
+		if err := AssignUltimateRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to re-assign uplink_ultimate role to %s: %v", logtoSub, err)
 		}
-	}()
+	} else if isProPlan(currentPlan) {
+		if err := AssignProRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to re-assign uplink_pro role to %s: %v", logtoSub, err)
+		}
+	} else {
+		if err := AssignUplinkRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to re-assign uplink role to %s: %v", logtoSub, err)
+		}
+	}
 }
 
 // handleInvoicePaymentFailed handles failed subscription payments.
@@ -346,6 +344,25 @@ func handleInvoicePaymentFailed(event stripe.Event) {
 		 WHERE logto_sub = $1 AND lifetime = false`,
 		logtoSub,
 	)
+}
+
+// handleTrialWillEnd is fired ~3 days before a trial expires.
+// Currently used for logging/monitoring. Future: send email notification.
+func handleTrialWillEnd(event stripe.Event) {
+	var sub stripe.Subscription
+	if err := json.Unmarshal(event.Data.Raw, &sub); err != nil {
+		log.Printf("[Stripe Webhook] Failed to parse trial_will_end: %v", err)
+		return
+	}
+
+	logtoSub := lookupLogtoSub(sub.Customer.ID)
+	if logtoSub == "" {
+		return
+	}
+
+	trialEnd := time.Unix(sub.TrialEnd, 0)
+	log.Printf("[Stripe Webhook] Trial ending soon for user=%s on %s (sub=%s)",
+		logtoSub, trialEnd.Format("2006-01-02"), sub.ID)
 }
 
 // lookupLogtoSub finds the Logto user ID for a Stripe customer ID.

--- a/api/migrations/000004_webhook_events_ttl.down.sql
+++ b/api/migrations/000004_webhook_events_ttl.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_webhook_events_created_at;

--- a/api/migrations/000004_webhook_events_ttl.up.sql
+++ b/api/migrations/000004_webhook_events_ttl.up.sql
@@ -1,0 +1,4 @@
+-- Add index on created_at for efficient cleanup of old webhook events.
+-- A cron job or application-level pruning should DELETE rows older than 90 days.
+CREATE INDEX IF NOT EXISTS idx_webhook_events_created_at
+    ON stripe_webhook_events (created_at);

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -214,7 +214,7 @@ export interface SubscriptionStatus {
     | 'pro_annual'
     | 'ultimate_monthly'
     | 'ultimate_annual'
-  status: 'none' | 'active' | 'canceling' | 'canceled' | 'past_due'
+  status: 'none' | 'active' | 'trialing' | 'canceling' | 'canceled' | 'past_due'
   current_period_end?: string
   lifetime: boolean
   pending_downgrade_plan?: string

--- a/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
+++ b/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
@@ -47,6 +47,7 @@ const STATUS_LABELS: Record<string, { label: string; color: string }> = {
   canceling: { label: 'Canceling', color: 'text-warning' },
   canceled: { label: 'Canceled', color: 'text-error' },
   past_due: { label: 'Past Due', color: 'text-error' },
+  trialing: { label: 'Free Trial', color: 'text-info' },
 }
 
 export default function SubscriptionStatus({
@@ -227,7 +228,9 @@ export default function SubscriptionStatus({
           <span className="text-xs text-base-content/40">
             {subscription.status === 'canceling'
               ? `Access until ${periodEnd.toLocaleDateString()}`
-              : `Renews ${periodEnd.toLocaleDateString()}`}
+              : subscription.status === 'trialing'
+                ? `Trial ends ${periodEnd.toLocaleDateString()} — billing starts after`
+                : `Renews ${periodEnd.toLocaleDateString()}`}
           </span>
         </div>
       ) : null}
@@ -279,7 +282,7 @@ export default function SubscriptionStatus({
             {openingPortal ? 'Opening...' : 'Update Payment Method'}
           </button>
         )}
-        {subscription.status === 'active' && !subscription.lifetime && (
+        {(subscription.status === 'active' || subscription.status === 'trialing') && !subscription.lifetime && (
           <>
             <button
               onClick={handleOpenPortal}


### PR DESCRIPTION
## Summary

Comprehensive billing audit fix addressing 10 issues ranked by severity.

### Critical fixes
- **Trial loophole closed**: Repeat subscribers no longer get 7-day free trial — checks subscription history before applying `trial_period_days`
- **Trial duplicate check**: Users in `trialing` status are now blocked from creating a second subscription
- **Role race conditions eliminated**: All 4 webhook handlers now assign Logto roles synchronously instead of via `go func()` goroutines

### High-priority fixes
- **Trialing status in UI**: Website billing page shows "Free Trial" label (blue) with trial end date
- **Portal return URL**: Desktop callers (`tauri://localhost` origin) now fall through to `FRONTEND_URL` instead of generating broken return URLs
- **past_due recovery**: `invoice.paid` webhook now resets `past_due` → `active`

### Medium-priority fixes
- `trial_will_end` webhook handler added (logging; future: email notification)
- Webhook event cleanup index migration (`000004_webhook_events_ttl`)
- Dead `CancelURL` field removed from `SubscriptionResponse`
- `IgnoreAPIVersionMismatch` removed from webhook signature verification

### Files changed
- `api/core/billing.go` — trial guard, duplicate check, portal URL fix
- `api/core/stripe_webhook.go` — sync roles, trialing condition, past_due reset, trial_will_end handler, strict API version
- `api/core/models.go` — removed CancelURL
- `api/migrations/000004_*` — webhook events TTL index
- `myscrollr.com/src/api/client.ts` — trialing in status union
- `myscrollr.com/src/components/billing/SubscriptionStatus.tsx` — trialing label + trial end date + actions