### PR TITLE
feat: unified billing UX across API, desktop, and website

### DIFF
--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -414,20 +414,39 @@ func HandleGetSubscription(c *fiber.Ctx) error {
 		Lifetime:         sc.Lifetime,
 	}
 
-	// Check if there's a pending downgrade via subscription schedule
+	// Fetch live subscription data from Stripe for billing details + schedule
 	if sc.StripeSubscriptionID != nil && *sc.StripeSubscriptionID != "" {
 		sub, err := stripesubscription.Get(*sc.StripeSubscriptionID, nil)
-		if err == nil && sub.Schedule != nil && sub.Schedule.ID != "" {
-			sched, err := subscriptionschedule.Get(sub.Schedule.ID, nil)
-			if err == nil && len(sched.Phases) > 1 {
-				// Phase 0 = current, Phase 1 = scheduled change
-				nextPhase := sched.Phases[1]
-				if len(nextPhase.Items) > 0 {
-					nextPlan := planFromPriceID(nextPhase.Items[0].Price.ID)
-					if nextPlan != "unknown" && planRank(nextPlan) < planRank(sc.Plan) {
-						resp.PendingDowngradePlan = nextPlan
-						changeAt := time.Unix(nextPhase.StartDate, 0)
-						resp.ScheduledChangeAt = &changeAt
+		if err == nil {
+			// Extract billing details from the subscription's current price
+			if len(sub.Items.Data) > 0 {
+				price := sub.Items.Data[0].Price
+				resp.Amount = price.UnitAmount
+				resp.Currency = string(price.Currency)
+				if price.Recurring != nil {
+					resp.Interval = string(price.Recurring.Interval)
+				}
+			}
+
+			// Extract trial end timestamp
+			if sub.TrialEnd > 0 {
+				trialEnd := sub.TrialEnd
+				resp.TrialEnd = &trialEnd
+			}
+
+			// Check for pending downgrade via subscription schedule
+			if sub.Schedule != nil && sub.Schedule.ID != "" {
+				sched, err := subscriptionschedule.Get(sub.Schedule.ID, nil)
+				if err == nil && len(sched.Phases) > 1 {
+					// Phase 0 = current, Phase 1 = scheduled change
+					nextPhase := sched.Phases[1]
+					if len(nextPhase.Items) > 0 {
+						nextPlan := planFromPriceID(nextPhase.Items[0].Price.ID)
+						if nextPlan != "unknown" && planRank(nextPlan) < planRank(sc.Plan) {
+							resp.PendingDowngradePlan = nextPlan
+							changeAt := time.Unix(nextPhase.StartDate, 0)
+							resp.ScheduledChangeAt = &changeAt
+						}
 					}
 				}
 			}

--- a/api/core/models.go
+++ b/api/core/models.go
@@ -103,6 +103,10 @@ type SubscriptionResponse struct {
 	Lifetime             bool       `json:"lifetime"`
 	PendingDowngradePlan string     `json:"pending_downgrade_plan,omitempty"`
 	ScheduledChangeAt    *time.Time `json:"scheduled_change_at,omitempty"`
+	Amount               int64      `json:"amount,omitempty"`
+	Currency             string     `json:"currency,omitempty"`
+	Interval             string     `json:"interval,omitempty"`
+	TrialEnd             *int64     `json:"trial_end,omitempty"`
 }
 
 // CheckoutReturnResponse tells the frontend about the checkout outcome.

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -151,6 +151,25 @@ export async function toggleChannelVisibility(
   await channelsApi.update(channelType, payload);
 }
 
+// ── Subscription Types & API ────────────────────────────────────
+
+export interface SubscriptionInfo {
+  plan: string;
+  status: "none" | "active" | "trialing" | "canceling" | "canceled" | "past_due";
+  current_period_end?: string;
+  lifetime: boolean;
+  pending_downgrade_plan?: string;
+  scheduled_change_at?: string;
+  amount?: number;
+  currency?: string;
+  interval?: string;
+  trial_end?: number;
+}
+
+export async function fetchSubscription(): Promise<SubscriptionInfo> {
+  return authFetch<SubscriptionInfo>("/users/me/subscription");
+}
+
 // ── RSS Types & API ─────────────────────────────────────────────
 
 export interface TrackedFeed {

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -4,22 +4,61 @@ import { TIER_LABELS, getUserIdentity } from "../../auth";
 import { authFetch } from "../../api/client";
 import { TIER_LIMITS, isUnlimited } from "../../tierLimits";
 import type { SubscriptionTier } from "../../auth";
+import type { SubscriptionInfo } from "../../api/client";
 import { Section, DisplayRow, ActionRow, ResetButton } from "./SettingsControls";
 import ConfirmDialog from "../ConfirmDialog";
 
-// ── Props ───────────────────────────────────────────────────────
+// ── Types ───────────────────────────────────────────────────────
 
 interface AccountSettingsProps {
   authenticated: boolean;
   tier: SubscriptionTier;
+  subscriptionInfo: SubscriptionInfo | null;
   onLogin: () => void;
   onLogout: () => void;
   onResetAll: () => void;
 }
 
+// ── Status helpers ──────────────────────────────────────────────
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; color: string; bg: string }
+> = {
+  none: { label: "No subscription", color: "text-fg-4", bg: "bg-fg-4/10" },
+  active: { label: "Active", color: "text-success", bg: "bg-success/10" },
+  trialing: { label: "Free Trial", color: "text-info", bg: "bg-info/10" },
+  canceling: { label: "Canceling", color: "text-warn", bg: "bg-warn/10" },
+  canceled: { label: "Canceled", color: "text-error", bg: "bg-error/10" },
+  past_due: { label: "Past Due", color: "text-error", bg: "bg-error/10" },
+};
+
+function formatAmount(amount: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+    minimumFractionDigits: 2,
+  }).format(amount / 100);
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function trialDaysRemaining(trialEnd: number): number {
+  return Math.max(0, Math.ceil((trialEnd * 1000 - Date.now()) / 86_400_000));
+}
+
+// ── Component ───────────────────────────────────────────────────
+
 export default function AccountSettings({
   authenticated,
   tier,
+  subscriptionInfo: sub,
   onLogin,
   onLogout,
   onResetAll,
@@ -36,18 +75,26 @@ export default function AccountSettings({
       setPortalError(null);
       const { url } = await authFetch<{ url: string }>(
         "/users/me/subscription/portal",
-        { method: "POST" }
+        { method: "POST" },
       );
       await open(url);
     } catch (err) {
-      setPortalError(err instanceof Error ? err.message : "Failed to open billing portal");
+      setPortalError(
+        err instanceof Error ? err.message : "Failed to open billing portal",
+      );
     } finally {
       setOpeningPortal(false);
     }
   }, []);
 
+  const status = sub?.status ?? "none";
+  const statusCfg = STATUS_CONFIG[status] ?? STATUS_CONFIG.none;
+  const hasSub = sub && sub.plan !== "free" && status !== "none";
+  const isLifetime = sub?.lifetime === true;
+
   return (
     <div>
+      {/* ── Account ──────────────────────────────────────────── */}
       <Section title="Account">
         {authenticated ? (
           <>
@@ -80,40 +127,146 @@ export default function AccountSettings({
         )}
       </Section>
 
-      {authenticated && tier !== "free" && (
+      {/* ── Subscription ─────────────────────────────────────── */}
+      {authenticated && hasSub && (
         <Section title="Subscription">
-          <div className="px-3 py-2 space-y-2">
-            <ActionRow
-              label="Manage billing, invoices & payment"
-              action={openingPortal ? "Opening..." : "Manage Subscription"}
-              actionClass="bg-accent/10 text-accent font-semibold hover:bg-accent/20"
-              onClick={handleOpenPortal}
-            />
+          <div className="px-3 py-2 space-y-2.5">
+            {/* Status badge + billing amount */}
+            <div className="flex items-center justify-between">
+              <span
+                className={`text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full ${statusCfg.color} ${statusCfg.bg}`}
+              >
+                {statusCfg.label}
+              </span>
+              {sub.amount && sub.currency && !isLifetime ? (
+                <span className="text-[11px] text-fg-3 tabular-nums">
+                  {formatAmount(sub.amount, sub.currency)}
+                  {sub.interval === "month" ? "/mo" : sub.interval === "year" ? "/yr" : ""}
+                </span>
+              ) : isLifetime ? (
+                <span className="text-[11px] text-fg-3">Lifetime access</span>
+              ) : null}
+            </div>
+
+            {/* Trial days remaining */}
+            {status === "trialing" && sub.trial_end && (
+              <p className="text-[11px] text-info">
+                {trialDaysRemaining(sub.trial_end)} days remaining in trial
+                {" \u2014 "}billing starts{" "}
+                {new Date(sub.trial_end * 1000).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                })}
+              </p>
+            )}
+
+            {/* Next billing date */}
+            {status === "active" && sub.current_period_end && !isLifetime && (
+              <p className="text-[11px] text-fg-4">
+                Renews {formatDate(sub.current_period_end)}
+              </p>
+            )}
+
+            {/* Canceling notice */}
+            {status === "canceling" && sub.current_period_end && (
+              <p className="text-[11px] text-warn">
+                Access until {formatDate(sub.current_period_end)}. After that,
+                you'll be on the Free plan.
+              </p>
+            )}
+
+            {/* Past due warning */}
+            {status === "past_due" && (
+              <p className="text-[11px] text-error">
+                Your payment failed. Update your payment method to keep your
+                plan active.
+              </p>
+            )}
+
+            {/* Canceled notice */}
+            {status === "canceled" && (
+              <p className="text-[11px] text-fg-4">
+                Your subscription has ended. Resubscribe to regain access to
+                paid features.
+              </p>
+            )}
+
+            {/* Pending downgrade */}
+            {sub.pending_downgrade_plan && sub.scheduled_change_at && (
+              <p className="text-[11px] text-warn">
+                Switching to{" "}
+                <span className="font-semibold">
+                  {sub.pending_downgrade_plan}
+                </span>{" "}
+                on {formatDate(sub.scheduled_change_at)}.
+              </p>
+            )}
+
+            {/* Action buttons */}
+            <div className="flex gap-2 pt-1">
+              {status === "past_due" && (
+                <button
+                  onClick={handleOpenPortal}
+                  disabled={openingPortal}
+                  className="flex-1 py-1.5 text-[11px] font-semibold rounded-lg bg-error/10 text-error hover:bg-error/20 transition-colors disabled:opacity-50"
+                >
+                  {openingPortal ? "Opening..." : "Update Payment"}
+                </button>
+              )}
+              {(status === "active" || status === "trialing" || status === "canceling") &&
+                !isLifetime && (
+                  <button
+                    onClick={handleOpenPortal}
+                    disabled={openingPortal}
+                    className="flex-1 py-1.5 text-[11px] font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
+                  >
+                    {openingPortal ? "Opening..." : "Manage Subscription"}
+                  </button>
+                )}
+              {status === "canceled" && (
+                <button
+                  onClick={() => open("https://myscrollr.com/uplink")}
+                  className="flex-1 py-1.5 text-[11px] font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
+                >
+                  See Plans
+                </button>
+              )}
+            </div>
+
             {portalError && (
-              <span className="text-[11px] text-error px-1">{portalError}</span>
+              <span className="text-[11px] text-error px-1">
+                {portalError}
+              </span>
             )}
           </div>
         </Section>
       )}
 
+      {/* ── Your Plan ────────────────────────────────────────── */}
       {authenticated && (
         <Section title="Your Plan">
           <TierLimitsTable tier={tier} />
-          {tier !== "uplink_ultimate" && (
+          {tier !== "uplink_ultimate" && !isLifetime && (
             <div className="px-3 pb-2">
               <button
                 onClick={() => open("https://myscrollr.com/uplink")}
                 className="w-full py-2 text-[11px] font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
               >
-                {tier === "free" ? "Upgrade to Uplink" : "Upgrade Plan"}
+                {tier === "free"
+                  ? "Upgrade to Uplink"
+                  : "Upgrade Plan"}
               </button>
             </div>
           )}
         </Section>
       )}
 
+      {/* ── Reset ────────────────────────────────────────────── */}
       <div className="flex items-center justify-end pt-2">
-        <ResetButton label="Reset all settings" onClick={() => setConfirmReset(true)} />
+        <ResetButton
+          label="Reset all settings"
+          onClick={() => setConfirmReset(true)}
+        />
       </div>
 
       <ConfirmDialog

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -43,7 +43,7 @@ import type { AppPreferences } from "../preferences";
 
 // Types
 import type { DeliveryMode } from "../types";
-import type { Channel } from "../api/client";
+import type { Channel, SubscriptionInfo } from "../api/client";
 
 // Hooks
 import { useTheme } from "../hooks/useTheme";
@@ -51,6 +51,7 @@ import { useAuthState } from "../hooks/useAuthState";
 import { useChannelActions } from "../hooks/useChannelActions";
 import { useWidgetActions } from "../hooks/useWidgetActions";
 import { weatherQueryOptions } from "../api/queries";
+import { fetchSubscription } from "../api/client";
 
 // Shell context
 import { ShellContext, ShellDataContext } from "../shell-context";
@@ -160,6 +161,7 @@ function RootLayout() {
   const [deliveryMode, setDeliveryMode] = useState<DeliveryMode>(() =>
     loadPref<DeliveryMode>("deliveryMode", "polling"),
   );
+  const [billingBannerDismissed, setBillingBannerDismissed] = useState(false);
 
   // ── Extracted hooks ─────────────────────────────────────────
 
@@ -174,6 +176,31 @@ function RootLayout() {
     ...weatherQueryOptions(),
     enabled: enabledWidgets.includes("weather"),
   });
+
+  // ── Subscription info — fetched for billing UI in Account tab + banner ──
+  const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
+
+  const refreshSubscription = useCallback(() => {
+    if (!auth.authenticated) { setSubscriptionInfo(null); return; }
+    fetchSubscription()
+      .then(setSubscriptionInfo)
+      .catch(() => setSubscriptionInfo(null));
+  }, [auth.authenticated]);
+
+  // Fetch on auth change + periodic refresh every 5 minutes
+  useEffect(() => {
+    refreshSubscription();
+    if (!auth.authenticated) return;
+    const id = setInterval(refreshSubscription, 5 * 60 * 1000);
+    return () => clearInterval(id);
+  }, [refreshSubscription]);
+
+  // Also refresh when window gains focus
+  useEffect(() => {
+    const onFocus = () => { if (auth.authenticated) refreshSubscription(); };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [auth.authenticated, refreshSubscription]);
 
   // Apply theme + UI scale
   useTheme("app-shell", prefs.appearance.theme, prefs.appearance.uiScale);
@@ -351,6 +378,7 @@ function RootLayout() {
       onPrefsChange: handlePrefsChange,
       authenticated: auth.authenticated,
       tier: auth.tier,
+      subscriptionInfo,
       onLogin: auth.handleLogin,
       onLogout: auth.handleLogout,
       autostartEnabled: autostartOn,
@@ -366,7 +394,7 @@ function RootLayout() {
       onSelectItem: handleSelectItem,
     }),
     [
-      prefs, handlePrefsChange, auth.authenticated, auth.tier,
+      prefs, handlePrefsChange, auth.authenticated, auth.tier, subscriptionInfo,
       auth.handleLogin, auth.handleLogout, autostartOn, handleAutostartChange,
       appVersion, allChannelManifests, allWidgets,
       channelActions.handleToggleChannel, widgetActions.handleToggleWidgetTicker,
@@ -431,6 +459,93 @@ function RootLayout() {
               </div>
             </div>
           )}
+
+          {/* Billing banner — trial ending, past-due, or canceling */}
+          {auth.authenticated && !billingBannerDismissed && (() => {
+            const s = subscriptionInfo;
+            if (!s) return null;
+            // Trial ending in ≤3 days
+            if (s.status === "trialing" && s.trial_end) {
+              const days = Math.max(0, Math.ceil((s.trial_end * 1000 - Date.now()) / 86_400_000));
+              if (days <= 3) {
+                return (
+                  <div className="flex items-center justify-between px-4 py-2 bg-info/10 border-b border-info/20 shrink-0">
+                    <span className="text-xs text-info">
+                      {days === 0 ? "Your trial ends today." : `Your trial ends in ${days} day${days === 1 ? "" : "s"}.`}
+                      {" "}Your card will be charged automatically.
+                    </span>
+                    <div className="flex items-center gap-2 shrink-0 ml-4">
+                      <button
+                        onClick={() => navigate({ to: "/settings", search: { tab: "account" } })}
+                        className="text-xs font-medium text-info hover:text-fg transition-colors"
+                      >
+                        View plan
+                      </button>
+                      <button
+                        onClick={() => setBillingBannerDismissed(true)}
+                        className="text-xs text-fg-4 hover:text-fg-3 transition-colors"
+                        aria-label="Dismiss"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </div>
+                );
+              }
+            }
+            // Past due
+            if (s.status === "past_due") {
+              return (
+                <div className="flex items-center justify-between px-4 py-2 bg-error/10 border-b border-error/20 shrink-0">
+                  <span className="text-xs text-error">
+                    Your payment failed. Update your payment method to keep your plan.
+                  </span>
+                  <div className="flex items-center gap-2 shrink-0 ml-4">
+                    <button
+                      onClick={() => navigate({ to: "/settings", search: { tab: "account" } })}
+                      className="text-xs font-medium text-error hover:text-fg transition-colors"
+                    >
+                      Fix payment
+                    </button>
+                    <button
+                      onClick={() => setBillingBannerDismissed(true)}
+                      className="text-xs text-fg-4 hover:text-fg-3 transition-colors"
+                      aria-label="Dismiss"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              );
+            }
+            // Canceling
+            if (s.status === "canceling") {
+              return (
+                <div className="flex items-center justify-between px-4 py-2 bg-warn/10 border-b border-warn/20 shrink-0">
+                  <span className="text-xs text-warn">
+                    Your subscription is set to cancel.
+                    {s.current_period_end && ` Access until ${new Date(s.current_period_end).toLocaleDateString("en-US", { month: "short", day: "numeric" })}.`}
+                  </span>
+                  <div className="flex items-center gap-2 shrink-0 ml-4">
+                    <button
+                      onClick={() => navigate({ to: "/settings", search: { tab: "account" } })}
+                      className="text-xs font-medium text-warn hover:text-fg transition-colors"
+                    >
+                      Manage
+                    </button>
+                    <button
+                      onClick={() => setBillingBannerDismissed(true)}
+                      className="text-xs text-fg-4 hover:text-fg-3 transition-colors"
+                      aria-label="Dismiss"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              );
+            }
+            return null;
+          })()}
 
           <div className="flex-1 overflow-y-auto scrollbar-thin" style={{ scrollbarGutter: "stable" }}>
             <ShellContext.Provider value={shellStableValue}>

--- a/desktop/src/routes/settings.tsx
+++ b/desktop/src/routes/settings.tsx
@@ -122,6 +122,7 @@ function SettingsRoute() {
           <AccountSettings
             authenticated={shell.authenticated}
             tier={shell.tier}
+            subscriptionInfo={shell.subscriptionInfo}
             onLogin={shell.onLogin}
             onLogout={shell.onLogout}
             onResetAll={handleResetAll}

--- a/desktop/src/shell-context.ts
+++ b/desktop/src/shell-context.ts
@@ -15,7 +15,7 @@
 import { createContext, useContext } from "react";
 import type { AppPreferences } from "./preferences";
 import type { SubscriptionTier } from "./auth";
-import type { ChannelType, Channel } from "./api/client";
+import type { ChannelType, Channel, SubscriptionInfo } from "./api/client";
 import type { DashboardResponse } from "./types";
 import type { ChannelManifest, WidgetManifest } from "./types";
 
@@ -26,6 +26,7 @@ export interface ShellState {
   onPrefsChange: (prefs: AppPreferences) => void;
   authenticated: boolean;
   tier: SubscriptionTier;
+  subscriptionInfo: SubscriptionInfo | null;
   onLogin: () => void;
   onLogout: () => void;
   autostartEnabled: boolean;

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -219,6 +219,10 @@ export interface SubscriptionStatus {
   lifetime: boolean
   pending_downgrade_plan?: string
   scheduled_change_at?: string
+  amount?: number
+  currency?: string
+  interval?: string
+  trial_end?: number
 }
 
 export interface CheckoutReturnStatus {

--- a/myscrollr.com/src/components/billing/CheckoutForm.tsx
+++ b/myscrollr.com/src/components/billing/CheckoutForm.tsx
@@ -4,7 +4,7 @@ import {
   EmbeddedCheckoutProvider,
 } from '@stripe/react-stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
-import { AlertTriangle, Loader2, X } from 'lucide-react'
+import { AlertTriangle, X } from 'lucide-react'
 import { billingApi } from '@/api/client'
 
 // Lazy-load Stripe once using the publishable key from env
@@ -18,7 +18,6 @@ interface CheckoutFormProps {
   isUltimate?: boolean
   getToken: () => Promise<string | null>
   onClose: () => void
-  onSuccess?: () => void
 }
 
 /**
@@ -162,16 +161,4 @@ export default function CheckoutForm({
   )
 }
 
-/**
- * CheckoutLoading renders a loading indicator while the checkout session is being created.
- */
-export function CheckoutLoading() {
-  return (
-    <div className="flex flex-col items-center justify-center gap-3 py-16">
-      <Loader2 size={24} className="animate-spin text-primary" />
-      <p className="text-xs text-base-content/40">
-        Initializing secure checkout...
-      </p>
-    </div>
-  )
-}
+

--- a/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
+++ b/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
-import { AlertTriangle, ArrowRight, Calendar, CreditCard, Crown, Infinity, Loader2 } from 'lucide-react'
-import type {SubscriptionStatus as SubStatus} from '@/api/client';
+import { AlertTriangle, ArrowRight, Calendar, Clock, CreditCard, Crown, Infinity, Loader2 } from 'lucide-react'
+import type { SubscriptionStatus as SubStatus } from '@/api/client'
 import {
   billingApi,
-  getPreferences
+  getPreferences,
 } from '@/api/client'
 
 interface SubscriptionStatusProps {
@@ -222,6 +222,13 @@ export default function SubscriptionStatus({
             Lifetime access — no expiration
           </span>
         </div>
+      ) : subscription.status === 'canceled' ? (
+        <div className="flex items-center gap-2">
+          <Calendar size={12} className="text-base-content/30" />
+          <span className="text-xs text-base-content/40">
+            Your subscription has ended. Resubscribe to restore your plan.
+          </span>
+        </div>
       ) : periodEnd ? (
         <div className="flex items-center gap-2">
           <Calendar size={12} className="text-base-content/30" />
@@ -269,8 +276,22 @@ export default function SubscriptionStatus({
         </div>
       )}
 
+      {/* Trial Days Remaining */}
+      {subscription.status === 'trialing' && subscription.trial_end && (
+        <div className="flex items-center gap-2">
+          <Clock size={12} className="text-info" />
+          <span className="text-xs text-info font-medium">
+            {(() => {
+              const days = Math.max(0, Math.ceil((subscription.trial_end * 1000 - Date.now()) / 86_400_000))
+              return `${days} day${days !== 1 ? 's' : ''} remaining in trial`
+            })()}
+          </span>
+        </div>
+      )}
+
       {/* Actions */}
       <div className="flex gap-2">
+        {/* Past due: update payment */}
         {subscription.status === 'past_due' && !subscription.lifetime && (
           <button
             onClick={handleOpenPortal}
@@ -282,6 +303,8 @@ export default function SubscriptionStatus({
             {openingPortal ? 'Opening...' : 'Update Payment Method'}
           </button>
         )}
+
+        {/* Active / Trialing: manage, change plan, cancel */}
         {(subscription.status === 'active' || subscription.status === 'trialing') && !subscription.lifetime && (
           <>
             <button
@@ -310,6 +333,42 @@ export default function SubscriptionStatus({
               {canceling ? 'Canceling...' : 'Cancel Subscription'}
             </button>
           </>
+        )}
+
+        {/* Canceling: manage (to resume) + change plan */}
+        {subscription.status === 'canceling' && !subscription.lifetime && (
+          <>
+            <button
+              onClick={handleOpenPortal}
+              disabled={openingPortal}
+              className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-base-content/10 rounded-lg
+                         text-base-content/40 hover:text-primary hover:border-primary/30 transition-colors disabled:opacity-50"
+            >
+              <CreditCard size={10} />
+              {openingPortal ? 'Opening...' : 'Resume Subscription'}
+            </button>
+            <Link
+              to="/uplink"
+              search={{ session_id: undefined }}
+              className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-base-content/10 rounded-lg
+                         text-base-content/40 hover:text-primary hover:border-primary/30 transition-colors"
+            >
+              Change Plan <ArrowRight size={10} />
+            </Link>
+          </>
+        )}
+
+        {/* Canceled: resubscribe */}
+        {subscription.status === 'canceled' && !subscription.lifetime && (
+          <Link
+            to="/uplink"
+            search={{ session_id: undefined }}
+            className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-primary/30 rounded-lg
+                       text-primary hover:bg-primary/10 transition-colors"
+          >
+            <Crown size={10} />
+            Resubscribe <ArrowRight size={10} />
+          </Link>
         )}
       </div>
     </div>

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -1148,9 +1148,9 @@ function UplinkPage() {
         >
           <CheckCircle2 size={18} className="text-success" />
           <div>
-            <p className="text-xs font-bold text-success">Uplink Activated</p>
+            <p className="text-xs font-bold text-success">{TIER_NAMES[selectedTier]} Activated</p>
             <p className="text-[10px] text-base-content/40">
-              Your subscription is active. Welcome to total coverage.
+              Your subscription is active. Welcome to {TIER_NAMES[selectedTier]}.
             </p>
           </div>
           <button
@@ -1379,7 +1379,7 @@ function UplinkPage() {
                     transition={{ delay: 1.6, duration: 0.5, ease: EASE }}
                   >
                     <span className="text-[9px] font-bold uppercase tracking-widest text-primary/70 bg-base-100/80 backdrop-blur-sm px-3 py-1 rounded-full border border-primary/15">
-                      Unlimited
+                      Ultimate
                     </span>
                   </motion.div>
                 </motion.div>
@@ -2035,10 +2035,10 @@ function UplinkPage() {
                         >
                           <div className="relative z-10">
                             <p className="text-[10px] text-primary/70 font-semibold mb-1">
-                              50% Off Unlimited — From $25.00/mo
+                              50% Off Ultimate — From $25.00/mo
                             </p>
                             <p className="text-[10px] text-base-content/35 leading-relaxed">
-                              Lifetime members get half off any Unlimited
+                              Lifetime members get half off any Ultimate
                               subscription. Real-time SSE, unlimited symbols and
                               feeds, webhooks, API access, and data export — all
                               at half price.
@@ -2651,7 +2651,7 @@ function UplinkPage() {
                           </div>
                           <div>
                             <h3 className="text-sm font-bold text-base-content">
-                              Unlimited
+                              Ultimate
                             </h3>
                             <p className="text-[11px] text-base-content/40 leading-snug mt-0.5">
                               Everything. Zero limits.
@@ -3092,7 +3092,7 @@ function UplinkPage() {
                   </span>
                 </motion.div>
                 <span className="text-xs font-bold uppercase tracking-wider text-primary inline-flex items-center gap-1.5">
-                  <Crown size={12} /> Unlimited
+                  <Crown size={12} /> Ultimate
                 </span>
               </div>
             </div>

--- a/myscrollr.com/src/routes/uplink_.lifetime.tsx
+++ b/myscrollr.com/src/routes/uplink_.lifetime.tsx
@@ -17,6 +17,7 @@ import { usePageMeta } from '@/lib/usePageMeta'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import { useGetToken } from '@/hooks/useGetToken'
 import { billingApi } from '@/api/client'
+import type { SubscriptionStatus } from '@/api/client'
 
 const CheckoutForm = lazy(() => import('@/components/billing/CheckoutForm'))
 
@@ -60,6 +61,19 @@ function LifetimePage() {
   const [showCheckout, setShowCheckout] = useState(false)
   const [checkoutSuccess, setCheckoutSuccess] = useState(false)
   const [checkingSession, setCheckingSession] = useState(false)
+  const [currentSub, setCurrentSub] = useState<SubscriptionStatus | null>(null)
+
+  // Fetch subscription status (to check for existing lifetime or active sub)
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setCurrentSub(null)
+      return
+    }
+    billingApi.getSubscription(getToken).then(setCurrentSub).catch(() => {})
+  }, [isAuthenticated, getToken, checkoutSuccess])
+
+  const isAlreadyLifetime = currentSub?.lifetime === true
+  const hasActiveSub = currentSub?.status === 'active' || currentSub?.status === 'trialing'
 
   // Handle return from Stripe checkout via ?session_id=
   useEffect(() => {
@@ -435,16 +449,37 @@ function LifetimePage() {
                   </div>
 
                   {/* Purchase button */}
-                  <button
-                    type="button"
-                    onClick={handlePurchase}
-                    className="btn btn-lg w-full gap-2.5 bg-warning/10 border-warning/30 text-warning hover:bg-warning/20 hover:border-warning/50"
-                  >
-                    <Sparkles size={14} />
-                    {isAuthenticated
-                      ? 'Purchase Lifetime Access'
-                      : 'Sign In to Purchase'}
-                  </button>
+                  {isAlreadyLifetime ? (
+                    <div className="w-full py-3 px-4 text-center text-xs font-semibold rounded-lg bg-success/10 border border-success/20 text-success">
+                      <CheckCircle2 size={14} className="inline mr-1.5 -mt-0.5" />
+                      You already have lifetime access
+                    </div>
+                  ) : hasActiveSub ? (
+                    <div className="space-y-3">
+                      <div className="py-2 px-3 text-center text-[10px] rounded-lg bg-info/10 border border-info/20 text-info/80">
+                        You have an active subscription. Purchasing lifetime will replace it.
+                      </div>
+                      <button
+                        type="button"
+                        onClick={handlePurchase}
+                        className="btn btn-lg w-full gap-2.5 bg-warning/10 border-warning/30 text-warning hover:bg-warning/20 hover:border-warning/50"
+                      >
+                        <Sparkles size={14} />
+                        Purchase Lifetime Access
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={handlePurchase}
+                      className="btn btn-lg w-full gap-2.5 bg-warning/10 border-warning/30 text-warning hover:bg-warning/20 hover:border-warning/50"
+                    >
+                      <Sparkles size={14} />
+                      {isAuthenticated
+                        ? 'Purchase Lifetime Access'
+                        : 'Sign In to Purchase'}
+                    </button>
+                  )}
 
                   {/* Trust signals */}
                   <div className="mt-6 flex items-center justify-center gap-6">


### PR DESCRIPTION
## Summary

- **API**: Extend `GET /users/me/subscription` with `amount`, `currency`, `interval`, and `trial_end` fields from the Stripe subscription object
- **Desktop**: Fetch subscription status into shell context, rewrite Account tab with status badges/billing details/action CTAs, add global billing banner for trial ≤3 days (blue), past-due (red), and canceling (yellow)
- **Website**: Fix SubscriptionStatus gaps (canceled gets resubscribe CTA, canceling gets resume/change plan, trialing shows days countdown), standardize "Unlimited" → "Ultimate" tier naming, success banner shows actual tier name, lifetime page checks existing subscription, remove dead CheckoutForm exports

## Files Changed (12)

### Go API
- `api/core/models.go` — 4 new fields on SubscriptionResponse
- `api/core/billing.go` — HandleGetSubscription extracts Stripe sub details

### Desktop
- `desktop/src/api/client.ts` — SubscriptionInfo type + fetchSubscription
- `desktop/src/shell-context.ts` — subscriptionInfo on ShellState
- `desktop/src/routes/__root.tsx` — subscription fetching, billing banner, shell context
- `desktop/src/components/settings/AccountSettings.tsx` — full rewrite with status-aware billing section
- `desktop/src/routes/settings.tsx` — passes subscriptionInfo prop

### Website
- `myscrollr.com/src/api/client.ts` — SubscriptionStatus extended with new fields
- `myscrollr.com/src/components/billing/SubscriptionStatus.tsx` — canceled/canceling/trialing fixes
- `myscrollr.com/src/components/billing/CheckoutForm.tsx` — dead code removal
- `myscrollr.com/src/routes/uplink.tsx` — naming consistency, success banner fix
- `myscrollr.com/src/routes/uplink_.lifetime.tsx` — subscription awareness