### PR TITLE
fix(api): fetch full subscription in checkout webhook to get actual status

### DIFF
--- a/api/core/stripe_webhook.go
+++ b/api/core/stripe_webhook.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/stripe/stripe-go/v82"
+	stripesubscription "github.com/stripe/stripe-go/v82/subscription"
 	"github.com/stripe/stripe-go/v82/webhook"
 )
 
@@ -116,13 +117,19 @@ func handleCheckoutCompleted(event stripe.Event) {
 			return
 		}
 	} else {
-		// Subscription — store subscription ID and actual status (may be 'trialing')
+		// Subscription — fetch the full subscription to get actual status.
+		// Webhook payloads don't expand the subscription object, so
+		// session.Subscription.Status is always empty. We must call the
+		// Stripe API to get the real status (e.g. "trialing" vs "active").
 		subID := ""
 		subStatus := "active"
 		if session.Subscription != nil {
 			subID = session.Subscription.ID
-			if session.Subscription.Status != "" {
-				subStatus = string(session.Subscription.Status)
+			fullSub, err := stripesubscription.Get(subID, nil)
+			if err == nil {
+				subStatus = string(fullSub.Status)
+			} else {
+				log.Printf("[Stripe Webhook] Failed to fetch subscription %s, defaulting to active: %v", subID, err)
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Webhook payloads don't expand the subscription object — `session.Subscription.Status` is always empty string
- This caused all new subscriptions (including trials) to be stored as `active` instead of their actual status like `trialing`
- Now fetches the full subscription via `stripesubscription.Get()` to get the real status

## After deploy

Resend the `customer.subscription.updated` webhook from Stripe Dashboard for the affected subscription to correct the existing DB record.