### PR TITLE
fix(billing): trial-aware plan changes and subscription UI text refresh

### DIFF
--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -597,6 +597,43 @@ func HandleChangePlan(c *fiber.Ctx) error {
 	}
 	periodEnd := time.Unix(periodEndUnix, 0)
 
+	// ── TRIAL: simple price swap, no proration or scheduling ─────
+	if sub.Status == stripe.SubscriptionStatusTrialing {
+		updateParams := &stripe.SubscriptionParams{
+			ProrationBehavior: stripe.String("none"),
+			Items: []*stripe.SubscriptionItemsParams{
+				{
+					ID:    stripe.String(itemID),
+					Price: stripe.String(req.PriceID),
+				},
+			},
+		}
+
+		_, err := stripesubscription.Update(*subID, updateParams)
+		if err != nil {
+			log.Printf("[Billing] Failed to switch trial plan for %s: %v", userID, err)
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error", Error: "Failed to switch plan",
+			})
+		}
+
+		// Update DB plan (status stays trialing)
+		_, _ = DBPool.Exec(context.Background(),
+			`UPDATE stripe_customers SET plan = $2, updated_at = now() WHERE logto_sub = $1`,
+			userID, newPlan,
+		)
+
+		trialEnd := time.Unix(sub.TrialEnd, 0)
+		log.Printf("[Billing] Trial plan switched for %s: %s → %s (billing starts %s)", userID, currentPlan, newPlan, trialEnd.Format(time.RFC3339))
+
+		return c.JSON(SubscriptionResponse{
+			Plan:             newPlan,
+			Status:           "trialing",
+			CurrentPeriodEnd: &trialEnd,
+			Lifetime:         false,
+		})
+	}
+
 	isUpgrade := planRank(newPlan) > planRank(currentPlan)
 
 	if isUpgrade {
@@ -776,6 +813,16 @@ func HandlePreviewPlanChange(c *fiber.Ctx) error {
 	if sub.Items == nil || len(sub.Items.Data) == 0 {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
 			Status: "error", Error: "Subscription has no items",
+		})
+	}
+
+	// Trial: no charge, just a price swap — return immediately
+	if sub.Status == stripe.SubscriptionStatusTrialing {
+		return c.JSON(PlanPreviewResponse{
+			AmountDue:     0,
+			Currency:      "usd",
+			IsTrialChange: true,
+			TrialEnd:      sub.TrialEnd,
 		})
 	}
 

--- a/api/core/models.go
+++ b/api/core/models.go
@@ -86,6 +86,8 @@ type PlanPreviewResponse struct {
 	ProrationDate int64  `json:"proration_date"`
 	IsDowngrade   bool   `json:"is_downgrade"`
 	ScheduledDate int64  `json:"scheduled_date,omitempty"`
+	IsTrialChange bool   `json:"is_trial_change,omitempty"`
+	TrialEnd      int64  `json:"trial_end,omitempty"`
 }
 
 // CheckoutResponse returns the client secret for the Payment Element.

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -92,6 +92,12 @@ export default function AccountSettings({
   const hasSub = sub && sub.plan !== "free" && status !== "none";
   const isLifetime = sub?.lifetime === true;
 
+  // Compute trial days once
+  const trialDays =
+    status === "trialing" && sub?.trial_end
+      ? trialDaysRemaining(sub.trial_end)
+      : null;
+
   return (
     <div>
       {/* ── Account ──────────────────────────────────────────── */}
@@ -102,13 +108,13 @@ export default function AccountSettings({
               <DisplayRow
                 label="Signed in as"
                 value={userLabel}
-                valueClass="text-[12px] text-fg-2 truncate max-w-[180px]"
+                valueClass="text-xs text-fg-2 truncate max-w-[180px]"
               />
             )}
             <DisplayRow
               label="Plan"
               value={TIER_LABELS[tier]}
-              valueClass="text-[12px] text-accent font-semibold"
+              valueClass="text-xs text-accent font-semibold"
             />
             <ActionRow
               label=""
@@ -130,16 +136,16 @@ export default function AccountSettings({
       {/* ── Subscription ─────────────────────────────────────── */}
       {authenticated && hasSub && (
         <Section title="Subscription">
-          <div className="px-3 py-2 space-y-2.5">
+          <div className="px-3 py-2 space-y-3">
             {/* Status badge + billing amount */}
             <div className="flex items-center justify-between">
               <span
-                className={`text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full ${statusCfg.color} ${statusCfg.bg}`}
+                className={`text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full ${statusCfg.color} ${statusCfg.bg}`}
               >
                 {statusCfg.label}
               </span>
               {sub.amount && sub.currency && !isLifetime ? (
-                <span className="text-[11px] text-fg-3 tabular-nums">
+                <span className="text-sm text-fg-3 tabular-nums">
                   {formatAmount(sub.amount, sub.currency)}
                   {sub.interval === "month" ? "/mo" : sub.interval === "year" ? "/yr" : ""}
                   {status === "trialing" && sub.trial_end
@@ -147,44 +153,45 @@ export default function AccountSettings({
                     : ""}
                 </span>
               ) : isLifetime ? (
-                <span className="text-[11px] text-fg-3">Lifetime access</span>
+                <span className="text-sm text-fg-3">Lifetime access</span>
               ) : null}
             </div>
 
-            {/* Trial days remaining + Ultimate access note */}
+            {/* Trial: consolidated days remaining + Ultimate access note */}
             {status === "trialing" && sub.trial_end && (
-              <div className="space-y-1.5">
-                <p className="text-[11px] text-info">
-                  {trialDaysRemaining(sub.trial_end)} days remaining in trial
-                </p>
-                <p className="text-[11px] text-fg-4">
-                  Your trial includes full{" "}
-                  <span className="font-semibold text-fg-3">
-                    Uplink Ultimate
-                  </span>{" "}
-                  access.
-                </p>
-              </div>
+              <p className="text-xs text-fg-4">
+                Your trial includes full{" "}
+                <span className="font-semibold text-fg-3">Uplink Ultimate</span>{" "}
+                access
+                {trialDays !== null && (
+                  <>
+                    {" · "}
+                    <span className="font-medium text-info">
+                      {trialDays} day{trialDays !== 1 ? "s" : ""} remaining
+                    </span>
+                  </>
+                )}
+              </p>
             )}
 
             {/* Next billing date */}
             {status === "active" && sub.current_period_end && !isLifetime && (
-              <p className="text-[11px] text-fg-4">
+              <p className="text-xs text-fg-4">
                 Renews {formatDate(sub.current_period_end)}
               </p>
             )}
 
             {/* Canceling notice */}
             {status === "canceling" && sub.current_period_end && (
-              <p className="text-[11px] text-warn">
+              <p className="text-xs text-warn">
                 Access until {formatDate(sub.current_period_end)}. After that,
-                you'll be on the Free plan.
+                you&apos;ll be on the Free plan.
               </p>
             )}
 
             {/* Past due warning */}
             {status === "past_due" && (
-              <p className="text-[11px] text-error">
+              <p className="text-xs text-error">
                 Your payment failed. Update your payment method to keep your
                 plan active.
               </p>
@@ -192,7 +199,7 @@ export default function AccountSettings({
 
             {/* Canceled notice */}
             {status === "canceled" && (
-              <p className="text-[11px] text-fg-4">
+              <p className="text-xs text-fg-4">
                 Your subscription has ended. Resubscribe to regain access to
                 paid features.
               </p>
@@ -200,7 +207,7 @@ export default function AccountSettings({
 
             {/* Pending downgrade */}
             {sub.pending_downgrade_plan && sub.scheduled_change_at && (
-              <p className="text-[11px] text-warn">
+              <p className="text-xs text-warn">
                 Switching to{" "}
                 <span className="font-semibold">
                   {sub.pending_downgrade_plan}
@@ -210,12 +217,12 @@ export default function AccountSettings({
             )}
 
             {/* Action buttons */}
-            <div className="flex gap-2 pt-1">
+            <div className="flex gap-2 pt-0.5">
               {status === "past_due" && (
                 <button
                   onClick={handleOpenPortal}
                   disabled={openingPortal}
-                  className="flex-1 py-1.5 text-[11px] font-semibold rounded-lg bg-error/10 text-error hover:bg-error/20 transition-colors disabled:opacity-50"
+                  className="flex-1 py-2 text-xs font-semibold rounded-lg bg-error/10 text-error hover:bg-error/20 transition-colors disabled:opacity-50"
                 >
                   {openingPortal ? "Opening..." : "Update Payment"}
                 </button>
@@ -225,7 +232,7 @@ export default function AccountSettings({
                   <button
                     onClick={handleOpenPortal}
                     disabled={openingPortal}
-                    className="flex-1 py-1.5 text-[11px] font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
+                    className="flex-1 py-2 text-xs font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
                   >
                     {openingPortal ? "Opening..." : "Manage Subscription"}
                   </button>
@@ -233,7 +240,7 @@ export default function AccountSettings({
               {status === "canceled" && (
                 <button
                   onClick={() => open("https://myscrollr.com/uplink")}
-                  className="flex-1 py-1.5 text-[11px] font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
+                  className="flex-1 py-2 text-xs font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
                 >
                   See Plans
                 </button>
@@ -241,7 +248,7 @@ export default function AccountSettings({
             </div>
 
             {portalError && (
-              <span className="text-[11px] text-error px-1">
+              <span className="text-xs text-error px-1">
                 {portalError}
               </span>
             )}
@@ -257,7 +264,7 @@ export default function AccountSettings({
             <div className="px-3 pb-2">
               <button
                 onClick={() => open("https://myscrollr.com/uplink")}
-                className="w-full py-2 text-[11px] font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
+                className="w-full py-2 text-xs font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors"
               >
                 {tier === "free"
                   ? "Upgrade to Uplink"
@@ -308,8 +315,8 @@ function TierLimitsTable({ tier }: { tier: SubscriptionTier }) {
     <div className="px-3 py-1.5 space-y-1">
       {LIMIT_ROWS.map(({ label, key }) => (
         <div key={key} className="flex items-center justify-between py-1">
-          <span className="text-[11px] text-fg-3">{label}</span>
-          <span className="text-[11px] font-medium text-fg-2 tabular-nums">
+          <span className="text-xs text-fg-3">{label}</span>
+          <span className="text-xs font-medium text-fg-2 tabular-nums">
             {isUnlimited(tier, key) ? "Unlimited" : limits[key]}
           </span>
         </div>

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -284,6 +284,8 @@ export const billingApi = {
       proration_date: number
       is_downgrade: boolean
       scheduled_date: number
+      is_trial_change?: boolean
+      trial_end?: number
     }>(
       `/users/me/subscription/preview?price_id=${encodeURIComponent(priceId)}`,
       {},

--- a/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
+++ b/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
-import { AlertTriangle, ArrowRight, Calendar, Clock, CreditCard, Crown, Infinity, Loader2, Zap } from 'lucide-react'
+import { AlertTriangle, ArrowRight, Calendar, CreditCard, Crown, Infinity, Loader2, Zap } from 'lucide-react'
 import type { SubscriptionStatus as SubStatus } from '@/api/client'
 import {
   billingApi,
@@ -60,8 +60,6 @@ export default function SubscriptionStatus({
   const [openingPortal, setOpeningPortal] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // Derive tier from both JWT-based preferences AND the plan string directly
-  // (plan updates immediately in DB, JWT roles may take a few seconds to sync)
   const isUltimate =
     tier === 'uplink_ultimate' ||
     subscription?.plan === 'ultimate_monthly' ||
@@ -123,9 +121,9 @@ export default function SubscriptionStatus({
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 py-4">
-        <Loader2 size={14} className="animate-spin text-base-content/30" />
-        <span className="text-xs text-base-content/30">
+      <div className="flex items-center gap-2 py-6">
+        <Loader2 size={16} className="animate-spin text-base-content/30" />
+        <span className="text-sm text-base-content/30">
           Loading subscription...
         </span>
       </div>
@@ -134,9 +132,9 @@ export default function SubscriptionStatus({
 
   if (error) {
     return (
-      <div className="flex items-center gap-2 py-4">
-        <AlertTriangle size={14} className="text-error" />
-        <span className="text-xs text-error">{error}</span>
+      <div className="flex items-center gap-2 py-6">
+        <AlertTriangle size={16} className="text-error" />
+        <span className="text-sm text-error">{error}</span>
       </div>
     )
   }
@@ -145,12 +143,12 @@ export default function SubscriptionStatus({
     return (
       <div className="space-y-3">
         <div className="flex items-center gap-2">
-          <Crown size={14} className="text-base-content/30" />
-          <span className="text-xs font-semibold text-base-content/40">
+          <Crown size={16} className="text-base-content/30" />
+          <span className="text-sm font-semibold text-base-content/40">
             Free Tier
           </span>
         </div>
-        <p className="text-xs text-base-content/30">
+        <p className="text-sm text-base-content/30">
           Upgrade to Uplink for faster polling, or Uplink Ultimate for real-time SSE.
         </p>
       </div>
@@ -160,6 +158,11 @@ export default function SubscriptionStatus({
   const statusInfo = STATUS_LABELS[subscription.status] || STATUS_LABELS.none
   const periodEnd = subscription.current_period_end
     ? new Date(subscription.current_period_end)
+    : null
+
+  // Compute trial days once
+  const trialDays = subscription.status === 'trialing' && subscription.trial_end
+    ? Math.max(0, Math.ceil((subscription.trial_end * 1000 - Date.now()) / 86_400_000))
     : null
 
   return (
@@ -178,7 +181,7 @@ export default function SubscriptionStatus({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Crown
-            size={14}
+            size={16}
             className={
               isUltimate
                 ? 'text-primary unlimited-dot-glow rounded-full'
@@ -186,14 +189,14 @@ export default function SubscriptionStatus({
             }
           />
           <span
-            className={`text-xs font-semibold text-primary ${isUltimate ? 'unlimited-text-glow' : ''}`}
+            className={`text-sm font-semibold text-primary ${isUltimate ? 'unlimited-text-glow' : ''}`}
           >
             {isUltimate ? 'Uplink Ultimate' : isPro ? 'Uplink Pro' : 'Uplink'}{' '}
             {PLAN_LABELS[subscription.plan] || subscription.plan}
           </span>
         </div>
         <span
-          className={`text-[10px] font-semibold uppercase tracking-wide ${statusInfo.color}`}
+          className={`text-xs font-semibold uppercase tracking-wide ${statusInfo.color}`}
         >
           {statusInfo.label}
         </span>
@@ -202,8 +205,8 @@ export default function SubscriptionStatus({
       {/* Billing Price */}
       {PLAN_PRICES[subscription.plan] && (
         <div className="flex items-center gap-2">
-          <CreditCard size={12} className="text-base-content/30" />
-          <span className="text-xs text-base-content/40">
+          <CreditCard size={14} className="text-base-content/30" />
+          <span className="text-sm text-base-content/50">
             {PLAN_PRICES[subscription.plan]}
             {subscription.plan.includes('monthly')
               ? ' · Monthly billing'
@@ -217,12 +220,15 @@ export default function SubscriptionStatus({
         </div>
       )}
 
-      {/* Trial: full Ultimate access note */}
+      {/* Trial: full Ultimate access + days remaining (consolidated) */}
       {subscription.status === 'trialing' && (
-        <div className="flex items-center gap-2 py-2 px-3 bg-info/5 border border-info/15 rounded-lg">
-          <Zap size={12} className="text-info shrink-0" />
-          <span className="text-[10px] text-base-content/50">
-            Your trial includes full <span className="font-semibold text-base-content/70">Uplink Ultimate</span> access.
+        <div className="flex items-center gap-2 py-2.5 px-3 bg-info/5 border border-info/15 rounded-lg">
+          <Zap size={14} className="text-info shrink-0" />
+          <span className="text-xs text-base-content/50">
+            Your trial includes full <span className="font-semibold text-base-content/70">Uplink Ultimate</span> access
+            {trialDays !== null && (
+              <> · <span className="font-medium text-info">{trialDays} day{trialDays !== 1 ? 's' : ''} remaining</span></>
+            )}
           </span>
         </div>
       )}
@@ -230,26 +236,26 @@ export default function SubscriptionStatus({
       {/* Period End / Lifetime */}
       {subscription.lifetime ? (
         <div className="flex items-center gap-2">
-          <Infinity size={12} className="text-base-content/30" />
-          <span className="text-xs text-base-content/40">
+          <Infinity size={14} className="text-base-content/30" />
+          <span className="text-sm text-base-content/40">
             Lifetime access — no expiration
           </span>
         </div>
       ) : subscription.status === 'canceled' ? (
         <div className="flex items-center gap-2">
-          <Calendar size={12} className="text-base-content/30" />
-          <span className="text-xs text-base-content/40">
+          <Calendar size={14} className="text-base-content/30" />
+          <span className="text-sm text-base-content/40">
             Your subscription has ended. Resubscribe to restore your plan.
           </span>
         </div>
       ) : periodEnd ? (
         <div className="flex items-center gap-2">
-          <Calendar size={12} className="text-base-content/30" />
-          <span className="text-xs text-base-content/40">
+          <Calendar size={14} className="text-base-content/30" />
+          <span className="text-sm text-base-content/40">
             {subscription.status === 'canceling'
               ? `Access until ${periodEnd.toLocaleDateString()}`
               : subscription.status === 'trialing'
-                ? `Trial ends ${periodEnd.toLocaleDateString()} — billing starts after`
+                ? `Trial ends ${periodEnd.toLocaleDateString()}`
                 : `Renews ${periodEnd.toLocaleDateString()}`}
           </span>
         </div>
@@ -258,9 +264,9 @@ export default function SubscriptionStatus({
       {/* Pending Downgrade Notice */}
       {subscription.pending_downgrade_plan &&
         subscription.scheduled_change_at && (
-          <div className="flex items-center gap-2 py-2 px-3 bg-warning/5 border border-warning/15 rounded-lg">
-            <AlertTriangle size={12} className="text-warning shrink-0" />
-            <span className="text-[10px] text-base-content/50">
+          <div className="flex items-center gap-2 py-2.5 px-3 bg-warning/5 border border-warning/15 rounded-lg">
+            <AlertTriangle size={14} className="text-warning shrink-0" />
+            <span className="text-xs text-base-content/50">
               Switching to{' '}
               <span className="font-semibold text-base-content/70">
                 {DOWNGRADE_PLAN_NAMES[subscription.pending_downgrade_plan] ||
@@ -281,23 +287,10 @@ export default function SubscriptionStatus({
 
       {/* Past Due Warning */}
       {subscription.status === 'past_due' && (
-        <div className="flex items-center gap-2 p-2.5 rounded-lg bg-error/10 border border-error/20">
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-error/10 border border-error/20">
           <AlertTriangle size={14} className="text-error shrink-0" />
-          <span className="text-[10px] text-error/80">
+          <span className="text-xs text-error/80">
             Your payment failed. Update your payment method to avoid service interruption.
-          </span>
-        </div>
-      )}
-
-      {/* Trial Days Remaining */}
-      {subscription.status === 'trialing' && subscription.trial_end && (
-        <div className="flex items-center gap-2">
-          <Clock size={12} className="text-info" />
-          <span className="text-xs text-info font-medium">
-            {(() => {
-              const days = Math.max(0, Math.ceil((subscription.trial_end * 1000 - Date.now()) / 86_400_000))
-              return `${days} day${days !== 1 ? 's' : ''} remaining in trial`
-            })()}
           </span>
         </div>
       )}
@@ -309,10 +302,10 @@ export default function SubscriptionStatus({
           <button
             onClick={handleOpenPortal}
             disabled={openingPortal}
-            className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-error/30 rounded-lg
+            className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-semibold border border-error/30 rounded-lg
                        text-error hover:bg-error/10 transition-colors disabled:opacity-50"
           >
-            <CreditCard size={10} />
+            <CreditCard size={12} />
             {openingPortal ? 'Opening...' : 'Update Payment Method'}
           </button>
         )}
@@ -323,24 +316,24 @@ export default function SubscriptionStatus({
             <button
               onClick={handleOpenPortal}
               disabled={openingPortal}
-              className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-base-content/10 rounded-lg
+              className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-semibold border border-base-content/10 rounded-lg
                          text-base-content/40 hover:text-primary hover:border-primary/30 transition-colors disabled:opacity-50"
             >
-              <CreditCard size={10} />
+              <CreditCard size={12} />
               {openingPortal ? 'Opening...' : 'Manage Subscription'}
             </button>
             <Link
               to="/uplink"
               search={{ session_id: undefined }}
-              className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-base-content/10 rounded-lg
+              className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-semibold border border-base-content/10 rounded-lg
                          text-base-content/40 hover:text-primary hover:border-primary/30 transition-colors"
             >
-              Change Plan <ArrowRight size={10} />
+              Change Plan <ArrowRight size={12} />
             </Link>
             <button
               onClick={handleCancel}
               disabled={canceling}
-              className="flex-1 py-2 text-[10px] font-semibold border border-base-content/10 rounded-lg
+              className="flex-1 py-2.5 text-xs font-semibold border border-base-content/10 rounded-lg
                          text-base-content/30 hover:text-error hover:border-error/30 transition-colors disabled:opacity-50"
             >
               {canceling ? 'Canceling...' : 'Cancel Subscription'}
@@ -354,19 +347,19 @@ export default function SubscriptionStatus({
             <button
               onClick={handleOpenPortal}
               disabled={openingPortal}
-              className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-base-content/10 rounded-lg
+              className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-semibold border border-base-content/10 rounded-lg
                          text-base-content/40 hover:text-primary hover:border-primary/30 transition-colors disabled:opacity-50"
             >
-              <CreditCard size={10} />
+              <CreditCard size={12} />
               {openingPortal ? 'Opening...' : 'Resume Subscription'}
             </button>
             <Link
               to="/uplink"
               search={{ session_id: undefined }}
-              className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-base-content/10 rounded-lg
+              className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-semibold border border-base-content/10 rounded-lg
                          text-base-content/40 hover:text-primary hover:border-primary/30 transition-colors"
             >
-              Change Plan <ArrowRight size={10} />
+              Change Plan <ArrowRight size={12} />
             </Link>
           </>
         )}
@@ -376,11 +369,11 @@ export default function SubscriptionStatus({
           <Link
             to="/uplink"
             search={{ session_id: undefined }}
-            className="flex-1 flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold border border-primary/30 rounded-lg
+            className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-semibold border border-primary/30 rounded-lg
                        text-primary hover:bg-primary/10 transition-colors"
           >
-            <Crown size={10} />
-            Resubscribe <ArrowRight size={10} />
+            <Crown size={12} />
+            Resubscribe <ArrowRight size={12} />
           </Link>
         )}
       </div>

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -897,6 +897,8 @@ function UplinkPage() {
     prorationDate: number
     isDowngrade: boolean
     scheduledDate: number
+    isTrialChange: boolean
+    trialEnd: number
   } | null>(null)
   const isLifetime = billingView === 'lifetime'
   const billingPeriod: PlanKey = isLifetime ? 'annual' : billingView
@@ -973,6 +975,8 @@ function UplinkPage() {
           prorationDate: preview.proration_date,
           isDowngrade: preview.is_downgrade,
           scheduledDate: preview.scheduled_date,
+          isTrialChange: preview.is_trial_change ?? false,
+          trialEnd: preview.trial_end ?? 0,
         })
       } catch (err) {
         setPlanChangeError(
@@ -1072,12 +1076,40 @@ function UplinkPage() {
             className="relative w-full max-w-sm mx-4 bg-base-200 border border-base-content/10 rounded-xl p-6"
           >
             <h3 className="text-sm font-semibold text-base-content/80 mb-4">
-              {pendingChange.isDowngrade ? 'Downgrade' : 'Upgrade'} to{' '}
+              {pendingChange.isTrialChange
+                ? 'Switch to'
+                : pendingChange.isDowngrade
+                  ? 'Downgrade to'
+                  : 'Upgrade to'}{' '}
               {TIER_NAMES[pendingChange.tier]}
             </h3>
 
             <div className="space-y-3 mb-6">
-              {pendingChange.isDowngrade ? (
+              {pendingChange.isTrialChange ? (
+                <>
+                  <p className="text-xs text-base-content/50">
+                    No charge during your trial. Your plan will switch to{' '}
+                    <span className="font-semibold text-base-content/80">
+                      {TIER_NAMES[pendingChange.tier]}
+                    </span>{' '}
+                    and billing starts{' '}
+                    <span className="font-semibold text-base-content/80">
+                      {new Date(
+                        pendingChange.trialEnd * 1000,
+                      ).toLocaleDateString('en-US', {
+                        month: 'long',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </span>
+                    .
+                  </p>
+                  <p className="text-[10px] text-base-content/30">
+                    You&rsquo;ll keep full Uplink Ultimate access until your
+                    trial ends.
+                  </p>
+                </>
+              ) : pendingChange.isDowngrade ? (
                 <>
                   <p className="text-xs text-base-content/50">
                     Your {activeTier ? TIER_NAMES[activeTier] : ''} access
@@ -1134,9 +1166,11 @@ function UplinkPage() {
               >
                 {planChanging
                   ? 'Processing...'
-                  : pendingChange.isDowngrade
-                    ? 'Confirm Downgrade'
-                    : 'Confirm Upgrade'}
+                  : pendingChange.isTrialChange
+                    ? 'Switch Plan'
+                    : pendingChange.isDowngrade
+                      ? 'Confirm Downgrade'
+                      : 'Confirm Upgrade'}
               </button>
             </div>
           </motion.div>


### PR DESCRIPTION
## Summary

- **Trial plan changes**: During a free trial, switching plans now does a simple price swap with no proration or scheduling. No charge occurs until the trial ends. Fixes the bug where the confirmation modal incorrectly showed "charged today" and where downgrades created broken subscription schedules.
- **Trial-aware confirmation modal**: Shows "No charge during your trial. Billing starts [date]." with a "Switch Plan" button instead of upgrade/downgrade language.
- **Subscription UI text refresh**: Bumped text sizes across both website `SubscriptionStatus` and desktop `AccountSettings` (from `text-[10px]`/`text-[11px]` to `text-xs`/`text-sm`). Consolidated trial info into single notes instead of separate sections.

## Files Changed (6)
- `api/core/models.go` — Added `IsTrialChange` + `TrialEnd` to `PlanPreviewResponse`
- `api/core/billing.go` — Trial branch in `HandleChangePlan` + `HandlePreviewPlanChange`
- `myscrollr.com/src/api/client.ts` — Added `is_trial_change` + `trial_end` to preview type
- `myscrollr.com/src/routes/uplink.tsx` — Trial-aware confirmation modal
- `myscrollr.com/src/components/billing/SubscriptionStatus.tsx` — Text size bump + layout consolidation
- `desktop/src/components/settings/AccountSettings.tsx` — Text size bump + layout consolidation