### PR TITLE
fix(billing): trial cancel UX — retention modal and trial-aware labels

### DIFF
--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -135,7 +135,7 @@ export default function AccountSettings({
 
       {/* ── Subscription ─────────────────────────────────────── */}
       {authenticated && hasSub && (
-        <Section title="Subscription">
+        <Section title={status === "trialing" ? "Free Trial" : "Subscription"}>
           <div className="px-3 py-2 space-y-3">
             {/* Status badge + billing amount */}
             <div className="flex items-center justify-between">
@@ -234,7 +234,11 @@ export default function AccountSettings({
                     disabled={openingPortal}
                     className="flex-1 py-2 text-xs font-semibold rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
                   >
-                    {openingPortal ? "Opening..." : "Manage Subscription"}
+                    {openingPortal
+                      ? "Opening..."
+                      : status === "trialing"
+                        ? "Manage Trial"
+                        : "Manage Subscription"}
                   </button>
                 )}
               {status === "canceled" && (

--- a/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
+++ b/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
-import { AlertTriangle, ArrowRight, Calendar, CreditCard, Crown, Infinity, Loader2, Zap } from 'lucide-react'
+import { AlertTriangle, ArrowRight, Calendar, CreditCard, Crown, Infinity, Loader2, ShieldAlert, Zap } from 'lucide-react'
 import type { SubscriptionStatus as SubStatus } from '@/api/client'
 import {
   billingApi,
@@ -59,6 +59,7 @@ export default function SubscriptionStatus({
   const [canceling, setCanceling] = useState(false)
   const [openingPortal, setOpeningPortal] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [showCancelModal, setShowCancelModal] = useState(false)
 
   const isUltimate =
     tier === 'uplink_ultimate' ||
@@ -100,16 +101,10 @@ export default function SubscriptionStatus({
     }
   }
 
-  async function handleCancel() {
-    if (
-      !confirm(
-        'Are you sure you want to cancel? You will keep access until the end of your billing period.',
-      )
-    ) {
-      return
-    }
+  async function handleConfirmCancel() {
     try {
       setCanceling(true)
+      setShowCancelModal(false)
       await billingApi.cancelSubscription(getToken)
       await loadSubscription()
     } catch (err) {
@@ -118,6 +113,8 @@ export default function SubscriptionStatus({
       setCanceling(false)
     }
   }
+
+  const isTrialing = subscription?.status === 'trialing'
 
   if (loading) {
     return (
@@ -331,12 +328,12 @@ export default function SubscriptionStatus({
               Change Plan <ArrowRight size={12} />
             </Link>
             <button
-              onClick={handleCancel}
+              onClick={() => setShowCancelModal(true)}
               disabled={canceling}
               className="flex-1 py-2.5 text-xs font-semibold border border-base-content/10 rounded-lg
                          text-base-content/30 hover:text-error hover:border-error/30 transition-colors disabled:opacity-50"
             >
-              {canceling ? 'Canceling...' : 'Cancel Subscription'}
+              {canceling ? 'Canceling...' : isTrialing ? 'Cancel Trial' : 'Cancel Subscription'}
             </button>
           </>
         )}
@@ -377,6 +374,68 @@ export default function SubscriptionStatus({
           </Link>
         )}
       </div>
+
+      {/* ── Cancel Retention Modal ──────────────────────────── */}
+      {showCancelModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
+          <div className="relative w-full max-w-sm mx-4 bg-base-200 border border-base-content/10 rounded-xl p-6 space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-full bg-error/10 flex items-center justify-center">
+                <ShieldAlert size={20} className="text-error" />
+              </div>
+              <h3 className="text-sm font-semibold text-base-content/80">
+                {isTrialing ? 'Cancel your free trial?' : 'Cancel your subscription?'}
+              </h3>
+            </div>
+
+            <div className="space-y-3 text-xs text-base-content/50 leading-relaxed">
+              {isTrialing ? (
+                <>
+                  <p>
+                    If you cancel now, you&apos;ll lose access to all premium features
+                    immediately &mdash; including real-time data, higher limits, and
+                    Uplink Ultimate access.
+                  </p>
+                  <p className="font-semibold text-base-content/70">
+                    This is the only free trial offered per account. Once canceled,
+                    you&apos;ll need to purchase a paid plan to access premium features
+                    again.
+                  </p>
+                  <p>Your card has not been charged and won&apos;t be if you cancel.</p>
+                </>
+              ) : (
+                <>
+                  <p>
+                    You&apos;ll keep access until the end of your current billing period,
+                    then your account will revert to the Free plan.
+                  </p>
+                  <p>
+                    On the Free plan, you&apos;ll have reduced limits and 60-second polling
+                    instead of real-time data.
+                  </p>
+                </>
+              )}
+            </div>
+
+            <div className="flex gap-2 pt-1">
+              <button
+                onClick={() => setShowCancelModal(false)}
+                className="flex-1 py-2.5 text-xs font-semibold border border-primary/30 rounded-lg
+                           text-primary hover:bg-primary/10 transition-colors"
+              >
+                {isTrialing ? 'Keep My Trial' : 'Keep My Plan'}
+              </button>
+              <button
+                onClick={handleConfirmCancel}
+                className="flex-1 py-2.5 text-xs font-semibold border border-error/30 rounded-lg
+                           text-error/60 hover:text-error hover:bg-error/10 transition-colors"
+              >
+                {isTrialing ? 'Cancel Trial' : 'Cancel Subscription'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -30,6 +30,7 @@ import {
   Rocket,
   Rss,
   Satellite,
+  ShieldAlert,
   Sparkles,
   TrendingUp,
   Trophy,
@@ -887,6 +888,8 @@ function UplinkPage() {
   const [currentSub, setCurrentSub] = useState<SubscriptionStatus | null>(null)
   const [planChanging, setPlanChanging] = useState(false)
   const [planChangeError, setPlanChangeError] = useState<string | null>(null)
+  const [showTrialCancelModal, setShowTrialCancelModal] = useState(false)
+  const [trialCanceling, setTrialCanceling] = useState(false)
   const [loadingPreview, setLoadingPreview] = useState(false)
   const [pendingChange, setPendingChange] = useState<{
     tier: TierKey
@@ -1177,28 +1180,96 @@ function UplinkPage() {
         </div>
       )}
 
-      {/* ── Checkout Success Banner ─────────────────────────── */}
-      {checkoutSuccess && (
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="fixed top-24 left-1/2 -translate-x-1/2 z-40 px-6 py-4 bg-success/10 border border-success/30 rounded-lg backdrop-blur-sm flex items-center gap-3"
-        >
-          <CheckCircle2 size={18} className="text-success" />
-          <div>
-            <p className="text-xs font-bold text-success">{TIER_NAMES[selectedTier]} Activated</p>
-            <p className="text-[10px] text-base-content/40">
-              Your subscription is active. Welcome to {TIER_NAMES[selectedTier]}.
-            </p>
-          </div>
-          <button
-            onClick={() => setCheckoutSuccess(false)}
-            className="ml-4 text-base-content/30 hover:text-base-content/60 transition-colors text-xs"
+      {/* ── Trial Cancel Retention Modal ──────────────────────── */}
+      {showTrialCancelModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className="relative w-full max-w-sm mx-4 bg-base-200 border border-base-content/10 rounded-xl p-6 space-y-4"
           >
-            \u2715
-          </button>
-        </motion.div>
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-full bg-error/10 flex items-center justify-center">
+                <ShieldAlert size={20} className="text-error" />
+              </div>
+              <h3 className="text-sm font-semibold text-base-content/80">
+                Cancel your free trial?
+              </h3>
+            </div>
+
+            <div className="space-y-3 text-xs text-base-content/50 leading-relaxed">
+              <p>
+                If you cancel now, you&apos;ll lose access to all premium features
+                immediately &mdash; including real-time data, higher limits, and
+                Uplink Ultimate access.
+              </p>
+              <p className="font-semibold text-base-content/70">
+                This is the only free trial offered per account. Once canceled,
+                you&apos;ll need to purchase a paid plan to access premium features again.
+              </p>
+              <p>Your card has not been charged and won&apos;t be if you cancel.</p>
+            </div>
+
+            <div className="flex gap-2 pt-1">
+              <button
+                onClick={() => setShowTrialCancelModal(false)}
+                className="flex-1 py-2.5 text-xs font-semibold border border-primary/30 rounded-lg
+                           text-primary hover:bg-primary/10 transition-colors"
+              >
+                Keep My Trial
+              </button>
+              <button
+                onClick={async () => {
+                  setTrialCanceling(true)
+                  setShowTrialCancelModal(false)
+                  try {
+                    await billingApi.cancelSubscription(getToken)
+                    const sub = await billingApi.getSubscription(getToken)
+                    setCurrentSub(sub)
+                  } catch {
+                    setPlanChangeError('Failed to cancel trial')
+                  } finally {
+                    setTrialCanceling(false)
+                  }
+                }}
+                className="flex-1 py-2.5 text-xs font-semibold border border-error/30 rounded-lg
+                           text-error/60 hover:text-error hover:bg-error/10 transition-colors"
+              >
+                Cancel Trial
+              </button>
+            </div>
+          </motion.div>
+        </div>
       )}
+
+      {/* ── Checkout Success Banner ─────────────────────────── */}
+      {checkoutSuccess && (() => {
+        const subTier = currentSub ? tierFromPlan(currentSub.plan) : null
+        const tierName = subTier ? TIER_NAMES[subTier] : 'Uplink'
+        return (
+          <motion.div
+            initial={{ opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="fixed top-24 left-1/2 -translate-x-1/2 z-40 px-6 py-4 bg-success/10 border border-success/30 rounded-lg backdrop-blur-sm flex items-center gap-3"
+          >
+            <CheckCircle2 size={18} className="text-success" />
+            <div>
+              <p className="text-xs font-bold text-success">{tierName} Activated</p>
+              <p className="text-[10px] text-base-content/40">
+                {currentSub?.status === 'trialing'
+                  ? `Your 7-day free trial is active. Enjoy full Uplink Ultimate access.`
+                  : `Your subscription is active. Welcome to ${tierName}.`}
+              </p>
+            </div>
+            <button
+              onClick={() => setCheckoutSuccess(false)}
+              className="ml-4 text-base-content/30 hover:text-base-content/60 transition-colors text-xs"
+            >
+              &times;
+            </button>
+          </motion.div>
+        )
+      })()}
 
       {/* ── Plan Change Error Banner ──────────────────────────── */}
       {planChangeError && (
@@ -2169,15 +2240,11 @@ function UplinkPage() {
                         {isTrialing ? (
                           <>
                             <button
-                              onClick={() =>
-                                billingApi
-                                  .cancelSubscription(getToken)
-                                  .then(() => billingApi.getSubscription(getToken))
-                                  .then(setCurrentSub)
-                              }
-                              className="block w-full py-2.5 text-center text-[10px] font-semibold border border-error/30 text-error/60 rounded-lg hover:border-error/50 hover:text-error/80 transition-colors cursor-pointer"
+                              onClick={() => setShowTrialCancelModal(true)}
+                              disabled={trialCanceling}
+                              className="block w-full py-2.5 text-center text-[10px] font-semibold border border-error/30 text-error/60 rounded-lg hover:border-error/50 hover:text-error/80 transition-colors cursor-pointer disabled:opacity-50"
                             >
-                              Cancel Trial
+                              {trialCanceling ? 'Canceling...' : 'Cancel Trial'}
                             </button>
                             <span className="text-[9px] text-base-content/20">
                               You won&apos;t be charged


### PR DESCRIPTION
## Summary
- **Success banner fix**: Uses actual subscription plan name from `currentSub` instead of `selectedTier` default (was always showing "Uplink Activated" regardless of tier, and close button used unicode literal that could render oddly)
- **Trial cancel retention modal** (website): Replaces browser `confirm()` with a proper modal warning that this is the only free trial per account, premium features are lost immediately, and they'll need to pay going forward. "Keep My Trial" (primary) vs "Cancel Trial" (destructive) buttons.
- **Pricing page**: Cancel Trial button on Free card now triggers the same retention modal instead of canceling inline
- **Website account page**: "Cancel Subscription" → "Cancel Trial" when status is `trialing`
- **Desktop account page**: Section title "Subscription" → "Free Trial", button "Manage Subscription" → "Manage Trial" when trialing

## Files Changed
- `myscrollr.com/src/routes/uplink.tsx` — success banner fix, trial cancel modal, ShieldAlert import
- `myscrollr.com/src/components/billing/SubscriptionStatus.tsx` — cancel button text, retention modal, ShieldAlert import
- `desktop/src/components/settings/AccountSettings.tsx` — trial-aware section title and button label