### PR TITLE
fix(desktop): sync tier from subscription status — force token refresh on mismatch

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -269,19 +269,34 @@ export default function App() {
       const isAuth = checkAuth();
       setAuthenticated(isAuth);
 
-      if (isAuth && !wasAuth) {
-        // Just logged in — update tier (drives refetchInterval)
-        const newTier = getTier();
-        setTier(newTier);
-        tierRef.current = newTier;
-        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
-        if (newTier === "uplink_ultimate") startSSE();
-      } else if (!isAuth && wasAuth) {
+      if (!isAuth && wasAuth) {
         // Just logged out — tear down SSE, reset to free tier
         if (sseActiveRef.current) stopSSE();
         setTier("free");
         tierRef.current = "free";
         queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        return;
+      }
+
+      if (isAuth) {
+        // Re-read tier on every auth store change (login OR token refresh).
+        // A forced refresh after subscription change writes new roles to the JWT.
+        const newTier = getTier();
+        const oldTier = tierRef.current;
+        setTier(newTier);
+        tierRef.current = newTier;
+
+        if (!wasAuth) {
+          // Fresh login — invalidate dashboard
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        }
+
+        // Start/stop SSE based on tier change
+        if (newTier === "uplink_ultimate" && oldTier !== "uplink_ultimate") {
+          startSSE();
+        } else if (newTier !== "uplink_ultimate" && sseActiveRef.current) {
+          stopSSE();
+        }
       }
     });
   }, [startSSE, stopSSE, queryClient]);

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -92,6 +92,10 @@ export default function AccountSettings({
   const hasSub = sub && sub.plan !== "free" && status !== "none";
   const isLifetime = sub?.lifetime === true;
 
+  // During trial, always show Uplink Ultimate (the JWT tier may lag behind)
+  const displayTier: SubscriptionTier =
+    status === "trialing" ? "uplink_ultimate" : tier;
+
   // Compute trial days once
   const trialDays =
     status === "trialing" && sub?.trial_end
@@ -113,7 +117,7 @@ export default function AccountSettings({
             )}
             <DisplayRow
               label="Plan"
-              value={TIER_LABELS[tier]}
+              value={TIER_LABELS[displayTier]}
               valueClass="text-xs text-accent font-semibold"
             />
             <ActionRow

--- a/desktop/src/hooks/useAuthState.ts
+++ b/desktop/src/hooks/useAuthState.ts
@@ -28,6 +28,7 @@ interface UseAuthStateReturn {
   handleLogin: () => Promise<void>;
   handleLogout: () => Promise<void>;
   syncAuthFromDashboard: (dashboard: DashboardResponse | undefined) => void;
+  refreshTier: () => void;
 }
 
 export function useAuthState(): UseAuthStateReturn {
@@ -83,6 +84,11 @@ export function useAuthState(): UseAuthStateReturn {
     [],
   );
 
+  /** Re-read tier from the current JWT (call after a forced token refresh). */
+  const refreshTier = useCallback(() => {
+    if (checkAuth()) setTier(getTier());
+  }, []);
+
   return {
     authenticated,
     tier,
@@ -93,5 +99,6 @@ export function useAuthState(): UseAuthStateReturn {
     handleLogin,
     handleLogout,
     syncAuthFromDashboard,
+    refreshTier,
   };
 }

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -52,6 +52,7 @@ import { useChannelActions } from "../hooks/useChannelActions";
 import { useWidgetActions } from "../hooks/useWidgetActions";
 import { weatherQueryOptions } from "../api/queries";
 import { fetchSubscription } from "../api/client";
+import { getValidToken } from "../auth";
 
 // Shell context
 import { ShellContext, ShellDataContext } from "../shell-context";
@@ -180,12 +181,29 @@ function RootLayout() {
   // ── Subscription info — fetched for billing UI in Account tab + banner ──
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
 
-  const refreshSubscription = useCallback(() => {
+  const refreshSubscription = useCallback(async () => {
     if (!auth.authenticated) { setSubscriptionInfo(null); return; }
-    fetchSubscription()
-      .then(setSubscriptionInfo)
-      .catch(() => setSubscriptionInfo(null));
-  }, [auth.authenticated]);
+    try {
+      const sub = await fetchSubscription();
+      setSubscriptionInfo(sub);
+
+      // Detect tier mismatch: the JWT may still carry stale roles after a
+      // subscription change.  Force a token refresh so the new Logto roles
+      // propagate to the JWT, which updates tier / SSE / enforcement.
+      const expected = sub.status === "trialing"
+        ? "uplink_ultimate"
+        : sub.plan.startsWith("ultimate") ? "uplink_ultimate"
+        : sub.plan.startsWith("pro") ? "uplink_pro"
+        : sub.plan === "free" || sub.status === "none" ? "free"
+        : "uplink";
+      if (auth.tier !== expected) {
+        await getValidToken(true);   // force refresh — writes new auth to store
+        auth.refreshTier();          // re-read tier from the fresh JWT
+      }
+    } catch {
+      setSubscriptionInfo(null);
+    }
+  }, [auth.authenticated, auth.tier, auth.refreshTier]);
 
   // Fetch on auth change + periodic refresh every 5 minutes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **AccountSettings**: Shows "Uplink Ultimate" during trial regardless of JWT tier lag
- **__root.tsx**: Detects tier mismatch after fetching subscription info, forces token refresh so JWT roles update immediately
- **useAuthState**: New `refreshTier()` method to re-read tier from fresh JWT
- **App.tsx (ticker window)**: Re-reads tier on every auth store change (not just login/logout), starts/stops SSE on tier transitions

Fixes: desktop showing "Plan: Uplink" and "Polling" instead of "Uplink Ultimate" and "SSE" during trial — JWT roles lagged behind subscription state.