### PR TITLE
fix(billing): immediate trial cancel, had_prior_sub flag, smart CTA labels

### DIFF
--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -407,11 +407,19 @@ func HandleGetSubscription(c *fiber.Ctx) error {
 		})
 	}
 
+	// Check if user has ever had a paid subscription (for trial eligibility display)
+	var hadPriorSub bool
+	_ = DBPool.QueryRow(context.Background(),
+		`SELECT EXISTS(SELECT 1 FROM stripe_customers WHERE logto_sub = $1 AND plan != 'free')`,
+		userID,
+	).Scan(&hadPriorSub)
+
 	resp := SubscriptionResponse{
 		Plan:             sc.Plan,
 		Status:           sc.Status,
 		CurrentPeriodEnd: sc.CurrentPeriodEnd,
 		Lifetime:         sc.Lifetime,
+		HadPriorSub:      hadPriorSub,
 	}
 
 	// Fetch live subscription data from Stripe for billing details + schedule
@@ -467,7 +475,9 @@ func HandleGetSubscription(c *fiber.Ctx) error {
 	return c.JSON(resp)
 }
 
-// HandleCancelSubscription cancels the user's Stripe subscription at period end.
+// HandleCancelSubscription cancels the user's Stripe subscription.
+// Trials are canceled immediately (no charge occurred). Paid subscriptions
+// are scheduled to cancel at the end of the current billing period.
 func HandleCancelSubscription(c *fiber.Ctx) error {
 	userID := GetUserID(c)
 	if userID == "" {
@@ -493,11 +503,49 @@ func HandleCancelSubscription(c *fiber.Ctx) error {
 		})
 	}
 
-	// Cancel at period end (user keeps access until then)
+	// Fetch the subscription to check if it's trialing
+	sub, err := stripesubscription.Get(*subID, nil)
+	if err != nil {
+		log.Printf("[Billing] Failed to fetch subscription %s for %s: %v", *subID, userID, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error", Error: "Failed to cancel subscription",
+		})
+	}
+
+	// Trialing: cancel immediately (no payment has been collected)
+	if sub.Status == stripe.SubscriptionStatusTrialing {
+		_, err := stripesubscription.Cancel(*subID, nil)
+		if err != nil {
+			log.Printf("[Billing] Failed to cancel trial %s for %s: %v", *subID, userID, err)
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error", Error: "Failed to cancel trial",
+			})
+		}
+
+		// Reset DB to free/canceled
+		_, _ = DBPool.Exec(context.Background(),
+			`UPDATE stripe_customers SET plan = 'free', status = 'canceled',
+			        stripe_subscription_id = NULL, current_period_end = NULL, updated_at = now()
+			 WHERE logto_sub = $1`, userID,
+		)
+
+		// Remove all Logto roles
+		_ = RemoveUplinkRole(userID)
+		_ = RemoveProRole(userID)
+		_ = RemoveUltimateRole(userID)
+
+		log.Printf("[Billing] Trial canceled immediately for %s", userID)
+		return c.JSON(fiber.Map{
+			"status":  "canceled",
+			"message": "Your trial has been ended",
+		})
+	}
+
+	// Paid subscription: cancel at period end (user keeps access until then)
 	params := &stripe.SubscriptionParams{
 		CancelAtPeriodEnd: stripe.Bool(true),
 	}
-	sub, err := stripesubscription.Update(*subID, params)
+	sub, err = stripesubscription.Update(*subID, params)
 	if err != nil {
 		log.Printf("[Billing] Failed to cancel subscription %s for %s: %v", *subID, userID, err)
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{

--- a/api/core/models.go
+++ b/api/core/models.go
@@ -109,6 +109,7 @@ type SubscriptionResponse struct {
 	Currency             string     `json:"currency,omitempty"`
 	Interval             string     `json:"interval,omitempty"`
 	TrialEnd             *int64     `json:"trial_end,omitempty"`
+	HadPriorSub          bool       `json:"had_prior_sub"`
 }
 
 // CheckoutReturnResponse tells the frontend about the checkout outcome.

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -164,6 +164,7 @@ export interface SubscriptionInfo {
   currency?: string;
   interval?: string;
   trial_end?: number;
+  had_prior_sub: boolean;
 }
 
 export async function fetchSubscription(): Promise<SubscriptionInfo> {

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -223,6 +223,7 @@ export interface SubscriptionStatus {
   currency?: string
   interval?: string
   trial_end?: number
+  had_prior_sub: boolean
 }
 
 export interface CheckoutReturnStatus {

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -544,8 +544,10 @@ function SignalBars() {
 
 function BottomCTA({
   handleSelectPlan,
+  hadPriorSub,
 }: {
   handleSelectPlan: (period: PlanKey, tier: TierKey) => void
+  hadPriorSub: boolean
 }) {
   const sectionRef = useRef<HTMLElement>(null)
   const isInView = useInView(sectionRef, { amount: 0.15 })
@@ -746,14 +748,18 @@ function BottomCTA({
                 onClick={() => handleSelectPlan('annual', 'ultimate')}
                 className="btn btn-pulse gap-2 text-base px-8 py-5 shadow-2xl"
               >
-                <Crown size={14} /> Start Free Trial — Ultimate
+                <Crown size={14} />{' '}
+                {hadPriorSub
+                  ? 'Subscribe — Ultimate'
+                  : 'Start Free Trial — Ultimate'}
               </button>
               <button
                 type="button"
                 onClick={() => handleSelectPlan('annual', 'pro')}
                 className="btn btn-outline gap-2 px-6 py-4"
               >
-                <Gauge size={14} /> Try Pro Free for 7 Days
+                <Gauge size={14} />{' '}
+                {hadPriorSub ? 'Subscribe — Pro' : 'Try Pro Free for 7 Days'}
               </button>
             </div>
           </motion.div>
@@ -906,13 +912,16 @@ function UplinkPage() {
   const isLifetime = billingView === 'lifetime'
   const billingPeriod: PlanKey = isLifetime ? 'annual' : billingView
 
-  // Derive active tier from current subscription (active or trialing)
+  // Derive active tier from current subscription (active, trialing, or canceling)
   const activeTier =
     currentSub &&
-    (currentSub.status === 'active' || currentSub.status === 'trialing')
+    (currentSub.status === 'active' ||
+      currentSub.status === 'trialing' ||
+      currentSub.status === 'canceling')
       ? tierFromPlan(currentSub.plan)
       : null
   const isTrialing = currentSub?.status === 'trialing'
+  const hadPriorSub = currentSub?.had_prior_sub ?? false
 
   // Derive pending downgrade tier (if a downgrade is scheduled)
   const pendingDowngradeTier = currentSub?.pending_downgrade_plan
@@ -1032,11 +1041,18 @@ function UplinkPage() {
   /** Get the CTA label for a tier card based on current subscription state. */
   const getCtaLabel = (tier: TierKey): string => {
     if (loadingPreview) return 'Fetching quote...'
-    if (!activeTier) return 'Start Free Trial'
+    if (!activeTier) {
+      // No active subscription — check if they've used their trial
+      return hadPriorSub ? 'Subscribe' : 'Start Free Trial'
+    }
     if (isTrialing && activeTier === tier) return 'Your Choice'
+    if (currentSub?.status === 'canceling' && activeTier === tier)
+      return 'Current Plan'
     if (activeTier === tier) return 'Current Plan'
     if (pendingDowngradeTier === tier) return 'Downgrade Scheduled'
     if (isTrialing) return 'Switch to ' + TIER_NAMES[tier]
+    if (currentSub?.status === 'canceling')
+      return TIER_RANK[tier] > TIER_RANK[activeTier] ? 'Upgrade' : 'Downgrade'
     return TIER_RANK[tier] > TIER_RANK[activeTier] ? 'Upgrade' : 'Downgrade'
   }
 
@@ -1436,13 +1452,15 @@ function UplinkPage() {
                   className="btn btn-pulse btn-lg gap-2.5"
                 >
                   <Zap size={14} />
-                  Start Free Trial
+                  {hadPriorSub ? 'View Plans' : 'Start Free Trial'}
                 </button>
 
                 <div className="flex items-center gap-3">
                   <span className="h-px w-6 bg-base-300/50" />
                   <span className="text-[10px] font-mono text-base-content/20">
-                    7 days free &middot; From $6.67/mo &middot; Cancel anytime
+                    {hadPriorSub
+                      ? 'From $6.67/mo \u00b7 Cancel anytime'
+                      : '7 days free \u00b7 From $6.67/mo \u00b7 Cancel anytime'}
                   </span>
                 </div>
               </motion.div>
@@ -2409,7 +2427,7 @@ function UplinkPage() {
                             ? 'Changing...'
                             : getCtaLabel('uplink')}
                         </div>
-                        {!activeTier && (
+                        {!activeTier && !hadPriorSub && (
                           <span className="text-[9px] text-base-content/20">
                             7 days free, then $
                             {PRICING.uplink[billingPeriod].perMonth}/mo
@@ -2571,7 +2589,7 @@ function UplinkPage() {
                             ? 'Changing...'
                             : getCtaLabel('pro')}
                         </div>
-                        {!activeTier && (
+                        {!activeTier && !hadPriorSub && (
                           <span className="text-[9px] text-base-content/20">
                             7 days free, then $
                             {PRICING.pro[billingPeriod].perMonth}/mo
@@ -2876,7 +2894,7 @@ function UplinkPage() {
                               ? 'Changing...'
                               : getCtaLabel('ultimate')}
                           </div>
-                          {!activeTier && (
+                          {!activeTier && !hadPriorSub && (
                             <span className="text-[9px] text-base-content/20">
                               7 days free, then $
                               {PRICING.ultimate[billingPeriod].perMonth}/mo
@@ -3710,15 +3728,17 @@ function UplinkPage() {
                               : 'border border-info/20 text-info/60 hover:border-info/40 hover:text-info/80'
                         }`}
                       >
-                        Start Free Trial
+                        {hadPriorSub ? 'Subscribe' : 'Start Free Trial'}
                       </button>
-                      <p className="text-center mt-1.5 text-[9px] text-base-content/20">
-                        {tier.tier === 'ultimate'
-                          ? '7 days free, then $33.33/mo'
-                          : tier.tier === 'pro'
-                            ? '7 days free, then $16.67/mo'
-                            : '7 days free, then $6.67/mo'}
-                      </p>
+                      {!hadPriorSub && (
+                        <p className="text-center mt-1.5 text-[9px] text-base-content/20">
+                          {tier.tier === 'ultimate'
+                            ? '7 days free, then $33.33/mo'
+                            : tier.tier === 'pro'
+                              ? '7 days free, then $16.67/mo'
+                              : '7 days free, then $6.67/mo'}
+                        </p>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -3953,7 +3973,7 @@ function UplinkPage() {
       {/* ================================================================
           BOTTOM CTA
           ================================================================ */}
-      <BottomCTA handleSelectPlan={handleSelectPlan} />
+      <BottomCTA handleSelectPlan={handleSelectPlan} hadPriorSub={hadPriorSub} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **API**: Cancel trialing subscriptions immediately via `stripesubscription.Cancel()` instead of scheduling with `CancelAtPeriodEnd`. Resets DB to free/canceled and removes all Logto roles.
- **API**: Add `had_prior_sub` boolean to `GET /users/me/subscription` response — queries subscription history to detect used trials.
- **Website**: Smart CTA labels on pricing page — shows "Subscribe" instead of "Start Free Trial" for users who already used their trial. Hides "7 days free" text. Includes `canceling` status in `activeTier` derivation so canceling users see "Current Plan" instead of "Start Free Trial".
- **Desktop**: Extended `SubscriptionInfo` type with `had_prior_sub` field.

Fixes three user-reported issues: infinite "canceling" state on trial cancel, misleading "Start Free Trial" buttons for used-trial users, and missing trial-awareness in pricing page CTAs.