### PR TITLE
fix(channels): make silent startup failures impossible in Rust services (1/6)

### DIFF
--- a/channels/finance/service/Cargo.toml
+++ b/channels/finance/service/Cargo.toml
@@ -23,3 +23,6 @@ dotenv = "0.15"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "chrono", "migrate"] }
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/channels/finance/service/src/database.rs
+++ b/channels/finance/service/src/database.rs
@@ -5,10 +5,14 @@ pub use sqlx::PgPool;
 use sqlx::{FromRow, query, query_as};
 pub use chrono::Utc;
 
+/// Build the sqlx migrator for this service.
+///
+/// `ignore_missing` is deliberately NOT set. A follow-up PR namespaces the
+/// `_sqlx_migrations` table per service, which eliminates the cross-service
+/// collision that `ignore_missing = true` used to paper over. Leaving it
+/// enabled now would just hide real migration drift.
 fn migrator() -> sqlx::migrate::Migrator {
-    let mut m = sqlx::migrate!("./migrations");
-    m.set_ignore_missing(true);
-    m
+    sqlx::migrate!("./migrations")
 }
 
 pub async fn initialize_pool() -> Result<PgPool> {
@@ -53,20 +57,20 @@ pub async fn initialize_pool() -> Result<PgPool> {
     .context("Failed to connect to the PostgreSQL database")?;
     eprintln!("[DB] Connected successfully, running migrations...");
 
-    // Run migrations with ignore_missing=true so multiple services sharing
-    // one PostgreSQL database don't fail on each other's migration records.
-    //
-    // A previous iteration of this code caught migration errors, wiped
-    // _sqlx_migrations, and re-ran the migrator. That recovery path was
-    // data-unsafe: on any checksum drift it would silently re-apply old
-    // migrations against a live schema, potentially duplicating or
-    // clobbering rows. Failed migrations now propagate — the service
-    // refuses to start and a human must diagnose before the ingestion
-    // loop writes anything.
+    // Run migrations. A previous iteration of this code caught migration
+    // errors, wiped `_sqlx_migrations`, and re-ran the migrator — that path
+    // was data-unsafe. Failed migrations now propagate with the full sqlx
+    // error chain (including `VersionMismatch(version)` and the colliding
+    // file name) so an on-call engineer can diagnose without having to
+    // re-run the binary under a debugger. See the long troubleshooting
+    // note in AGENTS.md under "Database Migrations".
     let m = migrator();
-    m.run(&pool)
-        .await
-        .context("Failed to run migrations (no automatic recovery — diagnose manually)")?;
+    if let Err(err) = m.run(&pool).await {
+        eprintln!("[DB] Migration failure: {err}");
+        eprintln!("[DB] Underlying error chain: {err:?}");
+        return Err(anyhow::Error::new(err)
+            .context("Failed to run migrations. No automatic recovery — inspect _sqlx_migrations"));
+    }
     eprintln!("[DB] Migrations complete");
 
     Ok(pool)

--- a/channels/finance/service/src/init.rs
+++ b/channels/finance/service/src/init.rs
@@ -1,0 +1,296 @@
+//! Service initialization and readiness tracking.
+//!
+//! Replaces the old silent-failure pattern where background init tasks could
+//! die while `/health` kept returning HTTP 200. Every fatal condition now
+//! either (a) sets [`ReadinessState::Failed`] and exits the process so
+//! Kubernetes restarts the pod, or (b) flips `/health/ready` to return HTTP
+//! 503 so probes can detect the problem.
+//!
+//! Copied into each Rust service (`finance`, `sports`, `rss`) rather than
+//! extracted as a shared crate, to match the existing isolation philosophy
+//! in AGENTS.md ("Module isolation is absolute. Each service owns its copy
+//! of database.rs and log.rs.").
+
+use std::{env, future::Future, panic::AssertUnwindSafe, time::Duration};
+
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use futures_util::FutureExt;
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+/// Single source of truth for whether the service should be receiving traffic.
+/// Kubernetes readiness probes consult this via `/health/ready`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ReadinessState {
+    /// Initial state. HTTP server is up but init (DB, migrations, config)
+    /// has not finished. `/health/ready` returns 503.
+    Starting,
+    /// Init finished successfully. `/health/ready` returns 200 as long as
+    /// background work stays fresh (see `max_poll_staleness`).
+    Ready,
+    /// Unrecoverable failure during init or runtime. `/health/ready` returns
+    /// 503. The process is usually on its way to `exit(1)` when this is set;
+    /// it is surfaced here so the last probe response before shutdown is
+    /// accurate and debuggable.
+    Failed { reason: String },
+}
+
+/// Readiness tracker shared between the main task and the health handler.
+///
+/// The gate records three things:
+/// * The current [`ReadinessState`].
+/// * `last_poll`: the timestamp of the last successful background poll (used
+///   to detect frozen workers that are nominally `Ready`).
+/// * `max_poll_staleness`: the threshold past which `Ready` silently becomes
+///   "stale" (rendered as HTTP 503 by `/health/ready`). `None` means the
+///   service has no polling loop and staleness does not apply.
+#[derive(Debug)]
+pub struct ReadinessGate {
+    inner: RwLock<ReadinessInner>,
+}
+
+#[derive(Debug)]
+struct ReadinessInner {
+    state: ReadinessState,
+    last_poll: Option<DateTime<Utc>>,
+    max_poll_staleness: Option<Duration>,
+}
+
+/// Snapshot of the readiness gate returned by `/health/ready`. Flat JSON so
+/// it can be merged into each service's own health payload without forcing
+/// callers to drill into a nested object.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReadinessSnapshot {
+    pub state: ReadinessState,
+    pub last_poll: Option<DateTime<Utc>>,
+    pub max_poll_staleness_secs: Option<u64>,
+    /// True when `state == Ready` but the newest poll is older than the
+    /// staleness threshold. Derived for convenience — callers shouldn't have
+    /// to recompute it.
+    pub stale: bool,
+}
+
+impl ReadinessGate {
+    /// Create a gate starting in [`ReadinessState::Starting`]. `max_poll_staleness`
+    /// is the freshness window past which a `Ready` service flips to 503
+    /// (typically ~2x the longest poll interval). Pass `None` for services
+    /// that have no polling loop.
+    pub fn new(max_poll_staleness: Option<Duration>) -> Self {
+        Self {
+            inner: RwLock::new(ReadinessInner {
+                state: ReadinessState::Starting,
+                last_poll: None,
+                max_poll_staleness,
+            }),
+        }
+    }
+
+    /// Mark the service as ready to receive traffic. Usually called once, at
+    /// the end of init, before the poll loops start.
+    pub async fn mark_ready(&self) {
+        self.inner.write().await.state = ReadinessState::Ready;
+    }
+
+    /// Mark the service as unrecoverably failed. `/health/ready` will return
+    /// 503 until the process exits.
+    pub async fn mark_failed(&self, reason: impl Into<String>) {
+        self.inner.write().await.state = ReadinessState::Failed {
+            reason: reason.into(),
+        };
+    }
+
+    /// Record that a background poll cycle just completed successfully. Used
+    /// by `/health/ready` to detect frozen workers.
+    pub async fn record_poll(&self) {
+        self.inner.write().await.last_poll = Some(Utc::now());
+    }
+
+    /// Snapshot for the health handler.
+    pub async fn snapshot(&self) -> ReadinessSnapshot {
+        let inner = self.inner.read().await;
+        let stale = matches!(inner.state, ReadinessState::Ready)
+            && inner
+                .max_poll_staleness
+                .zip(inner.last_poll)
+                .is_some_and(|(max, last)| {
+                    Utc::now().signed_duration_since(last).to_std().unwrap_or_default() > max
+                });
+        ReadinessSnapshot {
+            state: inner.state.clone(),
+            last_poll: inner.last_poll,
+            max_poll_staleness_secs: inner.max_poll_staleness.map(|d| d.as_secs()),
+            stale,
+        }
+    }
+
+    /// Compute the HTTP status code `/health/ready` should return. 200 only
+    /// when the service is `Ready` AND (no staleness threshold is set OR
+    /// the last poll is within the threshold OR no poll has been recorded
+    /// yet but the gate was only just marked ready — services without a
+    /// poll loop set `max_poll_staleness` to `None` to skip this check).
+    pub async fn http_status(&self) -> StatusCode {
+        let snap = self.snapshot().await;
+        match snap.state {
+            ReadinessState::Starting | ReadinessState::Failed { .. } => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            ReadinessState::Ready => {
+                // If a staleness threshold is configured, require at least one
+                // successful poll and enforce freshness. Services without a
+                // poll loop pass `None` and are considered ready immediately.
+                if snap.max_poll_staleness_secs.is_some()
+                    && (snap.last_poll.is_none() || snap.stale)
+                {
+                    return StatusCode::SERVICE_UNAVAILABLE;
+                }
+                StatusCode::OK
+            }
+        }
+    }
+}
+
+// ─── env-var helpers ─────────────────────────────────────────────────────
+
+/// Read an environment variable or log + exit(1). Use for values that are
+/// required for the service to do any work — there is no sensible fallback
+/// and continuing would only hide the misconfiguration.
+pub fn fatal_env(key: &str) -> String {
+    match env::var(key) {
+        Ok(v) if !v.trim().is_empty() => v,
+        Ok(_) => {
+            eprintln!("[FATAL] Required environment variable is empty: {key}");
+            log_flush_and_exit(1);
+        }
+        Err(_) => {
+            eprintln!("[FATAL] Required environment variable is not set: {key}");
+            log_flush_and_exit(1);
+        }
+    }
+}
+
+// ─── supervised task spawning ────────────────────────────────────────────
+
+/// Spawn a tokio task that will take the entire process down on panic or
+/// early return treated as fatal. Wraps the future with `catch_unwind` so a
+/// panic in a spawned task no longer disappears silently — instead it logs
+/// `{panic:?}` and calls `exit(1)`.
+///
+/// `name` is used only for log context.
+pub fn spawn_supervised<F>(name: &'static str, fut: F) -> tokio::task::JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let result = AssertUnwindSafe(fut).catch_unwind().await;
+        if let Err(panic) = result {
+            eprintln!(
+                "[FATAL] Supervised task '{name}' panicked: {:?}",
+                panic_message(&panic)
+            );
+            log_flush_and_exit(1);
+        }
+    })
+}
+
+fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("{:?}", panic)
+    }
+}
+
+// ─── graceful process exit ───────────────────────────────────────────────
+
+/// Sleep briefly so in-flight log messages can flush, then exit with the
+/// given code. Used for [`fatal_env`] and [`spawn_supervised`] on panic.
+///
+/// The sleep gives the async logger's mpsc receiver a chance to drain; it
+/// also guarantees Kubernetes sees at least one `/health/ready` 503 before
+/// the pod goes away, which keeps restart loops easier to diagnose.
+pub fn log_flush_and_exit(code: i32) -> ! {
+    std::thread::sleep(Duration::from_secs(2));
+    std::process::exit(code);
+}
+
+/// Mark a readiness gate as failed and then terminate the process after a
+/// short grace period so Kubernetes restarts the pod. Unlike the old
+/// `return;` pattern, this makes silent failure impossible.
+///
+/// The 5-second grace period lets at least one `readinessProbe` cycle
+/// observe the 503 before the pod terminates, making outages visible in
+/// `kubectl describe pod` output instead of just appearing as a restart
+/// with no context.
+pub async fn fatal(gate: &ReadinessGate, reason: impl Into<String>) -> ! {
+    let reason = reason.into();
+    eprintln!("[FATAL] {reason}");
+    gate.mark_failed(reason).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    log_flush_and_exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn starting_returns_503() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        let snap = gate.snapshot().await;
+        assert!(matches!(snap.state, ReadinessState::Starting));
+        assert!(!snap.stale);
+    }
+
+    #[tokio::test]
+    async fn ready_without_poll_returns_503_when_staleness_required() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        gate.mark_ready().await;
+        // Ready but no poll has happened yet — 503 so probes don't route traffic
+        // to a pod that hasn't done any real work.
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn ready_without_staleness_config_returns_200_immediately() {
+        let gate = ReadinessGate::new(None);
+        gate.mark_ready().await;
+        assert_eq!(gate.http_status().await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn ready_with_fresh_poll_returns_200() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        gate.mark_ready().await;
+        gate.record_poll().await;
+        assert_eq!(gate.http_status().await, StatusCode::OK);
+        assert!(!gate.snapshot().await.stale);
+    }
+
+    #[tokio::test]
+    async fn ready_with_stale_poll_returns_503() {
+        let gate = ReadinessGate::new(Some(Duration::from_millis(50)));
+        gate.mark_ready().await;
+        gate.record_poll().await;
+        // Wait past the staleness window
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(gate.snapshot().await.stale);
+    }
+
+    #[tokio::test]
+    async fn failed_always_returns_503() {
+        let gate = ReadinessGate::new(None);
+        gate.mark_failed("db init: boom").await;
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        let snap = gate.snapshot().await;
+        match snap.state {
+            ReadinessState::Failed { reason } => assert_eq!(reason, "db init: boom"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+}

--- a/channels/finance/service/src/lib.rs
+++ b/channels/finance/service/src/lib.rs
@@ -16,6 +16,7 @@ pub mod types;
 mod websocket;
 pub mod log;
 pub mod database;
+pub mod init;
 
 pub async fn start_finance_services(pool: Arc<PgPool>, health_state: Arc<Mutex<FinanceHealth>>) {
     info!("Starting finance service...");

--- a/channels/finance/service/src/main.rs
+++ b/channels/finance/service/src/main.rs
@@ -1,13 +1,40 @@
-use axum::{routing::get, Router, Json, extract::State};
+use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
 use dotenv::dotenv;
-use std::sync::Arc;
+use serde::Serialize;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use finance_service::{start_finance_services, types::FinanceHealth, log::init_async_logger, database::initialize_pool};
+use finance_service::{
+    database::initialize_pool,
+    init::{fatal, spawn_supervised, ReadinessGate, ReadinessSnapshot},
+    log::init_async_logger,
+    start_finance_services,
+    types::FinanceHealth,
+};
+
+/// Freshness window for `/health/ready`. If the WebSocket hasn't processed
+/// any batches within this window the pod is marked NotReady so Kubernetes
+/// stops routing traffic. 5 minutes is generous: the WS reconnect backoff
+/// is 5 minutes, so anything longer than 2x that means ingest is genuinely
+/// broken.
+const MAX_POLL_STALENESS: Duration = Duration::from_secs(10 * 60);
+
+/// How often the bridge loop checks `FinanceHealth.batch_number` for
+/// progress and forwards it to the readiness gate. This is cheap (one
+/// mutex-read + one RwLock-write) so it runs on a tight interval.
+const READINESS_BRIDGE_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 struct AppState {
     health: Arc<Mutex<FinanceHealth>>,
+    readiness: Arc<ReadinessGate>,
+}
+
+#[derive(Serialize)]
+struct ReadyPayload {
+    #[serde(flatten)]
+    readiness: ReadinessSnapshot,
+    health: FinanceHealth,
 }
 
 #[tokio::main]
@@ -16,14 +43,23 @@ async fn main() {
     let _ = init_async_logger("./logs");
 
     let health = Arc::new(Mutex::new(FinanceHealth::new()));
+    let readiness = Arc::new(ReadinessGate::new(Some(MAX_POLL_STALENESS)));
 
     // Cancellation token for coordinated shutdown
     let cancel = CancellationToken::new();
 
-    // Start HTTP server immediately so K8s startup probes pass
-    let state = AppState { health: health.clone() };
+    // Start HTTP server immediately so the k8s liveness probe always has
+    // something to talk to, but the readiness probe at /health/ready will
+    // return 503 until `readiness.mark_ready()` is called from the init
+    // task below.
+    let state = AppState {
+        health: health.clone(),
+        readiness: readiness.clone(),
+    };
     let app = Router::new()
-        .route("/health", get(health_handler))
+        .route("/health", get(health_ready_handler))
+        .route("/health/live", get(health_live_handler))
+        .route("/health/ready", get(health_ready_handler))
         .with_state(state);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3001".to_string());
@@ -31,30 +67,85 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     println!("Finance Service listening on {} (connecting to DB...)", addr);
 
-    // Spawn background task for DB connection + service init
-    let health_clone = health.clone();
-    let cancel_clone = cancel.clone();
-    tokio::spawn(async move {
-        let mut retries = 5;
+    // Spawn background task for DB connection + service init. Uses the
+    // supervised wrapper so a panic inside init (e.g. a `.expect()` on a
+    // missing env var someone forgot to convert) takes the whole process
+    // down instead of leaving a zombie pod behind.
+    let health_bg = health.clone();
+    let readiness_bg = readiness.clone();
+    let cancel_bg = cancel.clone();
+    spawn_supervised("finance-init", async move {
+        const RETRIES: u32 = 5;
+        let mut remaining = RETRIES;
         let pool = loop {
             match initialize_pool().await {
                 Ok(p) => break Arc::new(p),
+                Err(e) if remaining == 0 => {
+                    // All retries exhausted. Mark failed and exit so
+                    // Kubernetes restarts the pod.
+                    fatal(
+                        &readiness_bg,
+                        format!("DB init failed after {RETRIES} retries: {e:#}"),
+                    )
+                    .await;
+                }
                 Err(e) => {
-                    if retries == 0 {
-                        eprintln!("[FATAL] Failed to init DB after retries: {}", e);
-                        return;
-                    }
-                    eprintln!("[DB] Failed to connect, retrying in 2s... ({} attempts left) Error: {}", retries, e);
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    retries -= 1;
+                    eprintln!(
+                        "[DB] Connection attempt failed ({} remaining): {e:#}",
+                        remaining
+                    );
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    remaining -= 1;
                 }
             }
         };
 
-        // Start the background service (WebSocket)
+        // DB is up and migrations have succeeded. Readiness can flip to
+        // `Ready` — but /health/ready will keep returning 503 until the
+        // first batch is processed (staleness guard).
+        readiness_bg.mark_ready().await;
+
+        // Bridge loop: copy FinanceHealth.batch_number → readiness.record_poll()
+        // whenever the batch counter advances. This is how the readiness
+        // gate learns about "real work happening" without threading the
+        // gate through every websocket callsite.
+        let bridge_health = health_bg.clone();
+        let bridge_readiness = readiness_bg.clone();
+        let bridge_cancel = cancel_bg.clone();
+        tokio::spawn(async move {
+            let mut last_batch: u64 = 0;
+            let mut last_status = String::from("disconnected");
+            loop {
+                tokio::select! {
+                    _ = bridge_cancel.cancelled() => break,
+                    _ = tokio::time::sleep(READINESS_BRIDGE_INTERVAL) => {
+                        let snap = bridge_health.lock().await.get_health();
+                        // Websocket-connected counts as liveness progress
+                        // even when no trades are flowing (weekends,
+                        // off-hours, etc.). Otherwise we'd mark the pod
+                        // NotReady every Saturday.
+                        let connected = snap.connection_status == "connected";
+                        let progressed = snap.batch_number > last_batch;
+                        if connected || progressed {
+                            bridge_readiness.record_poll().await;
+                            last_batch = snap.batch_number;
+                            last_status = snap.connection_status.clone();
+                        } else if last_status == "connected" && !connected {
+                            // Lost connection recently; don't record a
+                            // poll so staleness kicks in after the
+                            // configured window.
+                            last_status = snap.connection_status.clone();
+                        }
+                    }
+                }
+            }
+        });
+
+        // Start the background service (WebSocket). Shutdown is cooperative
+        // via `cancel`.
         tokio::select! {
-            _ = start_finance_services(pool, health_clone) => {},
-            _ = cancel_clone.cancelled() => {
+            _ = start_finance_services(pool, health_bg) => {},
+            _ = cancel_bg.cancelled() => {
                 println!("Finance background service shutting down...");
             }
         }
@@ -93,7 +184,23 @@ async fn shutdown_signal() {
     }
 }
 
-async fn health_handler(State(state): State<AppState>) -> Json<FinanceHealth> {
+/// Liveness probe: returns 200 as long as the process is running. Lets
+/// Kubernetes tell apart "process crashed" (kill+restart) from "process is
+/// up but not doing work" (stop routing traffic, but don't restart — a
+/// restart won't fix a migration mismatch).
+async fn health_live_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(serde_json::json!({"status": "alive"})))
+}
+
+/// Readiness probe: 200 only when init succeeded AND the WebSocket is
+/// connected / has processed a batch within the staleness window. Returns
+/// the service's own health payload in the body so humans can `curl | jq`
+/// and see why.
+async fn health_ready_handler(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<ReadyPayload>) {
+    let readiness = state.readiness.snapshot().await;
+    let code = state.readiness.http_status().await;
     let health = state.health.lock().await.get_health();
-    Json(health)
+    (code, Json(ReadyPayload { readiness, health }))
 }

--- a/channels/finance/service/src/types.rs
+++ b/channels/finance/service/src/types.rs
@@ -1,9 +1,10 @@
-use std::{collections::HashMap, env, sync::Arc, time::{Duration, Instant}, pin::Pin};
+use std::{collections::HashMap, sync::Arc, time::{Duration, Instant}, pin::Pin};
 
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::time::Sleep;
 use crate::database::PgPool;
+use crate::init::fatal_env;
 
 /// A symbol entry from configs/subscriptions.json (categorized format).
 #[derive(Debug, Deserialize, Clone)]
@@ -139,14 +140,25 @@ pub struct FinanceState {
 
 impl FinanceState {
     pub async fn new(pool: Arc<PgPool>) -> Self {
-        let api_key = env::var("TWELVEDATA_API_KEY")
-            .expect("TWELVEDATA_API_KEY must be set in the environment");
+        // `.expect()` here used to panic *inside a spawned tokio task*, which
+        // did not kill the process — leaving the pod nominally healthy while
+        // no finance work was happening. `fatal_env` exits(1) so Kubernetes
+        // restarts the pod and the misconfiguration is visible.
+        let api_key = fatal_env("TWELVEDATA_API_KEY");
 
         // TwelveData uses apikey as a query parameter, no custom headers needed.
-        let client = Client::builder()
+        // A reqwest builder failure here would indicate a broken TLS/dns
+        // subsystem — unrecoverable, exit rather than fall back silently.
+        let client = match Client::builder()
             .timeout(Duration::from_millis(10_000))
             .build()
-            .expect("Failed creating finance Reqwest Client");
+        {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[FATAL] Failed to build finance reqwest client: {e:#}");
+                crate::init::log_flush_and_exit(1);
+            }
+        };
 
         // Load symbols from database instead of file
         let subscriptions = crate::database::get_tracked_symbols(pool.clone()).await;

--- a/channels/finance/service/tests/readiness_http.rs
+++ b/channels/finance/service/tests/readiness_http.rs
@@ -1,0 +1,143 @@
+//! Integration test for the readiness gate wired to an axum router.
+//!
+//! This test builds the same two-handler setup that lives in `main.rs`
+//! (`/health/live` and `/health/ready`), flips the [`ReadinessGate`] state
+//! by hand, and verifies the HTTP status codes — proving that the silent
+//! "always 200" failure mode is gone.
+//!
+//! Without this test, the per-gate unit tests in `init::tests` would still
+//! pass even if someone wired up the handler incorrectly (e.g. forgot to
+//! forward the status code). Catching that requires exercising the actual
+//! axum tower pipeline.
+
+use std::{sync::Arc, time::Duration};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    routing::get,
+    Json, Router,
+};
+use finance_service::init::{ReadinessGate, ReadinessSnapshot};
+use serde::Serialize;
+use tower::ServiceExt; // for `oneshot`
+
+#[derive(Clone)]
+struct TestState {
+    readiness: Arc<ReadinessGate>,
+}
+
+#[derive(Serialize)]
+struct ReadyPayload {
+    #[serde(flatten)]
+    readiness: ReadinessSnapshot,
+}
+
+async fn live_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(serde_json::json!({"status": "alive"})))
+}
+
+async fn ready_handler(State(state): State<TestState>) -> (StatusCode, Json<ReadyPayload>) {
+    let readiness = state.readiness.snapshot().await;
+    let code = state.readiness.http_status().await;
+    (code, Json(ReadyPayload { readiness }))
+}
+
+fn build_app(readiness: Arc<ReadinessGate>) -> Router {
+    let state = TestState { readiness };
+    Router::new()
+        .route("/health", get(ready_handler))
+        .route("/health/live", get(live_handler))
+        .route("/health/ready", get(ready_handler))
+        .with_state(state)
+}
+
+async fn status_of(app: &Router, path: &str) -> StatusCode {
+    let response = app
+        .clone()
+        .oneshot(Request::get(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    response.status()
+}
+
+#[tokio::test]
+async fn live_is_always_200_even_when_readiness_starting() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate);
+    // Starting state → /health/live should still return 200 because
+    // Kubernetes needs liveness separated from readiness.
+    assert_eq!(status_of(&app, "/health/live").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ready_returns_503_while_starting() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_503_after_mark_ready_but_no_poll_when_staleness_required() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    gate.mark_ready().await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "ready with no recorded poll must still be 503 when a staleness threshold is set"
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_200_after_poll_recorded() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    let app = build_app(gate);
+    assert_eq!(status_of(&app, "/health/ready").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ready_returns_503_when_poll_is_stale() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_millis(50))));
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_503_after_mark_failed() {
+    let gate = Arc::new(ReadinessGate::new(None));
+    gate.mark_failed("test: boom").await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn root_health_path_mirrors_ready() {
+    // Back-compat: the k8s probes currently point at /health. Until PR 5
+    // updates the manifests, /health must behave like /health/ready.
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate.clone());
+    assert_eq!(
+        status_of(&app, "/health").await,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "/health should alias /health/ready, not /health/live"
+    );
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    assert_eq!(status_of(&app, "/health").await, StatusCode::OK);
+}

--- a/channels/rss/service/Cargo.toml
+++ b/channels/rss/service/Cargo.toml
@@ -20,5 +20,9 @@ axum = { version = "0.8", features = ["json"] }
 dotenvy = "0.15"
 log = "0.4"
 anyhow = "1.0"
+futures-util = "0.3"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "chrono", "migrate"] }
 feed-rs = "2.3"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/channels/rss/service/src/database.rs
+++ b/channels/rss/service/src/database.rs
@@ -6,10 +6,14 @@ use sqlx::{FromRow, query, query_as};
 use serde::Deserialize;
 use chrono::{DateTime, Utc};
 
+/// Build the sqlx migrator for this service.
+///
+/// `ignore_missing` is deliberately NOT set. A follow-up PR namespaces the
+/// `_sqlx_migrations` table per service, which eliminates the cross-service
+/// collision that `ignore_missing = true` used to paper over. Leaving it
+/// enabled now would just hide real migration drift.
 fn migrator() -> sqlx::migrate::Migrator {
-    let mut m = sqlx::migrate!("./migrations");
-    m.set_ignore_missing(true);
-    m
+    sqlx::migrate!("./migrations")
 }
 
 pub async fn initialize_pool() -> Result<PgPool> {
@@ -54,20 +58,20 @@ pub async fn initialize_pool() -> Result<PgPool> {
     .context("Failed to connect to the PostgreSQL database")?;
     eprintln!("[DB] Connected successfully, running migrations...");
 
-    // Run migrations with ignore_missing=true so multiple services sharing
-    // one PostgreSQL database don't fail on each other's migration records.
-    //
-    // A previous iteration of this code caught migration errors, wiped
-    // _sqlx_migrations, and re-ran the migrator. That recovery path was
-    // data-unsafe: on any checksum drift it would silently re-apply old
-    // migrations against a live schema, potentially duplicating or
-    // clobbering rows. Failed migrations now propagate — the service
-    // refuses to start and a human must diagnose before the ingestion
-    // loop writes anything.
+    // Run migrations. A previous iteration of this code caught migration
+    // errors, wiped `_sqlx_migrations`, and re-ran the migrator — that path
+    // was data-unsafe. Failed migrations now propagate with the full sqlx
+    // error chain (including `VersionMismatch(version)` and the colliding
+    // file name) so an on-call engineer can diagnose without having to
+    // re-run the binary under a debugger. See the long troubleshooting
+    // note in AGENTS.md under "Database Migrations".
     let m = migrator();
-    m.run(&pool)
-        .await
-        .context("Failed to run migrations (no automatic recovery — diagnose manually)")?;
+    if let Err(err) = m.run(&pool).await {
+        eprintln!("[DB] Migration failure: {err}");
+        eprintln!("[DB] Underlying error chain: {err:?}");
+        return Err(anyhow::Error::new(err)
+            .context("Failed to run migrations. No automatic recovery — inspect _sqlx_migrations"));
+    }
     eprintln!("[DB] Migrations complete");
 
     Ok(pool)

--- a/channels/rss/service/src/init.rs
+++ b/channels/rss/service/src/init.rs
@@ -1,0 +1,296 @@
+//! Service initialization and readiness tracking.
+//!
+//! Replaces the old silent-failure pattern where background init tasks could
+//! die while `/health` kept returning HTTP 200. Every fatal condition now
+//! either (a) sets [`ReadinessState::Failed`] and exits the process so
+//! Kubernetes restarts the pod, or (b) flips `/health/ready` to return HTTP
+//! 503 so probes can detect the problem.
+//!
+//! Copied into each Rust service (`finance`, `sports`, `rss`) rather than
+//! extracted as a shared crate, to match the existing isolation philosophy
+//! in AGENTS.md ("Module isolation is absolute. Each service owns its copy
+//! of database.rs and log.rs.").
+
+use std::{env, future::Future, panic::AssertUnwindSafe, time::Duration};
+
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use futures_util::FutureExt;
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+/// Single source of truth for whether the service should be receiving traffic.
+/// Kubernetes readiness probes consult this via `/health/ready`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ReadinessState {
+    /// Initial state. HTTP server is up but init (DB, migrations, config)
+    /// has not finished. `/health/ready` returns 503.
+    Starting,
+    /// Init finished successfully. `/health/ready` returns 200 as long as
+    /// background work stays fresh (see `max_poll_staleness`).
+    Ready,
+    /// Unrecoverable failure during init or runtime. `/health/ready` returns
+    /// 503. The process is usually on its way to `exit(1)` when this is set;
+    /// it is surfaced here so the last probe response before shutdown is
+    /// accurate and debuggable.
+    Failed { reason: String },
+}
+
+/// Readiness tracker shared between the main task and the health handler.
+///
+/// The gate records three things:
+/// * The current [`ReadinessState`].
+/// * `last_poll`: the timestamp of the last successful background poll (used
+///   to detect frozen workers that are nominally `Ready`).
+/// * `max_poll_staleness`: the threshold past which `Ready` silently becomes
+///   "stale" (rendered as HTTP 503 by `/health/ready`). `None` means the
+///   service has no polling loop and staleness does not apply.
+#[derive(Debug)]
+pub struct ReadinessGate {
+    inner: RwLock<ReadinessInner>,
+}
+
+#[derive(Debug)]
+struct ReadinessInner {
+    state: ReadinessState,
+    last_poll: Option<DateTime<Utc>>,
+    max_poll_staleness: Option<Duration>,
+}
+
+/// Snapshot of the readiness gate returned by `/health/ready`. Flat JSON so
+/// it can be merged into each service's own health payload without forcing
+/// callers to drill into a nested object.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReadinessSnapshot {
+    pub state: ReadinessState,
+    pub last_poll: Option<DateTime<Utc>>,
+    pub max_poll_staleness_secs: Option<u64>,
+    /// True when `state == Ready` but the newest poll is older than the
+    /// staleness threshold. Derived for convenience — callers shouldn't have
+    /// to recompute it.
+    pub stale: bool,
+}
+
+impl ReadinessGate {
+    /// Create a gate starting in [`ReadinessState::Starting`]. `max_poll_staleness`
+    /// is the freshness window past which a `Ready` service flips to 503
+    /// (typically ~2x the longest poll interval). Pass `None` for services
+    /// that have no polling loop.
+    pub fn new(max_poll_staleness: Option<Duration>) -> Self {
+        Self {
+            inner: RwLock::new(ReadinessInner {
+                state: ReadinessState::Starting,
+                last_poll: None,
+                max_poll_staleness,
+            }),
+        }
+    }
+
+    /// Mark the service as ready to receive traffic. Usually called once, at
+    /// the end of init, before the poll loops start.
+    pub async fn mark_ready(&self) {
+        self.inner.write().await.state = ReadinessState::Ready;
+    }
+
+    /// Mark the service as unrecoverably failed. `/health/ready` will return
+    /// 503 until the process exits.
+    pub async fn mark_failed(&self, reason: impl Into<String>) {
+        self.inner.write().await.state = ReadinessState::Failed {
+            reason: reason.into(),
+        };
+    }
+
+    /// Record that a background poll cycle just completed successfully. Used
+    /// by `/health/ready` to detect frozen workers.
+    pub async fn record_poll(&self) {
+        self.inner.write().await.last_poll = Some(Utc::now());
+    }
+
+    /// Snapshot for the health handler.
+    pub async fn snapshot(&self) -> ReadinessSnapshot {
+        let inner = self.inner.read().await;
+        let stale = matches!(inner.state, ReadinessState::Ready)
+            && inner
+                .max_poll_staleness
+                .zip(inner.last_poll)
+                .is_some_and(|(max, last)| {
+                    Utc::now().signed_duration_since(last).to_std().unwrap_or_default() > max
+                });
+        ReadinessSnapshot {
+            state: inner.state.clone(),
+            last_poll: inner.last_poll,
+            max_poll_staleness_secs: inner.max_poll_staleness.map(|d| d.as_secs()),
+            stale,
+        }
+    }
+
+    /// Compute the HTTP status code `/health/ready` should return. 200 only
+    /// when the service is `Ready` AND (no staleness threshold is set OR
+    /// the last poll is within the threshold OR no poll has been recorded
+    /// yet but the gate was only just marked ready — services without a
+    /// poll loop set `max_poll_staleness` to `None` to skip this check).
+    pub async fn http_status(&self) -> StatusCode {
+        let snap = self.snapshot().await;
+        match snap.state {
+            ReadinessState::Starting | ReadinessState::Failed { .. } => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            ReadinessState::Ready => {
+                // If a staleness threshold is configured, require at least one
+                // successful poll and enforce freshness. Services without a
+                // poll loop pass `None` and are considered ready immediately.
+                if snap.max_poll_staleness_secs.is_some()
+                    && (snap.last_poll.is_none() || snap.stale)
+                {
+                    return StatusCode::SERVICE_UNAVAILABLE;
+                }
+                StatusCode::OK
+            }
+        }
+    }
+}
+
+// ─── env-var helpers ─────────────────────────────────────────────────────
+
+/// Read an environment variable or log + exit(1). Use for values that are
+/// required for the service to do any work — there is no sensible fallback
+/// and continuing would only hide the misconfiguration.
+pub fn fatal_env(key: &str) -> String {
+    match env::var(key) {
+        Ok(v) if !v.trim().is_empty() => v,
+        Ok(_) => {
+            eprintln!("[FATAL] Required environment variable is empty: {key}");
+            log_flush_and_exit(1);
+        }
+        Err(_) => {
+            eprintln!("[FATAL] Required environment variable is not set: {key}");
+            log_flush_and_exit(1);
+        }
+    }
+}
+
+// ─── supervised task spawning ────────────────────────────────────────────
+
+/// Spawn a tokio task that will take the entire process down on panic or
+/// early return treated as fatal. Wraps the future with `catch_unwind` so a
+/// panic in a spawned task no longer disappears silently — instead it logs
+/// `{panic:?}` and calls `exit(1)`.
+///
+/// `name` is used only for log context.
+pub fn spawn_supervised<F>(name: &'static str, fut: F) -> tokio::task::JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let result = AssertUnwindSafe(fut).catch_unwind().await;
+        if let Err(panic) = result {
+            eprintln!(
+                "[FATAL] Supervised task '{name}' panicked: {:?}",
+                panic_message(&panic)
+            );
+            log_flush_and_exit(1);
+        }
+    })
+}
+
+fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("{:?}", panic)
+    }
+}
+
+// ─── graceful process exit ───────────────────────────────────────────────
+
+/// Sleep briefly so in-flight log messages can flush, then exit with the
+/// given code. Used for [`fatal_env`] and [`spawn_supervised`] on panic.
+///
+/// The sleep gives the async logger's mpsc receiver a chance to drain; it
+/// also guarantees Kubernetes sees at least one `/health/ready` 503 before
+/// the pod goes away, which keeps restart loops easier to diagnose.
+pub fn log_flush_and_exit(code: i32) -> ! {
+    std::thread::sleep(Duration::from_secs(2));
+    std::process::exit(code);
+}
+
+/// Mark a readiness gate as failed and then terminate the process after a
+/// short grace period so Kubernetes restarts the pod. Unlike the old
+/// `return;` pattern, this makes silent failure impossible.
+///
+/// The 5-second grace period lets at least one `readinessProbe` cycle
+/// observe the 503 before the pod terminates, making outages visible in
+/// `kubectl describe pod` output instead of just appearing as a restart
+/// with no context.
+pub async fn fatal(gate: &ReadinessGate, reason: impl Into<String>) -> ! {
+    let reason = reason.into();
+    eprintln!("[FATAL] {reason}");
+    gate.mark_failed(reason).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    log_flush_and_exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn starting_returns_503() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        let snap = gate.snapshot().await;
+        assert!(matches!(snap.state, ReadinessState::Starting));
+        assert!(!snap.stale);
+    }
+
+    #[tokio::test]
+    async fn ready_without_poll_returns_503_when_staleness_required() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        gate.mark_ready().await;
+        // Ready but no poll has happened yet — 503 so probes don't route traffic
+        // to a pod that hasn't done any real work.
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn ready_without_staleness_config_returns_200_immediately() {
+        let gate = ReadinessGate::new(None);
+        gate.mark_ready().await;
+        assert_eq!(gate.http_status().await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn ready_with_fresh_poll_returns_200() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        gate.mark_ready().await;
+        gate.record_poll().await;
+        assert_eq!(gate.http_status().await, StatusCode::OK);
+        assert!(!gate.snapshot().await.stale);
+    }
+
+    #[tokio::test]
+    async fn ready_with_stale_poll_returns_503() {
+        let gate = ReadinessGate::new(Some(Duration::from_millis(50)));
+        gate.mark_ready().await;
+        gate.record_poll().await;
+        // Wait past the staleness window
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(gate.snapshot().await.stale);
+    }
+
+    #[tokio::test]
+    async fn failed_always_returns_503() {
+        let gate = ReadinessGate::new(None);
+        gate.mark_failed("db init: boom").await;
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        let snap = gate.snapshot().await;
+        match snap.state {
+            ReadinessState::Failed { reason } => assert_eq!(reason, "db init: boom"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+}

--- a/channels/rss/service/src/lib.rs
+++ b/channels/rss/service/src/lib.rs
@@ -12,6 +12,7 @@ pub use crate::types::RssHealth;
 
 pub mod log;
 pub mod database;
+pub mod init;
 pub mod types;
 
 pub async fn start_rss_service(pool: Arc<PgPool>, health_state: Arc<Mutex<RssHealth>>, client: &Client, cycle: u64) {

--- a/channels/rss/service/src/main.rs
+++ b/channels/rss/service/src/main.rs
@@ -1,13 +1,35 @@
-use axum::{routing::get, Router, Json, extract::State};
+use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
 use dotenvy::dotenv;
-use std::sync::Arc;
+use serde::Serialize;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use rss_service::{start_rss_service, RssHealth, log::init_async_logger, database::initialize_pool};
+use rss_service::{
+    database::initialize_pool,
+    init::{fatal, spawn_supervised, ReadinessGate, ReadinessSnapshot},
+    log::init_async_logger,
+    start_rss_service, RssHealth,
+};
+
+/// RSS polls on a 5-minute loop. Staleness = 2x that, giving one full cycle
+/// of runway before the pod drops out of the ready pool.
+const INGEST_INTERVAL: Duration = Duration::from_secs(300);
+const MAX_POLL_STALENESS: Duration = Duration::from_secs(300 * 2);
+
+/// How often the bridge loop checks `RssHealth.last_poll` for progress.
+const READINESS_BRIDGE_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 struct AppState {
     health: Arc<Mutex<RssHealth>>,
+    readiness: Arc<ReadinessGate>,
+}
+
+#[derive(Serialize)]
+struct ReadyPayload {
+    #[serde(flatten)]
+    readiness: ReadinessSnapshot,
+    health: RssHealth,
 }
 
 #[tokio::main]
@@ -16,14 +38,21 @@ async fn main() {
     let _ = init_async_logger("./logs");
 
     let health = Arc::new(Mutex::new(RssHealth::new()));
+    let readiness = Arc::new(ReadinessGate::new(Some(MAX_POLL_STALENESS)));
 
     // Cancellation token for coordinated shutdown
     let cancel = CancellationToken::new();
 
-    // Start HTTP server immediately so K8s startup probes pass
-    let state = AppState { health: health.clone() };
+    // Start HTTP server immediately. Liveness always 200, readiness 503
+    // until init + first poll.
+    let state = AppState {
+        health: health.clone(),
+        readiness: readiness.clone(),
+    };
     let app = Router::new()
-        .route("/health", get(health_handler))
+        .route("/health", get(health_ready_handler))
+        .route("/health/live", get(health_live_handler))
+        .route("/health/ready", get(health_ready_handler))
         .with_state(state);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3004".to_string());
@@ -31,49 +60,90 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     println!("RSS Service listening on {} (connecting to DB...)", addr);
 
-    // Spawn background task for DB connection + service init
-    let health_clone = health.clone();
-    let cancel_clone = cancel.clone();
-    tokio::spawn(async move {
-        let mut retries = 5;
+    // Spawn background task for DB connection + init + ingest loop.
+    // Supervised so a panic inside the task takes the process down.
+    let health_bg = health.clone();
+    let readiness_bg = readiness.clone();
+    let cancel_bg = cancel.clone();
+    spawn_supervised("rss-init", async move {
+        const RETRIES: u32 = 5;
+        let mut remaining = RETRIES;
         let pool = loop {
             match initialize_pool().await {
                 Ok(p) => break Arc::new(p),
+                Err(e) if remaining == 0 => {
+                    fatal(
+                        &readiness_bg,
+                        format!("DB init failed after {RETRIES} retries: {e:#}"),
+                    )
+                    .await;
+                }
                 Err(e) => {
-                    if retries == 0 {
-                        eprintln!("[FATAL] Failed to init DB after retries: {}", e);
-                        return;
-                    }
-                    eprintln!("[DB] Failed to connect, retrying in 2s... ({} attempts left) Error: {}", retries, e);
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    retries -= 1;
+                    eprintln!(
+                        "[DB] Connection attempt failed ({} remaining): {e:#}",
+                        remaining
+                    );
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    remaining -= 1;
                 }
             }
         };
 
-        // Build HTTP client once and reuse across all cycles for connection pooling
-        let http_client = reqwest::Client::builder()
+        // Build HTTP client once and reuse across all cycles for connection pooling.
+        // reqwest's builder failing means the TLS stack is broken — no fallback,
+        // just exit so Kubernetes surfaces the problem.
+        let http_client = match reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(15))
             .connect_timeout(std::time::Duration::from_secs(5))
             .gzip(true)
             .user_agent("MyScrollr RSS Bot/1.0")
             .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
+        {
+            Ok(c) => c,
+            Err(e) => {
+                fatal(&readiness_bg, format!("Failed to build reqwest client: {e:#}")).await;
+            }
+        };
 
-        // Start the background service (Periodic ingest)
-        let cancel_ingest = cancel_clone.clone();
+        // DB is up, client is built. Mark ready — /health/ready stays 503
+        // until the first ingest cycle records a poll timestamp.
+        readiness_bg.mark_ready().await;
+
+        // Bridge loop: forward RssHealth.last_poll to readiness gate.
+        let bridge_health = health_bg.clone();
+        let bridge_readiness = readiness_bg.clone();
+        let bridge_cancel = cancel_bg.clone();
+        tokio::spawn(async move {
+            let mut last_seen = None;
+            loop {
+                tokio::select! {
+                    _ = bridge_cancel.cancelled() => break,
+                    _ = tokio::time::sleep(READINESS_BRIDGE_INTERVAL) => {
+                        let snap = bridge_health.lock().await.get_health();
+                        if let Some(ts) = snap.last_poll {
+                            if last_seen != Some(ts) {
+                                bridge_readiness.record_poll().await;
+                                last_seen = Some(ts);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Periodic ingest loop.
         println!("Starting periodic RSS ingest loop (5 minute interval)...");
         let mut cycle: u64 = 0;
         loop {
             tokio::select! {
-                _ = cancel_ingest.cancelled() => {
+                _ = cancel_bg.cancelled() => {
                     println!("RSS ingest loop shutting down...");
                     break;
                 }
                 _ = async {
-                    start_rss_service(pool.clone(), health_clone.clone(), &http_client, cycle).await;
+                    start_rss_service(pool.clone(), health_bg.clone(), &http_client, cycle).await;
                     cycle += 1;
-                    tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+                    tokio::time::sleep(INGEST_INTERVAL).await;
                 } => {}
             }
         }
@@ -112,7 +182,18 @@ async fn shutdown_signal() {
     }
 }
 
-async fn health_handler(State(state): State<AppState>) -> Json<RssHealth> {
+/// Liveness probe: 200 as long as the process is up.
+async fn health_live_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(serde_json::json!({"status": "alive"})))
+}
+
+/// Readiness probe: 200 only when init succeeded AND the first poll cycle
+/// completed within `MAX_POLL_STALENESS`.
+async fn health_ready_handler(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<ReadyPayload>) {
+    let readiness = state.readiness.snapshot().await;
+    let code = state.readiness.http_status().await;
     let health = state.health.lock().await.get_health();
-    Json(health)
+    (code, Json(ReadyPayload { readiness, health }))
 }

--- a/channels/rss/service/src/types.rs
+++ b/channels/rss/service/src/types.rs
@@ -14,7 +14,11 @@ pub struct RssHealth {
 impl RssHealth {
     pub fn new() -> Self {
         Self {
-            status: String::from("healthy"),
+            // Start in "starting" so the informational payload agrees with
+            // readiness (which always starts as `Starting` regardless).
+            // `record_success` flips this to "healthy" after the first
+            // successful poll.
+            status: String::from("starting"),
             last_poll: None,
             feeds_polled: 0,
             items_ingested: 0,

--- a/channels/rss/service/tests/readiness_http.rs
+++ b/channels/rss/service/tests/readiness_http.rs
@@ -1,0 +1,143 @@
+//! Integration test for the readiness gate wired to an axum router.
+//!
+//! This test builds the same two-handler setup that lives in `main.rs`
+//! (`/health/live` and `/health/ready`), flips the [`ReadinessGate`] state
+//! by hand, and verifies the HTTP status codes — proving that the silent
+//! "always 200" failure mode is gone.
+//!
+//! Without this test, the per-gate unit tests in `init::tests` would still
+//! pass even if someone wired up the handler incorrectly (e.g. forgot to
+//! forward the status code). Catching that requires exercising the actual
+//! axum tower pipeline.
+
+use std::{sync::Arc, time::Duration};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    routing::get,
+    Json, Router,
+};
+use rss_service::init::{ReadinessGate, ReadinessSnapshot};
+use serde::Serialize;
+use tower::ServiceExt; // for `oneshot`
+
+#[derive(Clone)]
+struct TestState {
+    readiness: Arc<ReadinessGate>,
+}
+
+#[derive(Serialize)]
+struct ReadyPayload {
+    #[serde(flatten)]
+    readiness: ReadinessSnapshot,
+}
+
+async fn live_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(serde_json::json!({"status": "alive"})))
+}
+
+async fn ready_handler(State(state): State<TestState>) -> (StatusCode, Json<ReadyPayload>) {
+    let readiness = state.readiness.snapshot().await;
+    let code = state.readiness.http_status().await;
+    (code, Json(ReadyPayload { readiness }))
+}
+
+fn build_app(readiness: Arc<ReadinessGate>) -> Router {
+    let state = TestState { readiness };
+    Router::new()
+        .route("/health", get(ready_handler))
+        .route("/health/live", get(live_handler))
+        .route("/health/ready", get(ready_handler))
+        .with_state(state)
+}
+
+async fn status_of(app: &Router, path: &str) -> StatusCode {
+    let response = app
+        .clone()
+        .oneshot(Request::get(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    response.status()
+}
+
+#[tokio::test]
+async fn live_is_always_200_even_when_readiness_starting() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate);
+    // Starting state → /health/live should still return 200 because
+    // Kubernetes needs liveness separated from readiness.
+    assert_eq!(status_of(&app, "/health/live").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ready_returns_503_while_starting() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_503_after_mark_ready_but_no_poll_when_staleness_required() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    gate.mark_ready().await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "ready with no recorded poll must still be 503 when a staleness threshold is set"
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_200_after_poll_recorded() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    let app = build_app(gate);
+    assert_eq!(status_of(&app, "/health/ready").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ready_returns_503_when_poll_is_stale() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_millis(50))));
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_503_after_mark_failed() {
+    let gate = Arc::new(ReadinessGate::new(None));
+    gate.mark_failed("test: boom").await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn root_health_path_mirrors_ready() {
+    // Back-compat: the k8s probes currently point at /health. Until PR 5
+    // updates the manifests, /health must behave like /health/ready.
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate.clone());
+    assert_eq!(
+        status_of(&app, "/health").await,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "/health should alias /health/ready, not /health/live"
+    );
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    assert_eq!(status_of(&app, "/health").await, StatusCode::OK);
+}

--- a/channels/sports/service/Cargo.toml
+++ b/channels/sports/service/Cargo.toml
@@ -20,4 +20,8 @@ axum = { version = "0.8", features = ["macros", "json"] }
 dotenv = "0.15"
 log = "0.4"
 anyhow = "1.0"
+futures-util = "0.3"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "chrono", "migrate"] }
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -6,10 +6,14 @@ use sqlx::{FromRow, query, query_as};
 use chrono::Utc;
 use serde::Deserialize;
 
+/// Build the sqlx migrator for this service.
+///
+/// `ignore_missing` is deliberately NOT set. A follow-up PR namespaces the
+/// `_sqlx_migrations` table per service, which eliminates the cross-service
+/// collision that `ignore_missing = true` used to paper over. Leaving it
+/// enabled now would just hide real migration drift.
 fn migrator() -> sqlx::migrate::Migrator {
-    let mut m = sqlx::migrate!("./migrations");
-    m.set_ignore_missing(true);
-    m
+    sqlx::migrate!("./migrations")
 }
 
 pub async fn initialize_pool() -> Result<PgPool> {
@@ -54,20 +58,20 @@ pub async fn initialize_pool() -> Result<PgPool> {
     .context("Failed to connect to the PostgreSQL database")?;
     eprintln!("[DB] Connected successfully, running migrations...");
 
-    // Run migrations with ignore_missing=true so multiple services sharing
-    // one PostgreSQL database don't fail on each other's migration records.
-    //
-    // A previous iteration of this code caught migration errors, wiped
-    // _sqlx_migrations, and re-ran the migrator. That recovery path was
-    // data-unsafe: on any checksum drift it would silently re-apply old
-    // migrations against a live schema, potentially duplicating or
-    // clobbering rows. Failed migrations now propagate — the service
-    // refuses to start and a human must diagnose before the ingestion
-    // loop writes anything.
+    // Run migrations. A previous iteration of this code caught migration
+    // errors, wiped `_sqlx_migrations`, and re-ran the migrator — that path
+    // was data-unsafe. Failed migrations now propagate with the full sqlx
+    // error chain (including `VersionMismatch(version)` and the colliding
+    // file name) so an on-call engineer can diagnose without having to
+    // re-run the binary under a debugger. See the long troubleshooting
+    // note in AGENTS.md under "Database Migrations".
     let m = migrator();
-    m.run(&pool)
-        .await
-        .context("Failed to run migrations (no automatic recovery — diagnose manually)")?;
+    if let Err(err) = m.run(&pool).await {
+        eprintln!("[DB] Migration failure: {err}");
+        eprintln!("[DB] Underlying error chain: {err:?}");
+        return Err(anyhow::Error::new(err)
+            .context("Failed to run migrations. No automatic recovery — inspect _sqlx_migrations"));
+    }
     eprintln!("[DB] Migrations complete");
 
     Ok(pool)
@@ -212,14 +216,6 @@ pub async fn disable_stale_leagues(pool: &Arc<PgPool>, active_names: &[String]) 
         .bind(active_names)
         .execute(&mut *connection)
         .await?;
-    Ok(())
-}
-
-/// Wipe all games data. Called during the ESPN -> api-sports.io migration.
-pub async fn truncate_games(pool: &Arc<PgPool>) -> Result<()> {
-    let mut connection = pool.acquire().await?;
-    query("TRUNCATE TABLE games").execute(&mut *connection).await?;
-    log::info!("Truncated games table for data source migration");
     Ok(())
 }
 

--- a/channels/sports/service/src/init.rs
+++ b/channels/sports/service/src/init.rs
@@ -1,0 +1,296 @@
+//! Service initialization and readiness tracking.
+//!
+//! Replaces the old silent-failure pattern where background init tasks could
+//! die while `/health` kept returning HTTP 200. Every fatal condition now
+//! either (a) sets [`ReadinessState::Failed`] and exits the process so
+//! Kubernetes restarts the pod, or (b) flips `/health/ready` to return HTTP
+//! 503 so probes can detect the problem.
+//!
+//! Copied into each Rust service (`finance`, `sports`, `rss`) rather than
+//! extracted as a shared crate, to match the existing isolation philosophy
+//! in AGENTS.md ("Module isolation is absolute. Each service owns its copy
+//! of database.rs and log.rs.").
+
+use std::{env, future::Future, panic::AssertUnwindSafe, time::Duration};
+
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use futures_util::FutureExt;
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+/// Single source of truth for whether the service should be receiving traffic.
+/// Kubernetes readiness probes consult this via `/health/ready`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ReadinessState {
+    /// Initial state. HTTP server is up but init (DB, migrations, config)
+    /// has not finished. `/health/ready` returns 503.
+    Starting,
+    /// Init finished successfully. `/health/ready` returns 200 as long as
+    /// background work stays fresh (see `max_poll_staleness`).
+    Ready,
+    /// Unrecoverable failure during init or runtime. `/health/ready` returns
+    /// 503. The process is usually on its way to `exit(1)` when this is set;
+    /// it is surfaced here so the last probe response before shutdown is
+    /// accurate and debuggable.
+    Failed { reason: String },
+}
+
+/// Readiness tracker shared between the main task and the health handler.
+///
+/// The gate records three things:
+/// * The current [`ReadinessState`].
+/// * `last_poll`: the timestamp of the last successful background poll (used
+///   to detect frozen workers that are nominally `Ready`).
+/// * `max_poll_staleness`: the threshold past which `Ready` silently becomes
+///   "stale" (rendered as HTTP 503 by `/health/ready`). `None` means the
+///   service has no polling loop and staleness does not apply.
+#[derive(Debug)]
+pub struct ReadinessGate {
+    inner: RwLock<ReadinessInner>,
+}
+
+#[derive(Debug)]
+struct ReadinessInner {
+    state: ReadinessState,
+    last_poll: Option<DateTime<Utc>>,
+    max_poll_staleness: Option<Duration>,
+}
+
+/// Snapshot of the readiness gate returned by `/health/ready`. Flat JSON so
+/// it can be merged into each service's own health payload without forcing
+/// callers to drill into a nested object.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReadinessSnapshot {
+    pub state: ReadinessState,
+    pub last_poll: Option<DateTime<Utc>>,
+    pub max_poll_staleness_secs: Option<u64>,
+    /// True when `state == Ready` but the newest poll is older than the
+    /// staleness threshold. Derived for convenience — callers shouldn't have
+    /// to recompute it.
+    pub stale: bool,
+}
+
+impl ReadinessGate {
+    /// Create a gate starting in [`ReadinessState::Starting`]. `max_poll_staleness`
+    /// is the freshness window past which a `Ready` service flips to 503
+    /// (typically ~2x the longest poll interval). Pass `None` for services
+    /// that have no polling loop.
+    pub fn new(max_poll_staleness: Option<Duration>) -> Self {
+        Self {
+            inner: RwLock::new(ReadinessInner {
+                state: ReadinessState::Starting,
+                last_poll: None,
+                max_poll_staleness,
+            }),
+        }
+    }
+
+    /// Mark the service as ready to receive traffic. Usually called once, at
+    /// the end of init, before the poll loops start.
+    pub async fn mark_ready(&self) {
+        self.inner.write().await.state = ReadinessState::Ready;
+    }
+
+    /// Mark the service as unrecoverably failed. `/health/ready` will return
+    /// 503 until the process exits.
+    pub async fn mark_failed(&self, reason: impl Into<String>) {
+        self.inner.write().await.state = ReadinessState::Failed {
+            reason: reason.into(),
+        };
+    }
+
+    /// Record that a background poll cycle just completed successfully. Used
+    /// by `/health/ready` to detect frozen workers.
+    pub async fn record_poll(&self) {
+        self.inner.write().await.last_poll = Some(Utc::now());
+    }
+
+    /// Snapshot for the health handler.
+    pub async fn snapshot(&self) -> ReadinessSnapshot {
+        let inner = self.inner.read().await;
+        let stale = matches!(inner.state, ReadinessState::Ready)
+            && inner
+                .max_poll_staleness
+                .zip(inner.last_poll)
+                .is_some_and(|(max, last)| {
+                    Utc::now().signed_duration_since(last).to_std().unwrap_or_default() > max
+                });
+        ReadinessSnapshot {
+            state: inner.state.clone(),
+            last_poll: inner.last_poll,
+            max_poll_staleness_secs: inner.max_poll_staleness.map(|d| d.as_secs()),
+            stale,
+        }
+    }
+
+    /// Compute the HTTP status code `/health/ready` should return. 200 only
+    /// when the service is `Ready` AND (no staleness threshold is set OR
+    /// the last poll is within the threshold OR no poll has been recorded
+    /// yet but the gate was only just marked ready — services without a
+    /// poll loop set `max_poll_staleness` to `None` to skip this check).
+    pub async fn http_status(&self) -> StatusCode {
+        let snap = self.snapshot().await;
+        match snap.state {
+            ReadinessState::Starting | ReadinessState::Failed { .. } => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            ReadinessState::Ready => {
+                // If a staleness threshold is configured, require at least one
+                // successful poll and enforce freshness. Services without a
+                // poll loop pass `None` and are considered ready immediately.
+                if snap.max_poll_staleness_secs.is_some()
+                    && (snap.last_poll.is_none() || snap.stale)
+                {
+                    return StatusCode::SERVICE_UNAVAILABLE;
+                }
+                StatusCode::OK
+            }
+        }
+    }
+}
+
+// ─── env-var helpers ─────────────────────────────────────────────────────
+
+/// Read an environment variable or log + exit(1). Use for values that are
+/// required for the service to do any work — there is no sensible fallback
+/// and continuing would only hide the misconfiguration.
+pub fn fatal_env(key: &str) -> String {
+    match env::var(key) {
+        Ok(v) if !v.trim().is_empty() => v,
+        Ok(_) => {
+            eprintln!("[FATAL] Required environment variable is empty: {key}");
+            log_flush_and_exit(1);
+        }
+        Err(_) => {
+            eprintln!("[FATAL] Required environment variable is not set: {key}");
+            log_flush_and_exit(1);
+        }
+    }
+}
+
+// ─── supervised task spawning ────────────────────────────────────────────
+
+/// Spawn a tokio task that will take the entire process down on panic or
+/// early return treated as fatal. Wraps the future with `catch_unwind` so a
+/// panic in a spawned task no longer disappears silently — instead it logs
+/// `{panic:?}` and calls `exit(1)`.
+///
+/// `name` is used only for log context.
+pub fn spawn_supervised<F>(name: &'static str, fut: F) -> tokio::task::JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let result = AssertUnwindSafe(fut).catch_unwind().await;
+        if let Err(panic) = result {
+            eprintln!(
+                "[FATAL] Supervised task '{name}' panicked: {:?}",
+                panic_message(&panic)
+            );
+            log_flush_and_exit(1);
+        }
+    })
+}
+
+fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("{:?}", panic)
+    }
+}
+
+// ─── graceful process exit ───────────────────────────────────────────────
+
+/// Sleep briefly so in-flight log messages can flush, then exit with the
+/// given code. Used for [`fatal_env`] and [`spawn_supervised`] on panic.
+///
+/// The sleep gives the async logger's mpsc receiver a chance to drain; it
+/// also guarantees Kubernetes sees at least one `/health/ready` 503 before
+/// the pod goes away, which keeps restart loops easier to diagnose.
+pub fn log_flush_and_exit(code: i32) -> ! {
+    std::thread::sleep(Duration::from_secs(2));
+    std::process::exit(code);
+}
+
+/// Mark a readiness gate as failed and then terminate the process after a
+/// short grace period so Kubernetes restarts the pod. Unlike the old
+/// `return;` pattern, this makes silent failure impossible.
+///
+/// The 5-second grace period lets at least one `readinessProbe` cycle
+/// observe the 503 before the pod terminates, making outages visible in
+/// `kubectl describe pod` output instead of just appearing as a restart
+/// with no context.
+pub async fn fatal(gate: &ReadinessGate, reason: impl Into<String>) -> ! {
+    let reason = reason.into();
+    eprintln!("[FATAL] {reason}");
+    gate.mark_failed(reason).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    log_flush_and_exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn starting_returns_503() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        let snap = gate.snapshot().await;
+        assert!(matches!(snap.state, ReadinessState::Starting));
+        assert!(!snap.stale);
+    }
+
+    #[tokio::test]
+    async fn ready_without_poll_returns_503_when_staleness_required() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        gate.mark_ready().await;
+        // Ready but no poll has happened yet — 503 so probes don't route traffic
+        // to a pod that hasn't done any real work.
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn ready_without_staleness_config_returns_200_immediately() {
+        let gate = ReadinessGate::new(None);
+        gate.mark_ready().await;
+        assert_eq!(gate.http_status().await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn ready_with_fresh_poll_returns_200() {
+        let gate = ReadinessGate::new(Some(Duration::from_secs(60)));
+        gate.mark_ready().await;
+        gate.record_poll().await;
+        assert_eq!(gate.http_status().await, StatusCode::OK);
+        assert!(!gate.snapshot().await.stale);
+    }
+
+    #[tokio::test]
+    async fn ready_with_stale_poll_returns_503() {
+        let gate = ReadinessGate::new(Some(Duration::from_millis(50)));
+        gate.mark_ready().await;
+        gate.record_poll().await;
+        // Wait past the staleness window
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(gate.snapshot().await.stale);
+    }
+
+    #[tokio::test]
+    async fn failed_always_returns_503() {
+        let gate = ReadinessGate::new(None);
+        gate.mark_failed("db init: boom").await;
+        assert_eq!(gate.http_status().await, StatusCode::SERVICE_UNAVAILABLE);
+        let snap = gate.snapshot().await;
+        match snap.state {
+            ReadinessState::Failed { reason } => assert_eq!(reason, "db init: boom"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+}

--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -4,7 +4,7 @@ use tokio::sync::Mutex;
 use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, Utc};
 use crate::log::{error, info, warn};
 use crate::database::{
-    PgPool, truncate_games,
+    PgPool,
     get_tracked_leagues, seed_tracked_leagues, disable_stale_leagues,
     cleanup_old_games, get_live_yesterday_leagues,
     LeagueConfig, TrackedLeague, upsert_game, CleanedData, Team,
@@ -14,6 +14,7 @@ pub use crate::types::{SportsHealth, RateLimiter};
 
 pub mod log;
 pub mod database;
+pub mod init;
 pub mod types;
 
 /// Number of days ahead to poll in the schedule task.
@@ -29,10 +30,46 @@ const STARTUP_REQUEST_DELAY_MS: u64 = 200;
 // Service initialization (runs once on startup)
 // =============================================================================
 
-/// Initialize the sports service: create tables, run migrations, seed leagues,
-/// and handle any data source migration. Returns the API client and tracked
-/// leagues, or None if initialization failed.
-pub async fn init_sports_service(pool: &Arc<PgPool>) -> Option<(Client, Vec<TrackedLeague>)> {
+/// Outcome of `init_sports_service`. The failure variants name the exact
+/// condition so `main.rs` can surface a useful reason via the readiness
+/// gate before the process exits.
+#[derive(Debug)]
+pub enum InitError {
+    /// The `tracked_leagues` table has no enabled rows and `configs/leagues.json`
+    /// did not supply any either. There is no work to do and nothing to poll.
+    NoLeaguesConfigured,
+    /// `API_SPORTS_KEY` is missing or empty. The service literally cannot make
+    /// a single request.
+    MissingApiKey,
+}
+
+impl std::fmt::Display for InitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InitError::NoLeaguesConfigured => {
+                write!(f, "No leagues to track: tracked_leagues is empty and configs/leagues.json yielded no entries")
+            }
+            InitError::MissingApiKey => {
+                write!(f, "API_SPORTS_KEY is not set or empty")
+            }
+        }
+    }
+}
+
+/// Initialize the sports service: seed tracked leagues from the config file,
+/// then load the active set from the database. Returns the API client and
+/// tracked leagues on success, or an explicit [`InitError`] so the caller
+/// can surface the exact cause via the readiness gate before exiting.
+///
+/// Note: this function no longer inspects the `games` table for "old ESPN
+/// data" and truncates it. That startup-side effect existed during the
+/// ESPN → api-sports.io migration (early 2026). It is now an active
+/// foot-gun: anything that accidentally leaves a row with an empty `sport`
+/// field would wipe the whole table on the next pod restart. All production
+/// data has been in the new format for months.
+pub async fn init_sports_service(
+    pool: &Arc<PgPool>,
+) -> Result<(Client, Vec<TrackedLeague>), InitError> {
     info!("Starting sports service...");
 
     // Seed from JSON config — always upsert to pick up new leagues
@@ -55,40 +92,21 @@ pub async fn init_sports_service(pool: &Arc<PgPool>) -> Option<(Client, Vec<Trac
         warn!("Could not read ./configs/leagues.json");
     }
 
-    // Check for data source migration flag — truncate old ESPN data on first run
-    let migration_flag = pool.acquire().await.ok().map(|mut conn| async move {
-        sqlx::query_scalar::<_, bool>(
-            "SELECT EXISTS(SELECT 1 FROM games WHERE sport = '' OR sport IS NULL LIMIT 1)"
-        )
-        .fetch_one(&mut *conn)
-        .await
-        .unwrap_or(false)
-    });
-
-    if let Some(future) = migration_flag {
-        if future.await {
-            info!("Detected old ESPN data (games without sport field). Truncating for migration...");
-            if let Err(e) = truncate_games(pool).await {
-                error!("Failed to truncate games: {}", e);
-            }
-        }
-    }
-
     let leagues = get_tracked_leagues(pool.clone()).await;
     if leagues.is_empty() {
-        error!("No leagues to track. Sports service idling.");
-        return None;
+        error!("No leagues to track.");
+        return Err(InitError::NoLeaguesConfigured);
     }
 
     let api_key = env::var("API_SPORTS_KEY").unwrap_or_default();
     if api_key.is_empty() {
         error!("API_SPORTS_KEY not set. Cannot poll api-sports.io.");
-        return None;
+        return Err(InitError::MissingApiKey);
     }
 
     let client = build_client(&api_key);
     info!("Initialized with {} leagues", leagues.len());
-    Some((client, leagues))
+    Ok((client, leagues))
 }
 
 // =============================================================================

--- a/channels/sports/service/src/main.rs
+++ b/channels/sports/service/src/main.rs
@@ -1,21 +1,49 @@
-use axum::{routing::get, Router, Json, extract::State};
+use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
 use dotenv::dotenv;
-use std::sync::Arc;
+use serde::Serialize;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use sports_service::{
-    init_sports_service, poll_live, poll_schedule, poll_standings, poll_teams,
-    SportsHealth, RateLimiter,
-    log::init_async_logger, database::initialize_pool,
+    database::initialize_pool,
+    init::{fatal, spawn_supervised, ReadinessGate, ReadinessSnapshot},
+    init_sports_service,
+    log::init_async_logger,
+    poll_live, poll_schedule, poll_standings, poll_teams,
+    RateLimiter, SportsHealth,
 };
 
 #[derive(Clone)]
 struct AppState {
     health: Arc<Mutex<SportsHealth>>,
+    readiness: Arc<ReadinessGate>,
+}
+
+#[derive(Serialize)]
+struct ReadyPayload {
+    #[serde(flatten)]
+    readiness: ReadinessSnapshot,
+    health: SportsHealth,
 }
 
 /// Interval for the schedule poll (upcoming games + cleanup).
 const SCHEDULE_POLL_SECS: u64 = 30 * 60; // 30 minutes
+
+/// Fastest "live" poll interval. Actual interval is adaptive (30s when
+/// leagues_live > 0, 60s otherwise) but for staleness calculations we use
+/// the widest reasonable gap.
+const LIVE_POLL_MAX_INTERVAL_SECS: u64 = 60;
+
+/// Maximum acceptable staleness before `/health/ready` returns 503. The
+/// staleness threshold is deliberately 2x the widest expected gap between
+/// successful polls, so transient rate-limits or a slow external API don't
+/// flap readiness. If no poll has succeeded in this window something is
+/// actually wrong.
+const MAX_POLL_STALENESS_SECS: u64 = LIVE_POLL_MAX_INTERVAL_SECS * 2;
+
+/// How often the bridge loop checks `SportsHealth.last_poll` and forwards
+/// it to the readiness gate. Cheap, runs on a tight interval.
+const READINESS_BRIDGE_INTERVAL: Duration = Duration::from_secs(10);
 
 #[tokio::main]
 async fn main() {
@@ -23,14 +51,25 @@ async fn main() {
     let _ = init_async_logger("./logs");
 
     let health = Arc::new(Mutex::new(SportsHealth::new()));
+    let readiness = Arc::new(ReadinessGate::new(Some(Duration::from_secs(
+        MAX_POLL_STALENESS_SECS,
+    ))));
 
     // Cancellation token for coordinated shutdown
     let cancel = CancellationToken::new();
 
-    // Start HTTP server immediately so K8s startup probes pass
-    let state = AppState { health: health.clone() };
+    // Start HTTP server immediately so the k8s liveness probe has something
+    // to talk to, but the readiness probe at /health/ready will return 503
+    // until the init task calls `readiness.mark_ready()` AND the first
+    // poll cycle completes.
+    let state = AppState {
+        health: health.clone(),
+        readiness: readiness.clone(),
+    };
     let app = Router::new()
-        .route("/health", get(health_handler))
+        .route("/health", get(health_ready_handler))
+        .route("/health/live", get(health_live_handler))
+        .route("/health/ready", get(health_ready_handler))
         .with_state(state);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3002".to_string());
@@ -38,32 +77,43 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     println!("Sports Service listening on {} (connecting to DB...)", addr);
 
-    // Spawn background task for DB connection + service init
+    // Spawn background init. `spawn_supervised` catches panics so a bug
+    // inside init takes the process down instead of leaving a zombie pod.
     let health_bg = health.clone();
+    let readiness_bg = readiness.clone();
     let cancel_bg = cancel.clone();
-    tokio::spawn(async move {
-        let mut retries = 5;
+    spawn_supervised("sports-init", async move {
+        const RETRIES: u32 = 5;
+        let mut remaining = RETRIES;
         let pool = loop {
             match initialize_pool().await {
                 Ok(p) => break Arc::new(p),
+                Err(e) if remaining == 0 => {
+                    fatal(
+                        &readiness_bg,
+                        format!("DB init failed after {RETRIES} retries: {e:#}"),
+                    )
+                    .await;
+                }
                 Err(e) => {
-                    if retries == 0 {
-                        eprintln!("[FATAL] Failed to init DB after retries: {}", e);
-                        return;
-                    }
-                    eprintln!("[DB] Failed to connect, retrying in 2s... ({} attempts left) Error: {}", retries, e);
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    retries -= 1;
+                    eprintln!(
+                        "[DB] Connection attempt failed ({} remaining): {e:#}",
+                        remaining
+                    );
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    remaining -= 1;
                 }
             }
         };
 
         // ── Initialize service (tables, migrations, seeding) ─────────────
         let (client, leagues) = match init_sports_service(&pool).await {
-            Some(result) => result,
-            None => {
-                println!("Sports service initialization failed. Serving health endpoint only.");
-                return;
+            Ok(result) => result,
+            Err(e) => {
+                // Misconfiguration: no leagues or missing API key. Exit so
+                // Kubernetes surfaces the error and operator attention is
+                // forced; the old behavior silently served /health as 200.
+                fatal(&readiness_bg, format!("Sports init failed: {e}")).await;
             }
         };
 
@@ -80,6 +130,33 @@ async fn main() {
         let client = Arc::new(client);
         let leagues = Arc::new(leagues);
 
+        // Init finished. Mark ready — but /health/ready stays 503 until the
+        // first poll records a timestamp via the bridge loop below.
+        readiness_bg.mark_ready().await;
+
+        // Bridge: watch SportsHealth.last_poll and forward to readiness
+        // gate. Cheap + keeps the poll functions untouched.
+        let bridge_health = health_bg.clone();
+        let bridge_readiness = readiness_bg.clone();
+        let bridge_cancel = cancel_bg.clone();
+        tokio::spawn(async move {
+            let mut last_seen = None;
+            loop {
+                tokio::select! {
+                    _ = bridge_cancel.cancelled() => break,
+                    _ = tokio::time::sleep(READINESS_BRIDGE_INTERVAL) => {
+                        let snap = bridge_health.lock().await.get_health();
+                        if let Some(ts) = snap.last_poll {
+                            if last_seen != Some(ts) {
+                                bridge_readiness.record_poll().await;
+                                last_seen = Some(ts);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
         // ── Fast poll: live scores (today only, 30s live / 1min idle) ─────
         let pool_live = pool.clone();
         let client_live = client.clone();
@@ -87,7 +164,7 @@ async fn main() {
         let health_live = health_bg.clone();
         let rl_live = rate_limiter.clone();
         let cancel_live = cancel_bg.clone();
-        tokio::spawn(async move {
+        spawn_supervised("sports-live-poll", async move {
             println!("Starting live poll loop (adaptive intervals)...");
             loop {
                 tokio::select! {
@@ -120,7 +197,7 @@ async fn main() {
         let leagues_sched = leagues.clone();
         let rl_sched = rate_limiter.clone();
         let cancel_sched = cancel_bg.clone();
-        tokio::spawn(async move {
+        spawn_supervised("sports-schedule-poll", async move {
             println!("Starting schedule poll loop (every {} min)...", SCHEDULE_POLL_SECS / 60);
             // Run immediately on startup to populate the schedule
             poll_schedule(&pool_sched, &client_sched, &leagues_sched, &rl_sched).await;
@@ -144,7 +221,7 @@ async fn main() {
         let leagues_standings = leagues.clone();
         let rl_standings = rate_limiter.clone();
         let cancel_standings = cancel_bg.clone();
-        tokio::spawn(async move {
+        spawn_supervised("sports-standings-poll", async move {
             println!("Starting standings poll loop (daily)...");
             poll_standings(&pool_standings, &client_standings, &leagues_standings, &rl_standings).await;
             loop {
@@ -167,7 +244,7 @@ async fn main() {
         let leagues_teams = leagues.clone();
         let rl_teams = rate_limiter.clone();
         let cancel_teams = cancel_bg.clone();
-        tokio::spawn(async move {
+        spawn_supervised("sports-teams-poll", async move {
             println!("Starting teams poll loop (weekly)...");
             poll_teams(&pool_teams, &client_teams, &leagues_teams, &rl_teams).await;
             loop {
@@ -218,7 +295,18 @@ async fn shutdown_signal() {
     }
 }
 
-async fn health_handler(State(state): State<AppState>) -> Json<SportsHealth> {
+/// Liveness probe: 200 as long as the process is up.
+async fn health_live_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(serde_json::json!({"status": "alive"})))
+}
+
+/// Readiness probe: 200 only when DB init succeeded AND the first poll
+/// cycle completed within `MAX_POLL_STALENESS_SECS`.
+async fn health_ready_handler(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<ReadyPayload>) {
+    let readiness = state.readiness.snapshot().await;
+    let code = state.readiness.http_status().await;
     let health = state.health.lock().await.get_health();
-    Json(health)
+    (code, Json(ReadyPayload { readiness, health }))
 }

--- a/channels/sports/service/tests/readiness_http.rs
+++ b/channels/sports/service/tests/readiness_http.rs
@@ -1,0 +1,143 @@
+//! Integration test for the readiness gate wired to an axum router.
+//!
+//! This test builds the same two-handler setup that lives in `main.rs`
+//! (`/health/live` and `/health/ready`), flips the [`ReadinessGate`] state
+//! by hand, and verifies the HTTP status codes — proving that the silent
+//! "always 200" failure mode is gone.
+//!
+//! Without this test, the per-gate unit tests in `init::tests` would still
+//! pass even if someone wired up the handler incorrectly (e.g. forgot to
+//! forward the status code). Catching that requires exercising the actual
+//! axum tower pipeline.
+
+use std::{sync::Arc, time::Duration};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    routing::get,
+    Json, Router,
+};
+use sports_service::init::{ReadinessGate, ReadinessSnapshot};
+use serde::Serialize;
+use tower::ServiceExt; // for `oneshot`
+
+#[derive(Clone)]
+struct TestState {
+    readiness: Arc<ReadinessGate>,
+}
+
+#[derive(Serialize)]
+struct ReadyPayload {
+    #[serde(flatten)]
+    readiness: ReadinessSnapshot,
+}
+
+async fn live_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(serde_json::json!({"status": "alive"})))
+}
+
+async fn ready_handler(State(state): State<TestState>) -> (StatusCode, Json<ReadyPayload>) {
+    let readiness = state.readiness.snapshot().await;
+    let code = state.readiness.http_status().await;
+    (code, Json(ReadyPayload { readiness }))
+}
+
+fn build_app(readiness: Arc<ReadinessGate>) -> Router {
+    let state = TestState { readiness };
+    Router::new()
+        .route("/health", get(ready_handler))
+        .route("/health/live", get(live_handler))
+        .route("/health/ready", get(ready_handler))
+        .with_state(state)
+}
+
+async fn status_of(app: &Router, path: &str) -> StatusCode {
+    let response = app
+        .clone()
+        .oneshot(Request::get(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    response.status()
+}
+
+#[tokio::test]
+async fn live_is_always_200_even_when_readiness_starting() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate);
+    // Starting state → /health/live should still return 200 because
+    // Kubernetes needs liveness separated from readiness.
+    assert_eq!(status_of(&app, "/health/live").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ready_returns_503_while_starting() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_503_after_mark_ready_but_no_poll_when_staleness_required() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    gate.mark_ready().await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "ready with no recorded poll must still be 503 when a staleness threshold is set"
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_200_after_poll_recorded() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    let app = build_app(gate);
+    assert_eq!(status_of(&app, "/health/ready").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ready_returns_503_when_poll_is_stale() {
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_millis(50))));
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn ready_returns_503_after_mark_failed() {
+    let gate = Arc::new(ReadinessGate::new(None));
+    gate.mark_failed("test: boom").await;
+    let app = build_app(gate);
+    assert_eq!(
+        status_of(&app, "/health/ready").await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
+async fn root_health_path_mirrors_ready() {
+    // Back-compat: the k8s probes currently point at /health. Until PR 5
+    // updates the manifests, /health must behave like /health/ready.
+    let gate = Arc::new(ReadinessGate::new(Some(Duration::from_secs(60))));
+    let app = build_app(gate.clone());
+    assert_eq!(
+        status_of(&app, "/health").await,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "/health should alias /health/ready, not /health/live"
+    );
+    gate.mark_ready().await;
+    gate.record_poll().await;
+    assert_eq!(status_of(&app, "/health").await, StatusCode::OK);
+}


### PR DESCRIPTION
## Why

The sports-service pod has been nominally `Ready` in production for the last 3 days while doing **zero polling**. Users see sports data frozen at `2026-04-19 08:34:41 UTC`.

**Root cause (confirmed live in the DO cluster):** `sqlx::migrate::run` returned `VersionMismatch` because two migration files were edited on disk after being applied to production (commit `427e7d4`). The error was swallowed by a generic `.context("Failed to run migrations...")` wrapper, the background init task silently `return`'d from its `tokio::spawn`, and the HTTP server — spawned *before* init — kept happily returning HTTP 200 on `/health`. k8s liveness, readiness, and startup probes all hit that endpoint, so the pod stayed Ready with 0 restarts indefinitely.

The same silent-failure shape exists in `finance-service` and `rss-service`. This PR is step 1 of a 6-PR series that makes the whole class of failure impossible to repeat.

## What

New `init.rs` module (copy-pasted per-service, matching the AGENTS.md isolation policy for `database.rs` and `log.rs`) with:

- `ReadinessGate` — `Arc<RwLock<ReadinessState>>` wrapper with `Starting` / `Ready` / `Failed { reason }` states, plus per-service `max_poll_staleness` tracking.
- `spawn_supervised(name, fut)` — wraps `tokio::spawn` with `catch_unwind`. Panics in background tasks no longer disappear; they log and `exit(1)`.
- `fatal(gate, reason)` — marks the gate failed, sleeps 5s so probes observe the 503, then `exit(1)`. Replaces every silent `return;` after retry exhaustion.
- `fatal_env(var)` — replaces `.expect("VAR must be set")` on critical env vars. `.expect()` inside a spawned task panics the task only, leaving the pod nominally healthy; `fatal_env` exits the process.
- `log_flush_and_exit(code)` — 2s sleep + `exit`, gives the async logger time to drain before the pod goes away.

Split health endpoints:

- `GET /health/live` — always HTTP 200. Liveness only: is the process running?
- `GET /health/ready` — HTTP 503 when state is `Starting`, `Failed`, or when the last successful poll is older than `max_poll_staleness`. Otherwise 200.
- `GET /health` — aliases `/health/ready` for back-compat with current k8s probes (which PR 5 will repoint).

Response body is a flat JSON payload merging the readiness snapshot and the existing service-specific health struct, so humans can still `curl | jq` and see why a 503 fired.

Other fixes bundled here because they're the same bug class:

- Migration errors now print the full sqlx error chain (`{err:?}`) including `VersionMismatch(version)`. No more opaque wrapper message.
- `set_ignore_missing(true)` removed from all three services (PR 2 namespaces the migration tables, making the shared-`_sqlx_migrations` hack unnecessary).
- Sports: deleted the ESPN→api-sports.io truncation trap (a `TRUNCATE games` on startup based on sniffing for an empty `sport` field). Production data has been in the new format for months; keeping a self-destructing startup check is an active foot-gun.
- Sports: `init_sports_service` now returns `Result<_, InitError>` with explicit `NoLeaguesConfigured` / `MissingApiKey` variants, surfaced through the readiness gate before `fatal()`.
- Finance: `FinanceState::new` replaced `.expect("TWELVEDATA_API_KEY...")` (which silently panicked inside a spawned task) with `fatal_env`.
- RSS: `RssHealth::new()` defaults `status` to `"starting"` for consistency with Sports. The field is informational now that readiness is the source of truth.

## How I tested

- **Finance**: 13 lib + 7 integration = **20 passing**
- **Sports**: 29 lib + 7 integration = **36 passing**
- **RSS**: 18 lib + 7 integration = **25 passing**
- **Total: 81 tests, 0 failures**
- Release builds clean for all three services
- `cargo clippy --tests` introduces no new warnings

The 6 per-service unit tests exercise state transitions on the gate itself. The 7 per-service integration tests in `tests/readiness_http.rs` build the real axum router, hit `/health/live`, `/health/ready`, and `/health` with `tower::ServiceExt::oneshot`, and assert the status codes for each readiness state — catching the case where someone wires the handler up but forgets to forward the status code.

## Follow-up PRs (sequential, land in order)

- **PR 2**: namespace `_sqlx_migrations_{finance,sports,rss}` tables + one-off SQL split script. **This is the PR that resurrects sports ingestion** (the checksums are re-synced as part of the split).
- **PR 3**: rename migration version prefixes (finance `11*`, sports `12*`, rss `13*`).
- **PR 4**: make Go API `/internal/health` stubs do real work (DB + Redis ping, Rust-service proxy); fatal-at-startup on missing critical env.
- **PR 5**: update k8s manifests to point `readinessProbe` / `startupProbe` at `/health/ready`.
- **PR 6**: `scripts/smoke/production-readiness.sh` smoke-test harness.