### PR TITLE
fix(api): make Go API health endpoints actually reflect readiness (4/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ __pycache__/
 *.pyc
 .venv/
 channels/sports/api/scrollr-sports
+channels/finance/api/scrollr-finance
+channels/rss/api/scrollr-rss
+channels/fantasy/api/scrollr-fantasy
 scaling-changes/
 .worktrees/
 .superpowers/

--- a/api/core/auth.go
+++ b/api/core/auth.go
@@ -16,11 +16,15 @@ var (
 )
 
 // InitAuth initialises the JWKS keyfunc for JWT validation.
+//
+// LOGTO_JWKS_URL is required in all environments. The old behavior
+// (log a warning and continue) meant authenticated routes silently
+// 401'd at request time with "JWKS not initialized", which looked to
+// operators like a broken user rather than a broken deploy. Fail fast.
 func InitAuth() {
 	jwksURL := os.Getenv("LOGTO_JWKS_URL")
 	if jwksURL == "" {
-		log.Println("[Auth] LOGTO_JWKS_URL not set — authentication will fail")
-		return
+		log.Fatal("[Auth] LOGTO_JWKS_URL is required")
 	}
 
 	log.Printf("[Auth] Initializing with JWKS: %s", jwksURL)

--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -32,8 +32,15 @@ import (
 func initStripe() {
 	key := os.Getenv("STRIPE_SECRET_KEY")
 	if key == "" {
-		log.Println("[Billing] Warning: STRIPE_SECRET_KEY not set — billing endpoints will fail")
-		return
+		// STRIPE_DISABLED is the escape hatch for local dev or staging
+		// environments that intentionally run without billing. Production
+		// must always have a key set; silently continuing used to leave
+		// the /users/me/subscription/* routes 500ing forever.
+		if os.Getenv("STRIPE_DISABLED") == "true" {
+			log.Println("[Billing] STRIPE_SECRET_KEY not set and STRIPE_DISABLED=true — billing endpoints will return errors")
+			return
+		}
+		log.Fatal("[Billing] STRIPE_SECRET_KEY is required (set STRIPE_DISABLED=true to run without billing)")
 	}
 	stripe.Key = key
 

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -218,12 +218,17 @@ func (s *Server) setupRoutes() {
 
 // healthCheck returns the aggregated health status.
 // Results are cached in Redis for 10s. Singleflight prevents thundering herd.
+//
+// Returns HTTP 503 when `status == "degraded"` so Kubernetes readiness
+// probes can actually see degradation. Previously returned 200 with
+// `{"status":"degraded",…}` in the body, which k8s never inspected —
+// making partial outages of the core API invisible to the orchestrator.
+// The body shape is unchanged; only the status code in the degraded case
+// differs.
 func (s *Server) healthCheck(c *fiber.Ctx) error {
 	// Check Redis cache first
 	if val, err := Rdb.Get(context.Background(), HealthCacheKey).Result(); err == nil {
-		c.Set("Content-Type", "application/json")
-		c.Set("X-Cache", "HIT")
-		return c.SendString(val)
+		return sendHealthCached(c, []byte(val), "HIT")
 	}
 
 	// Singleflight: only one goroutine computes; others wait and share the result
@@ -286,9 +291,24 @@ func (s *Server) healthCheck(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{Error: "health check failed"})
 	}
 
+	return sendHealthCached(c, result.([]byte), "MISS")
+}
+
+// sendHealthCached writes a cached HealthResponse body, inferring the HTTP
+// status code from the status field inside the JSON. "healthy" → 200,
+// anything else → 503. Extracted so the cache hit and cache miss paths
+// return consistent status codes.
+func sendHealthCached(c *fiber.Ctx, body []byte, cacheHeader string) error {
 	c.Set("Content-Type", "application/json")
-	c.Set("X-Cache", "MISS")
-	return c.Send(result.([]byte))
+	c.Set("X-Cache", cacheHeader)
+	status := fiber.StatusOK
+	var probe struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &probe); err == nil && probe.Status != "healthy" {
+		status = fiber.StatusServiceUnavailable
+	}
+	return c.Status(status).Send(body)
 }
 
 // getDashboard retrieves aggregated data for the user dashboard.

--- a/channels/fantasy/api/handlers.go
+++ b/channels/fantasy/api/handlers.go
@@ -3,9 +3,15 @@ package main
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 )
+
+// InternalHealthTimeout is the aggregate timeout for a /internal/health
+// request, covering DB and Redis pings. Shorter than the k8s readiness
+// probe timeout so a slow downstream doesn't hold up the probe.
+const InternalHealthTimeout = 3 * time.Second
 
 // =============================================================================
 // Database Helpers
@@ -85,7 +91,49 @@ func (a *App) AddLeagueSubscriber(ctx context.Context, leagueKey, logtoSub strin
 // Internal Health Check
 // =============================================================================
 
-// handleInternalHealth is a simple liveness check for the core gateway.
+// handleInternalHealth is the endpoint the core gateway and k8s probes hit.
+//
+// It verifies that this API's own dependencies (Postgres, Redis) are
+// reachable and that the Yahoo sync loop has not exhausted its restart
+// budget. Any failure returns HTTP 503 so the k8s readinessProbe marks the
+// pod NotReady. Previously returned a static `{"status":"healthy"}` no
+// matter what, which meant a dead sync loop was invisible to Kubernetes
+// and the service kept receiving traffic it couldn't serve.
 func (a *App) handleInternalHealth(c *fiber.Ctx) error {
-	return c.JSON(fiber.Map{"status": "healthy"})
+	ctx, cancel := context.WithTimeout(c.Context(), InternalHealthTimeout)
+	defer cancel()
+
+	result := fiber.Map{"status": "healthy"}
+	degraded := false
+
+	if err := a.db.Ping(ctx); err != nil {
+		result["database"] = "unhealthy: " + err.Error()
+		degraded = true
+	} else {
+		result["database"] = "healthy"
+	}
+
+	if err := a.rdb.Ping(ctx).Err(); err != nil {
+		result["redis"] = "unhealthy: " + err.Error()
+		degraded = true
+	} else {
+		result["redis"] = "healthy"
+	}
+
+	// Sync-exhausted is a readiness failure: the pod is nominally alive,
+	// but no new Yahoo data will ever be written to Postgres. A restart
+	// is cheap and may clear a transient upstream error; if not, the
+	// sync will fail again and the pod will stay NotReady.
+	if a.syncState != nil && a.syncState.IsFailed() {
+		result["sync"] = "failed: exceeded max restarts"
+		degraded = true
+	} else if a.syncState != nil {
+		result["sync"] = "running"
+	}
+
+	if degraded {
+		result["status"] = "degraded"
+		return c.Status(fiber.StatusServiceUnavailable).JSON(result)
+	}
+	return c.JSON(result)
 }

--- a/channels/fantasy/api/health_test.go
+++ b/channels/fantasy/api/health_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestSyncHealth_IsFailedFlagFollowsSetFailed is the specific invariant that
+// handleInternalHealth relies on: `IsFailed()` returns true iff setFailed
+// has been called (and stays true until setRunning resets it). Without
+// this, the k8s readiness probe can't see a dead sync loop.
+func TestSyncHealth_IsFailedFlagFollowsSetFailed(t *testing.T) {
+	sh := &syncHealth{status: "starting"}
+
+	if sh.IsFailed() {
+		t.Fatalf("fresh syncHealth: IsFailed() = true; want false")
+	}
+
+	sh.setFailed(5)
+	if !sh.IsFailed() {
+		t.Fatalf("after setFailed: IsFailed() = false; want true")
+	}
+
+	sh.setRunning(42)
+	if sh.IsFailed() {
+		t.Fatalf("after setRunning: IsFailed() = true; want false")
+	}
+}
+
+// TestSyncHealth_IsFailedConcurrent verifies the atomic flag is safe to
+// read from the health handler without acquiring the mutex. A race
+// condition here would flap the readiness probe and cause pods to enter
+// NotReady on every sync cycle boundary.
+func TestSyncHealth_IsFailedConcurrent(t *testing.T) {
+	sh := &syncHealth{}
+	done := make(chan struct{})
+
+	go func() {
+		for i := 0; i < 10_000; i++ {
+			sh.setFailed(i)
+			sh.setRunning(i)
+		}
+		close(done)
+	}()
+
+	// Read side: must never panic or observe torn state.
+	for i := 0; i < 10_000; i++ {
+		_ = sh.IsFailed()
+	}
+	<-done
+}

--- a/channels/fantasy/api/main.go
+++ b/channels/fantasy/api/main.go
@@ -140,11 +140,18 @@ func main() {
 		}
 	}
 
-	if clientID != "" {
-		log.Printf("[Fantasy] Yahoo Client ID: %s... Redirect URI: %s", clientID[:min(5, len(clientID))], redirectURL)
-	} else {
-		log.Println("[Fantasy] Warning: YAHOO_CLIENT_ID not set")
+	// YAHOO_CLIENT_ID and YAHOO_CLIENT_SECRET are both required — the entire
+	// purpose of this service is Yahoo OAuth2 + sync. Booting without them
+	// leaves the sync goroutine in a permanent failure loop (`runSyncLoop`
+	// returns an error immediately if they're empty, crash-restart hits
+	// `maxSyncRestarts`, then sync gives up silently). Fail fast instead.
+	if clientID == "" {
+		log.Fatal("[Fantasy] YAHOO_CLIENT_ID is required")
 	}
+	if clientSecret == "" {
+		log.Fatal("[Fantasy] YAHOO_CLIENT_SECRET is required")
+	}
+	log.Printf("[Fantasy] Yahoo Client ID: %s... Redirect URI: %s", clientID[:min(5, len(clientID))], redirectURL)
 
 	// Use env-var-overridable token URL so tests can redirect to a mock server.
 	// The auth URL is only used for browser redirects (user-facing), so it

--- a/channels/fantasy/api/sync.go
+++ b/channels/fantasy/api/sync.go
@@ -29,12 +29,18 @@ const (
 )
 
 // syncHealth tracks the state of the sync loop for health reporting.
+//
+// `failed` is a dedicated atomic flag so the hot path in /internal/health
+// can check sync state without acquiring the mutex — readiness probes need
+// to be cheap. When the flag is true the pod is NotReady and Kubernetes
+// will stop routing traffic to it.
 type syncHealth struct {
 	mu             sync.RWMutex
 	status         string
 	lastCycleTime  time.Time
 	lastCycleUsers int
 	restartCount   int
+	failed         atomic.Bool
 }
 
 func (sh *syncHealth) setRunning(users int) {
@@ -43,6 +49,7 @@ func (sh *syncHealth) setRunning(users int) {
 	sh.status = "running"
 	sh.lastCycleTime = time.Now()
 	sh.lastCycleUsers = users
+	sh.failed.Store(false)
 }
 
 func (sh *syncHealth) setFailed(restarts int) {
@@ -50,6 +57,13 @@ func (sh *syncHealth) setFailed(restarts int) {
 	defer sh.mu.Unlock()
 	sh.status = "failed"
 	sh.restartCount = restarts
+	sh.failed.Store(true)
+}
+
+// IsFailed reports whether the sync loop has exhausted its restart budget
+// and given up. Safe to call from any goroutine without locking.
+func (sh *syncHealth) IsFailed() bool {
+	return sh.failed.Load()
 }
 
 func (sh *syncHealth) snapshot() map[string]any {

--- a/channels/finance/api/finance.go
+++ b/channels/finance/api/finance.go
@@ -211,9 +211,54 @@ func (a *App) handleInternalDashboard(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"finance": trades})
 }
 
-// handleInternalHealth is a simple liveness check for the core gateway.
+// handleInternalHealth is the endpoint the core gateway and k8s probes hit.
+//
+// It verifies that this API's own dependencies (Postgres, Redis) are reachable
+// and that the downstream Rust ingestion service's /health/ready returns 200.
+// Any failure returns HTTP 503 so the k8s readinessProbe can mark the pod
+// NotReady and stop routing traffic. The previous version returned a static
+// `{"status":"healthy"}` no matter what, which helped mask the ingestion
+// outage on 2026-04-19.
 func (a *App) handleInternalHealth(c *fiber.Ctx) error {
-	return c.JSON(fiber.Map{"status": "healthy"})
+	ctx, cancel := context.WithTimeout(c.Context(), InternalHealthTimeout)
+	defer cancel()
+
+	result := fiber.Map{"status": "healthy"}
+	degraded := false
+
+	if err := a.db.Ping(ctx); err != nil {
+		result["database"] = "unhealthy: " + err.Error()
+		degraded = true
+	} else {
+		result["database"] = "healthy"
+	}
+
+	if err := a.rdb.Ping(ctx).Err(); err != nil {
+		result["redis"] = "unhealthy: " + err.Error()
+		degraded = true
+	} else {
+		result["redis"] = "healthy"
+	}
+
+	if internalURL := os.Getenv("INTERNAL_FINANCE_URL"); internalURL != "" {
+		code, ingestErr := probeIngestion(ctx, internalURL)
+		result["ingestion_http_status"] = code
+		if ingestErr != nil {
+			result["ingestion"] = "unreachable: " + ingestErr.Error()
+			degraded = true
+		} else if code != fiber.StatusOK {
+			result["ingestion"] = fmt.Sprintf("not ready: HTTP %d", code)
+			degraded = true
+		} else {
+			result["ingestion"] = "healthy"
+		}
+	}
+
+	if degraded {
+		result["status"] = "degraded"
+		return c.Status(fiber.StatusServiceUnavailable).JSON(result)
+	}
+	return c.JSON(result)
 }
 
 // =============================================================================

--- a/channels/finance/api/health_test.go
+++ b/channels/finance/api/health_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestBuildReadyURL verifies that every input shape we'd reasonably get
+// from `INTERNAL_SPORTS_URL` produces the canonical /health/ready path.
+// Guards against the previous bug where `buildHealthURL` produced `/health`
+// and a follower typo turned it into `/healthy` without anyone noticing.
+func TestBuildReadyURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"http://finance-service:3001", "http://finance-service:3001/health/ready"},
+		{"http://finance-service:3001/", "http://finance-service:3001/health/ready"},
+		{"http://finance-service:3001/health", "http://finance-service:3001/health/ready"},
+		{"http://finance-service:3001/health/", "http://finance-service:3001/health/ready"},
+		{"http://finance-service:3001/health/ready", "http://finance-service:3001/health/ready"},
+		{"http://finance-service:3001/health/ready/", "http://finance-service:3001/health/ready"},
+	}
+	for _, tc := range cases {
+		if got := buildReadyURL(tc.in); got != tc.want {
+			t.Errorf("buildReadyURL(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestProbeIngestion_ForwardsStatusCode covers the critical invariant
+// enforced by handleInternalHealth: whatever HTTP status code the Rust
+// service's /health/ready returns, we need to propagate it so the k8s
+// readiness probe on the Go API can tell when ingestion is broken.
+func TestProbeIngestion_ForwardsStatusCode(t *testing.T) {
+	cases := []int{200, 503, 500}
+	for _, want := range cases {
+		want := want
+		t.Run(http.StatusText(want), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/health/ready" {
+					t.Errorf("unexpected path: %q", r.URL.Path)
+				}
+				w.WriteHeader(want)
+			}))
+			defer srv.Close()
+
+			got, err := probeIngestion(context.Background(), srv.URL)
+			if err != nil {
+				t.Fatalf("probeIngestion: unexpected error: %v", err)
+			}
+			if got != want {
+				t.Errorf("probeIngestion: got %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestProbeIngestion_NetworkErrorReturnsError verifies we surface a
+// connection-level failure (Rust service down entirely) as an error, so
+// handleInternalHealth can mark the pod degraded.
+func TestProbeIngestion_NetworkErrorReturnsError(t *testing.T) {
+	// Bind to :0 and immediately close — any client request will see
+	// ECONNREFUSED.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	_, err := probeIngestion(context.Background(), url)
+	if err == nil {
+		t.Fatalf("probeIngestion: expected network error, got nil")
+	}
+}
+
+// TestProbeIngestion_EmptyURLIsNoOp confirms the "no INTERNAL_*_URL
+// configured" case doesn't error — returns (0, nil) so the caller can
+// skip the ingestion branch entirely.
+func TestProbeIngestion_EmptyURLIsNoOp(t *testing.T) {
+	code, err := probeIngestion(context.Background(), "")
+	if err != nil {
+		t.Fatalf("probeIngestion(''): unexpected error: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("probeIngestion(''): got %d, want 0", code)
+	}
+}

--- a/channels/finance/api/helpers.go
+++ b/channels/finance/api/helpers.go
@@ -16,6 +16,11 @@ import (
 // HealthProxyTimeout is the HTTP timeout for proxying health checks.
 const HealthProxyTimeout = 5 * time.Second
 
+// InternalHealthTimeout is the aggregate timeout for a /internal/health
+// request, covering DB ping + Redis ping + ingestion probe. Shorter than the
+// k8s readiness probe timeout so a slow downstream doesn't hold up the probe.
+const InternalHealthTimeout = 3 * time.Second
+
 // GetCache attempts to retrieve and deserialize a value from Redis.
 // Returns true if the cache hit was successful.
 func GetCache(rdb *redis.Client, key string, target interface{}) bool {
@@ -61,16 +66,46 @@ func RemoveSubscriber(rdb *redis.Client, ctx context.Context, setKey, userSub st
 	}
 }
 
-// buildHealthURL ensures the URL ends with /health.
-func buildHealthURL(baseURL string) string {
+// buildReadyURL returns the /health/ready endpoint on the given base URL.
+// Callers pass the INTERNAL_* env var straight in; trailing slashes and
+// pre-existing /health or /health/ready suffixes are handled idempotently.
+func buildReadyURL(baseURL string) string {
 	url := strings.TrimSuffix(baseURL, "/")
-	if !strings.HasSuffix(url, "/health") {
-		url = url + "/health"
+	switch {
+	case strings.HasSuffix(url, "/health/ready"):
+		return url
+	case strings.HasSuffix(url, "/health"):
+		return url + "/ready"
+	default:
+		return url + "/health/ready"
 	}
-	return url
+}
+
+// probeIngestion checks the downstream Rust ingestion service's
+// /health/ready endpoint and returns the HTTP status code it emitted.
+// A 200 means the Rust service considers itself ready to produce data;
+// a 503 means it is starting / failed / stale. Used by this API's own
+// /internal/health to propagate ingestion readiness up to Kubernetes.
+func probeIngestion(ctx context.Context, internalURL string) (int, error) {
+	if internalURL == "" {
+		return 0, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, buildReadyURL(internalURL), nil)
+	if err != nil {
+		return 0, err
+	}
+	httpClient := &http.Client{Timeout: HealthProxyTimeout}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
 }
 
 // ProxyInternalHealth proxies a health check to an internal service URL.
+// Used by the public /finance/health endpoint so operators can curl the
+// full Rust-side payload without having to exec into the cluster.
 func ProxyInternalHealth(c *fiber.Ctx, internalURL string) error {
 	if internalURL == "" {
 		return c.Status(fiber.StatusServiceUnavailable).JSON(ErrorResponse{
@@ -79,7 +114,7 @@ func ProxyInternalHealth(c *fiber.Ctx, internalURL string) error {
 		})
 	}
 
-	targetURL := buildHealthURL(internalURL)
+	targetURL := buildReadyURL(internalURL)
 	httpClient := &http.Client{Timeout: HealthProxyTimeout}
 	resp, err := httpClient.Get(targetURL)
 	if err != nil {

--- a/channels/rss/api/health_test.go
+++ b/channels/rss/api/health_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestBuildReadyURL verifies that every input shape we'd reasonably get
+// from `INTERNAL_SPORTS_URL` produces the canonical /health/ready path.
+// Guards against the previous bug where `buildHealthURL` produced `/health`
+// and a follower typo turned it into `/healthy` without anyone noticing.
+func TestBuildReadyURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"http://rss-service:3004", "http://rss-service:3004/health/ready"},
+		{"http://rss-service:3004/", "http://rss-service:3004/health/ready"},
+		{"http://rss-service:3004/health", "http://rss-service:3004/health/ready"},
+		{"http://rss-service:3004/health/", "http://rss-service:3004/health/ready"},
+		{"http://rss-service:3004/health/ready", "http://rss-service:3004/health/ready"},
+		{"http://rss-service:3004/health/ready/", "http://rss-service:3004/health/ready"},
+	}
+	for _, tc := range cases {
+		if got := buildReadyURL(tc.in); got != tc.want {
+			t.Errorf("buildReadyURL(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestProbeIngestion_ForwardsStatusCode covers the critical invariant
+// enforced by handleInternalHealth: whatever HTTP status code the Rust
+// service's /health/ready returns, we need to propagate it so the k8s
+// readiness probe on the Go API can tell when ingestion is broken.
+func TestProbeIngestion_ForwardsStatusCode(t *testing.T) {
+	cases := []int{200, 503, 500}
+	for _, want := range cases {
+		want := want
+		t.Run(http.StatusText(want), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/health/ready" {
+					t.Errorf("unexpected path: %q", r.URL.Path)
+				}
+				w.WriteHeader(want)
+			}))
+			defer srv.Close()
+
+			got, err := probeIngestion(context.Background(), srv.URL)
+			if err != nil {
+				t.Fatalf("probeIngestion: unexpected error: %v", err)
+			}
+			if got != want {
+				t.Errorf("probeIngestion: got %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestProbeIngestion_NetworkErrorReturnsError verifies we surface a
+// connection-level failure (Rust service down entirely) as an error, so
+// handleInternalHealth can mark the pod degraded.
+func TestProbeIngestion_NetworkErrorReturnsError(t *testing.T) {
+	// Bind to :0 and immediately close — any client request will see
+	// ECONNREFUSED.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	_, err := probeIngestion(context.Background(), url)
+	if err == nil {
+		t.Fatalf("probeIngestion: expected network error, got nil")
+	}
+}
+
+// TestProbeIngestion_EmptyURLIsNoOp confirms the "no INTERNAL_*_URL
+// configured" case doesn't error — returns (0, nil) so the caller can
+// skip the ingestion branch entirely.
+func TestProbeIngestion_EmptyURLIsNoOp(t *testing.T) {
+	code, err := probeIngestion(context.Background(), "")
+	if err != nil {
+		t.Fatalf("probeIngestion(''): unexpected error: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("probeIngestion(''): got %d, want 0", code)
+	}
+}

--- a/channels/rss/api/helpers.go
+++ b/channels/rss/api/helpers.go
@@ -16,6 +16,10 @@ import (
 // HealthProxyTimeout is the HTTP timeout for proxying health checks.
 const HealthProxyTimeout = 5 * time.Second
 
+// InternalHealthTimeout is the aggregate timeout for a /internal/health
+// request, covering DB ping + Redis ping + ingestion probe.
+const InternalHealthTimeout = 3 * time.Second
+
 // GetCache attempts to retrieve and deserialize a value from Redis.
 // Returns true if the cache hit was successful.
 func GetCache(rdb *redis.Client, ctx context.Context, key string, target interface{}) bool {
@@ -57,19 +61,45 @@ func RemoveSubscriber(rdb *redis.Client, ctx context.Context, setKey, userSub st
 	return rdb.SRem(ctx, setKey, userSub).Err()
 }
 
-// buildHealthURL ensures the URL ends with /health.
-func buildHealthURL(baseURL string) string {
+// buildReadyURL returns the /health/ready endpoint on the given base URL.
+// Idempotent for trailing slashes and pre-existing /health or /health/ready.
+func buildReadyURL(baseURL string) string {
 	url := strings.TrimSuffix(baseURL, "/")
-	if !strings.HasSuffix(url, "/health") {
-		url = url + "/health"
+	switch {
+	case strings.HasSuffix(url, "/health/ready"):
+		return url
+	case strings.HasSuffix(url, "/health"):
+		return url + "/ready"
+	default:
+		return url + "/health/ready"
 	}
-	return url
+}
+
+// probeIngestion checks the downstream Rust ingestion service's
+// /health/ready endpoint and returns the HTTP status code it emitted.
+func probeIngestion(ctx context.Context, internalURL string) (int, error) {
+	if internalURL == "" {
+		return 0, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, buildReadyURL(internalURL), nil)
+	if err != nil {
+		return 0, err
+	}
+	httpClient := &http.Client{Timeout: HealthProxyTimeout}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
 }
 
 // maxHealthResponseBytes limits the body size read from internal health endpoints.
 const maxHealthResponseBytes = 1 << 20 // 1 MB
 
 // ProxyInternalHealth proxies a health check to an internal service URL.
+// Used by the public /rss/health endpoint so operators can curl the full
+// Rust-side payload without having to exec into the cluster.
 func ProxyInternalHealth(c *fiber.Ctx, httpClient *http.Client, internalURL string) error {
 	if internalURL == "" {
 		return c.Status(fiber.StatusServiceUnavailable).JSON(ErrorResponse{
@@ -78,7 +108,7 @@ func ProxyInternalHealth(c *fiber.Ctx, httpClient *http.Client, internalURL stri
 		})
 	}
 
-	targetURL := buildHealthURL(internalURL)
+	targetURL := buildReadyURL(internalURL)
 	resp, err := httpClient.Get(targetURL)
 	if err != nil {
 		return c.Status(fiber.StatusServiceUnavailable).JSON(ErrorResponse{

--- a/channels/rss/api/rss.go
+++ b/channels/rss/api/rss.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -299,9 +300,52 @@ func (a *App) handleInternalDashboard(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"rss": items})
 }
 
-// handleInternalHealth is a simple liveness check for the core gateway.
+// handleInternalHealth is the endpoint the core gateway and k8s probes hit.
+//
+// It verifies that this API's own dependencies (Postgres, Redis) are reachable
+// and that the downstream Rust ingestion service's /health/ready returns 200.
+// Any failure returns HTTP 503 so the k8s readinessProbe can mark the pod
+// NotReady. Previously returned a static `{"status":"healthy"}` no matter what.
 func (a *App) handleInternalHealth(c *fiber.Ctx) error {
-	return c.JSON(fiber.Map{"status": "healthy"})
+	ctx, cancel := context.WithTimeout(c.Context(), InternalHealthTimeout)
+	defer cancel()
+
+	result := fiber.Map{"status": "healthy"}
+	degraded := false
+
+	if err := a.db.Ping(ctx); err != nil {
+		result["database"] = "unhealthy: " + err.Error()
+		degraded = true
+	} else {
+		result["database"] = "healthy"
+	}
+
+	if err := a.rdb.Ping(ctx).Err(); err != nil {
+		result["redis"] = "unhealthy: " + err.Error()
+		degraded = true
+	} else {
+		result["redis"] = "healthy"
+	}
+
+	if internalURL := os.Getenv("INTERNAL_RSS_URL"); internalURL != "" {
+		code, ingestErr := probeIngestion(ctx, internalURL)
+		result["ingestion_http_status"] = code
+		if ingestErr != nil {
+			result["ingestion"] = "unreachable: " + ingestErr.Error()
+			degraded = true
+		} else if code != fiber.StatusOK {
+			result["ingestion"] = fmt.Sprintf("not ready: HTTP %d", code)
+			degraded = true
+		} else {
+			result["ingestion"] = "healthy"
+		}
+	}
+
+	if degraded {
+		result["status"] = "degraded"
+		return c.Status(fiber.StatusServiceUnavailable).JSON(result)
+	}
+	return c.JSON(result)
 }
 
 // =============================================================================

--- a/channels/sports/api/health_test.go
+++ b/channels/sports/api/health_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestBuildReadyURL verifies that every input shape we'd reasonably get
+// from `INTERNAL_SPORTS_URL` produces the canonical /health/ready path.
+// Guards against the previous bug where `buildHealthURL` produced `/health`
+// and a follower typo turned it into `/healthy` without anyone noticing.
+func TestBuildReadyURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"http://sports-service:3002", "http://sports-service:3002/health/ready"},
+		{"http://sports-service:3002/", "http://sports-service:3002/health/ready"},
+		{"http://sports-service:3002/health", "http://sports-service:3002/health/ready"},
+		{"http://sports-service:3002/health/", "http://sports-service:3002/health/ready"},
+		{"http://sports-service:3002/health/ready", "http://sports-service:3002/health/ready"},
+		{"http://sports-service:3002/health/ready/", "http://sports-service:3002/health/ready"},
+	}
+	for _, tc := range cases {
+		if got := buildReadyURL(tc.in); got != tc.want {
+			t.Errorf("buildReadyURL(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestProbeIngestion_ForwardsStatusCode covers the critical invariant
+// enforced by handleInternalHealth: whatever HTTP status code the Rust
+// service's /health/ready returns, we need to propagate it so the k8s
+// readiness probe on the Go API can tell when ingestion is broken.
+func TestProbeIngestion_ForwardsStatusCode(t *testing.T) {
+	cases := []int{200, 503, 500}
+	for _, want := range cases {
+		want := want
+		t.Run(http.StatusText(want), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/health/ready" {
+					t.Errorf("unexpected path: %q", r.URL.Path)
+				}
+				w.WriteHeader(want)
+			}))
+			defer srv.Close()
+
+			got, err := probeIngestion(context.Background(), srv.URL)
+			if err != nil {
+				t.Fatalf("probeIngestion: unexpected error: %v", err)
+			}
+			if got != want {
+				t.Errorf("probeIngestion: got %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestProbeIngestion_NetworkErrorReturnsError verifies we surface a
+// connection-level failure (Rust service down entirely) as an error, so
+// handleInternalHealth can mark the pod degraded.
+func TestProbeIngestion_NetworkErrorReturnsError(t *testing.T) {
+	// Bind to :0 and immediately close — any client request will see
+	// ECONNREFUSED.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	_, err := probeIngestion(context.Background(), url)
+	if err == nil {
+		t.Fatalf("probeIngestion: expected network error, got nil")
+	}
+}
+
+// TestProbeIngestion_EmptyURLIsNoOp confirms the "no INTERNAL_*_URL
+// configured" case doesn't error — returns (0, nil) so the caller can
+// skip the ingestion branch entirely.
+func TestProbeIngestion_EmptyURLIsNoOp(t *testing.T) {
+	code, err := probeIngestion(context.Background(), "")
+	if err != nil {
+		t.Fatalf("probeIngestion(''): unexpected error: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("probeIngestion(''): got %d, want 0", code)
+	}
+}

--- a/channels/sports/api/helpers.go
+++ b/channels/sports/api/helpers.go
@@ -16,6 +16,12 @@ import (
 // HealthProxyTimeout is the HTTP timeout for proxying health checks.
 const HealthProxyTimeout = 5 * time.Second
 
+// InternalHealthTimeout is the aggregate timeout for a /internal/health
+// request, covering DB ping + Redis ping + ingestion probe. Slightly shorter
+// than the k8s readiness probe timeout (default 1s per probe, but we bound it
+// here regardless so a slow Redis doesn't stall the pod).
+const InternalHealthTimeout = 3 * time.Second
+
 // GetCache attempts to retrieve and deserialize a value from Redis.
 // Returns true if the cache hit was successful.
 func GetCache(rdb *redis.Client, key string, target interface{}) bool {
@@ -66,16 +72,47 @@ func RemoveSubscriber(rdb *redis.Client, ctx context.Context, setKey, userSub st
 	}
 }
 
-// buildHealthURL ensures the URL ends with /health.
-func buildHealthURL(baseURL string) string {
+// buildReadyURL ensures the URL ends with /health/ready (the real readiness
+// endpoint; returns 503 if the ingestion service is starting, failed, or
+// hasn't completed a fresh poll). For back-compat with older services that
+// only expose /health, callers should fall back there on 404.
+func buildReadyURL(baseURL string) string {
 	url := strings.TrimSuffix(baseURL, "/")
-	if !strings.HasSuffix(url, "/health") {
-		url = url + "/health"
+	switch {
+	case strings.HasSuffix(url, "/health/ready"):
+		return url
+	case strings.HasSuffix(url, "/health"):
+		return url + "/ready"
+	default:
+		return url + "/health/ready"
 	}
-	return url
+}
+
+// probeIngestion checks the downstream Rust ingestion service's
+// /health/ready endpoint and returns the HTTP status code the upstream
+// emitted (200 when ready, 503 when starting/failed/stale). Used by the
+// channel API's own /internal/health to propagate ingestion readiness up
+// to Kubernetes.
+func probeIngestion(ctx context.Context, internalURL string) (int, error) {
+	if internalURL == "" {
+		return 0, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, buildReadyURL(internalURL), nil)
+	if err != nil {
+		return 0, err
+	}
+	httpClient := &http.Client{Timeout: HealthProxyTimeout}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
 }
 
 // ProxyInternalHealth proxies a health check to an internal service URL.
+// Used by the public /sports/health endpoint so operators can curl the full
+// Rust-side payload without having to exec into the cluster.
 func ProxyInternalHealth(c *fiber.Ctx, internalURL string) error {
 	if internalURL == "" {
 		return c.Status(fiber.StatusServiceUnavailable).JSON(ErrorResponse{
@@ -84,7 +121,7 @@ func ProxyInternalHealth(c *fiber.Ctx, internalURL string) error {
 		})
 	}
 
-	targetURL := buildHealthURL(internalURL)
+	targetURL := buildReadyURL(internalURL)
 	httpClient := &http.Client{Timeout: HealthProxyTimeout}
 	resp, err := httpClient.Get(targetURL)
 	if err != nil {

--- a/channels/sports/api/sports.go
+++ b/channels/sports/api/sports.go
@@ -282,9 +282,56 @@ func (a *App) handleInternalDashboard(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"sports": games})
 }
 
-// handleInternalHealth is a simple liveness check for the core gateway.
+// handleInternalHealth is the endpoint the core gateway and k8s probes hit.
+//
+// It verifies that this API's own dependencies (Postgres, Redis) are reachable
+// and that the downstream Rust ingestion service's /health/ready returns 200.
+// Any failure returns HTTP 503 so the k8s readinessProbe can mark the pod
+// NotReady and route traffic elsewhere. Until PR #106, the previous version
+// of this handler returned a static `{"status":"healthy"}` no matter what,
+// which is what let the sports-service outage stay invisible for 3 days.
 func (a *App) handleInternalHealth(c *fiber.Ctx) error {
-	return c.JSON(fiber.Map{"status": "healthy"})
+	ctx, cancel := context.WithTimeout(c.Context(), InternalHealthTimeout)
+	defer cancel()
+
+	result := fiber.Map{"status": "healthy"}
+	degraded := false
+
+	if err := a.db.Ping(ctx); err != nil {
+		result["database"] = "unhealthy: " + err.Error()
+		degraded = true
+	} else {
+		result["database"] = "healthy"
+	}
+
+	if err := a.rdb.Ping(ctx).Err(); err != nil {
+		result["redis"] = "unhealthy: " + err.Error()
+		degraded = true
+	} else {
+		result["redis"] = "healthy"
+	}
+
+	// Check the ingestion service's /health/ready. A 503 here means the Rust
+	// service is alive-but-not-ingesting and we should refuse traffic.
+	if internalURL := os.Getenv("INTERNAL_SPORTS_URL"); internalURL != "" {
+		code, ingestErr := probeIngestion(ctx, internalURL)
+		result["ingestion_http_status"] = code
+		if ingestErr != nil {
+			result["ingestion"] = "unreachable: " + ingestErr.Error()
+			degraded = true
+		} else if code != fiber.StatusOK {
+			result["ingestion"] = fmt.Sprintf("not ready: HTTP %d", code)
+			degraded = true
+		} else {
+			result["ingestion"] = "healthy"
+		}
+	}
+
+	if degraded {
+		result["status"] = "degraded"
+		return c.Status(fiber.StatusServiceUnavailable).JSON(result)
+	}
+	return c.JSON(result)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Part 4 of 6 in the silent-startup-failure fix series

Prior PRs: #106 (Rust services) and #107 (migration version prefixes). This PR fixes the Go side of the same class of bug. **Independent of #106/#107 at the code level** — can merge in any order relative to those — but logically completes the readiness-probe story.

## The bug

Before: every channel API's \`/internal/health\` was:
\`\`\`go
func (a *App) handleInternalHealth(c *fiber.Ctx) error {
    return c.JSON(fiber.Map{"status": "healthy"})
}
\`\`\`
No DB check, no Redis check, no downstream probe. The core API's \`/health\` at least *built* a degraded body but returned HTTP 200 anyway. k8s probes saw 200s forever while entire services were broken.

Additionally, three critical env vars used the "log warning and continue" antipattern:
- \`LOGTO_JWKS_URL\` → auth routes silently 401 with "JWKS not initialized"
- \`STRIPE_SECRET_KEY\` → billing routes silently 500
- \`YAHOO_CLIENT_ID\`/\`YAHOO_CLIENT_SECRET\` → fantasy sync hit \`maxSyncRestarts=5\`, gave up, /yahoo/health body said "failed" but HTTP was still 200

Every one of these paths hid real outages from Kubernetes.

## Fix

### Channel APIs (finance, sports, rss)
- \`/internal/health\` now pings DB, Redis, and (via new \`probeIngestion\` helper) proxies the downstream Rust \`/health/ready\`. Returns 503 on any failure.
- \`probeIngestion\` + \`buildReadyURL\` handle trailing slashes and pre-existing \`/health\`/\`/health/ready\` paths idempotently.
- Public \`/{name}/health\` (via \`ProxyInternalHealth\`) also targets \`/health/ready\` so operator curls match what k8s sees.

### Fantasy API
- New \`atomic.Bool\` on \`syncHealth\` surfaces \`IsFailed()\` without requiring the mutex. \`/internal/health\` returns 503 when the sync loop has exhausted its \`maxSyncRestarts\` budget. \`YAHOO_CLIENT_ID\`/\`YAHOO_CLIENT_SECRET\` now \`log.Fatal\` at startup instead of warning.

### Core API
- \`/health\` HTTP status code now mirrors the JSON \`status\` field: \`healthy\` → 200, anything else → 503. Body shape unchanged. Cache-hit and cache-miss paths route through a shared \`sendHealthCached\` helper for consistency.
- \`LOGTO_JWKS_URL\` → \`log.Fatal\` (was warning + continue).
- \`STRIPE_SECRET_KEY\` → \`log.Fatal\` unless \`STRIPE_DISABLED=true\` (dev/staging escape hatch).

## Testing

Every Go module builds clean (\`go build ./...\`) and vets clean (\`go vet ./...\`).

| Module | New tests |
|--------|-----------|
| \`api/core\` | None (health handler requires live pgxpool/redis) — all existing tests still pass |
| \`channels/finance/api\` | 3 (\`TestBuildReadyURL\`, \`TestProbeIngestion_*\`) |
| \`channels/sports/api\` | 3 (same set) |
| \`channels/rss/api\` | 3 (same set) |
| \`channels/fantasy/api\` | 2 (\`TestSyncHealth_IsFailedFlagFollowsSetFailed\`, \`TestSyncHealth_IsFailedConcurrent\`) |

Concurrency test on the fantasy atomic flag runs 10k iterations on each side to catch torn reads.

## Follow-up

- **PR 5** (\`chore/k8s-probes\`): update every \`k8s/*.yaml\` so \`readinessProbe\` and \`startupProbe\` consult these new endpoints. Until that lands, the probes still hit the legacy \`/health\` route — which now returns the same readiness signal via the back-compat alias in PR #106, plus the honest 503 in this PR.
- **PR 6** (\`test/production-readiness-harness\`): \`scripts/smoke/production-readiness.sh\` pre-launch gate.