### PR TITLE
chore(k8s): point probes at the real readiness endpoints (5/6)

### DIFF
--- a/k8s/core-api.yaml
+++ b/k8s/core-api.yaml
@@ -32,12 +32,25 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          # Core /health now returns 503 when any dependency is
+          # degraded (see PR #108 server.go changes). Add a startupProbe
+          # so a slow Postgres connection doesn't get misread as
+          # liveness failure during deploy.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
+            failureThreshold: 6
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
@@ -45,7 +58,12 @@ spec:
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
+            failureThreshold: 3
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/fantasy-api.yaml
+++ b/k8s/fantasy-api.yaml
@@ -88,18 +88,38 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+          # /internal/health pings DB + Redis and returns 503 when the
+          # Yahoo sync loop has exhausted its restart budget (see
+          # PR #108). Fantasy has no Rust ingestion service — sync
+          # runs in-process.
+          startupProbe:
+            httpGet:
+              path: /internal/health
+              port: 8084
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /internal/health
               port: 8084
             initialDelaySeconds: 10
             periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /internal/health
               port: 8084
             initialDelaySeconds: 5
             periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/finance-api.yaml
+++ b/k8s/finance-api.yaml
@@ -58,18 +58,37 @@ spec:
             limits:
               cpu: 250m
               memory: 128Mi
+          # /internal/health now pings DB, Redis, and the Rust ingestion
+          # service's /health/ready (see PR #108). It returns 503 when
+          # any dependency is down.
+          startupProbe:
+            httpGet:
+              path: /internal/health
+              port: 8081
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /internal/health
               port: 8081
             initialDelaySeconds: 10
             periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /internal/health
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/finance-service.yaml
+++ b/k8s/finance-service.yaml
@@ -41,25 +41,42 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+          # Startup: wait for DB init + first WebSocket connect. 5 min
+          # runway is enough even when TwelveData is slow to respond.
           startupProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 3001
             initialDelaySeconds: 5
-            periodSeconds: 10
-            failureThreshold: 120
+            periodSeconds: 5
+            failureThreshold: 60
+            timeoutSeconds: 3
+          # Liveness: process-alive only. WebSocket reconnects are a
+          # runtime concern handled by the reconnect loop, not a reason
+          # to SIGTERM.
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: 3001
             initialDelaySeconds: 15
             periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 3
+          # Readiness: 503 when staleness threshold (10 min) is exceeded
+          # with no batches processed. Pod drops out of the ready pool
+          # without restarting.
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 3001
             initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/rss-api.yaml
+++ b/k8s/rss-api.yaml
@@ -58,18 +58,37 @@ spec:
             limits:
               cpu: 250m
               memory: 128Mi
+          # /internal/health now pings DB, Redis, and the Rust ingestion
+          # service's /health/ready (see PR #108). It returns 503 when
+          # any dependency is down.
+          startupProbe:
+            httpGet:
+              path: /internal/health
+              port: 8083
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /internal/health
               port: 8083
             initialDelaySeconds: 10
             periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /internal/health
               port: 8083
             initialDelaySeconds: 5
             periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/rss-service.yaml
+++ b/k8s/rss-service.yaml
@@ -36,25 +36,39 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+          # Startup: first RSS poll cycle ingests 100+ feeds in parallel
+          # (~30-60s typically). 5 min runway is plenty.
           startupProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 3004
             initialDelaySeconds: 5
-            periodSeconds: 10
-            failureThreshold: 30
+            periodSeconds: 5
+            failureThreshold: 60
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: 3004
             initialDelaySeconds: 15
             periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 3
+          # Readiness: 503 when the 5-minute ingest interval has been
+          # exceeded by 2x (10 min). Pod drops out of the ready pool
+          # without restarting.
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 3004
             initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/sports-api.yaml
+++ b/k8s/sports-api.yaml
@@ -58,18 +58,37 @@ spec:
             limits:
               cpu: 250m
               memory: 128Mi
+          # /internal/health now pings DB, Redis, and the Rust ingestion
+          # service's /health/ready (see PR #108). It returns 503 when
+          # any dependency is down.
+          startupProbe:
+            httpGet:
+              path: /internal/health
+              port: 8082
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /internal/health
               port: 8082
             initialDelaySeconds: 10
             periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /internal/health
               port: 8082
             initialDelaySeconds: 5
             periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/sports-service.yaml
+++ b/k8s/sports-service.yaml
@@ -41,25 +41,52 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+          # Startup probe: wait until ingestion has completed its first
+          # successful poll. `failureThreshold: 60` * `periodSeconds: 5`
+          # = 5 minutes of runway — generous for the adaptive live poll
+          # and the 30-minute schedule poll's first iteration. If the
+          # pod isn't ready in 5 minutes, something is genuinely broken
+          # (bad migration, unreachable upstream, missing env var) and
+          # k8s should kill it and try again.
           startupProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 3002
             initialDelaySeconds: 5
-            periodSeconds: 10
+            periodSeconds: 5
             failureThreshold: 60
+            timeoutSeconds: 3
+          # Liveness probe targets /health/live (process alive only).
+          # A transient DB hiccup should NOT trigger a pod kill — that
+          # would mask the root cause. Use `failureThreshold: 6` so a
+          # brief stall doesn't restart the pod.
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: 3002
             initialDelaySeconds: 15
             periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 3
+          # Readiness probe targets /health/ready. Returns 503 when the
+          # service is starting, failed, or its last poll is older than
+          # 2x the widest expected interval. k8s stops routing traffic
+          # to a NotReady pod without restarting it — the right
+          # behavior for "ingestion stuck, service process fine".
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 3002
             initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          # preStop gives in-flight requests a grace period to complete
+          # before SIGTERM takes the process down.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Part 5 of 6

Depends on **#106** (which adds \`/health/ready\` and \`/health/live\` to the Rust services) and **#108** (which makes the Go \`/internal/health\` and core \`/health\` return real 503s). **Merge those first.** Until this PR is applied, probes still hit the legacy \`/health\` route — which is a back-compat alias in #106, so everything still works; this PR just makes the probes honest.

Independent of PR #107 (migration versioning) at the code level.

## What changes

### Rust services (\`sports-service\`, \`finance-service\`, \`rss-service\`)
- \`startupProbe\` → \`/health/ready\` with 5 min runway (\`periodSeconds: 5 × failureThreshold: 60\`). Pods stay in Starting state until the ingestion task has run its first successful poll cycle.
- \`livenessProbe\` → **\`/health/live\`** (new, always 200). A transient DB hiccup should not trigger SIGTERM — that would mask the root cause. Liveness is now strictly "process is alive."
- \`readinessProbe\` → \`/health/ready\`. Returns 503 when the service is Starting, Failed, or its last successful poll is stale. Pod drops out of the ready pool without restarting — the right answer for "ingestion stuck, process fine."

### Channel Go APIs (\`finance-api\`, \`sports-api\`, \`rss-api\`, \`fantasy-api\`)
- Probes stay on \`/internal/health\` (now a real DB + Redis + downstream-ingestion check per PR #108).
- Added \`startupProbe\` so a slow boot (managed-DB connection handshake, etc.) doesn't get misread as liveness failure and SIGTERM'd before the service is ready.

### Core API
- Probes stay on \`/health\` (now returns 503 when degraded per PR #108).
- Added \`startupProbe\` for the same reason.

### All services
- \`lifecycle.preStop: sleep 10\` for graceful in-flight request drain before SIGTERM.
- Explicit \`failureThreshold\` and \`timeoutSeconds\` on every probe so the reviewer can reason about exact behavior instead of relying on Kubernetes defaults (which differ between k8s versions and are a footgun).

## Validation

\`kubectl apply --dry-run=client\` against the **live DO cluster** passes for all 8 manifests:

\`\`\`
deployment.apps/sports-service configured (dry run)
deployment.apps/finance-service configured (dry run)
deployment.apps/rss-service configured (dry run)
deployment.apps/sports-api configured (dry run)
deployment.apps/finance-api configured (dry run)
deployment.apps/rss-api configured (dry run)
deployment.apps/fantasy-api configured (dry run)
deployment.apps/core-api configured (dry run)
\`\`\`

Services, replica counts, resource limits, env vars, and image tags all unchanged. Only probe configuration differs.

## Rollback

Revert commit, re-apply. Probes fall back to hitting the legacy \`/health\` paths, which the Rust services still expose as a back-compat alias of \`/health/ready\`.

## Follow-up

- **PR 6** (\`test/production-readiness-harness\`): shell script that curls every service's real endpoint as a pre-launch gate.