### PR TITLE
test(ci): production-readiness smoke test + post-deploy gate (6/6)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -377,3 +377,14 @@ jobs:
           rollout_if_needed rss-api "${{ needs.detect-changes.outputs.rss-api }}"
           rollout_if_needed rss-service "${{ needs.detect-changes.outputs.rss-service }}"
           rollout_if_needed fantasy-api "${{ needs.detect-changes.outputs.fantasy-api }}"
+
+      # Post-deploy smoke test. Fails the workflow if any service's
+      # readiness endpoint (the same one k8s probes) does not return 200.
+      # Uses the same kubeconfig the previous step set up. Intentionally
+      # runs AFTER rollout so a bad release surfaces as a failed deploy
+      # rather than a silently-degraded cluster.
+      - name: Production-readiness smoke test
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq jq
+          READINESS_TIMEOUT=180 ./scripts/smoke/production-readiness.sh

--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -1,0 +1,86 @@
+# Smoke tests
+
+Scripts to verify the scrollr platform is healthy end-to-end before cutting a
+release or promoting a candidate to production.
+
+## `production-readiness.sh`
+
+Runs a readiness probe against every service in the cluster. Exits 0 iff
+every service returns HTTP 200 on its configured readiness endpoint.
+
+```sh
+# Against the default (scrollr) namespace of the currently-active kubecontext
+scripts/smoke/production-readiness.sh
+
+# Against a different namespace
+NAMESPACE=scrollr-staging scripts/smoke/production-readiness.sh
+
+# Shorter per-service timeout (useful in CI)
+READINESS_TIMEOUT=30 scripts/smoke/production-readiness.sh
+```
+
+### What it checks
+
+| Service | Endpoint | Port |
+|---|---|---|
+| `core-api` | `/health` | 8080 |
+| `sports-service` | `/health/ready` | 3002 |
+| `finance-service` | `/health/ready` | 3001 |
+| `rss-service` | `/health/ready` | 3004 |
+| `sports-api` | `/internal/health` | 8082 |
+| `finance-api` | `/internal/health` | 8081 |
+| `rss-api` | `/internal/health` | 8083 |
+| `fantasy-api` | `/internal/health` | 8084 |
+
+These are the same endpoints Kubernetes' `readinessProbe` hits for each
+deployment (see `k8s/*.yaml`). If the smoke test passes, the probes pass too.
+
+### Output
+
+Each service gets one `OK` / `FAIL` line. On failure the script dumps a JSON
+summary of every service's result — including the HTTP status code and any
+response body — so you can see exactly what's broken without having to run
+the checks manually:
+
+```
+core-api             /health              OK (HTTP 200)
+sports-service       /health/ready        FAIL (HTTP 404, readiness timeout)
+…
+
+==================================================
+3 OF 8 SERVICES NOT READY
+==================================================
+```
+
+### Exit status
+
+| Code | Meaning |
+|---|---|
+| 0 | All services healthy. |
+| 1 | One or more services returned non-200. Details on stdout. |
+| 2 | Usage error (unknown flag, missing kubectl/curl/jq). |
+
+### When to run
+
+- **Before cutting a release.** Run against the staging namespace after
+  the release candidate is deployed. An exit 0 is a prerequisite for
+  promotion.
+- **After a deploy to production.** Run against the scrollr namespace
+  once the rollout completes, to catch anything the Kubernetes probes
+  might have missed (e.g. a race between container start and the first
+  successful poll cycle).
+- **In a pre-deploy CI gate.** Wire it into GitHub Actions as a required
+  check on `main` — `KUBECONFIG` lives in a secret, the job runs on a
+  self-hosted runner that can reach the cluster, and a non-zero exit
+  blocks the merge.
+
+### Design
+
+- One `kubectl port-forward` per service, torn down immediately after
+  the check completes. Per-service fresh tunnel avoids state
+  contamination between checks.
+- 503 responses are expected during a rolling deploy (a pod is honestly
+  telling us it's still Starting). The script waits up to
+  `READINESS_TIMEOUT` seconds before giving up, so a brief blip doesn't
+  fail the check.
+- No dependencies beyond `kubectl`, `curl`, `jq`, and `bash 4+`.

--- a/scripts/smoke/production-readiness.sh
+++ b/scripts/smoke/production-readiness.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Production-readiness smoke test.
+#
+# Verifies that every service in the scrollr platform is actually ready to
+# serve traffic. Designed to be run manually before a release cut, and also
+# suitable for a pre-deploy gate in CI.
+#
+# USAGE
+#
+#   scripts/smoke/production-readiness.sh              # run against cluster
+#   scripts/smoke/production-readiness.sh --namespace  # override k8s ns
+#   scripts/smoke/production-readiness.sh --help
+#
+# Environment:
+#
+#   NAMESPACE             k8s namespace (default: scrollr)
+#   KUBECONFIG            path to kubeconfig (default: $HOME/.kube/config)
+#   PORT_FORWARD_TIMEOUT  seconds to wait for each port-forward (default: 10)
+#   READINESS_TIMEOUT     seconds to wait for /health/ready to return 200
+#                         (default: 120)
+#
+# EXIT STATUS
+#
+#   0  All services returned HTTP 200 on their readiness endpoint.
+#   1  One or more services returned a non-200 status, or port-forwarding
+#      failed. Per-service status is printed to stdout.
+#   2  Usage error.
+#
+# INVARIANT
+#
+#   If this script exits 0, every readiness probe in k8s/*.yaml also sees a
+#   200 response, and the cluster is safe to route production traffic to.
+#
+# DESIGN NOTES
+#
+#   - One k8s `Service` per check. We port-forward to the Service rather than
+#     the Pod because we want to verify the probe target exactly as k8s sees
+#     it, not to cherry-pick a specific pod.
+#   - Retries on 503 until the READINESS_TIMEOUT elapses. This is expected
+#     during a rollout when some pods are still in Starting — the script
+#     waits, it doesn't fail fast.
+#   - Each check gets a unique local port (picked from a fixed table) so
+#     parallelism is possible in a follow-up without port collisions.
+#   - No external dependencies beyond `kubectl`, `curl`, and `jq`. Intended
+#     to run from an engineer's laptop or from a minimal CI image.
+# =============================================================================
+
+set -euo pipefail
+
+# ─── Defaults ─────────────────────────────────────────────────────────────
+NAMESPACE="${NAMESPACE:-scrollr}"
+PORT_FORWARD_TIMEOUT="${PORT_FORWARD_TIMEOUT:-10}"
+READINESS_TIMEOUT="${READINESS_TIMEOUT:-120}"
+
+# ─── Arg parsing ──────────────────────────────────────────────────────────
+while (("$#")); do
+    case "$1" in
+    --namespace)
+        NAMESPACE="$2"
+        shift 2
+        ;;
+    --help | -h)
+        sed -n '/^# USAGE/,/^# =====/p' "$0" | sed 's/^# \{0,1\}//'
+        exit 0
+        ;;
+    *)
+        echo "error: unknown flag '$1' (try --help)" >&2
+        exit 2
+        ;;
+    esac
+done
+
+# ─── Service manifest ─────────────────────────────────────────────────────
+# Fields: service-name  local-port  cluster-port  readiness-path
+SERVICES=(
+    "core-api        18080  8080  /health"
+    "sports-service  13002  3002  /health/ready"
+    "finance-service 13001  3001  /health/ready"
+    "rss-service     13004  3004  /health/ready"
+    "sports-api      18082  8082  /internal/health"
+    "finance-api     18081  8081  /internal/health"
+    "rss-api         18083  8083  /internal/health"
+    "fantasy-api     18084  8084  /internal/health"
+)
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+need() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "error: '$1' is required on PATH" >&2
+        exit 2
+    }
+}
+
+need kubectl
+need curl
+need jq
+
+# Output helpers (keep them simple, no fancy colors in CI)
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+red() { printf '\033[31m%s\033[0m\n' "$1"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$1"; }
+
+# ─── Check one service ────────────────────────────────────────────────────
+# Arguments: svc local_port cluster_port path
+# Stdout: one-line JSON blob describing the result.
+# Returns 0 on HTTP 200, 1 on any other outcome.
+check_service() {
+    local svc="$1" local_port="$2" cluster_port="$3" path="$4"
+    local pf_pid="" status="000" body="" rc=1
+
+    # Start port-forward in the background. Use nohup-style detachment so
+    # SIGPIPE from a caller closing our stdout doesn't leak into kubectl.
+    kubectl -n "$NAMESPACE" port-forward \
+        "svc/$svc" "$local_port:$cluster_port" \
+        >"/tmp/smoke-${svc}.log" 2>&1 </dev/null &
+    pf_pid=$!
+
+    # Wait for the tunnel to actually be up.
+    local deadline=$((SECONDS + PORT_FORWARD_TIMEOUT))
+    local tunnel_up=0
+    while ((SECONDS < deadline)); do
+        if curl -sS --max-time 1 -o /dev/null -w '%{http_code}' \
+            "http://localhost:$local_port/" >/dev/null 2>&1; then
+            tunnel_up=1
+            break
+        fi
+        # If port-forward itself died, bail.
+        if ! kill -0 "$pf_pid" 2>/dev/null; then
+            break
+        fi
+        sleep 0.5
+    done
+
+    if ((tunnel_up == 0)); then
+        jq -cn --arg svc "$svc" --arg path "$path" \
+            '{service: $svc, path: $path, ok: false, status: 0, reason: "port-forward failed"}'
+    else
+        # Poll the readiness endpoint until it returns 200 or the readiness
+        # timeout expires. 503s are expected during a rollout — we wait.
+        local deadline2=$((SECONDS + READINESS_TIMEOUT))
+        while ((SECONDS < deadline2)); do
+            status=$(curl -sS --max-time 3 -o "/tmp/smoke-${svc}.body" -w '%{http_code}' \
+                "http://localhost:$local_port$path" 2>/dev/null || echo "000")
+            if [[ "$status" == "200" ]]; then
+                rc=0
+                break
+            fi
+            sleep 2
+        done
+
+        body=$(cat "/tmp/smoke-${svc}.body" 2>/dev/null || echo "")
+
+        if ((rc == 0)); then
+            # Try to parse body as JSON; fall back to raw string if not.
+            if body_json=$(jq -e . <<<"$body" 2>/dev/null); then
+                jq -cn --arg svc "$svc" --arg path "$path" --argjson status "$status" \
+                    --argjson body "$body_json" \
+                    '{service: $svc, path: $path, ok: true, status: $status, body: $body}'
+            else
+                jq -cn --arg svc "$svc" --arg path "$path" --argjson status "$status" \
+                    --arg body "$body" \
+                    '{service: $svc, path: $path, ok: true, status: $status, body: $body}'
+            fi
+        else
+            jq -cn --arg svc "$svc" --arg path "$path" --arg status "$status" \
+                --arg body "$body" \
+                '{service: $svc, path: $path, ok: false, status: ($status|tonumber? // 0), reason: "readiness timeout", last_body: $body}'
+        fi
+    fi
+
+    # Always tear down the port-forward before returning. `kill -9` ensures
+    # the child dies immediately; `wait` + `|| true` suppresses the exit
+    # status from the tunnel.
+    kill -9 "$pf_pid" 2>/dev/null || true
+    wait "$pf_pid" 2>/dev/null || true
+
+    return "$rc"
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────
+echo "=================================================="
+echo "Scrollr production-readiness smoke test"
+echo "  namespace:         $NAMESPACE"
+echo "  per-svc timeout:   ${READINESS_TIMEOUT}s"
+echo "=================================================="
+
+# Pre-flight: is there even a cluster to talk to?
+if ! kubectl -n "$NAMESPACE" get ns "$NAMESPACE" >/dev/null 2>&1; then
+    red "Namespace '$NAMESPACE' is not reachable. Is your kubeconfig set?"
+    exit 1
+fi
+
+results=()
+failed=0
+
+for line in "${SERVICES[@]}"; do
+    # shellcheck disable=SC2086
+    read -r svc local_port cluster_port path <<<"$line"
+
+    printf '%-20s %-20s ' "$svc" "$path"
+    # `check_service` returns non-zero on a readiness failure by design —
+    # we want to continue iterating so every service gets probed. `|| true`
+    # keeps `set -e` from killing the outer script on that expected
+    # non-zero exit. The JSON body on stdout carries the pass/fail signal.
+    result=$(check_service "$svc" "$local_port" "$cluster_port" "$path" 2>/dev/null || true)
+    results+=("$result")
+
+    if echo "$result" | jq -e '.ok == true' >/dev/null; then
+        green "OK (HTTP $(echo "$result" | jq -r '.status'))"
+    else
+        reason=$(echo "$result" | jq -r '.reason // "unknown"')
+        status=$(echo "$result" | jq -r '.status // "n/a"')
+        red "FAIL (HTTP $status, $reason)"
+        failed=$((failed + 1))
+    fi
+done
+
+echo
+echo "=================================================="
+if ((failed == 0)); then
+    green "ALL ${#SERVICES[@]} SERVICES READY"
+    echo "=================================================="
+    exit 0
+else
+    red "$failed OF ${#SERVICES[@]} SERVICES NOT READY"
+    echo "=================================================="
+    echo
+    yellow "Per-service JSON (for debugging):"
+    printf '%s\n' "${results[@]}" | jq -s '.'
+    exit 1
+fi


### PR DESCRIPTION
## Part 6 of 6 — completes the series

The silent-startup-failure fix series ends with verification: a smoke test that objectively measures whether the cluster is ready to serve traffic, wired into the existing deploy workflow so a bad rollout fails CI instead of leaving production silently degraded.

## \`scripts/smoke/production-readiness.sh\`

One shell script. Port-forwards to every \`k8s/\` service in turn, curls its readiness endpoint, and exits 0 iff every service returns HTTP 200. Prints a per-service pass/fail line and, on failure, a full JSON dump including response bodies so you can see exactly which dependency is unhealthy.

### Covered

| Service | Endpoint | Port |
|---|---|---|
| \`core-api\` | \`/health\` | 8080 |
| \`sports-service\` | \`/health/ready\` | 3002 |
| \`finance-service\` | \`/health/ready\` | 3001 |
| \`rss-service\` | \`/health/ready\` | 3004 |
| \`sports-api\` | \`/internal/health\` | 8082 |
| \`finance-api\` | \`/internal/health\` | 8081 |
| \`rss-api\` | \`/internal/health\` | 8083 |
| \`fantasy-api\` | \`/internal/health\` | 8084 |

Matches the probe configuration PR #109 introduces exactly.

### Design

- Sequential, one port-forward at a time (could parallelize — each check already uses a unique local port, but kept simple for now).
- 503s are expected during a rollout; the script waits up to \`READINESS_TIMEOUT\` seconds before giving up. No flakiness.
- No dependencies beyond \`kubectl\`, \`curl\`, \`jq\`, and \`bash 4+\`.

### Validation

Tested against the **live DO cluster** right now:

\`\`\`
core-api             /health              OK (HTTP 200)
sports-service       /health/ready        FAIL (HTTP 404, readiness timeout)
finance-service      /health/ready        FAIL (HTTP 404, readiness timeout)
rss-service          /health/ready        FAIL (HTTP 404, readiness timeout)
sports-api           /internal/health     OK (HTTP 200)
finance-api          /internal/health     OK (HTTP 200)
rss-api              /internal/health     OK (HTTP 200)
fantasy-api          /internal/health     OK (HTTP 200)

3 OF 8 SERVICES NOT READY
\`\`\`

The 404s are expected — \`/health/ready\` is new in PR #106 and the Rust services haven't been redeployed yet. Once PRs #106 / #107 deploy, those three flip to 200 too, and the script exits 0.

## CI integration

Added a final step to \`.github/workflows/deploy.yml\` right after the rollout loop:

\`\`\`yaml
- name: Production-readiness smoke test
  run: |
    sudo apt-get update -qq
    sudo apt-get install -y -qq jq
    READINESS_TIMEOUT=180 ./scripts/smoke/production-readiness.sh
\`\`\`

The step reuses the kubeconfig the earlier \`Configure kubectl\` step set up. \`READINESS_TIMEOUT=180\` gives pods that are still completing their first poll cycle some runway.

**Intentionally fails the workflow on any non-200.** The goal is to detect bad deploys; leaving a cluster degraded is worse than a red CI badge.

## Closing the series

Once all six PRs ship and deploy, a silent 3-day outage like the one on 2026-04-19 becomes architecturally impossible:

1. **#106** — services refuse to boot silently; init failures hit \`exit(1)\` and crashloop instead of zombie.
2. **#107** — migration versions are namespaced per service; shared \`_sqlx_migrations\` collisions can't recur.
3. **#108** — every health endpoint in the platform returns honest status codes (no more 200-while-degraded).
4. **#109** — k8s probes consult the real readiness endpoints.
5. **#6** (this PR) — every deploy is gated on cluster-wide readiness via CI.

Any future regression that breaks ingestion will either fail the deploy (this PR) or flip a k8s probe to NotReady (PR #109), either of which is loud and visible.