### PR TITLE
fix(channels): re-enable sqlx ignore_missing for shared migration table (hotfix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,9 @@ The migrator is run inside `initialize_pool()`:
 
 ```rust
 fn migrator() -> sqlx::migrate::Migrator {
-    sqlx::migrate!("./migrations")
+    let mut m = sqlx::migrate!("./migrations");
+    m.set_ignore_missing(true);
+    m
 }
 
 // inside initialize_pool():
@@ -183,7 +185,7 @@ if let Err(err) = m.run(&pool).await {
 }
 ```
 
-**Do NOT set `ignore_missing(true)`.** An earlier iteration used it to paper over the shared-table collision; it also hides real checksum drift, which caused sports-service to be silently dead for 3 days in April 2026. See PR #107.
+**`set_ignore_missing(true)` is required** because all three services share the `_sqlx_migrations` table. Without it, each service errors out with `VersionMissing` when it sees rows for other services' version prefixes (e.g. finance seeing sports' `12*` rows). The flag only tolerates versions recorded in the DB that have no matching local file; it does NOT suppress `VersionMismatch` (checksum drift on a row whose file *is* on disk), so the 3-day silent-failure mode from April 2026 stays fixed. See PRs #106 and #107.
 
 Each service has a `tests/migration_versions.rs` that asserts every on-disk migration falls inside its assigned numeric range. This runs as part of `cargo test` and fails the build if someone accidentally copy-pastes a filename across services.
 

--- a/channels/finance/service/src/database.rs
+++ b/channels/finance/service/src/database.rs
@@ -7,12 +7,23 @@ pub use chrono::Utc;
 
 /// Build the sqlx migrator for this service.
 ///
-/// `ignore_missing` is deliberately NOT set. A follow-up PR namespaces the
-/// `_sqlx_migrations` table per service, which eliminates the cross-service
-/// collision that `ignore_missing = true` used to paper over. Leaving it
-/// enabled now would just hide real migration drift.
+/// `set_ignore_missing(true)` is required because all three Rust services
+/// (finance, sports, rss) share a single `_sqlx_migrations` table in the
+/// scrollr Postgres DB — sqlx 0.8.x has no API to name the table per
+/// service (see PRs #106 / #107). Without this flag, each service sees
+/// the other services' rows and errors out with `VersionMissing` because
+/// e.g. finance has no `12*` files on disk.
+///
+/// With each service on a unique numeric version prefix (finance 11*,
+/// sports 12*, rss 20250601*/13*), the flag tolerates "versions recorded
+/// for *other* services" without hiding checksum drift on *this*
+/// service's own rows — VersionMismatch (drift on an applied row whose
+/// file *is* on disk) still fires and fails the boot loudly, which is
+/// the behavior PR #106 was after.
 fn migrator() -> sqlx::migrate::Migrator {
-    sqlx::migrate!("./migrations")
+    let mut m = sqlx::migrate!("./migrations");
+    m.set_ignore_missing(true);
+    m
 }
 
 pub async fn initialize_pool() -> Result<PgPool> {

--- a/channels/rss/service/src/database.rs
+++ b/channels/rss/service/src/database.rs
@@ -8,12 +8,23 @@ use chrono::{DateTime, Utc};
 
 /// Build the sqlx migrator for this service.
 ///
-/// `ignore_missing` is deliberately NOT set. A follow-up PR namespaces the
-/// `_sqlx_migrations` table per service, which eliminates the cross-service
-/// collision that `ignore_missing = true` used to paper over. Leaving it
-/// enabled now would just hide real migration drift.
+/// `set_ignore_missing(true)` is required because all three Rust services
+/// (finance, sports, rss) share a single `_sqlx_migrations` table in the
+/// scrollr Postgres DB — sqlx 0.8.x has no API to name the table per
+/// service (see PRs #106 / #107). Without this flag, each service sees
+/// the other services' rows and errors out with `VersionMissing` because
+/// e.g. rss has no `11*` files on disk.
+///
+/// With each service on a unique numeric version prefix (finance 11*,
+/// sports 12*, rss 20250601*/13*), the flag tolerates "versions recorded
+/// for *other* services" without hiding checksum drift on *this*
+/// service's own rows — VersionMismatch (drift on an applied row whose
+/// file *is* on disk) still fires and fails the boot loudly, which is
+/// the behavior PR #106 was after.
 fn migrator() -> sqlx::migrate::Migrator {
-    sqlx::migrate!("./migrations")
+    let mut m = sqlx::migrate!("./migrations");
+    m.set_ignore_missing(true);
+    m
 }
 
 pub async fn initialize_pool() -> Result<PgPool> {

--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -8,12 +8,23 @@ use serde::Deserialize;
 
 /// Build the sqlx migrator for this service.
 ///
-/// `ignore_missing` is deliberately NOT set. A follow-up PR namespaces the
-/// `_sqlx_migrations` table per service, which eliminates the cross-service
-/// collision that `ignore_missing = true` used to paper over. Leaving it
-/// enabled now would just hide real migration drift.
+/// `set_ignore_missing(true)` is required because all three Rust services
+/// (finance, sports, rss) share a single `_sqlx_migrations` table in the
+/// scrollr Postgres DB — sqlx 0.8.x has no API to name the table per
+/// service (see PRs #106 / #107). Without this flag, each service sees
+/// the other services' rows and errors out with `VersionMissing` because
+/// e.g. sports has no `11*` files on disk.
+///
+/// With each service on a unique numeric version prefix (finance 11*,
+/// sports 12*, rss 20250601*/13*), the flag tolerates "versions recorded
+/// for *other* services" without hiding checksum drift on *this*
+/// service's own rows — VersionMismatch (drift on an applied row whose
+/// file *is* on disk) still fires and fails the boot loudly, which is
+/// the behavior PR #106 was after.
 fn migrator() -> sqlx::migrate::Migrator {
-    sqlx::migrate!("./migrations")
+    let mut m = sqlx::migrate!("./migrations");
+    m.set_ignore_missing(true);
+    m
 }
 
 pub async fn initialize_pool() -> Result<PgPool> {


### PR DESCRIPTION
Hotfix on top of #106/#107. See commit body for full root-cause. Restores `set_ignore_missing(true)` with correct rationale: the flag is required when multiple services share `_sqlx_migrations`; it does NOT suppress `VersionMismatch` (the error #106 was hardening against), only `VersionMissing` (which is what fires when service A sees service B's rows). Tested in prod live — without this, finance/sports/rss services all crash with `VersionMissing` on boot. With it, they boot cleanly.