### PR TITLE
chore(k8s): wire Contact Us form categories to distinct OS Ticket topics

### DIFF
--- a/k8s/configmap-core.yaml
+++ b/k8s/configmap-core.yaml
@@ -32,10 +32,23 @@ data:
   STRIPE_LIFETIME_ULTIMATE_COUPON_ID: "BLMMYMix"
 
   # Support / OS Ticket
+  #
+  # Each `OSTICKET_TOPIC_ID_*` corresponds to a category value sent by the
+  # desktop client's Contact Us form (see ContactForm.tsx:23 — Category type):
+  #
+  #   - bug      -> OSTICKET_TOPIC_ID (the default for any unspecified/future category)
+  #   - feature  -> OSTICKET_TOPIC_ID_FEATURE
+  #   - feedback -> OSTICKET_TOPIC_ID_FEEDBACK
+  #   - billing  -> OSTICKET_TOPIC_ID_BILLING
+  #   - account  -> OSTICKET_TOPIC_ID_ACCOUNT
+  #   - channel  -> OSTICKET_TOPIC_ID_CHANNEL
+  #
+  # Routing lives in api/core/support.go::buildOSTicketPayload. An empty
+  # per-category value falls back to OSTICKET_TOPIC_ID.
   OSTICKET_URL: "https://support.myscrollr.com"
-  OSTICKET_TOPIC_ID: "12"
-  OSTICKET_TOPIC_ID_FEATURE: "12"
-  OSTICKET_TOPIC_ID_FEEDBACK: "12"
-  OSTICKET_TOPIC_ID_BILLING: ""
-  OSTICKET_TOPIC_ID_ACCOUNT: ""
-  OSTICKET_TOPIC_ID_CHANNEL: ""
+  OSTICKET_TOPIC_ID: "12"          # Bug Report (default fallback)
+  OSTICKET_TOPIC_ID_FEATURE: "13"  # Feature Request
+  OSTICKET_TOPIC_ID_FEEDBACK: "14" # General Feedback
+  OSTICKET_TOPIC_ID_BILLING: "15"  # Billing & Subscriptions
+  OSTICKET_TOPIC_ID_ACCOUNT: "16"  # Account Issues
+  OSTICKET_TOPIC_ID_CHANNEL: "17"  # Channel Data Issues


### PR DESCRIPTION
Updates `k8s/configmap-core.yaml` so each of the 6 Contact Us form categories routes to its own OS Ticket help topic.

## Before

All categories routed to topic 12:

| Env var | Was | Now |
|---|---|---|
| `OSTICKET_TOPIC_ID` (bug) | 12 | 12 |
| `OSTICKET_TOPIC_ID_FEATURE` | 12 | 13 |
| `OSTICKET_TOPIC_ID_FEEDBACK` | 12 | 14 |
| `OSTICKET_TOPIC_ID_BILLING` | "" (→ fell back to 12) | 15 |
| `OSTICKET_TOPIC_ID_ACCOUNT` | "" (→ fell back to 12) | 16 |
| `OSTICKET_TOPIC_ID_CHANNEL` | "" (→ fell back to 12) | 17 |

Topic IDs correspond to the help topics already created in OS Ticket.

## What else

Added a comment block in the configmap mapping each env var to the frontend category value (`ContactForm.tsx:23`) that triggers it, plus a pointer to the routing switch in `api/core/support.go` so the next person wiring a new category doesn't have to search the codebase.

## Deployed

- `kubectl apply` ran against the live cluster; new values verified in the configmap.
- `core-api` restarted; new pod (`core-api-6f9dd84bb5-qmzm5`) env confirmed.
- Smoke test passes (`ALL 8 SERVICES READY`).