### PR TITLE
fix(support): surface 429 rate-limit to user + only record on success

### DIFF
--- a/api/core/support.go
+++ b/api/core/support.go
@@ -54,6 +54,12 @@ type osTicketAttachmentEntry struct {
 }
 
 // ===== Per-user rate limiting =====
+//
+// One accepted ticket per user per minute. "Accepted" means we
+// successfully pushed it to OS Ticket — if the OS Ticket API or our own
+// validation rejects the submission, the user isn't locked out for 60
+// seconds. Otherwise a single server-side glitch could silently trap a
+// user behind a cooldown they didn't earn.
 
 var (
 	supportRateMu    sync.Mutex
@@ -61,7 +67,12 @@ var (
 	supportRateLimit = 1 * time.Minute
 )
 
-func checkSupportRateLimit(userID string) bool {
+// allowedBySupportRateLimit returns true iff the user hasn't submitted
+// an accepted ticket within the last `supportRateLimit` window. Does
+// NOT record the submission — the caller must call
+// `recordSupportSubmission(userID)` AFTER the ticket is accepted by OS
+// Ticket.
+func allowedBySupportRateLimit(userID string) bool {
 	supportRateMu.Lock()
 	defer supportRateMu.Unlock()
 
@@ -70,8 +81,15 @@ func checkSupportRateLimit(userID string) bool {
 			return false
 		}
 	}
-	supportRateMap[userID] = time.Now()
 	return true
+}
+
+// recordSupportSubmission marks the user's most recent accepted
+// submission, starting the rate-limit window.
+func recordSupportSubmission(userID string) {
+	supportRateMu.Lock()
+	defer supportRateMu.Unlock()
+	supportRateMap[userID] = time.Now()
 }
 
 // ===== Handler =====
@@ -87,10 +105,10 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 		})
 	}
 
-	if !checkSupportRateLimit(userID) {
+	if !allowedBySupportRateLimit(userID) {
 		return c.Status(fiber.StatusTooManyRequests).JSON(ErrorResponse{
 			Status: "error",
-			Error:  "Please wait before submitting another ticket",
+			Error:  "Please wait a minute before submitting another ticket",
 		})
 	}
 
@@ -309,6 +327,10 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 
 		if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
 			log.Printf("[Support] Ticket created for user %s (key %d)", userID, i+1)
+			// Only record the submission AFTER OS Ticket confirms. If the
+			// request fails upstream the user isn't trapped in a cooldown
+			// they didn't earn — see allowedBySupportRateLimit.
+			recordSupportSubmission(userID)
 			return c.JSON(fiber.Map{
 				"status":  "ok",
 				"message": "Bug report submitted successfully",

--- a/api/core/support_test.go
+++ b/api/core/support_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSupportRateLimit_AllowsFirstSubmission is the baseline: a user
+// with no prior submission is allowed through.
+func TestSupportRateLimit_AllowsFirstSubmission(t *testing.T) {
+	resetSupportRateLimiter()
+
+	if !allowedBySupportRateLimit("user-a") {
+		t.Fatal("first submission should be allowed")
+	}
+}
+
+// TestSupportRateLimit_CheckIsSideEffectFree verifies the key contract:
+// `allowedBySupportRateLimit` is read-only. Pre-incident, the check and
+// the timestamp-update were fused, meaning a check done on a 429 path
+// (before the actual submission) would lock the user out unintentionally.
+func TestSupportRateLimit_CheckIsSideEffectFree(t *testing.T) {
+	resetSupportRateLimiter()
+
+	// 100 checks in a row should all return true — nothing is being
+	// recorded.
+	for i := 0; i < 100; i++ {
+		if !allowedBySupportRateLimit("user-b") {
+			t.Fatalf("check #%d flipped to false — allowedBy... must be read-only", i)
+		}
+	}
+}
+
+// TestSupportRateLimit_BlocksWithinWindow covers the happy path after a
+// submission is recorded: subsequent submissions inside the window are
+// rejected.
+func TestSupportRateLimit_BlocksWithinWindow(t *testing.T) {
+	resetSupportRateLimiter()
+
+	if !allowedBySupportRateLimit("user-c") {
+		t.Fatal("first check should be allowed")
+	}
+
+	recordSupportSubmission("user-c")
+
+	if allowedBySupportRateLimit("user-c") {
+		t.Fatal("submission recorded — next check should be blocked")
+	}
+}
+
+// TestSupportRateLimit_IsolatesUsers is a guard against a classic bug in
+// global-map rate limiters: a recorded submission for one user should not
+// affect another user.
+func TestSupportRateLimit_IsolatesUsers(t *testing.T) {
+	resetSupportRateLimiter()
+
+	recordSupportSubmission("user-d")
+
+	if !allowedBySupportRateLimit("user-e") {
+		t.Fatal("user-e has no submissions recorded and should be allowed")
+	}
+	if allowedBySupportRateLimit("user-d") {
+		t.Fatal("user-d just submitted and should be blocked")
+	}
+}
+
+// TestSupportRateLimit_ExpiresAfterWindow proves the cooldown actually
+// releases. We temporarily shrink the rate-limit window so the test can
+// run in milliseconds rather than a minute.
+func TestSupportRateLimit_ExpiresAfterWindow(t *testing.T) {
+	resetSupportRateLimiter()
+
+	originalLimit := supportRateLimit
+	supportRateLimit = 50 * time.Millisecond
+	t.Cleanup(func() { supportRateLimit = originalLimit })
+
+	recordSupportSubmission("user-f")
+	if allowedBySupportRateLimit("user-f") {
+		t.Fatal("immediately after submission, should still be blocked")
+	}
+
+	time.Sleep(75 * time.Millisecond)
+
+	if !allowedBySupportRateLimit("user-f") {
+		t.Fatal("after window elapsed, should be allowed again")
+	}
+}
+
+// resetSupportRateLimiter empties the per-user map. Only used by tests
+// to ensure each test case starts from a clean slate.
+func resetSupportRateLimiter() {
+	supportRateMu.Lock()
+	defer supportRateMu.Unlock()
+	supportRateMap = make(map[string]time.Time)
+}

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -16,13 +16,30 @@ export { API_BASE };
 
 // ── Request helpers ─────────────────────────────────────────────
 
+/**
+ * Error thrown by `request()` / `authFetch()` on non-2xx responses.
+ * Preserves the HTTP status code so callers can react to specific
+ * failures (e.g. 429 rate-limiting) without string-matching on the
+ * message.
+ */
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
 /** Parse error body and throw — shared by request() and authFetch(). */
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
     const error = await response
       .json()
       .catch(() => ({ error: "Request failed" }));
-    throw new Error(
+    throw new ApiError(
+      response.status,
       (error as { error?: string }).error || "Request failed",
     );
   }

--- a/desktop/src/components/support/ContactForm.tsx
+++ b/desktop/src/components/support/ContactForm.tsx
@@ -11,7 +11,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { Bug, Lightbulb, MessageSquare, CreditCard, UserCog, Radio, Paperclip, X, Loader2 } from "lucide-react";
 import clsx from "clsx";
 import { toast } from "sonner";
-import { authFetch } from "../../api/client";
+import { authFetch, ApiError } from "../../api/client";
 import { getUserIdentity, isAuthenticated } from "../../auth";
 
 // ── Types ────────────────────────────────────────────────────────
@@ -304,26 +304,40 @@ export default function ContactForm({ onBack }: ContactFormProps) {
       });
 
       toast.success(SUCCESS_MESSAGES[category]);
-
-      // Start 60s cooldown
-      setCooldown(60);
-      cooldownRef.current = setInterval(() => {
-        setCooldown((prev) => {
-          if (prev <= 1) {
-            if (cooldownRef.current) clearInterval(cooldownRef.current);
-            cooldownRef.current = null;
-            return 0;
-          }
-          return prev - 1;
-        });
-      }, 1000);
-
+      startCooldown(60);
       onBack();
-    } catch {
+    } catch (err) {
+      // HTTP 429 — backend's per-user rate limit rejected this submission.
+      // Surface the specific message AND start the client-side cooldown so
+      // the user can't immediately retry (which would just 429 again).
+      // Without this, the form's Submit button re-enables instantly and
+      // every retry fires another useless 429; the user's UX is "nothing
+      // works" when the real answer is "wait a minute."
+      if (err instanceof ApiError && err.status === 429) {
+        toast.error(err.message || "Please wait before submitting another ticket");
+        startCooldown(60);
+        return;
+      }
       toast.error(`Failed to submit ${SUBMIT_LABELS[category].toLowerCase()} — please try again`);
     } finally {
       setSubmitting(false);
     }
+  };
+
+  /** Start the 60s submit-button cooldown. Used on both success and 429. */
+  const startCooldown = (seconds: number) => {
+    setCooldown(seconds);
+    if (cooldownRef.current) clearInterval(cooldownRef.current);
+    cooldownRef.current = setInterval(() => {
+      setCooldown((prev) => {
+        if (prev <= 1) {
+          if (cooldownRef.current) clearInterval(cooldownRef.current);
+          cooldownRef.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
   };
 
   // ── Render helpers ──────────────────────────────────────────────


### PR DESCRIPTION
## Why

When submitting Contact Us tickets, only the first category succeeded — the other 5 all failed with generic 'Failed to submit' toasts. Root cause: server-side rate limit is 1 ticket/user/60s, but the client's 60s cooldown only started on success. So after the Bug Report succeeded, every rapid retry hit 429 and the UI told the user 'try again' — which then 429'd again.

Ingress logs confirm:

```
19:09:07  200 OK   ← Bug Report succeeded
19:09:18  429      ← 11s later — blocked
19:09:26  429      ← 19s later — blocked
19:09:33  429      ← 26s later — blocked
```

OS Ticket itself is healthy; all 6 topic IDs accept posts (confirmed via direct API tests returning 201).

## What changed

### Desktop
- **`ApiError`** class in `desktop/src/api/client.ts` preserves HTTP status codes on thrown errors.
- **`ContactForm`** catch block special-cases 429: shows the server's specific message AND starts the 60s cooldown, so the button disables and retry attempts are blocked client-side.

### Core API
- Split `checkSupportRateLimit` (which both checked and recorded in one call) into two functions: `allowedBySupportRateLimit` (read-only) and `recordSupportSubmission` (explicit).
- Moved `recordSupportSubmission` to the 200/201 branch of the OS Ticket POST. Previously, a 5xx from OS Ticket would still trap the user behind a 60s cooldown they didn't earn.

### Tests
Added 5 tests for the refactored rate limiter covering read-only checks, isolation between users, and window expiration.

## Verified
- Go: `go test ./core/` — all tests pass (incl. 5 new rate-limit tests).
- Desktop: `npm run build` clean, `tsc --noEmit` clean.