### PR TITLE
fix(desktop): make relative-time labels actually tick, debounce CDC safety-net refetch

### DIFF
--- a/desktop/src/channels/finance/FeedTab.tsx
+++ b/desktop/src/channels/finance/FeedTab.tsx
@@ -14,10 +14,11 @@ import { clsx } from "clsx";
 import { TrendingUp } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { dashboardQueryOptions, financeCatalogOptions } from "../../api/queries";
-import { formatPrice, formatChange, timeAgo } from "../../utils/format";
+import { formatPrice, formatChange, relativeTime } from "../../utils/format";
 import EmptyChannelState from "../../components/EmptyChannelState";
 import CategoryFilter from "../rss/CategoryFilter";
 import { useShell } from "../../shell-context";
+import { useNow } from "../../hooks/useNow";
 import type { Trade, FeedTabProps, ChannelManifest } from "../../types";
 import type { FinanceDisplayPrefs } from "../../preferences";
 
@@ -71,6 +72,11 @@ function FinanceFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
 
   const { data: dashboard } = useQuery(dashboardQueryOptions());
   const { data: catalog } = useQuery(financeCatalogOptions());
+
+  // One subscription for the whole list — passed down to each row so
+  // every `TradeItem` re-renders together on the 1s tick. Without this
+  // the per-row "Xs ago" labels never advance between price updates.
+  const now = useNow();
 
   const trades = useMemo(
     () => (dashboard?.data?.finance as Trade[] | undefined) ?? [],
@@ -348,6 +354,7 @@ function FinanceFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
                 mode={mode}
                 display={dp}
                 category={categoryMap.get(trade.symbol)}
+                now={now}
               />
             ))}
           </div>
@@ -395,13 +402,17 @@ interface TradeItemProps {
   mode: "comfort" | "compact";
   display: FinanceDisplayPrefs;
   category?: string;
+  /** Shared "now" from `useNow()` in the parent list — drives the `Xs ago` label. */
+  now: number;
 }
 
-const TradeItem = memo(function TradeItem({ trade, mode, display, category }: TradeItemProps) {
+const TradeItem = memo(function TradeItem({ trade, mode, display, category, now }: TradeItemProps) {
   const isUp = trade.direction === "up";
   const isDown = trade.direction === "down";
 
-  // Track previous price for flash animation
+  // Track previous price for flash animation. Single effect owns the ref —
+  // the previous split-effect version could overwrite the ref before the
+  // flash branch ran on rapid back-to-back CDC events, swallowing flashes.
   const prevPriceRef = useRef<number | null>(null);
   const [flash, setFlash] = useState<"up" | "down" | null>(null);
 
@@ -409,25 +420,19 @@ const TradeItem = memo(function TradeItem({ trade, mode, display, category }: Tr
     const currentPrice =
       typeof trade.price === "string" ? parseFloat(trade.price) : trade.price;
     const prevPrice = prevPriceRef.current;
+    prevPriceRef.current = currentPrice;
 
     if (
-      prevPrice !== null &&
-      !isNaN(currentPrice) &&
-      currentPrice !== prevPrice
+      prevPrice === null ||
+      isNaN(currentPrice) ||
+      currentPrice === prevPrice
     ) {
-      setFlash(currentPrice > prevPrice ? "up" : "down");
-      const timer = setTimeout(() => setFlash(null), 800);
-      return () => clearTimeout(timer);
+      return;
     }
 
-    prevPriceRef.current = currentPrice;
-  }, [trade.price]);
-
-  // Keep ref in sync after flash logic
-  useEffect(() => {
-    const currentPrice =
-      typeof trade.price === "string" ? parseFloat(trade.price) : trade.price;
-    prevPriceRef.current = currentPrice;
+    setFlash(currentPrice > prevPrice ? "up" : "down");
+    const timer = setTimeout(() => setFlash(null), 800);
+    return () => clearTimeout(timer);
   }, [trade.price]);
 
   const dirColor = isUp ? "text-up" : isDown ? "text-down" : "text-fg-3";
@@ -506,8 +511,11 @@ const TradeItem = memo(function TradeItem({ trade, mode, display, category }: Tr
             </span>
           )}
           {display.showLastUpdated && trade.last_updated && (
-            <span className="text-[9px] font-mono text-fg-3 tabular-nums">
-              {timeAgo(trade.last_updated, { includeSeconds: true })}
+            <span
+              className="text-[9px] font-mono text-fg-3 tabular-nums"
+              title="Last price update"
+            >
+              {relativeTime(trade.last_updated, now, { includeSeconds: true })}
             </span>
           )}
         </div>
@@ -518,6 +526,10 @@ const TradeItem = memo(function TradeItem({ trade, mode, display, category }: Tr
   prev.mode === next.mode &&
   prev.display === next.display &&
   prev.category === next.category &&
+  // `now` must trigger a re-render while the "Xs ago" label is visible
+  // so it advances on every tick. When the label is hidden the tick
+  // is irrelevant — skip it to avoid churning the whole list.
+  (!next.display.showLastUpdated || next.mode !== "comfort" || prev.now === next.now) &&
   prev.trade.symbol === next.trade.symbol &&
   prev.trade.price === next.trade.price &&
   prev.trade.percentage_change === next.trade.percentage_change &&

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -10,10 +10,11 @@ import { Rss, ChevronDown, ChevronUp } from "lucide-react";
 import { clsx } from "clsx";
 import { useQuery } from "@tanstack/react-query";
 import { dashboardQueryOptions, rssCatalogOptions } from "../../api/queries";
-import { timeAgo, truncate } from "../../utils/format";
+import { relativeTime, truncate } from "../../utils/format";
 import EmptyChannelState from "../../components/EmptyChannelState";
 import CategoryFilter from "./CategoryFilter";
 import { useShell } from "../../shell-context";
+import { useNow } from "../../hooks/useNow";
 import type {
   RssItem as RssItemType,
   FeedTabProps,
@@ -153,6 +154,10 @@ function RssFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
 
   const { data: dashboard } = useQuery(dashboardQueryOptions());
   const { data: catalog } = useQuery(rssCatalogOptions());
+
+  // Shared 1s tick so every `RssArticle` advances its "Xm ago" label in
+  // sync without each row spawning its own timer.
+  const now = useNow();
 
   const rssItems = useMemo(
     () => (dashboard?.data?.rss as RssItemType[] | undefined) ?? [],
@@ -511,6 +516,7 @@ function RssFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
                 mode={mode}
                 display={dp}
                 category={entry.category}
+                now={now}
               />
             );
           })}
@@ -572,10 +578,12 @@ interface RssArticleProps {
   mode: FeedMode;
   display: RssDisplayPrefs;
   category?: string;
+  /** Shared "now" from `useNow()` so the "Xm ago" label advances between renders. */
+  now: number;
 }
 
-const RssArticle = memo(function RssArticle({ item, mode, display, category }: RssArticleProps) {
-  const ago = display.showTimestamps ? timeAgo(item.published_at) : null;
+const RssArticle = memo(function RssArticle({ item, mode, display, category, now }: RssArticleProps) {
+  const ago = display.showTimestamps ? relativeTime(item.published_at, now) : null;
 
   const categoryBadge = display.showSource && category ? (
     <span className="px-1.5 py-px rounded text-[9px] text-fg-3 bg-accent/10 shrink-0 whitespace-nowrap">
@@ -644,6 +652,10 @@ const RssArticle = memo(function RssArticle({ item, mode, display, category }: R
   prev.mode === next.mode &&
   prev.display === next.display &&
   prev.category === next.category &&
+  // Only re-render on the `now` tick when this row actually renders
+  // a timestamp — otherwise the tick would churn the whole list for
+  // no visible change.
+  (!next.display.showTimestamps || prev.now === next.now) &&
   prev.item.guid === next.item.guid &&
   prev.item.feed_url === next.item.feed_url &&
   prev.item.title === next.item.title &&

--- a/desktop/src/hooks/useDashboardCDC.ts
+++ b/desktop/src/hooks/useDashboardCDC.ts
@@ -12,6 +12,7 @@
  * bus and are merged in-place, giving instant UI updates without
  * waiting for the next polling cycle.
  */
+import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTauriListener } from "./useTauriListener";
 import { queryKeys } from "../api/queries";
@@ -120,6 +121,21 @@ const FANTASY_REFETCH_DELAY_MS = 250;
 export function useDashboardCDC(): void {
   const queryClient = useQueryClient();
 
+  // Debounce state for the safety-net and fantasy refetches. Production
+  // SSE throughput can hit ~47 events/sec; without coalescing, every
+  // event scheduled its own `setTimeout(invalidate, 500)` and we'd queue
+  // ~24 simultaneous refetch timers per burst. Trailing-edge debounce
+  // collapses a burst into one refetch fired after the storm settles.
+  const pendingSafetyRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingFantasyRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pendingSafetyRef.current) clearTimeout(pendingSafetyRef.current);
+      if (pendingFantasyRef.current) clearTimeout(pendingFantasyRef.current);
+    };
+  }, []);
+
   useTauriListener<SSEPayload>(
     "sse-event",
     (event) => {
@@ -177,22 +193,24 @@ export function useDashboardCDC(): void {
         (r) => r.metadata?.table_name && FANTASY_CDC_TABLES.has(r.metadata.table_name),
       );
       if (fantasyTouched) {
-        setTimeout(
-          () => queryClient.invalidateQueries({ queryKey: queryKeys.dashboard }),
-          FANTASY_REFETCH_DELAY_MS,
-        );
+        if (pendingFantasyRef.current) clearTimeout(pendingFantasyRef.current);
+        pendingFantasyRef.current = setTimeout(() => {
+          pendingFantasyRef.current = null;
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        }, FANTASY_REFETCH_DELAY_MS);
         return;
       }
 
       // ── Safety-net refetch ──────────────────────────────────
       // A full dashboard re-fetch after a short delay ensures the
-      // optimistic cache stays consistent with the server. This is
-      // the same pattern the ticker window used previously.
-      setTimeout(
-        () =>
-          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard }),
-        SSE_REFETCH_DELAY_MS,
-      );
+      // optimistic cache stays consistent with the server. Trailing-edge
+      // debounced so a burst of CDC events produces one refetch, not
+      // one-per-event.
+      if (pendingSafetyRef.current) clearTimeout(pendingSafetyRef.current);
+      pendingSafetyRef.current = setTimeout(() => {
+        pendingSafetyRef.current = null;
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+      }, SSE_REFETCH_DELAY_MS);
     },
     [queryClient],
   );

--- a/desktop/src/hooks/useNow.ts
+++ b/desktop/src/hooks/useNow.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared "now" ticker — single app-wide interval for relative-time labels.
+ *
+ * Why a singleton interval?
+ *   The old `timeAgo(...)` renders were pure and computed `Date.now()` at
+ *   render time. A row therefore only advanced its "Xs ago" label when the
+ *   row itself re-rendered, which was driven by either (a) a CDC event for
+ *   that exact row or (b) a polling refetch. In SSE mode that made labels
+ *   jump "now → now → now" on every price update; in polling mode labels
+ *   often stuck at "now" because refetches always returned fresh rows.
+ *
+ *   Subscribing to `useNow()` forces a re-render once per tick so the label
+ *   advances predictably ("now", "5s", "1m", ...). Doing this via a shared
+ *   module-level interval guarantees we never have more than one timer in
+ *   the page regardless of how many rows are on screen.
+ *
+ *   The interval starts lazily on first subscribe and stops on last
+ *   unsubscribe, so non-time-sensitive screens don't pay the (tiny) cost.
+ */
+import { useEffect, useState } from "react";
+
+type Subscriber = (now: number) => void;
+
+const subscribers = new Set<Subscriber>();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/** Start the singleton interval if it isn't already running. */
+function startInterval(): void {
+  if (intervalId !== null) return;
+  intervalId = setInterval(() => {
+    const now = Date.now();
+    // Copy to an array so subscribers can safely unsubscribe during the loop.
+    for (const fn of Array.from(subscribers)) {
+      fn(now);
+    }
+  }, 1000);
+}
+
+/** Stop the singleton interval if no subscribers remain. */
+function stopIntervalIfIdle(): void {
+  if (intervalId !== null && subscribers.size === 0) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * Returns the current epoch-ms "now", refreshed once per second.
+ *
+ * Components that render relative timestamps should call this at the
+ * level that owns the list (not per row) and pass `now` down as a prop.
+ * That way all visible rows re-render together in a single commit.
+ *
+ * @returns `Date.now()` that advances every ~1000ms while subscribed.
+ */
+export function useNow(): number {
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    subscribers.add(setNow);
+    startInterval();
+    // Resync once on mount so a freshly-mounted subscriber doesn't wait
+    // up to a full second for its first value.
+    setNow(Date.now());
+    return () => {
+      subscribers.delete(setNow);
+      stopIntervalIfIdle();
+    };
+  }, []);
+
+  return now;
+}
+
+// ── Test/diagnostic helpers ──────────────────────────────────────
+// Exported for unit tests and devtools. Do not rely on these from
+// application code.
+
+/** @internal subscriber count. */
+export function __getSubscriberCount(): number {
+  return subscribers.size;
+}
+
+/** @internal whether the singleton interval is active. */
+export function __isIntervalActive(): boolean {
+  return intervalId !== null;
+}

--- a/desktop/src/utils/format.ts
+++ b/desktop/src/utils/format.ts
@@ -5,23 +5,33 @@
  */
 
 /**
- * Format a date string as relative time.
+ * Format a date string as relative time against an injected `now`.
  *
- * Returns "now" for < 1 min, "Xm" for minutes, "Xh" for hours,
- * "Xd" for days < 7, then a short date for older.
+ * Prefer this over `timeAgo` for any label that needs to advance
+ * between renders — pair it with the `useNow()` hook so React
+ * re-renders once per second and the label counts up naturally.
  *
- * @param includeSeconds  Show seconds granularity (e.g. "12s") for < 1 min.
- * @param suffix          Append " ago" to the result (e.g. "5m ago").
+ * Returns "now" for < 1 min (or < 5s with `includeSeconds`),
+ * "Xs" / "Xm" / "Xh" / "Xd" for progressively older values, then
+ * a short locale date ("Apr 23") after 7 days.
+ *
+ * @param dateStr        ISO-8601 timestamp, or `null` / `undefined`.
+ * @param now            Reference "now" in epoch-ms (usually from `useNow()`).
+ * @param includeSeconds Show seconds granularity ("12s") for < 1 min.
+ * @param suffix         Append " ago" to the result (e.g. "5m ago").
  */
-export function timeAgo(
+export function relativeTime(
   dateStr: string | null | undefined,
+  now: number,
   options?: { includeSeconds?: boolean; suffix?: boolean },
 ): string {
   if (!dateStr) return "";
   const d = new Date(dateStr);
-  if (isNaN(d.getTime())) return "";
+  const t = d.getTime();
+  if (isNaN(t)) return "";
 
-  const diff = Date.now() - d.getTime();
+  // Clamp negative diffs (clock skew — server slightly ahead of client).
+  const diff = Math.max(0, now - t);
   const secs = Math.floor(diff / 1000);
   const mins = Math.floor(secs / 60);
   const hours = Math.floor(mins / 60);
@@ -44,6 +54,21 @@ export function timeAgo(
     month: "short",
     day: "numeric",
   });
+}
+
+/**
+ * Format a date string as relative time against the current wall clock.
+ *
+ * Thin wrapper around {@link relativeTime} for static callers that
+ * don't need the label to tick (e.g. toasts, one-shot messages).
+ * Components that render ongoing timestamps should use `relativeTime`
+ * directly with `useNow()` so labels advance between CDC events.
+ */
+export function timeAgo(
+  dateStr: string | null | undefined,
+  options?: { includeSeconds?: boolean; suffix?: boolean },
+): string {
+  return relativeTime(dateStr, Date.now(), options);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the dodgy per-row \"Xs ago\" timer on the finance FeedTab (and while
we're here, the same pattern on RSS). Also debounces the CDC safety-net
refetch so the 47 events/sec firehose doesn't schedule 47 overlapping
refetch timers.

## What was broken

1. **SSE (Ultimate tier) — flash \u2192 now \u2192 glitch pattern.** Every CDC event
   triggered a row re-render plus a 500ms `setTimeout(invalidate, 500)`.
   With ~47 events/sec that queued dozens of simultaneous refetches, each
   re-running the FeedTab's sort and rebuilding the list. Visible as
   \"flashes, updates correctly, timer goes to 'now', then glitches again.\"
2. **Polling (Free/Uplink/Pro) — labels stuck on \"now\".** Rows only
   re-rendered on refetch. Between refetches the label couldn't advance
   because `timeAgo` computed `Date.now()` at render time with nothing
   subscribed. Rows effectively said \"now\" forever.
3. **`TradeItem` flash race.** Two `useEffect`s both touched
   `prevPriceRef`; the second unconditionally overwrote the ref,
   swallowing flashes on rapid back-to-back updates for the same symbol.

## What changed

### `desktop/src/hooks/useNow.ts` (new)
Shared 1 s ticker. Module-level `setInterval` + `Set<Subscriber>` with
lazy start / ref-counted stop. One timer total, regardless of how many
rows are on screen.

### `desktop/src/utils/format.ts`
- New pure `relativeTime(str, now, opts)` takes `now` as a parameter so
  the caller decides when the label refreshes.
- `timeAgo(str, opts)` preserved as a one-line wrapper around
  `relativeTime(str, Date.now(), opts)` \u2014 backwards compatible for
  non-ticking callers (toasts, tooltips, ticker chips).
- Also clamps negative diffs (server clock slightly ahead of client
  no longer shows garbage).

### Finance + RSS FeedTabs
- Subscribe to `useNow()` once at the list level, pass `now` down to
  `TradeItem` / `RssArticle`.
- Memo comparators include `now`, **gated on whether the label is
  actually visible** so hidden timestamps don't churn the list every
  second.
- Added `title=\"Last price update\"` on the finance timestamp so users
  hovering understand this is price-change recency, not connection
  freshness.
- Collapsed the `TradeItem` dual `useEffect` into one that reads the
  old ref, updates it, and fires the flash animation atomically.

### `desktop/src/hooks/useDashboardCDC.ts`
- Trailing-edge debounce for both the safety-net refetch and the
  fantasy fast-path. Refs stored per-hook-instance; `useEffect` cleanup
  clears pending timers on unmount.
- A 47 events/sec burst now fires one refetch 500 ms after the storm
  settles, not 47.

### Ticker / `RssChip` \u2014 intentionally untouched
Ticker chips scroll past in seconds so tick-level precision doesn't
matter. Subscribing inside the chip build memo would bust the whole
marquee on every tick. RssChip keeps using `timeAgo` (the non-ticking
wrapper), which is correct for that surface.

## Verification

- `npm run build` \u2014 clean (Vite + `tsc --noEmit`)
- `npx tsc --noEmit` \u2014 no errors
- Manual: launch desktop, Finance tab, confirm timer counts up
  \"now \u2192 5s \u2192 1m\" between price updates in SSE mode and also between
  refetches in polling mode (throttle the tier to Free to test).

## Out of scope (follow-ups)

- Connection-status dot in the FeedTab header (\"Approach A\" from
  brainstorm). If per-row timers still feel confusing after this
  lands, we can layer that on top.
- Per-row \"stale\" badge with thresholds.
- Adding vitest to the desktop package and unit tests for `useNow` +
  `relativeTime` \u2014 deliberately skipped because the desktop package
  currently has no test infrastructure (per AGENTS.md) and wiring it
  up belongs in its own PR.