### PR TITLE
Super-user invite polish + early-access legal terms

### DIFF
--- a/myscrollr.com/src/components/legal/documents.ts
+++ b/myscrollr.com/src/components/legal/documents.ts
@@ -12,6 +12,7 @@ import {
   Scale,
   Shield,
   ShieldAlert,
+  Sparkles,
   TrendingUp,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
@@ -874,6 +875,99 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         heading: 'Continuous Improvement',
         content: [
           'Accessibility is an ongoing effort. As we develop new features and update existing ones, we will continue to evaluate and improve the accessibility of the Platform. We are committed to making Scrollr usable by as many people as possible.',
+        ],
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────
+  // 15. SUPER USER EARLY ACCESS TERMS
+  // ─────────────────────────────────────────────────────────────
+  {
+    slug: 'super-user',
+    title: 'Super User Early Access Terms',
+    shortTitle: 'Super User',
+    icon: Sparkles,
+    category: 'community',
+    lastUpdated: 'April 2026',
+    effectiveDate: 'April 25, 2026',
+    badge: 'Invite only',
+    sections: [
+      {
+        heading: 'Overview',
+        content: [
+          'These Super User Early Access Terms ("Super User Terms") supplement the Scrollr Terms of Service. They apply to accounts that have been added to the Scrollr Super User early-access program by invitation. The program exists so that a small group of trusted testers can use Scrollr ahead of public launch, report issues, and shape the product before broader release.',
+          'When these Super User Terms conflict with the general Terms of Service, these Super User Terms control for the limited matters they address (eligibility, complimentary tier access, revocation). Everything else continues to be governed by the main Terms of Service.',
+        ],
+        callout: {
+          type: 'info',
+          text: 'You become a Super User by accepting an invite emailed to you from invites@myscrollr.com. There is no public sign-up.',
+        },
+      },
+      {
+        heading: 'Eligibility and Account',
+        content: [
+          'Super User access is granted by invitation only. Each invitation is tied to a single email address and is non-transferable. You may not sell, lend, gift, or otherwise transfer your Super User account or its associated benefits to another person.',
+          'You must use a single account for your own personal access to the Platform. Sharing credentials, automating account use to circumvent rate limits, or operating multiple Super User accounts to multiply benefits is a material violation of these Super User Terms and grounds for revocation under the section below.',
+          'You must meet the eligibility requirements stated in the main Terms of Service.',
+        ],
+      },
+      {
+        heading: 'Complimentary Ultimate Tier Access',
+        content: [
+          'For as long as you remain in good standing under these Super User Terms and the general Terms of Service, your account will receive complimentary access at the Ultimate tier (or its equivalent successor tier, if Scrollr renames or restructures its tier system in the future).',
+          'Tier access means access at the tier level. Specific features, limits, providers, and capabilities included in the Ultimate tier may change over time as the Platform evolves. We may add, remove, replace, or modify the features delivered at the Ultimate tier without prior notice. Your continued benefit is the equivalent tier-level access offered to paying Ultimate subscribers from time to time, not any specific feature or quota that exists at the moment of your invite.',
+          'This benefit is provided at no cost to you and is not refundable, exchangeable, or convertible to monetary value. Taxes, if any apply in your jurisdiction, are your responsibility.',
+        ],
+      },
+      {
+        heading: 'Duration of the Benefit',
+        content: [
+          'We commit to maintaining your complimentary Ultimate tier access for the lifetime of the program, subject to the conditions in this document. "Lifetime of the program" means the continuous period during which Scrollr operates the Super User early-access offering or operates the Platform at all.',
+          'If we permanently discontinue the Platform, are acquired by or merged into another company that ceases to operate the Platform, dissolve, or otherwise cease commercial operation of Scrollr in any form, the complimentary Ultimate tier access ends at the same time as the underlying offering. We will provide reasonable advance notice (no less than thirty days where commercially practicable) before such a discontinuation, except in cases of insolvency or events outside our reasonable control.',
+          'In the event of a sale or transfer of substantially all of the Scrollr business or assets to a successor that continues to operate the Platform, your Super User benefits will transfer to the successor and these Super User Terms will continue to apply, subject to any reasonable, non-material modifications the successor may publish.',
+        ],
+      },
+      {
+        heading: 'Revocation',
+        content: [
+          'We may suspend or revoke your Super User status, including the complimentary Ultimate tier access, immediately and without refund (none is owed) if any of the following occur:',
+          'You materially violate the Terms of Service or these Super User Terms; you engage in fraud, abuse, or illegal activity; you attempt to circumvent rate limits, billing, security, or access controls; you operate multiple accounts to multiply benefits; you transfer or attempt to transfer your account; you use the Platform to harm other users, ourselves, or third parties; you fail to respond to lawful requests for information needed to verify your eligibility; you have not used the account for a continuous period of twelve months or more (in which case we may, at our discretion, deactivate the account with at least thirty days advance notice and an opportunity to reactivate).',
+          'Where the issue is correctable and not severe, we will typically warn you before revoking. Where the issue is severe, ongoing, fraudulent, or illegal, we may act without warning. After revocation you may appeal in writing within thirty days; we are not obligated to reinstate but will consider appeals in good faith.',
+        ],
+      },
+      {
+        heading: 'No Service Level Guarantees',
+        content: [
+          'The Super User program is an early-access program. The Platform is in active development. We do not provide service-level agreements, uptime guarantees, response-time guarantees, or any guarantee that specific features, integrations, providers, or behaviors will continue to work as expected. Bugs, downtime, data delays, and breaking changes are expected during this period and are part of the reason we recruit Super Users.',
+          'We provide the Platform on an "as is" and "as available" basis as set forth more fully in the general Terms of Service.',
+        ],
+      },
+      {
+        heading: 'Feedback You Provide',
+        content: [
+          'Feedback you submit through the in-app Contact Us flow, by email reply, or through any other channel may be used by us to improve the Platform without compensation, attribution, or further notice to you. By submitting feedback you grant us a perpetual, worldwide, royalty-free, non-exclusive license to use, reproduce, modify, and incorporate that feedback into the Platform and related materials.',
+          'You retain ownership of any pre-existing intellectual property contained in your feedback. This grant covers our use of the feedback for product improvement; it does not transfer ownership of your underlying ideas to us.',
+        ],
+      },
+      {
+        heading: 'Personal, Non-Commercial Use',
+        content: [
+          'The complimentary Ultimate tier access is for your personal, non-commercial use. You may not resell access, expose the Platform as part of a commercial product or service offered by you to third parties, or use Super User access to substitute for a commercial agreement that would otherwise apply.',
+          'We may impose reasonable use limits if individual usage is materially out of line with typical Ultimate-tier usage and shows signs of abuse or commercial use. We will attempt to discuss any such limits with you before applying them.',
+        ],
+      },
+      {
+        heading: 'Changes to These Super User Terms',
+        content: [
+          'We may update these Super User Terms from time to time as the program evolves. Material changes will be communicated to your Super User account email address and posted at this URL. The "Last Updated" date at the top of this document reflects the most recent revision.',
+          'Continued use of your Super User account after a posted revision becomes effective constitutes acceptance of the revised Super User Terms. If you do not agree with the revisions, you may discontinue use; doing so does not entitle you to any compensation since the program is provided at no charge.',
+        ],
+      },
+      {
+        heading: 'Contact',
+        content: [
+          'For questions about the Super User program, reply to your invitation email. For product feedback, please use the in-app Contact Us flow so submissions are tracked. For legal or compliance questions, see the contact details in the main Terms of Service.',
         ],
       },
     ],

--- a/scripts/invite-super-users.go
+++ b/scripts/invite-super-users.go
@@ -85,7 +85,7 @@ type config struct {
 // fallback when LOGTO_SUPER_USER_ROLE_ID is unset so the script keeps
 // working out of the box for the current Logto deployment. If you ever
 // rotate the role ID in Logto, set the env var rather than editing
-// this constant — the API server reads the same env var
+// this constant. The API server reads the same env var
 // (api/core/invite.go) so keeping them aligned avoids drift.
 const fallbackSuperUserRoleID = "saaf40fy2iaxu1bwhy0m8"
 
@@ -210,7 +210,15 @@ func randomPassword() string {
 	return hex.EncodeToString(b) + "Aa1!" // Ensure complexity requirements
 }
 
-// createUser creates a Logto user and returns the user ID.
+// userAlreadyExistsErr is returned by `createUser` when Logto's
+// `POST /api/users` rejects the request with `user.email_already_in_use`
+// (HTTP 422). Callers can switch on this to gracefully recover by
+// looking up the existing user by email and proceeding with a
+// re-invite instead of treating it as a fatal error.
+var userAlreadyExistsErr = fmt.Errorf("user already exists")
+
+// createUser creates a Logto user and returns the user ID. Returns
+// `userAlreadyExistsErr` if the email is already registered.
 func createUser(endpoint, token, email, password string) (string, error) {
 	payload := map[string]interface{}{
 		"primaryEmail": email,
@@ -219,6 +227,9 @@ func createUser(endpoint, token, email, password string) (string, error) {
 	body, status, err := logtoRequest("POST", endpoint+"/api/users", token, payload)
 	if err != nil {
 		return "", fmt.Errorf("create user: %w", err)
+	}
+	if status == http.StatusUnprocessableEntity && strings.Contains(string(body), "email_already_in_use") {
+		return "", userAlreadyExistsErr
 	}
 	if status != http.StatusOK {
 		return "", fmt.Errorf("create user returned %d: %s", status, string(body))
@@ -231,6 +242,33 @@ func createUser(endpoint, token, email, password string) (string, error) {
 		return "", fmt.Errorf("parse create user response: %w", err)
 	}
 	return user.ID, nil
+}
+
+// findUserIDByEmail looks up an existing Logto user by primary email
+// and returns their `id`. Used to recover from `userAlreadyExistsErr`
+// during re-invite flows. The `search.primaryEmail` exact-match query
+// param is the same pattern used by the API server in
+// `api/core/invite.go:findUserByEmail`.
+func findUserIDByEmail(endpoint, token, email string) (string, error) {
+	searchURL := fmt.Sprintf("%s/api/users?search.primaryEmail=%s", endpoint, url.QueryEscape(email))
+	body, status, err := logtoRequest("GET", searchURL, token, nil)
+	if err != nil {
+		return "", fmt.Errorf("find user: %w", err)
+	}
+	if status != http.StatusOK {
+		return "", fmt.Errorf("find user returned %d: %s", status, string(body))
+	}
+
+	var users []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &users); err != nil {
+		return "", fmt.Errorf("parse find user response: %w", err)
+	}
+	if len(users) == 0 {
+		return "", fmt.Errorf("no user found with email %s", email)
+	}
+	return users[0].ID, nil
 }
 
 // assignRole assigns a role to a Logto user.
@@ -275,26 +313,32 @@ func createOneTimeToken(endpoint, token, email string) (string, error) {
 // inviteSubject keeps the recipient's inbox preview readable. Inboxes
 // typically render ~50 chars of subject + ~80 chars of preheader, so
 // the subject states what / preheader states why-bother.
-const inviteSubject = "Welcome to MyScrollr Early Access"
+const inviteSubject = "We'd love for you to test out MyScrollr"
 
-const invitePreheader = "Your Super User account is ready. Setup takes about a minute."
+const invitePreheader = "You're literally one of our first users. Your account is ready and setup takes about a minute."
 
-const inviteSupportAddress = "support@myscrollr.com"
+// Feedback channel is the in-app Contact Us flow, NOT a public-facing
+// email address. The invite-only audience for this script knows the
+// app is unreleased and we want feedback consolidated through the
+// Contact Us pipeline (which produces tickets) rather than scattered
+// across email threads. The "reply to this email" footer line below
+// is for invite-flow problems only (lost link, wrong email, etc.)
+// and not for product feedback.
 
 // inviteHTMLTemplate is the production HTML body. Two `%s` placeholders:
 //  1. preheader text (hidden in body, shown in inbox preview)
 //  2. invite URL (used in CTA button)
 //
 // Design notes:
-//   - Table-based layout (max email-client compatibility — Outlook
-//     for Windows still chokes on flexbox/grid).
+//   - Table-based layout (max email-client compatibility, since
+//     Outlook for Windows still chokes on flexbox/grid).
 //   - Light-mode by default (most clients render light by default);
 //     `prefers-color-scheme: dark` media query overrides for dark
-//     clients. Some clients ignore the media query — that's why the
+//     clients. Some clients ignore the media query, which is why the
 //     light-mode palette is the safe baseline.
 //   - 560px max width (standard email column; mobile media query
 //     drops to full-width with reduced padding).
-//   - Brand color #10b981 (emerald-500) — matches Scrollr's accent.
+//   - Brand color #10b981 (emerald-500) matches Scrollr's accent.
 //   - Body uses neutral system fonts to avoid web-font load issues
 //     in clients that block external assets.
 //   - All styles are inlined except the <style> block in <head>,
@@ -307,7 +351,7 @@ const inviteHTMLTemplate = `<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="x-apple-disable-message-reformatting">
-<title>Welcome to MyScrollr Early Access</title>
+<title>We'd love for you to test out MyScrollr</title>
 <style>
   body { margin: 0; padding: 0; background: #f5f5f5; }
   @media only screen and (max-width: 600px) {
@@ -319,11 +363,12 @@ const inviteHTMLTemplate = `<!DOCTYPE html>
     body { background: #0a0a0a !important; }
     .card { background: #141414 !important; border-color: #262626 !important; }
     .footer-bg { background: #0f0f0f !important; }
-    .step-bg { background: #1a1a1a !important; border-color: #262626 !important; }
-    .h1, .step-num { color: #ffffff !important; }
+    .step-bg, .feedback-bg { background: #1a1a1a !important; border-color: #262626 !important; }
+    .h1, .step-num, .h2 { color: #ffffff !important; }
     .text-secondary { color: #a0a0a0 !important; }
     .text-muted { color: #666666 !important; }
     .text-strong { color: #e5e5e5 !important; }
+    .bullet { color: #10b981 !important; }
   }
 </style>
 </head>
@@ -359,23 +404,24 @@ const inviteHTMLTemplate = `<!DOCTYPE html>
               </td>
             </tr>
 
-            <!-- Hero -->
+            <!-- Hero + warm intro -->
             <tr>
               <td class="px" style="padding:16px 32px 8px;">
                 <h1 class="h1" style="margin:0 0 12px;font-size:28px;font-weight:700;line-height:1.15;color:#111111;letter-spacing:-0.5px;">
                   You're in.
                 </h1>
-                <p class="text-secondary" style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#555555;">
-                  You've been picked to test MyScrollr before public launch. Your
+                <p class="text-secondary" style="margin:0 0 14px;font-size:15px;line-height:1.6;color:#555555;">
+                  Hey, thank you for testing MyScrollr. You are <em>literally</em> one of our first users, and we
+                  really need your help before we ship to the public. Your
                   <strong class="text-strong" style="color:#111111;font-weight:600;">Super User</strong>
-                  account is ready &mdash; setup takes about a minute.
+                  account is ready and setup takes about a minute.
                 </p>
               </td>
             </tr>
 
             <!-- CTA -->
             <tr>
-              <td align="center" style="padding:0 32px 28px;">
+              <td align="center" style="padding:8px 32px 28px;">
                 <table role="presentation" cellspacing="0" cellpadding="0" border="0">
                   <tr><td style="background:#10b981;border-radius:8px;">
                     <a href="%s" style="display:inline-block;padding:14px 32px;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;letter-spacing:0.2px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
@@ -400,8 +446,8 @@ const inviteHTMLTemplate = `<!DOCTYPE html>
                           <span class="step-num" style="display:inline-block;color:#10b981;font-weight:700;font-size:13px;">1.</span>
                         </td>
                         <td style="padding:4px 0;font-size:13.5px;color:#444444;line-height:1.55;">
-                          <strong class="text-strong" style="color:#111111;font-weight:600;">Pick a username</strong>
-                          &mdash; yours to keep, used as your public profile handle.
+                          <strong class="text-strong" style="color:#111111;font-weight:600;">Pick a username.</strong>
+                          Yours to keep, used as your public profile handle.
                         </td>
                       </tr>
                       <tr>
@@ -410,7 +456,7 @@ const inviteHTMLTemplate = `<!DOCTYPE html>
                         </td>
                         <td style="padding:4px 0;font-size:13.5px;color:#444444;line-height:1.55;">
                           <strong class="text-strong" style="color:#111111;font-weight:600;">Download the desktop app</strong>
-                          &mdash; macOS, Windows, or Linux. The link's on the welcome screen.
+                          for macOS, Windows, or Linux. The link is on the welcome screen.
                         </td>
                       </tr>
                       <tr>
@@ -428,15 +474,70 @@ const inviteHTMLTemplate = `<!DOCTYPE html>
               </td>
             </tr>
 
-            <!-- Value prop -->
+            <!-- Your job -->
             <tr>
-              <td class="px" style="padding:0 32px 28px;">
-                <p class="text-secondary" style="margin:0;font-size:13px;line-height:1.65;color:#666666;">
-                  <strong class="text-strong" style="color:#111111;font-weight:600;">Quick context:</strong>
-                  MyScrollr is an always-on-top desktop ticker that streams live financial markets, sports scores,
-                  RSS headlines, and your Yahoo Fantasy leagues &mdash; without browser-tab juggling. As a Super User
-                  you get every paid tier free during the testing period plus a direct line to the team. Reply to this
-                  email any time with feedback or bugs.
+              <td class="px" style="padding:8px 32px 8px;">
+                <h2 class="h2" style="margin:0 0 8px;font-size:17px;font-weight:600;color:#111111;letter-spacing:-0.2px;">
+                  Your job: try to break it.
+                </h2>
+                <p class="text-secondary" style="margin:0 0 12px;font-size:13.5px;line-height:1.6;color:#555555;">
+                  Honestly, we want you to push the app until something cracks. If you find any bugs or glitches,
+                  let us know. Beyond just finding errors, we would love your honest take on:
+                </p>
+                <table role="presentation" width="100%%" cellspacing="0" cellpadding="0" border="0">
+                  <tr><td style="padding:0 0 4px;font-size:13.5px;color:#444444;line-height:1.6;">
+                    <span class="bullet" style="color:#10b981;font-weight:700;">&bull;</span>&nbsp;&nbsp;What new features would actually be useful to you?
+                  </td></tr>
+                  <tr><td style="padding:0 0 4px;font-size:13.5px;color:#444444;line-height:1.6;">
+                    <span class="bullet" style="color:#10b981;font-weight:700;">&bull;</span>&nbsp;&nbsp;Is there anything you flat out dislike?
+                  </td></tr>
+                  <tr><td style="padding:0 0 4px;font-size:13.5px;color:#444444;line-height:1.6;">
+                    <span class="bullet" style="color:#10b981;font-weight:700;">&bull;</span>&nbsp;&nbsp;How does the design look to you?
+                  </td></tr>
+                  <tr><td style="padding:0 0 4px;font-size:13.5px;color:#444444;line-height:1.6;">
+                    <span class="bullet" style="color:#10b981;font-weight:700;">&bull;</span>&nbsp;&nbsp;Is the app easy to navigate?
+                  </td></tr>
+                  <tr><td style="padding:0 0 4px;font-size:13.5px;color:#444444;line-height:1.6;">
+                    <span class="bullet" style="color:#10b981;font-weight:700;">&bull;</span>&nbsp;&nbsp;Do you actually find it useful?
+                  </td></tr>
+                  <tr><td style="padding:0 0 0;font-size:13.5px;color:#444444;line-height:1.6;">
+                    <span class="bullet" style="color:#10b981;font-weight:700;">&bull;</span>&nbsp;&nbsp;Is it cool?
+                  </td></tr>
+                </table>
+              </td>
+            </tr>
+
+            <!-- Where to send feedback (in-app, NOT email) -->
+            <tr>
+              <td class="px" style="padding:20px 32px 4px;">
+                <table role="presentation" class="feedback-bg" width="100%%" cellspacing="0" cellpadding="0" border="0" style="background:rgba(16,185,129,0.06);border:1px solid rgba(16,185,129,0.2);border-radius:10px;">
+                  <tr><td style="padding:16px 20px;">
+                    <p style="margin:0 0 4px;font-size:13px;font-weight:600;color:#10b981;">
+                      Where to send feedback
+                    </p>
+                    <p class="text-secondary" style="margin:0;font-size:13px;line-height:1.55;color:#555555;">
+                      Hit
+                      <strong class="text-strong" style="color:#111111;font-weight:600;">Contact Us</strong>
+                      inside the app whenever something pops into your head: bug, idea, complaint,
+                      &ldquo;this is sweet,&rdquo; whatever. We are reading every single submission and using
+                      it to shape the public release.
+                    </p>
+                  </td></tr>
+                </table>
+              </td>
+            </tr>
+
+            <!-- Thank-you / Ultimate forever -->
+            <tr>
+              <td class="px" style="padding:18px 32px 28px;">
+                <p class="text-secondary" style="margin:0 0 10px;font-size:13px;line-height:1.65;color:#666666;">
+                  <strong class="text-strong" style="color:#111111;font-weight:600;">A massive thank you in advance.</strong>
+                  We put you on the
+                  <strong class="text-strong" style="color:#10b981;font-weight:600;">Ultimate tier</strong>:
+                  zero restrictions, fastest data, every feature unlocked. As our way of saying thanks
+                  for being one of our first testers, your account keeps complimentary Ultimate access for as
+                  long as we operate the early-access program. The fine print lives at
+                  <a href="https://myscrollr.com/legal?doc=super-user" style="color:#10b981;text-decoration:none;font-weight:500;">myscrollr.com/legal</a>.
                 </p>
               </td>
             </tr>
@@ -444,12 +545,8 @@ const inviteHTMLTemplate = `<!DOCTYPE html>
             <!-- Inner footer -->
             <tr>
               <td class="footer-bg px" style="padding:20px 32px;border-top:1px solid #e5e5e5;background:#fafafa;">
-                <p class="text-muted" style="margin:0 0 6px;font-size:11.5px;color:#888888;line-height:1.55;">
-                  This invite expires in 7 days. Need a fresh one? Reply &mdash; we'll send another.
-                </p>
                 <p class="text-muted" style="margin:0;font-size:11.5px;color:#888888;line-height:1.55;">
-                  Questions or feedback? Reply to this email or write to
-                  <a href="mailto:` + inviteSupportAddress + `" style="color:#10b981;text-decoration:none;font-weight:500;">` + inviteSupportAddress + `</a>.
+                  This invite expires in 7 days. Lost it? Just reply to this email and we'll send a new one.
                 </p>
               </td>
             </tr>
@@ -475,10 +572,12 @@ const inviteHTMLTemplate = `<!DOCTYPE html>
 // inviteTextTemplate mirrors the HTML body for clients that strip
 // HTML or for users who view plain-text mode. One `%s` placeholder
 // for the invite URL.
-const inviteTextTemplate = `Welcome to MyScrollr Early Access
+const inviteTextTemplate = `We'd love for you to test out MyScrollr
 
-You've been picked to test MyScrollr before public launch. Your
-Super User account is ready — setup takes about a minute.
+Hey, thank you for testing MyScrollr! You are literally one of our
+first users, and we really need your help before we ship to the
+public. Your Super User account is ready and setup takes about a
+minute.
 
 ➜ Set up your account
    %s
@@ -486,22 +585,42 @@ Super User account is ready — setup takes about a minute.
 WHAT HAPPENS NEXT
 ─────────────────────────────────────────────
 1. Pick a username (yours to keep)
-2. Download the desktop app — macOS, Windows, or Linux
+2. Download the desktop app for macOS, Windows, or Linux
 3. Sign in once and start tracking what matters
 
-QUICK CONTEXT
+YOUR JOB: TRY TO BREAK IT
 ─────────────────────────────────────────────
-MyScrollr is an always-on-top desktop ticker that streams live
-financial markets, sports scores, RSS headlines, and your Yahoo
-Fantasy leagues — without browser-tab juggling. As a Super User
-you get every paid tier free during the testing period plus a
-direct line to the team. Reply with feedback any time.
+Honestly, we want you to push the app until something cracks.
+If you find bugs or glitches, let us know. Beyond just finding
+errors, we would love your honest take on:
+
+  • What new features would actually be useful to you?
+  • Is there anything you flat out dislike?
+  • How does the design look to you?
+  • Is the app easy to navigate?
+  • Do you actually find it useful?
+  • Is it cool?
+
+WHERE TO SEND FEEDBACK
+─────────────────────────────────────────────
+Hit "Contact Us" inside the app whenever something pops into your
+head: bug, idea, complaint, "this is sweet," whatever. We are
+reading every single submission and using it to shape the public
+release.
+
+A MASSIVE THANK YOU IN ADVANCE
+─────────────────────────────────────────────
+We put you on the Ultimate tier: zero restrictions, fastest data,
+every feature unlocked. As our way of saying thanks for being one
+of our first testers, your account keeps complimentary Ultimate
+access for as long as we operate the early-access program. The
+fine print lives at:
+
+   https://myscrollr.com/legal?doc=super-user
 
 ─────────────────────────────────────────────
-This invite expires in 7 days. Need a fresh one? Reply and we'll
-send another.
-
-Questions? Reply or write to ` + inviteSupportAddress + `.
+This invite expires in 7 days. Lost it? Just reply and we will
+send a new one.
 
 MyScrollr · You received this because your email was added to the
 early access list.
@@ -585,10 +704,23 @@ func main() {
 
 		fmt.Printf("[%d/%d] %s\n", i+1, len(emails), email)
 
-		// 1. Create user (no username — user picks it during onboarding)
+		// 1. Create user (no username; user picks it during onboarding).
+		// If the email already exists in Logto (re-invite scenario, or
+		// the user signed up directly), look them up and re-issue an
+		// invite token instead of failing. The role assign + token
+		// generation steps below are idempotent so this Just Works.
 		password := randomPassword()
 		userID, err := createUser(cfg.LogtoEndpoint, m2mToken, email, password)
-		if err != nil {
+		if err == userAlreadyExistsErr {
+			fmt.Printf("  → user already exists, looking up ID...\n")
+			existingID, lookupErr := findUserIDByEmail(cfg.LogtoEndpoint, m2mToken, email)
+			if lookupErr != nil {
+				fmt.Printf("  ✗ Could not locate existing user: %v\n", lookupErr)
+				failures++
+				continue
+			}
+			userID = existingID
+		} else if err != nil {
 			fmt.Printf("  ✗ User creation failed: %v\n", err)
 			failures++
 			continue


### PR DESCRIPTION
## Summary

- **Email rewrite**: warmer copy, bullet list of feedback prompts, in-app Contact Us as the feedback channel, em dashes stripped throughout (HTML + plain text + comments).
- **Recovery path** for `user.email_already_in_use` so the script supports re-inviting addresses that already exist in Logto (the common case during testing).
- **New legal doc** at `/legal?doc=super-user` (Super User Early Access Terms) that backs the "complimentary Ultimate access" promise with carve-outs for revocation, transferability, M&A, SLA disclaimers, and feedback licensing. The thank-you paragraph in the email now links to this doc.

## What's in the diff

### `scripts/invite-super-users.go`

| Change | Why |
|---|---|
| `userAlreadyExistsErr` sentinel + `findUserIDByEmail` helper + main-loop recovery | Re-inviting a previously seeded email is the common case during testing — should not fail the run |
| Subject / preheader / hero / "Your job" / "Where to send feedback" / thank-you sections rewritten | Tone borrowed from a teammate's draft; in-app Contact Us replaces email replies as the feedback channel |
| Em dashes removed everywhere (HTML body, plain-text body, comments) | "Looks too AI" feedback from maintainer |
| Thank-you paragraph references new legal doc | Backs the lifetime-Ultimate promise with documented carve-outs |

### `myscrollr.com/src/components/legal/documents.ts`

New `super-user` slug under the `community` category. Ten sections:

1. Overview + relationship to main ToS
2. Eligibility (invite-only, single account, non-transferable)
3. Complimentary Ultimate Tier Access (tier-LEVEL not feature-level guarantee; features may evolve)
4. Duration of the Benefit (lasts for life of program; ends on permanent discontinuation; survives M&A to a successor that keeps operating the platform)
5. Revocation triggers (ToS violations, fraud, abuse, multi-account, transfer, 12mo inactivity) with 30-day appeal window
6. No Service Level Guarantees (early-access expectation-setting)
7. Feedback You Provide (perpetual royalty-free license to use feedback; user retains underlying IP)
8. Personal Non-Commercial Use (no resale, reasonable-use limits)
9. Changes to These Super User Terms (revision process)
10. Contact

Uses the `Sparkles` lucide icon (added to the existing imports) with an "Invite only" badge.

## Verification

- `go build` clean on the script
- Live test send to `bch713@pm.me` succeeded with the new content (3 sends total during development; final one used the rewritten content + legal-doc link)
- `npm run build` clean for the marketing site
- `npm run check` clean (lint + tsc)
- New legal doc renders correctly in the existing legal sidebar layout

## Out of scope (intentional)

- Click-through "I agree to Super User Terms" gate on the invite acceptance page. The current `/invite?token=...` flow leads into the existing onboarding which already requires the main ToS. The Super User Terms supplement that rather than requiring a separate acceptance step. If a stronger acceptance flow is needed for a wider rollout, that's a separate PR touching the marketing-site invite page and Logto user metadata.
- Public lawyer review. For the current invite-only test cohort this is solid groundwork; before broader rollout (50+ users, paid testers, or partners) a real lawyer should pass over the legal doc.

## Out-of-tree files (deliberately not committed)

- `.env` — local-only update of `RESEND_FROM_EMAIL=invites@myscrollr.com` (was `noreply@myscrollr.com`). Wherever this script runs in the future needs the same env value set. `.env` is gitignored, as expected.
- `scripts/emails.json` — recipient list for the script. Gitignored.

## Merge plan

Squash-merge per repo convention. Once merged:

1. The marketing site Coolify app picks up the new legal doc on its next deploy and `/legal?doc=super-user` becomes live.
2. Future runs of the invite script (locally) ship the new email content.
3. No backend / desktop changes — nothing else needs to deploy.