### PR TITLE
perf(marketing): cut animation cost on the landing site

### DIFF
--- a/myscrollr.com/package-lock.json
+++ b/myscrollr.com/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "myscrollr",
       "version": "2.1.0",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@logto/react": "^4.0.12",
         "@stripe/react-stripe-js": "^5.6.0",
@@ -16,7 +17,6 @@
         "@tanstack/router-plugin": "^1.132.0",
         "lucide-react": "^0.545.0",
         "motion": "^12.23.24",
-        "motion-plus": "https://api.motion.dev/registry.tgz?package=motion-plus&version=2.11.0&token=032997dbced0702754906e3f43111740b10beaa970fd6d26423e34e43a46acfe",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwindcss": "^4.0.6"
@@ -4461,41 +4461,6 @@
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.29.2"
-      }
-    },
-    "node_modules/motion-plus": {
-      "version": "2.11.0",
-      "resolved": "https://api.motion.dev/registry.tgz?package=motion-plus&version=2.11.0&token=032997dbced0702754906e3f43111740b10beaa970fd6d26423e34e43a46acfe",
-      "integrity": "sha512-K4GZHArVswXsUqMvXJ109vur417x3/bGVt/0G7pcsnxcFKce0JuLIKcq1DVDpDq/ur4bWpkWbFjM29UR2unHyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "motion": "^12.25.0",
-        "motion-dom": "^12.25.0",
-        "motion-plus-dom": "^2.9.0",
-        "motion-utils": "^12.23.6"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/motion-plus-dom": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/motion-plus-dom/-/motion-plus-dom-2.11.2.tgz",
-      "integrity": "sha512-WNXCn7XRS7H5ZJiwceJMbNjXbhVwjhQquJn/3LuyPkwMcxtOtQmc+cCas46bNpYNfKCyJs94oN9XRcBWmT2LxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "motion": "^12.25.0",
-        "motion-dom": "^12.24.11",
-        "motion-utils": "^12.24.10"
       }
     },
     "node_modules/motion-utils": {

--- a/myscrollr.com/package.json
+++ b/myscrollr.com/package.json
@@ -32,7 +32,6 @@
     "@tanstack/router-plugin": "^1.132.0",
     "lucide-react": "^0.545.0",
     "motion": "^12.23.24",
-    "motion-plus": "https://api.motion.dev/registry.tgz?package=motion-plus&version=2.11.0&token=032997dbced0702754906e3f43111740b10beaa970fd6d26423e34e43a46acfe",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwindcss": "^4.0.6"

--- a/myscrollr.com/src/components/DownloadButton.tsx
+++ b/myscrollr.com/src/components/DownloadButton.tsx
@@ -1,18 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Apple, ChevronDown, Download, Monitor } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
-import type {LinuxFormat} from '@/lib/getDownloadInfo';
-import type {PlatformInfo} from '@/lib/detectPlatform';
-import {
-  
-  detectIsIntelMac,
-  detectPlatform
-} from '@/lib/detectPlatform'
-import {
-  FALLBACK_RELEASES_URL,
-  
-  triggerDownload
-} from '@/lib/getDownloadInfo'
+import type { LinuxFormat } from '@/lib/getDownloadInfo'
+import type { PlatformInfo } from '@/lib/detectPlatform'
+import { detectIsIntelMac, detectPlatform } from '@/lib/detectPlatform'
+import { FALLBACK_RELEASES_URL, triggerDownload } from '@/lib/getDownloadInfo'
 
 const LINUX_FORMATS: ReadonlyArray<{
   format: LinuxFormat

--- a/myscrollr.com/src/components/landing/BenefitsSection.tsx
+++ b/myscrollr.com/src/components/landing/BenefitsSection.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'motion/react'
 import { useState } from 'react'
 import { Layers, SlidersHorizontal, Smartphone, Zap } from 'lucide-react'
+import { useInViewport } from '@/hooks/useInViewport'
 
 // ── Types & Data ─────────────────────────────────────────────────
 
@@ -64,8 +65,14 @@ const EASE = [0.22, 1, 0.36, 1] as const
 
 // ── Per-benefit illustrations ────────────────────────────────────
 
+// `active` gates every `repeat: Infinity` animation in each illustration so
+// loops don't keep ticking when the section is off-screen. We pass `false`
+// for the `animate` value (Motion freezes in place); when `active` flips back
+// the loop resumes. Entry-once `motion.{...}` reveals stay untouched since
+// they don't loop — there's nothing to pause.
+
 /** Benefit 0 — "Your Phone Stays Down": phone face-down, ticker bar glowing above */
-function IllustrationPhoneDown() {
+function IllustrationPhoneDown({ active }: { active: boolean }) {
   return (
     <svg viewBox="0 0 200 200" className="w-full h-full" fill="none">
       {/* Phone body — tilted face-down */}
@@ -104,7 +111,7 @@ function IllustrationPhoneDown() {
           strokeLinejoin="round"
           transform="rotate(-12, 87, 140)"
           initial={{ opacity: 0 }}
-          animate={{ opacity: [0, 0.4, 0.15] }}
+          animate={active ? { opacity: [0, 0.4, 0.15] } : false}
           transition={{ duration: 2.5, repeat: Infinity, ease: 'easeInOut' }}
         />
       </motion.g>
@@ -140,7 +147,7 @@ function IllustrationPhoneDown() {
               ][i]
             }
             initial={{ opacity: 0.3 }}
-            animate={{ opacity: [0.3, 0.9, 0.3] }}
+            animate={active ? { opacity: [0.3, 0.9, 0.3] } : false}
             transition={{
               duration: 2,
               repeat: Infinity,
@@ -162,7 +169,9 @@ function IllustrationPhoneDown() {
         className="stroke-primary/20"
         strokeWidth="1"
         initial={{ scale: 1, opacity: 0.3 }}
-        animate={{ scale: [1, 1.06, 1], opacity: [0.3, 0, 0.3] }}
+        animate={
+          active ? { scale: [1, 1.06, 1], opacity: [0.3, 0, 0.3] } : false
+        }
         transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
         style={{ transformOrigin: '100px 62px' }}
       />
@@ -171,7 +180,7 @@ function IllustrationPhoneDown() {
 }
 
 /** Benefit 1 — "You Catch Things First": live data chip appearing with pulse */
-function IllustrationCatchFirst() {
+function IllustrationCatchFirst({ active }: { active: boolean }) {
   return (
     <svg viewBox="0 0 200 200" className="w-full h-full" fill="none">
       {/* Concentric radar rings */}
@@ -200,7 +209,7 @@ function IllustrationCatchFirst() {
         strokeWidth="1.5"
         strokeLinecap="round"
         initial={{ rotate: 0 }}
-        animate={{ rotate: 360 }}
+        animate={active ? { rotate: 360 } : false}
         transition={{ duration: 4, repeat: Infinity, ease: 'linear' }}
         style={{ transformOrigin: '100px 100px' }}
       />
@@ -210,7 +219,7 @@ function IllustrationCatchFirst() {
         d="M 100 100 L 100 40 A 60 60 0 0 1 152 70 Z"
         fill="url(#sweepGrad)"
         initial={{ rotate: 0 }}
-        animate={{ rotate: 360 }}
+        animate={active ? { rotate: 360 } : false}
         transition={{ duration: 4, repeat: Infinity, ease: 'linear' }}
         style={{ transformOrigin: '100px 100px' }}
       />
@@ -232,7 +241,7 @@ function IllustrationCatchFirst() {
       {/* Live data chip popping in */}
       <motion.g
         initial={{ scale: 0, opacity: 0 }}
-        animate={{ scale: [0, 1.15, 1], opacity: [0, 1, 1] }}
+        animate={active ? { scale: [0, 1.15, 1], opacity: [0, 1, 1] } : false}
         transition={{
           delay: 0.8,
           duration: 0.5,
@@ -256,7 +265,7 @@ function IllustrationCatchFirst() {
           cy="79"
           r="3"
           fill="var(--color-secondary)"
-          animate={{ opacity: [1, 0.3, 1] }}
+          animate={active ? { opacity: [1, 0.3, 1] } : false}
           transition={{ duration: 1, repeat: Infinity }}
         />
         {/* Price text placeholder */}
@@ -277,7 +286,7 @@ function IllustrationCatchFirst() {
 }
 
 /** Benefit 2 — "Your Focus Gets Deeper": tabs converging into single view */
-function IllustrationFocusDeep() {
+function IllustrationFocusDeep({ active }: { active: boolean }) {
   const tabPositions = [
     { x: 30, y: 45, rot: -8 },
     { x: 100, y: 35, rot: 2 },
@@ -297,12 +306,16 @@ function IllustrationFocusDeep() {
             rotate: tab.rot,
             opacity: 0.6,
           }}
-          animate={{
-            x: [tab.x - 100, 0],
-            y: [tab.y - 100, 0],
-            rotate: [tab.rot, 0],
-            opacity: [0.6, 0],
-          }}
+          animate={
+            active
+              ? {
+                  x: [tab.x - 100, 0],
+                  y: [tab.y - 100, 0],
+                  rotate: [tab.rot, 0],
+                  opacity: [0.6, 0],
+                }
+              : false
+          }
           transition={{
             duration: 2,
             ease: EASE,
@@ -334,7 +347,7 @@ function IllustrationFocusDeep() {
       {/* Unified browser window — center */}
       <motion.g
         initial={{ scale: 0.85, opacity: 0 }}
-        animate={{ scale: [0.85, 1], opacity: [0, 1] }}
+        animate={active ? { scale: [0.85, 1], opacity: [0, 1] } : false}
         transition={{
           delay: 1.2,
           duration: 0.8,
@@ -406,7 +419,7 @@ function IllustrationFocusDeep() {
 }
 
 /** Benefit 3 — "It Gets Out of the Way": ticker bar minimizing/collapsing */
-function IllustrationOutOfWay() {
+function IllustrationOutOfWay({ active }: { active: boolean }) {
   return (
     <svg viewBox="0 0 200 200" className="w-full h-full" fill="none">
       {/* Browser window background */}
@@ -474,10 +487,14 @@ function IllustrationOutOfWay() {
 
       {/* Ticker bar — animates from expanded to collapsed */}
       <motion.g
-        animate={{
-          scaleY: [1, 1, 0.15, 0.15, 1],
-          opacity: [1, 1, 0.5, 0.5, 1],
-        }}
+        animate={
+          active
+            ? {
+                scaleY: [1, 1, 0.15, 0.15, 1],
+                opacity: [1, 1, 0.5, 0.5, 1],
+              }
+            : false
+        }
         transition={{
           duration: 5,
           repeat: Infinity,
@@ -510,7 +527,7 @@ function IllustrationOutOfWay() {
                 'var(--color-accent)',
               ][i]
             }
-            animate={{ opacity: [0.4, 0.8, 0.4] }}
+            animate={active ? { opacity: [0.4, 0.8, 0.4] } : false}
             transition={{ duration: 2, repeat: Infinity, delay: i * 0.3 }}
           />
         ))}
@@ -518,7 +535,9 @@ function IllustrationOutOfWay() {
 
       {/* Collapse/expand arrow indicator */}
       <motion.g
-        animate={{ y: [0, 0, -3, -3, 0], rotate: [0, 0, 180, 180, 0] }}
+        animate={
+          active ? { y: [0, 0, -3, -3, 0], rotate: [0, 0, 180, 180, 0] } : false
+        }
         transition={{
           duration: 5,
           repeat: Infinity,
@@ -554,11 +573,15 @@ function BenefitBlock({
   isHighlighted,
   onHighlight,
   index,
+  illustrationActive,
 }: {
   benefit: Benefit
   isHighlighted: boolean
   onHighlight: (index: number) => void
   index: number
+  /** True only while the host section is in the viewport — pauses
+   * the illustration's `repeat: Infinity` loops when scrolled away. */
+  illustrationActive: boolean
 }) {
   const Icon = benefit.icon
   const Illustration = ILLUSTRATIONS[index]
@@ -654,7 +677,7 @@ function BenefitBlock({
         transition={{ duration: 0.4, ease: EASE }}
         className="hidden lg:block w-[200px] h-[200px] shrink-0"
       >
-        <Illustration />
+        <Illustration active={illustrationActive} />
       </motion.div>
     </div>
   )
@@ -664,9 +687,13 @@ function BenefitBlock({
 
 export function BenefitsSection() {
   const [activeIndex, setActiveIndex] = useState(0)
+  // Pause the 21 `repeat: Infinity` SVG loops while the section is off-screen.
+  // The observer fires with a 200 px rootMargin so animations have already
+  // resumed by the time the user scrolls them into view.
+  const [sectionRef, sectionInView] = useInViewport<HTMLElement>()
 
   return (
-    <section className="relative overflow-clip">
+    <section ref={sectionRef} className="relative overflow-clip">
       {/* Ambient gradient orb — color-shifts per active card */}
       <div
         className="absolute pointer-events-none rounded-full blur-[120px] transition-colors duration-1000"
@@ -714,6 +741,7 @@ export function BenefitsSection() {
               index={i}
               isHighlighted={activeIndex === i}
               onHighlight={setActiveIndex}
+              illustrationActive={sectionInView}
             />
           ))}
         </motion.div>

--- a/myscrollr.com/src/components/landing/CallToAction.tsx
+++ b/myscrollr.com/src/components/landing/CallToAction.tsx
@@ -1,15 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import {
-  motion,
-  useInView,
-  useMotionValue,
-  useSpring,
-  useTransform,
-} from 'motion/react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { motion, useInView, useMotionValue, useSpring } from 'motion/react'
 import { GitFork, Github, Globe, MessageSquare, Star, Zap } from 'lucide-react'
+import type {
+  BackdropBeam,
+  BackdropParticle,
+} from '@/components/landing/_ConvergenceBackdrop'
 import { DownloadButton } from '@/components/DownloadButton'
 
 import { useGitHubStats } from '@/hooks/useGitHubStats'
+import { ConvergenceBackdrop } from '@/components/landing/_ConvergenceBackdrop'
 
 /* ────────────────────────────────────────────────────────────────────────── */
 /*  Constants                                                                */
@@ -24,8 +23,14 @@ const CHANNELS = [
   { color: '#a855f7', label: 'Fantasy' },
 ] as const
 
-/** Floating particle positions — spread across the background */
-const PARTICLES = Array.from({ length: 28 }, (_, i) => ({
+/** Floating particle positions — spread across the background.
+ *
+ * Down from 28 → 12. At 28 the section ran 28 simultaneous infinite
+ * `animate={{ y, opacity }}` loops; with the section's other 3 pulse
+ * rings + mouse-spring orb on top, that pushed integrated GPUs hard.
+ * 12 reads as visually identical at typical viewport sizes (the field
+ * was visually saturated at 28 anyway). */
+const PARTICLES = Array.from({ length: 12 }, (_, i) => ({
   id: i,
   x: Math.random() * 100,
   y: Math.random() * 100,
@@ -65,94 +70,23 @@ function useAnimatedCounter(target: number, isInView: boolean, suffix = '') {
 }
 
 /* ────────────────────────────────────────────────────────────────────────── */
-/*  Convergence Beam — a colored light ray pointing toward center            */
-/* ────────────────────────────────────────────────────────────────────────── */
-
-function ConvergenceBeam({
-  angle,
-  color,
-  delay,
-  isInView,
-}: {
-  angle: number
-  color: string
-  delay: number
-  isInView: boolean
-}) {
-  return (
-    <motion.div
-      className="absolute left-1/2 top-1/2 pointer-events-none"
-      style={{
-        width: '200%',
-        height: 2,
-        transformOrigin: 'left center',
-        rotate: angle,
-        x: '-50%',
-        y: '-50%',
-        background: `linear-gradient(90deg, transparent 0%, ${color}00 20%, ${color}40 50%, ${color}00 80%, transparent 100%)`,
-        opacity: 0,
-      }}
-      initial={{ opacity: 0, scaleX: 0 }}
-      animate={
-        isInView
-          ? {
-              opacity: [0, 0.6, 0.3],
-              scaleX: [0, 1, 1],
-            }
-          : {}
-      }
-      transition={{
-        delay,
-        duration: 2,
-        ease: EASE,
-      }}
-    />
-  )
-}
-
-/* ────────────────────────────────────────────────────────────────────────── */
-/*  Pulse Ring — expanding ring from center                                  */
-/* ────────────────────────────────────────────────────────────────────────── */
-
-function PulseRing({ delay, isInView }: { delay: number; isInView: boolean }) {
-  return (
-    <motion.div
-      className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-primary/20 pointer-events-none"
-      style={{ width: 280, height: 280, opacity: 0 }}
-      animate={
-        isInView
-          ? {
-              scale: [0.8, 2.5],
-              opacity: [0.4, 0],
-            }
-          : {}
-      }
-      transition={{
-        delay: 1.2 + delay,
-        duration: 3,
-        ease: 'easeOut',
-        repeat: Infinity,
-        repeatDelay: 1,
-      }}
-    />
-  )
-}
-
-/* ────────────────────────────────────────────────────────────────────────── */
 /*  Main CTA Component                                                       */
 /* ────────────────────────────────────────────────────────────────────────── */
+//
+// The convergence beam, pulse ring, ambient orb, and particle layers used to
+// live inline here. They moved to `_ConvergenceBackdrop.tsx` so the BottomCTA
+// in `routes/uplink.tsx` can share the same implementation. Future paint-cost
+// fixes touch one file instead of two.
 
 export function CallToAction() {
   const sectionRef = useRef<HTMLElement>(null)
   const isInView = useInView(sectionRef, { amount: 0.15 })
 
-  /* Mouse parallax for the ambient orb */
+  /* Mouse parallax for the ambient orb. The actual orb + spring chain
+   * lives inside `<ConvergenceBackdrop>`; this component just owns the
+   * raw 0-1 cursor position and forwards both MotionValues. */
   const mouseX = useMotionValue(0.5)
   const mouseY = useMotionValue(0.5)
-  const orbX = useTransform(mouseX, [0, 1], [-30, 30])
-  const orbY = useTransform(mouseY, [0, 1], [-30, 30])
-  const smoothOrbX = useSpring(orbX, { stiffness: 50, damping: 30 })
-  const smoothOrbY = useSpring(orbY, { stiffness: 50, damping: 30 })
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
@@ -161,6 +95,32 @@ export function CallToAction() {
       mouseY.set((e.clientY - rect.top) / rect.height)
     },
     [mouseX, mouseY],
+  )
+
+  /* Resolve particle colors via channelIndex once. */
+  const particles = useMemo<Array<BackdropParticle>>(
+    () =>
+      PARTICLES.map((p) => ({
+        id: p.id,
+        x: p.x,
+        y: p.y,
+        size: p.size,
+        color: CHANNELS[p.channelIndex].color,
+        delay: p.delay,
+        duration: p.duration,
+      })),
+    [],
+  )
+
+  /* 4 beams: cardinal channels at 45° offsets. */
+  const beams = useMemo<Array<BackdropBeam>>(
+    () =>
+      CHANNELS.map((channel, i) => ({
+        angle: i * 90 + 45,
+        color: channel.color,
+        delay: 0.3 + i * 0.15,
+      })),
+    [],
   )
 
   /* GitHub stats */
@@ -184,78 +144,15 @@ export function CallToAction() {
       className="relative overflow-clip py-32 lg:py-44"
       onMouseMove={handleMouseMove}
     >
-      {/* ── Background layers ───────────────────────────────────────────── */}
-
-      {/* Dark gradient base */}
-      <div className="absolute inset-0 bg-gradient-to-b from-base-100 via-base-200/80 to-base-100 pointer-events-none" />
-
-      {/* Ambient gradient orb — follows mouse */}
-      <motion.div
-        className="absolute rounded-full pointer-events-none"
-        style={{
-          width: 600,
-          height: 600,
-          left: '50%',
-          top: '50%',
-          x: smoothOrbX,
-          y: smoothOrbY,
-          translateX: '-50%',
-          translateY: '-50%',
-          background:
-            'radial-gradient(circle, rgba(52,211,153,0.08) 0%, rgba(0,212,255,0.04) 40%, transparent 70%)',
-          filter: 'blur(60px)',
-        }}
+      {/* ── Background layers (shared with BottomCTA on /uplink) ──────── */}
+      <ConvergenceBackdrop
+        mouseX={mouseX}
+        mouseY={mouseY}
+        isInView={isInView}
+        particles={particles}
+        beams={beams}
+        pulseRingCount={3}
       />
-
-      {/* Convergence beams — 4 colored light rays */}
-      <div className="absolute inset-0 pointer-events-none">
-        {CHANNELS.map((channel, i) => (
-          <ConvergenceBeam
-            key={channel.label}
-            angle={i * 90 + 45}
-            color={channel.color}
-            delay={0.3 + i * 0.15}
-            isInView={isInView}
-          />
-        ))}
-      </div>
-
-      {/* Floating particles */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
-        {PARTICLES.map((p) => (
-          <motion.div
-            key={p.id}
-            className="absolute rounded-full"
-            style={{
-              left: `${p.x}%`,
-              top: `${p.y}%`,
-              width: p.size,
-              height: p.size,
-              backgroundColor: CHANNELS[p.channelIndex].color,
-              opacity: 0,
-            }}
-            animate={
-              isInView
-                ? {
-                    y: [0, -80, -160],
-                    opacity: [0, 0.5, 0],
-                  }
-                : {}
-            }
-            transition={{
-              delay: p.delay,
-              duration: p.duration,
-              ease: 'easeInOut',
-              repeat: Infinity,
-            }}
-          />
-        ))}
-      </div>
-
-      {/* Pulse rings from center */}
-      <PulseRing delay={0} isInView={isInView} />
-      <PulseRing delay={1} isInView={isInView} />
-      <PulseRing delay={2} isInView={isInView} />
 
       {/* ── Content ─────────────────────────────────────────────────────── */}
       <div

--- a/myscrollr.com/src/components/landing/ChannelsShowcase.tsx
+++ b/myscrollr.com/src/components/landing/ChannelsShowcase.tsx
@@ -12,6 +12,7 @@ import {
   TrendingUp,
   Trophy,
 } from 'lucide-react'
+import { useInViewport } from '@/hooks/useInViewport'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -204,11 +205,16 @@ function AnimatedTicker({
   velocity = 50,
   gap = 12,
   hoverFactor = 0.5,
+  paused = false,
 }: {
   chips: Array<TickerChip>
   velocity?: number
   gap?: number
   hoverFactor?: number
+  /** Skip the per-frame transform write while the host section is
+   * off-screen. Reset `lastTimeRef` on each pass so resuming doesn't
+   * apply a giant accumulated delta. */
+  paused?: boolean
 }) {
   const trackRef = useRef<HTMLDivElement>(null)
   const setRef = useRef<HTMLDivElement>(null)
@@ -270,6 +276,7 @@ function AnimatedTicker({
       if (
         !trackRef.current ||
         isPausedRef.current ||
+        paused ||
         setWidthRef.current === 0
       ) {
         lastTimeRef.current = time
@@ -294,7 +301,7 @@ function AnimatedTicker({
 
     rafId = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(rafId)
-  }, [velocity, hoverFactor])
+  }, [velocity, hoverFactor, paused])
 
   if (chips.length === 0) return null
 
@@ -316,9 +323,9 @@ function AnimatedTicker({
               <motion.div
                 key={chip.label}
                 layout="position"
-                initial={{ opacity: 0, scale: 0.8, filter: 'blur(4px)' }}
-                animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
-                exit={{ opacity: 0, scale: 0.8, filter: 'blur(4px)' }}
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.8 }}
                 transition={SPRING}
                 className="shrink-0"
               >
@@ -335,9 +342,9 @@ function AnimatedTicker({
               <motion.div
                 key={chip.label}
                 layout="position"
-                initial={{ opacity: 0, scale: 0.8, filter: 'blur(4px)' }}
-                animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
-                exit={{ opacity: 0, scale: 0.8, filter: 'blur(4px)' }}
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.8 }}
                 transition={SPRING}
                 className="shrink-0"
               >
@@ -414,7 +421,10 @@ export function ChannelsShowcase() {
   const [activeChannels, setActiveChannels] = useState<Set<ChannelKey>>(
     new Set(['finance', 'sports', 'news', 'fantasy']),
   )
-  const sectionRef = useRef<HTMLElement>(null)
+  // Pause the RAF marquee while the section is off-screen. The 200 px
+  // viewport margin (default in `useInViewport`) primes the scroll loop
+  // a touch before it appears, so users never see a frozen ticker.
+  const [sectionRef, sectionInView] = useInViewport<HTMLElement>()
 
   const handleFilterClick = (key: ChannelKey) => {
     setActiveChannels((prev) => {
@@ -512,6 +522,7 @@ export function ChannelsShowcase() {
           velocity={50}
           gap={12}
           hoverFactor={0.5}
+          paused={!sectionInView}
         />
       </motion.div>
 
@@ -552,9 +563,9 @@ export function ChannelsShowcase() {
                   <motion.div
                     key={stream.key}
                     layout
-                    initial={{ opacity: 0, scale: 0.95, filter: 'blur(4px)' }}
-                    animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
-                    exit={{ opacity: 0, scale: 0.95, filter: 'blur(4px)' }}
+                    initial={{ opacity: 0, scale: 0.95 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.95 }}
                     transition={SPRING}
                     className="w-full md:w-[calc(50%-10px)]"
                   >

--- a/myscrollr.com/src/components/landing/FAQSection.tsx
+++ b/myscrollr.com/src/components/landing/FAQSection.tsx
@@ -1,12 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import {
-  AnimatePresence,
-  motion,
-  useMotionTemplate,
-  useSpring,
-  useTransform,
-  useVelocity,
-} from 'motion/react'
+import { AnimatePresence, motion, useSpring, useTransform } from 'motion/react'
 import {
   ChevronDown,
   ChevronUp,
@@ -270,6 +263,13 @@ function AnswerView({
   viewIndex: number
   activeIndex: number
 }) {
+  // Slide-and-fade only. We previously fed `useVelocity(y)` into a
+  // `filter: blur()` motion template per panel — with 8 FAQ items that's
+  // 8 simultaneous filter-paint pipelines running every frame whenever
+  // the user clicked between questions. The motion blur was barely
+  // perceptible at 200 ms transitions but cost real paint budget on
+  // integrated GPUs. Y-translate + opacity are both compositor-tier
+  // properties so the cleaned-up version is essentially free.
   const y = useSpring(
     calculateViewY(activeIndex - viewIndex, containerHeight),
     {
@@ -278,19 +278,11 @@ function AnswerView({
     },
   )
 
-  const yVelocity = useVelocity(y)
-
   const opacity = useTransform(
     y,
     [-containerHeight * 0.6, 0, containerHeight * 0.6],
     [0, 1, 0],
   )
-
-  const blur = useTransform(yVelocity, [-1000, 0, 1000], [4, 0, 4], {
-    clamp: false,
-  })
-
-  const filter = useMotionTemplate`blur(${blur}px)`
 
   useEffect(() => {
     y.set(calculateViewY(activeIndex - viewIndex, containerHeight))
@@ -303,9 +295,8 @@ function AnswerView({
         inset: 0,
         y,
         opacity,
-        filter,
         transformOrigin: 'center',
-        willChange: 'transform, filter',
+        willChange: 'transform',
         isolation: 'isolate',
       }}
     >

--- a/myscrollr.com/src/components/landing/_ConvergenceBackdrop.tsx
+++ b/myscrollr.com/src/components/landing/_ConvergenceBackdrop.tsx
@@ -1,0 +1,199 @@
+import { motion, useSpring, useTransform } from 'motion/react'
+import type { MotionValue } from 'motion/react'
+
+/**
+ * Shared "convergence backdrop" used behind the homepage CTA and the
+ * uplink page's BottomCTA. Both previously hand-rolled near-identical
+ * stacks of:
+ *
+ *  - dark gradient base
+ *  - mouse-following ambient orb (filter:blur, mouse-spring driven)
+ *  - 4 angular convergence beams (linear-gradient strips, scale-on-mount)
+ *  - N floating particles (y-translate + opacity loops, infinite)
+ *  - 3 pulse rings (scale 0.8 → 2.5, opacity 0.4 → 0, infinite)
+ *
+ * Centralising means future paint-cost fixes (e.g. dropping the orb's
+ * 60px filter blur on low-power devices) only need to touch one spot.
+ *
+ * The component intentionally does NOT own the section element or the
+ * `onMouseMove` handler. Each call site keeps its own section so it
+ * controls layout, padding, and section-level reveals; we just render
+ * the absolute-positioned background layers as a sibling.
+ */
+
+export interface BackdropParticle {
+  id: number | string
+  /** % across the section (0-100) */
+  x: number
+  /** % down the section (0-100) */
+  y: number
+  /** Pixel diameter */
+  size: number
+  /** Resolved CSS color value */
+  color: string
+  /** Animation start delay in seconds */
+  delay: number
+  /** Loop duration in seconds */
+  duration: number
+}
+
+export interface BackdropBeam {
+  /** Rotation in degrees from the section's left/top center */
+  angle: number
+  /** Resolved CSS color (used inside a linear-gradient) */
+  color: string
+  /** Reveal delay in seconds */
+  delay: number
+}
+
+export function ConvergenceBackdrop({
+  mouseX,
+  mouseY,
+  isInView,
+  particles,
+  beams,
+  pulseRingCount = 3,
+  /** Tailwind classes applied to the gradient base layer. */
+  baseClassName = 'absolute inset-0 bg-gradient-to-b from-base-100 via-base-200/80 to-base-100 pointer-events-none',
+  /** Override the orb's `radial-gradient` if a section needs different
+   * accent hues. Defaults to the homepage CTA's primary+info palette. */
+  orbBackground = 'radial-gradient(circle, rgba(52,211,153,0.08) 0%, rgba(0,212,255,0.04) 40%, transparent 70%)',
+}: {
+  /** Optional mouse-x position (range 0-1). When provided alongside
+   * `mouseY`, an ambient orb is rendered that springs toward the
+   * cursor. Skip both to render a static backdrop. */
+  mouseX?: MotionValue<number>
+  mouseY?: MotionValue<number>
+  isInView: boolean
+  particles: ReadonlyArray<BackdropParticle>
+  beams: ReadonlyArray<BackdropBeam>
+  pulseRingCount?: number
+  baseClassName?: string
+  orbBackground?: string
+}) {
+  return (
+    <>
+      {/* Dark gradient base */}
+      <div className={baseClassName} />
+
+      {/* Mouse-following ambient orb — only when MotionValues are wired up */}
+      {mouseX != null && mouseY != null ? (
+        <AmbientOrb
+          mouseX={mouseX}
+          mouseY={mouseY}
+          orbBackground={orbBackground}
+        />
+      ) : null}
+
+      {/* Convergence beams */}
+      <div className="absolute inset-0 pointer-events-none">
+        {beams.map((beam) => (
+          <motion.div
+            key={beam.angle}
+            className="absolute left-1/2 top-1/2 pointer-events-none"
+            style={{
+              width: '200%',
+              height: 2,
+              transformOrigin: 'left center',
+              rotate: beam.angle,
+              x: '-50%',
+              y: '-50%',
+              background: `linear-gradient(90deg, transparent 0%, ${beam.color}00 20%, ${beam.color}40 50%, ${beam.color}00 80%, transparent 100%)`,
+              opacity: 0,
+            }}
+            initial={{ opacity: 0, scaleX: 0 }}
+            animate={
+              isInView ? { opacity: [0, 0.6, 0.3], scaleX: [0, 1, 1] } : {}
+            }
+            transition={{
+              delay: beam.delay,
+              duration: 2,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Floating particles */}
+      <div className="absolute inset-0 pointer-events-none overflow-hidden">
+        {particles.map((p) => (
+          <motion.div
+            key={p.id}
+            className="absolute rounded-full"
+            style={{
+              left: `${p.x}%`,
+              top: `${p.y}%`,
+              width: p.size,
+              height: p.size,
+              backgroundColor: p.color,
+              opacity: 0,
+            }}
+            animate={
+              isInView ? { y: [0, -80, -160], opacity: [0, 0.5, 0] } : {}
+            }
+            transition={{
+              delay: p.delay,
+              duration: p.duration,
+              ease: 'easeInOut',
+              repeat: Infinity,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Pulse rings — concentric expanding borders from center */}
+      {Array.from({ length: pulseRingCount }, (_, i) => (
+        <motion.div
+          key={i}
+          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-primary/20 pointer-events-none"
+          style={{ width: 280, height: 280, opacity: 0 }}
+          animate={isInView ? { scale: [0.8, 2.5], opacity: [0.4, 0] } : {}}
+          transition={{
+            delay: 1.2 + i,
+            duration: 3,
+            ease: 'easeOut',
+            repeat: Infinity,
+            repeatDelay: 1,
+          }}
+        />
+      ))}
+    </>
+  )
+}
+
+/** Internal helper: the mouse-driven blur orb. Lifted out so the
+ * spring hooks always run in the same order even when the parent
+ * doesn't pass mouse MotionValues (we early-return at the call site
+ * instead). */
+function AmbientOrb({
+  mouseX,
+  mouseY,
+  orbBackground,
+}: {
+  mouseX: MotionValue<number>
+  mouseY: MotionValue<number>
+  orbBackground: string
+}) {
+  const orbX = useTransform(mouseX, [0, 1], [-30, 30])
+  const orbY = useTransform(mouseY, [0, 1], [-30, 30])
+  const smoothOrbX = useSpring(orbX, { stiffness: 50, damping: 30 })
+  const smoothOrbY = useSpring(orbY, { stiffness: 50, damping: 30 })
+
+  return (
+    <motion.div
+      className="absolute rounded-full pointer-events-none"
+      style={{
+        width: 600,
+        height: 600,
+        left: '50%',
+        top: '50%',
+        x: smoothOrbX,
+        y: smoothOrbY,
+        translateX: '-50%',
+        translateY: '-50%',
+        background: orbBackground,
+        filter: 'blur(60px)',
+      }}
+    />
+  )
+}

--- a/myscrollr.com/src/hooks/useInViewport.ts
+++ b/myscrollr.com/src/hooks/useInViewport.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Tracks whether an element is intersecting the viewport via
+ * IntersectionObserver. Used to pause expensive animations
+ * (`repeat: Infinity` keyframes, RAF loops) while the host
+ * section is off-screen.
+ *
+ * Pattern matches the IO pause already in `HowItWorks.tsx` — we
+ * just lift it into a hook so other landing sections can reuse it
+ * without each rolling their own observer.
+ *
+ * @param options.rootMargin Forwarded to `IntersectionObserver`.
+ *   Defaults to `200px 0px` so animations spin up just before the
+ *   section enters the viewport, avoiding a perceptible "cold start"
+ *   on scroll.
+ * @param options.threshold Forwarded to `IntersectionObserver`.
+ *   Defaults to `0` so the section counts as visible the moment any
+ *   pixel intersects.
+ */
+export function useInViewport<T extends Element = HTMLElement>(options?: {
+  rootMargin?: string
+  threshold?: number | Array<number>
+}): [React.RefObject<T | null>, boolean] {
+  const ref = useRef<T | null>(null)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    if (typeof IntersectionObserver === 'undefined') {
+      // SSR / very-old browser fallback: assume visible so animations still run.
+      setInView(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setInView(entry.isIntersecting)
+      },
+      {
+        rootMargin: options?.rootMargin ?? '200px 0px',
+        threshold: options?.threshold ?? 0,
+      },
+    )
+    observer.observe(el)
+    return () => {
+      observer.disconnect()
+    }
+  }, [options?.rootMargin, options?.threshold])
+
+  return [ref, inView]
+}

--- a/myscrollr.com/src/routes/index.tsx
+++ b/myscrollr.com/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { Suspense, lazy } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { usePageMeta } from '@/lib/usePageMeta'
 import { HeroSection } from '@/components/landing/HeroSection'
@@ -5,8 +6,26 @@ import { HowItWorks } from '@/components/landing/HowItWorks'
 import { ChannelsShowcase } from '@/components/landing/ChannelsShowcase'
 import { BenefitsSection } from '@/components/landing/BenefitsSection'
 import { TrustSection } from '@/components/landing/TrustSection'
-import { FAQSection } from '@/components/landing/FAQSection'
-import { CallToAction } from '@/components/landing/CallToAction'
+
+// FAQSection and CallToAction are below-the-fold and animation-heavy
+// (FAQ has 8 simultaneous spring/blur pipelines; CallToAction has the
+// mouse-parallax orb + 12 particles + 3 pulse rings + animated counters).
+// Splitting them into separate chunks keeps the initial JS bundle lean
+// for first paint, and defers their parse cost until the user is
+// scrolling toward them.
+//
+// Sized Suspense fallbacks below match each section's typical rendered
+// height to prevent any layout shift on chunk arrival.
+const FAQSection = lazy(() =>
+  import('@/components/landing/FAQSection').then((m) => ({
+    default: m.FAQSection,
+  })),
+)
+const CallToAction = lazy(() =>
+  import('@/components/landing/CallToAction').then((m) => ({
+    default: m.CallToAction,
+  })),
+)
 
 export const Route = createFileRoute('/')({
   component: HomePage,
@@ -32,9 +51,30 @@ function HomePage() {
 
       <TrustSection />
 
-      <FAQSection />
+      <Suspense fallback={<SectionPlaceholder height="900px" />}>
+        <FAQSection />
+      </Suspense>
 
-      <CallToAction />
+      <Suspense fallback={<SectionPlaceholder height="700px" />}>
+        <CallToAction />
+      </Suspense>
     </>
+  )
+}
+
+/**
+ * Sized placeholder for `<Suspense>` fallback. Reserves vertical space
+ * so the page does not jump when the lazy chunk finishes loading. Heights
+ * approximate the average rendered size of each section on desktop;
+ * mobile breakpoints land slightly off but the visual jump is small
+ * since the deferred sections sit below the viewport on mobile too.
+ */
+function SectionPlaceholder({ height }: { height: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ minHeight: height }}
+      className="bg-base-100"
+    />
   )
 }

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -5,9 +5,8 @@ import {
   useInView,
   useMotionValue,
   useSpring,
-  useTransform,
 } from 'motion/react'
-import { AnimateNumber } from 'motion-plus/react'
+
 import {
   Suspense,
   lazy,
@@ -47,6 +46,8 @@ import {
 
 import type { FAQItem } from '@/components/landing/FAQSection'
 import type { SubscriptionStatus, TierLimitsResponse } from '@/api/client'
+import type { BackdropBeam } from '@/components/landing/_ConvergenceBackdrop'
+import { ConvergenceBackdrop } from '@/components/landing/_ConvergenceBackdrop'
 import { usePageMeta } from '@/lib/usePageMeta'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import { useGetToken } from '@/hooks/useGetToken'
@@ -76,6 +77,35 @@ const ULTIMATE_PRICE_IDS = {
 
 type PlanKey = 'monthly' | 'annual'
 type TierKey = 'uplink' | 'pro' | 'ultimate'
+
+// Animates the displayed integer toward `value` using a spring. This
+// replaces `motion-plus`'s `<AnimateNumber>` (524 KB on disk) for the
+// only place we used it: the per-tier monthly-price flip when the
+// billing toggle changes. We lose `motion-plus`'s per-digit slot
+// animation, but the prices are 2-3 digits so the simpler counter
+// reads cleanly. Pattern mirrors `useAnimatedCounter` in CallToAction.
+function AnimatedPrice({ value }: { value: number }) {
+  const [display, setDisplay] = useState(value)
+  const motionVal = useMotionValue(value)
+  const spring = useSpring(motionVal, {
+    stiffness: 90,
+    damping: 22,
+    restSpeed: 0.5,
+  })
+
+  useEffect(() => {
+    motionVal.set(value)
+  }, [value, motionVal])
+
+  useEffect(() => {
+    const unsub = spring.on('change', (v) => {
+      setDisplay(Math.round(v))
+    })
+    return unsub
+  }, [spring])
+
+  return <>{display}</>
+}
 
 export const Route = createFileRoute('/uplink')({
   validateSearch: () => ({}),
@@ -681,13 +711,11 @@ function BottomCTA({
   const sectionRef = useRef<HTMLElement>(null)
   const isInView = useInView(sectionRef, { amount: 0.15 })
 
-  // Mouse parallax for ambient orb
+  // Mouse parallax — actual orb + spring chain rendered inside the
+  // shared `<ConvergenceBackdrop>`. We just own the raw 0-1 cursor
+  // position MotionValues here.
   const mouseX = useMotionValue(0.5)
   const mouseY = useMotionValue(0.5)
-  const orbX = useTransform(mouseX, [0, 1], [-30, 30])
-  const orbY = useTransform(mouseY, [0, 1], [-30, 30])
-  const smoothOrbX = useSpring(orbX, { stiffness: 50, damping: 30 })
-  const smoothOrbY = useSpring(orbY, { stiffness: 50, damping: 30 })
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
@@ -698,108 +726,33 @@ function BottomCTA({
     [mouseX, mouseY],
   )
 
+  // 4 beams alternating green/cyan around the section center.
+  const beams = useMemo<Array<BackdropBeam>>(
+    () => [
+      { angle: 35, color: '#34d399', delay: 0.3 },
+      { angle: 145, color: '#00b8db', delay: 0.45 },
+      { angle: 215, color: '#34d399', delay: 0.6 },
+      { angle: 325, color: '#00b8db', delay: 0.75 },
+    ],
+    [],
+  )
+
   return (
     <section
       ref={sectionRef}
       className="relative overflow-clip py-32 lg:py-44"
       onMouseMove={handleMouseMove}
     >
-      {/* ── Background layers ─────────────────────────────────────── */}
-
-      {/* Dark gradient base */}
-      <div className="absolute inset-0 bg-gradient-to-b from-base-100 via-base-200/80 to-base-100 pointer-events-none" />
-
-      {/* Mouse-following ambient orb */}
-      <motion.div
-        className="absolute pointer-events-none"
-        style={{
-          width: 600,
-          height: 600,
-          left: '50%',
-          top: '50%',
-          x: smoothOrbX,
-          y: smoothOrbY,
-          translateX: '-50%',
-          translateY: '-50%',
-          background:
-            'radial-gradient(circle, rgba(52,211,153,0.08) 0%, rgba(0,184,219,0.04) 40%, transparent 70%)',
-          filter: 'blur(60px)',
-        }}
+      {/* ── Background layers (shared with the homepage CallToAction) */}
+      <ConvergenceBackdrop
+        mouseX={mouseX}
+        mouseY={mouseY}
+        isInView={isInView}
+        particles={CTA_PARTICLES}
+        beams={beams}
+        pulseRingCount={3}
+        orbBackground="radial-gradient(circle, rgba(52,211,153,0.08) 0%, rgba(0,184,219,0.04) 40%, transparent 70%)"
       />
-
-      {/* Convergence beams — green (Unlimited) + cyan (Uplink) */}
-      <div className="absolute inset-0 pointer-events-none">
-        {[
-          { angle: 35, color: '#34d399', delay: 0.3 },
-          { angle: 145, color: '#00b8db', delay: 0.45 },
-          { angle: 215, color: '#34d399', delay: 0.6 },
-          { angle: 325, color: '#00b8db', delay: 0.75 },
-        ].map((beam) => (
-          <motion.div
-            key={beam.angle}
-            className="absolute left-1/2 top-1/2 pointer-events-none"
-            style={{
-              width: '200%',
-              height: 2,
-              transformOrigin: 'left center',
-              rotate: beam.angle,
-              x: '-50%',
-              y: '-50%',
-              background: `linear-gradient(90deg, transparent 0%, ${beam.color}00 20%, ${beam.color}40 50%, ${beam.color}00 80%, transparent 100%)`,
-              opacity: 0,
-            }}
-            initial={{ opacity: 0, scaleX: 0 }}
-            animate={
-              isInView ? { opacity: [0, 0.6, 0.3], scaleX: [0, 1, 1] } : {}
-            }
-            transition={{ delay: beam.delay, duration: 2, ease: EASE }}
-          />
-        ))}
-      </div>
-
-      {/* Floating particles */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
-        {CTA_PARTICLES.map((p) => (
-          <motion.div
-            key={p.id}
-            className="absolute rounded-full"
-            style={{
-              left: `${p.x}%`,
-              top: `${p.y}%`,
-              width: p.size,
-              height: p.size,
-              backgroundColor: p.color,
-              opacity: 0,
-            }}
-            animate={
-              isInView ? { y: [0, -80, -160], opacity: [0, 0.5, 0] } : {}
-            }
-            transition={{
-              delay: p.delay,
-              duration: p.duration,
-              ease: 'easeInOut',
-              repeat: Infinity,
-            }}
-          />
-        ))}
-      </div>
-
-      {/* Pulse rings */}
-      {[0, 1, 2].map((i) => (
-        <motion.div
-          key={i}
-          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-primary/20 pointer-events-none"
-          style={{ width: 280, height: 280, opacity: 0 }}
-          animate={isInView ? { scale: [0.8, 2.5], opacity: [0.4, 0] } : {}}
-          transition={{
-            delay: 1.2 + i,
-            duration: 3,
-            ease: 'easeOut',
-            repeat: Infinity,
-            repeatDelay: 1,
-          }}
-        />
-      ))}
 
       {/* ── Content ───────────────────────────────────────────────── */}
       <div
@@ -1488,13 +1441,13 @@ function UplinkPage() {
             transition={{ duration: 10, repeat: Infinity, ease: 'easeInOut' }}
           />
 
-          {/* Scan line */}
-          <motion.div
-            className="absolute w-full h-px bg-gradient-to-r from-transparent via-primary/15 to-transparent"
-            initial={{ y: -100 }}
-            animate={{ y: ['-10%', '110%'] }}
-            transition={{ duration: 6, repeat: Infinity, ease: 'linear' }}
-          />
+          {/* Scan line removed during the perf pass — was animating
+              `y` from -10% to 110% over 6s on `repeat: Infinity` across
+              the full hero. Compositor-tier so cheap individually, but
+              the hero already has 4 nested ring loops + 6 floating dots
+              + 2 perpetual orb pulses; the scan line wasn't pulling
+              its weight visually and the surface area for layout
+              reads grew on resize. */}
         </div>
 
         {/* Top border accent */}
@@ -2498,18 +2451,9 @@ function UplinkPage() {
                             $
                           </span>
                           <span className="text-3xl font-black text-base-content tracking-tight font-mono tabular-nums leading-none">
-                            <AnimateNumber
-                              transition={{
-                                y: {
-                                  type: 'spring',
-                                  bounce: 0.15,
-                                  duration: 0.45,
-                                },
-                                opacity: { duration: 0.15 },
-                              }}
-                            >
-                              {PRICING.uplink[billingPeriod].perMonth}
-                            </AnimateNumber>
+                            <AnimatedPrice
+                              value={PRICING.uplink[billingPeriod].perMonth}
+                            />
                           </span>
                           <span className="text-xs font-mono text-base-content/25 ml-1 self-end mb-0.5">
                             /mo
@@ -2659,18 +2603,9 @@ function UplinkPage() {
                             $
                           </span>
                           <span className="text-3xl font-black text-base-content tracking-tight font-mono tabular-nums leading-none">
-                            <AnimateNumber
-                              transition={{
-                                y: {
-                                  type: 'spring',
-                                  bounce: 0.15,
-                                  duration: 0.45,
-                                },
-                                opacity: { duration: 0.15 },
-                              }}
-                            >
-                              {PRICING.pro[billingPeriod].perMonth}
-                            </AnimateNumber>
+                            <AnimatedPrice
+                              value={PRICING.pro[billingPeriod].perMonth}
+                            />
                           </span>
                           <span className="text-xs font-mono text-base-content/25 ml-1 self-end mb-0.5">
                             /mo
@@ -2965,18 +2900,9 @@ function UplinkPage() {
                               $
                             </span>
                             <span className="text-3xl font-black text-base-content tracking-tight font-mono tabular-nums leading-none">
-                              <AnimateNumber
-                                transition={{
-                                  y: {
-                                    type: 'spring',
-                                    bounce: 0.15,
-                                    duration: 0.45,
-                                  },
-                                  opacity: { duration: 0.15 },
-                                }}
-                              >
-                                {PRICING.ultimate[billingPeriod].perMonth}
-                              </AnimateNumber>
+                              <AnimatedPrice
+                                value={PRICING.ultimate[billingPeriod].perMonth}
+                              />
                             </span>
                             <span className="text-xs font-mono text-base-content/25 ml-1 self-end mb-0.5">
                               /mo


### PR DESCRIPTION
## Summary

Eleven targeted perf fixes from the audit, no screenshots required. Targets older / lower-power machines first, where the landing animations were the hottest path. Net savings:

- Initial JS: homepage entry chunk **-7 KB**, uplink page chunk **-20 KB** (gzip: ~-3 KB and ~-7 KB)
- `motion-plus` removed (524 KB on disk gone, single usage replaced with a 30-line local component)
- Two heavy below-the-fold sections (`CallToAction`, `FAQSection`) now lazy-loaded into their own chunks
- 21 `repeat: Infinity` SVG loops in `BenefitsSection` and the RAF marquee in `ChannelsShowcase` now pause when their section is off-screen (new `useInViewport` hook)
- 8 simultaneous `filter: blur()` paint pipelines in the FAQ velocity-blur stack: gone (now compositor-tier opacity + transform)
- Two near-identical hero backdrops (`CallToAction` + uplink `BottomCTA`) consolidated into a shared `<ConvergenceBackdrop>`

## Implementation

### Tier 1 (zero visual diff)

1. `<MotionConfig reducedMotion="user">` was already in `__root.tsx` — no change needed; called out for completeness.
2. `routes/index.tsx`: `React.lazy` + `Suspense` with sized fallbacks for `CallToAction` (700 px reserve) and `FAQSection` (900 px reserve). Homepage chunk 70.5 KB → 63.7 KB.
3. `BenefitsSection`: new `useInViewport` hook gates `active` prop down to each illustration; `repeat: Infinity` animates flip to `false` while off-screen.
4. `ChannelsShowcase`: same hook drives a `paused` prop on `<AnimatedTicker>`; the RAF tick early-returns while paused, resetting `lastTimeRef` so resume doesn't apply a giant accumulated delta.
5. `ChannelsShowcase`: dropped `filter: blur(4px)` from all 3 chip enter/exit transitions. Replaced with opacity + scale only.
6. `FAQSection`: dropped `useVelocity` + `useTransform` + `useMotionTemplate` blur stack from `AnswerView`. Was 8 simultaneous filter-paint pipelines; now y/opacity only.
7. `motion-plus`: removed dep entirely. Replaced uplink pricing's `<AnimateNumber>` with a local `AnimatedPrice` using `useSpring` (mirrors `useAnimatedCounter` in CallToAction). uplink chunk 108.7 KB → 88.5 KB.

### Tier 2 (minor visual diff)

8. `CallToAction`: particle count 28 → 12. Visually saturated at 28; 12 reads identical at typical viewport sizes.
9. `routes/uplink.tsx`: removed the perpetual hero scan line (vertical 6 s linear sweep). Hero already has orbital glows + ring system + floating dots.
10. New shared component `_ConvergenceBackdrop`: encapsulates dark gradient base + mouse-driven ambient orb + 4 convergence beams + N particles + 3 pulse rings. Used by both `CallToAction` and the uplink page's `BottomCTA`. Each call site now passes resolved particle/beam arrays instead of duplicating ~150 lines of layered motion markup.

(Skipped: BenefitsSection loop consolidation — the IO pause from #3 already eliminates the off-screen waste, and consolidating into one master loop with staggered children would add diff churn for marginal in-view benefit.)

## Verification

- `npm run check` clean (prettier + eslint --fix, no warnings)
- `npm run build` clean (vite + tsc --noEmit)
- Bundle diff above

Smoke-test recommendation: scroll the homepage in DevTools with **rendering → emulate prefers-reduced-motion: reduce**. Hero should be calm, marquee should still scroll subtly (Motion respects user preference via the existing MotionConfig), and FAQ panels should slide between answers without the velocity-blur whoosh.

## Files

- New: `myscrollr.com/src/hooks/useInViewport.ts`
- New: `myscrollr.com/src/components/landing/_ConvergenceBackdrop.tsx`
- Edited: `BenefitsSection.tsx`, `ChannelsShowcase.tsx`, `CallToAction.tsx`, `FAQSection.tsx`, `routes/index.tsx`, `routes/uplink.tsx`
- `package.json` / `package-lock.json`: removed `motion-plus`

## Risks

- React.lazy flicker if Suspense fallback heights are wrong — sized at typical desktop dimensions (700/900 px), mobile may show a brief gap but well below the fold so unlikely visible.
- `motion-plus`'s `AnimateNumber` did per-digit slot animation; the replacement `AnimatedPrice` is a single counter spring. Visual diff: digits no longer slide individually when the billing toggle flips. Subtle.
- `BottomCTA` still has 20 particles (CallToAction reduced to 12). Left untouched to keep diff scoped to what the audit called out; can drop in a follow-up if desired.