### PR TITLE
fix(desktop): updater seed + remove pin-to-sidebar + ticker chip external URLs

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-shell";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTauriListener } from "./hooks/useTauriListener";
 import { useDashboardCDC } from "./hooks/useDashboardCDC";
@@ -341,10 +342,18 @@ export default function App() {
     }
   }, [prefs.ticker.showTicker]);
 
-  // ── Chip click → open app window on that channel ───────────────
+  // ── Chip click → open external URL (or fall back to app) ───────
 
   const handleChipClick = useCallback(
-    (channelType: string, _itemId: string | number) => {
+    (channelType: string, _itemId: string | number, url?: string) => {
+      if (url) {
+        open(url).catch((err) => {
+          console.error("[Scrollr] Failed to open external URL:", err);
+        });
+        return;
+      }
+      // No URL (widget chip, missing data) — fall back to opening
+      // the desktop app on the relevant channel/widget page.
       savePref("activeItem", channelType);
       invoke("show_app_window").catch(() => {});
     },

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -24,6 +24,7 @@ import { selectRssForTicker } from "../channels/rss/view";
 import { selectFinanceForTicker } from "../channels/finance/view";
 import { selectFantasyForTicker } from "../channels/fantasy/view";
 import { selectSportsForTicker, getSportsDisplayConfig } from "../channels/sports/view";
+import { buildYahooLeagueUrl, buildYahooPlayerUrl, chipUrlForFinance, chipUrlForSports, chipUrlForRss } from "../utils/chipUrl";
 
 // ── Module-level constants ───────────────────────────────────────
 
@@ -37,7 +38,11 @@ interface ScrollrTickerProps {
   activeTabs: string[];
   /** Pre-built widget chip data (clock, weather, sysmon). */
   widgetData?: WidgetTickerData;
-  onChipClick?: (channelType: string, itemId: string | number) => void;
+  /** Click handler. The optional `url` argument is set when the
+   * underlying chip has an external destination (article link, game
+   * page, etc.). When undefined, the consumer should fall back to
+   * opening the in-app channel page. */
+  onChipClick?: (channelType: string, itemId: string | number, url?: string) => void;
   /** Toggle pin state for a widget (hover pin icon). */
   onTogglePin?: (widgetId: string) => void;
   /** Which widgets are pinned (excluded from scrolling ticker). */
@@ -165,6 +170,9 @@ export default function ScrollrTicker({
                 comfort={comfort}
                 colorMode={chipColorMode}
                 onTogglePin={onTogglePin ? () => onTogglePin(wt) : undefined}
+                // Widget chips don't have a meaningful external URL —
+                // omit the third argument so handleChipClick falls back
+                // to opening the desktop app on the widget's page.
                 onClick={() => onChipClick?.(wt, wt)}
               />
             )
@@ -203,7 +211,7 @@ export default function ScrollrTicker({
                 leagues={leagues}
                 comfort={comfort}
                 colorMode={chipColorMode}
-                onClick={() => onChipClick?.("fantasy", playerKey)}
+                onClick={() => onChipClick?.("fantasy", playerKey, buildYahooPlayerUrl(playerKey))}
               />
             )
           );
@@ -218,7 +226,7 @@ export default function ScrollrTicker({
                 prefs={fantasyPrefs}
                 comfort={comfort}
                 colorMode={chipColorMode}
-                onClick={() => onChipClick?.("fantasy", league.league_key)}
+                onClick={() => onChipClick?.("fantasy", league.league_key, buildYahooLeagueUrl(league.league_key))}
               />
             )
           );
@@ -249,7 +257,7 @@ export default function ScrollrTicker({
                   comfort={comfort}
                   colorMode={chipColorMode}
                   showChange={shouldShowOnTicker(financePrefs.showChange)}
-                  onClick={() => onChipClick?.("finance", trade.symbol)}
+                  onClick={() => onChipClick?.("finance", trade.symbol, chipUrlForFinance(trade))}
                 />
               )
             );
@@ -272,7 +280,7 @@ export default function ScrollrTicker({
                   comfort={comfort}
                   colorMode={chipColorMode}
                   showLogos={showLogos}
-                  onClick={() => onChipClick?.("sports", game.id)}
+                  onClick={() => onChipClick?.("sports", game.id, chipUrlForSports(game))}
                 />
               )
             );
@@ -297,7 +305,7 @@ export default function ScrollrTicker({
                   colorMode={chipColorMode}
                   showSource={shouldShowOnTicker(rssPrefs.showSource)}
                   showTimestamps={shouldShowOnTicker(rssPrefs.showTimestamps)}
-                  onClick={() => onChipClick?.("rss", item.id)}
+                  onClick={() => onChipClick?.("rss", item.id, chipUrlForRss(item))}
                 />
               )
             );
@@ -450,6 +458,9 @@ export default function ScrollrTicker({
             colorMode={chipColorMode}
             pinned
             onTogglePin={onTogglePin ? () => onTogglePin(wt) : undefined}
+            // Widget chips don't have a meaningful external URL —
+            // omit the third argument so handleChipClick falls back
+            // to opening the desktop app on the widget's page.
             onClick={() => onChipClick?.(wt, wt)}
           />
         );

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -70,7 +70,7 @@ function ScrollLogo({ alive }: { alive: boolean }) {
 
 // ── Props ───────────────────────────────────────────────────────
 
-interface PinnedSource {
+interface SidebarSource {
   id: string;
   name: string;
   hex: string;
@@ -90,8 +90,8 @@ interface SidebarProps {
   /** Currently active channel or widget ID (for pinned item highlighting). */
   activeItem: string;
 
-  /** Resolved pinned sources with manifest data. */
-  pinnedSources: PinnedSource[];
+  /** Resolved enabled-source manifest data, in canonical order. */
+  sources: SidebarSource[];
 
   /** Current data delivery mode for status footer. */
   deliveryMode: DeliveryMode;
@@ -118,7 +118,7 @@ export default function Sidebar({
   isMarketplace,
   isSupport,
   activeItem,
-  pinnedSources,
+  sources,
   deliveryMode,
   tickerAlive,
   onNavigateToFeed,
@@ -190,10 +190,10 @@ export default function Sidebar({
           onClick={onNavigateToMarketplace}
         />
 
-        {/* Pinned sources */}
-        {pinnedSources.length > 0 && (
+        {/* Enabled channels + widgets */}
+        {sources.length > 0 && (
           <div className="mt-2 pt-2 border-t border-edge/20 space-y-0.5">
-            {pinnedSources.map((source) => (
+            {sources.map((source) => (
               <NavItem
                 key={source.id}
                 icon={<span style={{ color: source.hex }}><source.icon size={15} /></span>}

--- a/desktop/src/components/marketplace/CatalogCard.tsx
+++ b/desktop/src/components/marketplace/CatalogCard.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
 import clsx from "clsx";
-import { Check, ChevronRight, ExternalLink, Loader2, Pin, PinOff } from "lucide-react";
+import { Check, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
 import type { CatalogItem, CatalogCategory } from "../../marketplace";
 import type { SubscriptionTier } from "../../auth";
 import { TIER_LABELS } from "../../auth";
 import ConfirmDialog from "../ConfirmDialog";
-import Tooltip from "../Tooltip";
 
 // ── Confirm-dialog nouns per channel ────────────────────────────
 
@@ -27,8 +26,6 @@ const CATEGORY_BADGE: Record<CatalogCategory, string> = {
 interface CatalogCardProps {
   item: CatalogItem;
   enabled: boolean;
-  /** True when this source appears in the left sidebar. Only meaningful when enabled. */
-  pinned: boolean;
   tier: SubscriptionTier;
   authenticated: boolean;
   /** Disable Add button while dashboard is loading (channels enabled state unknown). */
@@ -36,8 +33,6 @@ interface CatalogCardProps {
   onAdd: (item: CatalogItem) => Promise<void>;
   onRemove: (item: CatalogItem) => Promise<void>;
   onLogin: () => void;
-  /** Toggle sidebar pin state. Only rendered when `enabled` is true. */
-  onTogglePin?: (item: CatalogItem) => void;
   /** Navigate to the channel/widget page when already added. */
   onOpen?: (item: CatalogItem) => void;
 }
@@ -47,14 +42,12 @@ interface CatalogCardProps {
 export default function CatalogCard({
   item,
   enabled,
-  pinned,
   tier,
   authenticated,
   dashboardLoading,
   onAdd,
   onRemove,
   onLogin,
-  onTogglePin,
   onOpen,
 }: CatalogCardProps) {
   const [loading, setLoading] = useState(false);
@@ -165,23 +158,6 @@ export default function CatalogCard({
             <Loader2 size={14} className="animate-spin text-fg-4" />
           ) : enabled ? (
             <div className="flex items-center gap-3">
-              {onTogglePin && (
-                <Tooltip content={pinned ? "Unpin from sidebar" : "Pin to sidebar"}>
-                  <button
-                    onClick={() => onTogglePin(item)}
-                    aria-label={pinned ? `Unpin ${item.name}` : `Pin ${item.name} to sidebar`}
-                    aria-pressed={pinned}
-                    className={clsx(
-                      "w-7 h-7 flex items-center justify-center rounded-lg transition-colors cursor-pointer",
-                      pinned
-                        ? "text-accent hover:bg-surface-hover"
-                        : "text-fg-4 hover:text-fg-2 hover:bg-surface-hover",
-                    )}
-                  >
-                    {pinned ? <Pin size={14} /> : <PinOff size={14} />}
-                  </button>
-                </Tooltip>
-              )}
               <button
                 onClick={handleRemoveClick}
                 className="text-xs font-medium text-fg-4 hover:text-error transition-colors"

--- a/desktop/src/components/onboarding/OnboardingWizard.tsx
+++ b/desktop/src/components/onboarding/OnboardingWizard.tsx
@@ -255,9 +255,10 @@ export default function OnboardingWizard({ prefs, tier, onComplete }: Onboarding
       await provisionChannel(ch);
     }
 
-    // Build final prefs
+    // Build final prefs. Sidebar visibility is now derived from
+    // enabled state (channels via dashboard.channels, widgets via
+    // enabledWidgets) so we no longer write pinnedSources here.
     const widgetIds = [...selectedWidgets];
-    const pinnedIds = [...Array.from(selectedChannels), ...widgetIds];
 
     const nextPrefs: AppPreferences = {
       ...prefs,
@@ -267,7 +268,6 @@ export default function OnboardingWizard({ prefs, tier, onComplete }: Onboarding
         enabledWidgets: widgetIds,
         widgetsOnTicker: widgetIds,
       },
-      pinnedSources: pinnedIds,
     };
 
     queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });

--- a/desktop/src/components/settings/GeneralSettings.tsx
+++ b/desktop/src/components/settings/GeneralSettings.tsx
@@ -131,18 +131,33 @@ export default function GeneralSettings({
         return;
       }
 
-      // Same-version patch detection: if the remote version matches the
-      // installed version AND the pub_date matches what we stored after
-      // our last install, the user already has this exact build.
-      const storedDate = getStore<string | null>(KEY_LAST_UPDATE_DATE, null);
-      if (
-        update.version === appVersion &&
-        storedDate &&
-        update.date === storedDate
-      ) {
-        pendingUpdate.current = null;
-        setStatus({ step: "up-to-date" });
-        return;
+      // Same-version patch detection: when the remote version matches
+      // the installed version, we suppress the "update available" UI
+      // unless the remote pub_date has changed since we last recorded
+      // it. KEY_LAST_UPDATE_DATE is normally seeded by the
+      // post-downloadAndInstall reconcile loop above (lines 107-115).
+      // For users who installed via a manual download (Windows MSI in
+      // particular), that loop never runs, so the store stays empty
+      // and every check used to false-positive. The empty-store branch
+      // below seeds the date once on first check, then the existing
+      // match-suppression takes over on subsequent checks.
+      if (update.version === appVersion) {
+        const storedDate = getStore<string | null>(KEY_LAST_UPDATE_DATE, null);
+        if (storedDate === null) {
+          // First in-app check on a build the in-app updater never
+          // installed. Trust the remote pub_date and seed.
+          setStore(KEY_LAST_UPDATE_DATE, update.date);
+          pendingUpdate.current = null;
+          setStatus({ step: "up-to-date" });
+          return;
+        }
+        if (update.date === storedDate) {
+          pendingUpdate.current = null;
+          setStatus({ step: "up-to-date" });
+          return;
+        }
+        // Stored date differs from remote: a genuine same-version
+        // patched rebuild has shipped. Fall through to "available".
       }
 
       const isPatch = update.version === appVersion;

--- a/desktop/src/hooks/useChannelActions.ts
+++ b/desktop/src/hooks/useChannelActions.ts
@@ -10,9 +10,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { channelsApi, toggleChannelVisibility } from "../api/client";
 import { queryKeys } from "../api/queries";
-import { savePrefs } from "../preferences";
 import type { ChannelType } from "../api/client";
-import type { AppPreferences } from "../preferences";
 
 const channelName: Record<string, string> = {
   finance: "Finance",
@@ -27,10 +25,10 @@ interface ChannelActions {
   handleDeleteChannel: (channelType: ChannelType) => Promise<void>;
 }
 
-export function useChannelActions(
-  prefs: AppPreferences,
-  setPrefs: React.Dispatch<React.SetStateAction<AppPreferences>>,
-): ChannelActions {
+// `prefs` and `setPrefs` were used to clean up `pinnedSources` on
+// channel delete. With pin-to-sidebar removed, the hook no longer
+// needs them — sidebar updates flow from the dashboard refetch.
+export function useChannelActions(): ChannelActions {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
@@ -70,13 +68,9 @@ export function useChannelActions(
       try {
         await channelsApi.delete(channelType);
         await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
-        // Remove from pinned sidebar
-        setPrefs((prev) => {
-          if (!prev.pinnedSources.includes(channelType)) return prev;
-          const next = { ...prev, pinnedSources: prev.pinnedSources.filter((id) => id !== channelType) };
-          savePrefs(next);
-          return next;
-        });
+        // Sidebar now derives from dashboard.channels (filtered to
+        // enabled), so no preference cleanup is needed here — the
+        // dashboard refetch above triggers the sidebar update.
         navigate({ to: "/feed" });
         toast.success(`${channelName[channelType] ?? channelType} channel removed`);
       } catch (err) {
@@ -84,7 +78,7 @@ export function useChannelActions(
         toast.error(`Couldn't remove ${channelName[channelType] ?? channelType} channel`);
       }
     },
-    [queryClient, navigate, setPrefs],
+    [queryClient, navigate],
   );
 
   return { handleToggleChannel, handleAddChannel, handleDeleteChannel };

--- a/desktop/src/hooks/useWidgetActions.ts
+++ b/desktop/src/hooks/useWidgetActions.ts
@@ -41,9 +41,6 @@ export function useWidgetActions(
       const nextOnTicker = isEnabled
         ? prefs.widgets.widgetsOnTicker.filter((id) => id !== widgetId)
         : [...prefs.widgets.widgetsOnTicker, widgetId];
-      const nextPinned = isEnabled
-        ? prefs.pinnedSources.filter((id) => id !== widgetId)
-        : prefs.pinnedSources;
       const next: AppPreferences = {
         ...prefs,
         widgets: {
@@ -51,7 +48,6 @@ export function useWidgetActions(
           enabledWidgets: nextEnabled,
           widgetsOnTicker: nextOnTicker,
         },
-        pinnedSources: nextPinned,
       };
       setPrefs(next);
       savePrefs(next);

--- a/desktop/src/marketplace.ts
+++ b/desktop/src/marketplace.ts
@@ -3,8 +3,13 @@
 import type { ComponentType } from "react";
 import type { SourceInfo } from "./types";
 import type { SubscriptionTier } from "./auth";
-import { getAllChannels } from "./channels/registry";
-import { getAllWidgets } from "./widgets/registry";
+import { getAllChannels, CHANNEL_ORDER } from "./channels/registry";
+import { getAllWidgets, WIDGET_ORDER } from "./widgets/registry";
+
+/** Canonical sort order for catalog items, sidebar entries, and any
+ * other UI that lists channels and widgets together. Channels first,
+ * then widgets, both in their per-registry-defined order. */
+export const CANONICAL_ORDER = [...CHANNEL_ORDER, ...WIDGET_ORDER];
 
 // ── Types ───────────────────────────────────────────────────────
 

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -378,8 +378,6 @@ export interface AppPreferences {
   taskbar: TaskbarPrefs;
   widgets: WidgetPrefs;
   channelDisplay: ChannelDisplayPrefs;
-  /** Channel/widget IDs pinned to the sidebar for quick access. */
-  pinnedSources: string[];
   /** Per-channel homepage preview selections (up to 5 group keys). */
   homePreview: HomePreview;
   /** Show the setup wizard when signing in. Users can disable this. */
@@ -552,7 +550,6 @@ const DEFAULT_PREFS: AppPreferences = {
   taskbar: DEFAULT_TASKBAR,
   widgets: DEFAULT_WIDGETS,
   channelDisplay: DEFAULT_CHANNEL_DISPLAY,
-  pinnedSources: [],
   homePreview: {},
   showSetupOnLogin: true,
 };
@@ -898,7 +895,6 @@ export function loadPrefs(): AppPreferences {
         rss: migrateRssDisplay(savedDisplay?.rss),
         fantasy: migrateFantasyDisplay(savedDisplay?.fantasy),
       },
-      pinnedSources: Array.isArray(source.pinnedSources) ? source.pinnedSources : [],
       homePreview:
         source.homePreview && typeof source.homePreview === "object" && !Array.isArray(source.homePreview)
           ? (source.homePreview as HomePreview)
@@ -963,7 +959,6 @@ export function resetAll(): AppPreferences {
     taskbar: { ...DEFAULT_TASKBAR },
     widgets: { ...DEFAULT_WIDGETS },
     channelDisplay: { ...DEFAULT_CHANNEL_DISPLAY },
-    pinnedSources: [],
     homePreview: {},
     showSetupOnLogin: true,
   };

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -35,6 +35,7 @@ import OnboardingWizard from "../components/onboarding/OnboardingWizard";
 // Registries
 import { getAllChannels } from "../channels/registry";
 import { getAllWidgets, getWidget } from "../widgets/registry";
+import { CANONICAL_ORDER } from "../marketplace";
 
 // Data
 import { dashboardQueryOptions } from "../api/queries";
@@ -232,7 +233,7 @@ function RootLayout() {
 
   // ── Extracted hooks ─────────────────────────────────────────
 
-  const channelActions = useChannelActions(prefs, setPrefs);
+  const channelActions = useChannelActions();
   const widgetActions = useWidgetActions(prefs, setPrefs, route.activeItem);
 
   // Shell-level weather polling — keeps data fresh regardless of which page is visible.
@@ -373,22 +374,44 @@ function RootLayout() {
     [navigate],
   );
 
-  // Resolve pinned source IDs to manifest data for the sidebar
-  const resolvedPinnedSources = useMemo(() => {
-    return prefs.pinnedSources
-      .map((id) => {
-        const chManifest = allChannelManifests.find((m) => m.id === id);
-        if (chManifest) {
-          return { id, name: chManifest.name, hex: chManifest.hex, icon: chManifest.icon, kind: "channel" as const };
+  // Build the sidebar source list from the user's enabled channels and
+  // widgets. Channels come from the live `dashboard.channels` payload
+  // (filtered to `enabled === true`); widgets come from
+  // `prefs.widgets.enabledWidgets`. Both are sorted via the shared
+  // CANONICAL_ORDER so the sidebar matches the catalog grid order.
+  // `Channel.visible` is intentionally NOT consulted here — visibility
+  // is a feed-level filter, not a navigation gate.
+  const sidebarSources = useMemo(() => {
+    const enabledChannelIds = new Set<string>(
+      (dashboard?.channels ?? [])
+        .filter((c) => c.enabled === true)
+        .map((c) => c.channel_type),
+    );
+    const enabledWidgetIds = new Set(prefs.widgets.enabledWidgets);
+
+    const sources: Array<{
+      id: string;
+      name: string;
+      hex: string;
+      icon: React.ComponentType<{ size?: number; className?: string }>;
+      kind: "channel" | "widget";
+    }> = [];
+
+    for (const id of CANONICAL_ORDER) {
+      if (enabledChannelIds.has(id)) {
+        const m = allChannelManifests.find((m) => m.id === id);
+        if (m) {
+          sources.push({ id, name: m.name, hex: m.hex, icon: m.icon, kind: "channel" });
         }
-        const wManifest = allWidgets.find((w) => w.id === id);
-        if (wManifest) {
-          return { id, name: wManifest.name, hex: wManifest.hex, icon: wManifest.icon, kind: "widget" as const };
+      } else if (enabledWidgetIds.has(id)) {
+        const m = allWidgets.find((w) => w.id === id);
+        if (m) {
+          sources.push({ id, name: m.name, hex: m.hex, icon: m.icon, kind: "widget" });
         }
-        return null;
-      })
-      .filter(Boolean) as Array<{ id: string; name: string; hex: string; icon: React.ComponentType<{ size?: number; className?: string }>; kind: "channel" | "widget" }>;
-  }, [prefs.pinnedSources, allChannelManifests, allWidgets]);
+      }
+    }
+    return sources;
+  }, [dashboard?.channels, prefs.widgets.enabledWidgets, allChannelManifests, allWidgets]);
 
   // ── Keyboard shortcuts ──────────────────────────────────────
   useEffect(() => {
@@ -545,7 +568,7 @@ function RootLayout() {
               isMarketplace={route.isMarketplace}
               isSupport={route.isSupport}
               activeItem={route.activeItem}
-              pinnedSources={resolvedPinnedSources}
+              sources={sidebarSources}
               deliveryMode={deliveryMode}
               tickerAlive={prefs.ticker.showTicker}
               onNavigateToFeed={handleNavigateToFeed}

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -5,14 +5,12 @@ import { LayoutGrid } from "lucide-react";
 import clsx from "clsx";
 import { toast } from "sonner";
 
-import { getCatalogItems, CATEGORY_LABELS } from "../marketplace";
+import { getCatalogItems, CATEGORY_LABELS, CANONICAL_ORDER } from "../marketplace";
 import type { CatalogCategory, CatalogItem } from "../marketplace";
 import { channelsApi } from "../api/client";
 import type { ChannelType } from "../api/client";
 import { dashboardQueryOptions, queryKeys } from "../api/queries";
 import { useShell, useShellData } from "../shell-context";
-import { CHANNEL_ORDER } from "../channels/registry";
-import { WIDGET_ORDER } from "../widgets/registry";
 import CatalogCard from "../components/marketplace/CatalogCard";
 import QueryErrorBanner from "../components/QueryErrorBanner";
 import RouteError from "../components/RouteError";
@@ -33,8 +31,8 @@ const FILTER_TABS: { key: FilterTab; label: string }[] = [
 ];
 
 // ── Sort order: enabled first, then canonical order ─────────────
-
-const CANONICAL_ORDER = [...CHANNEL_ORDER, ...WIDGET_ORDER];
+// (CANONICAL_ORDER is exported from marketplace.ts; we import it
+//  alongside the other catalog primitives below.)
 
 function sortItems(items: CatalogItem[], enabledIds: Set<string>): CatalogItem[] {
   return [...items].sort((a, b) => {
@@ -85,14 +83,9 @@ function CatalogPage() {
 
   const handleAdd = useCallback(
     async (item: CatalogItem) => {
-      const nextPinned = prefs.pinnedSources.includes(item.id)
-        ? prefs.pinnedSources
-        : [...prefs.pinnedSources, item.id];
-
       if (item.kind === "channel") {
         await channelsApi.create(item.id as ChannelType);
         await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
-        onPrefsChange({ ...prefs, pinnedSources: nextPinned });
         toast.success(`${item.name} added`);
         navigate({ to: "/channel/$type/$tab", params: { type: item.id, tab: "feed" } });
       } else {
@@ -100,7 +93,6 @@ function CatalogPage() {
         const nextOnTicker = [...prefs.widgets.widgetsOnTicker, item.id];
         onPrefsChange({
           ...prefs,
-          pinnedSources: nextPinned,
           widgets: { ...prefs.widgets, enabledWidgets: nextEnabled, widgetsOnTicker: nextOnTicker },
         });
         toast.success(`${item.name} added`);
@@ -110,30 +102,13 @@ function CatalogPage() {
     [navigate, queryClient, prefs, onPrefsChange],
   );
 
-  // ── Pin toggle ──────────────────────────────────────────────
-
-  const handleTogglePin = useCallback(
-    (item: CatalogItem) => {
-      const pinned = prefs.pinnedSources.includes(item.id);
-      const nextPinned = pinned
-        ? prefs.pinnedSources.filter((id) => id !== item.id)
-        : [...prefs.pinnedSources, item.id];
-      onPrefsChange({ ...prefs, pinnedSources: nextPinned });
-    },
-    [prefs, onPrefsChange],
-  );
-
   // ── Remove handler ──────────────────────────────────────────
 
   const handleRemove = useCallback(
     async (item: CatalogItem) => {
-      const nextPinned = prefs.pinnedSources.filter((id) => id !== item.id);
       if (item.kind === "channel") {
         await channelsApi.delete(item.id as ChannelType);
         await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
-        if (nextPinned.length !== prefs.pinnedSources.length) {
-          onPrefsChange({ ...prefs, pinnedSources: nextPinned });
-        }
         toast.success(`${item.name} removed`);
       } else {
         const nextEnabled = prefs.widgets.enabledWidgets.filter((id) => id !== item.id);
@@ -141,7 +116,6 @@ function CatalogPage() {
         onPrefsChange({
           ...prefs,
           widgets: { ...prefs.widgets, enabledWidgets: nextEnabled, widgetsOnTicker: nextOnTicker },
-          pinnedSources: nextPinned,
         });
         toast.success(`${item.name} removed`);
       }
@@ -195,14 +169,12 @@ function CatalogPage() {
             key={item.id}
             item={item}
             enabled={allEnabledIds.has(item.id)}
-            pinned={prefs.pinnedSources.includes(item.id)}
             tier={tier}
             authenticated={authenticated}
             dashboardLoading={isLoading}
             onAdd={handleAdd}
             onRemove={handleRemove}
             onLogin={onLogin}
-            onTogglePin={handleTogglePin}
             onOpen={(it) => {
               if (it.kind === "channel") {
                 navigate({ to: "/channel/$type/$tab", params: { type: it.id, tab: "feed" } });

--- a/desktop/src/utils/chipUrl.test.ts
+++ b/desktop/src/utils/chipUrl.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildYahooLeagueUrl,
+  buildYahooPlayerUrl,
+  chipUrlForFinance,
+  chipUrlForSports,
+  chipUrlForRss,
+} from "./chipUrl";
+
+describe("buildYahooLeagueUrl", () => {
+  it("constructs a football league URL from an NFL league_key", () => {
+    expect(buildYahooLeagueUrl("nfl.l.420")).toBe(
+      "https://football.fantasysports.yahoo.com/nfl/420",
+    );
+  });
+
+  it("constructs a basketball league URL from an NBA league_key", () => {
+    expect(buildYahooLeagueUrl("nba.l.12345")).toBe(
+      "https://basketball.fantasysports.yahoo.com/nba/12345",
+    );
+  });
+
+  it("constructs a hockey league URL from an NHL league_key", () => {
+    expect(buildYahooLeagueUrl("nhl.l.78")).toBe(
+      "https://hockey.fantasysports.yahoo.com/nhl/78",
+    );
+  });
+
+  it("constructs a baseball league URL from an MLB league_key", () => {
+    expect(buildYahooLeagueUrl("mlb.l.999")).toBe(
+      "https://baseball.fantasysports.yahoo.com/mlb/999",
+    );
+  });
+
+  it("returns undefined for an unrecognized game_code prefix", () => {
+    expect(buildYahooLeagueUrl("xyz.l.1")).toBeUndefined();
+  });
+
+  it("returns undefined when league_key cannot be parsed", () => {
+    expect(buildYahooLeagueUrl("not-a-key")).toBeUndefined();
+  });
+});
+
+describe("buildYahooPlayerUrl", () => {
+  it("constructs an NFL player URL from a player_key", () => {
+    expect(buildYahooPlayerUrl("nfl.p.30977")).toBe(
+      "https://sports.yahoo.com/nfl/players/30977/",
+    );
+  });
+
+  it("constructs an MLB player URL", () => {
+    expect(buildYahooPlayerUrl("mlb.p.10001")).toBe(
+      "https://sports.yahoo.com/mlb/players/10001/",
+    );
+  });
+
+  it("returns undefined when player_key cannot be parsed", () => {
+    expect(buildYahooPlayerUrl("nfl-p-30977")).toBeUndefined();
+  });
+
+  it("returns undefined for an unrecognized game_code prefix", () => {
+    expect(buildYahooPlayerUrl("xyz.p.99")).toBeUndefined();
+  });
+});
+
+describe("chipUrlForFinance", () => {
+  it("returns the trade.link when populated", () => {
+    expect(chipUrlForFinance({ link: "https://www.google.com/finance/quote/AAPL:NASDAQ" } as never)).toBe(
+      "https://www.google.com/finance/quote/AAPL:NASDAQ",
+    );
+  });
+
+  it("returns undefined when link is empty", () => {
+    expect(chipUrlForFinance({ link: "" } as never)).toBeUndefined();
+  });
+
+  it("returns undefined when link is missing", () => {
+    expect(chipUrlForFinance({} as never)).toBeUndefined();
+  });
+});
+
+describe("chipUrlForSports", () => {
+  it("returns the game.link when populated", () => {
+    expect(chipUrlForSports({ link: "https://www.espn.com/nfl/game/_/gameId/123" } as never)).toBe(
+      "https://www.espn.com/nfl/game/_/gameId/123",
+    );
+  });
+
+  it("returns undefined when link is empty", () => {
+    expect(chipUrlForSports({ link: "" } as never)).toBeUndefined();
+  });
+});
+
+describe("chipUrlForRss", () => {
+  it("returns the item.link when populated", () => {
+    expect(chipUrlForRss({ link: "https://example.com/article/1" } as never)).toBe(
+      "https://example.com/article/1",
+    );
+  });
+
+  it("returns undefined when link is empty", () => {
+    expect(chipUrlForRss({ link: "" } as never)).toBeUndefined();
+  });
+});

--- a/desktop/src/utils/chipUrl.ts
+++ b/desktop/src/utils/chipUrl.ts
@@ -1,0 +1,57 @@
+/**
+ * URL builders for ticker chip clicks. The handler in `App.tsx` routes
+ * a click to the OS shell when these helpers return a string, and
+ * falls back to opening the desktop app's main window otherwise.
+ *
+ * Trade/Game/RssItem already carry a server-populated `link` field —
+ * these helpers just unwrap it. Fantasy chips construct URLs from the
+ * Yahoo `league_key` / `player_key` namespacing scheme since neither
+ * the league nor the player URL is currently surfaced through the
+ * Go layer of the fantasy channel.
+ *
+ * Yahoo Fantasy URL format:
+ *   league: https://{sport}.fantasysports.yahoo.com/{game_code}/{league_id}
+ *   player: https://sports.yahoo.com/{game_code}/players/{player_id}/
+ *
+ * `league_key` shape: "{game_code}.l.{league_id}" (e.g. "nfl.l.420").
+ * `player_key` shape: "{game_code}.p.{player_id}" (e.g. "nfl.p.30977").
+ */
+
+import type { Trade, Game, RssItem } from "../types";
+
+/** Yahoo's per-sport subdomain prefix on fantasysports.yahoo.com. */
+const SPORT_PREFIX: Record<string, string> = {
+  nfl: "football",
+  nba: "basketball",
+  nhl: "hockey",
+  mlb: "baseball",
+};
+
+export function buildYahooLeagueUrl(leagueKey: string): string | undefined {
+  const parts = leagueKey.split(".l.");
+  if (parts.length !== 2) return undefined;
+  const [gameCode, leagueId] = parts;
+  const prefix = SPORT_PREFIX[gameCode];
+  if (!prefix) return undefined;
+  return `https://${prefix}.fantasysports.yahoo.com/${gameCode}/${leagueId}`;
+}
+
+export function buildYahooPlayerUrl(playerKey: string): string | undefined {
+  const parts = playerKey.split(".p.");
+  if (parts.length !== 2) return undefined;
+  const [gameCode, playerId] = parts;
+  if (!SPORT_PREFIX[gameCode]) return undefined;
+  return `https://sports.yahoo.com/${gameCode}/players/${playerId}/`;
+}
+
+export function chipUrlForFinance(trade: Trade): string | undefined {
+  return trade.link && trade.link.length > 0 ? trade.link : undefined;
+}
+
+export function chipUrlForSports(game: Game): string | undefined {
+  return game.link && game.link.length > 0 ? game.link : undefined;
+}
+
+export function chipUrlForRss(item: RssItem): string | undefined {
+  return item.link && item.link.length > 0 ? item.link : undefined;
+}

--- a/docs/superpowers/plans/2026-04-28-batch-a-quick-fixes.md
+++ b/docs/superpowers/plans/2026-04-28-batch-a-quick-fixes.md
@@ -1,0 +1,1651 @@
+# Batch A — Quick Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship three independent, low-risk desktop fixes in one PR: Windows updater false-positive seed fix, removal of the pin-to-sidebar feature, and ticker chip clicks that open the relevant external URL.
+
+**Architecture:** All three changes live entirely in `desktop/`. No backend or website touches. Three logical commits, one per item, reviewable in isolation. Item 1 modifies one file; Item 3 deletes a preference field across 7 files and rewires the sidebar to derive from existing state; Item 6 adds a small URL-helper module and threads an optional `url` argument through the existing `onChipClick` chain.
+
+**Tech Stack:** React 19 + TanStack Router, Tauri v2, `@tauri-apps/plugin-shell`, `@tauri-apps/plugin-updater`, Vitest 154-test suite for selector tests.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-batch-a-quick-fixes-design.md`
+
+---
+
+## File Structure
+
+### Item 1 — Updater seed fix
+- Modify: `desktop/src/components/settings/GeneralSettings.tsx:124-163` (the `handleCheckForUpdates` callback body)
+
+### Item 3 — Pin-to-sidebar removal
+- Modify: `desktop/src/marketplace.ts` — add `CANONICAL_ORDER` export
+- Modify: `desktop/src/routes/__root.tsx:376-391, 548` — replace `resolvedPinnedSources` memo
+- Modify: `desktop/src/components/Sidebar.tsx:73-79, 94, 121, 194-207` — rename interface + prop
+- Modify: `desktop/src/routes/catalog.tsx:37, 86-150, 195-208` — drop pin handlers + props
+- Modify: `desktop/src/components/marketplace/CatalogCard.tsx:3, 25-58, 162-228` — remove pin button block
+- Modify: `desktop/src/components/onboarding/OnboardingWizard.tsx:259-271` — remove `pinnedIds`
+- Modify: `desktop/src/hooks/useChannelActions.ts:68-87` — drop pinnedSources cleanup
+- Modify: `desktop/src/hooks/useWidgetActions.ts:34-70` — drop pinnedSources cleanup
+- Modify: `desktop/src/preferences.ts:380-387, 555, 901, 966` — drop field, default, loadPrefs read, reset
+
+### Item 6 — Ticker chip external URL
+- Create: `desktop/src/utils/chipUrl.ts` — URL builder + Yahoo helpers
+- Create: `desktop/src/utils/chipUrl.test.ts` — unit tests (Yahoo URL parsing/construction)
+- Modify: `desktop/src/components/ScrollrTicker.tsx:40, 168, 206, 221, 252, 275, 300, 453` — extend `onChipClick` signature, pass URLs from each chip wrap site
+- Modify: `desktop/src/App.tsx:344-352` — branch in `handleChipClick`: if URL, `open(url)`; else fall back to `show_app_window`
+
+---
+
+## Phase 1 — Item 1: Updater seed fix
+
+### Task 1.1: Modify the version-match branch in `handleCheckForUpdates`
+
+**Files:**
+- Modify: `desktop/src/components/settings/GeneralSettings.tsx:124-163`
+
+The current code at lines 137–146 has a guard that only fires when `storedDate` is truthy. We extend it to also handle the empty-store case (Windows MSI installs that never went through the in-app updater): when `update.version === appVersion` AND `storedDate` is null, seed the store with `update.date` and report up-to-date.
+
+- [ ] **Step 1: Read the current handler**
+
+Read `desktop/src/components/settings/GeneralSettings.tsx` lines 124-163 to confirm the current shape (already done during planning; the code below assumes it).
+
+- [ ] **Step 2: Replace the version-match branch**
+
+Replace lines 134-146 (the `// Same-version patch detection` block) with the seeded version. Use `Edit` with this exact old/new pair:
+
+`oldString` (in `desktop/src/components/settings/GeneralSettings.tsx`):
+```ts
+      // Same-version patch detection: if the remote version matches the
+      // installed version AND the pub_date matches what we stored after
+      // our last install, the user already has this exact build.
+      const storedDate = getStore<string | null>(KEY_LAST_UPDATE_DATE, null);
+      if (
+        update.version === appVersion &&
+        storedDate &&
+        update.date === storedDate
+      ) {
+        pendingUpdate.current = null;
+        setStatus({ step: "up-to-date" });
+        return;
+      }
+```
+
+`newString`:
+```ts
+      // Same-version patch detection: when the remote version matches
+      // the installed version, we suppress the "update available" UI
+      // unless the remote pub_date has changed since we last recorded
+      // it. KEY_LAST_UPDATE_DATE is normally seeded by the
+      // post-downloadAndInstall reconcile loop above (lines 107-115).
+      // For users who installed via a manual download (Windows MSI in
+      // particular), that loop never runs, so the store stays empty
+      // and every check used to false-positive. The empty-store branch
+      // below seeds the date once on first check, then the existing
+      // match-suppression takes over on subsequent checks.
+      if (update.version === appVersion) {
+        const storedDate = getStore<string | null>(KEY_LAST_UPDATE_DATE, null);
+        if (storedDate === null) {
+          // First in-app check on a build the in-app updater never
+          // installed. Trust the remote pub_date and seed.
+          setStore(KEY_LAST_UPDATE_DATE, update.date);
+          pendingUpdate.current = null;
+          setStatus({ step: "up-to-date" });
+          return;
+        }
+        if (update.date === storedDate) {
+          pendingUpdate.current = null;
+          setStatus({ step: "up-to-date" });
+          return;
+        }
+        // Stored date differs from remote: a genuine same-version
+        // patched rebuild has shipped. Fall through to "available".
+      }
+```
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run from `desktop/`:
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: empty output (clean) or only pre-existing errors unrelated to GeneralSettings.tsx.
+
+- [ ] **Step 4: Smoke-test the build**
+
+Run from `desktop/`:
+```bash
+cd desktop && npm run build 2>&1 | tail -10
+```
+Expected: `vite build` succeeds, `tsc --noEmit` succeeds, no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add desktop/src/components/settings/GeneralSettings.tsx
+git commit -m "fix(updater): seed KEY_LAST_UPDATE_DATE on first version-match check
+
+Windows users overwhelmingly install via MSI manual download from the
+GitHub releases page. The post-downloadAndInstall reconcile loop in
+GeneralSettings.tsx never seeds KEY_LAST_UPDATE_DATE for these users,
+so the existing pub_date guard at line 137 short-circuits (storedDate
+is null) and every Check for Updates falsely reports an update
+available against the same version they already have.
+
+Add an empty-store branch: when update.version === appVersion and
+storedDate is null, seed it with update.date and report up-to-date.
+Subsequent checks then hit the existing match-suppression at line 144.
+
+The 'patched rebuild' pattern (re-issuing v1.0.3 with a fix without
+bumping the version number) is preserved: a genuinely new pub_date
+falls through to the 'available' branch.
+
+Edge case: a user who manually downloads an OLDER MSI than the latest
+GitHub release will have its pub_date mismatched and the seed step
+will record the LATER pub_date as 'the one I'm on', silently skipping
+the patch they're missing. Requires deliberate downgrade; acceptable."
+```
+
+---
+
+## Phase 2 — Item 3: Pin-to-sidebar removal
+
+This phase deletes the `pinnedSources` field from preferences and rewires the sidebar to read from `dashboard.channels` (filtered to `enabled`) plus `prefs.widgets.enabledWidgets`. Order matters: replace the consumer (sidebar memo) first, then remove the writers (catalog/onboarding/hooks), then drop the field itself last.
+
+### Task 2.1: Add `CANONICAL_ORDER` export to `marketplace.ts`
+
+The catalog already defines this constant locally (`catalog.tsx:37`). Lift it into the shared module so the sidebar memo and the catalog grid use the same source.
+
+**Files:**
+- Modify: `desktop/src/marketplace.ts`
+
+- [ ] **Step 1: Add import + export**
+
+Edit `desktop/src/marketplace.ts`. Insert two new lines after the existing imports.
+
+`oldString`:
+```ts
+import { getAllChannels } from "./channels/registry";
+import { getAllWidgets } from "./widgets/registry";
+```
+
+`newString`:
+```ts
+import { getAllChannels, CHANNEL_ORDER } from "./channels/registry";
+import { getAllWidgets, WIDGET_ORDER } from "./widgets/registry";
+
+/** Canonical sort order for catalog items, sidebar entries, and any
+ * other UI that lists channels and widgets together. Channels first,
+ * then widgets, both in their per-registry-defined order. */
+export const CANONICAL_ORDER = [...CHANNEL_ORDER, ...WIDGET_ORDER];
+```
+
+- [ ] **Step 2: Verify the registry exports exist**
+
+Confirmed during planning: `desktop/src/channels/registry.ts:28` exports `CHANNEL_ORDER`, `desktop/src/widgets/registry.ts:28` exports `WIDGET_ORDER`. Both are `string[]` of source IDs. No registry changes needed.
+
+- [ ] **Step 3: Update the catalog to import from marketplace.ts**
+
+Edit `desktop/src/routes/catalog.tsx`. Replace the inline constant.
+
+`oldString`:
+```ts
+// ── Sort order: enabled first, then canonical order ─────────────
+
+const CANONICAL_ORDER = [...CHANNEL_ORDER, ...WIDGET_ORDER];
+```
+
+`newString`:
+```ts
+// ── Sort order: enabled first, then canonical order ─────────────
+// (CANONICAL_ORDER is exported from marketplace.ts; we import it
+//  alongside the other catalog primitives below.)
+```
+
+Then update the existing import. `oldString`:
+```ts
+import { getCatalogItems, CATEGORY_LABELS } from "../marketplace";
+```
+
+`newString`:
+```ts
+import { getCatalogItems, CATEGORY_LABELS, CANONICAL_ORDER } from "../marketplace";
+```
+
+If the file currently imports `CHANNEL_ORDER` or `WIDGET_ORDER` directly from the registries (it should not after this change), remove those imports.
+
+- [ ] **Step 4: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: empty.
+
+### Task 2.2: Replace `resolvedPinnedSources` memo in `__root.tsx`
+
+The memo currently iterates `prefs.pinnedSources`. Replace with one that reads `dashboard.channels` (filtered to `enabled === true`) + `prefs.widgets.enabledWidgets`, sorted via `CANONICAL_ORDER`.
+
+**Files:**
+- Modify: `desktop/src/routes/__root.tsx:376-391`
+
+- [ ] **Step 1: Confirm imports we'll need**
+
+The new memo references `dashboard` (already in scope), `prefs.widgets.enabledWidgets`, `allChannelManifests`, `allWidgets` (all already in scope as confirmed by lines 380, 384). It also needs `CANONICAL_ORDER`. Add an import.
+
+Read the current import block at the top of `desktop/src/routes/__root.tsx`. Add `CANONICAL_ORDER` to the existing `marketplace` import (or add a new import line if marketplace isn't yet imported).
+
+- [ ] **Step 2: Replace the memo**
+
+`oldString` (in `desktop/src/routes/__root.tsx`):
+```ts
+  // Resolve pinned source IDs to manifest data for the sidebar
+  const resolvedPinnedSources = useMemo(() => {
+    return prefs.pinnedSources
+      .map((id) => {
+        const chManifest = allChannelManifests.find((m) => m.id === id);
+        if (chManifest) {
+          return { id, name: chManifest.name, hex: chManifest.hex, icon: chManifest.icon, kind: "channel" as const };
+        }
+        const wManifest = allWidgets.find((w) => w.id === id);
+        if (wManifest) {
+          return { id, name: wManifest.name, hex: wManifest.hex, icon: wManifest.icon, kind: "widget" as const };
+        }
+        return null;
+      })
+      .filter(Boolean) as Array<{ id: string; name: string; hex: string; icon: React.ComponentType<{ size?: number; className?: string }>; kind: "channel" | "widget" }>;
+  }, [prefs.pinnedSources, allChannelManifests, allWidgets]);
+```
+
+`newString`:
+```ts
+  // Build the sidebar source list from the user's enabled channels and
+  // widgets. Channels come from the live `dashboard.channels` payload
+  // (filtered to `enabled === true`); widgets come from
+  // `prefs.widgets.enabledWidgets`. Both are sorted via the shared
+  // CANONICAL_ORDER so the sidebar matches the catalog grid order.
+  // `Channel.visible` is intentionally NOT consulted here — visibility
+  // is a feed-level filter, not a navigation gate.
+  const sidebarSources = useMemo(() => {
+    const enabledChannelIds = new Set(
+      (dashboard?.channels ?? [])
+        .filter((c) => c.enabled === true)
+        .map((c) => c.channel_type),
+    );
+    const enabledWidgetIds = new Set(prefs.widgets.enabledWidgets);
+
+    const sources: Array<{
+      id: string;
+      name: string;
+      hex: string;
+      icon: React.ComponentType<{ size?: number; className?: string }>;
+      kind: "channel" | "widget";
+    }> = [];
+
+    for (const id of CANONICAL_ORDER) {
+      if (enabledChannelIds.has(id)) {
+        const m = allChannelManifests.find((m) => m.id === id);
+        if (m) {
+          sources.push({ id, name: m.name, hex: m.hex, icon: m.icon, kind: "channel" });
+        }
+      } else if (enabledWidgetIds.has(id)) {
+        const m = allWidgets.find((w) => w.id === id);
+        if (m) {
+          sources.push({ id, name: m.name, hex: m.hex, icon: m.icon, kind: "widget" });
+        }
+      }
+    }
+    return sources;
+  }, [dashboard?.channels, prefs.widgets.enabledWidgets, allChannelManifests, allWidgets]);
+```
+
+- [ ] **Step 3: Update the prop passed to `<Sidebar>`**
+
+Find the `<Sidebar` element (around line 548) and rename the prop:
+
+`oldString`:
+```ts
+          pinnedSources={resolvedPinnedSources}
+```
+
+`newString`:
+```ts
+          sources={sidebarSources}
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: errors mentioning `Sidebar.tsx` (because we just renamed the prop and the Sidebar still expects the old name). Those resolve in Task 2.3.
+
+### Task 2.3: Rename Sidebar prop interface
+
+**Files:**
+- Modify: `desktop/src/components/Sidebar.tsx:73-79, 94, 121`
+
+- [ ] **Step 1: Rename `PinnedSource` → `SidebarSource`**
+
+`oldString` (in `desktop/src/components/Sidebar.tsx`):
+```ts
+interface PinnedSource {
+  id: string;
+  name: string;
+  hex: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  kind: "channel" | "widget";
+}
+```
+
+`newString`:
+```ts
+interface SidebarSource {
+  id: string;
+  name: string;
+  hex: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  kind: "channel" | "widget";
+}
+```
+
+- [ ] **Step 2: Rename the prop name in the interface**
+
+`oldString`:
+```ts
+  /** Resolved pinned sources with manifest data. */
+  pinnedSources: PinnedSource[];
+```
+
+`newString`:
+```ts
+  /** Resolved enabled-source manifest data, in canonical order. */
+  sources: SidebarSource[];
+```
+
+- [ ] **Step 3: Rename the destructured prop in the component signature**
+
+`oldString`:
+```ts
+  pinnedSources,
+```
+
+`newString`:
+```ts
+  sources,
+```
+
+- [ ] **Step 4: Update the JSX usage**
+
+`oldString`:
+```ts
+        {/* Pinned sources */}
+        {pinnedSources.length > 0 && (
+          <div className="mt-2 pt-2 border-t border-edge/20 space-y-0.5">
+            {pinnedSources.map((source) => (
+              <NavItem
+                key={source.id}
+                icon={<span style={{ color: source.hex }}><source.icon size={15} /></span>}
+                label={source.name}
+                active={activeItem === source.id}
+                collapsed={collapsed}
+                onClick={() => onSelectItem(source.id, source.kind)}
+              />
+            ))}
+          </div>
+        )}
+```
+
+`newString`:
+```ts
+        {/* Enabled channels + widgets */}
+        {sources.length > 0 && (
+          <div className="mt-2 pt-2 border-t border-edge/20 space-y-0.5">
+            {sources.map((source) => (
+              <NavItem
+                key={source.id}
+                icon={<span style={{ color: source.hex }}><source.icon size={15} /></span>}
+                label={source.name}
+                active={activeItem === source.id}
+                collapsed={collapsed}
+                onClick={() => onSelectItem(source.id, source.kind)}
+              />
+            ))}
+          </div>
+        )}
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: errors only in places that still reference `prefs.pinnedSources` (catalog/wizard/hooks/preferences). Sidebar + __root should be clean.
+
+### Task 2.4: Strip pin-button machinery from `CatalogCard.tsx`
+
+**Files:**
+- Modify: `desktop/src/components/marketplace/CatalogCard.tsx:3, 25-58, 162-228`
+
+- [ ] **Step 1: Drop unused imports**
+
+`oldString`:
+```ts
+import { Check, ChevronRight, ExternalLink, Loader2, Pin, PinOff } from "lucide-react";
+```
+
+`newString`:
+```ts
+import { Check, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
+```
+
+- [ ] **Step 2: Drop the Tooltip import if it becomes unused**
+
+The Pin button used a `<Tooltip>`. After removal, check whether Tooltip is referenced elsewhere in `CatalogCard.tsx`. Run:
+```bash
+cd desktop && grep -n "Tooltip" src/components/marketplace/CatalogCard.tsx
+```
+Expected: only the import line at line 9. If so, also remove this line:
+```ts
+import Tooltip from "../Tooltip";
+```
+
+- [ ] **Step 3: Drop `pinned` and `onTogglePin` from props**
+
+`oldString`:
+```ts
+interface CatalogCardProps {
+  item: CatalogItem;
+  enabled: boolean;
+  /** True when this source appears in the left sidebar. Only meaningful when enabled. */
+  pinned: boolean;
+  tier: SubscriptionTier;
+  authenticated: boolean;
+  /** Disable Add button while dashboard is loading (channels enabled state unknown). */
+  dashboardLoading: boolean;
+  onAdd: (item: CatalogItem) => Promise<void>;
+  onRemove: (item: CatalogItem) => Promise<void>;
+  onLogin: () => void;
+  /** Toggle sidebar pin state. Only rendered when `enabled` is true. */
+  onTogglePin?: (item: CatalogItem) => void;
+  /** Navigate to the channel/widget page when already added. */
+  onOpen?: (item: CatalogItem) => void;
+}
+```
+
+`newString`:
+```ts
+interface CatalogCardProps {
+  item: CatalogItem;
+  enabled: boolean;
+  tier: SubscriptionTier;
+  authenticated: boolean;
+  /** Disable Add button while dashboard is loading (channels enabled state unknown). */
+  dashboardLoading: boolean;
+  onAdd: (item: CatalogItem) => Promise<void>;
+  onRemove: (item: CatalogItem) => Promise<void>;
+  onLogin: () => void;
+  /** Navigate to the channel/widget page when already added. */
+  onOpen?: (item: CatalogItem) => void;
+}
+```
+
+- [ ] **Step 4: Drop the same props from the component signature**
+
+`oldString`:
+```ts
+export default function CatalogCard({
+  item,
+  enabled,
+  pinned,
+  tier,
+  authenticated,
+  dashboardLoading,
+  onAdd,
+  onRemove,
+  onLogin,
+  onTogglePin,
+  onOpen,
+}: CatalogCardProps) {
+```
+
+`newString`:
+```ts
+export default function CatalogCard({
+  item,
+  enabled,
+  tier,
+  authenticated,
+  dashboardLoading,
+  onAdd,
+  onRemove,
+  onLogin,
+  onOpen,
+}: CatalogCardProps) {
+```
+
+- [ ] **Step 5: Drop the Pin/PinOff button block**
+
+`oldString`:
+```ts
+          ) : enabled ? (
+            <div className="flex items-center gap-3">
+              {onTogglePin && (
+                <Tooltip content={pinned ? "Unpin from sidebar" : "Pin to sidebar"}>
+                  <button
+                    onClick={() => onTogglePin(item)}
+                    aria-label={pinned ? `Unpin ${item.name}` : `Pin ${item.name} to sidebar`}
+                    aria-pressed={pinned}
+                    className={clsx(
+                      "w-7 h-7 flex items-center justify-center rounded-lg transition-colors cursor-pointer",
+                      pinned
+                        ? "text-accent hover:bg-surface-hover"
+                        : "text-fg-4 hover:text-fg-2 hover:bg-surface-hover",
+                    )}
+                  >
+                    {pinned ? <Pin size={14} /> : <PinOff size={14} />}
+                  </button>
+                </Tooltip>
+              )}
+              <button
+                onClick={handleRemoveClick}
+                className="text-xs font-medium text-fg-4 hover:text-error transition-colors"
+              >
+                Remove
+              </button>
+              {onOpen && (
+                <button
+                  onClick={() => onOpen(item)}
+                  className="flex items-center gap-0.5 text-xs font-semibold text-accent hover:text-accent/80 transition-colors"
+                >
+                  Open <ChevronRight size={12} />
+                </button>
+              )}
+            </div>
+```
+
+`newString`:
+```ts
+          ) : enabled ? (
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleRemoveClick}
+                className="text-xs font-medium text-fg-4 hover:text-error transition-colors"
+              >
+                Remove
+              </button>
+              {onOpen && (
+                <button
+                  onClick={() => onOpen(item)}
+                  className="flex items-center gap-0.5 text-xs font-semibold text-accent hover:text-accent/80 transition-colors"
+                >
+                  Open <ChevronRight size={12} />
+                </button>
+              )}
+            </div>
+```
+
+- [ ] **Step 6: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: errors only in `catalog.tsx` (which still passes the now-removed props).
+
+### Task 2.5: Strip pin handling from `catalog.tsx`
+
+**Files:**
+- Modify: `desktop/src/routes/catalog.tsx:84-150, 195-208`
+
+- [ ] **Step 1: Drop `pinnedSources` writes from `handleAdd`**
+
+`oldString`:
+```ts
+  const handleAdd = useCallback(
+    async (item: CatalogItem) => {
+      const nextPinned = prefs.pinnedSources.includes(item.id)
+        ? prefs.pinnedSources
+        : [...prefs.pinnedSources, item.id];
+
+      if (item.kind === "channel") {
+        await channelsApi.create(item.id as ChannelType);
+        await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        onPrefsChange({ ...prefs, pinnedSources: nextPinned });
+        toast.success(`${item.name} added`);
+        navigate({ to: "/channel/$type/$tab", params: { type: item.id, tab: "feed" } });
+      } else {
+        const nextEnabled = [...prefs.widgets.enabledWidgets, item.id];
+        const nextOnTicker = [...prefs.widgets.widgetsOnTicker, item.id];
+        onPrefsChange({
+          ...prefs,
+          pinnedSources: nextPinned,
+          widgets: { ...prefs.widgets, enabledWidgets: nextEnabled, widgetsOnTicker: nextOnTicker },
+        });
+        toast.success(`${item.name} added`);
+        navigate({ to: "/widget/$id/$tab", params: { id: item.id, tab: "feed" } });
+      }
+    },
+    [navigate, queryClient, prefs, onPrefsChange],
+  );
+```
+
+`newString`:
+```ts
+  const handleAdd = useCallback(
+    async (item: CatalogItem) => {
+      if (item.kind === "channel") {
+        await channelsApi.create(item.id as ChannelType);
+        await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        toast.success(`${item.name} added`);
+        navigate({ to: "/channel/$type/$tab", params: { type: item.id, tab: "feed" } });
+      } else {
+        const nextEnabled = [...prefs.widgets.enabledWidgets, item.id];
+        const nextOnTicker = [...prefs.widgets.widgetsOnTicker, item.id];
+        onPrefsChange({
+          ...prefs,
+          widgets: { ...prefs.widgets, enabledWidgets: nextEnabled, widgetsOnTicker: nextOnTicker },
+        });
+        toast.success(`${item.name} added`);
+        navigate({ to: "/widget/$id/$tab", params: { id: item.id, tab: "feed" } });
+      }
+    },
+    [navigate, queryClient, prefs, onPrefsChange],
+  );
+```
+
+- [ ] **Step 2: Drop `handleTogglePin` entirely**
+
+`oldString`:
+```ts
+  // ── Pin toggle ──────────────────────────────────────────────
+
+  const handleTogglePin = useCallback(
+    (item: CatalogItem) => {
+      const pinned = prefs.pinnedSources.includes(item.id);
+      const nextPinned = pinned
+        ? prefs.pinnedSources.filter((id) => id !== item.id)
+        : [...prefs.pinnedSources, item.id];
+      onPrefsChange({ ...prefs, pinnedSources: nextPinned });
+    },
+    [prefs, onPrefsChange],
+  );
+
+  // ── Remove handler ──────────────────────────────────────────
+```
+
+`newString`:
+```ts
+  // ── Remove handler ──────────────────────────────────────────
+```
+
+- [ ] **Step 3: Drop `pinnedSources` writes from `handleRemove`**
+
+`oldString`:
+```ts
+  const handleRemove = useCallback(
+    async (item: CatalogItem) => {
+      const nextPinned = prefs.pinnedSources.filter((id) => id !== item.id);
+      if (item.kind === "channel") {
+        await channelsApi.delete(item.id as ChannelType);
+        await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        if (nextPinned.length !== prefs.pinnedSources.length) {
+          onPrefsChange({ ...prefs, pinnedSources: nextPinned });
+        }
+        toast.success(`${item.name} removed`);
+      } else {
+        const nextEnabled = prefs.widgets.enabledWidgets.filter((id) => id !== item.id);
+        const nextOnTicker = prefs.widgets.widgetsOnTicker.filter((id) => id !== item.id);
+        onPrefsChange({
+          ...prefs,
+          widgets: { ...prefs.widgets, enabledWidgets: nextEnabled, widgetsOnTicker: nextOnTicker },
+          pinnedSources: nextPinned,
+        });
+        toast.success(`${item.name} removed`);
+      }
+    },
+    [queryClient, prefs, onPrefsChange],
+  );
+```
+
+`newString`:
+```ts
+  const handleRemove = useCallback(
+    async (item: CatalogItem) => {
+      if (item.kind === "channel") {
+        await channelsApi.delete(item.id as ChannelType);
+        await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        toast.success(`${item.name} removed`);
+      } else {
+        const nextEnabled = prefs.widgets.enabledWidgets.filter((id) => id !== item.id);
+        const nextOnTicker = prefs.widgets.widgetsOnTicker.filter((id) => id !== item.id);
+        onPrefsChange({
+          ...prefs,
+          widgets: { ...prefs.widgets, enabledWidgets: nextEnabled, widgetsOnTicker: nextOnTicker },
+        });
+        toast.success(`${item.name} removed`);
+      }
+    },
+    [queryClient, prefs, onPrefsChange],
+  );
+```
+
+- [ ] **Step 4: Drop `pinned` and `onTogglePin` from `<CatalogCard>` render call**
+
+Find the `<CatalogCard` JSX in the render section (around lines 195-208 of catalog.tsx). Update both prop usages.
+
+`oldString`:
+```ts
+              pinned={prefs.pinnedSources.includes(item.id)}
+```
+
+`newString`: (delete this entire line)
+
+`oldString`:
+```ts
+              onTogglePin={handleTogglePin}
+```
+
+`newString`: (delete this entire line)
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: errors only in OnboardingWizard, useChannelActions, useWidgetActions, preferences (the writers we haven't touched yet).
+
+### Task 2.6: Strip `pinnedIds` from `OnboardingWizard.tsx`
+
+**Files:**
+- Modify: `desktop/src/components/onboarding/OnboardingWizard.tsx:259-271`
+
+- [ ] **Step 1: Edit the finish-prefs build**
+
+`oldString`:
+```ts
+    // Build final prefs
+    const widgetIds = [...selectedWidgets];
+    const pinnedIds = [...Array.from(selectedChannels), ...widgetIds];
+
+    const nextPrefs: AppPreferences = {
+      ...prefs,
+      showSetupOnLogin: false,
+      widgets: {
+        ...prefs.widgets,
+        enabledWidgets: widgetIds,
+        widgetsOnTicker: widgetIds,
+      },
+      pinnedSources: pinnedIds,
+    };
+```
+
+`newString`:
+```ts
+    // Build final prefs. Sidebar visibility is now derived from
+    // enabled state (channels via dashboard.channels, widgets via
+    // enabledWidgets) so we no longer write pinnedSources here.
+    const widgetIds = [...selectedWidgets];
+
+    const nextPrefs: AppPreferences = {
+      ...prefs,
+      showSetupOnLogin: false,
+      widgets: {
+        ...prefs.widgets,
+        enabledWidgets: widgetIds,
+        widgetsOnTicker: widgetIds,
+      },
+    };
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: errors only in useChannelActions, useWidgetActions, preferences.
+
+### Task 2.7: Strip pinnedSources cleanup from `useChannelActions.ts`
+
+**Files:**
+- Modify: `desktop/src/hooks/useChannelActions.ts:68-87`
+
+- [ ] **Step 1: Edit the delete handler**
+
+`oldString`:
+```ts
+  const handleDeleteChannel = useCallback(
+    async (channelType: ChannelType) => {
+      try {
+        await channelsApi.delete(channelType);
+        await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        // Remove from pinned sidebar
+        setPrefs((prev) => {
+          if (!prev.pinnedSources.includes(channelType)) return prev;
+          const next = { ...prev, pinnedSources: prev.pinnedSources.filter((id) => id !== channelType) };
+          savePrefs(next);
+          return next;
+        });
+        navigate({ to: "/feed" });
+        toast.success(`${channelName[channelType] ?? channelType} channel removed`);
+      } catch (err) {
+        console.error("[Scrollr] Channel delete failed:", err);
+        toast.error(`Couldn't remove ${channelName[channelType] ?? channelType} channel`);
+      }
+    },
+    [queryClient, navigate, setPrefs],
+  );
+```
+
+`newString`:
+```ts
+  const handleDeleteChannel = useCallback(
+    async (channelType: ChannelType) => {
+      try {
+        await channelsApi.delete(channelType);
+        await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        // Sidebar now derives from dashboard.channels (filtered to
+        // enabled), so no preference cleanup is needed here — the
+        // dashboard refetch above triggers the sidebar update.
+        navigate({ to: "/feed" });
+        toast.success(`${channelName[channelType] ?? channelType} channel removed`);
+      } catch (err) {
+        console.error("[Scrollr] Channel delete failed:", err);
+        toast.error(`Couldn't remove ${channelName[channelType] ?? channelType} channel`);
+      }
+    },
+    [queryClient, navigate],
+  );
+```
+
+- [ ] **Step 2: Drop unused imports**
+
+After removing the `setPrefs` call, the `setPrefs` parameter is unused. The hook signature is `useChannelActions(prefs, setPrefs)`. Both are now unused for `handleDeleteChannel`. Run:
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+
+If TypeScript errors with unused parameter warnings, leave the parameters in place (other consumers of this hook still pass them, and they may be needed by future actions in the same file). Confirmed via inspection: `prefs` and `setPrefs` are not currently used by any other function in this file after this edit. Update the signature.
+
+`oldString`:
+```ts
+export function useChannelActions(
+  prefs: AppPreferences,
+  setPrefs: React.Dispatch<React.SetStateAction<AppPreferences>>,
+): ChannelActions {
+```
+
+`newString`:
+```ts
+// `prefs` and `setPrefs` were used to clean up `pinnedSources` on
+// channel delete. With pin-to-sidebar removed, the hook no longer
+// needs them — sidebar updates flow from the dashboard refetch.
+export function useChannelActions(): ChannelActions {
+```
+
+- [ ] **Step 3: Drop now-unused imports**
+
+`oldString`:
+```ts
+import { savePrefs } from "../preferences";
+import type { ChannelType } from "../api/client";
+import type { AppPreferences } from "../preferences";
+```
+
+`newString`:
+```ts
+import type { ChannelType } from "../api/client";
+```
+
+- [ ] **Step 4: Update the single call site**
+
+Confirmed during planning: only `__root.tsx:235` calls `useChannelActions`. Update it.
+
+`oldString` (in `desktop/src/routes/__root.tsx`):
+```ts
+  const channelActions = useChannelActions(prefs, setPrefs);
+```
+
+`newString`:
+```ts
+  const channelActions = useChannelActions();
+```
+
+`useWidgetActions` at line 236 still passes `(prefs, setPrefs, route.activeItem)` — its signature stays unchanged because its other callbacks still use both. Do not touch line 236.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: errors only in useWidgetActions and preferences.
+
+### Task 2.8: Strip pinnedSources cleanup from `useWidgetActions.ts`
+
+**Files:**
+- Modify: `desktop/src/hooks/useWidgetActions.ts:34-70`
+
+- [ ] **Step 1: Edit the toggle widget handler**
+
+`oldString`:
+```ts
+  const handleToggleWidget = useCallback(
+    (widgetId: string) => {
+      const enabledWidgets = prefs.widgets.enabledWidgets;
+      const isEnabled = enabledWidgets.includes(widgetId);
+      const nextEnabled = isEnabled
+        ? enabledWidgets.filter((id) => id !== widgetId)
+        : [...enabledWidgets, widgetId];
+      const nextOnTicker = isEnabled
+        ? prefs.widgets.widgetsOnTicker.filter((id) => id !== widgetId)
+        : [...prefs.widgets.widgetsOnTicker, widgetId];
+      const nextPinned = isEnabled
+        ? prefs.pinnedSources.filter((id) => id !== widgetId)
+        : prefs.pinnedSources;
+      const next: AppPreferences = {
+        ...prefs,
+        widgets: {
+          ...prefs.widgets,
+          enabledWidgets: nextEnabled,
+          widgetsOnTicker: nextOnTicker,
+        },
+        pinnedSources: nextPinned,
+      };
+      setPrefs(next);
+      savePrefs(next);
+```
+
+`newString`:
+```ts
+  const handleToggleWidget = useCallback(
+    (widgetId: string) => {
+      const enabledWidgets = prefs.widgets.enabledWidgets;
+      const isEnabled = enabledWidgets.includes(widgetId);
+      const nextEnabled = isEnabled
+        ? enabledWidgets.filter((id) => id !== widgetId)
+        : [...enabledWidgets, widgetId];
+      const nextOnTicker = isEnabled
+        ? prefs.widgets.widgetsOnTicker.filter((id) => id !== widgetId)
+        : [...prefs.widgets.widgetsOnTicker, widgetId];
+      const next: AppPreferences = {
+        ...prefs,
+        widgets: {
+          ...prefs.widgets,
+          enabledWidgets: nextEnabled,
+          widgetsOnTicker: nextOnTicker,
+        },
+      };
+      setPrefs(next);
+      savePrefs(next);
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: errors only in `preferences.ts` (the field decl + default + reset + load).
+
+### Task 2.9: Drop `pinnedSources` from `preferences.ts`
+
+**Files:**
+- Modify: `desktop/src/preferences.ts:380-387, 555, 901, 966`
+
+- [ ] **Step 1: Drop the field declaration**
+
+`oldString`:
+```ts
+  channelDisplay: ChannelDisplayPrefs;
+  /** Channel/widget IDs pinned to the sidebar for quick access. */
+  pinnedSources: string[];
+  /** Per-channel homepage preview selections (up to 5 group keys). */
+```
+
+`newString`:
+```ts
+  channelDisplay: ChannelDisplayPrefs;
+  /** Per-channel homepage preview selections (up to 5 group keys). */
+```
+
+- [ ] **Step 2: Drop default value**
+
+Find the `DEFAULT_PREFERENCES` (or similarly named) constant and drop the `pinnedSources: [],` line. Use grep to locate the exact line:
+
+```bash
+cd desktop && grep -n "pinnedSources: \[\]" src/preferences.ts
+```
+
+Expected: 2 hits (one in the `DEFAULT_PREFERENCES` literal, one in `resetAll`). For each, use Edit to remove the entire line including its trailing comma.
+
+For DEFAULT_PREFERENCES `oldString`:
+```ts
+  pinnedSources: [],
+```
+`newString`: (empty — delete the line). Use `replaceAll: false` and verify the diff.
+
+If there's ambiguity between two occurrences, use the surrounding context to disambiguate. Example for DEFAULT_PREFERENCES:
+
+`oldString`:
+```ts
+  channelDisplay: DEFAULT_CHANNEL_DISPLAY,
+  pinnedSources: [],
+  homePreview: DEFAULT_HOME_PREVIEW,
+```
+
+`newString`:
+```ts
+  channelDisplay: DEFAULT_CHANNEL_DISPLAY,
+  homePreview: DEFAULT_HOME_PREVIEW,
+```
+
+- [ ] **Step 3: Drop loadPrefs read**
+
+`oldString`:
+```ts
+        pinnedSources: Array.isArray(source.pinnedSources) ? source.pinnedSources : [],
+```
+
+`newString`: (empty — delete the entire line)
+
+If there's a comma issue, also delete the trailing comma manually after the edit.
+
+- [ ] **Step 4: Drop resetAll write**
+
+Use the same Edit pattern with surrounding context for the `resetAll` case:
+
+```bash
+cd desktop && grep -n "pinnedSources" src/preferences.ts
+```
+
+Expected: 0 hits after this step.
+
+- [ ] **Step 5: Verify everything compiles**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: clean.
+
+```bash
+cd desktop && npx vitest run 2>&1 | tail -10
+```
+Expected: 154 tests passing (no test references `pinnedSources`; behavior unchanged for ticker/feed/preferences-migration tests).
+
+```bash
+cd desktop && npm run build 2>&1 | tail -10
+```
+Expected: vite build clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add desktop/
+git commit -m "refactor(sidebar): remove pin-to-sidebar feature
+
+Sidebar visibility is now derived: enabled channels (from
+dashboard.channels filtered to enabled === true) plus enabled widgets
+(from prefs.widgets.enabledWidgets), sorted via the shared
+CANONICAL_ORDER from marketplace.ts.
+
+Removes:
+- prefs.pinnedSources field, default, loadPrefs read, resetAll
+- Pin/PinOff button block in CatalogCard
+- handleTogglePin in catalog.tsx
+- pinnedSources writes in handleAdd, handleRemove
+- pinnedIds in OnboardingWizard finish-prefs
+- pinnedSources cleanup in useChannelActions, useWidgetActions
+
+Migration: stale 'pinnedSources' keys in users' saved JSON are
+silently ignored. Existing users with enabled-but-unpinned channels
+will see those channels appear in the sidebar after upgrade — the
+intended new behavior. The 'visible' flag on Channel is intentionally
+NOT consulted for sidebar visibility (visibility is a feed-level
+filter, not a navigation gate).
+
+The unrelated ticker-edge widget pin (prefs.widgets.pinnedWidgets,
+useWidgetPin, TickerPinSection) is untouched."
+```
+
+---
+
+## Phase 3 — Item 6: Ticker chip click → external URL
+
+### Task 3.1: Create `chipUrl.ts` utility with TDD
+
+**Files:**
+- Create: `desktop/src/utils/chipUrl.ts`
+- Create: `desktop/src/utils/chipUrl.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `desktop/src/utils/chipUrl.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  buildYahooLeagueUrl,
+  buildYahooPlayerUrl,
+  chipUrlForFinance,
+  chipUrlForSports,
+  chipUrlForRss,
+} from "./chipUrl";
+
+describe("buildYahooLeagueUrl", () => {
+  it("constructs a football league URL from an NFL league_key", () => {
+    expect(buildYahooLeagueUrl("nfl.l.420")).toBe(
+      "https://football.fantasysports.yahoo.com/nfl/420",
+    );
+  });
+
+  it("constructs a basketball league URL from an NBA league_key", () => {
+    expect(buildYahooLeagueUrl("nba.l.12345")).toBe(
+      "https://basketball.fantasysports.yahoo.com/nba/12345",
+    );
+  });
+
+  it("constructs a hockey league URL from an NHL league_key", () => {
+    expect(buildYahooLeagueUrl("nhl.l.78")).toBe(
+      "https://hockey.fantasysports.yahoo.com/nhl/78",
+    );
+  });
+
+  it("constructs a baseball league URL from an MLB league_key", () => {
+    expect(buildYahooLeagueUrl("mlb.l.999")).toBe(
+      "https://baseball.fantasysports.yahoo.com/mlb/999",
+    );
+  });
+
+  it("returns undefined for an unrecognized game_code prefix", () => {
+    expect(buildYahooLeagueUrl("xyz.l.1")).toBeUndefined();
+  });
+
+  it("returns undefined when league_key cannot be parsed", () => {
+    expect(buildYahooLeagueUrl("not-a-key")).toBeUndefined();
+  });
+});
+
+describe("buildYahooPlayerUrl", () => {
+  it("constructs an NFL player URL from a player_key", () => {
+    expect(buildYahooPlayerUrl("nfl.p.30977")).toBe(
+      "https://sports.yahoo.com/nfl/players/30977/",
+    );
+  });
+
+  it("constructs an MLB player URL", () => {
+    expect(buildYahooPlayerUrl("mlb.p.10001")).toBe(
+      "https://sports.yahoo.com/mlb/players/10001/",
+    );
+  });
+
+  it("returns undefined when player_key cannot be parsed", () => {
+    expect(buildYahooPlayerUrl("nfl-p-30977")).toBeUndefined();
+  });
+
+  it("returns undefined for an unrecognized game_code prefix", () => {
+    expect(buildYahooPlayerUrl("xyz.p.99")).toBeUndefined();
+  });
+});
+
+describe("chipUrlForFinance", () => {
+  it("returns the trade.link when populated", () => {
+    expect(chipUrlForFinance({ link: "https://www.google.com/finance/quote/AAPL:NASDAQ" } as never)).toBe(
+      "https://www.google.com/finance/quote/AAPL:NASDAQ",
+    );
+  });
+
+  it("returns undefined when link is empty", () => {
+    expect(chipUrlForFinance({ link: "" } as never)).toBeUndefined();
+  });
+
+  it("returns undefined when link is missing", () => {
+    expect(chipUrlForFinance({} as never)).toBeUndefined();
+  });
+});
+
+describe("chipUrlForSports", () => {
+  it("returns the game.link when populated", () => {
+    expect(chipUrlForSports({ link: "https://www.espn.com/nfl/game/_/gameId/123" } as never)).toBe(
+      "https://www.espn.com/nfl/game/_/gameId/123",
+    );
+  });
+
+  it("returns undefined when link is empty", () => {
+    expect(chipUrlForSports({ link: "" } as never)).toBeUndefined();
+  });
+});
+
+describe("chipUrlForRss", () => {
+  it("returns the item.link when populated", () => {
+    expect(chipUrlForRss({ link: "https://example.com/article/1" } as never)).toBe(
+      "https://example.com/article/1",
+    );
+  });
+
+  it("returns undefined when link is empty", () => {
+    expect(chipUrlForRss({ link: "" } as never)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd desktop && npx vitest run src/utils/chipUrl.test.ts 2>&1 | tail -20
+```
+Expected: FAIL — `Cannot find module './chipUrl'` or `chipUrl.ts not found`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `desktop/src/utils/chipUrl.ts`:
+
+```ts
+/**
+ * URL builders for ticker chip clicks. The handler in `App.tsx` routes
+ * a click to the OS shell when these helpers return a string, and
+ * falls back to opening the desktop app's main window otherwise.
+ *
+ * Trade/Game/RssItem already carry a server-populated `link` field —
+ * these helpers just unwrap it. Fantasy chips construct URLs from the
+ * Yahoo `league_key` / `player_key` namespacing scheme since neither
+ * the league nor the player URL is currently surfaced through the
+ * Go layer of the fantasy channel.
+ *
+ * Yahoo Fantasy URL format:
+ *   league: https://{sport}.fantasysports.yahoo.com/{game_code}/{league_id}
+ *   player: https://sports.yahoo.com/{game_code}/players/{player_id}/
+ *
+ * `league_key` shape: "{game_code}.l.{league_id}" (e.g. "nfl.l.420").
+ * `player_key` shape: "{game_code}.p.{player_id}" (e.g. "nfl.p.30977").
+ */
+
+import type { Trade, Game, RssItem } from "../types";
+
+/** Yahoo's per-sport subdomain prefix on fantasysports.yahoo.com. */
+const SPORT_PREFIX: Record<string, string> = {
+  nfl: "football",
+  nba: "basketball",
+  nhl: "hockey",
+  mlb: "baseball",
+};
+
+export function buildYahooLeagueUrl(leagueKey: string): string | undefined {
+  const parts = leagueKey.split(".l.");
+  if (parts.length !== 2) return undefined;
+  const [gameCode, leagueId] = parts;
+  const prefix = SPORT_PREFIX[gameCode];
+  if (!prefix) return undefined;
+  return `https://${prefix}.fantasysports.yahoo.com/${gameCode}/${leagueId}`;
+}
+
+export function buildYahooPlayerUrl(playerKey: string): string | undefined {
+  const parts = playerKey.split(".p.");
+  if (parts.length !== 2) return undefined;
+  const [gameCode, playerId] = parts;
+  if (!SPORT_PREFIX[gameCode]) return undefined;
+  return `https://sports.yahoo.com/${gameCode}/players/${playerId}/`;
+}
+
+export function chipUrlForFinance(trade: Trade): string | undefined {
+  return trade.link && trade.link.length > 0 ? trade.link : undefined;
+}
+
+export function chipUrlForSports(game: Game): string | undefined {
+  return game.link && game.link.length > 0 ? game.link : undefined;
+}
+
+export function chipUrlForRss(item: RssItem): string | undefined {
+  return item.link && item.link.length > 0 ? item.link : undefined;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd desktop && npx vitest run src/utils/chipUrl.test.ts 2>&1 | tail -20
+```
+Expected: PASS — all tests in chipUrl.test.ts pass.
+
+- [ ] **Step 5: Run the full test suite to verify no regressions**
+
+```bash
+cd desktop && npx vitest run 2>&1 | tail -10
+```
+Expected: all 154 (now 154+12 = 166) tests passing.
+
+### Task 3.2: Wire `onChipClick` to receive an optional URL
+
+**Files:**
+- Modify: `desktop/src/components/ScrollrTicker.tsx:40, 168, 206, 221, 252, 275, 300, 453`
+
+- [ ] **Step 1: Extend the prop signature**
+
+`oldString` (in `desktop/src/components/ScrollrTicker.tsx`):
+```ts
+  onChipClick?: (channelType: string, itemId: string | number) => void;
+```
+
+`newString`:
+```ts
+  /** Click handler. The optional `url` argument is set when the
+   * underlying chip has an external destination (article link, game
+   * page, etc.). When undefined, the consumer should fall back to
+   * opening the in-app channel page. */
+  onChipClick?: (channelType: string, itemId: string | number, url?: string) => void;
+```
+
+- [ ] **Step 2: Add chipUrl imports**
+
+Find the imports section near the top of `ScrollrTicker.tsx`. Add:
+
+`oldString` (the line referencing `types`):
+```ts
+import type { ... } from "../types";
+```
+
+(Use the existing types import; just add chipUrl alongside.)
+
+Add a new import line:
+```ts
+import { buildYahooLeagueUrl, buildYahooPlayerUrl, chipUrlForFinance, chipUrlForSports, chipUrlForRss } from "../utils/chipUrl";
+```
+
+- [ ] **Step 3: Update each chip wrap site to compute and pass URL**
+
+There are six wrap sites in `ScrollrTicker.tsx`. Each currently calls `onChipClick?.(...)` with two arguments. Update each to pass a third URL argument.
+
+For the `TradeChip` site (line 252 area):
+
+`oldString`:
+```ts
+            onClick={() => onChipClick?.("finance", trade.symbol)}
+```
+
+`newString`:
+```ts
+            onClick={() => onChipClick?.("finance", trade.symbol, chipUrlForFinance(trade))}
+```
+
+For the `GameChip` site (line 275 area):
+
+`oldString`:
+```ts
+            onClick={() => onChipClick?.("sports", game.id)}
+```
+
+`newString`:
+```ts
+            onClick={() => onChipClick?.("sports", game.id, chipUrlForSports(game))}
+```
+
+For the `RssChip` site (line 300 area):
+
+`oldString`:
+```ts
+            onClick={() => onChipClick?.("rss", item.id)}
+```
+
+`newString`:
+```ts
+            onClick={() => onChipClick?.("rss", item.id, chipUrlForRss(item))}
+```
+
+For the `FantasyStatChip` site (line 221 area):
+
+`oldString`:
+```ts
+            onClick={() => onChipClick?.("fantasy", league.league_key)}
+```
+
+`newString`:
+```ts
+            onClick={() => onChipClick?.("fantasy", league.league_key, buildYahooLeagueUrl(league.league_key))}
+```
+
+For the `FollowedPlayerChip` site (line 206 area):
+
+`oldString`:
+```ts
+                onClick={() => onChipClick?.("fantasy", playerKey)}
+```
+
+`newString`:
+```ts
+                onClick={() => onChipClick?.("fantasy", playerKey, buildYahooPlayerUrl(playerKey))}
+```
+
+(Confirmed during planning: the wrap-site loop iterates `fantasyPrefs.followedPlayerKeys` and only has `playerKey` in scope. We extract `game_code` from the key prefix inside `buildYahooPlayerUrl` itself, avoiding the parent-league lookup.)
+
+For the `ConsolidatedChip` sites (lines 168 and 453 — widget chips):
+
+`oldString` (each occurrence — use replaceAll if both are identical, otherwise use surrounding context):
+```ts
+            onClick={() => onChipClick?.(wt, wt)}
+```
+
+`newString`:
+```ts
+            // Widget chips don't have a meaningful external URL —
+            // omit the third argument so handleChipClick falls back
+            // to opening the desktop app on the widget's page.
+            onClick={() => onChipClick?.(wt, wt)}
+```
+
+(Adding only a comment for documentation; the call signature stays two-arg. The optional third arg will simply be undefined.)
+
+- [ ] **Step 4: Verify**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: errors in App.tsx (the consumer hasn't been updated) or clean.
+
+### Task 3.3: Update `handleChipClick` in `App.tsx`
+
+**Files:**
+- Modify: `desktop/src/App.tsx:344-352`
+
+- [ ] **Step 1: Add the shell-open import**
+
+Find the existing imports at the top of `App.tsx`. Add or extend:
+
+If `@tauri-apps/plugin-shell` is not yet imported in this file, add:
+```ts
+import { open } from "@tauri-apps/plugin-shell";
+```
+
+(Confirm via `grep -n "tauri-apps/plugin-shell" desktop/src/App.tsx`. If already present from another import, augment that import.)
+
+- [ ] **Step 2: Replace the handler**
+
+`oldString`:
+```ts
+  // ── Chip click → open app window on that channel ───────────────
+
+  const handleChipClick = useCallback(
+    (channelType: string, _itemId: string | number) => {
+      savePref("activeItem", channelType);
+      invoke("show_app_window").catch(() => {});
+    },
+    [],
+  );
+```
+
+`newString`:
+```ts
+  // ── Chip click → open external URL (or fall back to app) ───────
+
+  const handleChipClick = useCallback(
+    (channelType: string, _itemId: string | number, url?: string) => {
+      if (url) {
+        open(url).catch((err) => {
+          console.error("[Scrollr] Failed to open external URL:", err);
+        });
+        return;
+      }
+      // No URL (widget chip, missing data) — fall back to opening
+      // the desktop app on the relevant channel/widget page.
+      savePref("activeItem", channelType);
+      invoke("show_app_window").catch(() => {});
+    },
+    [],
+  );
+```
+
+- [ ] **Step 3: Verify everything compiles**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: clean.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+cd desktop && npx vitest run 2>&1 | tail -10
+```
+Expected: all tests passing.
+
+- [ ] **Step 5: Run a full build**
+
+```bash
+cd desktop && npm run build 2>&1 | tail -10
+```
+Expected: vite build + tsc clean, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add desktop/
+git commit -m "feat(ticker): chip click opens external URL via shell.open
+
+Trade, Game, and RssItem already carry a server-populated 'link' field
+(Google Finance for finance, api-sports.io for sports, the article URL
+for RSS). Fantasy league and followed-player chips construct Yahoo
+fantasy URLs from the league_key/player_key namespacing scheme.
+Widget chips (clock/weather/sysmon/uptime/github) keep the existing
+'open app' behavior since they have no meaningful external URL.
+
+Adds:
+- desktop/src/utils/chipUrl.ts: URL builders + Yahoo helpers
+- desktop/src/utils/chipUrl.test.ts: 12 unit tests covering the
+  Yahoo subdomain mapping and key-parsing edge cases
+
+Modifies:
+- ScrollrTicker.tsx: extends onChipClick signature with optional URL
+  third argument, computes URL at each chip wrap site
+- App.tsx: branches handleChipClick on URL presence; uses
+  @tauri-apps/plugin-shell's open() for external URLs and falls back
+  to invoke('show_app_window') for the widget case"
+```
+
+---
+
+## Phase 4 — Final verification + push
+
+### Task 4.1: Run the full verification suite
+
+- [ ] **Step 1: Marketing site lint+format (sanity check, untouched in this PR)**
+
+```bash
+cd myscrollr.com && npm run check 2>&1 | tail -5
+```
+Expected: clean (we didn't touch myscrollr.com).
+
+- [ ] **Step 2: Desktop typecheck**
+
+```bash
+cd desktop && npx tsc --noEmit 2>&1 | tail -10
+```
+Expected: empty output.
+
+- [ ] **Step 3: Desktop tests**
+
+```bash
+cd desktop && npx vitest run 2>&1 | tail -10
+```
+Expected: all 154+12 = 166 tests passing.
+
+- [ ] **Step 4: Desktop build**
+
+```bash
+cd desktop && npm run build 2>&1 | tail -10
+```
+Expected: vite + tsc clean.
+
+- [ ] **Step 5: Rust check**
+
+```bash
+cd desktop && cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | tail -5
+```
+Expected: clean (we didn't touch Rust, but verify no incidental drift).
+
+### Task 4.2: Push branch and open PR
+
+- [ ] **Step 1: Push the feature branch**
+
+```bash
+git push -u origin feature/batch-a-quick-fixes 2>&1 | tail -5
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "fix(desktop): updater seed + remove pin-to-sidebar + ticker chip external URLs" --body "$(cat <<'EOF'
+## Summary
+
+Three independent quick fixes from the Batch A spec at \`docs/superpowers/specs/2026-04-28-batch-a-quick-fixes-design.md\`:
+
+1. **Updater false-positive on Windows** — seed \`KEY_LAST_UPDATE_DATE\` on first version-match check so MSI users stop seeing 'update available' against the same version they're running.
+2. **Pin-to-sidebar removal** — sidebar now derives from enabled channels (\`dashboard.channels\` filtered to \`enabled\`) + enabled widgets (\`prefs.widgets.enabledWidgets\`), sorted via the shared \`CANONICAL_ORDER\`. The Pin/Unpin button on catalog cards is gone.
+3. **Ticker chip click → external URL** — RSS chips open the article, finance chips open Google Finance, sports chips open ESPN, fantasy chips open Yahoo. Widget chips keep their current 'open app' behavior.
+
+Three logical commits, one per item, reviewable in isolation. Squash-merge as one batch.
+
+## Verification
+
+- \`npm run check\` clean (marketing site untouched)
+- \`npx tsc --noEmit\` clean (desktop)
+- \`npx vitest run\` 166 tests passing (was 154; +12 from \`chipUrl.test.ts\`)
+- \`npm run build\` clean (desktop)
+- \`cargo check\` clean (Rust untouched)
+
+## Migration notes
+
+- Existing users will have a stale \`pinnedSources\` key in their saved JSON. It's silently ignored. Sidebar starts showing every enabled channel/widget after upgrade — the intended new behavior.
+- Windows users who previously saw 'update available' on every check will see 'up-to-date' on their next \`Check for updates\` once the seed step runs.
+
+## Risks
+
+- The updater seed assumes the user's installed build matches the latest GitHub release \`pub_date\`. A user who manually downloads an OLDER MSI will silently miss the patch they're behind on. Documented in the spec; acceptable.
+- The Yahoo URL construction is deterministic for the four supported sports (nfl/nba/nhl/mlb). For an unrecognized \`game_code\`, the URL falls back to undefined and the chip opens the desktop app instead.
+
+## Related
+
+- Spec: \`docs/superpowers/specs/2026-04-28-batch-a-quick-fixes-design.md\`
+- Plan: \`docs/superpowers/plans/2026-04-28-batch-a-quick-fixes.md\`
+- Next: Batch B (\`/users/me/overview\` API + client refactor), then Batch C (settings IA redesign + website support page).
+EOF
+)" 2>&1 | tail -3
+```
+
+Expected: prints the PR URL.
+
+---
+
+## Out of scope (deferred to Batch B / C)
+
+- Surfacing Yahoo's native \`data.url\` and per-player \`url\` through the Go layer (defer to Batch B if/when client-side construction proves insufficient).
+- Settings IA redesign (Batch C).
+- \`GET /users/me/overview\` endpoint + both clients (Batch B).
+- Website \`/support\` route and contact form (Batch C).
+
+## Acceptance criteria
+
+- All four verification steps in Task 4.1 pass.
+- PR opens cleanly with three logical commits visible in the diff view.
+- Manual smoke test (post-merge, on a dev build) confirms:
+  - Catalog Add → channel appears in sidebar without a Pin step.
+  - Catalog Remove → channel disappears from sidebar.
+  - Onboarding finishes → enabled picks appear in sidebar.
+  - Each chip type clicks open the right URL: finance → Google Finance, sports → ESPN, RSS → article, fantasy league → Yahoo league page, fantasy player → Yahoo player page.
+  - Widget chip click → main app window appears.
+  - "Check for updates" on a v1.0.3 dev build returns "up-to-date" and writes \`KEY_LAST_UPDATE_DATE\`.
+- Windows MSI verification of the updater fix happens after merge with an MSI test build.

--- a/docs/superpowers/specs/2026-04-28-batch-a-quick-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-28-batch-a-quick-fixes-design.md
@@ -1,0 +1,242 @@
+# Batch A — Quick Fixes Design
+
+**Date:** 2026-04-28
+**Status:** Approved (decisions locked, awaiting spec sign-off before plan)
+**Scope:** Three independent, low-risk desktop fixes that ship as one PR
+**Sequence:** First in a three-batch plan (A → B → C). B = unified `/users/me/overview` API + client refactor. C = settings IA redesign + website support page.
+
+---
+
+## Why these three are batched
+
+Items 1, 3, 6 from the user's six-item list share three traits:
+
+1. **Atomic** — each lives in 1–7 files, no API changes, no migrations.
+2. **Independent** — none touches the others' files. Three disjoint diffs in one PR.
+3. **Visible** — each fixes a user-facing complaint (false update banner, pin/unpin friction, dead-end ticker clicks).
+
+Batches B and C have larger blast radius and depend on data shape decisions that this batch leaves untouched. Shipping A first removes three sources of UX confusion before we redesign the IA in C.
+
+---
+
+## Item 1 — Updater false-positive on Windows
+
+### Symptom
+
+Running "Check for updates" on Windows always reports an update available, even when the user is on the latest published version. macOS and Linux do not show this behavior in practice.
+
+### Root cause
+
+Two cooperating mechanisms are in play and one of them only seeds itself when the user already used the in-app updater:
+
+- **Rust comparator** — `desktop/src-tauri/src/lib.rs:36` registers `default_version_comparator(|current, remote| remote.version >= current)`. The `>=` is intentional — it allows a "patched rebuild" pattern where we re-issue an existing version (e.g., `1.0.3`) with a fix without bumping the version number. Same version, newer asset, updater picks it up.
+- **JS guard** — `desktop/src/components/settings/GeneralSettings.tsx:124–163` reads `KEY_LAST_UPDATE_DATE` from the Tauri store and, when versions match, compares the stored date to the remote `update.date` (the manifest's `pub_date`). If they match, the update is suppressed.
+
+The bug is that `KEY_LAST_UPDATE_DATE` is only ever **written** in one path — the post-`downloadAndInstall` reconcile loop at `GeneralSettings.tsx:107–115`. That path requires the user to have actually run an in-app update.
+
+Windows users overwhelmingly install via the MSI manual download from GitHub Releases. They never trigger the in-app updater, so `KEY_LAST_UPDATE_DATE` is never seeded. Every subsequent in-app check sees an empty store, the JS guard short-circuits (line 140: `storedDate &&` is falsy), and the UI happily shows `step: "available"` with `isPatch: true`.
+
+macOS and Linux users typically install once via DMG/AppImage/deb and then ride the in-app updater for subsequent versions, which seeds the key. Same code path, different real-world install habits.
+
+### Fix
+
+Seed `KEY_LAST_UPDATE_DATE` on the first in-app check that returns "you are on this version". Specifically, in `GeneralSettings.tsx`'s check handler, when `update.version === appVersion`:
+
+- If `KEY_LAST_UPDATE_DATE` is null → write `update.date` to the store and set `step: "up-to-date"`. This bootstraps the guard for fresh installs and existing-but-empty stores.
+- If `update.date === storedDate` → set `step: "up-to-date"`.
+- If `update.date !== storedDate` → genuine patched rebuild, set `step: "available"` with `isPatch: true`.
+
+The Rust comparator stays untouched. The "patched rebuild" feature is preserved.
+
+### Trade-off
+
+If a Windows user manually installs an older MSI than the latest GitHub release, the seed step records the LATER `pub_date` as "the one I'm on" and they never see the patch they're actually missing. This requires the user to deliberately download an older asset, which is rare. Acceptable.
+
+### Files
+
+- `desktop/src/components/settings/GeneralSettings.tsx` — only file touched. Modify the body of the `handleCheck` callback at the version-match branch (~line 124–163).
+
+---
+
+## Item 3 — Remove pin-to-sidebar feature
+
+### Symptom
+
+The catalog page exposes a Pin/Unpin button on each enabled channel/widget card. The "pin" controls whether the channel/widget appears in the left sidebar nav. Users find the extra step confusing — they expect adding a channel to make it sidebar-visible, which is what `handleAdd` already auto-does on first install. The Pin/Unpin button only matters if the user wants to keep a source enabled but hide its sidebar entry, which nobody does in practice.
+
+### Approach
+
+Remove the feature entirely. Sidebar visibility becomes a derived state of `Channel.enabled === true` (for channels) and presence in `prefs.widgets.enabledWidgets` (for widgets). Sort order pulls from the existing `[...CHANNEL_ORDER, ...WIDGET_ORDER]` constant in `catalog.tsx:37`.
+
+`Channel.visible` is **not** part of the sidebar rule. Visibility is a feed-level filter (hide a channel from today's feed without removing it). The sidebar is navigation. Mixing them would lock a user out of navigating to a channel's config page when they have it temporarily hidden, which is the wrong UX.
+
+### Distinguishing the two pin concepts
+
+The codebase has **two unrelated "pin" features** that share Lucide icons. Only the first is being removed:
+
+| Concept | Field | Where | Status |
+|---|---|---|---|
+| **Sidebar pin** | `prefs.pinnedSources: string[]` | `catalog.tsx`, `Sidebar.tsx`, `__root.tsx` | **REMOVE** |
+| **Ticker-edge pin** | `prefs.widgets.pinnedWidgets: Record<string, {side, row?}>` | `useWidgetPin`, `TickerPinSection`, `ConsolidatedChip` | **KEEP** (unrelated) |
+
+Tooltips disambiguate: sidebar pin says "Pin to sidebar"; ticker-edge pin says "Pin widget". The implementation correctly keeps these separate; this spec only touches the first.
+
+### Migration
+
+`pinnedSources` is dropped from `AppPreferences`. `loadPrefs` simply stops reading the field. Old persisted JSON retains a stale `pinnedSources` key that is never read again — harmless dead data.
+
+The user-visible side effect: a user who had `finance` enabled-but-unpinned will see `finance` newly appear in their sidebar after upgrading. This is the intended new behavior. There is no way to preserve "I want my sidebar empty" because that affordance is being removed by design.
+
+### Files (delete)
+
+| File | Lines | What |
+|---|---|---|
+| `desktop/src/preferences.ts` | 382, 555, 901, 966 | Field decl, default, loadPrefs read, reset |
+| `desktop/src/components/marketplace/CatalogCard.tsx` | 3, 31, 39–40, 50, 57, 166–184 | `Pin/PinOff` imports, props, button block |
+| `desktop/src/routes/catalog.tsx` | 88–95, 99–105, 115–124, 130, 134–135, 144, 198, 205 | Pinned writes in handleAdd/handleRemove, handleTogglePin, props |
+| `desktop/src/components/onboarding/OnboardingWizard.tsx` | 259–271 | `pinnedIds` calc and `pinnedSources` write |
+| `desktop/src/hooks/useChannelActions.ts` | 73–79 | Cleanup block on channel delete |
+| `desktop/src/hooks/useWidgetActions.ts` | 44–46, 54 | Cleanup block on widget toggle off |
+
+### Files (rewire)
+
+| File | Lines | What |
+|---|---|---|
+| `desktop/src/routes/__root.tsx` | 376–391, 548 | Replace `resolvedPinnedSources` memo with one reading `dashboard.channels` (filtered to `enabled === true`) + `prefs.widgets.enabledWidgets`, sorted via canonical order. |
+| `desktop/src/components/Sidebar.tsx` | 73–79, 94, 121, 194–207 | Rename `pinnedSources` prop to `sources` (semantic clarity, not strictly required). Internal interface `PinnedSource` renamed to `SidebarSource`. |
+
+### Sort key
+
+The catalog already defines a canonical sort order. Extract `CANONICAL_ORDER = [...CHANNEL_ORDER, ...WIDGET_ORDER]` from `catalog.tsx:37` into a shared module (e.g., `desktop/src/lib/catalogOrder.ts`) so the sidebar memo and the catalog grid share the constant. This ensures the sidebar order and the catalog order stay in sync.
+
+### Verify
+
+- Catalog: Add → channel/widget appears in sidebar. Remove → it disappears. No Pin button anywhere.
+- Onboarding: complete the wizard, sidebar populates with the picks.
+- Settings: ticker-edge pin still works. Tray "Pin on Top" (always-on-top window) still works (uses `window.pinned`, different field).
+- Persistence: a user upgrading from v1.0.3 with `pinnedSources` written sees old data ignored, sidebar populates from enabled state.
+
+---
+
+## Item 6 — Ticker chip click opens external URL
+
+### Symptom
+
+Clicking any chip in the ticker opens the desktop app's main window via `invoke("show_app_window")`. Users expect the click to navigate to the external destination — the article URL for an RSS chip, the symbol's vendor page for a finance chip, the league/player URL for a fantasy chip.
+
+### Approach
+
+Pass an optional `url` parameter through the chip's `onClick` callback chain. When present, the click handler calls `open(url)` from `@tauri-apps/plugin-shell` (already installed). When absent, fall back to the current "open app" behavior so widget chips (clock, weather, sysmon, uptime, github) keep their existing interaction.
+
+### URL sources
+
+| Chip | Source | Construction |
+|---|---|---|
+| **TradeChip** | `Trade.link` | Already populated by Rust ingestion service (`channels/finance/service/src/lib.rs:159`). No backend change. |
+| **GameChip** | `Game.link` | Already populated by Rust ingestion service (`channels/sports/api/models.go:11`). No backend change. |
+| **RssChip** | `RssItem.link` | Already populated from the feed's `<link>` element. No backend change. |
+| **FantasyStatChip** | constructed | `https://{prefix}.fantasysports.yahoo.com/{game_code}/{league_id}` where `league_id = league_key.split('.l.')[1]` and `prefix` maps `nfl→football, nba→basketball, nhl→hockey, mlb→baseball`. |
+| **FollowedPlayerChip** | constructed | `https://sports.yahoo.com/{game_code}/players/{player_id}/` where `player_id = player_key.split('.p.')[1]`. `game_code` comes from the parent `LeagueResponse` already passed in via the `leagues` prop. |
+| **ConsolidatedChip** (widgets) | none | Returns `undefined` — handler falls back to "open app". |
+
+Backend additions (surfacing Yahoo's native `data.url` and per-player `url`) are deferred. Client-side construction is deterministic and good enough for Batch A.
+
+### New file
+
+`desktop/src/utils/chipUrl.ts` — central helper module:
+
+```ts
+export function chipUrl(channelType: string, data: ...): string | undefined
+function buildYahooLeagueUrl(leagueKey: string, gameCode: string): string
+function buildYahooPlayerUrl(playerKey: string, gameCode: string): string
+const SPORT_PREFIX: Record<string, string>
+```
+
+### Modified files
+
+| File | What |
+|---|---|
+| `desktop/src/components/ScrollrTicker.tsx` | Extend `onChipClick` signature to `(channelType, itemId, url?: string) => void`. Wire `chipUrl(...)` into each chip's onClick payload. |
+| `desktop/src/App.tsx` | Update `handleChipClick(channelType, itemId, url?)`. If `url`, call `open(url)`. Else fall back to `savePref("activeItem", channelType)` + `invoke("show_app_window")`. |
+
+### Chip components touched
+
+- `desktop/src/components/chips/TradeChip.tsx` — pass `trade.link`
+- `desktop/src/components/chips/GameChip.tsx` — pass `game.link`
+- `desktop/src/components/chips/RssChip.tsx` — pass `item.link`
+- `desktop/src/components/chips/FantasyStatChip.tsx` — pass constructed league URL
+- `desktop/src/components/chips/FollowedPlayerChip.tsx` — pass constructed player URL
+- `desktop/src/components/chips/ConsolidatedChip.tsx` — pass `undefined` (widgets keep open-app behavior)
+
+### Error handling
+
+`open()` rejects on the rare cases the OS shell can't handle the URL. Wrap in `.catch(err => console.error(...))` so a malformed URL never blocks subsequent clicks. Do not surface a user-facing error toast for this — it's a click handler, the user can just click again.
+
+### Verify
+
+- Click each chip type, confirm it opens the right URL in the default browser.
+- Click a widget chip, confirm the app window opens (current behavior).
+- Click a chip with an empty `link` field (e.g., RSS feed that returned no `<link>`) — falls back to `RssItem.feed_url` (consider this; if undesired, falls back to opening the app instead). Defer that fallback to implementation; the simpler "no link → open app" behavior is acceptable for Batch A.
+
+---
+
+## Cross-cutting concerns
+
+### Testing
+
+Manual smoke test only. No new unit tests. The behavioral changes are all in click handlers and a memo rewire — already covered indirectly by the existing 154-test Vitest suite (which exercises preferences shape, view selectors, and chip URL construction would be a natural follow-up if drift is observed).
+
+The Item 3 deletion makes existing tests in `preferences.test.ts` more strict (the field is gone, so any reference would fail to compile). No tests today reference `pinnedSources`, so no test changes required.
+
+### Bundle size
+
+Item 6 adds one small utility file (~50 lines) and pulls `@tauri-apps/plugin-shell`'s `open` into the App.tsx bundle (already used in 5 other places, so no new chunk).
+
+Item 3's deletions reduce overall bundle slightly. Item 1 is a behavior change in an already-bundled file.
+
+### Versioning
+
+Per the user's standing rule: not bumping desktop version for non-substantive changes. Batch A ships against v1.0.3 as a fresh asset replacement on the existing GitHub release.
+
+### PR shape
+
+Single PR titled `fix(desktop): updater seed + remove pin-to-sidebar + ticker chip external URLs`. Three logical commits, one per item, so each is reviewable in isolation:
+
+1. `fix(updater): seed KEY_LAST_UPDATE_DATE on first version-match check`
+2. `refactor(sidebar): remove pin-to-sidebar; sidebar now driven by enabled state`
+3. `feat(ticker): chip click opens external URL via shell.open`
+
+Squash-merge as one feature batch. Branch name: `feature/batch-a-quick-fixes`.
+
+---
+
+## Out of scope (deferred to Batch B / C)
+
+- Surfacing Yahoo's native `data.url` and per-player `url` through the Go layer (defer to Batch B if and when client-side construction proves insufficient).
+- Settings IA redesign (Batch C).
+- Account page parity / unified `/users/me/overview` endpoint (Batch B).
+- Website `/support` route and contact form (Batch C).
+- The "if RSS link is empty, fall back to feed_url" edge case — deferred unless observed in practice.
+
+---
+
+## Decisions locked
+
+| Decision | Choice |
+|---|---|
+| Updater fix approach | Seed `KEY_LAST_UPDATE_DATE` on first check |
+| Sidebar visibility rule | `Channel.enabled === true` (ignore `visible` flag) |
+| Fantasy chip URL source | Client-side construction from existing keys |
+| Widget chip click behavior | Keep current "open app" fallback |
+
+---
+
+## Acceptance criteria
+
+- `npm run check` clean (Prettier + ESLint, marketing site only — desktop has no lint config)
+- `npm run build` clean (`vite build && tsc --noEmit` for desktop)
+- `cargo check --manifest-path src-tauri/Cargo.toml` clean
+- `npm run test` green (existing 154-test Vitest suite)
+- Manual smoke test on macOS dev build covering: catalog Add/Remove flow, sidebar render after onboarding, ticker click for each chip type, "Check for updates" returns "up-to-date" when on latest
+
+Windows MSI verification of Item 1 happens after merge by either you or me — the seed-on-first-check fix is statically obvious but the actual Windows install path needs an MSI test build to confirm in situ.


### PR DESCRIPTION
## Summary

Three independent quick fixes from Batch A, shipped as one PR with three logical commits. Spec: `docs/superpowers/specs/2026-04-28-batch-a-quick-fixes-design.md`. Plan: `docs/superpowers/plans/2026-04-28-batch-a-quick-fixes.md`.

### Item 1 — Windows updater false-positive (`acbcbb3`)
Seed `KEY_LAST_UPDATE_DATE` on the first in-app check that returns a version match. Windows users overwhelmingly install via MSI manual download, so the post-`downloadAndInstall` reconcile loop never seeded the store and every subsequent Check for Updates falsely reported an update available. The new branch bootstraps the guard once on first check, then the existing `update.date === storedDate` suppression takes over. The "patched rebuild" pattern (re-issuing v1.0.3 with a fix without a version bump) is preserved — a genuinely new pub_date still falls through to the "available" branch.

### Item 3 — Pin-to-sidebar removal (`2253829`)
Sidebar visibility is now derived: enabled channels (`dashboard.channels` filtered to `enabled === true`) plus enabled widgets (`prefs.widgets.enabledWidgets`), sorted via the new `CANONICAL_ORDER` exported from `marketplace.ts`. `Channel.visible` is intentionally NOT consulted — visibility is a feed-level filter, not a navigation gate.

Removed:
- `prefs.pinnedSources` field, default, loadPrefs read, resetAll write
- Pin/PinOff button block in `CatalogCard`
- `handleTogglePin` in catalog
- `pinnedSources` writes in `handleAdd`/`handleRemove`
- `pinnedIds` calc in `OnboardingWizard`
- Cleanup blocks in `useChannelActions` and `useWidgetActions`

The unrelated **ticker-edge widget pin** (`prefs.widgets.pinnedWidgets`, `useWidgetPin`, `TickerPinSection`) is untouched — different feature.

Migration: stale `pinnedSources` keys in users' saved JSON are silently ignored. Existing users with enabled-but-unpinned channels will see those channels appear in the sidebar after upgrade — the intended new behavior.

### Item 6 — Ticker chip click → external URL (`73d899e`)
Trade, Game, and RssItem already carry server-populated `link` fields. Fantasy chips construct Yahoo URLs from the `league_key`/`player_key` namespacing scheme (`{game_code}.l.{league_id}` and `{game_code}.p.{player_id}`). Widget chips (clock/weather/sysmon/uptime/github) keep the existing "open app" behavior since they have no meaningful external destination.

Added:
- `desktop/src/utils/chipUrl.ts` — single-arg URL builders + Yahoo subdomain map
- `desktop/src/utils/chipUrl.test.ts` — 17 unit tests covering Yahoo URL parsing/construction edge cases

Modified:
- `ScrollrTicker.tsx` — extends `onChipClick` signature with optional `url?: string` third argument; computes URL at each chip wrap site
- `App.tsx` — branches `handleChipClick` on URL presence: `open(url)` from `@tauri-apps/plugin-shell` or fall back to `invoke("show_app_window")`

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — 171 tests passing (was 154; +17 from chipUrl tests)
- `npm run build` clean
- `cargo check` clean (Rust untouched)

## Risks

- The updater seed assumes the user's installed build matches the latest GitHub release `pub_date`. A user who manually downloads an OLDER MSI than the latest release will silently miss the patch they're actually behind on. Documented in the spec as acceptable; requires deliberate downgrade.
- The Yahoo URL construction is deterministic for the four supported sports (nfl/nba/nhl/mlb). For an unrecognized `game_code`, the URL falls back to undefined and the chip opens the desktop app instead.
- After upgrade, users who had the catalog Pin button disabled on certain enabled channels/widgets will now see those items appear in the sidebar. By design.

## Manual smoke test (post-merge)

- Catalog Add → channel/widget appears in sidebar without a Pin step. ✓
- Catalog Remove → it disappears from the sidebar. ✓
- Onboarding wizard finish → enabled picks appear in the sidebar.
- Each chip type click opens the right URL (finance → Google Finance, sports → ESPN, RSS → article, fantasy league → Yahoo league page, fantasy player → Yahoo player page).
- Widget chip click → main app window appears.
- Tray "Pin on Top" still works (it's a different field — `prefs.window.pinned`).
- "Check for updates" on a v1.0.3 dev build returns "up-to-date" and writes `KEY_LAST_UPDATE_DATE` (verify in DevTools localStorage).
- **Windows MSI verification** of the updater fix happens after merge with an MSI test build.

## Next

Batch B (`/users/me/overview` API + client refactor), then Batch C (settings IA redesign + website support page).