### PR TITLE
feat(account): unified /users/me/overview endpoint + both clients (v1.0.4)

### DIFF
--- a/api/core/auth.go
+++ b/api/core/auth.go
@@ -150,6 +150,20 @@ func ValidateAuth(c *fiber.Ctx) error {
 		c.Locals("user_email", email)
 	}
 
+	// Extract name + username (custom claims wired via Logto Custom JWT).
+	// The overview endpoint surfaces these to the client; a missing claim
+	// must coerce to empty string so callers can rely on .(string) reads.
+	if name, ok := claims["name"].(string); ok {
+		c.Locals("user_name", name)
+	} else {
+		c.Locals("user_name", "")
+	}
+	if username, ok := claims["username"].(string); ok {
+		c.Locals("user_username", username)
+	} else {
+		c.Locals("user_username", "")
+	}
+
 	return nil
 }
 

--- a/api/core/channels.go
+++ b/api/core/channels.go
@@ -326,6 +326,9 @@ func CreateChannel(c *fiber.Ctx) error {
 
 	// Invalidate dashboard cache so next poll gets fresh data
 	InvalidateDashboardCache(userID)
+	// Channel summary in the overview response changed — drop the
+	// per-user overview cache so the next /users/me/overview rebuilds.
+	InvalidateOverviewCache(ctx, userID)
 
 	return c.Status(fiber.StatusCreated).JSON(ch)
 }
@@ -471,6 +474,8 @@ func UpdateChannel(c *fiber.Ctx) error {
 
 	// Invalidate dashboard cache so next poll gets fresh data
 	InvalidateDashboardCache(userID)
+	// Enabled/visible toggles change the overview's by_type summary.
+	InvalidateOverviewCache(ctx, userID)
 
 	return c.JSON(ch)
 }
@@ -537,6 +542,8 @@ func DeleteChannel(c *fiber.Ctx) error {
 
 	// Invalidate dashboard cache so next poll gets fresh data
 	InvalidateDashboardCache(userID)
+	// Total/enabled counts in the overview are now stale.
+	InvalidateOverviewCache(ctx, userID)
 
 	return c.JSON(fiber.Map{"status": "ok", "message": "Channel removed"})
 }
@@ -590,6 +597,7 @@ func PruneUserChannelsForTier(ctx context.Context, logtoSub, tier string) {
 		callChannelLifecycle(ctx, ch.ChannelType, "updated", logtoSub, newConfig, ch.Config, nil)
 	}
 	InvalidateDashboardCache(logtoSub)
+	InvalidateOverviewCache(ctx, logtoSub)
 }
 
 // extractSportsLeaguesFromConfig reads the "leagues" array from a sports

--- a/api/core/handlers_overview.go
+++ b/api/core/handlers_overview.go
@@ -1,0 +1,506 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/redis/go-redis/v9"
+	"golang.org/x/sync/singleflight"
+)
+
+// ─── Response types ─────────────────────────────────────────────────
+
+// OverviewResponse is the unified read shape for GET /users/me/overview.
+// Single round-trip for the desktop account pane: identity, tier, billing,
+// channel summary, GDPR state, fantasy summary, and useful outbound links.
+//
+// The endpoint is cached per-user in Redis for 30s with singleflight in
+// front of the assemble path; cache invalidation hooks fire from the
+// Stripe webhook, channel CRUD handlers, and the GDPR request lifecycle
+// so user-visible state never lags more than one request.
+type OverviewResponse struct {
+	Identity     OverviewIdentity      `json:"identity"`
+	Tier         OverviewTier          `json:"tier"`
+	Subscription *SubscriptionResponse `json:"subscription"`
+	Channels     OverviewChannels      `json:"channels"`
+	Fantasy      *OverviewFantasy      `json:"fantasy"`
+	GDPR         OverviewGDPR          `json:"gdpr"`
+	Links        OverviewLinks         `json:"links"`
+}
+
+// OverviewIdentity carries the JWT-sourced identity claims. Username is
+// empty until the user picks one in the invite flow — clients render an
+// "claim your username" affordance when this is "".
+type OverviewIdentity struct {
+	Sub      string `json:"sub"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+}
+
+// OverviewTier resolves the tier from JWT roles and embeds the matching
+// limits row so clients don't need a second `/tier-limits` round-trip.
+type OverviewTier struct {
+	Current     string        `json:"current"`
+	IsSuperUser bool          `json:"is_super_user"`
+	Label       string        `json:"label"`
+	Limits      ChannelLimits `json:"limits"`
+}
+
+// OverviewChannels summarises the user_channels table for the account
+// pane. `total` and `enabled` drive the headline counts; `by_type` is
+// the per-channel toggle state used to render the channel list.
+type OverviewChannels struct {
+	Total   int                  `json:"total"`
+	Enabled int                  `json:"enabled"`
+	ByType  []OverviewChannelRow `json:"by_type"`
+}
+
+type OverviewChannelRow struct {
+	Type    string `json:"type"`
+	Enabled bool   `json:"enabled"`
+	Visible bool   `json:"visible"`
+}
+
+// OverviewFantasy is the optional fan-out result from the fantasy
+// channel's /users/me/yahoo-summary endpoint. nil when the user has no
+// enabled fantasy channel, when the channel hasn't registered, or when
+// the fan-out call fails (timeout, non-200, or transport error). The
+// account pane treats nil as "fantasy section hidden".
+type OverviewFantasy struct {
+	YahooConnected bool `json:"yahoo_connected"`
+	YahooSynced    bool `json:"yahoo_synced"`
+	LeagueCount    int  `json:"league_count"`
+}
+
+// OverviewGDPR mirrors the deletion-request row in a typed shape. Status
+// is one of "none" | "pending" | "canceled" | "purged". Timestamps are
+// RFC3339 strings (rather than time.Time) so JSON null is the natural
+// representation when the field is missing.
+type OverviewGDPR struct {
+	DeletionStatus string  `json:"deletion_status"`
+	RequestedAt    *string `json:"requested_at"`
+	PurgeAt        *string `json:"purge_at"`
+}
+
+// OverviewLinks holds outbound URLs the account pane needs to render.
+// LogtoAccount is empty when LOGTO_ENDPOINT/LOGTO_APP_ID are unset (e.g.
+// in tests) — clients hide the link in that case.
+type OverviewLinks struct {
+	LogtoAccount string `json:"logto_account"`
+}
+
+// ─── Cache constants ────────────────────────────────────────────────
+
+const (
+	// RedisOverviewCachePrefix is the per-user key prefix for the
+	// overview cache. Format: overview:{logto_sub}.
+	RedisOverviewCachePrefix = "overview:"
+
+	// OverviewCacheTTL caps stale reads at 30s. Invalidation hooks fire
+	// on every state-changing endpoint that affects the response, so
+	// the TTL is a safety net rather than the primary correctness lever.
+	OverviewCacheTTL = 30 * time.Second
+
+	// FantasyFanoutTimeout bounds the optional fantasy-channel call.
+	// The overview is a foreground request; we'd rather return without
+	// a fantasy block than hold the page on a slow channel.
+	FantasyFanoutTimeout = 1 * time.Second
+)
+
+// overviewGroup coalesces concurrent cache misses for the same user
+// into a single assemble pass. Mirrors the dashboardGroup pattern in
+// server.go.
+var overviewGroup singleflight.Group
+
+// ─── Identity ───────────────────────────────────────────────────────
+
+// buildIdentityFromContext reads the four identity claims that
+// LogtoAuth (auth.go) parks in c.Locals. Missing claims coerce to
+// empty strings — the JWT middleware writes "" for missing name /
+// username so callers can rely on .(string) reads here.
+func buildIdentityFromContext(c *fiber.Ctx) OverviewIdentity {
+	getStr := func(key string) string {
+		v, _ := c.Locals(key).(string)
+		return v
+	}
+	return OverviewIdentity{
+		Sub:      getStr("user_id"),
+		Email:    getStr("user_email"),
+		Name:     getStr("user_name"),
+		Username: getStr("user_username"),
+	}
+}
+
+// ─── Tier ───────────────────────────────────────────────────────────
+
+// buildTierFromContext resolves the user's tier from JWT roles and
+// embeds the matching limits row. This matches the resolution used
+// elsewhere (preferences.go, channels.go) so the overview never
+// disagrees with what the channel handlers actually enforce.
+func buildTierFromContext(c *fiber.Ctx) OverviewTier {
+	tier := tierFromRoles(GetUserRoles(c))
+	limits, ok := DefaultTierLimits[tier]
+	if !ok {
+		limits = DefaultTierLimits["free"]
+	}
+	return OverviewTier{
+		Current:     tier,
+		IsSuperUser: tier == "super_user",
+		Label:       TierDisplayName(tier),
+		Limits:      limits,
+	}
+}
+
+// ─── Channel summary ────────────────────────────────────────────────
+
+// getChannelSummary aggregates user_channels into the headline counts
+// + per-row toggle state in a single query. Empty users return zero
+// counts and an empty by_type slice.
+func getChannelSummary(ctx context.Context, userID string) (OverviewChannels, error) {
+	const q = `
+		SELECT
+			COUNT(*) AS total,
+			COUNT(*) FILTER (WHERE enabled = true) AS enabled_count,
+			COALESCE(json_agg(json_build_object(
+				'type', channel_type,
+				'enabled', enabled,
+				'visible', visible
+			) ORDER BY channel_type) FILTER (WHERE channel_type IS NOT NULL), '[]'::json) AS by_type
+		FROM user_channels
+		WHERE logto_sub = $1
+	`
+
+	var (
+		total      int
+		enabled    int
+		byTypeJSON []byte
+	)
+	err := DBPool.QueryRow(ctx, q, userID).Scan(&total, &enabled, &byTypeJSON)
+	if err != nil {
+		return OverviewChannels{}, fmt.Errorf("getChannelSummary query: %w", err)
+	}
+
+	byType := []OverviewChannelRow{}
+	if len(byTypeJSON) > 0 {
+		if err := json.Unmarshal(byTypeJSON, &byType); err != nil {
+			return OverviewChannels{}, fmt.Errorf("getChannelSummary unmarshal: %w", err)
+		}
+	}
+
+	return OverviewChannels{
+		Total:   total,
+		Enabled: enabled,
+		ByType:  byType,
+	}, nil
+}
+
+// ─── Fantasy fan-out ────────────────────────────────────────────────
+
+// fetchFantasySummary calls the fantasy channel's
+// GET /users/me/yahoo-summary endpoint with a tight timeout. Returns
+// nil on any failure path (channel not registered, timeout, non-200,
+// unmarshal error) so the overview gracefully degrades: the account
+// pane just hides the fantasy section.
+func fetchFantasySummary(ctx context.Context, userID string) *OverviewFantasy {
+	baseURL := getFantasyBaseURL()
+	if baseURL == "" {
+		return nil
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/users/me/yahoo-summary"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Printf("[Overview] build fantasy request: %v", err)
+		return nil
+	}
+	// X-User-Sub is the same convention the proxy uses to forward
+	// identity into channel APIs (see proxy.go).
+	req.Header.Set("X-User-Sub", userID)
+
+	client := &http.Client{Timeout: FantasyFanoutTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("[Overview] fantasy fan-out failed (timeout/network): %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("[Overview] fantasy fan-out non-200: %d", resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("[Overview] fantasy fan-out read body: %v", err)
+		return nil
+	}
+
+	var out OverviewFantasy
+	if err := json.Unmarshal(body, &out); err != nil {
+		log.Printf("[Overview] fantasy fan-out unmarshal: %v", err)
+		return nil
+	}
+	return &out
+}
+
+// getFantasyBaseURL resolves the fantasy channel's internal base URL
+// via the discovery registry (Redis-backed). Returns "" if the channel
+// hasn't registered yet; callers treat that as "skip fan-out".
+func getFantasyBaseURL() string {
+	info := GetChannel("fantasy")
+	if info == nil {
+		return ""
+	}
+	return info.InternalURL
+}
+
+// ─── GDPR ───────────────────────────────────────────────────────────
+
+// getDeletionStatusForOverview wraps the existing getUserDeletionStatus
+// helper (which returns a map[string]any used by other endpoints) and
+// re-shapes it into the typed OverviewGDPR. Errors and missing rows
+// both collapse to "none" — the overview must never fail because the
+// GDPR table is unreachable.
+func getDeletionStatusForOverview(ctx context.Context, userID string) OverviewGDPR {
+	status, err := getUserDeletionStatus(ctx, userID)
+	if err != nil {
+		log.Printf("[Overview] deletion status for %s: %v", userID, err)
+		return OverviewGDPR{DeletionStatus: "none"}
+	}
+	if status == nil {
+		return OverviewGDPR{DeletionStatus: "none"}
+	}
+
+	out := OverviewGDPR{DeletionStatus: "none"}
+	if s, ok := status["status"].(string); ok {
+		out.DeletionStatus = s
+	}
+	if t, ok := status["requested_at"].(time.Time); ok {
+		s := t.UTC().Format(time.RFC3339)
+		out.RequestedAt = &s
+	}
+	if t, ok := status["purge_at"].(time.Time); ok {
+		s := t.UTC().Format(time.RFC3339)
+		out.PurgeAt = &s
+	}
+	return out
+}
+
+// ─── Subscription ───────────────────────────────────────────────────
+
+// getSubscriptionForOverview returns a DB-only snapshot of the user's
+// subscription. Unlike HandleGetSubscription, this does NOT call out to
+// Stripe — the overview is a foreground, cacheable read, and a 200ms
+// Stripe round-trip per pageload (or per cache miss) is too expensive.
+//
+// Trade-off: the live billing details (Amount/Currency/Interval/TrialEnd
+// + pending downgrade schedule) come from Stripe in HandleGetSubscription
+// but are unavailable here. The account pane that wants those details
+// fetches /users/me/subscription separately. The overview's purpose is
+// the headline plan/status, which the local DB has.
+//
+// Returns nil for users on the free plan (no stripe_customers row).
+func getSubscriptionForOverview(ctx context.Context, userID string) *SubscriptionResponse {
+	var sc StripeCustomer
+	err := DBPool.QueryRow(ctx,
+		`SELECT logto_sub, stripe_customer_id, stripe_subscription_id, plan, status,
+		        current_period_end, lifetime, created_at, updated_at
+		 FROM stripe_customers WHERE logto_sub = $1`, userID,
+	).Scan(&sc.LogtoSub, &sc.StripeCustomerID, &sc.StripeSubscriptionID,
+		&sc.Plan, &sc.Status, &sc.CurrentPeriodEnd, &sc.Lifetime,
+		&sc.CreatedAt, &sc.UpdatedAt)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil
+		}
+		log.Printf("[Overview] subscription query for %s: %v", userID, err)
+		return nil
+	}
+
+	return &SubscriptionResponse{
+		Plan:             sc.Plan,
+		Status:           sc.Status,
+		CurrentPeriodEnd: sc.CurrentPeriodEnd,
+		Lifetime:         sc.Lifetime,
+	}
+}
+
+// ─── Links ──────────────────────────────────────────────────────────
+
+// buildAccountLinks composes outbound URLs the account pane renders.
+// Empty when LOGTO_ENDPOINT or LOGTO_APP_ID is unset (tests, local dev
+// without Logto configured) — the client hides the affected link.
+func buildAccountLinks() OverviewLinks {
+	endpoint := strings.TrimRight(os.Getenv("LOGTO_ENDPOINT"), "/")
+	appID := os.Getenv("LOGTO_APP_ID")
+	if endpoint == "" || appID == "" {
+		return OverviewLinks{LogtoAccount: ""}
+	}
+	return OverviewLinks{
+		LogtoAccount: fmt.Sprintf("%s/account?client_id=%s", endpoint, appID),
+	}
+}
+
+// ─── Assemble ───────────────────────────────────────────────────────
+
+// assembleOverview is the slow path called from the cache-miss branch
+// of HandleGetOverview. Order:
+//
+//  1. Identity + tier — pure context reads, no I/O.
+//  2. Subscription — single DB query.
+//  3. Channels — single DB query (also gates the fantasy fan-out).
+//  4. GDPR — single DB query.
+//  5. Fantasy — only when the user has an enabled fantasy channel; HTTP
+//     call with a 1s timeout so a slow fantasy API can't pin the
+//     overview.
+//
+// Failures in optional sections (subscription, GDPR, fantasy) degrade
+// gracefully to nil/none rather than failing the whole call. The
+// channels query is the only one that can hard-fail — without it the
+// summary is meaningless.
+func assembleOverview(ctx context.Context, c *fiber.Ctx, userID string) (*OverviewResponse, error) {
+	identity := buildIdentityFromContext(c)
+	tier := buildTierFromContext(c)
+	subscription := getSubscriptionForOverview(ctx, userID)
+
+	channels, err := getChannelSummary(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("assembleOverview: channels: %w", err)
+	}
+
+	gdpr := getDeletionStatusForOverview(ctx, userID)
+
+	var fantasy *OverviewFantasy
+	if hasFantasyChannel(channels) {
+		fanCtx, cancel := context.WithTimeout(ctx, FantasyFanoutTimeout)
+		defer cancel()
+		fantasy = fetchFantasySummary(fanCtx, userID)
+	}
+
+	return &OverviewResponse{
+		Identity:     identity,
+		Tier:         tier,
+		Subscription: subscription,
+		Channels:     channels,
+		Fantasy:      fantasy,
+		GDPR:         gdpr,
+		Links:        buildAccountLinks(),
+	}, nil
+}
+
+// hasFantasyChannel returns true when the user has an enabled fantasy
+// channel — the only condition under which the fantasy fan-out is
+// worth the latency cost.
+func hasFantasyChannel(channels OverviewChannels) bool {
+	for _, c := range channels.ByType {
+		if c.Type == "fantasy" && c.Enabled {
+			return true
+		}
+	}
+	return false
+}
+
+// ─── Cache invalidation ─────────────────────────────────────────────
+
+// InvalidateOverviewCache deletes the per-user overview cache key.
+// Called from the Stripe webhook (subscription state changes), the
+// channel CRUD handlers (toggle state changes), and the GDPR request
+// lifecycle (deletion status changes) so the next request always sees
+// fresh data instead of waiting up to OverviewCacheTTL for the cache
+// to expire.
+//
+// Failures are logged and swallowed — the caller's primary write has
+// already succeeded; an invalidation miss only delays the visible
+// effect by OverviewCacheTTL, which is acceptable.
+func InvalidateOverviewCache(ctx context.Context, userID string) {
+	if userID == "" || Rdb == nil {
+		return
+	}
+	key := RedisOverviewCachePrefix + userID
+	if err := Rdb.Del(ctx, key).Err(); err != nil {
+		log.Printf("[Overview] cache invalidate failed for %s: %v", userID, err)
+	}
+}
+
+// ─── Handler ────────────────────────────────────────────────────────
+
+// HandleGetOverview serves GET /users/me/overview. Fast path: serve
+// from Redis. Slow path: assemble + cache, with singleflight to
+// coalesce concurrent misses for the same user.
+//
+// The X-Cache header ("hit" | "miss") helps operators verify the cache
+// is doing its job in production traces. The body shape is identical
+// on both paths.
+func HandleGetOverview(c *fiber.Ctx) error {
+	userID := GetUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Status: "unauthorized",
+			Error:  "Authentication required",
+		})
+	}
+
+	cacheKey := RedisOverviewCachePrefix + userID
+
+	// Fast path: serve from Redis. We use raw bytes (Send) instead of
+	// JSON-decode-then-re-encode so cache hits are zero-copy.
+	if Rdb != nil {
+		if cached, err := Rdb.Get(c.Context(), cacheKey).Bytes(); err == nil {
+			c.Set("X-Cache", "hit")
+			c.Set("Content-Type", "application/json")
+			return c.Send(cached)
+		} else if err != redis.Nil {
+			log.Printf("[Overview] cache read for %s: %v", userID, err)
+		}
+	}
+
+	// Slow path: singleflight ensures concurrent misses for the same
+	// user assemble exactly once.
+	result, err, _ := overviewGroup.Do(userID, func() (interface{}, error) {
+		return assembleOverview(c.Context(), c, userID)
+	})
+	if err != nil {
+		log.Printf("[Overview] assemble for %s: %v", userID, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Failed to assemble overview",
+		})
+	}
+
+	overview, ok := result.(*OverviewResponse)
+	if !ok || overview == nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Invalid overview shape",
+		})
+	}
+
+	payload, err := json.Marshal(overview)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  fmt.Sprintf("marshal overview: %v", err),
+		})
+	}
+
+	if Rdb != nil {
+		if setErr := Rdb.Set(c.Context(), cacheKey, payload, OverviewCacheTTL).Err(); setErr != nil {
+			log.Printf("[Overview] cache write for %s: %v", userID, setErr)
+		}
+	}
+
+	c.Set("X-Cache", "miss")
+	c.Set("Content-Type", "application/json")
+	return c.Send(payload)
+}

--- a/api/core/handlers_overview_test.go
+++ b/api/core/handlers_overview_test.go
@@ -1,0 +1,353 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// ─── Test helpers ───────────────────────────────────────────────────
+
+// testDBAvailable skips the calling test when the DB pool isn't
+// initialised. Most unit-test runs (`go test ./core/`) bring up the
+// package without a real database, so any test that touches DBPool
+// must guard itself.
+func testDBAvailable(t *testing.T) bool {
+	t.Helper()
+	if DBPool == nil {
+		t.Skip("DBPool not initialised; skipping integration test")
+		return false
+	}
+	return true
+}
+
+// testRedisAvailable skips when Rdb is nil — same reason as above for
+// the cache-related tests.
+func testRedisAvailable(t *testing.T) bool {
+	t.Helper()
+	if Rdb == nil {
+		t.Skip("Rdb not initialised; skipping integration test")
+		return false
+	}
+	return true
+}
+
+// makeTestUser returns a unique synthetic logto_sub for use as a row key.
+func makeTestUser() string {
+	return fmt.Sprintf("test-overview-%d", time.Now().UnixNano())
+}
+
+// cleanupTestUser drops any rows the overview tests insert.
+func cleanupTestUser(_ *testing.T, userID string) {
+	if DBPool == nil {
+		return
+	}
+	_, _ = DBPool.Exec(context.Background(),
+		`DELETE FROM user_channels WHERE logto_sub = $1`, userID)
+}
+
+// mustExec runs an INSERT/UPDATE in the test DB or fails the test.
+func mustExec(t *testing.T, query string, args ...interface{}) {
+	t.Helper()
+	if DBPool == nil {
+		t.Skip("DBPool not initialised")
+		return
+	}
+	_, err := DBPool.Exec(context.Background(), query, args...)
+	if err != nil {
+		t.Fatalf("mustExec failed: %v", err)
+	}
+}
+
+// runWithLocals stands up a minimal Fiber app, registers a single GET
+// handler that seeds c.Locals before calling fn, and returns the
+// captured value. Avoids reaching into Fiber's internal AcquireCtx,
+// which is not part of the v2 public API and behaves erratically.
+func runWithLocals(t *testing.T, locals map[string]interface{}, fn func(c *fiber.Ctx) interface{}) interface{} {
+	t.Helper()
+	app := fiber.New()
+	var captured interface{}
+	app.Get("/_test", func(c *fiber.Ctx) error {
+		for k, v := range locals {
+			c.Locals(k, v)
+		}
+		captured = fn(c)
+		return c.SendStatus(http.StatusOK)
+	})
+	req, _ := http.NewRequest(http.MethodGet, "/_test", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test failed: %v", err)
+	}
+	resp.Body.Close()
+	return captured
+}
+
+// ─── Identity ───────────────────────────────────────────────────────
+
+func TestBuildIdentityFromContext_AllClaimsPresent(t *testing.T) {
+	got := runWithLocals(t, map[string]interface{}{
+		"user_id":       "logto-uuid-1",
+		"user_email":    "user@example.com",
+		"user_name":     "Brandon",
+		"user_username": "brandon",
+	}, func(c *fiber.Ctx) interface{} {
+		return buildIdentityFromContext(c)
+	}).(OverviewIdentity)
+
+	want := OverviewIdentity{
+		Sub:      "logto-uuid-1",
+		Email:    "user@example.com",
+		Name:     "Brandon",
+		Username: "brandon",
+	}
+	if got != want {
+		t.Errorf("identity mismatch:\ngot:  %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestBuildIdentityFromContext_MissingUsername(t *testing.T) {
+	// Simulates the auth middleware writing "" for a missing username
+	// claim — which is what auth.go does after the change in this PR.
+	got := runWithLocals(t, map[string]interface{}{
+		"user_id":       "logto-uuid-2",
+		"user_email":    "user2@example.com",
+		"user_name":     "",
+		"user_username": "",
+	}, func(c *fiber.Ctx) interface{} {
+		return buildIdentityFromContext(c)
+	}).(OverviewIdentity)
+
+	if got.Username != "" {
+		t.Errorf("expected empty username when claim missing, got %q", got.Username)
+	}
+	if got.Sub != "logto-uuid-2" {
+		t.Errorf("sub mismatch: got %q", got.Sub)
+	}
+}
+
+// ─── Tier ───────────────────────────────────────────────────────────
+
+func TestBuildTierFromContext_FreeTier(t *testing.T) {
+	// Empty roles slice → tierFromRoles falls through to "free".
+	got := runWithLocals(t, map[string]interface{}{
+		"user_roles": []string{},
+	}, func(c *fiber.Ctx) interface{} {
+		return buildTierFromContext(c)
+	}).(OverviewTier)
+
+	if got.Current != "free" {
+		t.Errorf("expected current=free, got %q", got.Current)
+	}
+	if got.IsSuperUser {
+		t.Error("expected is_super_user=false for free tier")
+	}
+	if got.Label == "" {
+		t.Error("expected non-empty label")
+	}
+}
+
+func TestBuildTierFromContext_SuperUser(t *testing.T) {
+	got := runWithLocals(t, map[string]interface{}{
+		"user_roles": []string{"super_user"},
+	}, func(c *fiber.Ctx) interface{} {
+		return buildTierFromContext(c)
+	}).(OverviewTier)
+
+	if !got.IsSuperUser {
+		t.Error("expected is_super_user=true for super_user tier")
+	}
+	if got.Current != "super_user" {
+		t.Errorf("current mismatch: got %q", got.Current)
+	}
+}
+
+func TestBuildTierFromContext_UplinkPro(t *testing.T) {
+	got := runWithLocals(t, map[string]interface{}{
+		"user_roles": []string{"uplink_pro"},
+	}, func(c *fiber.Ctx) interface{} {
+		return buildTierFromContext(c)
+	}).(OverviewTier)
+
+	if got.Current != "uplink_pro" {
+		t.Errorf("expected current=uplink_pro, got %q", got.Current)
+	}
+	if got.Label != "Uplink Pro" {
+		t.Errorf("expected label=Uplink Pro, got %q", got.Label)
+	}
+	// Pro tier has Symbols=75 — sanity check the limits row threaded through.
+	if got.Limits.Symbols == nil || *got.Limits.Symbols != 75 {
+		t.Errorf("expected Symbols=75 for uplink_pro; got %v", got.Limits.Symbols)
+	}
+}
+
+// ─── Channel summary ────────────────────────────────────────────────
+
+func TestGetChannelSummary_NoChannels(t *testing.T) {
+	if !testDBAvailable(t) {
+		return
+	}
+	userID := makeTestUser()
+	defer cleanupTestUser(t, userID)
+
+	got, err := getChannelSummary(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Total != 0 || got.Enabled != 0 || len(got.ByType) != 0 {
+		t.Errorf("expected empty summary, got %+v", got)
+	}
+}
+
+func TestGetChannelSummary_MixedEnabledStates(t *testing.T) {
+	if !testDBAvailable(t) {
+		return
+	}
+	userID := makeTestUser()
+	defer cleanupTestUser(t, userID)
+
+	mustExec(t, `INSERT INTO user_channels (logto_sub, channel_type, enabled, visible) VALUES
+		($1, 'finance', true, true),
+		($1, 'sports', true, true),
+		($1, 'rss', true, false),
+		($1, 'fantasy', false, false)`, userID)
+
+	got, err := getChannelSummary(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Total != 4 {
+		t.Errorf("total: want 4, got %d", got.Total)
+	}
+	if got.Enabled != 3 {
+		t.Errorf("enabled: want 3, got %d", got.Enabled)
+	}
+	if len(got.ByType) != 4 {
+		t.Errorf("by_type len: want 4, got %d", len(got.ByType))
+	}
+}
+
+// ─── hasFantasyChannel ──────────────────────────────────────────────
+
+func TestHasFantasyChannel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   OverviewChannels
+		want bool
+	}{
+		{"no rows", OverviewChannels{}, false},
+		{"fantasy disabled", OverviewChannels{ByType: []OverviewChannelRow{{Type: "fantasy", Enabled: false}}}, false},
+		{"fantasy enabled", OverviewChannels{ByType: []OverviewChannelRow{{Type: "fantasy", Enabled: true}}}, true},
+		{"only finance", OverviewChannels{ByType: []OverviewChannelRow{{Type: "finance", Enabled: true}}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasFantasyChannel(tc.in); got != tc.want {
+				t.Errorf("hasFantasyChannel: want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+// ─── Cache invalidation ─────────────────────────────────────────────
+
+func TestInvalidateOverviewCache_DeletesKey(t *testing.T) {
+	if !testRedisAvailable(t) {
+		return
+	}
+	userID := fmt.Sprintf("test-invalidate-%d", time.Now().UnixNano())
+	key := RedisOverviewCachePrefix + userID
+
+	if err := Rdb.Set(context.Background(), key, []byte("test"), 60*time.Second).Err(); err != nil {
+		t.Fatalf("seed Set failed: %v", err)
+	}
+	InvalidateOverviewCache(context.Background(), userID)
+
+	_, err := Rdb.Get(context.Background(), key).Result()
+	if err == nil {
+		t.Error("expected cache key to be deleted, but it still exists")
+	}
+}
+
+func TestInvalidateOverviewCache_EmptyUserIDIsNoop(t *testing.T) {
+	// Defensive: an empty user must never wildcard-delete the namespace.
+	// We can verify this without a Redis connection because the function
+	// short-circuits before touching the client.
+	InvalidateOverviewCache(context.Background(), "")
+	// If we got here without panicking, the no-op path works.
+}
+
+// ─── Roundtrip cache behavior ───────────────────────────────────────
+
+func TestHandleGetOverview_CacheRoundtrip(t *testing.T) {
+	if !testDBAvailable(t) {
+		return
+	}
+	if !testRedisAvailable(t) {
+		return
+	}
+
+	userID := makeTestUser()
+	defer cleanupTestUser(t, userID)
+
+	mustExec(t, `INSERT INTO user_channels (logto_sub, channel_type, enabled, visible)
+		VALUES ($1, 'finance', true, true)`, userID)
+
+	// Ensure no stale entry from a previous run.
+	Rdb.Del(context.Background(), RedisOverviewCachePrefix+userID)
+
+	app := fiber.New()
+	app.Get("/users/me/overview", func(c *fiber.Ctx) error {
+		c.Locals("user_id", userID)
+		c.Locals("user_email", "test@example.com")
+		c.Locals("user_roles", []string{})
+		c.Locals("user_name", "")
+		c.Locals("user_username", "")
+		return HandleGetOverview(c)
+	})
+
+	// First call: cache miss.
+	req1, _ := http.NewRequest(http.MethodGet, "/users/me/overview", nil)
+	resp1, err := app.Test(req1)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if resp1.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp1.Body)
+		t.Fatalf("first call status %d: %s", resp1.StatusCode, body)
+	}
+	if got := resp1.Header.Get("X-Cache"); got != "miss" {
+		t.Errorf("first call X-Cache: want miss, got %q", got)
+	}
+
+	// Body must be valid JSON shaped like OverviewResponse.
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+	var ov OverviewResponse
+	if err := json.Unmarshal(body1, &ov); err != nil {
+		t.Fatalf("first body unmarshal: %v\nbody: %s", err, body1)
+	}
+	if ov.Identity.Sub != userID {
+		t.Errorf("identity.sub want %q, got %q", userID, ov.Identity.Sub)
+	}
+
+	// Second call: cache hit.
+	req2, _ := http.NewRequest(http.MethodGet, "/users/me/overview", nil)
+	resp2, err := app.Test(req2)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if got := resp2.Header.Get("X-Cache"); got != "hit" {
+		t.Errorf("second call X-Cache: want hit, got %q", got)
+	}
+	resp2.Body.Close()
+
+	// Cleanup.
+	Rdb.Del(context.Background(), RedisOverviewCachePrefix+userID)
+}

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -194,6 +194,7 @@ func (s *Server) setupRoutes() {
 	s.App.Post("/checkout/payment-intent", LogtoAuth, HandleCreatePaymentIntent)
 	s.App.Get("/checkout/return", LogtoAuth, HandleCheckoutReturn)
 	s.App.Get("/users/me/subscription", LogtoAuth, HandleGetSubscription)
+	s.App.Get("/users/me/overview", LogtoAuth, HandleGetOverview)
 	s.App.Get("/users/me/subscription/preview", LogtoAuth, HandlePreviewPlanChange)
 	s.App.Put("/users/me/subscription/plan", LogtoAuth, HandleChangePlan)
 	s.App.Post("/users/me/subscription/cancel", LogtoAuth, HandleCancelSubscription)

--- a/api/core/stripe_webhook.go
+++ b/api/core/stripe_webhook.go
@@ -174,6 +174,10 @@ func handleCheckoutCompleted(event stripe.Event) {
 			log.Printf("[Stripe Webhook] Failed to assign uplink role to %s: %v", logtoSub, err)
 		}
 	}
+
+	// Subscription state changed — overview's tier + subscription
+	// blocks are now stale.
+	InvalidateOverviewCache(context.Background(), logtoSub)
 }
 
 // handleSubscriptionUpdated handles subscription changes (renewals, plan changes, cancellations).
@@ -275,6 +279,9 @@ func handleSubscriptionUpdated(event stripe.Event) {
 	if newTier != "" {
 		PruneUserChannelsForTier(context.Background(), logtoSub, newTier)
 	}
+
+	// Tier and subscription fields in the overview response just changed.
+	InvalidateOverviewCache(context.Background(), logtoSub)
 }
 
 // handleSubscriptionDeleted fires when a subscription is fully cancelled (period ended).
@@ -326,6 +333,9 @@ func handleSubscriptionDeleted(event stripe.Event) {
 		// configs they accumulated while on a paid plan down to free caps.
 		PruneUserChannelsForTier(context.Background(), logtoSub, "free")
 	}
+
+	// Subscription went away (or downgraded to free) — overview is stale.
+	InvalidateOverviewCache(context.Background(), logtoSub)
 }
 
 // handleInvoicePaid confirms successful payment for a subscription renewal.

--- a/api/core/user_deletion.go
+++ b/api/core/user_deletion.go
@@ -212,6 +212,9 @@ func HandleRequestAccountDeletion(c *fiber.Ctx) error {
 
 	log.Printf("[GDPR] Account deletion scheduled: user=%s purge_at=%s", userID, purgeAt.Format(time.RFC3339))
 
+	// Overview's gdpr block flipped from "none" to "pending".
+	InvalidateOverviewCache(ctx, userID)
+
 	return c.JSON(fiber.Map{
 		"status":       "pending",
 		"requested_at": now,
@@ -252,6 +255,10 @@ func HandleCancelAccountDeletion(c *fiber.Ctx) error {
 	}
 
 	log.Printf("[GDPR] Account deletion canceled: user=%s", userID)
+
+	// Overview's gdpr block flipped back from "pending" to "canceled".
+	InvalidateOverviewCache(context.Background(), userID)
+
 	return c.JSON(fiber.Map{
 		"status":      "canceled",
 		"canceled_at": now,
@@ -468,6 +475,10 @@ func purgeUserAccount(ctx context.Context, logtoSub string) error {
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
 	}
+
+	// User row is gone; drop any cached overview so a stale background
+	// poll doesn't briefly return data for a purged account.
+	InvalidateOverviewCache(ctx, logtoSub)
 
 	log.Printf("[GDPR Purge] Completed purge for %s", logtoSub)
 	return nil

--- a/channels/fantasy/api/main.go
+++ b/channels/fantasy/api/main.go
@@ -260,6 +260,7 @@ func main() {
 
 	// Protected routes (core gateway sets X-User-Sub header)
 	fiberApp.Get("/users/me/yahoo-status", app.GetYahooStatus)
+	fiberApp.Get("/users/me/yahoo-summary", app.GetYahooSummary)
 	fiberApp.Get("/users/me/yahoo-leagues", app.GetMyYahooLeagues)
 	fiberApp.Post("/users/me/yahoo-leagues/discover", app.DiscoverYahooLeagues)
 	fiberApp.Post("/users/me/yahoo-leagues/import", app.ImportYahooLeague)
@@ -329,6 +330,7 @@ func startRegistration(ctx context.Context, rdb *redis.Client) {
 			{Method: "GET", Path: "/yahoo/health", Auth: false},
 			// Protected (auth required)
 			{Method: "GET", Path: "/users/me/yahoo-status", Auth: true},
+			{Method: "GET", Path: "/users/me/yahoo-summary", Auth: true},
 			{Method: "GET", Path: "/users/me/yahoo-leagues", Auth: true},
 			{Method: "POST", Path: "/users/me/yahoo-leagues/discover", Auth: true},
 			{Method: "POST", Path: "/users/me/yahoo-leagues/import", Auth: true},

--- a/channels/fantasy/api/yahoo_summary.go
+++ b/channels/fantasy/api/yahoo_summary.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// YahooSummaryResponse is the minimal account-overview payload consumed by
+// the core API's GET /users/me/overview fan-out. It avoids any Yahoo API
+// round-trips — connection state and league count are both Postgres reads.
+type YahooSummaryResponse struct {
+	YahooConnected bool `json:"yahoo_connected"`
+	YahooSynced    bool `json:"yahoo_synced"`
+	LeagueCount    int  `json:"league_count"`
+}
+
+// GetYahooSummary returns whether the user has Yahoo connected, whether
+// their leagues have ever been synced, and how many leagues are currently
+// imported. Mirrors the GetYahooStatus convention of treating "no row" as
+// the unconnected happy path rather than an error.
+func (a *App) GetYahooSummary(c *fiber.Ctx) error {
+	userID := GetUserSub(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Status: "unauthorized",
+			Error:  "Authentication required",
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), 5*time.Second)
+	defer cancel()
+
+	// 1. Resolve guid + sync state for this logto_sub. yahoo_users does not
+	//    have a boolean `synced` column; sync is recorded as a non-NULL
+	//    `last_sync` timestamp, matching GetYahooStatus's derivation.
+	var (
+		guid     string
+		lastSync sql.NullTime
+	)
+	err := a.db.QueryRow(ctx, `
+		SELECT guid, last_sync
+		FROM yahoo_users
+		WHERE logto_sub = $1
+	`, userID).Scan(&guid, &lastSync)
+	if err != nil {
+		if err == sql.ErrNoRows || strings.Contains(err.Error(), "no rows") {
+			// User has never connected Yahoo — happy path, not an error.
+			return c.JSON(YahooSummaryResponse{})
+		}
+		log.Printf("[GetYahooSummary] DB error for logto_sub=%s: %v", userID, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Failed to load Yahoo summary",
+		})
+	}
+
+	// 2. Count imported leagues. Don't fail the request on a count error —
+	//    connection state is more valuable than the count, so we degrade
+	//    gracefully to 0 and log.
+	var leagueCount int
+	if err := a.db.QueryRow(ctx, `
+		SELECT count(*) FROM yahoo_user_leagues WHERE guid = $1
+	`, guid).Scan(&leagueCount); err != nil {
+		log.Printf("[GetYahooSummary] count leagues failed for guid=%s: %v", guid, err)
+		leagueCount = 0
+	}
+
+	return c.JSON(YahooSummaryResponse{
+		YahooConnected: guid != "",
+		YahooSynced:    lastSync.Valid,
+		LeagueCount:    leagueCount,
+	})
+}

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
@@ -34,6 +34,8 @@
         "@tanstack/router-plugin": "^1.166.7",
         "@tauri-apps/cli": "^2.0.0",
         "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.0.4",
@@ -2403,6 +2405,46 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2422,6 +2464,56 @@
         "npm": ">=6",
         "yarn": ">=1"
       }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2681,6 +2773,31 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ansis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
@@ -2778,7 +2895,7 @@
       }
     },
     "node_modules/bidi-js": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
@@ -2990,6 +3107,17 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -3769,6 +3897,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4029,6 +4168,30 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4469,7 +4632,7 @@
       "license": "MIT"
     },
     "node_modules/tiny-warning": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",
@@ -50,6 +50,8 @@
     "@tanstack/router-plugin": "^1.166.7",
     "@tauri-apps/cli": "^2.0.0",
     "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.0.4",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -224,6 +224,85 @@ export async function fetchSubscription(): Promise<SubscriptionInfo> {
   return authFetch<SubscriptionInfo>("/users/me/subscription");
 }
 
+// ── User Overview ───────────────────────────────────────────────
+
+/**
+ * Aggregated account view returned by `GET /users/me/overview`.
+ *
+ * The `subscription` field here is DB-only (no live Stripe enrichment) —
+ * it carries plan/status/period/lifetime flags but NOT amount/currency/
+ * interval/trial_end. Callers needing live billing detail must still hit
+ * `fetchSubscription()` against `/users/me/subscription`.
+ */
+export interface UserOverview {
+  identity: {
+    sub: string;
+    email: string;
+    name: string;
+    username: string;
+  };
+  tier: {
+    current: string;
+    is_super_user: boolean;
+    label: string;
+    limits: {
+      symbols: number;
+      feeds: number;
+      custom_feeds: number;
+      leagues: number;
+      fantasy: number;
+      max_ticker_rows: number;
+      max_ticker_customization: boolean;
+    };
+  };
+  subscription: SubscriptionInfo | null;
+  channels: {
+    total: number;
+    enabled: number;
+    by_type: Array<{ type: string; enabled: boolean; visible: boolean }>;
+  };
+  fantasy: {
+    yahoo_connected: boolean;
+    yahoo_synced: boolean;
+    league_count: number;
+  } | null;
+  gdpr: {
+    deletion_status: "none" | "pending" | "canceled" | "purged";
+    requested_at: string | null;
+    purge_at: string | null;
+  };
+  links: {
+    logto_account: string;
+  };
+}
+
+export async function fetchOverview(): Promise<UserOverview> {
+  return authFetch<UserOverview>("/users/me/overview");
+}
+
+/**
+ * Fetch the GDPR data export ZIP. Bypasses `authFetch` because that helper
+ * parses JSON; we need the raw Response to call `.blob()`.
+ */
+export async function exportUserData(): Promise<Blob> {
+  const token = await getValidToken();
+  const headers: HeadersInit = {};
+  if (token) {
+    (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
+  }
+
+  const response = await fetchWithTimeout(`${API_BASE}/users/me/export`, {
+    method: "GET",
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new ApiError(response.status, `export failed: ${response.status}`);
+  }
+
+  return response.blob();
+}
+
 // ── RSS Types & API ─────────────────────────────────────────────
 
 export interface TrackedFeed {

--- a/desktop/src/api/queries.ts
+++ b/desktop/src/api/queries.ts
@@ -6,8 +6,8 @@
  */
 import { queryOptions } from "@tanstack/react-query";
 import { isAuthenticated, hasRefreshToken } from "../auth";
-import { authFetch, request, rssApi } from "./client";
-import type { TrackedFeed } from "./client";
+import { authFetch, request, rssApi, fetchOverview } from "./client";
+import type { TrackedFeed, UserOverview } from "./client";
 import type { DashboardResponse } from "../types";
 
 // ── Query Keys ───────────────────────────────────────────────────
@@ -26,7 +26,26 @@ export const queryKeys = {
     leagues: ["fantasy", "leagues"] as const,
   },
   standings: (league: string) => ["standings", league] as const,
+  userOverview: ["userOverview"] as const,
 };
+
+// ── User Overview Query ──────────────────────────────────────────
+
+/**
+ * Aggregated account view: identity + tier + subscription summary +
+ * channel counts + fantasy summary + GDPR state. Backed by the core
+ * API's singleflight cache (~30s).
+ */
+export function userOverviewQueryOptions() {
+  return queryOptions<UserOverview>({
+    queryKey: queryKeys.userOverview,
+    queryFn: fetchOverview,
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+    retry: 1,
+    refetchOnWindowFocus: true,
+  });
+}
 
 // ── Dashboard Query ──────────────────────────────────────────────
 

--- a/desktop/src/components/settings/AccountExportButton.test.tsx
+++ b/desktop/src/components/settings/AccountExportButton.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import AccountExportButton from "./AccountExportButton";
+
+vi.mock("../../api/client", () => ({
+  exportUserData: vi.fn().mockResolvedValue(new Blob(["test"], { type: "application/zip" })),
+}));
+
+describe("AccountExportButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the button in idle state", () => {
+    render(<AccountExportButton />);
+    expect(screen.getByRole("button", { name: /download my data/i })).toBeInTheDocument();
+  });
+
+  it("shows loading state when clicked", async () => {
+    render(<AccountExportButton />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByText(/preparing/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders error state when fetch fails", async () => {
+    const { exportUserData } = await import("../../api/client");
+    vi.mocked(exportUserData).mockRejectedValueOnce(new Error("network down"));
+
+    render(<AccountExportButton />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/desktop/src/components/settings/AccountExportButton.tsx
+++ b/desktop/src/components/settings/AccountExportButton.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Download, Loader2, AlertCircle } from "lucide-react";
+import { exportUserData } from "../../api/client";
+
+type ButtonState = "idle" | "loading" | "error";
+
+export default function AccountExportButton() {
+  const [state, setState] = useState<ButtonState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  async function handleClick() {
+    setState("loading");
+    setErrorMessage("");
+    try {
+      const blob = await exportUserData();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `myscrollr-export-${new Date().toISOString().slice(0, 10)}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setState("idle");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      setErrorMessage(msg);
+      setState("error");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        onClick={handleClick}
+        disabled={state === "loading"}
+        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50 self-start"
+      >
+        {state === "loading" ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span>Preparing your data…</span>
+          </>
+        ) : (
+          <>
+            <Download className="w-4 h-4" />
+            <span>Download my data</span>
+          </>
+        )}
+      </button>
+      {state === "error" && (
+        <div className="flex items-center gap-1.5 text-xs text-down">
+          <AlertCircle className="w-3.5 h-3.5" />
+          <span>Failed: {errorMessage}</span>
+        </div>
+      )}
+      <p className="text-xs text-fg-4">
+        To delete your account, visit{" "}
+        <span className="text-fg-3">myscrollr.com/account</span>.
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -1,12 +1,16 @@
 import { useState, useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-shell";
 import { TIER_LABELS, getUserIdentity } from "../../auth";
 import { authFetch } from "../../api/client";
+import { userOverviewQueryOptions } from "../../api/queries";
 import { TIER_LIMITS, isUnlimited, type NumericLimitKey } from "../../tierLimits";
 import type { SubscriptionTier } from "../../auth";
 import type { SubscriptionInfo } from "../../api/client";
 import { Section, DisplayRow, ActionRow, ResetButton } from "./SettingsControls";
 import ConfirmDialog from "../ConfirmDialog";
+import AccountStatsRow from "./AccountStatsRow";
+import AccountExportButton from "./AccountExportButton";
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -68,6 +72,13 @@ export default function AccountSettings({
   const [portalError, setPortalError] = useState<string | null>(null);
   const identity = authenticated ? getUserIdentity() : null;
   const userLabel = identity?.email ?? identity?.name ?? null;
+
+  // Aggregated overview: channels count, fantasy summary, GDPR state.
+  // Only fires when authenticated; query is cheap (cached server-side, 30s stale).
+  const { data: overview } = useQuery({
+    ...userOverviewQueryOptions(),
+    enabled: authenticated,
+  });
 
   const handleOpenPortal = useCallback(async () => {
     try {
@@ -138,6 +149,17 @@ export default function AccountSettings({
           />
         )}
       </Section>
+
+      {/* ── Quick stats ──────────────────────────────────────── */}
+      {authenticated && overview && (
+        <div className="px-3 pb-2">
+          <AccountStatsRow
+            channelsTotal={overview.channels.total}
+            channelsEnabled={overview.channels.enabled}
+            fantasy={overview.fantasy}
+          />
+        </div>
+      )}
 
       {/* ── Subscription ─────────────────────────────────────── */}
       {authenticated && hasSub && (
@@ -282,6 +304,15 @@ export default function AccountSettings({
               </button>
             </div>
           )}
+        </Section>
+      )}
+
+      {/* ── Your Data ────────────────────────────────────────── */}
+      {authenticated && (
+        <Section title="Your Data">
+          <div className="px-3 py-2">
+            <AccountExportButton />
+          </div>
         </Section>
       )}
 

--- a/desktop/src/components/settings/AccountStatsRow.test.tsx
+++ b/desktop/src/components/settings/AccountStatsRow.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import AccountStatsRow from "./AccountStatsRow";
+
+describe("AccountStatsRow", () => {
+  it("renders nothing when total channels is 0", () => {
+    const { container } = render(
+      <AccountStatsRow
+        channelsTotal={0}
+        channelsEnabled={0}
+        fantasy={null}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the channel count when channels exist", () => {
+    render(
+      <AccountStatsRow
+        channelsTotal={4}
+        channelsEnabled={3}
+        fantasy={null}
+      />
+    );
+    expect(screen.getByText(/3/)).toBeInTheDocument();
+    expect(screen.getByText(/4/)).toBeInTheDocument();
+    expect(screen.getByText(/channels enabled/i)).toBeInTheDocument();
+  });
+
+  it("hides fantasy line when fantasy is null", () => {
+    render(
+      <AccountStatsRow
+        channelsTotal={2}
+        channelsEnabled={2}
+        fantasy={null}
+      />
+    );
+    expect(screen.queryByText(/fantasy league/i)).toBeNull();
+  });
+
+  it("shows fantasy league count when connected", () => {
+    const { container } = render(
+      <AccountStatsRow
+        channelsTotal={2}
+        channelsEnabled={2}
+        fantasy={{ yahoo_connected: true, yahoo_synced: true, league_count: 3 }}
+      />
+    );
+    // Count + label live in adjacent spans (bold count, muted label).
+    // Match against the parent's flattened textContent.
+    expect(container.textContent).toMatch(/3\s*fantasy league/i);
+  });
+});

--- a/desktop/src/components/settings/AccountStatsRow.tsx
+++ b/desktop/src/components/settings/AccountStatsRow.tsx
@@ -1,0 +1,40 @@
+import type { UserOverview } from "../../api/client";
+
+interface AccountStatsRowProps {
+  channelsTotal: number;
+  channelsEnabled: number;
+  fantasy: UserOverview["fantasy"];
+}
+
+export default function AccountStatsRow({
+  channelsTotal,
+  channelsEnabled,
+  fantasy,
+}: AccountStatsRowProps) {
+  if (channelsTotal === 0) return null;
+
+  const showFantasy =
+    fantasy !== null && fantasy.yahoo_connected && fantasy.league_count > 0;
+
+  return (
+    <div className="flex flex-col gap-1 px-3 py-2 rounded-lg bg-base-200 border border-edge">
+      <div className="text-xs text-fg-3 uppercase tracking-wider">
+        Quick stats
+      </div>
+      <div className="text-sm text-fg-2">
+        <span className="font-medium text-fg">{channelsEnabled}</span>
+        <span className="text-fg-3"> of </span>
+        <span className="font-medium text-fg">{channelsTotal}</span>
+        <span className="text-fg-3"> channels enabled</span>
+      </div>
+      {showFantasy && (
+        <div className="text-sm text-fg-2">
+          <span className="font-medium text-fg">{fantasy!.league_count}</span>
+          <span className="text-fg-3">
+            {" "}fantasy league{fantasy!.league_count !== 1 ? "s" : ""} imported
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-04-28-batch-b-account-overview.md
+++ b/docs/superpowers/plans/2026-04-28-batch-b-account-overview.md
@@ -1,0 +1,2201 @@
+# Batch B — Account Overview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `GET /users/me/overview` endpoint that consolidates identity + tier + subscription + channels + GDPR + fantasy summary into one round-trip, refactor desktop and website Account pages to consume it, and add a GDPR export button + channel/league stats card to desktop.
+
+**Architecture:** New core API handler aggregates from existing helpers (Postgres, JWT, channel discovery for fantasy fan-out), caches per-user in Redis with 30s TTL + singleflight. Webhook + CRUD + GDPR mutations invalidate the cache. Both clients consume via TanStack Query.
+
+**Tech Stack:** Go 1.22 (Fiber v2, pgx v5, go-redis v9, golang.org/x/sync/singleflight already imported in `api/core/handlers_channel.go`); React 19 + TypeScript + TanStack Query (desktop + website); Vitest (desktop only); Tauri v2 (desktop binary).
+
+**Spec:** `docs/superpowers/specs/2026-04-28-batch-b-account-overview-design.md`
+
+**Decisions locked (from spec):**
+1. GDPR on desktop: export only, no delete
+2. Stats card: yes (channel + fantasy counts)
+3. In-app cancel sub on desktop: no, portal-only
+4. Tier limits table: desktop only, website ignores
+5. Cache: 30s Redis with singleflight
+6. JWT identity: add `username` + `name` to existing custom JWT script
+7. Desktop bump: v1.0.3 → v1.0.4
+
+---
+
+## File structure overview
+
+### Backend (Go API)
+
+| File | Action | Responsibility |
+|---|---|---|
+| `channels/fantasy/api/yahoo_summary.go` | **New** (~50 lines) | `GET /users/me/yahoo-summary` handler returning `{yahoo_connected, yahoo_synced, league_count}` |
+| `channels/fantasy/api/main.go` | Modify line 331-333 | Register the new route |
+| `api/core/handlers_overview.go` | **New** (~250 lines) | `HandleGetOverview` + helpers (identity, tier, channel summary, fantasy fan-out, cache, invalidator) |
+| `api/core/handlers_overview_test.go` | **New** (~200 lines) | 6 test cases covering cache hit/miss, fantasy fail-open, GDPR pending, free-tier null subscription, etc. |
+| `api/core/server.go` | Modify ~line 200 | Register `GET /users/me/overview` |
+| `api/core/stripe_webhook.go` | Modify webhook handler tail | `core.InvalidateOverviewCache(ctx, userID)` after subscription mutations |
+| `api/core/handlers_channel.go` | Modify CreateChannel, UpdateChannel, DeleteChannel | Same invalidation call |
+| `api/core/user_deletion.go` | Modify RequestDeletion, CancelDeletion, PurgeUser | Same invalidation call |
+
+### Desktop (TypeScript)
+
+| File | Action | Responsibility |
+|---|---|---|
+| `desktop/src/api/client.ts` | Modify | `UserOverview` interface + `userApi.overview()` method |
+| `desktop/src/api/queries.ts` | Modify | `userOverviewQueryOptions` (TanStack Query options) |
+| `desktop/src/components/settings/AccountStatsRow.tsx` | **New** (~70 lines) | Renders "X of Y channels enabled" + (when fantasy connected) "Z fantasy leagues imported" |
+| `desktop/src/components/settings/AccountStatsRow.test.tsx` | **New** (~80 lines) | 4 tests: hidden when total=0; basic render; fantasy line shown/hidden |
+| `desktop/src/components/settings/AccountExportButton.tsx` | **New** (~80 lines) | Calls `/users/me/export`, opens result via Tauri shell |
+| `desktop/src/components/settings/AccountExportButton.test.tsx` | **New** (~60 lines) | 3 tests: idle/loading/error states |
+| `desktop/src/components/settings/AccountSettings.tsx` | Modify | Consume `userOverviewQueryOptions`; render new sections; remove duplicate fetches |
+| `desktop/src/routes/__root.tsx` | Modify | Derive `subscriptionInfo` from overview; remove standalone `fetchSubscription` |
+| `desktop/src-tauri/tauri.conf.json` | Modify | Version `1.0.3` → `1.0.4` |
+| `desktop/src-tauri/Cargo.toml` | Modify | Version `1.0.3` → `1.0.4` |
+| `desktop/package.json` | Modify | Version `1.0.3` → `1.0.4` |
+| `desktop/package-lock.json` | Modify | Version `1.0.3` → `1.0.4` (top-level + scrollr-desktop entry) |
+
+### Website (TypeScript)
+
+| File | Action | Responsibility |
+|---|---|---|
+| `myscrollr.com/src/api/client.ts` | Modify | `UserOverview` type + `userApi.overview()` method |
+| `myscrollr.com/src/routes/account.tsx` | Modify | Replace 3 separate queries with one overview query |
+| `myscrollr.com/src/components/billing/SubscriptionStatus.tsx` | Modify | Accept overview-shaped subscription prop OR consume overview internally |
+| `myscrollr.com/src/components/account/AccountDangerZone.tsx` | Modify | Read `overview.gdpr.deletion_status` for the pending banner |
+
+---
+
+# PHASE 1 — Yahoo summary endpoint (fantasy API)
+
+This phase ships the small handler that core API will fan out to.
+
+### Task 1.1: Yahoo summary handler
+
+**Files:**
+- Create: `channels/fantasy/api/yahoo_summary.go`
+- Modify: `channels/fantasy/api/main.go` (route registration only)
+
+- [ ] **Step 1: Inspect existing yahoo-status handler for reference**
+
+Run: `grep -n "yahoo-status\|YahooStatus\|HandleYahooStatus\|GetYahooStatus" channels/fantasy/api/*.go`
+
+Expected: Locate the existing handler that returns `{yahoo_connected, yahoo_synced}`. Read it to understand the pattern for `db` access, `userID` extraction (`GetUserSub(c)`), and JSON response shape.
+
+- [ ] **Step 2: Inspect yahoo_user_leagues schema for league count query**
+
+Run: `grep -n "yahoo_user_leagues\|YahooUserLeagues" channels/fantasy/api/migrations/*.sql channels/fantasy/api/*.go | head -10`
+
+Expected: Confirm the table name is `yahoo_user_leagues` and the user-id column is `guid` (Yahoo GUID, not logto_sub). The existing import handler at `user_handlers.go` uses this table.
+
+- [ ] **Step 3: Write the new handler**
+
+Create `channels/fantasy/api/yahoo_summary.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type yahooSummaryResponse struct {
+	YahooConnected bool `json:"yahoo_connected"`
+	YahooSynced    bool `json:"yahoo_synced"`
+	LeagueCount    int  `json:"league_count"`
+}
+
+// HandleYahooSummary returns the minimal summary needed by the core API's
+// /users/me/overview fan-out. Reads connection state from yahoo_users,
+// counts imported leagues from yahoo_user_leagues. One DB transaction,
+// no Yahoo API calls.
+func (a *App) HandleYahooSummary(c *fiber.Ctx) error {
+	logtoSub := GetUserSub(c)
+	if logtoSub == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Status: "unauthorized",
+			Error:  "authentication required",
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), DBQueryTimeout)
+	defer cancel()
+
+	// 1. Look up the Yahoo guid + connection state for this logto_sub.
+	var (
+		guid     string
+		synced   bool
+	)
+	err := a.db.QueryRow(ctx, `
+		SELECT guid, COALESCE(synced, false)
+		FROM yahoo_users
+		WHERE logto_sub = $1
+	`, logtoSub).Scan(&guid, &synced)
+	if err != nil {
+		// No row = user has never connected Yahoo; happy path.
+		return c.JSON(yahooSummaryResponse{
+			YahooConnected: false,
+			YahooSynced:    false,
+			LeagueCount:    0,
+		})
+	}
+
+	// 2. Count imported leagues for that guid.
+	var leagueCount int
+	if err := a.db.QueryRow(ctx, `
+		SELECT count(*) FROM yahoo_user_leagues WHERE guid = $1
+	`, guid).Scan(&leagueCount); err != nil {
+		log.Printf("[YahooSummary] count leagues failed for guid=%s: %v", guid, err)
+		// Don't fail the request — return 0 for the count and continue.
+		leagueCount = 0
+	}
+
+	return c.JSON(yahooSummaryResponse{
+		YahooConnected: guid != "",
+		YahooSynced:    synced,
+		LeagueCount:    leagueCount,
+	})
+}
+```
+
+Note: if `DBQueryTimeout` constant doesn't exist in this package, use `5*time.Second` inline and add the import. Verify by running `grep -n "DBQueryTimeout" channels/fantasy/api/`.
+
+- [ ] **Step 4: Register the route**
+
+Modify `channels/fantasy/api/main.go` near line 331-333 where existing yahoo routes are registered. Find the block:
+
+```go
+{Method: "GET", Path: "/users/me/yahoo-status", Auth: true},
+{Method: "GET", Path: "/users/me/yahoo-leagues", Auth: true},
+```
+
+Add immediately after:
+
+```go
+{Method: "GET", Path: "/users/me/yahoo-summary", Auth: true},
+```
+
+Then find where these routes are wired to handlers (search for `app.Get("/users/me/yahoo-status"` or similar) and add:
+
+```go
+app.Get("/users/me/yahoo-summary", a.HandleYahooSummary)
+```
+
+- [ ] **Step 5: Verify build + vet**
+
+Run: `cd channels/fantasy/api && go vet ./... && go build -o /tmp/fantasy_check . && rm -f /tmp/fantasy_check`
+
+Expected: clean (no errors, empty output from go vet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add channels/fantasy/api/yahoo_summary.go channels/fantasy/api/main.go
+git commit -m "feat(fantasy): GET /users/me/yahoo-summary for overview fan-out"
+```
+
+---
+
+# PHASE 2 — Overview endpoint (core API)
+
+This phase ships the new core endpoint, types, helpers, tests, and cache invalidation hooks. The work is tightly coupled — tasks must be done in order; the package won't compile until all helpers exist.
+
+### Task 2.1: OverviewResponse types
+
+**Files:**
+- Create: `api/core/handlers_overview.go` (start the file)
+
+- [ ] **Step 1: Create the file scaffold with types**
+
+Create `api/core/handlers_overview.go`:
+
+```go
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+	"golang.org/x/sync/singleflight"
+)
+
+// ─── Response types ─────────────────────────────────────────────
+
+type OverviewResponse struct {
+	Identity     OverviewIdentity        `json:"identity"`
+	Tier         OverviewTier            `json:"tier"`
+	Subscription *SubscriptionResponse   `json:"subscription"` // nullable
+	Channels     OverviewChannels        `json:"channels"`
+	Fantasy      *OverviewFantasy        `json:"fantasy"` // nullable
+	GDPR         OverviewGDPR            `json:"gdpr"`
+	Links        OverviewLinks           `json:"links"`
+}
+
+type OverviewIdentity struct {
+	Sub      string `json:"sub"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`     // empty string when JWT claim missing
+	Username string `json:"username"` // empty string when not yet set
+}
+
+type OverviewTier struct {
+	Current      string         `json:"current"`
+	IsSuperUser  bool           `json:"is_super_user"`
+	Label        string         `json:"label"`
+	Limits       ChannelLimits  `json:"limits"`
+}
+
+type OverviewChannels struct {
+	Total   int                  `json:"total"`
+	Enabled int                  `json:"enabled"`
+	ByType  []OverviewChannelRow `json:"by_type"`
+}
+
+type OverviewChannelRow struct {
+	Type    string `json:"type"`
+	Enabled bool   `json:"enabled"`
+	Visible bool   `json:"visible"`
+}
+
+type OverviewFantasy struct {
+	YahooConnected bool `json:"yahoo_connected"`
+	YahooSynced    bool `json:"yahoo_synced"`
+	LeagueCount    int  `json:"league_count"`
+}
+
+type OverviewGDPR struct {
+	DeletionStatus string  `json:"deletion_status"` // none | pending | canceled | purged
+	RequestedAt    *string `json:"requested_at"`
+	PurgeAt        *string `json:"purge_at"`
+}
+
+type OverviewLinks struct {
+	LogtoAccount string `json:"logto_account"`
+}
+
+// ─── Cache constants ────────────────────────────────────────────
+
+const (
+	RedisOverviewCachePrefix = "overview:"
+	OverviewCacheTTL         = 30 * time.Second
+	FantasyFanoutTimeout     = 1 * time.Second
+)
+
+var overviewGroup singleflight.Group
+```
+
+- [ ] **Step 2: Verify file compiles in isolation**
+
+Run: `cd api && go build ./core/... 2>&1 | head -20`
+
+Expected: errors about `SubscriptionResponse` (already exists in `models.go`, OK) or `ChannelLimits` (already exists in `tier_limits.go`, OK). Errors about `HandleGetOverview` undefined are expected since we haven't added it yet — those will be resolved in later tasks. The package as a whole won't build cleanly until all tasks in Phase 2 are done; that's expected.
+
+- [ ] **Step 3: No commit yet** — types are partial. Commit at end of Phase 2.
+
+---
+
+### Task 2.2: Identity + tier builders (with tests)
+
+**Files:**
+- Modify: `api/core/handlers_overview.go`
+- Create: `api/core/handlers_overview_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/core/handlers_overview_test.go`:
+
+```go
+package core
+
+import (
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestBuildIdentityFromContext_AllClaimsPresent(t *testing.T) {
+	app := fiber.New()
+	c := app.AcquireCtx(&fiber.Ctx{})
+	defer app.ReleaseCtx(c)
+
+	c.Locals("user_id", "logto-uuid-1")
+	c.Locals("user_email", "user@example.com")
+	c.Locals("user_name", "Brandon")
+	c.Locals("user_username", "brandon")
+
+	got := buildIdentityFromContext(c)
+
+	want := OverviewIdentity{
+		Sub:      "logto-uuid-1",
+		Email:    "user@example.com",
+		Name:     "Brandon",
+		Username: "brandon",
+	}
+	if got != want {
+		t.Errorf("identity mismatch:\ngot:  %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestBuildIdentityFromContext_MissingUsername(t *testing.T) {
+	app := fiber.New()
+	c := app.AcquireCtx(&fiber.Ctx{})
+	defer app.ReleaseCtx(c)
+
+	c.Locals("user_id", "logto-uuid-2")
+	c.Locals("user_email", "user2@example.com")
+	c.Locals("user_name", "")
+	// user_username intentionally not set (simulates JWT script not yet updated)
+
+	got := buildIdentityFromContext(c)
+
+	if got.Username != "" {
+		t.Errorf("expected empty username when claim missing, got %q", got.Username)
+	}
+	if got.Sub != "logto-uuid-2" {
+		t.Errorf("sub mismatch: got %q", got.Sub)
+	}
+}
+
+func TestBuildTierFromContext_FreeTier(t *testing.T) {
+	app := fiber.New()
+	c := app.AcquireCtx(&fiber.Ctx{})
+	defer app.ReleaseCtx(c)
+
+	c.Locals("user_tier", "free")
+
+	got := buildTierFromContext(c)
+
+	if got.Current != "free" {
+		t.Errorf("expected current=free, got %q", got.Current)
+	}
+	if got.IsSuperUser {
+		t.Error("expected is_super_user=false for free tier")
+	}
+	if got.Label == "" {
+		t.Error("expected non-empty label")
+	}
+	if got.Limits.Symbols != DefaultTierLimits["free"].Symbols {
+		t.Errorf("limits.symbols mismatch: got %d", got.Limits.Symbols)
+	}
+}
+
+func TestBuildTierFromContext_SuperUser(t *testing.T) {
+	app := fiber.New()
+	c := app.AcquireCtx(&fiber.Ctx{})
+	defer app.ReleaseCtx(c)
+
+	c.Locals("user_tier", "super_user")
+
+	got := buildTierFromContext(c)
+
+	if !got.IsSuperUser {
+		t.Error("expected is_super_user=true for super_user tier")
+	}
+	if got.Current != "super_user" {
+		t.Errorf("current mismatch: got %q", got.Current)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd api && go test ./core/ -run TestBuildIdentity -v 2>&1 | head -30`
+
+Expected: FAIL with `undefined: buildIdentityFromContext` and similar undefined errors.
+
+- [ ] **Step 3: Inspect existing JWT middleware to confirm c.Locals key names**
+
+Run: `grep -n "c.Locals" api/core/auth.go api/core/server.go | head -10`
+
+Expected: Confirm the existing keys (`"user_id"`, `"user_email"`, `"user_tier"`, `"user_roles"`). If `"user_name"` or `"user_username"` aren't set yet by the auth middleware, those reads will return nil interface, which the helper must handle. Also note the existing `GetUserSub`, `GetUserEmail`, `GetUserTier` helpers in `users.go` — use them where they exist.
+
+- [ ] **Step 4: Update JWT middleware to expose name + username**
+
+Locate the JWT-claims-to-locals code in `api/core/auth.go` (around the function that decodes JWT and calls `c.Locals(...)`). Find the block that sets `"user_id"`, `"user_email"`, etc. Add:
+
+```go
+if name, ok := claims["name"].(string); ok {
+    c.Locals("user_name", name)
+} else {
+    c.Locals("user_name", "")
+}
+if username, ok := claims["username"].(string); ok {
+    c.Locals("user_username", username)
+} else {
+    c.Locals("user_username", "")
+}
+```
+
+These claims will be empty until the Logto JWT script update is deployed AND existing tokens roll over (~1h after deployment). Empty string is the correct fallback.
+
+- [ ] **Step 5: Add the helpers to handlers_overview.go**
+
+Append to `api/core/handlers_overview.go`:
+
+```go
+// ─── Identity ───────────────────────────────────────────────────
+
+func buildIdentityFromContext(c *fiber.Ctx) OverviewIdentity {
+	getStr := func(key string) string {
+		v, _ := c.Locals(key).(string)
+		return v
+	}
+	return OverviewIdentity{
+		Sub:      getStr("user_id"),
+		Email:    getStr("user_email"),
+		Name:     getStr("user_name"),
+		Username: getStr("user_username"),
+	}
+}
+
+// ─── Tier ───────────────────────────────────────────────────────
+
+func buildTierFromContext(c *fiber.Ctx) OverviewTier {
+	tier, _ := c.Locals("user_tier").(string)
+	if tier == "" {
+		tier = "free"
+	}
+	limits, ok := DefaultTierLimits[tier]
+	if !ok {
+		limits = DefaultTierLimits["free"]
+	}
+	return OverviewTier{
+		Current:     tier,
+		IsSuperUser: tier == "super_user",
+		Label:       tierLabelFor(tier),
+		Limits:      limits,
+	}
+}
+
+func tierLabelFor(tier string) string {
+	switch tier {
+	case "free":
+		return "Free"
+	case "uplink":
+		return "Uplink"
+	case "uplink_pro":
+		return "Uplink Pro"
+	case "uplink_ultimate":
+		return "Uplink Ultimate"
+	case "super_user":
+		return "Super User"
+	default:
+		return tier
+	}
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd api && go test ./core/ -run "TestBuildIdentity|TestBuildTier" -v 2>&1 | tail -15`
+
+Expected: 4 tests pass.
+
+- [ ] **Step 7: No commit yet** — Phase 2 commits as a unit at the end.
+
+---
+
+### Task 2.3: Channel summary helper (with test)
+
+**Files:**
+- Modify: `api/core/handlers_overview.go`
+- Modify: `api/core/handlers_overview_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `api/core/handlers_overview_test.go`:
+
+```go
+import (
+	"context"
+	// ... other imports
+)
+
+// NOTE: Using real DBPool against a test DB requires environment setup.
+// Per AGENTS.md, "No test infrastructure exists yet". For this batch,
+// channel-summary tests are integration-style and will only run when
+// DATABASE_URL is set. Skip when not.
+
+func TestGetChannelSummary_NoChannels(t *testing.T) {
+	if !testDBAvailable(t) {
+		return
+	}
+	userID := makeTestUser(t)
+	defer cleanupTestUser(t, userID)
+
+	got, err := getChannelSummary(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Total != 0 || got.Enabled != 0 || len(got.ByType) != 0 {
+		t.Errorf("expected empty summary, got %+v", got)
+	}
+}
+
+func TestGetChannelSummary_MixedEnabledStates(t *testing.T) {
+	if !testDBAvailable(t) {
+		return
+	}
+	userID := makeTestUser(t)
+	defer cleanupTestUser(t, userID)
+
+	mustExec(t, `INSERT INTO user_channels (logto_sub, channel_type, enabled, visible) VALUES
+		($1, 'finance', true, true),
+		($1, 'sports', true, true),
+		($1, 'rss', true, false),
+		($1, 'fantasy', false, false)`, userID)
+
+	got, err := getChannelSummary(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Total != 4 {
+		t.Errorf("total: want 4, got %d", got.Total)
+	}
+	if got.Enabled != 3 {
+		t.Errorf("enabled: want 3, got %d", got.Enabled)
+	}
+	if len(got.ByType) != 4 {
+		t.Errorf("by_type len: want 4, got %d", len(got.ByType))
+	}
+}
+```
+
+The helpers `testDBAvailable`, `makeTestUser`, `cleanupTestUser`, and `mustExec` are test infrastructure that may not exist yet. Check for `testDBAvailable` in `api/core/*_test.go`:
+
+Run: `grep -rn "testDBAvailable\|makeTestUser" api/core/*_test.go`
+
+If they don't exist, prepend their definitions to the test file:
+
+```go
+func testDBAvailable(t *testing.T) bool {
+	if DBPool == nil {
+		t.Skip("DBPool not initialised; skipping integration test")
+		return false
+	}
+	return true
+}
+
+func makeTestUser(t *testing.T) string {
+	id := fmt.Sprintf("test-overview-%d", time.Now().UnixNano())
+	return id
+}
+
+func cleanupTestUser(t *testing.T, userID string) {
+	if DBPool == nil {
+		return
+	}
+	_, _ = DBPool.Exec(context.Background(),
+		`DELETE FROM user_channels WHERE logto_sub = $1`, userID)
+}
+
+func mustExec(t *testing.T, query string, args ...interface{}) {
+	t.Helper()
+	if DBPool == nil {
+		t.Skip("DBPool not initialised")
+		return
+	}
+	_, err := DBPool.Exec(context.Background(), query, args...)
+	if err != nil {
+		t.Fatalf("mustExec failed: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && go test ./core/ -run TestGetChannelSummary -v 2>&1 | head -20`
+
+Expected: FAIL with `undefined: getChannelSummary` (or skip if DBPool nil — that's OK for now).
+
+- [ ] **Step 3: Add the helper**
+
+Append to `api/core/handlers_overview.go`:
+
+```go
+// ─── Channel summary ────────────────────────────────────────────
+
+func getChannelSummary(ctx context.Context, userID string) (OverviewChannels, error) {
+	const q = `
+		SELECT
+			COUNT(*) AS total,
+			COUNT(*) FILTER (WHERE enabled = true) AS enabled_count,
+			COALESCE(json_agg(json_build_object(
+				'type', channel_type,
+				'enabled', enabled,
+				'visible', visible
+			) ORDER BY channel_type), '[]'::json) AS by_type
+		FROM user_channels
+		WHERE logto_sub = $1
+	`
+
+	var (
+		total      int
+		enabled    int
+		byTypeJSON []byte
+	)
+	err := DBPool.QueryRow(ctx, q, userID).Scan(&total, &enabled, &byTypeJSON)
+	if err != nil {
+		return OverviewChannels{}, fmt.Errorf("getChannelSummary query: %w", err)
+	}
+
+	var byType []OverviewChannelRow
+	if err := json.Unmarshal(byTypeJSON, &byType); err != nil {
+		return OverviewChannels{}, fmt.Errorf("getChannelSummary unmarshal: %w", err)
+	}
+
+	return OverviewChannels{
+		Total:   total,
+		Enabled: enabled,
+		ByType:  byType,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes (or skips when no DB)**
+
+Run: `cd api && go test ./core/ -run TestGetChannelSummary -v 2>&1 | tail -10`
+
+Expected: PASS or SKIP (depending on DB availability locally; CI has DB so it'll run there).
+
+- [ ] **Step 5: No commit yet** — continue to next task.
+
+---
+
+### Task 2.4: Fantasy fan-out helper
+
+**Files:**
+- Modify: `api/core/handlers_overview.go`
+
+- [ ] **Step 1: Inspect existing channel-discovery / fan-out code for the pattern**
+
+Run: `grep -n "discoverChannels\|channelBaseURL\|GetChannelBaseURL" api/core/*.go | head -10`
+
+Expected: Locate the helper that, given a channel name (e.g. "fantasy"), returns its base URL from Redis registration. The dashboard handler uses this. If named differently, find via:
+
+Run: `grep -n "ChannelService\|RedisChannelKey\|fantasy.*base" api/core/*.go | head`
+
+Note the function name (e.g. `GetChannelService("fantasy")` or similar) for use below. If no helper exists, the discovery is direct via Redis: `Rdb.Get(ctx, "channel:fantasy:url")` — confirm key prefix from existing usage.
+
+- [ ] **Step 2: Add the fan-out helper**
+
+Append to `api/core/handlers_overview.go`. Replace `getFantasyBaseURL(...)` with whatever helper is in use:
+
+```go
+// ─── Fantasy fan-out ────────────────────────────────────────────
+
+// fetchFantasySummary queries the fantasy channel's /users/me/yahoo-summary
+// endpoint via the registered base URL. Returns nil when fantasy is not
+// reachable, not registered, or returns an error — never fails the parent
+// request.
+func fetchFantasySummary(ctx context.Context, userID string) *OverviewFantasy {
+	baseURL, err := getFantasyBaseURL(ctx)
+	if err != nil || baseURL == "" {
+		return nil
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/users/me/yahoo-summary"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Printf("[Overview] build fantasy request: %v", err)
+		return nil
+	}
+	req.Header.Set("X-User-Sub", userID)
+
+	client := &http.Client{Timeout: FantasyFanoutTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("[Overview] fantasy fan-out failed (timeout/network): %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("[Overview] fantasy fan-out non-200: %d", resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("[Overview] fantasy fan-out read body: %v", err)
+		return nil
+	}
+
+	var out OverviewFantasy
+	if err := json.Unmarshal(body, &out); err != nil {
+		log.Printf("[Overview] fantasy fan-out unmarshal: %v", err)
+		return nil
+	}
+	return &out
+}
+
+// getFantasyBaseURL returns the registered base URL for the fantasy
+// channel from Redis, or "" when not registered.
+//
+// Replace this with a call to whichever discovery helper the rest of the
+// codebase uses. If none exists, fall back to direct Redis read with the
+// channel-registration key prefix used in main.go's registerChannel calls.
+func getFantasyBaseURL(ctx context.Context) (string, error) {
+	// Inspect existing dashboard fan-out for the right key/helper.
+	// Common pattern: Rdb.Get(ctx, "channel:fantasy:url").Result()
+	url, err := Rdb.Get(ctx, "channel:fantasy:url").Result()
+	if err != nil {
+		return "", err
+	}
+	return url, nil
+}
+```
+
+If the codebase uses a different key prefix or helper, swap in the correct version (the placeholder above is a defensive default; the existing `/dashboard` handler will show the correct pattern).
+
+- [ ] **Step 3: Verify the imports**
+
+The file should already import `net/http`, `io`, `strings`, `encoding/json`, `log`, `time` from earlier tasks. Run:
+
+Run: `cd api && go build ./core/... 2>&1 | head -10`
+
+Fix any missing imports inline.
+
+- [ ] **Step 4: No commit yet** — continue.
+
+---
+
+### Task 2.5: GDPR helper + Stripe helper + assemble + invalidate + handler
+
+**Files:**
+- Modify: `api/core/handlers_overview.go`
+
+- [ ] **Step 1: Inspect existing helpers we can reuse**
+
+Run: `grep -n "getDeletionStatus\|GetDeletionStatus\|deletion_status" api/core/user_deletion.go | head -10`
+
+Expected: Confirm a helper or query already exists in `user_deletion.go` for deletion status. Note the function signature.
+
+Run: `grep -n "getSubscriptionForUser\|GetSubscription\|stripe_customers" api/core/billing.go | head -10`
+
+Expected: Find the existing helper that reads from `stripe_customers` and builds a `SubscriptionResponse`. Note the signature (likely returns `(*SubscriptionResponse, error)` with `nil, nil` for no row).
+
+- [ ] **Step 2: Add the assemble + cache + handler code**
+
+Append to `api/core/handlers_overview.go`. Adjust `getDeletionStatusForOverview` and `getSubscriptionForOverview` to call the existing helpers identified in Step 1:
+
+```go
+// ─── GDPR ───────────────────────────────────────────────────────
+
+func getDeletionStatusForOverview(ctx context.Context, userID string) OverviewGDPR {
+	// Reuses the existing deletion-status query from user_deletion.go.
+	// Replace 'GetUserDeletionStatus' with the actual helper name found
+	// in step 1.
+	status, err := GetUserDeletionStatus(ctx, userID)
+	if err != nil || status == nil {
+		return OverviewGDPR{DeletionStatus: "none"}
+	}
+
+	out := OverviewGDPR{DeletionStatus: status.Status}
+	if status.RequestedAt != nil {
+		s := status.RequestedAt.UTC().Format(time.RFC3339)
+		out.RequestedAt = &s
+	}
+	if status.PurgeAt != nil {
+		s := status.PurgeAt.UTC().Format(time.RFC3339)
+		out.PurgeAt = &s
+	}
+	return out
+}
+
+// ─── Subscription ───────────────────────────────────────────────
+
+func getSubscriptionForOverview(ctx context.Context, userID string) *SubscriptionResponse {
+	// Reuses the existing helper. Replace 'GetSubscription' with the
+	// actual helper name found in step 1. Free-tier user (no row) returns
+	// (nil, nil) by convention; nil response means "no subscription".
+	sub, err := GetSubscription(ctx, userID)
+	if err != nil {
+		log.Printf("[Overview] subscription query for %s: %v", userID, err)
+		return nil
+	}
+	return sub
+}
+
+// ─── Links ──────────────────────────────────────────────────────
+
+func buildAccountLinks() OverviewLinks {
+	endpoint := strings.TrimRight(getEnv("LOGTO_ENDPOINT", ""), "/")
+	appID := getEnv("LOGTO_APP_ID", "")
+	if endpoint == "" || appID == "" {
+		return OverviewLinks{LogtoAccount: ""}
+	}
+	return OverviewLinks{
+		LogtoAccount: fmt.Sprintf("%s/account?client_id=%s", endpoint, appID),
+	}
+}
+
+// ─── Assemble ───────────────────────────────────────────────────
+
+func assembleOverview(ctx context.Context, c *fiber.Ctx, userID string) (*OverviewResponse, error) {
+	identity := buildIdentityFromContext(c)
+	tier := buildTierFromContext(c)
+	subscription := getSubscriptionForOverview(ctx, userID)
+
+	channels, err := getChannelSummary(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("assembleOverview: channels: %w", err)
+	}
+
+	gdpr := getDeletionStatusForOverview(ctx, userID)
+
+	var fantasy *OverviewFantasy
+	if hasFantasyChannel(channels) {
+		fanCtx, cancel := context.WithTimeout(ctx, FantasyFanoutTimeout)
+		defer cancel()
+		fantasy = fetchFantasySummary(fanCtx, userID)
+	}
+
+	return &OverviewResponse{
+		Identity:     identity,
+		Tier:         tier,
+		Subscription: subscription,
+		Channels:     channels,
+		Fantasy:      fantasy,
+		GDPR:         gdpr,
+		Links:        buildAccountLinks(),
+	}, nil
+}
+
+func hasFantasyChannel(channels OverviewChannels) bool {
+	for _, c := range channels.ByType {
+		if c.Type == "fantasy" && c.Enabled {
+			return true
+		}
+	}
+	return false
+}
+
+// ─── Cache invalidation (called from webhook + CRUD + GDPR paths) ──
+
+func InvalidateOverviewCache(ctx context.Context, userID string) {
+	if userID == "" || Rdb == nil {
+		return
+	}
+	key := RedisOverviewCachePrefix + userID
+	if err := Rdb.Del(ctx, key).Err(); err != nil {
+		log.Printf("[Overview] cache invalidate failed for %s: %v", userID, err)
+	}
+}
+
+// ─── Handler ────────────────────────────────────────────────────
+
+func HandleGetOverview(c *fiber.Ctx) error {
+	userID := GetUserSub(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Status: "unauthorized",
+			Error:  "authentication required",
+		})
+	}
+
+	cacheKey := RedisOverviewCachePrefix + userID
+
+	// Fast path: serve from Redis cache.
+	if cached, err := Rdb.Get(c.Context(), cacheKey).Bytes(); err == nil {
+		c.Set("X-Cache", "hit")
+		c.Set("Content-Type", "application/json")
+		return c.Send(cached)
+	} else if err != redis.Nil {
+		// Redis miss is the normal path; only log unexpected errors.
+		log.Printf("[Overview] cache read for %s: %v", userID, err)
+	}
+
+	// Slow path: assemble + cache, with singleflight to coalesce concurrent misses.
+	result, err, _ := overviewGroup.Do(userID, func() (interface{}, error) {
+		return assembleOverview(c.Context(), c, userID)
+	})
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  err.Error(),
+		})
+	}
+
+	overview, ok := result.(*OverviewResponse)
+	if !ok || overview == nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "invalid overview shape",
+		})
+	}
+
+	payload, err := json.Marshal(overview)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  fmt.Sprintf("marshal overview: %v", err),
+		})
+	}
+
+	if setErr := Rdb.Set(c.Context(), cacheKey, payload, OverviewCacheTTL).Err(); setErr != nil {
+		log.Printf("[Overview] cache write for %s: %v", userID, setErr)
+	}
+
+	c.Set("X-Cache", "miss")
+	c.Set("Content-Type", "application/json")
+	return c.Send(payload)
+}
+```
+
+Note the import for `redis.Nil` — add `"github.com/redis/go-redis/v9"` to the import block at the top of the file (or the appropriate alias used elsewhere in `api/core/`).
+
+If `getEnv` doesn't exist, use `os.Getenv` directly with empty-string fallback. If `GetUserDeletionStatus` doesn't return the shape expected, adjust to match the actual return type — the test in step 3 below will catch mismatches.
+
+- [ ] **Step 3: Build verify**
+
+Run: `cd api && go vet ./core/... 2>&1 | head -20`
+
+Expected: clean. Any errors here indicate the helper-name placeholders need to be swapped to actual names. Fix and re-run.
+
+Run: `cd api && go build -o /tmp/api_check . && rm -f /tmp/api_check`
+
+Expected: clean.
+
+- [ ] **Step 4: No commit yet.**
+
+---
+
+### Task 2.6: Cache invalidation hooks (Stripe webhook + channel CRUD + GDPR)
+
+**Files:**
+- Modify: `api/core/stripe_webhook.go`
+- Modify: `api/core/handlers_channel.go`
+- Modify: `api/core/user_deletion.go`
+
+- [ ] **Step 1: Add invalidation to Stripe webhook**
+
+Open `api/core/stripe_webhook.go`. Find the handler section that processes `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted` events. After the database write completes (typically marked by an `INSERT ... ON CONFLICT` or `UPDATE`), add:
+
+```go
+// Invalidate the per-user overview cache so the next /users/me/overview
+// reflects the new subscription state immediately.
+InvalidateOverviewCache(ctx, sub.LogtoSub) // adjust variable name to match local scope
+```
+
+The exact spot depends on the existing handler structure. Search for the function that handles each of these events (e.g. `handleSubscriptionUpdated`) and insert the call near the end, before the success return.
+
+Run: `grep -n "subscription.updated\|customer.subscription" api/core/stripe_webhook.go | head -5`
+
+- [ ] **Step 2: Add invalidation to channel CRUD**
+
+Open `api/core/handlers_channel.go`. Find these three handler functions (search via grep):
+- `CreateChannel` (or `HandleCreateChannel`)
+- `UpdateChannel` (or `HandleUpdateChannel`)
+- `DeleteChannel` (or `HandleDeleteChannel`)
+
+In each, after the database write succeeds and before returning the response, add:
+
+```go
+InvalidateOverviewCache(c.Context(), userID)
+```
+
+Where `userID` is whatever variable holds the logto_sub in that handler (commonly extracted via `GetUserSub(c)` near the top).
+
+- [ ] **Step 3: Add invalidation to GDPR handlers**
+
+Open `api/core/user_deletion.go`. Find these three handlers:
+- `HandleRequestDeletion` (or similar)
+- `HandleCancelDeletion` (or similar)
+- `PurgeUser` (or `processPurge` — the purger goroutine)
+
+After successful state mutation in each, add `InvalidateOverviewCache(ctx, userID)`. For the purger goroutine, `ctx` is `context.Background()` — that's fine.
+
+- [ ] **Step 4: Verify build**
+
+Run: `cd api && go vet ./... && go build -o /tmp/api_check . && rm -f /tmp/api_check`
+
+Expected: clean.
+
+- [ ] **Step 5: No commit yet.**
+
+---
+
+### Task 2.7: Add the route + remaining tests
+
+**Files:**
+- Modify: `api/core/server.go`
+- Modify: `api/core/handlers_overview_test.go`
+
+- [ ] **Step 1: Register the route**
+
+Open `api/core/server.go`. Find the block where authenticated user routes are registered (around line 200, where you see `app.Get("/users/me/subscription", ...)` etc.). Add:
+
+```go
+app.Get("/users/me/overview", LogtoAuth, HandleGetOverview)
+```
+
+Match the exact middleware-chain pattern used by neighboring routes (e.g. some routes use `app.Get(path, LogtoAuth, handler)`, others use a route group with the auth middleware applied once). Use the same pattern as `/users/me/subscription`.
+
+- [ ] **Step 2: Add cache hit/miss test**
+
+Append to `api/core/handlers_overview_test.go`:
+
+```go
+func TestHandleGetOverview_CacheRoundtrip(t *testing.T) {
+	if !testDBAvailable(t) {
+		return
+	}
+	if Rdb == nil {
+		t.Skip("Redis not initialised; skipping integration test")
+	}
+
+	userID := makeTestUser(t)
+	defer cleanupTestUser(t, userID)
+
+	// Pre-warm: insert a single channel
+	mustExec(t, `INSERT INTO user_channels (logto_sub, channel_type, enabled, visible)
+		VALUES ($1, 'finance', true, true)`, userID)
+
+	// Clear any existing cache
+	Rdb.Del(context.Background(), RedisOverviewCachePrefix+userID)
+
+	// First call: cache miss, builds from DB
+	app := fiber.New()
+	app.Get("/users/me/overview", func(c *fiber.Ctx) error {
+		c.Locals("user_id", userID)
+		c.Locals("user_email", "test@example.com")
+		c.Locals("user_tier", "free")
+		return HandleGetOverview(c)
+	})
+	req1, _ := http.NewRequest("GET", "/users/me/overview", nil)
+	resp1, err := app.Test(req1)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if resp1.StatusCode != 200 {
+		body, _ := io.ReadAll(resp1.Body)
+		t.Fatalf("first call status %d: %s", resp1.StatusCode, body)
+	}
+	if got := resp1.Header.Get("X-Cache"); got != "miss" {
+		t.Errorf("first call X-Cache: want miss, got %q", got)
+	}
+
+	// Second call: cache hit
+	req2, _ := http.NewRequest("GET", "/users/me/overview", nil)
+	resp2, err := app.Test(req2)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if got := resp2.Header.Get("X-Cache"); got != "hit" {
+		t.Errorf("second call X-Cache: want hit, got %q", got)
+	}
+
+	// Cleanup
+	Rdb.Del(context.Background(), RedisOverviewCachePrefix+userID)
+}
+
+func TestInvalidateOverviewCache_DeletesKey(t *testing.T) {
+	if Rdb == nil {
+		t.Skip("Redis not initialised")
+	}
+	userID := "test-invalidate-" + fmt.Sprintf("%d", time.Now().UnixNano())
+	key := RedisOverviewCachePrefix + userID
+
+	Rdb.Set(context.Background(), key, []byte("test"), 60*time.Second)
+	InvalidateOverviewCache(context.Background(), userID)
+
+	_, err := Rdb.Get(context.Background(), key).Result()
+	if err == nil {
+		t.Error("expected cache key to be deleted, but it still exists")
+	}
+}
+```
+
+Add the missing imports if needed: `net/http`, `io`.
+
+- [ ] **Step 3: Run all overview tests**
+
+Run: `cd api && go test ./core/ -run "TestBuildIdentity|TestBuildTier|TestGetChannelSummary|TestHandleGetOverview|TestInvalidateOverview" -v 2>&1 | tail -25`
+
+Expected: all PASS or SKIP (depending on DB/Redis availability locally).
+
+- [ ] **Step 4: Run full Go test suite**
+
+Run: `cd api && go test ./... 2>&1 | tail -10`
+
+Expected: all existing tests still pass; new ones pass or skip gracefully.
+
+- [ ] **Step 5: Commit Phase 2**
+
+```bash
+git add api/core/handlers_overview.go api/core/handlers_overview_test.go api/core/server.go api/core/stripe_webhook.go api/core/handlers_channel.go api/core/user_deletion.go api/core/auth.go
+git commit -m "feat(api): GET /users/me/overview with singleflight + invalidation"
+```
+
+---
+
+# PHASE 3 — Desktop client refactor
+
+This phase consumes the new endpoint, adds the GDPR export and stats components, and bumps to v1.0.4.
+
+### Task 3.1: UserOverview interface + userApi.overview()
+
+**Files:**
+- Modify: `desktop/src/api/client.ts`
+
+- [ ] **Step 1: Inspect existing userApi shape**
+
+Run: `grep -n "userApi\|export const userApi\|fetchSubscription" desktop/src/api/client.ts | head -10`
+
+Expected: Find the existing `userApi` namespace (or equivalent). Note how other methods are written (`authFetch`, error handling, return shape).
+
+- [ ] **Step 2: Add UserOverview interface**
+
+In `desktop/src/api/client.ts`, near the existing `SubscriptionInfo` interface, add:
+
+```ts
+export interface UserOverview {
+  identity: {
+    sub: string;
+    email: string;
+    name: string;
+    username: string;
+  };
+  tier: {
+    current: string;
+    is_super_user: boolean;
+    label: string;
+    limits: {
+      symbols: number;
+      feeds: number;
+      custom_feeds: number;
+      leagues: number;
+      fantasy: number;
+      max_ticker_rows: number;
+      max_ticker_customization: boolean;
+    };
+  };
+  subscription: SubscriptionInfo | null;
+  channels: {
+    total: number;
+    enabled: number;
+    by_type: Array<{ type: string; enabled: boolean; visible: boolean }>;
+  };
+  fantasy: {
+    yahoo_connected: boolean;
+    yahoo_synced: boolean;
+    league_count: number;
+  } | null;
+  gdpr: {
+    deletion_status: "none" | "pending" | "canceled" | "purged";
+    requested_at: string | null;
+    purge_at: string | null;
+  };
+  links: {
+    logto_account: string;
+  };
+}
+```
+
+- [ ] **Step 3: Add the fetcher method**
+
+Append to the existing `userApi` namespace (or wherever `fetchSubscription` lives):
+
+```ts
+async overview(): Promise<UserOverview> {
+  const response = await authFetch("/users/me/overview", { method: "GET" });
+  if (!response.ok) {
+    throw new Error(`overview fetch failed: ${response.status}`);
+  }
+  return response.json();
+}
+```
+
+If the existing pattern uses standalone functions (not a namespace), add:
+
+```ts
+export async function fetchOverview(): Promise<UserOverview> {
+  const response = await authFetch("/users/me/overview", { method: "GET" });
+  if (!response.ok) {
+    throw new Error(`overview fetch failed: ${response.status}`);
+  }
+  return response.json();
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd desktop && npx tsc --noEmit 2>&1 | head -10`
+
+Expected: clean (no errors).
+
+- [ ] **Step 5: No commit yet** — Phase 3 commits as a unit at the end.
+
+---
+
+### Task 3.2: Query options
+
+**Files:**
+- Modify: `desktop/src/api/queries.ts`
+
+- [ ] **Step 1: Inspect queryKeys + existing options shape**
+
+Run: `grep -n "queryKeys\|queryOptions\|dashboard" desktop/src/api/queries.ts | head -10`
+
+Expected: Locate `queryKeys` constant (used for query identification across the app) and the existing `dashboardQueryOptions` pattern.
+
+- [ ] **Step 2: Extend queryKeys + add options**
+
+In `desktop/src/api/queries.ts`, add to the `queryKeys` const:
+
+```ts
+userOverview: ["userOverview"] as const,
+```
+
+Then add (near `dashboardQueryOptions`):
+
+```ts
+import { fetchOverview, type UserOverview } from "./client";  // adjust import shape if userApi.overview() pattern is in use
+
+export function userOverviewQueryOptions() {
+  return queryOptions<UserOverview>({
+    queryKey: queryKeys.userOverview,
+    queryFn: fetchOverview,
+    staleTime: 30_000,        // matches server cache
+    gcTime: 5 * 60_000,
+    retry: 1,
+    refetchOnWindowFocus: true,
+  });
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd desktop && npx tsc --noEmit 2>&1 | head -10`
+
+Expected: clean.
+
+- [ ] **Step 4: No commit yet.**
+
+---
+
+### Task 3.3: AccountStatsRow component (with test)
+
+**Files:**
+- Create: `desktop/src/components/settings/AccountStatsRow.tsx`
+- Create: `desktop/src/components/settings/AccountStatsRow.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `desktop/src/components/settings/AccountStatsRow.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { AccountStatsRow } from "./AccountStatsRow";
+
+describe("AccountStatsRow", () => {
+  it("renders nothing when total channels is 0", () => {
+    const { container } = render(
+      <AccountStatsRow
+        channelsTotal={0}
+        channelsEnabled={0}
+        fantasy={null}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the channel count when channels exist", () => {
+    render(
+      <AccountStatsRow
+        channelsTotal={4}
+        channelsEnabled={3}
+        fantasy={null}
+      />
+    );
+    expect(screen.getByText(/3 of 4/)).toBeInTheDocument();
+  });
+
+  it("hides fantasy line when fantasy is null", () => {
+    render(
+      <AccountStatsRow
+        channelsTotal={2}
+        channelsEnabled={2}
+        fantasy={null}
+      />
+    );
+    expect(screen.queryByText(/fantasy league/i)).toBeNull();
+  });
+
+  it("shows fantasy league count when connected", () => {
+    render(
+      <AccountStatsRow
+        channelsTotal={2}
+        channelsEnabled={2}
+        fantasy={{ yahoo_connected: true, yahoo_synced: true, league_count: 3 }}
+      />
+    );
+    expect(screen.getByText(/3 fantasy league/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd desktop && npx vitest run src/components/settings/AccountStatsRow.test.tsx 2>&1 | tail -10`
+
+Expected: FAIL with `Cannot find module './AccountStatsRow'`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `desktop/src/components/settings/AccountStatsRow.tsx`:
+
+```tsx
+import type { UserOverview } from "../../api/client";
+
+interface AccountStatsRowProps {
+  channelsTotal: number;
+  channelsEnabled: number;
+  fantasy: UserOverview["fantasy"];
+}
+
+export function AccountStatsRow({
+  channelsTotal,
+  channelsEnabled,
+  fantasy,
+}: AccountStatsRowProps) {
+  if (channelsTotal === 0) return null;
+
+  const showFantasy = fantasy !== null && fantasy.yahoo_connected && fantasy.league_count > 0;
+
+  return (
+    <div className="flex flex-col gap-1 px-3 py-2 rounded-lg bg-base-200 border border-edge">
+      <div className="text-xs text-fg-3 uppercase tracking-wider">Quick stats</div>
+      <div className="text-sm text-fg-2">
+        <span className="font-medium text-fg">{channelsEnabled}</span>
+        <span className="text-fg-3"> of </span>
+        <span className="font-medium text-fg">{channelsTotal}</span>
+        <span className="text-fg-3"> channels enabled</span>
+      </div>
+      {showFantasy && (
+        <div className="text-sm text-fg-2">
+          <span className="font-medium text-fg">{fantasy!.league_count}</span>
+          <span className="text-fg-3"> fantasy league{fantasy!.league_count !== 1 ? "s" : ""} imported</span>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd desktop && npx vitest run src/components/settings/AccountStatsRow.test.tsx 2>&1 | tail -10`
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: No commit yet.**
+
+---
+
+### Task 3.4: AccountExportButton component (with test)
+
+**Files:**
+- Create: `desktop/src/components/settings/AccountExportButton.tsx`
+- Create: `desktop/src/components/settings/AccountExportButton.test.tsx`
+
+- [ ] **Step 1: Inspect existing API patterns**
+
+Run: `grep -n "authFetch\|/users/me/export" desktop/src/api/client.ts | head -5`
+
+Expected: locate `authFetch` and verify there's no existing export call. We'll add it as part of this task since the website already has it but desktop doesn't.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `desktop/src/components/settings/AccountExportButton.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AccountExportButton } from "./AccountExportButton";
+
+// Mock the @tauri-apps/plugin-shell open() function
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock the API
+vi.mock("../../api/client", () => ({
+  exportUserData: vi.fn().mockResolvedValue(new Blob(["test"], { type: "application/zip" })),
+}));
+
+describe("AccountExportButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the button in idle state", () => {
+    render(<AccountExportButton />);
+    expect(screen.getByRole("button", { name: /download my data/i })).toBeInTheDocument();
+  });
+
+  it("shows loading state when clicked", async () => {
+    render(<AccountExportButton />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByText(/preparing/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders error state when fetch fails", async () => {
+    const { exportUserData } = await import("../../api/client");
+    vi.mocked(exportUserData).mockRejectedValueOnce(new Error("network down"));
+
+    render(<AccountExportButton />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed/i)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd desktop && npx vitest run src/components/settings/AccountExportButton.test.tsx 2>&1 | tail -10`
+
+Expected: FAIL.
+
+- [ ] **Step 4: Add the export API helper**
+
+Modify `desktop/src/api/client.ts` — add a new function near `userApi`:
+
+```ts
+export async function exportUserData(): Promise<Blob> {
+  const response = await authFetch("/users/me/export", { method: "GET" });
+  if (!response.ok) {
+    throw new Error(`export failed: ${response.status}`);
+  }
+  return response.blob();
+}
+```
+
+- [ ] **Step 5: Implement the button component**
+
+Create `desktop/src/components/settings/AccountExportButton.tsx`:
+
+```tsx
+import { useState } from "react";
+import { Download, Loader2, AlertCircle } from "lucide-react";
+import { exportUserData } from "../../api/client";
+
+type ButtonState = "idle" | "loading" | "error";
+
+export function AccountExportButton() {
+  const [state, setState] = useState<ButtonState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  async function handleClick() {
+    setState("loading");
+    setErrorMessage("");
+    try {
+      const blob = await exportUserData();
+      // Trigger browser download via blob URL — works in Tauri webview.
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `myscrollr-export-${new Date().toISOString().slice(0, 10)}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setState("idle");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      setErrorMessage(msg);
+      setState("error");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        onClick={handleClick}
+        disabled={state === "loading"}
+        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
+      >
+        {state === "loading" ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span>Preparing your data…</span>
+          </>
+        ) : (
+          <>
+            <Download className="w-4 h-4" />
+            <span>Download my data</span>
+          </>
+        )}
+      </button>
+      {state === "error" && (
+        <div className="flex items-center gap-1.5 text-xs text-down">
+          <AlertCircle className="w-3.5 h-3.5" />
+          <span>Failed: {errorMessage}</span>
+        </div>
+      )}
+      <p className="text-xs text-fg-4">
+        To delete your account, visit{" "}
+        <span className="text-fg-3">myscrollr.com/account</span>.
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd desktop && npx vitest run src/components/settings/AccountExportButton.test.tsx 2>&1 | tail -10`
+
+Expected: 3 PASS.
+
+- [ ] **Step 7: No commit yet.**
+
+---
+
+### Task 3.5: Refactor AccountSettings.tsx to consume overview
+
+**Files:**
+- Modify: `desktop/src/components/settings/AccountSettings.tsx`
+
+- [ ] **Step 1: Read current state**
+
+Run: `cd desktop && wc -l src/components/settings/AccountSettings.tsx`
+
+Note total line count. Open the file and identify:
+- Where `useShell()` provides `subscriptionInfo`, `tier`, `authenticated`
+- Where `TierLimitsTable` is rendered
+- Where existing API calls happen (none on this page directly, per spec)
+
+- [ ] **Step 2: Add overview query**
+
+Near the top of the component:
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+import { userOverviewQueryOptions } from "../../api/queries";
+import { AccountStatsRow } from "./AccountStatsRow";
+import { AccountExportButton } from "./AccountExportButton";
+
+// Inside component body:
+const { data: overview } = useQuery(userOverviewQueryOptions());
+```
+
+- [ ] **Step 3: Render the new sections**
+
+Find the existing layout (Account → Subscription → Your Plan → Reset). Insert sections so the order becomes:
+1. Account (unchanged)
+2. **Quick Stats** (NEW)
+3. Subscription (data sourced from overview, fallback to shell context)
+4. Your Plan (TierLimitsTable; prefer `overview?.tier.limits ?? TIER_LIMITS[currentTier]`)
+5. **Your Data** (NEW)
+6. Reset all settings (unchanged)
+
+For Quick Stats:
+
+```tsx
+{overview && (
+  <AccountStatsRow
+    channelsTotal={overview.channels.total}
+    channelsEnabled={overview.channels.enabled}
+    fantasy={overview.fantasy}
+  />
+)}
+```
+
+For Your Data:
+
+```tsx
+<section className="flex flex-col gap-3">
+  <h3 className="text-xs text-fg-3 uppercase tracking-wider">Your data</h3>
+  <AccountExportButton />
+</section>
+```
+
+For Tier Limits, change:
+
+```tsx
+<TierLimitsTable tier={tier} />
+```
+
+to:
+
+```tsx
+<TierLimitsTable tier={tier} limits={overview?.tier.limits ?? undefined} />
+```
+
+(Then update `TierLimitsTable` to accept the optional `limits` prop and use it when provided. If `TierLimitsTable` doesn't take a limits prop today, this is a small follow-up edit.)
+
+- [ ] **Step 4: Run type-check + tests**
+
+Run: `cd desktop && npx tsc --noEmit 2>&1 | head -10`
+
+Expected: clean. If `TierLimitsTable` needs the new optional prop, add it.
+
+Run: `cd desktop && npx vitest run 2>&1 | tail -10`
+
+Expected: all 171+ tests pass (any new failures indicate test fixtures need updating).
+
+- [ ] **Step 5: No commit yet.**
+
+---
+
+### Task 3.6: Update __root.tsx to derive subscriptionInfo from overview
+
+**Files:**
+- Modify: `desktop/src/routes/__root.tsx`
+
+- [ ] **Step 1: Inspect current subscription wiring**
+
+Run: `grep -n "fetchSubscription\|subscriptionInfo" desktop/src/routes/__root.tsx | head -10`
+
+Expected: Find the existing `fetchSubscription()` call and where `subscriptionInfo` is plumbed into `useShell()` context.
+
+- [ ] **Step 2: Replace with overview-derived value**
+
+Replace:
+
+```tsx
+const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
+
+useEffect(() => {
+  fetchSubscription().then(setSubscriptionInfo).catch(...);
+  // ... window focus refresh
+}, []);
+```
+
+With:
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+import { userOverviewQueryOptions } from "../api/queries";
+
+const { data: overview } = useQuery(userOverviewQueryOptions());
+const subscriptionInfo = overview?.subscription ?? null;
+```
+
+The window-focus refresh is preserved by `refetchOnWindowFocus: true` in the query options (Task 3.2).
+
+If the existing tier-mismatch detector hook reads from `subscriptionInfo` and JWT roles, leave it alone — it'll just use the new value automatically.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd desktop && npx tsc --noEmit 2>&1 | head -10`
+
+Expected: clean.
+
+- [ ] **Step 4: No commit yet.**
+
+---
+
+### Task 3.7: Bump desktop to v1.0.4
+
+**Files:**
+- Modify: `desktop/package.json`
+- Modify: `desktop/package-lock.json`
+- Modify: `desktop/src-tauri/tauri.conf.json`
+- Modify: `desktop/src-tauri/Cargo.toml`
+
+- [ ] **Step 1: Bump package.json**
+
+Run: `grep -n '"version"' desktop/package.json | head -3`
+
+Edit the top-level `"version": "1.0.3"` → `"version": "1.0.4"`.
+
+- [ ] **Step 2: Bump tauri.conf.json**
+
+Run: `grep -n '"version"' desktop/src-tauri/tauri.conf.json | head -3`
+
+Edit `"version": "1.0.3"` → `"version": "1.0.4"`.
+
+- [ ] **Step 3: Bump Cargo.toml**
+
+Run: `grep -n 'version' desktop/src-tauri/Cargo.toml | head -3`
+
+Edit `version = "1.0.3"` → `version = "1.0.4"` (typically near the top of `[package]`).
+
+- [ ] **Step 4: Bump package-lock.json**
+
+Run: `grep -n '"version"' desktop/package-lock.json | head -5`
+
+Edit BOTH the top-level `"version": "1.0.3"` and the `"packages": { "": { ... "version": "1.0.3" } }` entry → `"1.0.4"`. This file has two version strings that must both be updated.
+
+- [ ] **Step 5: Verify all four match**
+
+Run: `grep -n '"version"' desktop/package.json desktop/package-lock.json desktop/src-tauri/tauri.conf.json && grep -n 'version = "1' desktop/src-tauri/Cargo.toml`
+
+Expected: All entries show `1.0.4`.
+
+- [ ] **Step 6: No commit yet.**
+
+---
+
+### Task 3.8: Final verify + commit Phase 3
+
+- [ ] **Step 1: Full TypeScript check**
+
+Run: `cd desktop && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: clean.
+
+- [ ] **Step 2: Run all Vitest**
+
+Run: `cd desktop && npx vitest run 2>&1 | tail -15`
+
+Expected: all tests pass (171 from Batch A + the 7 new ones in Phase 3 = 178 total).
+
+- [ ] **Step 3: Build verify**
+
+Run: `cd desktop && npm run build 2>&1 | tail -5`
+
+Expected: `built in <X>s`. The 500 KB chunk-size warning is pre-existing and unchanged.
+
+- [ ] **Step 4: Cargo check (Tauri backend)**
+
+Run: `cd desktop && cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | tail -5`
+
+Expected: `Finished dev profile`.
+
+- [ ] **Step 5: Commit Phase 3**
+
+```bash
+git add desktop/src/api/client.ts desktop/src/api/queries.ts \
+  desktop/src/components/settings/AccountStatsRow.tsx \
+  desktop/src/components/settings/AccountStatsRow.test.tsx \
+  desktop/src/components/settings/AccountExportButton.tsx \
+  desktop/src/components/settings/AccountExportButton.test.tsx \
+  desktop/src/components/settings/AccountSettings.tsx \
+  desktop/src/routes/__root.tsx \
+  desktop/package.json desktop/package-lock.json \
+  desktop/src-tauri/tauri.conf.json desktop/src-tauri/Cargo.toml
+git commit -m "feat(desktop): consume /users/me/overview + GDPR export + stats card (v1.0.4)"
+```
+
+---
+
+# PHASE 4 — Website client refactor
+
+This phase swaps the website's 4-fetch fan-out for a single overview consumer.
+
+### Task 4.1: UserOverview type + userApi.overview()
+
+**Files:**
+- Modify: `myscrollr.com/src/api/client.ts`
+
+- [ ] **Step 1: Inspect existing client shape**
+
+Run: `grep -n "userApi\|getSubscription\|exportUserData" myscrollr.com/src/api/client.ts | head -10`
+
+- [ ] **Step 2: Add the same UserOverview interface**
+
+Add to `myscrollr.com/src/api/client.ts`. The shape mirrors the desktop interface verbatim (use `'`, no `;`, trailing comma per Prettier config):
+
+```ts
+export interface UserOverview {
+  identity: {
+    sub: string
+    email: string
+    name: string
+    username: string
+  }
+  tier: {
+    current: string
+    is_super_user: boolean
+    label: string
+    limits: {
+      symbols: number
+      feeds: number
+      custom_feeds: number
+      leagues: number
+      fantasy: number
+      max_ticker_rows: number
+      max_ticker_customization: boolean
+    }
+  }
+  subscription: SubscriptionResponse | null
+  channels: {
+    total: number
+    enabled: number
+    by_type: Array<{ type: string; enabled: boolean; visible: boolean }>
+  }
+  fantasy: {
+    yahoo_connected: boolean
+    yahoo_synced: boolean
+    league_count: number
+  } | null
+  gdpr: {
+    deletion_status: 'none' | 'pending' | 'canceled' | 'purged'
+    requested_at: string | null
+    purge_at: string | null
+  }
+  links: {
+    logto_account: string
+  }
+}
+```
+
+(Note: website uses `SubscriptionResponse`; desktop uses `SubscriptionInfo`. Same shape, different name. Both are fine.)
+
+- [ ] **Step 3: Add the fetcher to userApi**
+
+Inside the existing `userApi` namespace:
+
+```ts
+async overview(): Promise<UserOverview> {
+  return apiFetch<UserOverview>('/users/me/overview')
+},
+```
+
+(`apiFetch` is the website's existing fetch wrapper — match the pattern of neighboring methods.)
+
+- [ ] **Step 4: Type-check + format**
+
+Run: `cd myscrollr.com && npm run check 2>&1 | tail -10`
+
+Expected: clean (Prettier formats automatically; ESLint --fix passes).
+
+Run: `cd myscrollr.com && npx tsc --noEmit 2>&1 | head -10`
+
+Expected: clean.
+
+- [ ] **Step 5: No commit yet.**
+
+---
+
+### Task 4.2: Refactor account.tsx
+
+**Files:**
+- Modify: `myscrollr.com/src/routes/account.tsx`
+
+- [ ] **Step 1: Inspect current fetches**
+
+Run: `grep -n "useQuery\|getIdTokenClaims\|channelsApi.getAll\|deletion-status" myscrollr.com/src/routes/account.tsx | head -10`
+
+Expected: 3 separate `useQuery` calls + Logto SDK usage for claims.
+
+- [ ] **Step 2: Replace with single overview query**
+
+Find:
+
+```ts
+const { data: claims } = useQuery({ queryKey: ['claims'], queryFn: getIdTokenClaims })
+const { data: channelsData } = useQuery({ queryKey: ['channels'], queryFn: channelsApi.getAll })
+const { data: deletionStatus } = useQuery({ queryKey: ['deletion-status'], queryFn: ... })
+```
+
+(or whatever the actual code is)
+
+Replace with:
+
+```ts
+import { userApi, type UserOverview } from '@/api/client'
+
+const { data: overview } = useQuery({
+  queryKey: ['user-overview'],
+  queryFn: userApi.overview,
+  staleTime: 30_000,
+  retry: 1,
+})
+```
+
+- [ ] **Step 3: Re-route reads to overview shape**
+
+Find every reference to `claims.username`, `claims.name`, `channelsData.length`, `deletionStatus.status` — replace each:
+
+| Old | New |
+|---|---|
+| `claims?.username` | `overview?.identity.username` |
+| `claims?.name` | `overview?.identity.name` |
+| `claims?.email` | `overview?.identity.email` |
+| `channelsData?.length` | `overview?.channels.total` |
+| `channelsData?.filter(c => c.enabled).length` | `overview?.channels.enabled` |
+| `deletionStatus?.status` | `overview?.gdpr.deletion_status` |
+| `deletionStatus?.requested_at` | `overview?.gdpr.requested_at` |
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd myscrollr.com && npx tsc --noEmit 2>&1 | head -10`
+
+Expected: clean.
+
+- [ ] **Step 5: No commit yet.**
+
+---
+
+### Task 4.3: Refactor SubscriptionStatus.tsx
+
+**Files:**
+- Modify: `myscrollr.com/src/components/billing/SubscriptionStatus.tsx`
+
+- [ ] **Step 1: Inspect current shape**
+
+Run: `grep -n "useQuery\|billingApi\|getPreferences\|tier" myscrollr.com/src/components/billing/SubscriptionStatus.tsx | head -10`
+
+- [ ] **Step 2: Switch to consuming overview**
+
+Change the component to accept `subscription` and `tier` as props from `account.tsx` (passed in from the overview query), instead of fetching internally:
+
+```tsx
+interface SubscriptionStatusProps {
+  subscription: UserOverview['subscription']
+  tier: string
+}
+
+export function SubscriptionStatus({ subscription, tier }: SubscriptionStatusProps) {
+  // existing render logic — replace internal queries with the props
+}
+```
+
+In `account.tsx`, update the render call:
+
+```tsx
+{overview && (
+  <SubscriptionStatus
+    subscription={overview.subscription}
+    tier={overview.tier.current}
+  />
+)}
+```
+
+Mutating actions (`createPortalSession`, `cancelSubscription`) remain inside `SubscriptionStatus` and continue to call their existing endpoints directly — those endpoints aren't superseded by overview.
+
+- [ ] **Step 3: Type-check + format**
+
+Run: `cd myscrollr.com && npm run check 2>&1 | tail -10`
+
+Expected: clean.
+
+- [ ] **Step 4: No commit yet.**
+
+---
+
+### Task 4.4: Update AccountDangerZone for gdpr from overview
+
+**Files:**
+- Modify: `myscrollr.com/src/components/account/AccountDangerZone.tsx`
+
+- [ ] **Step 1: Inspect current shape**
+
+Run: `grep -n "deletion_status\|deletionStatus\|useQuery" myscrollr.com/src/components/account/AccountDangerZone.tsx | head -10`
+
+- [ ] **Step 2: Switch to prop-driven for the pending banner**
+
+Change the component to accept `deletionStatus` as a prop:
+
+```tsx
+interface AccountDangerZoneProps {
+  deletionStatus: UserOverview['gdpr']['deletion_status']
+  requestedAt: string | null
+  purgeAt: string | null
+}
+```
+
+Existing mutation calls (`requestDeletion`, `cancelDeletion`, `exportUserData`) stay as-is — they're mutating endpoints not covered by overview.
+
+In `account.tsx`:
+
+```tsx
+{overview && (
+  <AccountDangerZone
+    deletionStatus={overview.gdpr.deletion_status}
+    requestedAt={overview.gdpr.requested_at}
+    purgeAt={overview.gdpr.purge_at}
+  />
+)}
+```
+
+- [ ] **Step 3: Type-check + format + build**
+
+Run: `cd myscrollr.com && npm run check 2>&1 | tail -10`
+
+Expected: clean.
+
+Run: `cd myscrollr.com && npm run build 2>&1 | tail -5`
+
+Expected: `vite build` clean.
+
+- [ ] **Step 4: Commit Phase 4**
+
+```bash
+git add myscrollr.com/src/api/client.ts \
+  myscrollr.com/src/routes/account.tsx \
+  myscrollr.com/src/components/billing/SubscriptionStatus.tsx \
+  myscrollr.com/src/components/account/AccountDangerZone.tsx
+git commit -m "refactor(marketing): /account consumes /users/me/overview"
+```
+
+---
+
+# PHASE 5 — Verification, push, PR, post-merge ops
+
+### Task 5.1: Final verification across the stack
+
+- [ ] **Step 1: Backend full test**
+
+Run: `cd api && go vet ./... && go test ./... 2>&1 | tail -10`
+
+Expected: clean vet, all tests pass or skip gracefully.
+
+Run: `cd channels/fantasy/api && go vet ./... && go build -o /tmp/f && rm -f /tmp/f`
+
+Expected: clean.
+
+- [ ] **Step 2: Desktop full test**
+
+Run: `cd desktop && npx tsc --noEmit && npx vitest run && npm run build 2>&1 | tail -10`
+
+Expected: 178+ tests pass, build clean.
+
+Run: `cd desktop && cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | tail -3`
+
+Expected: `Finished dev profile`.
+
+- [ ] **Step 3: Website check + build**
+
+Run: `cd myscrollr.com && npm run check && npm run build 2>&1 | tail -10`
+
+Expected: clean lint + format, vite build succeeds.
+
+- [ ] **Step 4: Inspect uncommitted state**
+
+Run: `git status`
+
+Expected: clean working tree (4 commits made: phase 1, 2, 3, 4).
+
+Run: `git log --oneline main..HEAD`
+
+Expected: 4 commits (one per phase).
+
+---
+
+### Task 5.2: Push branch + open PR
+
+- [ ] **Step 1: Push branch**
+
+Run: `git push -u origin feature/batch-b-account-overview 2>&1 | tail -3`
+
+Expected: branch published.
+
+- [ ] **Step 2: Open PR**
+
+Run:
+
+```bash
+gh pr create --title "feat(account): unified /users/me/overview endpoint + both clients (v1.0.4)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `GET /users/me/overview` to core API: identity + tier + subscription + channel summary + GDPR + fantasy summary in one round-trip; 30s Redis cache with singleflight; webhook + CRUD + GDPR mutations invalidate.
+- Adds `GET /users/me/yahoo-summary` to fantasy API for the overview fan-out.
+- Refactors desktop Account tab to consume `/users/me/overview` once; adds Quick Stats card and a GDPR export button. Bumps desktop to **v1.0.4**.
+- Refactors website `/account` to drop 3 separate fetches in favor of the overview endpoint.
+
+## Spec
+
+- `docs/superpowers/specs/2026-04-28-batch-b-account-overview-design.md`
+
+## Plan
+
+- `docs/superpowers/plans/2026-04-28-batch-b-account-overview.md`
+
+## Post-merge ops
+
+After merge, update the Logto custom JWT script to add `username` and `name` claims:
+
+```js
+const getCustomJwtClaims = async ({ token, context }) => {
+  const { user } = context;
+  return {
+    roles: user.roles?.map((role) => role.name) ?? [],
+    email: user.primaryEmail ?? '',
+    username: user.username ?? '',
+    name: user.name ?? '',
+  };
+};
+```
+
+Until rolled out, the API returns `''` for `identity.name` and `identity.username` — clients handle this gracefully.
+
+## Verification
+
+- Backend: `go vet ./... && go test ./...` (api + channels/fantasy/api) — clean
+- Desktop: `npx tsc --noEmit && npx vitest run && npm run build` — clean (178+ tests)
+- Website: `npm run check && npm run build` — clean
+- Manual smoke: desktop Account tab renders Quick Stats + Subscription + Tier Limits + Your Data; export button downloads ZIP; website /account renders identically with one fetch.
+
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 3: Mark Phase 5 complete**
+
+Done. Plan exhausted.
+
+---
+
+### Task 5.3: Post-merge — update Logto JWT script
+
+**External step (manual, after PR merges):**
+
+- [ ] **Step 1: Open Logto admin console**
+- [ ] **Step 2: Navigate to "Custom JWT" → "Access token"**
+- [ ] **Step 3: Replace the script content with the four-line version from the spec**
+- [ ] **Step 4: Save and redeploy if needed**
+- [ ] **Step 5: Wait for token rollover (~1h)** — `identity.name` and `identity.username` will start populating
+
+---
+
+# Self-review
+
+**Spec coverage check:**
+- ✅ GET /users/me/overview endpoint shape — Tasks 2.1–2.7
+- ✅ Yahoo summary endpoint — Task 1.1
+- ✅ Logto JWT script update — documented in Task 5.3 + spec
+- ✅ Desktop Account tab Quick Stats — Task 3.3, 3.5
+- ✅ Desktop Account tab GDPR export — Task 3.4, 3.5
+- ✅ Desktop tier-limits from overview — Task 3.5
+- ✅ Desktop subscription from overview — Task 3.6
+- ✅ Desktop v1.0.4 bump — Task 3.7
+- ✅ Website /account refactor — Task 4.2
+- ✅ Website SubscriptionStatus refactor — Task 4.3
+- ✅ Website AccountDangerZone refactor — Task 4.4
+- ✅ Cache invalidation hooks — Task 2.6
+- ✅ Singleflight + 30s cache — Task 2.5
+- ✅ Fantasy fan-out 1s timeout, fail-open — Task 2.4
+- ✅ Tests for backend (cache, identity, tier, GDPR pending) — Tasks 2.2, 2.3, 2.7
+- ✅ Tests for desktop (stats card, export button) — Tasks 3.3, 3.4
+
+**Out of scope (per spec) and excluded:**
+- ❌ In-app cancel subscription (Decision 3 = no)
+- ❌ Delete account on desktop (Decision 1 = no)
+- ❌ Tier limits on website /account (Decision 4 = desktop only)
+- ❌ Settings IA redesign (Batch C)
+- ❌ Channel.visible rename (Batch C)
+- ❌ Removing tierLimits.ts hardcoded constants entirely (future cleanup)
+
+**Type consistency check:**
+- `UserOverview` interface defined identically in desktop and website (Tasks 3.1, 4.1)
+- Backend `OverviewResponse` Go struct mirrors the TS interface (Task 2.1)
+- Cache key prefix `overview:` consistent across handler + invalidator (Task 2.5)
+- `SubscriptionResponse` (website) vs `SubscriptionInfo` (desktop) — pre-existing naming difference, not introduced by this batch
+- `InvalidateOverviewCache` signature matches across all 3 invalidation hook sites (Task 2.6)
+
+**No placeholders detected.** All steps have concrete code, exact paths, exact commands.
+
+---

--- a/docs/superpowers/specs/2026-04-28-batch-b-account-overview-design.md
+++ b/docs/superpowers/specs/2026-04-28-batch-b-account-overview-design.md
@@ -1,0 +1,446 @@
+# Batch B — Account Overview Design
+
+**Date:** 2026-04-28
+**Status:** Approved (decisions locked, awaiting spec sign-off before plan)
+**Scope:** New `GET /users/me/overview` endpoint that consolidates identity + tier + subscription + channel summary + GDPR + fantasy summary into one round-trip; refactor desktop and website Account pages to consume it; minor desktop additions (GDPR export button, channel/league stats card)
+**Sequence:** Second in a three-batch plan. Batch A (quick fixes) shipped at PR #124. Batch C (settings IA redesign + website support page) follows.
+
+---
+
+## Why this batch
+
+The website's `/account` page currently fans out across 4-5 separate fetches: identity claims via the Logto SDK, channels via `/users/me/channels`, subscription via `/users/me/subscription`, preferences via `/users/me/preferences`, and GDPR status via `/users/me/delete/status`. The desktop's Account tab is similar but coarser — it fetches subscription only, decodes the JWT for identity, and uses local hardcoded constants for tier limits.
+
+That divergence is the source of "data all over the place" — both clients touch overlapping concerns through different shapes. A single `GET /users/me/overview` endpoint becomes the source-of-truth for both surfaces, eliminates per-platform drift on identity/billing/tier, and reduces page-load round-trips on the website from 4-5 to 1.
+
+This is the foundation Batch C needs: with overview shipping, the settings IA redesign on desktop can confidently remove or relocate Account sections knowing their data still flows through one canonical endpoint.
+
+---
+
+## Decisions locked
+
+| # | Decision | Choice | Rationale |
+|---|---|---|---|
+| 1 | GDPR on desktop | Export only; delete website-only | Desktop adds a "Download my data" button. Account deletion stays gated to website to keep accidental clicks rare. |
+| 2 | Stats card on desktop | Yes, match website Quick Stats | Show "X of Y channels enabled" + "Z fantasy leagues imported" when applicable. Pulled from overview response. |
+| 3 | In-app cancel on desktop | No, portal-only | Desktop continues to send users to Stripe portal. Website is the canonical billing surface. |
+| 4 | Tier-limits table | Desktop only | Website ignores `tier.limits` field; visitors looking for tier comparisons go to `/uplink`. Cleaner separation. |
+| 5 | Cache TTL | 30s Redis with singleflight | Mirror the `/dashboard` pattern. Webhook-driven invalidation handles real-time state. |
+| 6 | JWT identity source | Add `username` + `name` to existing custom JWT | One-line script change. Zero Logto admin round-trips per request. Lowest latency. |
+| 7 | Desktop release | Bump to v1.0.4 | Substantive user-visible changes (Account tab section). |
+
+---
+
+## API contract — `GET /users/me/overview`
+
+### Endpoint
+
+- **Method:** `GET`
+- **Path:** `/users/me/overview`
+- **Auth:** Required (Logto JWT via existing middleware)
+- **Cache:** 30s per-user in Redis under key `overview:{logto_sub}`. Singleflight via a package-level `overviewGroup singleflight.Group` (mirrors `dashboardGroup` in `handlers_channel.go`).
+- **Invalidation triggers** (`Rdb.Del("overview:" + sub)`):
+  - Stripe webhook events that mutate `stripe_customers` (`api/core/stripe_webhook.go` — add to the existing handler tail)
+  - Channel CRUD (`api/core/handlers_channel.go` — add to create/update/delete paths)
+  - GDPR state changes (`api/core/user_deletion.go` — add to request/cancel/purge paths)
+
+### Response shape
+
+```jsonc
+{
+  "identity": {
+    "sub": "logto-uuid",
+    "email": "user@example.com",     // from JWT
+    "name": "Brandon",                // from JWT (custom claim — see "Logto JWT script update" below)
+    "username": "brandon"             // from JWT (custom claim) — null when user hasn't set one
+  },
+  "tier": {
+    "current": "uplink_pro",          // resolved from JWT roles claim
+    "is_super_user": false,
+    "label": "Uplink Pro",            // server-rendered display name
+    "limits": {                       // desktop consumes this; website ignores
+      "symbols": 75,
+      "feeds": 100,
+      "custom_feeds": 3,
+      "leagues": 20,
+      "fantasy": 3,
+      "max_ticker_rows": 3,
+      "max_ticker_customization": false
+    }
+  },
+  "subscription": {                   // SubscriptionResponse, embedded inline
+    "plan": "pro_monthly",
+    "status": "active",
+    "current_period_end": "2026-05-21T00:00:00Z",
+    "lifetime": false,
+    "amount": 2499,
+    "currency": "usd",
+    "interval": "month",
+    "trial_end": null,
+    "pending_downgrade_plan": null,
+    "scheduled_change_at": null,
+    "had_prior_sub": true
+  },
+  "channels": {
+    "total": 4,
+    "enabled": 3,
+    "by_type": [
+      { "type": "finance",  "enabled": true,  "visible": true },
+      { "type": "sports",   "enabled": true,  "visible": true },
+      { "type": "rss",      "enabled": true,  "visible": false },
+      { "type": "fantasy",  "enabled": false, "visible": false }
+    ]
+  },
+  "fantasy": {                        // null when fantasy channel disabled or unreachable
+    "yahoo_connected": true,
+    "yahoo_synced": true,
+    "league_count": 2
+  },
+  "gdpr": {
+    "deletion_status": "none",        // none | pending | canceled | purged
+    "requested_at": null,
+    "purge_at": null
+  },
+  "links": {                          // server-built so clients don't need env vars
+    "logto_account": "https://logto.example.com/account?client_id=...&redirect=..."
+  }
+}
+```
+
+### Error & degradation behavior
+
+- **Fantasy channel unreachable** (timeout, 5xx, channel not registered in Redis) → `fantasy: null` in the response; rest of the payload still serves. 1-second context timeout per fan-out call. Same pattern as `/dashboard`'s per-channel error handling.
+- **Logto admin call failure** — not applicable since identity reads from JWT only (no admin call in the hot path after Decision 6).
+- **Stripe data missing** (user has no `stripe_customers` row) → `subscription: null` (free-tier user with no past subscription); rest of the payload serves.
+- **GDPR table empty** for this user → `gdpr.deletion_status: "none"` and the timestamps are null.
+- **Database failure** → 500 with the standard error envelope. No partial response.
+
+### Cache key collision avoidance
+
+- Key prefix `overview:` is distinct from `dashboard:` and `tier-limits:`. No collision with existing entries.
+- Cache value is the full JSON-serialized response payload (same pattern as `/dashboard`).
+- TTL: 30 seconds. Long enough to coalesce dashboard polling + Account tab visits; short enough that Stripe webhook lag-driven staleness self-resolves quickly even if invalidation hooks fail.
+
+---
+
+## Logto JWT script update
+
+The existing custom JWT script needs two additional claims. **Drop-in replacement** for the Logto admin's getCustomJwtClaims script:
+
+```js
+const getCustomJwtClaims = async ({ token, context }) => {
+  const { user } = context;
+  return {
+    roles: user.roles?.map((role) => role.name) ?? [],
+    email: user.primaryEmail ?? '',
+    username: user.username ?? '',
+    name: user.name ?? '',
+  };
+};
+```
+
+The change is purely additive — existing consumers (desktop's `getTier()`, `getUserIdentity()`) continue to work unchanged; new consumers (the overview handler) read `username` and `name` from the JWT directly.
+
+After deployment of the JWT script change, existing access tokens still won't carry `username`/`name` until they're refreshed (token TTL ~1h on Logto's default config). The overview endpoint should treat both fields as nullable strings to handle the rollout window gracefully — `username: ""` is valid and means "not set".
+
+---
+
+## Backend implementation (Go)
+
+### Files
+
+- **New:** `api/core/handlers_overview.go` — handler + assembly + cache invalidation helper
+- **New:** `api/core/handlers_overview_test.go` — happy path + fantasy-down + cache hit/miss + GDPR pending state
+- **Modify:** `api/core/server.go` — register `GET /users/me/overview`
+- **Modify:** `api/core/stripe_webhook.go` — invalidate cache on `customer.subscription.*` and `customer.subscription.updated/deleted` events
+- **Modify:** `api/core/handlers_channel.go` — invalidate cache in CreateChannel, UpdateChannel, DeleteChannel handlers
+- **Modify:** `api/core/user_deletion.go` — invalidate cache in RequestDeletion, CancelDeletion, PurgeUser handlers
+- **New:** `channels/fantasy/api/yahoo_summary.go` (or similar) — small handler returning `{ yahoo_connected, yahoo_synced, league_count }`
+- **Modify:** `channels/fantasy/api/main.go` — register the new route at `/users/me/yahoo-summary`
+
+### Handler structure (pseudocode)
+
+```go
+package core
+
+import (
+  "context"
+  "fmt"
+  "encoding/json"
+  "time"
+  "golang.org/x/sync/singleflight"
+  "github.com/gofiber/fiber/v2"
+)
+
+var overviewGroup singleflight.Group
+
+const (
+  RedisOverviewCachePrefix = "overview:"
+  OverviewCacheTTL = 30 * time.Second
+  FantasyFanoutTimeout = 1 * time.Second
+)
+
+func HandleGetOverview(c *fiber.Ctx) error {
+  userID := GetUserSub(c)  // from JWT middleware
+
+  // 1. Fast path: serve from cache
+  cacheKey := RedisOverviewCachePrefix + userID
+  if cached, err := Rdb.Get(c.Context(), cacheKey).Bytes(); err == nil {
+    c.Set("X-Cache-Hit", "1")
+    return c.Send(cached)
+  }
+
+  // 2. Slow path: assemble + cache, with singleflight to coalesce
+  result, err, _ := overviewGroup.Do(userID, func() (interface{}, error) {
+    return assembleOverview(c.Context(), userID, c)
+  })
+  if err != nil {
+    return c.Status(500).JSON(ErrorResponse{Status: "error", Error: err.Error()})
+  }
+
+  payload, _ := json.Marshal(result)
+  Rdb.Set(c.Context(), cacheKey, payload, OverviewCacheTTL)
+  return c.Send(payload)
+}
+
+func assembleOverview(ctx context.Context, userID string, c *fiber.Ctx) (*OverviewResponse, error) {
+  identity := buildIdentityFromJWT(c)  // reads sub, email, name, username from c.Locals
+  tier := buildTierFromJWT(c)          // reads roles claim, builds {current, label, is_super_user, limits}
+  subscription, _ := getSubscriptionForUser(ctx, userID)  // reuses existing code from handlers_billing.go
+  channels, _ := getChannelSummary(ctx, userID)            // SELECT count, COUNT(enabled), array_agg from user_channels
+  gdpr, _ := getDeletionStatus(ctx, userID)                // reuses existing code from user_deletion.go
+  fantasy := nil
+  if hasFantasyChannel(channels) {
+    // fan out to fantasy channel with 1s timeout; on error, leave nil
+    ctxFantasy, cancel := context.WithTimeout(ctx, FantasyFanoutTimeout)
+    defer cancel()
+    fantasy, _ = fetchFantasySummary(ctxFantasy, userID)
+  }
+
+  return &OverviewResponse{
+    Identity:     identity,
+    Tier:         tier,
+    Subscription: subscription,
+    Channels:     channels,
+    Fantasy:      fantasy,
+    GDPR:         gdpr,
+    Links:        buildAccountLinks(),  // logto_account URL from env
+  }, nil
+}
+
+func InvalidateOverviewCache(ctx context.Context, userID string) {
+  if userID == "" { return }
+  key := RedisOverviewCachePrefix + userID
+  if err := Rdb.Del(ctx, key).Err(); err != nil {
+    log.Printf("[Overview] cache invalidate failed for %s: %v", userID, err)
+  }
+}
+```
+
+### Fantasy fan-out
+
+Today the fantasy API exposes `/users/me/yahoo-status` (boolean state) and `/users/me/yahoo-leagues` (full leagues list). For overview, we want a single coalesced read returning `{ yahoo_connected, yahoo_synced, league_count }`.
+
+**Add as part of this batch:** new endpoint `GET /users/me/yahoo-summary` to `channels/fantasy/api/`, registered in the discovery payload at `channels/fantasy/api/main.go:331-333`. The handler is small — counts rows in `yahoo_user_leagues` for the user and reads `yahoo_users.connected`, `yahoo_users.synced` flags. Reuses the existing per-channel auth (`Auth: true`).
+
+The core overview handler proxies via the existing channel-discovery mechanism (Redis-registered base URL), makes the call with the 1-second timeout, parses, and embeds. On error: `fantasy: null` in the response, log the failure but don't fail the whole request.
+
+### Database queries needed
+
+Most queries reuse existing helpers; only one new query is required:
+
+```sql
+-- Channel summary: total, enabled count, per-type breakdown
+SELECT
+  COUNT(*) AS total,
+  COUNT(*) FILTER (WHERE enabled = true) AS enabled_count,
+  COALESCE(json_agg(json_build_object(
+    'type', channel_type,
+    'enabled', enabled,
+    'visible', visible
+  ) ORDER BY channel_type), '[]'::json) AS by_type
+FROM user_channels
+WHERE logto_sub = $1;
+```
+
+Lives in `handlers_overview.go` as a `getChannelSummary(ctx, userID)` helper. No new tables, no migrations.
+
+---
+
+## Desktop refactor
+
+### Files
+
+- **New:** `desktop/src/components/settings/AccountStatsRow.tsx` — small stats card showing channel + fantasy counts
+- **New:** `desktop/src/components/settings/AccountExportButton.tsx` — GDPR export button
+- **Modify:** `desktop/src/api/client.ts` — `userApi.overview()` method, `UserOverview` interface mirroring the response shape
+- **Modify:** `desktop/src/api/queries.ts` — `userOverviewQueryOptions` for TanStack Query
+- **Modify:** `desktop/src/components/settings/AccountSettings.tsx` — consume overview, render new sections
+- **Modify:** `desktop/src/routes/__root.tsx` — derive `subscriptionInfo` from overview query result instead of separate `fetchSubscription` call (single source of truth in shell context)
+- **Modify:** `desktop/src/auth.ts` — keep `getTier()` working (reads JWT roles); `getUserIdentity()` continues to decode JWT — both unchanged. Overview is for full-shape data needs.
+
+### Account tab layout (top to bottom)
+
+1. **Account** — email + plan label + Sign out (unchanged shape; data sourced from overview)
+2. **Quick Stats** *(NEW)* — `X of Y channels enabled` + (when fantasy is connected) `Z fantasy leagues imported`. Hidden when channels.total === 0 (fresh install).
+3. **Subscription** — same UX as today; data sourced from overview
+4. **Your Plan** — `TierLimitsTable`, data sourced from `overview.tier.limits` (replaces local hardcoded constants in `desktop/src/tierLimits.ts` over time; for this batch the table reads from overview, but the hardcoded fallback stays for first-paint before the query resolves)
+5. **Your Data** *(NEW)* — single button: `Download my data`. Below it, a small note: *"To delete your account, visit myscrollr.com/account."*
+6. **Reset all settings** — local-only, unchanged
+
+### `tierLimits.ts` strategy
+
+Today's hardcoded constants in `desktop/src/tierLimits.ts` are used as a synchronous render-time mirror. The overview query is async and may not have resolved on first render. Strategy:
+
+- Keep `desktop/src/tierLimits.ts` for first-paint fallback values (current behavior).
+- After the overview query resolves, prefer `overview.tier.limits` for display (component-level prop drilling — `AccountSettings` passes `overview?.tier.limits ?? TIER_LIMITS[currentTier]` to `TierLimitsTable`).
+- Long-term: a future cleanup could remove the hardcoded constants entirely if first-paint fallback isn't strictly necessary, but that's out of scope for Batch B.
+
+### Loading and error states
+
+The overview query's TanStack Query options include `staleTime: 30_000` (matches server cache) and `retry: 1`. The Account tab renders a skeleton state while loading and falls back to existing per-endpoint queries (subscription only) on error so it never shows a blank page. Same defensive degradation as the fantasy fan-out.
+
+### `useTierMismatchDetector` hook
+
+Today `__root.tsx:259-270` has a hook that detects when JWT roles disagree with subscription state and calls `auth.refreshTier()`. After Batch B, `overview.tier.current` is the canonical tier (sourced from JWT roles), and `overview.subscription.status` is the Stripe state. The mismatch detector reads both from overview directly — one less independent fetch.
+
+---
+
+## Website refactor
+
+### Files
+
+- **Modify:** `myscrollr.com/src/api/client.ts` — `userApi.overview()` method, `UserOverview` type
+- **Modify:** `myscrollr.com/src/routes/account.tsx` — replace 4-5 separate fetches with single overview query; remove `getIdTokenClaims()` Logto SDK call (read identity from overview instead)
+- **Modify:** `myscrollr.com/src/components/billing/SubscriptionStatus.tsx` — accept overview-shaped props or fetch from overview internally; remove the standalone `billingApi.getSubscription()` + `getPreferences()` round-trips for the tier mismatch
+- **Modify:** `myscrollr.com/src/components/account/AccountDangerZone.tsx` — keep calling `/users/me/delete/*` and `/users/me/export` directly (these are mutating endpoints, not data reads); only the `gdpr.deletion_status` for the pending banner reads from overview
+
+### `account.tsx` changes (specific)
+
+Today's structure:
+
+```tsx
+// 5 separate fetches:
+const { data: claims } = useQuery({ queryKey: ["claims"], queryFn: getIdTokenClaims });
+const { data: channels } = useQuery({ queryKey: ["channels"], queryFn: channelsApi.getAll });
+const { data: deletionStatus } = useQuery({ queryKey: ["deletion-status"], queryFn: ... });
+// + SubscriptionStatus internally fetches subscription + preferences
+```
+
+After Batch B:
+
+```tsx
+// 1 fetch covering everything:
+const { data: overview } = useQuery({ ...userOverviewQueryOptions });
+```
+
+The greeting (`Welcome back, {name}`) reads from `overview.identity.username ?? overview.identity.name`. The Public Profile card visibility (currently `claims.username` truthy check) reads from `overview.identity.username` truthy. Quick Stats card reads `overview.channels.total`, `overview.channels.enabled`. Subscription card reads `overview.subscription`. AccountDangerZone reads `overview.gdpr` for the pending banner; uses its existing direct API for mutations.
+
+### Logto SDK retention
+
+The `@logto/react` SDK stays installed. It's still needed for:
+- Auth state lifecycle (sign-in, sign-out, refresh) — none of which Batch B touches
+- The hub card link to Logto Account Center (Logto's own profile management)
+
+We just stop calling `getIdTokenClaims()` on `/account` for display purposes; identity for display comes from overview.
+
+---
+
+## Migration & rollout
+
+1. **Backend deploy first.** `/users/me/overview` goes live with cache + singleflight + invalidation hooks. Existing endpoints stay live and unchanged so existing client builds keep working.
+2. **Logto JWT script update second.** Apply the one-line change in the Logto admin console. Existing access tokens still don't have `username`/`name` until they refresh (~1h). The overview handler reads JWT claims optimistically; missing claims serialize as `""` (empty strings).
+3. **Desktop refactor next.** Account tab switches to consuming overview. Bump `desktop/src-tauri/tauri.conf.json` to v1.0.4 and ship a new release. Smoke-test the page renders identically plus the new Quick Stats and Export sections.
+4. **Website refactor last.** Marketing site `/account` page consumes overview. Deploy.
+
+### Stale-cache safety
+
+If `overview` returns 5xx or times out (1s default, 5s hard cap), each client falls back to the existing per-endpoint queries for that page render. No hard dependency on the new endpoint for this rollout.
+
+### `tier_limits` deprecation
+
+The `/tier-limits` endpoint stays in service — it's still consumed by:
+- The website's `/uplink` page (pricing/comparison view)
+- The desktop tier limits hardcoded fallback (which will be removed in a future cleanup)
+- Public, anonymous callers (no auth required) for marketing-site pre-render
+
+Overview's `tier.limits` is for authenticated users only and is a pre-baked subset of `/tier-limits`; the two endpoints coexist with different audiences.
+
+---
+
+## Testing
+
+### Backend
+
+- **`api/core/handlers_overview_test.go`** — uses the existing pgx mock pattern from `core/billing_test.go`:
+  - `TestOverview_HappyPath` — paid user with all fields populated
+  - `TestOverview_FreeTier_NoSubscription` — `subscription: null` branch
+  - `TestOverview_FantasyDisconnected` — `fantasy: null` branch
+  - `TestOverview_FantasyChannelUnreachable` — fan-out timeout, `fantasy: null`, rest of payload serves
+  - `TestOverview_DeletionPending` — `gdpr.deletion_status: "pending"`
+  - `TestOverview_CacheHit` — second call returns cached bytes without re-assembly
+  - `TestOverview_CacheInvalidation` — `InvalidateOverviewCache` deletes the key, next call rebuilds
+
+### Desktop
+
+- **`desktop/src/components/settings/AccountStatsRow.test.tsx`** — renders count line correctly with various `(total, enabled)` combinations; hides when total is 0
+- **`desktop/src/components/settings/AccountExportButton.test.tsx`** — calls export endpoint, opens result via Tauri shell
+- **`desktop/src/api/client.test.ts`** *(extend)* — `userApi.overview()` request shape
+
+No new tests for the website (no Vitest setup currently for `/account` page; spec doesn't require adding one). Smoke test inline.
+
+---
+
+## Versioning
+
+- **Desktop:** v1.0.3 → v1.0.4 (per Decision 7). Bump `desktop/package.json`, `desktop/package-lock.json`, `desktop/src-tauri/tauri.conf.json`, `desktop/src-tauri/Cargo.toml` (4 files) all to `1.0.4`.
+- **Website:** No version bump (rolling deploy via Coolify).
+- **API:** No version bump (rolling deploy; this is an additive endpoint that doesn't break existing consumers).
+
+---
+
+## PR shape
+
+Single PR titled `feat(account): unified /users/me/overview endpoint + both clients (v1.0.4)`. Three logical commits:
+
+1. `feat(api): GET /users/me/overview endpoint with singleflight + invalidation hooks`
+2. `feat(desktop): consume /users/me/overview on Account tab + GDPR export + stats card (v1.0.4)`
+3. `refactor(marketing): /account consumes /users/me/overview`
+
+Branch name: `feature/batch-b-account-overview`.
+
+Post-merge: deploy API first, update Logto JWT script second, then ship the desktop release (Coolify auto-deploys the website).
+
+---
+
+## Out of scope (deferred to Batch C)
+
+- Settings IA redesign on desktop (Batch C)
+- `Channel.visible` field rename to `tickerEnabled` (Batch C — flagged during Batch B due to user-reported confusion about RSS chips not appearing on the ticker)
+- Website `/support` route + contact form (Batch C)
+- Website `/account` getting tier-limits table (Decision 4 = no; if reversed, that's a separate cleanup)
+- Removing `desktop/src/tierLimits.ts` hardcoded constants entirely (kept for first-paint fallback; future cleanup)
+- Adding `cancel subscription` to desktop UI (Decision 3 = no)
+- Adding `delete account` to desktop UI (Decision 1 = no)
+
+---
+
+## Acceptance criteria
+
+- `go test ./api/core/...` clean (existing 7 tests + new overview tests)
+- `cd api && go vet ./...` clean
+- `cd desktop && npx tsc --noEmit` clean
+- `cd desktop && npx vitest run` — all tests passing (171 from Batch A + new overview tests)
+- `cd desktop && npm run build` clean
+- `cd myscrollr.com && npm run check` clean
+- `cd myscrollr.com && npm run build` clean
+- Manual smoke test on dev API + dev desktop + dev marketing build:
+  - Desktop Account tab renders Quick Stats, Subscription, Tier Limits, Your Data sections in order
+  - Desktop "Download my data" button downloads a ZIP via shell
+  - Website /account renders with one fetch (verify in Network tab)
+  - Website username greeting + Public Profile hub card visibility match overview response
+  - Cancellation a paid sub from Stripe portal → website /account reflects within 30s
+  - Adding a channel via desktop → desktop and website Account tabs both update within 30s
+  - Disconnecting fantasy → `overview.fantasy` becomes `null`; both clients hide the league count gracefully
+- Logto JWT script updated; verify a freshly-issued access token contains `username` and `name` claims
+- Desktop v1.0.4 release published (or draft ready for publish)

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -427,6 +427,74 @@ export const billingApi = {
     ),
 }
 
+// ── User Overview API ─────────────────────────────────────────────
+//
+// Single round-trip read shape for the /account hub. Replaces the
+// fan-out across claims + channels + deletion-status. Live billing
+// detail (Amount/Interval/TrialEnd) is returned in `subscription` when
+// the DB has it cached, but components that render those exact fields
+// should keep using billingApi.getSubscription (which is Stripe-backed
+// and authoritative). Backed server-side by a 30s Redis cache and
+// invalidation hooks on every mutating endpoint that touches this shape.
+
+export interface UserOverviewIdentity {
+  sub: string
+  email: string
+  name: string
+  username: string
+}
+
+export interface UserOverviewTier {
+  current: string
+  is_super_user: boolean
+  label: string
+  limits: ChannelLimits
+}
+
+export interface UserOverviewChannelRow {
+  type: ChannelType
+  enabled: boolean
+  visible: boolean
+}
+
+export interface UserOverviewChannels {
+  total: number
+  enabled: number
+  by_type: Array<UserOverviewChannelRow>
+}
+
+export interface UserOverviewFantasy {
+  yahoo_connected: boolean
+  yahoo_synced: boolean
+  league_count: number
+}
+
+export interface UserOverviewGDPR {
+  deletion_status: 'none' | 'pending' | 'canceled' | 'purged'
+  requested_at: string | null
+  purge_at: string | null
+}
+
+export interface UserOverviewLinks {
+  logto_account: string
+}
+
+export interface UserOverview {
+  identity: UserOverviewIdentity
+  tier: UserOverviewTier
+  subscription: SubscriptionStatus | null
+  channels: UserOverviewChannels
+  fantasy: UserOverviewFantasy | null
+  gdpr: UserOverviewGDPR
+  links: UserOverviewLinks
+}
+
+export const userApi = {
+  /** Unified read for the /account hub — identity, tier, channels, GDPR, fantasy. */
+  overview: (getToken: () => Promise<string | null>) =>
+    authenticatedFetch<UserOverview>('/users/me/overview', {}, getToken),
+}
+
 // ── Invite API ───────────────────────────────────────────────────
 
 export interface CompleteInviteRequest {

--- a/myscrollr.com/src/components/account/AccountDangerZone.tsx
+++ b/myscrollr.com/src/components/account/AccountDangerZone.tsx
@@ -8,44 +8,37 @@
  *   3. A "Delete Account" button that opens a type-to-confirm modal and,
  *      on success, schedules purge 30 days out.
  *
+ * Deletion status is read from the parent's /users/me/overview fetch
+ * (passed in as props). Mutating actions (export, request, cancel) still
+ * hit the dedicated GDPR endpoints; on success we call onDeletionChange
+ * so the parent re-fetches overview and re-renders us with fresh state.
+ *
  * Lives at the bottom of the Account hub. Intentionally destructive
  * visual treatment so users don't click it casually.
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { AlertTriangle, Download, Loader2, Trash2, X } from 'lucide-react'
 import { motion } from 'motion/react'
-import type { AccountDeletionStatus } from '@/api/client'
 import { gdprApi } from '@/api/client'
 
 interface AccountDangerZoneProps {
   getToken: () => Promise<string | null>
+  deletionStatus: 'none' | 'pending' | 'canceled' | 'purged'
+  /** ISO RFC3339 string. Drives the pending banner's countdown. Null when no pending request. */
+  purgeAt: string | null
+  /** Called after a deletion request is scheduled or canceled, so the parent can re-fetch overview. */
+  onDeletionChange?: () => void | Promise<void>
 }
 
 export default function AccountDangerZone({
   getToken,
+  deletionStatus,
+  purgeAt,
+  onDeletionChange,
 }: AccountDangerZoneProps) {
-  const [status, setStatus] = useState<AccountDeletionStatus | null>(null)
-  const [statusError, setStatusError] = useState<string | null>(null)
   const [exporting, setExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
   const [modalOpen, setModalOpen] = useState(false)
-
-  // Fetch current status on mount + whenever we mutate it.
-  const refreshStatus = useCallback(async () => {
-    try {
-      const data = await gdprApi.getDeletionStatus(getToken)
-      setStatus(data)
-      setStatusError(null)
-    } catch (err) {
-      setStatusError(
-        err instanceof Error ? err.message : 'Failed to load deletion status',
-      )
-    }
-  }, [getToken])
-
-  useEffect(() => {
-    refreshStatus()
-  }, [refreshStatus])
 
   // ── Export ──────────────────────────────────────────────────
 
@@ -71,7 +64,7 @@ export default function AccountDangerZone({
     setCancelError(null)
     try {
       await gdprApi.cancelDeletion(getToken)
-      await refreshStatus()
+      await onDeletionChange?.()
     } catch (err) {
       setCancelError(
         err instanceof Error ? err.message : 'Failed to cancel deletion',
@@ -79,7 +72,7 @@ export default function AccountDangerZone({
     } finally {
       setCanceling(false)
     }
-  }, [getToken, refreshStatus])
+  }, [getToken, onDeletionChange])
 
   return (
     <section className="relative overflow-hidden">
@@ -100,9 +93,9 @@ export default function AccountDangerZone({
           </p>
         </motion.div>
 
-        {status?.status === 'pending' && (
+        {deletionStatus === 'pending' && purgeAt && (
           <PendingBanner
-            purgeAt={status.purge_at}
+            purgeAt={purgeAt}
             canceling={canceling}
             cancelError={cancelError}
             onCancel={handleCancel}
@@ -161,18 +154,15 @@ export default function AccountDangerZone({
                   first. If you have a lifetime membership, we keep an
                   anonymized purchase record for accounting.
                 </p>
-                {statusError && (
-                  <p className="mt-2 text-xs text-error">{statusError}</p>
-                )}
               </div>
               <button
                 type="button"
                 onClick={() => setModalOpen(true)}
-                disabled={status?.status === 'pending'}
+                disabled={deletionStatus === 'pending'}
                 className="shrink-0 inline-flex items-center gap-2 rounded-lg border border-error/40 bg-error/10 px-4 py-2 text-xs font-semibold text-error hover:bg-error/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 <Trash2 size={14} />
-                {status?.status === 'pending' ? 'Scheduled' : 'Delete…'}
+                {deletionStatus === 'pending' ? 'Scheduled' : 'Delete…'}
               </button>
             </div>
           </div>
@@ -185,7 +175,7 @@ export default function AccountDangerZone({
           onClose={() => setModalOpen(false)}
           onScheduled={async () => {
             setModalOpen(false)
-            await refreshStatus()
+            await onDeletionChange?.()
           }}
         />
       )}

--- a/myscrollr.com/src/routes/account.tsx
+++ b/myscrollr.com/src/routes/account.tsx
@@ -13,11 +13,11 @@ import {
 } from 'lucide-react'
 import { motion } from 'motion/react'
 import type { ComponentType } from 'react'
-import type { IdTokenClaims } from '@logto/react'
+import type { UserOverview } from '@/api/client'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import { pageVariants, sectionVariants } from '@/lib/animations'
-import { channelsApi } from '@/api/client'
+import { userApi } from '@/api/client'
 import { useGetToken } from '@/hooks/useGetToken'
 import SubscriptionStatus from '@/components/billing/SubscriptionStatus'
 import AccountDangerZone from '@/components/account/AccountDangerZone'
@@ -26,16 +26,6 @@ import { usePageMeta } from '@/lib/usePageMeta'
 export const Route = createFileRoute('/account')({
   component: AccountHub,
 })
-
-const LOGTO_ENDPOINT = (import.meta.env.VITE_LOGTO_ENDPOINT || '').replace(
-  /\/+$/,
-  '',
-)
-const LOGTO_APP_ID = import.meta.env.VITE_LOGTO_APP_ID || ''
-const SECURITY_NODE_HREF =
-  LOGTO_ENDPOINT && LOGTO_APP_ID
-    ? `${LOGTO_ENDPOINT}/account?${new URLSearchParams({ client_id: LOGTO_APP_ID })}`
-    : undefined
 
 // ── Signature easing (matches homepage) ────────────────────────
 const EASE = [0.22, 1, 0.36, 1] as const
@@ -90,7 +80,7 @@ const HUB_CARDS: Array<HubCardDef> = [
   {
     title: 'Security Node',
     desc: 'Manage password, MFA & linked accounts',
-    href: SECURITY_NODE_HREF,
+    // href is injected at render time from overview.links.logto_account
     Icon: Lock,
     hex: HEX.secondary,
     WatermarkIcon: Lock,
@@ -113,8 +103,7 @@ function AccountHub() {
       'Manage your Scrollr account, subscription, and connected services.',
     canonicalUrl: 'https://myscrollr.com/account',
   })
-  const { isAuthenticated, isLoading, getIdTokenClaims } = useScrollrAuth()
-  const [userClaims, setUserClaims] = useState<IdTokenClaims>()
+  const { isAuthenticated, isLoading } = useScrollrAuth()
   const navigate = useNavigate()
   const getToken = useGetToken()
 
@@ -122,18 +111,20 @@ function AccountHub() {
   const hasLoaded = useRef(false)
   const autoRedirectTriggered = useRef(false)
 
-  // ── Quick Stats state ──────────────────────────────────────────
-  const [channelCount, setChannelCount] = useState<number | null>(null)
-  const [enabledCount, setEnabledCount] = useState<number | null>(null)
+  // ── Unified overview state ────────────────────────────────────
+  // One round-trip replaces the previous claims + channels +
+  // deletion-status fan-out. SubscriptionStatus and the GDPR mutating
+  // actions still use their dedicated endpoints.
+  const [overview, setOverview] = useState<UserOverview | null>(null)
 
-  const fetchStats = useCallback(async () => {
+  const fetchOverview = useCallback(async () => {
     try {
-      const data = await channelsApi.getAll(getToken)
-      const all = data.channels
-      setChannelCount(all.length)
-      setEnabledCount(all.filter((s) => s.enabled).length)
-    } catch {
-      // Silently fail — stats are non-critical
+      const data = await userApi.overview(getToken)
+      setOverview(data)
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('Failed to load account overview', err)
+      }
     }
   }, [getToken])
 
@@ -148,17 +139,9 @@ function AccountHub() {
   // ── Fetch data when authenticated ─────────────────────────────
   useEffect(() => {
     if (isAuthenticated) {
-      getIdTokenClaims()
-        .then(setUserClaims)
-        .catch((error: unknown) => {
-          if (import.meta.env.DEV) {
-            console.warn('Failed to load account identity claims', error)
-          }
-          setUserClaims(undefined)
-        })
-      fetchStats()
+      fetchOverview()
     }
-  }, [isAuthenticated, getIdTokenClaims, fetchStats])
+  }, [isAuthenticated, fetchOverview])
 
   // ── Loading / auth guards ─────────────────────────────────────
   if (isLoading && !hasLoaded.current) {
@@ -186,7 +169,9 @@ function AccountHub() {
             <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-4">
               Welcome back,{' '}
               <span className="text-gradient-primary">
-                {userClaims?.name || userClaims?.username || 'User'}
+                {overview?.identity.name ||
+                  overview?.identity.username ||
+                  'User'}
               </span>
             </h1>
             <p className="text-base text-base-content/45 leading-relaxed max-w-lg mx-auto">
@@ -221,16 +206,34 @@ function AccountHub() {
               // Hide Public Profile if user has no username set —
               // /u/me would otherwise expose the raw Logto sub UUID.
               if (card.title === 'Public Profile') {
-                return Boolean(userClaims?.username)
+                return Boolean(overview?.identity.username)
+              }
+              // Hide Security Node until overview supplies the link —
+              // the href comes from overview.links.logto_account.
+              if (card.title === 'Security Node') {
+                return Boolean(overview?.links.logto_account)
               }
               return true
             })
               .map((card) => {
                 // Route Public Profile to the user's actual username
-                if (card.title === 'Public Profile' && userClaims?.username) {
+                if (
+                  card.title === 'Public Profile' &&
+                  overview?.identity.username
+                ) {
                   return {
                     ...card,
-                    params: { username: userClaims.username },
+                    params: { username: overview.identity.username },
+                  }
+                }
+                // Inject Security Node href from overview
+                if (
+                  card.title === 'Security Node' &&
+                  overview?.links.logto_account
+                ) {
+                  return {
+                    ...card,
+                    href: overview.links.logto_account,
                   }
                 }
                 return card
@@ -379,7 +382,7 @@ function AccountHub() {
                 <div className="grid grid-cols-2 gap-4 text-center">
                   <div className="p-4 bg-base-200/40 border border-base-300/25 rounded-xl">
                     <div className="text-2xl font-black text-base-content font-mono tabular-nums">
-                      {channelCount ?? '—'}
+                      {overview?.channels.total ?? '—'}
                     </div>
                     <div className="text-[10px] text-base-content/30 flex items-center justify-center gap-1 mt-1">
                       <Radio size={10} />
@@ -388,7 +391,7 @@ function AccountHub() {
                   </div>
                   <div className="p-4 bg-base-200/40 border border-base-300/25 rounded-xl">
                     <div className="text-2xl font-black text-base-content font-mono tabular-nums">
-                      {enabledCount ?? '—'}
+                      {overview?.channels.enabled ?? '—'}
                     </div>
                     <div className="text-[10px] text-base-content/30 flex items-center justify-center gap-1 mt-1">
                       <Wifi size={10} />
@@ -474,7 +477,12 @@ function AccountHub() {
       </section>
 
       {/* ── GDPR: Export + Delete ── */}
-      <AccountDangerZone getToken={getToken} />
+      <AccountDangerZone
+        getToken={getToken}
+        deletionStatus={overview?.gdpr.deletion_status ?? 'none'}
+        purgeAt={overview?.gdpr.purge_at ?? null}
+        onDeletionChange={fetchOverview}
+      />
     </motion.main>
   )
 }


### PR DESCRIPTION
## Summary

- **API:** new `GET /users/me/overview` endpoint consolidates identity + tier + subscription + channel summary + GDPR + fantasy summary. 30s Redis cache per-user with singleflight; webhook + CRUD + GDPR mutations invalidate. Dispatched from `api/core/handlers_overview.go`.
- **Fantasy API:** new `GET /users/me/yahoo-summary` (read-only fan-out target for overview).
- **Desktop:** Account tab consumes overview, gets a Quick Stats card and a GDPR export button. Bumped to **v1.0.4**.
- **Marketing:** `/account` page swaps 4 separate fetches for the overview endpoint (3 net, since live billing detail still uses the existing `/users/me/subscription`).

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-04-28-batch-b-account-overview-design.md`
- Plan: `docs/superpowers/plans/2026-04-28-batch-b-account-overview.md`

## Implementation deviations from the spec (all defensible)

1. **Subscription is DB-only on overview**, not Stripe-enriched. Adding live Stripe calls per cache miss would defeat the 30s cache. Live billing detail (`amount`, `interval`, `trial_end`) still flows through the existing `/users/me/subscription` endpoint, which both clients keep using for the Subscription card.
2. **JWT identity additions**: `auth.go` now exposes `user_name` and `user_username` claims on `c.Locals`. After the post-merge Logto JWT script update, fresh tokens carry these claims; existing tokens use `""` until refresh (~1h TTL).
3. **Tier resolves via `tierFromRoles(GetUserRoles(c))`** so overview tier never disagrees with what `channels.go` actually enforces.
4. **Marketing site doesn't use TanStack Query** — used existing `useState` + `useEffect` + `useCallback` pattern matching `account.tsx`.
5. **Desktop `__root.tsx` unchanged** — `subscriptionInfo` continues to come from `fetchSubscription`. AccountSettings mounts the overview query separately.

## Post-merge ops

After merge, update the Logto custom JWT script to add `username` and `name` claims:

```js
const getCustomJwtClaims = async ({ token, context }) => {
  const { user } = context;
  return {
    roles: user.roles?.map((role) => role.name) ?? [],
    email: user.primaryEmail ?? '',
    username: user.username ?? '',
    name: user.name ?? '',
  };
};
```

Until rolled out, the API returns `''` for `identity.name` and `identity.username` — clients handle this gracefully (Public Profile + Security Node hub cards on the website hide; Account tab's identity strip falls back to email).

## Verification

- Core API: `go vet ./...` clean, `go test ./core/` passes (9 unit tests + 4 integration that skip without DB)
- Fantasy API: `go vet ./...` clean, `go build` clean
- Desktop: `npx tsc --noEmit` clean, `npx vitest run` 178/178 passing (171 baseline + 7 new), `npm run build` clean, `cargo check` clean. Version 1.0.4 confirmed in `package.json`, `package-lock.json`, `tauri.conf.json`, `Cargo.toml`.
- Marketing: `npm run check` clean (Prettier + ESLint), `npm run build` clean.

## Desktop release

Bumping to v1.0.4. After merge, the Desktop Release workflow will trigger on push to `main` (since `desktop/` files changed) and create a draft release at `desktop-v1.0.4`. Publish via `gh release edit desktop-v1.0.4 --draft=false` once binaries are built.

## Net win for the account flow

Before:
- Website `/account`: 4 separate fetches (claims, channels, deletion-status, subscription+preferences inside SubscriptionStatus)
- Desktop Account tab: 1 fetch (subscription) + JWT decode + hardcoded tier limits

After:
- Website `/account`: 3 fetches (overview + subscription-for-billing-detail + preferences-for-tier — could be 2 if SubscriptionStatus accepts a tier prop, deferred)
- Desktop Account tab: 2 fetches (overview + subscription) + JWT decode for getTier (which still needs to ship for cache-warm scenarios)

Plus brand-new affordances on desktop: Quick Stats card and GDPR export button. Plus a single source-of-truth in the response shape for both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)