### PR TITLE
chore(desktop): npm audit fix (postcss + vite dev-dep advisories)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -4125,9 +4125,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -4912,9 +4912,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

`npm audit fix` resolves both desktop dev-dep advisories surfaced during the v1.0.4 release build:

- **postcss** (moderate) — XSS via unescaped `</style>` in CSS stringify (GHSA-qx2v-qp2m-jg93)
- **vite** (high, 3 advisories) — path traversal in optimized deps `.map`, `server.fs.deny` bypass, dev-server WebSocket arbitrary file read

Both are **dev-time only** — the production binaries shipped in v1.0.4 are unaffected. The patches are within existing semver ranges (lockfile-only update; `package.json` unchanged).

## Why this PR

The v1.0.4 Desktop Release build (commit `6416a2e`) showed red "Process completed with exit code 1" annotations from the `Audit Node dependencies` step, even though all platform builds succeeded. This silences future build annotations and removes a small but recurring noise source on the CI dashboard.

## Verification

- `npm audit` → `found 0 vulnerabilities`
- `npx tsc --noEmit` → clean
- `npx vitest run` → 178/178 passing
- `npm run build` → built clean

## Diff

1 file changed: `desktop/package-lock.json` (+6 / -6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)