### PR TITLE
feat(standardization): Batch C — ticker_enabled alias + /support route + Settings IA polish

### DIFF
--- a/api/core/channels.go
+++ b/api/core/channels.go
@@ -364,16 +364,24 @@ func UpdateChannel(c *fiber.Ctx) error {
 		})
 	}
 
+	// Both `visible` (legacy, v1.0.3 and earlier) and `ticker_enabled`
+	// (modern, v1.0.4+) are accepted. Whichever is set non-nil wins;
+	// `ticker_enabled` takes precedence if both are sent. The DB column
+	// is still `visible` — the rename is wire-format only.
 	var req struct {
-		Enabled *bool                  `json:"enabled"`
-		Visible *bool                  `json:"visible"`
-		Config  map[string]interface{} `json:"config"`
+		Enabled       *bool                  `json:"enabled"`
+		Visible       *bool                  `json:"visible"`
+		TickerEnabled *bool                  `json:"ticker_enabled"`
+		Config        map[string]interface{} `json:"config"`
 	}
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
 			Status: "error",
 			Error:  "Invalid request body",
 		})
+	}
+	if req.TickerEnabled != nil {
+		req.Visible = req.TickerEnabled
 	}
 
 	// Tier-gate any incoming config. We only check when config is

--- a/api/core/handlers_overview.go
+++ b/api/core/handlers_overview.go
@@ -66,9 +66,9 @@ type OverviewChannels struct {
 }
 
 type OverviewChannelRow struct {
-	Type    string `json:"type"`
-	Enabled bool   `json:"enabled"`
-	Visible bool   `json:"visible"`
+	Type          string `json:"type"`
+	Enabled       bool   `json:"enabled"`
+	TickerEnabled bool   `json:"ticker_enabled"`
 }
 
 // OverviewFantasy is the optional fan-out result from the fantasy
@@ -174,7 +174,7 @@ func getChannelSummary(ctx context.Context, userID string) (OverviewChannels, er
 			COALESCE(json_agg(json_build_object(
 				'type', channel_type,
 				'enabled', enabled,
-				'visible', visible
+				'ticker_enabled', visible
 			) ORDER BY channel_type) FILTER (WHERE channel_type IS NOT NULL), '[]'::json) AS by_type
 		FROM user_channels
 		WHERE logto_sub = $1

--- a/api/core/handlers_support_public.go
+++ b/api/core/handlers_support_public.go
@@ -1,0 +1,212 @@
+package core
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// PublicSupportRequest is the body shape for POST /support/ticket/public.
+// Anonymous endpoint — requires email since we don't have a JWT identity.
+// Diagnostics + attachments are NOT accepted: this endpoint sits outside
+// the authenticated rate limiter, so we keep the attack surface narrow.
+type PublicSupportRequest struct {
+	Email    string `json:"email"`
+	Category string `json:"category"`
+	Subject  string `json:"subject"`
+	Message  string `json:"message"`
+	Name     string `json:"name,omitempty"`
+}
+
+// publicSupportRateLimitKey produces the Redis key used to cap anonymous
+// ticket submissions per source IP. Key TTL = 1 hour.
+func publicSupportRateLimitKey(ip string) string {
+	return "support:public:" + ip + ":hour"
+}
+
+const (
+	publicSupportMaxPerHour = 5
+	publicSupportRateWindow = time.Hour
+)
+
+// allowedPublicCategories restricts what an unauthenticated user can
+// file. Account-related issues are intentionally NOT here — those are
+// reserved for the authenticated flow where we already know who's
+// asking, and so we don't accidentally reset / leak data based on an
+// unverified email.
+var allowedPublicCategories = map[string]string{
+	"bug":      "Bug Report",
+	"feedback": "Feedback",
+	"billing":  "Billing",
+	"feature":  "Feature Request",
+}
+
+// HandleSubmitPublicSupportTicket accepts anonymous support requests
+// from the marketing site /support contact form. Per-IP rate-limited
+// via Redis (5/hour). Validates email format, restricts categories to
+// non-account ones, and forwards via the shared forwardToOSTicket
+// helper so the upstream contract stays in sync with the authenticated
+// handler.
+func HandleSubmitPublicSupportTicket(c *fiber.Ctx) error {
+	setCORSHeaders(c)
+
+	var req PublicSupportRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Invalid request body",
+		})
+	}
+
+	req.Email = strings.TrimSpace(req.Email)
+	req.Subject = strings.TrimSpace(req.Subject)
+	req.Message = strings.TrimSpace(req.Message)
+	req.Name = strings.TrimSpace(req.Name)
+	req.Category = strings.TrimSpace(strings.ToLower(req.Category))
+
+	if req.Email == "" || !strings.Contains(req.Email, "@") || len(req.Email) > 254 {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Valid email required",
+		})
+	}
+	categoryLabel, ok := allowedPublicCategories[req.Category]
+	if !ok {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Invalid category",
+		})
+	}
+	if len(req.Subject) < 3 || len(req.Subject) > 200 {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Subject must be 3-200 characters",
+		})
+	}
+	if len(req.Message) < 10 || len(req.Message) > 5000 {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Message must be 10-5000 characters",
+		})
+	}
+
+	// Per-IP rate limit. Soft-fail on Redis errors — we'd rather accept
+	// a ticket than lose one. The IP-based fiber limiter that wraps the
+	// route gives us a coarse outer bound; this counter is the per-IP
+	// hourly cap on top of that.
+	ip := c.IP()
+	if Rdb != nil && ip != "" {
+		key := publicSupportRateLimitKey(ip)
+		count, err := Rdb.Incr(c.Context(), key).Result()
+		if err == nil {
+			if count == 1 {
+				_ = Rdb.Expire(c.Context(), key, publicSupportRateWindow).Err()
+			}
+			if count > publicSupportMaxPerHour {
+				return c.Status(fiber.StatusTooManyRequests).JSON(ErrorResponse{
+					Status: "error",
+					Error:  "Too many requests; please try again in an hour",
+				})
+			}
+		} else {
+			log.Printf("[PublicSupport] Redis INCR failed (continuing): %v", err)
+		}
+	}
+
+	// Resolve topic ID — reuse the per-category overrides the
+	// authenticated handler honors, so anonymous tickets land in the
+	// same OS Ticket queues as their authenticated equivalents.
+	topicID := os.Getenv("OSTICKET_TOPIC_ID")
+	switch req.Category {
+	case "feature":
+		if id := os.Getenv("OSTICKET_TOPIC_ID_FEATURE"); id != "" {
+			topicID = id
+		}
+	case "feedback":
+		if id := os.Getenv("OSTICKET_TOPIC_ID_FEEDBACK"); id != "" {
+			topicID = id
+		}
+	case "billing":
+		if id := os.Getenv("OSTICKET_TOPIC_ID_BILLING"); id != "" {
+			topicID = id
+		}
+	}
+
+	// Build OS Ticket payload. Match the same Message format the
+	// authenticated handler uses (data: URL with HTML body) so OS
+	// Ticket renders both submission types consistently.
+	bodyHTML := fmt.Sprintf(
+		"<h3>%s</h3><p>%s</p><hr/><p><em>Submitted anonymously from the marketing site (IP %s).</em></p>",
+		escapeHTML(categoryLabel),
+		escapeHTML(req.Message),
+		escapeHTML(redactIP(ip)),
+	)
+
+	payload := OSTicketPayload{
+		Name:    fallbackName(req.Name, req.Email),
+		Email:   req.Email,
+		Subject: fmt.Sprintf("[%s] %s", categoryLabel, req.Subject),
+		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", bodyHTML),
+	}
+	if topicID != "" {
+		payload.TopicID = topicID
+	}
+
+	if err := forwardToOSTicket(c.Context(), payload); err != nil {
+		log.Printf("[PublicSupport] forwardToOSTicket failed for ip=%s email=%s: %v",
+			redactIP(ip), redactEmail(req.Email), err)
+		return c.Status(fiber.StatusBadGateway).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Failed to submit ticket; please try again later",
+		})
+	}
+
+	log.Printf("[PublicSupport] Ticket created from ip=%s email=%s category=%s",
+		redactIP(ip), redactEmail(req.Email), req.Category)
+
+	return c.JSON(fiber.Map{
+		"status":  "ok",
+		"message": "Ticket submitted",
+	})
+}
+
+// fallbackName returns the supplied name or, failing that, the local
+// part of the email address. OS Ticket requires a non-empty name.
+func fallbackName(name, email string) string {
+	if name != "" {
+		return name
+	}
+	return strings.SplitN(email, "@", 2)[0]
+}
+
+// redactIP keeps the first three octets of an IPv4 / first /64 of an
+// IPv6 for log correlation while dropping host bits. Used in log lines
+// so an operator can grep for repeated abuse without storing full IPs.
+func redactIP(ip string) string {
+	if ip == "" {
+		return ""
+	}
+	if parsed := net.ParseIP(ip); parsed != nil {
+		if v4 := parsed.To4(); v4 != nil {
+			return fmt.Sprintf("%d.%d.%d.x", v4[0], v4[1], v4[2])
+		}
+		return parsed.Mask(net.CIDRMask(64, 128)).String() + "/64"
+	}
+	return "x"
+}
+
+// redactEmail keeps the first character of the local part and the full
+// domain — enough to disambiguate spam patterns in logs without storing
+// the full identifier.
+func redactEmail(email string) string {
+	at := strings.IndexByte(email, '@')
+	if at <= 0 {
+		return "x"
+	}
+	return string(email[0]) + "***" + email[at:]
+}

--- a/api/core/models.go
+++ b/api/core/models.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -18,6 +19,12 @@ type UserPreferences struct {
 }
 
 // Channel represents a user's subscription to a data channel.
+//
+// The DB column and Go field stay named `Visible` to avoid a migration
+// and to keep wire compatibility with shipped v1.0.3 desktops. The
+// MarshalJSON below also emits `ticker_enabled` so v1.0.4+ clients can
+// read a clearer name. Inbound updates accept both names — see
+// channels.go:UpdateChannel.
 type Channel struct {
 	ID          int                    `json:"id"`
 	LogtoSub    string                 `json:"-"`
@@ -27,6 +34,21 @@ type Channel struct {
 	Config      map[string]interface{} `json:"config"`
 	CreatedAt   time.Time              `json:"created_at"`
 	UpdatedAt   time.Time              `json:"updated_at"`
+}
+
+// MarshalJSON emits both `visible` (legacy) and `ticker_enabled` (clearer
+// modern name) so v1.0.3 desktops and v1.0.4+ desktops both read the
+// same value. The DB column and struct field stay `visible` to avoid a
+// migration; this is wire-format backwards compatibility only.
+func (c Channel) MarshalJSON() ([]byte, error) {
+	type alias Channel
+	return json.Marshal(&struct {
+		alias
+		TickerEnabled bool `json:"ticker_enabled"`
+	}{
+		alias:         alias(c),
+		TickerEnabled: c.Visible,
+	})
 }
 
 // DashboardResponse is the aggregated response for the /dashboard endpoint.

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -181,6 +181,10 @@ func (s *Server) setupRoutes() {
 
 	// Support
 	s.App.Post("/support/ticket", LogtoAuth, HandleSubmitSupportTicket)
+	// Anonymous support endpoint for the marketing /support page. NOT
+	// added to coreExemptPaths — the IP rate limiter + the per-IP
+	// hourly Redis counter inside the handler both protect this route.
+	s.App.Post("/support/ticket/public", HandleSubmitPublicSupportTicket)
 
 	// Invite (no auth — user isn't logged in yet, token-verified server-side)
 	s.App.Post("/invite/complete", HandleCompleteInvite)

--- a/api/core/support.go
+++ b/api/core/support.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -38,7 +40,12 @@ type TicketAttachment struct {
 	Data     string `json:"data"`
 }
 
-type osTicketPayload struct {
+// OSTicketPayload is the wire shape we send to the OS Ticket REST API.
+// Exported so the anonymous public handler in handlers_support_public.go
+// can reuse the same forwarding helper as the authenticated handler —
+// keeping a single source of truth for the upstream contract. Field
+// tags are pinned by what OS Ticket expects; do not rename.
+type OSTicketPayload struct {
 	Name        string                    `json:"name"`
 	Email       string                    `json:"email"`
 	Subject     string                    `json:"subject"`
@@ -252,7 +259,7 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 	}
 
 	// Build OS Ticket payload
-	payload := osTicketPayload{
+	payload := OSTicketPayload{
 		Name:    name,
 		Email:   email,
 		Subject: subject,
@@ -272,16 +279,71 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 		})
 	}
 
-	// POST to OS Ticket — try each API key (comma-separated) until one succeeds.
-	// OS Ticket ties API keys to specific IPs, and pods can land on different nodes.
+	if err := forwardToOSTicket(c.Context(), payload); err != nil {
+		// Distinguish "not configured" so we can keep the existing 500
+		// vs. upstream rejection (502).
+		if errors.Is(err, errOSTicketNotConfigured) {
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "Support ticket system is not configured",
+			})
+		}
+		if errors.Is(err, errOSTicketMarshal) {
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "Failed to prepare ticket",
+			})
+		}
+		return c.Status(fiber.StatusBadGateway).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Failed to submit bug report — support system rejected all API keys",
+		})
+	}
+
+	log.Printf("[Support] Ticket created for user %s", userID)
+	// Only record the submission AFTER OS Ticket confirms. If the
+	// request fails upstream the user isn't trapped in a cooldown
+	// they didn't earn — see allowedBySupportRateLimit.
+	recordSupportSubmission(userID)
+	return c.JSON(fiber.Map{
+		"status":  "ok",
+		"message": "Bug report submitted successfully",
+	})
+}
+
+// ===== OS Ticket forwarding helper =====
+//
+// Single source of truth for talking to OS Ticket. Used by both the
+// authenticated HandleSubmitSupportTicket and the anonymous
+// HandleSubmitPublicSupportTicket so they can't drift on auth headers,
+// retry behaviour, or timeouts.
+//
+// Caller responsibilities (NOT done here):
+//   - All input validation (subject/body length, email format, etc.)
+//   - Rate limiting (per-user for authed, per-IP for anonymous)
+//   - Persisting any local audit trail
+//   - Recording cooldown state on success
+//
+// Returns nil on a 2xx response from OS Ticket. Returns one of the
+// sentinel errors below for known-failure modes; otherwise wraps the
+// underlying transport / status error so the caller can log it.
+
+var (
+	errOSTicketNotConfigured = errors.New("osticket: OSTICKET_URL or OSTICKET_API_KEY not configured")
+	errOSTicketMarshal       = errors.New("osticket: failed to marshal payload")
+	errOSTicketAllKeysFailed = errors.New("osticket: all API keys rejected")
+)
+
+// forwardToOSTicket POSTs the payload to OS Ticket, trying each
+// comma-separated API key in OSTICKET_API_KEY in order. OS Ticket ties
+// keys to source IPs and pods can land on different nodes, so a 401 on
+// one key just means try the next; any other non-2xx aborts the loop.
+func forwardToOSTicket(ctx context.Context, payload OSTicketPayload) error {
 	osTicketURL := os.Getenv("OSTICKET_URL")
 	apiKeysRaw := os.Getenv("OSTICKET_API_KEY")
 	if osTicketURL == "" || apiKeysRaw == "" {
 		log.Println("[Support] OSTICKET_URL or OSTICKET_API_KEY not configured")
-		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
-			Status: "error",
-			Error:  "Support ticket system is not configured",
-		})
+		return errOSTicketNotConfigured
 	}
 
 	ticketURL := strings.TrimSuffix(osTicketURL, "/") + "/api/tickets.json"
@@ -289,10 +351,7 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		log.Printf("[Support] Failed to marshal OS Ticket payload: %v", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
-			Status: "error",
-			Error:  "Failed to prepare ticket",
-		})
+		return fmt.Errorf("%w: %v", errOSTicketMarshal, err)
 	}
 
 	apiKeys := strings.Split(apiKeysRaw, ",")
@@ -306,7 +365,7 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 			continue
 		}
 
-		httpReq, err := http.NewRequest("POST", ticketURL, bytes.NewReader(payloadBytes))
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", ticketURL, bytes.NewReader(payloadBytes))
 		if err != nil {
 			log.Printf("[Support] Failed to create OS Ticket request: %v", err)
 			continue
@@ -326,34 +385,22 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 		lastBody = string(respBody)
 
 		if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
-			log.Printf("[Support] Ticket created for user %s (key %d)", userID, i+1)
-			// Only record the submission AFTER OS Ticket confirms. If the
-			// request fails upstream the user isn't trapped in a cooldown
-			// they didn't earn — see allowedBySupportRateLimit.
-			recordSupportSubmission(userID)
-			return c.JSON(fiber.Map{
-				"status":  "ok",
-				"message": "Bug report submitted successfully",
-			})
+			return nil
 		}
 
-		// If 401 (wrong IP for this key), try the next key
+		// 401 (wrong IP for this key) — try next key.
 		if resp.StatusCode == http.StatusUnauthorized {
 			log.Printf("[Support] Key %d rejected (401), trying next...", i+1)
 			continue
 		}
 
-		// Any other error — don't retry, it's not an IP issue
+		// Any other error — don't retry, it's not an IP issue.
 		log.Printf("[Support] OS Ticket returned %d: %s", resp.StatusCode, lastBody)
 		break
 	}
 
 	log.Printf("[Support] All API keys failed. Last status: %d, body: %s", lastStatus, lastBody)
-
-	return c.Status(fiber.StatusBadGateway).JSON(ErrorResponse{
-		Status: "error",
-		Error:  "Failed to submit bug report — support system rejected all API keys",
-	})
+	return fmt.Errorf("%w: last status %d", errOSTicketAllKeysFailed, lastStatus)
 }
 
 // escapeHTML replaces < > & " with HTML entities.

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -15,7 +15,11 @@ import {
   isAuthenticated as checkAuth,
   getTier,
 } from "./auth";
-import { channelsApi, toggleChannelVisibility } from "./api/client";
+import {
+  channelsApi,
+  isChannelTickerEnabled,
+  toggleChannelVisibility,
+} from "./api/client";
 import {
   loadPref,
   savePref,
@@ -92,7 +96,7 @@ export default function App() {
       return loadPref("activeFeedTabs", ["finance", "sports"]);
     }
     return channels
-      .filter((ch) => ch.enabled && ch.visible)
+      .filter((ch) => ch.enabled && isChannelTickerEnabled(ch))
       .map((ch) => ch.channel_type);
   }, [channels]);
 
@@ -477,7 +481,7 @@ export default function App() {
         const channelItems: CheckMenuItem[] = [];
         for (const ch of chs) {
           const channelType = ch.channel_type;
-          const isVisible = ch.enabled && ch.visible;
+          const isVisible = ch.enabled && isChannelTickerEnabled(ch);
           const label =
             channelType.charAt(0).toUpperCase() + channelType.slice(1);
           channelItems.push(
@@ -490,7 +494,7 @@ export default function App() {
                 const target = channelsRef.current.find(
                   (c) => c.channel_type === channelType,
                 );
-                if (target) target.visible = !isVisible;
+                if (target) target.ticker_enabled = !isVisible;
                 handleChannelToggle(channelType, !isVisible);
               },
             }),

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -143,10 +143,31 @@ export interface Channel {
   id: number;
   channel_type: ChannelType;
   enabled: boolean;
-  visible: boolean;
+  /** Whether this channel's chips appear on the ticker. Server emits both
+   * `ticker_enabled` (preferred) and `visible` (legacy alias) — read either
+   * via {@link isChannelTickerEnabled}. */
+  ticker_enabled: boolean;
+  /** @deprecated Use {@link ticker_enabled}. Server still emits this for
+   *  v1.0.3 compatibility; will be removed in a future release. */
+  visible?: boolean;
   config: Record<string, unknown>;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * Read the ticker-enabled flag, tolerant of both the new
+ * (`ticker_enabled`) and legacy (`visible`) field names. Returns `true`
+ * by default if neither is set so freshly-added channels appear on the
+ * ticker.
+ */
+export function isChannelTickerEnabled(ch: {
+  ticker_enabled?: boolean;
+  visible?: boolean;
+}): boolean {
+  if (typeof ch.ticker_enabled === "boolean") return ch.ticker_enabled;
+  if (typeof ch.visible === "boolean") return ch.visible;
+  return true;
 }
 
 export interface RssChannelConfig {
@@ -170,7 +191,7 @@ export const channelsApi = {
     channelType: ChannelType,
     data: {
       enabled?: boolean;
-      visible?: boolean;
+      ticker_enabled?: boolean;
       config?: Record<string, unknown>;
     },
   ) =>
@@ -187,19 +208,25 @@ export const channelsApi = {
     ),
 };
 
-// ── Channel visibility toggle ───────────────────────────────────
+// ── Channel ticker toggle ───────────────────────────────────────
 
 /**
- * Toggle a channel's visibility (and optionally mark it enabled).
- * Returns a promise that resolves when the API call completes.
- * Callers are responsible for invalidating queries afterward.
+ * Toggle whether a channel's chips appear on the ticker (and optionally
+ * mark the channel itself enabled). Returns a promise that resolves
+ * when the API call completes. Callers are responsible for invalidating
+ * queries afterward.
+ *
+ * The wire field is `ticker_enabled` (v1.0.4+); the server also accepts
+ * the legacy `visible` field for older clients.
  */
 export async function toggleChannelVisibility(
   channelType: ChannelType,
-  visible: boolean,
+  tickerEnabled: boolean,
   enabled?: boolean,
 ): Promise<void> {
-  const payload: { visible: boolean; enabled?: boolean } = { visible };
+  const payload: { ticker_enabled: boolean; enabled?: boolean } = {
+    ticker_enabled: tickerEnabled,
+  };
   if (enabled !== undefined) payload.enabled = enabled;
   await channelsApi.update(channelType, payload);
 }
@@ -259,7 +286,11 @@ export interface UserOverview {
   channels: {
     total: number;
     enabled: number;
-    by_type: Array<{ type: string; enabled: boolean; visible: boolean }>;
+    by_type: Array<{
+      type: string;
+      enabled: boolean;
+      ticker_enabled: boolean;
+    }>;
   };
   fantasy: {
     yahoo_connected: boolean;

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -7,8 +7,7 @@ import { userOverviewQueryOptions } from "../../api/queries";
 import { TIER_LIMITS, isUnlimited, type NumericLimitKey } from "../../tierLimits";
 import type { SubscriptionTier } from "../../auth";
 import type { SubscriptionInfo } from "../../api/client";
-import { Section, DisplayRow, ActionRow, ResetButton } from "./SettingsControls";
-import ConfirmDialog from "../ConfirmDialog";
+import { Section, DisplayRow, ActionRow } from "./SettingsControls";
 import AccountStatsRow from "./AccountStatsRow";
 import AccountExportButton from "./AccountExportButton";
 
@@ -20,7 +19,6 @@ interface AccountSettingsProps {
   subscriptionInfo: SubscriptionInfo | null;
   onLogin: () => void;
   onLogout: () => void;
-  onResetAll: () => void;
 }
 
 // ── Status helpers ──────────────────────────────────────────────
@@ -65,9 +63,7 @@ export default function AccountSettings({
   subscriptionInfo: sub,
   onLogin,
   onLogout,
-  onResetAll,
 }: AccountSettingsProps) {
-  const [confirmReset, setConfirmReset] = useState(false);
   const [openingPortal, setOpeningPortal] = useState(false);
   const [portalError, setPortalError] = useState<string | null>(null);
   const identity = authenticated ? getUserIdentity() : null;
@@ -316,26 +312,6 @@ export default function AccountSettings({
         </Section>
       )}
 
-      {/* ── Reset ────────────────────────────────────────────── */}
-      <div className="flex items-center justify-end pt-2">
-        <ResetButton
-          label="Reset all settings"
-          onClick={() => setConfirmReset(true)}
-        />
-      </div>
-
-      <ConfirmDialog
-        open={confirmReset}
-        title="Reset all settings?"
-        description="This will set everything back to the original settings. Your account and saved content won't change."
-        confirmLabel="Reset everything"
-        destructive
-        onConfirm={() => {
-          setConfirmReset(false);
-          onResetAll();
-        }}
-        onCancel={() => setConfirmReset(false)}
-      />
     </div>
   );
 }

--- a/desktop/src/components/settings/ResetSettings.tsx
+++ b/desktop/src/components/settings/ResetSettings.tsx
@@ -1,0 +1,71 @@
+/**
+ * ResetSettings — destructive action: wipe every local preference.
+ *
+ * Lives on its own Settings tab so it cannot be triggered by accident
+ * while the user is browsing account/billing controls. Account, billing,
+ * and channel data on the server is untouched — this only affects local
+ * preferences (theme, ticker layout, channel display, followed players,
+ * etc.).
+ */
+import { useState } from "react";
+import { Trash2, AlertTriangle } from "lucide-react";
+import ConfirmDialog from "../ConfirmDialog";
+import { Section } from "./SettingsControls";
+
+interface ResetSettingsProps {
+  onResetAll: () => void;
+}
+
+export default function ResetSettings({ onResetAll }: ResetSettingsProps) {
+  const [confirmReset, setConfirmReset] = useState(false);
+
+  const handleConfirm = () => {
+    setConfirmReset(false);
+    onResetAll();
+  };
+
+  return (
+    <div>
+      <Section title="Reset all settings">
+        <div className="px-3 py-2 flex flex-col gap-3">
+          <p className="text-[12px] text-fg-3 leading-relaxed">
+            Clear every local preference: theme, ticker layout, channel
+            display, followed players, and more. Your account, billing, and
+            channel data on the server is untouched.
+          </p>
+
+          <div className="flex flex-col gap-3 p-3 rounded-lg bg-error/5 border border-error/20">
+            <div className="flex items-start gap-2 text-[12px] text-error leading-relaxed">
+              <AlertTriangle
+                className="w-4 h-4 mt-0.5 shrink-0"
+                aria-hidden
+              />
+              <p>
+                This action is local-only and cannot be undone. You will be
+                asked to confirm before anything is reset.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setConfirmReset(true)}
+              className="self-start flex items-center gap-2 px-3 py-2 rounded-lg bg-error/10 text-error hover:bg-error/20 transition-colors cursor-pointer text-[12px] font-semibold"
+            >
+              <Trash2 className="w-4 h-4" aria-hidden />
+              <span>Reset all settings</span>
+            </button>
+          </div>
+        </div>
+      </Section>
+
+      <ConfirmDialog
+        open={confirmReset}
+        title="Reset all settings?"
+        description="This will set everything back to the original settings. Your account and saved content won't change."
+        confirmLabel="Reset everything"
+        destructive
+        onConfirm={handleConfirm}
+        onCancel={() => setConfirmReset(false)}
+      />
+    </div>
+  );
+}

--- a/desktop/src/hooks/useDashboardCDC.ts
+++ b/desktop/src/hooks/useDashboardCDC.ts
@@ -91,10 +91,14 @@ function mergeChannelRecords(
     if (cdc.action === "delete") {
       if (idx !== -1) updated.splice(idx, 1);
     } else if (idx !== -1) {
+      // CDC payload comes straight from Postgres replication, so the
+      // raw column name is still `visible` (the DB column wasn't
+      // renamed). The Channel type's canonical field is now
+      // `ticker_enabled` — map between them here.
       updated[idx] = {
         ...updated[idx],
         enabled: cdc.record.enabled as boolean,
-        visible: cdc.record.visible as boolean,
+        ticker_enabled: cdc.record.visible as boolean,
       };
     }
   }

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -379,8 +379,9 @@ function RootLayout() {
   // (filtered to `enabled === true`); widgets come from
   // `prefs.widgets.enabledWidgets`. Both are sorted via the shared
   // CANONICAL_ORDER so the sidebar matches the catalog grid order.
-  // `Channel.visible` is intentionally NOT consulted here — visibility
-  // is a feed-level filter, not a navigation gate.
+  // `Channel.ticker_enabled` is intentionally NOT consulted here — that
+  // flag controls whether chips appear on the ticker, not whether the
+  // channel appears in navigation.
   const sidebarSources = useMemo(() => {
     const enabledChannelIds = new Set<string>(
       (dashboard?.channels ?? [])

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -32,6 +32,7 @@ import {
   LS_WEATHER_UNIT,
   LS_SYSMON_DATA,
 } from "../constants";
+import { isChannelTickerEnabled } from "../api/client";
 import type { ChannelType, Channel } from "../api/client";
 import type {
   ChannelManifest,
@@ -148,11 +149,11 @@ function HomePage() {
             channel={ch}
             manifest={manifest}
             data={dashboard?.data}
-            tickerEnabled={ch.visible}
+            tickerEnabled={isChannelTickerEnabled(ch)}
             onToggleTicker={() =>
               onToggleChannelTicker(
                 ch.channel_type as ChannelType,
-                !ch.visible,
+                !isChannelTickerEnabled(ch),
               )
             }
             selectedKeys={homePreview[ch.channel_type] ?? []}

--- a/desktop/src/routes/settings.tsx
+++ b/desktop/src/routes/settings.tsx
@@ -1,32 +1,44 @@
 /**
  * Settings route — consolidated settings page with tabs.
  *
- * Three tabs:
- *   General  — appearance, window, startup
+ * Four tabs:
+ *   General  — appearance, window, startup, updates
  *   Ticker   — ticker presentation settings with live preview
- *   Account  — profile, billing, updates, reset
+ *   Account  — profile, billing, plan, data export
+ *   Reset    — destructive: reset all local preferences
  *
  * Tab state is persisted in the URL via ?tab= search param.
  */
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { clsx } from "clsx";
+import { Settings, Sliders, User, RotateCcw } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import RouteError from "../components/RouteError";
 import { useShell } from "../shell-context";
 import GeneralSettings from "../components/settings/GeneralSettings";
 import TickerSettings from "../components/settings/TickerSettings";
 import AccountSettings from "../components/settings/AccountSettings";
+import ResetSettings from "../components/settings/ResetSettings";
 import { resetCategory, resetAll, type AppPreferences } from "../preferences";
 
 // ── Types ───────────────────────────────────────────────────────
 
-type SettingsTab = "general" | "ticker" | "account";
+type SettingsTab = "general" | "ticker" | "account" | "reset";
 
-const VALID_TABS: SettingsTab[] = ["general", "ticker", "account"];
+const VALID_TABS: SettingsTab[] = ["general", "ticker", "account", "reset"];
 
 const TAB_LABELS: Record<SettingsTab, string> = {
   general: "General",
   ticker: "Ticker",
   account: "Account",
+  reset: "Reset",
+};
+
+const TAB_ICONS: Record<SettingsTab, LucideIcon> = {
+  general: Settings,
+  ticker: Sliders,
+  account: User,
+  reset: RotateCcw,
 };
 
 // ── Route ───────────────────────────────────────────────────────
@@ -71,22 +83,28 @@ function SettingsRoute() {
       </div>
 
       {/* ── Tabs ───────────────────────────────────────────────── */}
-      <div className="flex gap-1 mb-5">
-        {VALID_TABS.map((t) => (
-          <button
-            key={t}
-            onClick={() => setTab(t)}
-            className={clsx(
-              "px-3 py-1.5 rounded-lg text-xs font-medium transition-colors cursor-pointer",
-              tab === t
-                ? "bg-accent/10 text-accent"
-                : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
-            )}
-          >
-            {TAB_LABELS[t]}
-          </button>
-        ))}
-      </div>
+      <nav className="flex flex-wrap gap-2 mb-6" aria-label="Settings sections">
+        {VALID_TABS.map((t) => {
+          const Icon = TAB_ICONS[t];
+          const isActive = tab === t;
+          return (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              aria-current={isActive ? "page" : undefined}
+              className={clsx(
+                "flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors cursor-pointer border",
+                isActive
+                  ? "bg-accent/15 text-accent border-accent/30"
+                  : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover border-transparent",
+              )}
+            >
+              <Icon className="w-4 h-4" aria-hidden />
+              <span>{TAB_LABELS[t]}</span>
+            </button>
+          );
+        })}
+      </nav>
 
       {/* ── Tab content ────────────────────────────────────────── */}
       <div className="max-w-2xl">
@@ -129,9 +147,10 @@ function SettingsRoute() {
             subscriptionInfo={shell.subscriptionInfo}
             onLogin={shell.onLogin}
             onLogout={shell.onLogout}
-            onResetAll={handleResetAll}
           />
         )}
+
+        {tab === "reset" && <ResetSettings onResetAll={handleResetAll} />}
       </div>
     </div>
   );

--- a/docs/superpowers/specs/2026-04-28-batch-c-standardization-design.md
+++ b/docs/superpowers/specs/2026-04-28-batch-c-standardization-design.md
@@ -1,0 +1,101 @@
+# Batch C — Standardization (final batch)
+
+**Date:** 2026-04-28
+**Status:** In flight; user authorized direct execution
+**Scope:** Three workstreams shipping the remaining standardization work identified in the pre-launch audit.
+
+## Workstreams
+
+### Stream A — Rename `Channel.visible` → `Channel.ticker_enabled`
+
+`visible` semantically misled users (the field controls whether a channel's chips appear on the ticker, NOT whether the channel itself is hidden from the UI). Caused a real reported bug where RSS chips silently disappeared from the ticker even though the channel was enabled.
+
+**Surface area:**
+- Migration: `api/migrations/000007_rename_channel_visible.up.sql` + `.down.sql` — `ALTER TABLE user_channels RENAME COLUMN visible TO ticker_enabled`
+- Core API: `api/core/models.go` (struct field + JSON tag), `api/core/channels.go` (queries), `api/core/handlers_overview.go` (overview by_type), any other reads/writes
+- Desktop: `desktop/src/api/client.ts` (`Channel` interface), `desktop/src/App.tsx:95, 480` (filter usage), `desktop/src/routes/feed.tsx:151-156` (the toggle UI label "ticker"), all chip filtering paths
+- No marketing site changes (it doesn't read this field)
+
+**Decisions:**
+- JSON field becomes `ticker_enabled` (snake_case server contract)
+- TypeScript field becomes `tickerEnabled` (camelCase client convention)
+- The user-facing toggle label stays "Show on ticker" (already correct in `feed.tsx`)
+- Migration is renaming, not duplicating — no compatibility shim. Pre-1.0.4 desktop builds reading `visible` will see `null` and treat it as falsy → the toggle defaults to off. Acceptable since v1.0.4 ships in the same release.
+
+### Stream B — Website `/support` route + anonymous contact endpoint
+
+The marketing site has zero support surface today (just `mailto:support@myscrollr.com` in footer). The desktop has a comprehensive support hub. Port the desktop's content as a single-page `/support` route on the website, plus a contact form that works for anonymous visitors.
+
+**Surface area:**
+- New: `myscrollr.com/src/routes/support.tsx` — Hero + sections (Getting Started / FAQ / Troubleshooting / Billing / Contact form)
+- New: `myscrollr.com/src/components/support/` — section components, content lifted from desktop's `support-content.ts` (literal copy, both files diverge over time independently)
+- New: `myscrollr.com/src/components/support/ContactForm.tsx` — auth-aware form
+- Modify: `myscrollr.com/src/components/Footer.tsx` — replace `mailto:` with `/support` link
+- Modify: `myscrollr.com/src/api/client.ts` — `supportApi.submitTicket(payload, isAuthed)` (chooses authed vs public endpoint)
+
+**Backend (additive, additive only):**
+- New: `api/core/handlers_support_public.go` — `HandleSubmitPublicSupportTicket` (anonymous, requires `email` in body, per-IP rate limit)
+- Modify: `api/core/support.go` — extract `forwardToOSTicket(ticket SupportTicket) error` helper (single-source for OS Ticket forwarding logic; both authed + public callers use it)
+- Modify: `api/core/server.go` — register `POST /support/ticket/public` (no `LogtoAuth`)
+
+**Decisions:**
+- Anonymous tickets restricted categories: `bug | feedback | billing | feature` (no `account` — account issues require auth)
+- Per-IP rate limit: 5 tickets/hour for `/support/ticket/public`. Use Redis key `support:public:{ip}:hour`.
+- Diagnostics field omitted entirely on the website (no Tauri to collect from)
+- Attachments NOT supported on the public endpoint (anti-spam vector)
+- FAQ/Troubleshooting/Getting Started/Billing content **copied** from desktop, not abstracted — accept divergence; both files are content, not logic
+- One `/support` route on the website (no sub-routes); collapsible sections inside the page
+- "Channels" category from desktop's contact form omitted on the website (auth-required context)
+
+### Stream C — Settings IA polish on desktop
+
+The Settings tab strip is too small/text-only and users miss it entirely. The General tab is a junk drawer of unrelated topics. The Account tab carries an unrelated "Reset all settings" destructive action.
+
+**Surface area:**
+- Modify: `desktop/src/routes/settings.tsx` — search param now accepts `general | ticker | account | reset`. Tab strip gets icons + larger spacing + descriptive labels.
+- Modify: `desktop/src/components/settings/AccountSettings.tsx` — REMOVE "Reset all settings" section (move to new Reset tab)
+- New: `desktop/src/components/settings/ResetSettings.tsx` — extracted Reset section + ConfirmDialog
+- Modify: `desktop/src/components/settings/GeneralSettings.tsx` — add subtle visual section dividers (Appearance / Window / Startup / Updates / About) so the tab reads like a structured page rather than a list
+- Modify: `desktop/src/components/Sidebar.tsx` (or wherever the Settings link comes from) — add a small "Channels" cross-link beneath Settings that navigates to `/catalog` (where channels are managed)
+
+**Decisions:**
+- Don't redo the IA from scratch — keep the 3-tab base (General / Ticker / Account). Add a 4th: **Reset**.
+- Tab nav: bigger pill (`px-4 py-2.5 text-sm`), icons (`Cog6Tooth`/`Wrench`/`Person`/`ArrowPath` from lucide-react), uppercase labels.
+- General tab section headers get small icon + tighter spacing — visual hierarchy improvement only, no logic changes.
+- "Channels" cross-link under Settings is the cheapest way to point users at where channel-specific configs live (the catalog page already drives users into `/channel/$type/$tab`).
+
+## Integration / cross-stream concerns
+
+- Stream A and Stream C both touch `desktop/src/api/client.ts` — Stream A renames `Channel.visible`. Stream C doesn't touch the Channel interface directly; it only consumes existing types.
+- Stream A and Stream B both touch `api/core/server.go` — Stream A modifies queries elsewhere, Stream B adds a route. Different lines, no conflict.
+- The Stream A migration runs on backend deploy. Backend deploys before desktop. Desktop v1.0.4 ships TODAY (current draft). Decision: **Stream A migration changes are server-side only on this PR. Desktop changes go in this PR but ship to users via v1.0.5 next desktop release.**
+
+Wait — that's a problem. If we rename the column and the API serves `ticker_enabled` while v1.0.4 desktop reads `visible`, v1.0.4 users break.
+
+**Resolution:** v1.0.4 hasn't shipped to users yet (draft is unpublished). We have two windows:
+1. Hold v1.0.4 publish until Batch C ships AND another v1.0.5 with the rename ships
+2. Make the Stream A API change backwards-compatible: server returns BOTH `visible` and `ticker_enabled` in JSON until next desktop release; future cleanup removes `visible` after v1.0.5 ships
+
+Going with option 2 — simpler operationally. Marshal `visible` AND `ticker_enabled` from the same struct field with two JSON tags via a wrapper, OR (simpler) just embed both in the response struct. Update the desktop here to read `ticker_enabled`; v1.0.4 still reads `visible` and works fine because the API still emits it as an alias.
+
+Actually, simplest: keep the column AND struct field as `Visible` server-side, just add a JSON-output alias `ticker_enabled` so clients reading either name get the same data. The "rename" becomes purely client-facing terminology, not a column rename. Database stays `visible`; struct stays `Visible`; JSON output is `{"visible": true, "ticker_enabled": true}` (both populated). Desktop reads `tickerEnabled` going forward. Migration NOT needed for this batch.
+
+Adopting that resolution: Stream A skips the migration entirely. Just adds a JSON alias on the response side.
+
+## Acceptance criteria
+
+- `go vet ./...` clean across api/core
+- `go test ./api/core/...` all pass
+- Desktop: `npx tsc --noEmit` clean, `npx vitest run` 178/178+, `npm run build` clean, `cargo check` clean
+- Marketing: `npm run check` clean, `npm run build` clean
+- Manual smoke (post-deploy):
+  - RSS toggle on /feed page works (now correctly labeled "ticker")
+  - Website /support page renders, FAQ accordion works, contact form submits as anonymous + as authed
+  - Desktop Settings has 4 tabs (General / Ticker / Account / Reset); icons visible; Reset tab contains the danger button; Channels cross-link navigates to catalog
+
+## Out of scope
+
+- Database column rename (deferred — see Resolution above)
+- Settings tab full IA rebuild (only polish in this batch)
+- New Logto JWT claims (already done in Batch B)
+- Per-channel settings consolidation under global Settings (deferred — `/catalog` cross-link is sufficient for now)

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -532,6 +532,60 @@ export const inviteApi = {
     ),
 }
 
+// ── Support API ───────────────────────────────────────────────────
+//
+// Two endpoints, identical wire shape:
+//   - /support/ticket          (LogtoAuth required)
+//   - /support/ticket/public   (anonymous, per-IP rate-limited 5/hour)
+//
+// The marketing site contact form picks the right one based on whether
+// the visitor is signed in. Anonymous tickets MUST include `email` so
+// support can reply; authenticated tickets carry it implicitly via the
+// JWT but we send it anyway for forwards-compatibility with OS Ticket.
+
+export type SupportCategory = 'bug' | 'feature' | 'billing' | 'feedback'
+
+export interface SupportTicketPayload {
+  email: string
+  category: SupportCategory
+  subject: string
+  message: string
+  name?: string
+}
+
+export interface SupportTicketResponse {
+  status: string
+  message: string
+}
+
+export const supportApi = {
+  /** Submit a ticket as an authenticated user. Token required. */
+  submitTicket: (
+    payload: SupportTicketPayload,
+    getToken: () => Promise<string | null>,
+  ) =>
+    authenticatedFetch<SupportTicketResponse>(
+      '/support/ticket',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      },
+      getToken,
+    ),
+
+  /**
+   * Submit a ticket anonymously. Per-IP rate-limited (5/hour) on the
+   * server. Throws on validation/transport failure.
+   */
+  submitTicketPublic: (payload: SupportTicketPayload) =>
+    request<SupportTicketResponse>('/support/ticket/public', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+}
+
 // ── GDPR Account Export + Delete ──────────────────────────────────
 //
 // 30-day soft-delete grace window. Users can cancel from the Account

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -559,7 +559,14 @@ export interface SupportTicketResponse {
 }
 
 export const supportApi = {
-  /** Submit a ticket as an authenticated user. Token required. */
+  /**
+   * Submit a ticket as an authenticated user. Token required.
+   *
+   * The authed `/support/ticket` endpoint expects `description` (or
+   * `what_went_wrong`) — NOT `message`. Map our marketing-side
+   * `message` field to both so the server validator accepts it
+   * regardless of which legacy field it prefers.
+   */
   submitTicket: (
     payload: SupportTicketPayload,
     getToken: () => Promise<string | null>,
@@ -569,7 +576,12 @@ export const supportApi = {
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({
+          ...payload,
+          // Authed handler legacy field names — keep both for safety:
+          description: payload.message,
+          what_went_wrong: payload.message,
+        }),
       },
       getToken,
     ),

--- a/myscrollr.com/src/components/Footer.tsx
+++ b/myscrollr.com/src/components/Footer.tsx
@@ -29,7 +29,7 @@ export default function Footer() {
       { label: 'Privacy', href: '/legal?doc=privacy' },
       { label: 'Legal', href: '/legal' },
       { label: 'License', href: '/legal?doc=license' },
-      { label: 'Contact', href: 'mailto:support@myscrollr.com' },
+      { label: 'Support', href: '/support' },
     ],
     social: [
       {
@@ -39,8 +39,8 @@ export default function Footer() {
       },
       {
         icon: Mail,
-        href: 'mailto:support@myscrollr.com',
-        label: 'Email',
+        href: '/support',
+        label: 'Contact support',
       },
     ],
   }
@@ -242,24 +242,45 @@ export default function Footer() {
 
           {/* Social Links */}
           <div className="flex items-center gap-4">
-            {links.social.map((social) => (
-              <motion.a
-                key={social.label}
-                href={social.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                whileHover={{
-                  scale: 1.1,
-                  y: -2,
-                  transition: { type: 'tween', duration: 0.2 },
-                }}
-                whileTap={{ scale: 0.95 }}
-                className="flex items-center justify-center w-10 h-10 rounded-lg bg-base-200/50 border border-base-300/30 text-base-content/40 hover:text-primary hover:border-primary/30 hover:bg-primary/5 transition-colors cursor-pointer"
-                aria-label={social.label}
-              >
-                <social.icon size={16} />
-              </motion.a>
-            ))}
+            {links.social.map((social) => {
+              const external = isExternalHref(social.href)
+              const className =
+                'flex items-center justify-center w-10 h-10 rounded-lg bg-base-200/50 border border-base-300/30 text-base-content/40 hover:text-primary hover:border-primary/30 hover:bg-primary/5 transition-colors cursor-pointer'
+              const hover = {
+                scale: 1.1,
+                y: -2,
+                transition: { type: 'tween' as const, duration: 0.2 },
+              }
+              const Icon = social.icon
+
+              if (external) {
+                return (
+                  <motion.a
+                    key={social.label}
+                    href={social.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    whileHover={hover}
+                    whileTap={{ scale: 0.95 }}
+                    className={className}
+                    aria-label={social.label}
+                  >
+                    <Icon size={16} />
+                  </motion.a>
+                )
+              }
+
+              return (
+                <Link
+                  key={social.label}
+                  to={social.href}
+                  className={className}
+                  aria-label={social.label}
+                >
+                  <Icon size={16} />
+                </Link>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/myscrollr.com/src/components/support/SupportAccordion.tsx
+++ b/myscrollr.com/src/components/support/SupportAccordion.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { ChevronDown } from 'lucide-react'
+
+// SupportAccordion — generic single-expanded-at-a-time accordion used
+// for FAQ, troubleshooting, and billing sections on /support.
+//
+// Why not reuse landing/FAQSection.tsx? That one uses a split desktop
+// layout with iconography per item and a sliding spring panel — great
+// for the homepage but heavy for a long-page support reference where
+// users want to scan many items quickly. This is the simpler, denser
+// accordion for that use case. Keyboard nav (Enter/Space toggle) is
+// handled by native <button> semantics; the AnimatePresence height
+// transition matches the landing accordion's feel.
+
+const EASE = [0.22, 1, 0.36, 1] as const
+
+export interface AccordionEntry {
+  /** The summary line shown when collapsed. */
+  title: string
+  /** Pre-rendered body content. Use ReactNode to allow lists/paragraphs. */
+  body: React.ReactNode
+}
+
+interface SupportAccordionProps {
+  entries: Array<AccordionEntry>
+  /** Optional id prefix so multiple accordions on the page get unique ids. */
+  idPrefix?: string
+}
+
+export function SupportAccordion({
+  entries,
+  idPrefix = 'acc',
+}: SupportAccordionProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
+
+  return (
+    <div className="space-y-3">
+      {entries.map((entry, i) => {
+        const isOpen = openIndex === i
+        const id = `${idPrefix}-${i}`
+
+        return (
+          <div
+            key={id}
+            className={`group relative rounded-xl border bg-base-200/40 transition-[border-color,background-color] duration-200 ${
+              isOpen
+                ? 'border-primary/25'
+                : 'border-base-300/30 hover:border-base-300/50'
+            }`}
+          >
+            <button
+              type="button"
+              id={`${id}-trigger`}
+              aria-expanded={isOpen}
+              aria-controls={`${id}-panel`}
+              onClick={() => setOpenIndex(isOpen ? null : i)}
+              className="flex w-full cursor-pointer items-center justify-between gap-4 px-5 py-4 text-left"
+            >
+              <span
+                className={`text-[15px] leading-snug font-semibold transition-colors duration-200 ${
+                  isOpen ? 'text-base-content' : 'text-base-content/70'
+                }`}
+              >
+                {entry.title}
+              </span>
+              <motion.span
+                animate={{ rotate: isOpen ? 180 : 0 }}
+                transition={{ duration: 0.25, ease: 'easeInOut' }}
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
+                  isOpen
+                    ? 'bg-primary/10 text-primary'
+                    : 'bg-base-300/20 text-base-content/30'
+                }`}
+              >
+                <ChevronDown size={15} />
+              </motion.span>
+            </button>
+
+            <AnimatePresence initial={false}>
+              {isOpen ? (
+                <motion.div
+                  key="panel"
+                  id={`${id}-panel`}
+                  role="region"
+                  aria-labelledby={`${id}-trigger`}
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: 'auto', opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{
+                    height: { duration: 0.3, ease: EASE },
+                    opacity: { duration: 0.2, delay: 0.05 },
+                  }}
+                  className="overflow-hidden"
+                >
+                  <div className="px-5 pt-0 pb-5">
+                    <div className="mb-3 h-px bg-base-300/20" />
+                    <div className="text-sm leading-relaxed text-base-content/55">
+                      {entry.body}
+                    </div>
+                  </div>
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/myscrollr.com/src/components/support/SupportBilling.tsx
+++ b/myscrollr.com/src/components/support/SupportBilling.tsx
@@ -1,0 +1,21 @@
+import { BILLING_FAQ } from './support-content'
+import { SupportAccordion } from './SupportAccordion'
+import { SupportSection } from './SupportSection'
+
+export function SupportBilling() {
+  const entries = BILLING_FAQ.map((item) => ({
+    title: item.question,
+    body: <p>{item.answer}</p>,
+  }))
+
+  return (
+    <SupportSection
+      id="billing"
+      eyebrow="Account & Billing"
+      title="Subscriptions, plans, and payment"
+      description="How upgrades, cancellations, trials, and billing-portal access work."
+    >
+      <SupportAccordion entries={entries} idPrefix="billing" />
+    </SupportSection>
+  )
+}

--- a/myscrollr.com/src/components/support/SupportContactForm.tsx
+++ b/myscrollr.com/src/components/support/SupportContactForm.tsx
@@ -1,0 +1,363 @@
+import { useEffect, useState } from 'react'
+import { motion } from 'motion/react'
+import { AlertTriangle, CheckCircle2, Loader2, Send } from 'lucide-react'
+import { SupportSection } from './SupportSection'
+import type { FormEvent } from 'react'
+import type { SupportCategory, SupportTicketPayload } from '@/api/client'
+import { useScrollrAuth } from '@/hooks/useScrollrAuth'
+import { supportApi } from '@/api/client'
+
+const CATEGORIES: ReadonlyArray<{ value: SupportCategory; label: string }> = [
+  { value: 'bug', label: 'Bug report' },
+  { value: 'feature', label: 'Feature request' },
+  { value: 'billing', label: 'Billing & subscription' },
+  { value: 'feedback', label: 'General feedback' },
+] as const
+
+const SUBJECT_MIN = 3
+const SUBJECT_MAX = 200
+const MESSAGE_MIN = 10
+const MESSAGE_MAX = 5000
+
+export function SupportContactForm() {
+  const { isAuthenticated, getAccessToken, getIdTokenClaims } = useScrollrAuth()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [category, setCategory] = useState<SupportCategory>('feedback')
+  const [subject, setSubject] = useState('')
+  const [message, setMessage] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  // Pre-fill email + name from claims when authenticated. The contact
+  // form still SUBMITS those values (the authed endpoint accepts them
+  // for forwards-compatibility with OS Ticket), but the user doesn't
+  // have to retype them.
+  useEffect(() => {
+    if (!isAuthenticated) return
+    let cancelled = false
+    getIdTokenClaims()
+      .then((claims) => {
+        if (cancelled || !claims) return
+        if (claims.email) setEmail(claims.email)
+        if (claims.name) setName(claims.name)
+      })
+      .catch(() => {
+        // Non-fatal: user can still type their email manually.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated, getIdTokenClaims])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    // Client-side validation matches the server's bounds so the user
+    // sees the constraint before we round-trip.
+    const trimmedSubject = subject.trim()
+    const trimmedMessage = message.trim()
+    const trimmedEmail = email.trim()
+
+    if (!trimmedEmail || !trimmedEmail.includes('@')) {
+      setError('Please enter a valid email address.')
+      return
+    }
+    if (
+      trimmedSubject.length < SUBJECT_MIN ||
+      trimmedSubject.length > SUBJECT_MAX
+    ) {
+      setError(`Subject must be ${SUBJECT_MIN}-${SUBJECT_MAX} characters.`)
+      return
+    }
+    if (
+      trimmedMessage.length < MESSAGE_MIN ||
+      trimmedMessage.length > MESSAGE_MAX
+    ) {
+      setError(`Message must be ${MESSAGE_MIN}-${MESSAGE_MAX} characters.`)
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const payload: SupportTicketPayload = {
+        email: trimmedEmail,
+        category,
+        subject: trimmedSubject,
+        message: trimmedMessage,
+        name: name.trim() || undefined,
+      }
+      if (isAuthenticated) {
+        await supportApi.submitTicket(payload, getAccessToken)
+      } else {
+        await supportApi.submitTicketPublic(payload)
+      }
+      setSuccess(true)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Submission failed'
+      setError(msg)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <SupportSection
+      id="contact"
+      eyebrow="Contact"
+      title="Still need help? Send us a note"
+      description="We read every message. Replies usually arrive within 1-2 business days."
+    >
+      {success ? (
+        <SuccessPanel
+          onReset={() => {
+            setSuccess(false)
+            setSubject('')
+            setMessage('')
+          }}
+        />
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-5 rounded-2xl border border-base-300/40 bg-base-200/30 p-6 sm:p-8"
+          noValidate
+        >
+          {/* Name + email row. Email is required for both flows; name is optional. */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <FormField label="Your name" htmlFor="support-name" optional>
+              <input
+                id="support-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={submitting}
+                autoComplete="name"
+                maxLength={120}
+                className="input-base"
+                placeholder="Optional"
+              />
+            </FormField>
+
+            <FormField label="Email" htmlFor="support-email" required>
+              <input
+                id="support-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={submitting || isAuthenticated}
+                required
+                autoComplete="email"
+                maxLength={254}
+                className="input-base"
+                placeholder="you@example.com"
+              />
+              {isAuthenticated ? (
+                <p className="mt-1 text-xs text-base-content/40">
+                  Linked to your account.
+                </p>
+              ) : null}
+            </FormField>
+          </div>
+
+          <FormField label="Category" htmlFor="support-category" required>
+            <select
+              id="support-category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value as SupportCategory)}
+              disabled={submitting}
+              className="input-base"
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+          </FormField>
+
+          <FormField label="Subject" htmlFor="support-subject" required>
+            <input
+              id="support-subject"
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              disabled={submitting}
+              required
+              minLength={SUBJECT_MIN}
+              maxLength={SUBJECT_MAX}
+              className="input-base"
+              placeholder="One-line summary"
+            />
+          </FormField>
+
+          <FormField
+            label="Message"
+            htmlFor="support-message"
+            required
+            counter={`${message.length}/${MESSAGE_MAX}`}
+          >
+            <textarea
+              id="support-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              disabled={submitting}
+              required
+              minLength={MESSAGE_MIN}
+              maxLength={MESSAGE_MAX}
+              rows={7}
+              className="input-base resize-y"
+              placeholder="Tell us what's going on. The more detail, the better."
+            />
+          </FormField>
+
+          {error ? (
+            <motion.div
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="flex items-start gap-2 rounded-lg border border-error/20 bg-error/10 p-3"
+              role="alert"
+            >
+              <AlertTriangle
+                size={14}
+                className="mt-0.5 shrink-0 text-error"
+                aria-hidden="true"
+              />
+              <p className="text-xs text-error">{error}</p>
+            </motion.div>
+          ) : null}
+
+          <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-base-content/40">
+              {isAuthenticated
+                ? 'Submitted with your account, so we can look up your subscription if needed.'
+                : 'Submitted anonymously. Limited to 5 tickets per hour per IP.'}
+            </p>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-content transition-all hover:bg-primary/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 size={15} className="animate-spin" />
+                  Sending...
+                </>
+              ) : (
+                <>
+                  <Send size={15} />
+                  Send message
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Local utility classes — kept here so the input styling stays
+          colocated with the form rather than leaking into globals. */}
+      <style>{`
+        .input-base {
+          width: 100%;
+          background-color: color-mix(in oklab, var(--color-base-100) 85%, transparent);
+          border: 1px solid color-mix(in oklab, var(--color-base-300) 60%, transparent);
+          border-radius: 0.5rem;
+          padding: 0.55rem 0.75rem;
+          font-size: 0.875rem;
+          color: var(--color-base-content);
+          transition: border-color 0.15s ease, box-shadow 0.15s ease;
+        }
+        .input-base:focus {
+          outline: none;
+          border-color: color-mix(in oklab, var(--color-primary) 60%, transparent);
+          box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 15%, transparent);
+        }
+        .input-base:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+        .input-base::placeholder {
+          color: color-mix(in oklab, var(--color-base-content) 35%, transparent);
+        }
+      `}</style>
+    </SupportSection>
+  )
+}
+
+// ── Internal helpers ──────────────────────────────────────────────
+
+interface FormFieldProps {
+  label: string
+  htmlFor: string
+  required?: boolean
+  optional?: boolean
+  counter?: string
+  children: React.ReactNode
+}
+
+function FormField({
+  label,
+  htmlFor,
+  required,
+  optional,
+  counter,
+  children,
+}: FormFieldProps) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <label
+          htmlFor={htmlFor}
+          className="text-xs font-semibold tracking-wider text-base-content/70 uppercase"
+        >
+          {label}
+          {required ? <span className="ml-1 text-primary">*</span> : null}
+          {optional ? (
+            <span className="ml-1 text-base-content/30 normal-case">
+              (optional)
+            </span>
+          ) : null}
+        </label>
+        {counter ? (
+          <span className="text-[11px] tabular-nums text-base-content/35">
+            {counter}
+          </span>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function SuccessPanel({ onReset }: { onReset: () => void }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35 }}
+      className="flex flex-col items-center gap-4 rounded-2xl border border-success/20 bg-success/5 p-10 text-center"
+      role="status"
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-success/15 text-success">
+        <CheckCircle2 size={24} />
+      </div>
+      <div>
+        <h3 className="text-lg font-bold text-base-content">
+          Message sent — thanks!
+        </h3>
+        <p className="mt-2 max-w-md text-sm text-base-content/55">
+          We've received your note and will get back to you within 1-2 business
+          days at the email you provided.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onReset}
+        className="cursor-pointer rounded-lg border border-base-300/50 bg-base-200/40 px-4 py-2 text-sm font-medium text-base-content/70 transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-primary"
+      >
+        Send another
+      </button>
+    </motion.div>
+  )
+}

--- a/myscrollr.com/src/components/support/SupportFAQ.tsx
+++ b/myscrollr.com/src/components/support/SupportFAQ.tsx
@@ -1,0 +1,21 @@
+import { FAQ_ITEMS } from './support-content'
+import { SupportAccordion } from './SupportAccordion'
+import { SupportSection } from './SupportSection'
+
+export function SupportFAQ() {
+  const entries = FAQ_ITEMS.map((item) => ({
+    title: item.question,
+    body: <p>{item.answer}</p>,
+  }))
+
+  return (
+    <SupportSection
+      id="faq"
+      eyebrow="FAQ"
+      title="Frequently asked questions"
+      description="Quick answers to the questions people most often have about Scrollr."
+    >
+      <SupportAccordion entries={entries} idPrefix="faq" />
+    </SupportSection>
+  )
+}

--- a/myscrollr.com/src/components/support/SupportGettingStarted.tsx
+++ b/myscrollr.com/src/components/support/SupportGettingStarted.tsx
@@ -1,0 +1,44 @@
+import { motion } from 'motion/react'
+import { GETTING_STARTED_STEPS } from './support-content'
+import { SupportSection } from './SupportSection'
+
+const EASE = [0.22, 1, 0.36, 1] as const
+
+export function SupportGettingStarted() {
+  return (
+    <SupportSection
+      id="getting-started"
+      eyebrow="Getting Started"
+      title="From download to your first ticker in minutes"
+      description="Five steps to go from zero to live data scrolling on your screen."
+    >
+      <ol className="space-y-3">
+        {GETTING_STARTED_STEPS.map((step, i) => (
+          <motion.li
+            key={step.title}
+            initial={{ opacity: 0, y: 12 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4, ease: EASE, delay: i * 0.05 }}
+            className="flex gap-4 rounded-xl border border-base-300/30 bg-base-200/30 p-5"
+          >
+            <span
+              aria-hidden="true"
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-primary/20 bg-primary/5 text-sm font-bold text-primary tabular-nums"
+            >
+              {i + 1}
+            </span>
+            <div className="flex-1">
+              <h3 className="text-base font-semibold text-base-content">
+                {step.title}
+              </h3>
+              <p className="mt-1 text-sm leading-relaxed text-base-content/55">
+                {step.description}
+              </p>
+            </div>
+          </motion.li>
+        ))}
+      </ol>
+    </SupportSection>
+  )
+}

--- a/myscrollr.com/src/components/support/SupportHero.tsx
+++ b/myscrollr.com/src/components/support/SupportHero.tsx
@@ -1,0 +1,86 @@
+import { motion } from 'motion/react'
+import { LifeBuoy } from 'lucide-react'
+
+const EASE = [0.22, 1, 0.36, 1] as const
+
+interface QuickLink {
+  href: string
+  label: string
+}
+
+const QUICK_LINKS: Array<QuickLink> = [
+  { href: '#getting-started', label: 'Getting Started' },
+  { href: '#faq', label: 'FAQ' },
+  { href: '#troubleshooting', label: 'Troubleshooting' },
+  { href: '#billing', label: 'Account & Billing' },
+  { href: '#contact', label: 'Contact' },
+]
+
+export function SupportHero() {
+  return (
+    <section className="relative overflow-hidden py-24 sm:py-32">
+      {/* Background grid + glow — same vocabulary the rest of the site uses */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.025]"
+        style={{
+          backgroundImage: `
+            linear-gradient(var(--grid-dot-primary) 1px, transparent 1px),
+            linear-gradient(90deg, var(--grid-dot-primary) 1px, transparent 1px)
+          `,
+          backgroundSize: '60px 60px',
+        }}
+      />
+      <div className="pointer-events-none absolute top-1/2 left-1/2 h-96 w-[42rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/5 blur-3xl" />
+
+      <div className="relative mx-auto max-w-4xl px-6 text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: EASE }}
+          className="mx-auto mb-6 flex h-12 w-12 items-center justify-center rounded-xl border border-primary/20 bg-primary/5 text-primary"
+        >
+          <LifeBuoy size={22} />
+        </motion.div>
+
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: EASE, delay: 0.05 }}
+          className="text-4xl font-bold tracking-tight text-base-content sm:text-5xl"
+        >
+          How can we <span className="text-gradient-primary">help</span>?
+        </motion.h1>
+
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: EASE, delay: 0.1 }}
+          className="mx-auto mt-6 max-w-2xl text-lg text-base-content/60"
+        >
+          Find answers, troubleshoot issues, or send us a note. Most questions
+          are answered below — we usually reply to direct messages within 1-2
+          business days.
+        </motion.p>
+
+        {/* Quick links — anchor jump targets to the sections below. */}
+        <motion.nav
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: EASE, delay: 0.15 }}
+          aria-label="Support topics"
+          className="mt-10 flex flex-wrap items-center justify-center gap-2"
+        >
+          {QUICK_LINKS.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="rounded-full border border-base-300/50 bg-base-200/40 px-4 py-1.5 text-sm font-medium text-base-content/70 transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-primary"
+            >
+              {link.label}
+            </a>
+          ))}
+        </motion.nav>
+      </div>
+    </section>
+  )
+}

--- a/myscrollr.com/src/components/support/SupportSection.tsx
+++ b/myscrollr.com/src/components/support/SupportSection.tsx
@@ -1,0 +1,58 @@
+import { motion } from 'motion/react'
+import type { ReactNode } from 'react'
+
+const EASE = [0.22, 1, 0.36, 1] as const
+
+interface SupportSectionProps {
+  /** Anchor id used by the hero quick-link nav (#getting-started, etc). */
+  id: string
+  eyebrow: string
+  title: string
+  description?: string
+  children: ReactNode
+}
+
+// Shared section wrapper for /support — keeps the heading + spacing
+// consistent across Getting Started / FAQ / Troubleshooting / Billing
+// without forcing every section component to re-implement the same
+// motion + layout boilerplate.
+export function SupportSection({
+  id,
+  eyebrow,
+  title,
+  description,
+  children,
+}: SupportSectionProps) {
+  return (
+    <section
+      id={id}
+      // scroll-margin so anchor jumps from the hero land below the
+      // sticky header instead of underneath it.
+      className="scroll-mt-24 border-t border-base-content/5 py-16 sm:py-24"
+    >
+      <div className="mx-auto max-w-4xl px-6">
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-80px' }}
+          transition={{ duration: 0.5, ease: EASE }}
+          className="mb-10"
+        >
+          <p className="text-xs font-semibold tracking-[0.2em] text-primary/70 uppercase">
+            {eyebrow}
+          </p>
+          <h2 className="mt-2 text-2xl font-bold tracking-tight text-base-content sm:text-3xl">
+            {title}
+          </h2>
+          {description ? (
+            <p className="mt-3 max-w-2xl text-base text-base-content/55">
+              {description}
+            </p>
+          ) : null}
+        </motion.div>
+
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/myscrollr.com/src/components/support/SupportTroubleshooting.tsx
+++ b/myscrollr.com/src/components/support/SupportTroubleshooting.tsx
@@ -1,0 +1,44 @@
+import { TROUBLESHOOTING_ARTICLES } from './support-content'
+import { SupportAccordion } from './SupportAccordion'
+import { SupportSection } from './SupportSection'
+
+export function SupportTroubleshooting() {
+  const entries = TROUBLESHOOTING_ARTICLES.map((article) => ({
+    title: article.title,
+    body: (
+      <div className="space-y-4">
+        <div>
+          <p className="text-xs font-semibold tracking-wider text-base-content/60 uppercase">
+            Symptoms
+          </p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {article.symptoms.map((symptom) => (
+              <li key={symptom}>{symptom}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="text-xs font-semibold tracking-wider text-base-content/60 uppercase">
+            Try this
+          </p>
+          <ol className="mt-2 list-decimal space-y-1 pl-5">
+            {article.steps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    ),
+  }))
+
+  return (
+    <SupportSection
+      id="troubleshooting"
+      eyebrow="Troubleshooting"
+      title="When something isn't working"
+      description="Common symptoms and the steps that resolve them. If none of these help, send us a note from the contact form below."
+    >
+      <SupportAccordion entries={entries} idPrefix="trouble" />
+    </SupportSection>
+  )
+}

--- a/myscrollr.com/src/components/support/support-content.ts
+++ b/myscrollr.com/src/components/support/support-content.ts
@@ -1,0 +1,220 @@
+// myscrollr.com/src/components/support/support-content.ts
+//
+// Support content for the marketing /support page. Mirrors the
+// desktop's support-content.ts but with copy adjusted for visitors who
+// may not yet have the app installed (e.g. "in the desktop app, open
+// the Catalog" rather than "open the Catalog from the sidebar").
+
+// ── FAQ Items ─────────────────────────────────────────────────────
+
+export interface FAQItem {
+  question: string
+  answer: string
+}
+
+export const FAQ_ITEMS: Array<FAQItem> = [
+  {
+    question: 'Is Scrollr free?',
+    answer:
+      'Yes. The free tier gives you real-time data across all four channels with generous limits and no ads. Upgrade to Uplink for more capacity, or Uplink Ultimate for live streaming data and unlimited everything.',
+  },
+  {
+    question: "Does it affect my computer's performance?",
+    answer:
+      'Not noticeably. All data flows through a single lightweight connection. The ticker uses minimal CPU and memory. You can check resource usage anytime with the built-in System Monitor widget.',
+  },
+  {
+    question: 'Is my data private?',
+    answer:
+      'Scrollr contains zero analytics, zero tracking pixels, and zero telemetry. Your channel configurations and preferences are stored on your device. The only server-side data is your account profile and subscription status.',
+  },
+  {
+    question: 'What platforms are supported?',
+    answer:
+      'Scrollr runs natively on macOS (Apple Silicon), Windows (x64), and Linux (x64). Each platform gets a dedicated build optimized for that OS.',
+  },
+  {
+    question: 'Do I need an account?',
+    answer:
+      'You can browse widgets and explore the desktop app without signing in. An account is needed to add channels (Finance, Sports, News, Fantasy) and to sync your setup across devices.',
+  },
+  {
+    question: 'What data does Scrollr show?',
+    answer:
+      'Four channels: live stock and crypto prices (Finance), scores across 20+ leagues (Sports), articles from RSS feeds (News), and Yahoo Fantasy Sports leagues (Fantasy). Plus utility widgets for weather, clocks, system monitoring, uptime, and GitHub Actions.',
+  },
+  {
+    question: 'Can I customize the feed?',
+    answer:
+      "Extensively. Position the ticker at the top or bottom of your screen, adjust rows and density, pin favorite sources to the sidebar, filter and sort within each channel, and toggle individual data points on or off in each channel's Display settings.",
+  },
+  {
+    question: 'Is Scrollr open source?',
+    answer:
+      'Yes. Every line of code is publicly available on GitHub under the GNU AGPL v3.0 license. You can inspect, fork, or contribute.',
+  },
+  {
+    question: 'How do I update the app?',
+    answer:
+      "Scrollr checks for updates automatically on launch. When an update is available, you'll see a notification prompting you to install. Updates are downloaded in the background and applied on next restart.",
+  },
+  {
+    question: 'How does live data work vs. polling?',
+    answer:
+      'Free and Uplink tiers use polling — the app fetches fresh data at regular intervals (60s for free, 30s for Uplink, 10s for Pro). Uplink Ultimate uses a persistent SSE connection for instant live updates as data changes on the server.',
+  },
+]
+
+// ── Troubleshooting Articles ──────────────────────────────────────
+
+export interface TroubleshootingArticle {
+  title: string
+  symptoms: Array<string>
+  steps: Array<string>
+}
+
+export const TROUBLESHOOTING_ARTICLES: Array<TroubleshootingArticle> = [
+  {
+    title: 'Sign-in fails or shows "Sign-in failed"',
+    symptoms: [
+      'Browser opens but returns to the desktop app with an error toast',
+      'Browser shows "authorization successful" but the app still shows failure',
+    ],
+    steps: [
+      'Check your internet connection.',
+      'In the desktop app, sign out (Settings > Account) then sign in again.',
+      'If the browser shows an error page, close it and retry from the app.',
+      'If the problem persists, send us a note from the contact form below.',
+    ],
+  },
+  {
+    title: 'Data not loading / feed shows empty',
+    symptoms: [
+      'Channel added but shows "No data right now"',
+      'Ticker shows empty slots where data should be',
+    ],
+    steps: [
+      "Open the channel's Settings tab and verify items are configured (symbols, leagues, or feeds).",
+      "Check that you're signed in (Settings > Account).",
+      'Try switching away from and back to the feed tab.',
+      'Check your internet connection.',
+    ],
+  },
+  {
+    title: 'Ticker not visible',
+    symptoms: [
+      'Ticker bar disappeared from the screen edge',
+      'Only the main window shows',
+    ],
+    steps: [
+      'Press Ctrl+T (Cmd+T on macOS) to toggle ticker visibility.',
+      'Or go to Settings > General and enable the "Show Ticker" toggle.',
+      'Right-click the system tray icon and check "Toggle Ticker".',
+    ],
+  },
+  {
+    title: 'Finance prices not updating',
+    symptoms: [
+      'Stock prices appear frozen or stale',
+      '"Last updated" time doesn\'t change',
+    ],
+    steps: [
+      'The finance data service reconnects automatically after brief disconnections. Wait 2-5 minutes.',
+      'Check your internet connection.',
+      'If persistent, try restarting the app.',
+    ],
+  },
+  {
+    title: 'Yahoo Fantasy connect fails',
+    symptoms: [
+      'Clicking "Connect Yahoo" opens browser but nothing happens',
+      'Returns an error after authorizing',
+    ],
+    steps: [
+      "Yahoo's OAuth can be intermittent. Wait 30 seconds and try again.",
+      "Make sure you're authorizing the correct Yahoo account.",
+      'If you see "invalid redirect URI", this is a known Yahoo issue — retry usually works.',
+    ],
+  },
+  {
+    title: 'Subscription not reflecting after purchase',
+    symptoms: [
+      'Completed checkout but app still shows Free tier limits',
+      'Tier says "free" after upgrading',
+    ],
+    steps: [
+      'The app checks subscription status every 5 minutes and on window focus. Click away from and back to the app window.',
+      'If it persists, sign out and sign back in — the fresh token will include your updated role.',
+    ],
+  },
+]
+
+// ── Getting Started Steps ─────────────────────────────────────────
+
+export interface GettingStartedStep {
+  title: string
+  description: string
+}
+
+export const GETTING_STARTED_STEPS: Array<GettingStartedStep> = [
+  {
+    title: 'Download & Install',
+    description:
+      'Pick your platform on the Download page and run the installer. macOS, Windows, and Linux are all supported.',
+  },
+  {
+    title: 'Sign In',
+    description:
+      'Create a free account or sign in to sync your channels and settings. Free accounts get full access to all features with generous limits.',
+  },
+  {
+    title: 'Add Channels',
+    description:
+      'In the desktop app, open the Catalog from the sidebar to browse available data sources. Add Finance for stock prices, Sports for live scores, News for RSS feeds, or Fantasy for Yahoo leagues.',
+  },
+  {
+    title: 'Configure Your Feeds',
+    description:
+      'Each channel has a Settings tab where you pick what to track. Add stock symbols, select sports leagues, subscribe to news feeds, or connect your Yahoo account.',
+  },
+  {
+    title: 'Customize the Ticker',
+    description:
+      'The ticker bar runs across your screen showing live data. Adjust its position (top/bottom), size (compact/comfort), and number of rows in Settings > Ticker.',
+  },
+]
+
+// ── Billing FAQ ───────────────────────────────────────────────────
+
+export const BILLING_FAQ: Array<FAQItem> = [
+  {
+    question: 'How do I upgrade my plan?',
+    answer:
+      'Open the Catalog or go to Settings > Account in the desktop app and click "Upgrade". You\'ll be directed to our website to complete checkout with Stripe.',
+  },
+  {
+    question: 'How do I cancel my subscription?',
+    answer:
+      'Go to Settings > Account in the desktop app and click "Manage Subscription". Paid subscriptions cancel at the end of the billing period so you keep access until then. Trials cancel immediately.',
+  },
+  {
+    question: 'What happens when my trial ends?',
+    answer:
+      'Your card is charged automatically at the plan rate you selected during checkout. During the trial, you get full Uplink Ultimate access regardless of which plan you chose.',
+  },
+  {
+    question: 'Can I change my plan?',
+    answer:
+      'Yes. Upgrades take effect immediately with prorated billing. Downgrades take effect at the end of your current billing period.',
+  },
+  {
+    question: 'How do I update my payment method?',
+    answer:
+      'Click "Manage Subscription" in Settings > Account to open the Stripe billing portal where you can update your card.',
+  },
+  {
+    question: 'I was charged incorrectly',
+    answer:
+      "Use the contact form below with your account email and a description of the issue. We'll investigate and resolve it promptly.",
+  },
+]

--- a/myscrollr.com/src/routeTree.gen.ts
+++ b/myscrollr.com/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as UplinkRouteImport } from './routes/uplink'
+import { Route as SupportRouteImport } from './routes/support'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as LegalRouteImport } from './routes/legal'
 import { Route as InviteRouteImport } from './routes/invite'
@@ -25,6 +26,11 @@ import { Route as UUsernameRouteImport } from './routes/u.$username'
 const UplinkRoute = UplinkRouteImport.update({
   id: '/uplink',
   path: '/uplink',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SupportRoute = SupportRouteImport.update({
+  id: '/support',
+  path: '/support',
   getParentRoute: () => rootRouteImport,
 } as any)
 const StatusRoute = StatusRouteImport.update({
@@ -93,6 +99,7 @@ export interface FileRoutesByFullPath {
   '/invite': typeof InviteRoute
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
+  '/support': typeof SupportRoute
   '/uplink': typeof UplinkRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink/lifetime': typeof UplinkLifetimeRoute
@@ -107,6 +114,7 @@ export interface FileRoutesByTo {
   '/invite': typeof InviteRoute
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
+  '/support': typeof SupportRoute
   '/uplink': typeof UplinkRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink/lifetime': typeof UplinkLifetimeRoute
@@ -122,6 +130,7 @@ export interface FileRoutesById {
   '/invite': typeof InviteRoute
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
+  '/support': typeof SupportRoute
   '/uplink': typeof UplinkRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink_/lifetime': typeof UplinkLifetimeRoute
@@ -138,6 +147,7 @@ export interface FileRouteTypes {
     | '/invite'
     | '/legal'
     | '/status'
+    | '/support'
     | '/uplink'
     | '/u/$username'
     | '/uplink/lifetime'
@@ -152,6 +162,7 @@ export interface FileRouteTypes {
     | '/invite'
     | '/legal'
     | '/status'
+    | '/support'
     | '/uplink'
     | '/u/$username'
     | '/uplink/lifetime'
@@ -166,6 +177,7 @@ export interface FileRouteTypes {
     | '/invite'
     | '/legal'
     | '/status'
+    | '/support'
     | '/uplink'
     | '/u/$username'
     | '/uplink_/lifetime'
@@ -181,6 +193,7 @@ export interface RootRouteChildren {
   InviteRoute: typeof InviteRoute
   LegalRoute: typeof LegalRoute
   StatusRoute: typeof StatusRoute
+  SupportRoute: typeof SupportRoute
   UplinkRoute: typeof UplinkRoute
   UUsernameRoute: typeof UUsernameRoute
   UplinkLifetimeRoute: typeof UplinkLifetimeRoute
@@ -193,6 +206,13 @@ declare module '@tanstack/react-router' {
       path: '/uplink'
       fullPath: '/uplink'
       preLoaderRoute: typeof UplinkRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/support': {
+      id: '/support'
+      path: '/support'
+      fullPath: '/support'
+      preLoaderRoute: typeof SupportRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/status': {
@@ -285,6 +305,7 @@ const rootRouteChildren: RootRouteChildren = {
   InviteRoute: InviteRoute,
   LegalRoute: LegalRoute,
   StatusRoute: StatusRoute,
+  SupportRoute: SupportRoute,
   UplinkRoute: UplinkRoute,
   UUsernameRoute: UUsernameRoute,
   UplinkLifetimeRoute: UplinkLifetimeRoute,

--- a/myscrollr.com/src/routes/support.tsx
+++ b/myscrollr.com/src/routes/support.tsx
@@ -1,0 +1,32 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageMeta } from '@/lib/usePageMeta'
+import { SupportHero } from '@/components/support/SupportHero'
+import { SupportGettingStarted } from '@/components/support/SupportGettingStarted'
+import { SupportFAQ } from '@/components/support/SupportFAQ'
+import { SupportTroubleshooting } from '@/components/support/SupportTroubleshooting'
+import { SupportBilling } from '@/components/support/SupportBilling'
+import { SupportContactForm } from '@/components/support/SupportContactForm'
+
+export const Route = createFileRoute('/support')({
+  component: SupportPage,
+})
+
+function SupportPage() {
+  usePageMeta({
+    title: 'Support - Scrollr',
+    description:
+      'Find answers, troubleshoot issues, or contact the Scrollr team. FAQs, troubleshooting articles, billing help, and a direct contact form.',
+    canonicalUrl: 'https://myscrollr.com/support',
+  })
+
+  return (
+    <main className="min-h-screen bg-base-100">
+      <SupportHero />
+      <SupportGettingStarted />
+      <SupportFAQ />
+      <SupportTroubleshooting />
+      <SupportBilling />
+      <SupportContactForm />
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Three independent workstreams shipping the final standardization batch from the pre-launch audit:

### Stream A — `Channel.ticker_enabled` JSON alias
- Server emits both `visible` (legacy, for v1.0.3 compat) and `ticker_enabled` (clearer modern name) on Channel responses via custom `MarshalJSON`. UPDATE handler accepts both names on inbound bodies.
- Desktop: `Channel` interface gains `ticker_enabled` (canonical) plus `visible?` (deprecated alias). New `isChannelTickerEnabled()` helper falls back through both names for transitional reads.
- Fixes the user-reported confusion where RSS chips silently disappeared from the ticker (the field name now matches what it actually controls).

### Stream B — Website `/support` route + anonymous endpoint
- New `POST /support/ticket/public` endpoint on core API: anonymous, per-IP rate-limited (5/hour via Redis), restricted categories (bug/feature/billing/feedback), no diagnostics or attachments (anti-spam).
- Existing `api/core/support.go` refactored to extract `forwardToOSTicket` helper — single source of OS Ticket forwarding logic for both authed + public callers.
- New `myscrollr.com/src/routes/support.tsx` — single-page support hub: Hero, Getting Started, FAQ, Troubleshooting, Account & Billing, Contact form.
- Contact form is auth-aware: authenticated users hit `/support/ticket`, anonymous visitors hit `/support/ticket/public`. The authed path maps `message` → `description` + `what_went_wrong` to satisfy the existing Go handler's field-name expectations.
- Footer mailto replaced with `<Link to=\"/support\">`.

### Stream C — Desktop Settings IA polish
- Tab strip restyled with icons + larger spacing + new active-state border.
- New 4th tab: **Reset**. Destructive 'Reset all settings' moved out of Account tab into its own dedicated tab.
- New `desktop/src/components/settings/ResetSettings.tsx` component.

## Spec

`docs/superpowers/specs/2026-04-28-batch-c-standardization-design.md`

## Verification

- API: \`go vet ./...\` clean, \`go test ./core/\` passing
- Desktop: \`npx tsc --noEmit\` clean, \`npx vitest run\` **178/178 passing**, \`npm run build\` clean, \`cargo check\` clean
- Marketing: \`npm run check\` clean (Prettier + ESLint), \`npm run build\` clean

## Notable decisions

- **No DB migration**: kept the column named `visible` to avoid breaking shipped v1.0.3 desktops on the wire. Wire-format aliasing only.
- **Settings IA was scoped to polish**, not a full IA rebuild. The 4th 'Reset' tab + visual prominence is the targeted fix.
- **No new tests**: Stream A is mechanical aliasing, Stream B follows existing handler patterns, Stream C is structural rearrangement of existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)