### PR TITLE
feat(account+ticker): inline edit, super_user fix, /support sweep, unified row selector

### DIFF
--- a/api/core/handlers_account.go
+++ b/api/core/handlers_account.go
@@ -1,0 +1,307 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// ─────────────────────────────────────────────────────────────────────
+//  Account self-service handlers
+//
+//  These endpoints let an authenticated user update their own display
+//  name and primary email, and request a password-reset email. Username
+//  changes are explicitly rejected — usernames are immutable per
+//  product policy (also enforced read-only in Logto admin config).
+//
+//  All Logto Management API mutations go through the cached M2M token
+//  (getM2MToken()). On success, the per-user overview cache is
+//  invalidated so the next /users/me/overview reflects the change
+//  immediately instead of waiting up to 30s for the singleflight
+//  cache to expire.
+// ─────────────────────────────────────────────────────────────────────
+
+// UpdateProfileRequest is the body for PUT /users/me/profile.
+//
+// All fields are optional pointers so we can distinguish "absent" from
+// "explicitly empty". Username is accepted in the schema only so we
+// can return a clear 403 instead of a generic validation error if a
+// client tries to send it; the field is never honored.
+type UpdateProfileRequest struct {
+	Name     *string `json:"name,omitempty"`
+	Email    *string `json:"email,omitempty"`
+	Username *string `json:"username,omitempty"`
+}
+
+// UpdateProfileResponse echoes the fields that were applied.
+type UpdateProfileResponse struct {
+	Status string `json:"status"`
+	Name   string `json:"name,omitempty"`
+	Email  string `json:"email,omitempty"`
+}
+
+// HandleUpdateProfile updates the user's display name and/or primary
+// email via Logto Management API. Username changes are rejected.
+func HandleUpdateProfile(c *fiber.Ctx) error {
+	userID := GetUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Status: "unauthorized",
+			Error:  "authentication required",
+		})
+	}
+
+	var req UpdateProfileRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "invalid request body",
+		})
+	}
+
+	if req.Username != nil {
+		return c.Status(fiber.StatusForbidden).JSON(ErrorResponse{
+			Status: "forbidden",
+			Error:  "username changes are not permitted",
+		})
+	}
+
+	if req.Name == nil && req.Email == nil {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "at least one of name or email is required",
+		})
+	}
+
+	cfg := getM2MConfig()
+	if cfg.Endpoint == "" {
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Logto not configured",
+		})
+	}
+
+	token, err := getM2MToken()
+	if err != nil {
+		log.Printf("[UpdateProfile] m2m token: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "auth backend unavailable",
+		})
+	}
+
+	if req.Name != nil {
+		if err := updateUserName(cfg.Endpoint, token, userID, *req.Name); err != nil {
+			log.Printf("[UpdateProfile] name update for %s: %v", userID, err)
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "failed to update name",
+			})
+		}
+	}
+	if req.Email != nil {
+		if err := updateUserEmail(cfg.Endpoint, token, userID, *req.Email); err != nil {
+			log.Printf("[UpdateProfile] email update for %s: %v", userID, err)
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "failed to update email",
+			})
+		}
+	}
+
+	// Refresh the overview cache so /users/me/overview returns the new
+	// values on the very next call.
+	ctx, cancel := context.WithTimeout(c.Context(), 2*time.Second)
+	defer cancel()
+	InvalidateOverviewCache(ctx, userID)
+
+	resp := UpdateProfileResponse{Status: "ok"}
+	if req.Name != nil {
+		resp.Name = *req.Name
+	}
+	if req.Email != nil {
+		resp.Email = *req.Email
+	}
+	return c.JSON(resp)
+}
+
+// updateUserName patches the user's display name via Logto Management API.
+func updateUserName(endpoint, token, userID, name string) error {
+	payload, _ := json.Marshal(map[string]string{"name": name})
+
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		fmt.Sprintf("%s/api/users/%s", endpoint, userID),
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("build name request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: LogtoM2MTokenTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("name request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("name update returned %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// updateUserEmail patches the user's primary email via Logto Management API.
+func updateUserEmail(endpoint, token, userID, email string) error {
+	payload, _ := json.Marshal(map[string]string{"primaryEmail": email})
+
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		fmt.Sprintf("%s/api/users/%s", endpoint, userID),
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("build email request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: LogtoM2MTokenTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("email request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("email update returned %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Password reset
+//
+//  We don't ship Logto's hosted "forgot password" flow inside the
+//  desktop app — instead, the user clicks a button that emails them
+//  a link to the Logto sign-in page where they can use the standard
+//  "Forgot password?" affordance. This avoids embedding a second OIDC
+//  flow inside the Tauri webview.
+//
+//  The email goes through Resend. We don't carry any reset token —
+//  Logto generates and validates that itself once the user reaches
+//  its UI. From our side this is just a notification.
+// ─────────────────────────────────────────────────────────────────────
+
+// HandleRequestPasswordReset sends the authenticated user a password-
+// reset email. The email contains a CTA pointing at the Logto sign-in
+// page so they can use the built-in "Forgot password?" flow.
+func HandleRequestPasswordReset(c *fiber.Ctx) error {
+	userID := GetUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Status: "unauthorized",
+			Error:  "authentication required",
+		})
+	}
+
+	email, _ := c.Locals("user_email").(string)
+	if email == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "no email associated with this account",
+		})
+	}
+
+	signInURL := strings.TrimRight(os.Getenv("LOGTO_ENDPOINT"), "/")
+	if signInURL == "" {
+		signInURL = "https://auth.myscrollr.com"
+	}
+
+	if err := sendPasswordResetEmail(email, signInURL); err != nil {
+		log.Printf("[PasswordReset] send failed for %s: %v", userID, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "failed to send reset email",
+		})
+	}
+
+	log.Printf("[PasswordReset] sent reset email to %s for user %s", email, userID)
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// sendPasswordResetEmail dispatches a transactional email via Resend.
+// Reuses RESEND_API_KEY and RESEND_FROM_EMAIL env vars; the API key is
+// the only required setting — the From address falls back to a sane
+// default if unset.
+func sendPasswordResetEmail(toEmail, signInURL string) error {
+	apiKey := os.Getenv("RESEND_API_KEY")
+	if apiKey == "" {
+		return fmt.Errorf("RESEND_API_KEY not configured")
+	}
+	from := os.Getenv("RESEND_FROM_EMAIL")
+	if from == "" {
+		from = "MyScrollr <noreply@myscrollr.com>"
+	}
+
+	subject := "Reset your MyScrollr password"
+	html := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0b0d10;color:#e6e6e6;padding:24px;">
+  <div style="max-width:520px;margin:0 auto;background:#14181d;border:1px solid #1e252d;border-radius:12px;padding:32px;">
+    <h2 style="margin:0 0 16px;font-size:20px;color:#fff;">Reset your password</h2>
+    <p style="margin:0 0 16px;line-height:1.6;color:#b8b8b8;">We received a request to reset the password on your MyScrollr account.</p>
+    <p style="margin:24px 0;text-align:center;">
+      <a href="%s/sign-in" style="display:inline-block;padding:12px 28px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">Reset password</a>
+    </p>
+    <p style="margin:0 0 16px;line-height:1.6;color:#b8b8b8;font-size:14px;">On the sign-in page, click <strong style="color:#e6e6e6;">Forgot password?</strong> and follow the instructions sent to your email.</p>
+    <p style="margin:0;line-height:1.6;color:#7a7a7a;font-size:12px;">If you didn't request this, you can safely ignore this email — your password won't change.</p>
+  </div>
+  <p style="text-align:center;margin-top:16px;color:#5a5a5a;font-size:11px;">— The MyScrollr Team</p>
+</body>
+</html>`, signInURL)
+
+	payload, _ := json.Marshal(map[string]interface{}{
+		"from":    from,
+		"to":      []string{toEmail},
+		"subject": subject,
+		"html":    html,
+	})
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://api.resend.com/emails",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("build resend request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -204,6 +204,10 @@ func (s *Server) setupRoutes() {
 	s.App.Post("/users/me/subscription/cancel", LogtoAuth, HandleCancelSubscription)
 	s.App.Post("/users/me/subscription/portal", LogtoAuth, HandleCreatePortalSession)
 
+	// Account self-service: profile (name/email) + password reset email
+	s.App.Put("/users/me/profile", LogtoAuth, HandleUpdateProfile)
+	s.App.Post("/users/me/password/reset", LogtoAuth, HandleRequestPasswordReset)
+
 	// User Routes — specific /users/me/* paths BEFORE parameterized /users/:username
 	s.App.Get("/users/me/preferences", LogtoAuth, HandleGetPreferences)
 	s.App.Put("/users/me/preferences", LogtoAuth, HandleUpdatePreferences)

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
     "directory": "desktop"
   },
   "homepage": "https://myscrollr.com",
-  "bugs": "https://github.com/brandon-relentnet/myscrollr/issues",
+  "bugs": "https://myscrollr.com/support",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5174",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -27,9 +27,13 @@ import {
   savePrefs,
   TICKER_GAPS,
   TICKER_HEIGHTS,
-  toggleWidgetOnTicker,
   toggleWidgetPin,
+  setChannelTickerRow,
+  setWidgetTickerRow,
+  getChannelTickerRow,
+  getWidgetTickerRow,
 } from "./preferences";
+import { getMaxTickerRows } from "./tierLimits";
 import type { SubscriptionTier } from "./auth";
 import type { ChannelType } from "./api/client";
 import type { DeliveryMode } from "./types";
@@ -366,30 +370,39 @@ export default function App() {
 
   // ── Channel quick-toggle (for context menu) ────────────────────
 
-  const handleChannelToggle = useCallback(
-    async (channelType: ChannelType, visible: boolean) => {
+  // ── Unified row-selector handlers (for tray submenus) ──────────
+  // Both feed.tsx and the tray menu now use the same mental model
+  // ("Where should this source live? Off / Row 1 / 2 / 3"), so these
+  // handlers mirror the row-change logic in routes/feed.tsx exactly.
+  // See preferences.ts §"Unified ticker row selector helpers".
+
+  const handleChannelRowChange = useCallback(
+    async (channelType: ChannelType, row: number | null) => {
+      // 1) Client-side: assign / unassign in tickerLayout. Optimistic update
+      //    so the next tray menu rebuild reflects the change immediately.
+      setPrefs((prev) => {
+        const updated = setChannelTickerRow(prev, channelType, row);
+        savePrefs(updated);
+        return updated;
+      });
+      // 2) Server-side: flip Channel.ticker_enabled (true if row is set).
       try {
-        await toggleChannelVisibility(channelType, visible);
+        await toggleChannelVisibility(channelType, row !== null);
         queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
       } catch {
-        // Silently fail — will sync on next poll
+        // Silently fail — will sync on next dashboard poll/CDC event.
       }
     },
     [queryClient],
   );
 
-  // ── Widget quick-toggle (for context menu) ─────────────────────
-
-  const handleWidgetToggle = useCallback(
-    (widgetId: string) => {
-      setPrefs((prev) => {
-        const updated = toggleWidgetOnTicker(prev, widgetId);
-        savePrefs(updated);
-        return updated;
-      });
-    },
-    [],
-  );
+  const handleWidgetRowChange = useCallback((widgetId: string, row: number | null) => {
+    setPrefs((prev) => {
+      const updated = setWidgetTickerRow(prev, widgetId, row);
+      savePrefs(updated);
+      return updated;
+    });
+  }, []);
 
   // ── Widget pin toggle (hover icon on consolidated chip) ─────────
 
@@ -476,53 +489,100 @@ export default function App() {
 
       items.push(await PredefinedMenuItem.new({ item: "Separator" }));
 
+      // Per-source row picker — same mental model as the feed page
+      // RowSelector. Each channel/widget gets its own submenu with
+      // [Off, Row 1, Row 2, …] CheckMenuItems where exactly one is
+      // checked at any time. The maxRows entries reflect the user's
+      // tier (Free=1, Uplink=2, Pro/Ultimate=3).
+      const maxRows = getMaxTickerRows(tierRef.current);
+
+      // Build one submenu of row CheckMenuItems for a source. The "Off"
+      // entry is always present; row entries 1..maxRows follow.
+      async function buildRowSubmenuItems(
+        currentRow: number | null,
+        onPick: (row: number | null) => void,
+        disabled: boolean,
+      ): Promise<CheckMenuItem[]> {
+        const rowItems: CheckMenuItem[] = [];
+        rowItems.push(
+          await CheckMenuItem.new({
+            text: "Off",
+            checked: currentRow === null,
+            enabled: !disabled,
+            action: () => onPick(null),
+          }),
+        );
+        if (maxRows === 1) {
+          rowItems.push(
+            await CheckMenuItem.new({
+              text: "On",
+              checked: currentRow === 0,
+              enabled: !disabled,
+              action: () => onPick(0),
+            }),
+          );
+        } else {
+          for (let i = 0; i < maxRows; i++) {
+            rowItems.push(
+              await CheckMenuItem.new({
+                text: `Row ${i + 1}`,
+                checked: currentRow === i,
+                enabled: !disabled,
+                action: () => onPick(i),
+              }),
+            );
+          }
+        }
+        return rowItems;
+      }
+
       // Channels submenu (only when authenticated with channels)
       if (chs.length > 0) {
-        const channelItems: CheckMenuItem[] = [];
+        const channelSubmenus: Submenu[] = [];
         for (const ch of chs) {
           const channelType = ch.channel_type;
-          const isVisible = ch.enabled && isChannelTickerEnabled(ch);
           const label =
             channelType.charAt(0).toUpperCase() + channelType.slice(1);
-          channelItems.push(
-            await CheckMenuItem.new({
-              text: label,
-              checked: isVisible,
-              action: () => {
-                // Optimistic update — flip the ref immediately so the next
-                // menu build reflects the change without waiting for the API
-                const target = channelsRef.current.find(
-                  (c) => c.channel_type === channelType,
-                );
-                if (target) target.ticker_enabled = !isVisible;
-                handleChannelToggle(channelType, !isVisible);
-              },
-            }),
+          const currentRow = getChannelTickerRow(prefsRef.current, ch);
+          const rowItems = await buildRowSubmenuItems(
+            currentRow,
+            (row) => {
+              // Optimistic update — flip the ref immediately so the next
+              // menu build reflects the change without waiting for the API.
+              const target = channelsRef.current.find(
+                (c) => c.channel_type === channelType,
+              );
+              if (target) target.ticker_enabled = row !== null;
+              handleChannelRowChange(channelType, row);
+            },
+            !ch.enabled,
+          );
+          channelSubmenus.push(
+            await Submenu.new({ text: label, items: rowItems }),
           );
         }
         items.push(
-          await Submenu.new({ text: "Channels", items: channelItems }),
+          await Submenu.new({ text: "Channels", items: channelSubmenus }),
         );
       }
 
-      // Widgets submenu
+      // Widgets submenu — same row-picker pattern.
       const allWidgets = getAllWidgets();
       if (allWidgets.length > 0) {
-        const widgetItems: CheckMenuItem[] = [];
+        const widgetSubmenus: Submenu[] = [];
         for (const widget of allWidgets) {
-          const isEnabled = prefsRef.current.widgets.widgetsOnTicker.includes(widget.id);
-          widgetItems.push(
-            await CheckMenuItem.new({
-              text: widget.name,
-              checked: isEnabled,
-              action: () => {
-                handleWidgetToggle(widget.id);
-              },
-            }),
+          const currentRow = getWidgetTickerRow(prefsRef.current, widget.id);
+          const rowItems = await buildRowSubmenuItems(
+            currentRow,
+            (row) => handleWidgetRowChange(widget.id, row),
+            false,
+          );
+          widgetSubmenus.push(
+            await Submenu.new({ text: widget.name, items: rowItems }),
           );
         }
         items.push(
-          await Submenu.new({ text: "Widgets", items: widgetItems }),
+          await Submenu.new({ text: "Widgets", items: widgetSubmenus }),
         );
       }
 
@@ -597,7 +657,7 @@ export default function App() {
     }
     document.addEventListener("contextmenu", onContextMenu);
     return () => document.removeEventListener("contextmenu", onContextMenu);
-  }, [handleChannelToggle, handleWidgetToggle, handleTogglePosition]);
+  }, [handleChannelRowChange, handleWidgetRowChange, handleTogglePosition]);
 
   // ── Merge channel + widget tabs ──────────────────────────────
   const activeTabs = useMemo(

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -311,6 +311,56 @@ export async function fetchOverview(): Promise<UserOverview> {
   return authFetch<UserOverview>("/users/me/overview");
 }
 
+// ── Account self-service ────────────────────────────────────────
+//
+// Update display name and/or primary email via Logto Management API
+// (proxied through our own `/users/me/profile` so we don't ship the
+// M2M secret to the desktop client). Username is intentionally not
+// exposed — the server rejects it with 403.
+
+export interface UpdateProfileResponse {
+  status: string;
+  name?: string;
+  email?: string;
+}
+
+export async function updateProfile(payload: {
+  name?: string;
+  email?: string;
+}): Promise<UpdateProfileResponse> {
+  return authFetch<UpdateProfileResponse>("/users/me/profile", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+/**
+ * Trigger a password-reset email. The server emails the user a link
+ * to the Logto sign-in page where they can use the standard "Forgot
+ * password?" affordance — we don't reveal a token client-side.
+ *
+ * `authFetch` parses JSON; this endpoint returns 204 No Content, so
+ * skip it and use the raw token-aware fetch path.
+ */
+export async function requestPasswordReset(): Promise<void> {
+  const token = await getValidToken();
+  const headers: HeadersInit = {};
+  if (token) {
+    (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
+  }
+  const response = await fetchWithTimeout(
+    `${API_BASE}/users/me/password/reset`,
+    { method: "POST", headers },
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      `password reset failed: ${response.status}`,
+    );
+  }
+}
+
 /**
  * Fetch the GDPR data export ZIP. Bypasses `authFetch` because that helper
  * parses JSON; we need the raw Response to call `.blob()`.

--- a/desktop/src/components/RowSelector.tsx
+++ b/desktop/src/components/RowSelector.tsx
@@ -1,0 +1,111 @@
+/**
+ * RowSelector — radio-segmented control for ticker visibility.
+ *
+ * Replaces the duplicated Eye/EyeOff buttons (feed page) and tray-menu
+ * CheckMenuItem flips with a single mental model:
+ *
+ *     "Where should this source appear?  Off / Row 1 / Row 2 / Row 3"
+ *
+ * The component is dumb — it renders a row picker and bubbles the
+ * selection up. Callers (feed.tsx, App.tsx tray) wire the
+ * `setChannelTickerRow` / `setWidgetTickerRow` helpers from
+ * preferences.ts, plus `channelsApi.update` for channels' server-side
+ * `ticker_enabled` flag.
+ *
+ * Visual: small inline segmented control in the same row as a channel
+ * /widget header. When `maxRows === 1` (Free tier) labels collapse to
+ * `[Off] [On]` since there's only one row to choose from.
+ *
+ * Disabled state: when the channel is disabled at the catalog level,
+ * the entire control fades and shows a hint to enable it from Catalog.
+ *
+ * See docs/superpowers/specs/2026-04-28-batch-d-…-design.md §Stream 3.
+ */
+import clsx from "clsx";
+
+interface RowSelectorProps {
+  /** Currently selected row (0..maxRows-1) or null for off. */
+  value: number | null;
+  /** Total number of rows the user can choose from (1, 2, or 3 based on tier). */
+  maxRows: number;
+  /** Disabled state (e.g. when channel.enabled === false). */
+  disabled?: boolean;
+  /** Hint text shown beneath the control when disabled. */
+  disabledHint?: string;
+  /** Called when the user picks a row or "Off". */
+  onChange: (next: number | null) => void;
+  /** Optional aria-label for the radiogroup (defaults to "Ticker row"). */
+  ariaLabel?: string;
+  /** Optional className appended to the radiogroup container. */
+  className?: string;
+}
+
+interface RowButton {
+  key: string;
+  label: string;
+  row: number | null;
+}
+
+export default function RowSelector({
+  value,
+  maxRows,
+  disabled = false,
+  disabledHint,
+  onChange,
+  ariaLabel = "Ticker row",
+  className,
+}: RowSelectorProps) {
+  // Build the button list. With a single row available we use [Off]/[On]
+  // because "Row 1" sounds wrong when there's nothing else.
+  const rowsAvailable = Math.max(1, maxRows);
+  const buttons: RowButton[] = [{ key: "off", label: "Off", row: null }];
+  if (rowsAvailable === 1) {
+    buttons.push({ key: "row-0", label: "On", row: 0 });
+  } else {
+    for (let i = 0; i < rowsAvailable; i++) {
+      buttons.push({ key: `row-${i}`, label: `Row ${i + 1}`, row: i });
+    }
+  }
+
+  return (
+    <div className={clsx("flex flex-col gap-1", className)}>
+      <div
+        role="radiogroup"
+        aria-label={ariaLabel}
+        aria-disabled={disabled || undefined}
+        className={clsx(
+          "inline-flex items-center gap-0.5 p-0.5 rounded-md border border-edge/30 bg-base-200/60",
+          disabled && "opacity-50 pointer-events-none",
+        )}
+      >
+        {buttons.map(({ key, label, row }) => {
+          const active = value === row;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!disabled) onChange(row);
+              }}
+              disabled={disabled}
+              className={clsx(
+                "px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
+                active
+                  ? "bg-accent/15 text-accent"
+                  : "text-fg-3 hover:text-fg-2 hover:bg-base-300",
+              )}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+      {disabled && disabledHint && (
+        <p className="text-[11px] text-fg-4">{disabledHint}</p>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -1,15 +1,22 @@
 import { useState, useCallback } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-shell";
+import { toast } from "sonner";
+import { Check, KeyRound, Loader2 } from "lucide-react";
 import { TIER_LABELS, getUserIdentity } from "../../auth";
-import { authFetch } from "../../api/client";
-import { userOverviewQueryOptions } from "../../api/queries";
+import {
+  authFetch,
+  requestPasswordReset,
+  updateProfile,
+} from "../../api/client";
+import { queryKeys, userOverviewQueryOptions } from "../../api/queries";
 import { TIER_LIMITS, isUnlimited, type NumericLimitKey } from "../../tierLimits";
 import type { SubscriptionTier } from "../../auth";
 import type { SubscriptionInfo } from "../../api/client";
 import { Section, DisplayRow, ActionRow } from "./SettingsControls";
 import AccountStatsRow from "./AccountStatsRow";
 import AccountExportButton from "./AccountExportButton";
+import ProfileField from "./ProfileField";
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -66,8 +73,12 @@ export default function AccountSettings({
 }: AccountSettingsProps) {
   const [openingPortal, setOpeningPortal] = useState(false);
   const [portalError, setPortalError] = useState<string | null>(null);
+  const [resetState, setResetState] = useState<
+    "idle" | "sending" | "sent"
+  >("idle");
   const identity = authenticated ? getUserIdentity() : null;
   const userLabel = identity?.email ?? identity?.name ?? null;
+  const queryClient = useQueryClient();
 
   // Aggregated overview: channels count, fantasy summary, GDPR state.
   // Only fires when authenticated; query is cheap (cached server-side, 30s stale).
@@ -75,6 +86,34 @@ export default function AccountSettings({
     ...userOverviewQueryOptions(),
     enabled: authenticated,
   });
+
+  const handleProfileSave = useCallback(
+    async (payload: { name?: string; email?: string }, label: string) => {
+      await updateProfile(payload);
+      // Force a refetch so the new value lands in the UI immediately
+      // — the server-side overview cache was already invalidated by
+      // the handler, so this hits a fresh read.
+      await queryClient.invalidateQueries({ queryKey: queryKeys.userOverview });
+      toast.success(`${label} updated`);
+    },
+    [queryClient],
+  );
+
+  const handleSendReset = useCallback(async () => {
+    try {
+      setResetState("sending");
+      await requestPasswordReset();
+      setResetState("sent");
+      toast.success("Password reset email sent");
+    } catch (err) {
+      setResetState("idle");
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to send password reset email",
+      );
+    }
+  }, []);
 
   const handleOpenPortal = useCallback(async () => {
     try {
@@ -145,6 +184,67 @@ export default function AccountSettings({
           />
         )}
       </Section>
+
+      {/* ── Profile (inline edit) ────────────────────────────── */}
+      {authenticated && (
+        <Section title="Profile">
+          <ProfileField
+            label="Display name"
+            value={overview?.identity.name ?? ""}
+            placeholder="Add a display name"
+            onSave={(next) =>
+              handleProfileSave({ name: next }, "Display name")
+            }
+          />
+          <ProfileField
+            label="Email"
+            type="email"
+            value={overview?.identity.email ?? ""}
+            placeholder="you@example.com"
+            onSave={(next) => handleProfileSave({ email: next }, "Email")}
+          />
+          <DisplayRow
+            label="Username"
+            value={overview?.identity.username || "—"}
+            valueClass="text-xs text-fg-3 font-mono truncate max-w-[180px]"
+          />
+        </Section>
+      )}
+
+      {/* ── Security ─────────────────────────────────────────── */}
+      {authenticated && (
+        <Section title="Security">
+          <div className="px-3 py-2.5 flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="text-[12px] text-fg-2 leading-tight">
+                Password
+              </div>
+              <div className="text-[11px] text-fg-4 leading-snug mt-0.5">
+                We&apos;ll email you a reset link.
+              </div>
+            </div>
+            <button
+              onClick={handleSendReset}
+              disabled={resetState !== "idle"}
+              className="shrink-0 flex items-center gap-1 text-[11px] font-medium px-2.5 py-1 rounded-md bg-base-250 text-fg-3 hover:text-fg-2 hover:bg-base-300 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            >
+              {resetState === "sending" ? (
+                <>
+                  <Loader2 size={11} className="animate-spin" /> Sending…
+                </>
+              ) : resetState === "sent" ? (
+                <>
+                  <Check size={11} /> Email sent
+                </>
+              ) : (
+                <>
+                  <KeyRound size={11} /> Send reset email
+                </>
+              )}
+            </button>
+          </div>
+        </Section>
+      )}
 
       {/* ── Quick stats ──────────────────────────────────────── */}
       {authenticated && overview && (

--- a/desktop/src/components/settings/ProfileField.tsx
+++ b/desktop/src/components/settings/ProfileField.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from "react";
+import { Check, Loader2, Pencil, X } from "lucide-react";
+import { clsx } from "clsx";
+
+// ── ProfileField ────────────────────────────────────────────────
+//
+// Inline edit-in-place row for the Account settings panel. Renders as
+// a label + value with an "Edit" pencil; on click, swaps the value
+// for an input and Save/Cancel buttons. The save handler is async so
+// the parent can run a server mutation before we re-collapse the row.
+//
+// Errors are surfaced inline beneath the input. We deliberately do
+// NOT collapse the row on error so the user can correct and retry
+// without re-typing. A blank/unchanged save is treated as a no-op
+// cancel for forgiving UX.
+
+interface ProfileFieldProps {
+  label: string;
+  value: string;
+  placeholder?: string;
+  type?: "text" | "email";
+  onSave: (next: string) => Promise<void>;
+}
+
+export default function ProfileField({
+  label,
+  value,
+  placeholder,
+  type = "text",
+  onSave,
+}: ProfileFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Resync the draft when the parent re-fetches and the user isn't
+  // mid-edit. Prevents the input from showing a stale value if the
+  // server-side update was applied via another client.
+  useEffect(() => {
+    if (!editing) setDraft(value);
+  }, [value, editing]);
+
+  async function handleSave() {
+    const trimmed = draft.trim();
+    if (!trimmed || trimmed === value) {
+      setEditing(false);
+      setError(null);
+      return;
+    }
+    try {
+      setSaving(true);
+      setError(null);
+      await onSave(trimmed);
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleCancel() {
+    setDraft(value);
+    setEditing(false);
+    setError(null);
+  }
+
+  return (
+    <div className="px-3 py-2.5">
+      <div className="text-[10px] uppercase tracking-wider text-fg-4 mb-1.5">
+        {label}
+      </div>
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <input
+            type={type}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={placeholder}
+            disabled={saving}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSave();
+              if (e.key === "Escape") handleCancel();
+            }}
+            className="flex-1 px-2.5 py-1.5 text-xs bg-base-300 border border-edge rounded-md text-fg focus:outline-none focus:border-accent/60 disabled:opacity-60"
+          />
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            aria-label="Save"
+            className={clsx(
+              "p-1.5 rounded-md transition-colors",
+              "bg-accent/10 text-accent hover:bg-accent/20",
+              "disabled:opacity-60 disabled:cursor-not-allowed",
+            )}
+          >
+            {saving ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Check size={12} />
+            )}
+          </button>
+          <button
+            onClick={handleCancel}
+            disabled={saving}
+            aria-label="Cancel"
+            className="p-1.5 rounded-md text-fg-4 hover:text-fg-2 hover:bg-base-300 disabled:opacity-60 transition-colors"
+          >
+            <X size={12} />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs text-fg-2 truncate min-w-0 flex-1">
+            {value || (
+              <span className="italic text-fg-4">
+                {placeholder ?? "Not set"}
+              </span>
+            )}
+          </span>
+          <button
+            onClick={() => setEditing(true)}
+            className="shrink-0 flex items-center gap-1 px-2 py-1 text-[11px] font-medium text-fg-4 hover:text-fg-2 hover:bg-base-300 rounded-md transition-colors"
+          >
+            <Pencil size={10} /> Edit
+          </button>
+        </div>
+      )}
+      {error && (
+        <p className="mt-1.5 text-[11px] text-error/80 leading-snug">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -22,8 +22,14 @@ import {
   migrateFinanceDisplay,
   migrateRssDisplay,
   migrateFantasyDisplay,
+  getSourceTickerRow,
+  getChannelTickerRow,
+  getWidgetTickerRow,
+  setSourceTickerRow,
+  setChannelTickerRow,
+  setWidgetTickerRow,
 } from "./preferences";
-import type { Venue } from "./preferences";
+import type { Venue, AppPreferences } from "./preferences";
 
 describe("migrateVenue", () => {
   it("keeps valid venue strings as-is", () => {
@@ -322,5 +328,148 @@ describe("migrateFantasyDisplay", () => {
     expect(migrated.worstStarter).toBe("feed");
     expect(migrated.benchOpportunity).toBe("off");
     expect(migrated.injuryDetail).toBe("both");
+  });
+});
+
+// ── Unified ticker row selector helpers (Stream 3 of Batch D) ────
+//
+// These tests lock in the contract for the new row-selector mental model:
+//   "Where should this source appear? Off / Row 1 / Row 2 / Row 3"
+//
+// The helpers must:
+//  - return the correct row for a source explicitly listed in tickerLayout
+//  - fall back to legacy `Channel.ticker_enabled` (or `visible`) when the
+//    source isn't in any row, so users upgrading from pre-multi-deck
+//    builds don't see all their channels suddenly go dark
+//  - move a source between rows atomically (remove from old row, add to new)
+//  - silently ignore out-of-bounds row indices (caller's job to clamp to tier)
+
+/**
+ * Build a minimal AppPreferences fixture with the given ticker rows. Other
+ * fields are set to whatever shape the helpers don't touch — the tests
+ * cast to AppPreferences because they only exercise the appearance.tickerLayout
+ * branch.
+ */
+function makePrefs(rows: { sources: string[] }[]): AppPreferences {
+  return {
+    appearance: {
+      tickerLayout: { rows },
+      tickerRows: Math.max(1, Math.min(3, rows.length)),
+    },
+  } as unknown as AppPreferences;
+}
+
+describe("getSourceTickerRow / getChannelTickerRow / getWidgetTickerRow", () => {
+  it("returns the row index when the source is in tickerLayout sources", () => {
+    const prefs = makePrefs([
+      { sources: ["finance"] },
+      { sources: ["sports", "rss"] },
+    ]);
+    expect(getSourceTickerRow(prefs, null, "rss")).toBe(1);
+    expect(getSourceTickerRow(prefs, null, "finance")).toBe(0);
+    expect(getSourceTickerRow(prefs, null, "sports")).toBe(1);
+  });
+
+  it("falls back to ticker_enabled=true for channels missing from rows", () => {
+    const prefs = makePrefs([{ sources: [] }]);
+    const ch = { channel_type: "finance", ticker_enabled: true };
+    expect(getSourceTickerRow(prefs, ch, "finance")).toBe(0);
+    expect(getChannelTickerRow(prefs, ch)).toBe(0);
+  });
+
+  it("returns null when ticker_enabled is false and the channel isn't in any row", () => {
+    const prefs = makePrefs([{ sources: [] }]);
+    const ch = { channel_type: "finance", ticker_enabled: false };
+    expect(getSourceTickerRow(prefs, ch, "finance")).toBeNull();
+    expect(getChannelTickerRow(prefs, ch)).toBeNull();
+  });
+
+  it("honours the legacy `visible` alias when ticker_enabled is missing", () => {
+    const prefs = makePrefs([{ sources: [] }]);
+    const ch = { channel_type: "finance", visible: false };
+    expect(getSourceTickerRow(prefs, ch, "finance")).toBeNull();
+    expect(getChannelTickerRow(prefs, ch)).toBeNull();
+  });
+
+  it("returns null for widgets that aren't in any row", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }]);
+    expect(getWidgetTickerRow(prefs, "clock")).toBeNull();
+  });
+
+  it("returns the row index for widgets that are in a row", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }, { sources: ["clock"] }]);
+    expect(getWidgetTickerRow(prefs, "clock")).toBe(1);
+  });
+
+  it("explicit row assignment beats the legacy ticker_enabled fallback", () => {
+    // Channel has ticker_enabled=true, but it's pinned to row 1 explicitly.
+    const prefs = makePrefs([{ sources: [] }, { sources: ["finance"] }]);
+    const ch = { channel_type: "finance", ticker_enabled: true };
+    expect(getChannelTickerRow(prefs, ch)).toBe(1);
+  });
+});
+
+describe("setSourceTickerRow / setChannelTickerRow / setWidgetTickerRow", () => {
+  it("removes the source from any other row when moving it", () => {
+    const prefs = makePrefs([
+      { sources: ["finance", "sports"] },
+      { sources: ["rss"] },
+    ]);
+    const next = setSourceTickerRow(prefs, "finance", 1);
+    expect(next.appearance.tickerLayout.rows[0].sources).toEqual(["sports"]);
+    expect(next.appearance.tickerLayout.rows[1].sources).toEqual([
+      "rss",
+      "finance",
+    ]);
+  });
+
+  it("removes the source from every row when row is null", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }, { sources: ["rss"] }]);
+    const next = setSourceTickerRow(prefs, "finance", null);
+    expect(next.appearance.tickerLayout.rows[0].sources).toEqual([]);
+    expect(next.appearance.tickerLayout.rows[1].sources).toEqual(["rss"]);
+  });
+
+  it("returns prefs unchanged when row is out of bounds", () => {
+    const prefs = makePrefs([{ sources: [] }]);
+    const next = setSourceTickerRow(prefs, "finance", 5);
+    expect(next).toBe(prefs);
+  });
+
+  it("returns prefs unchanged for negative rows", () => {
+    const prefs = makePrefs([{ sources: [] }]);
+    const next = setSourceTickerRow(prefs, "finance", -1);
+    expect(next).toBe(prefs);
+  });
+
+  it("setChannelTickerRow forwards to setSourceTickerRow", () => {
+    const prefs = makePrefs([{ sources: [] }, { sources: [] }]);
+    const next = setChannelTickerRow(prefs, "sports", 1);
+    expect(next.appearance.tickerLayout.rows[1].sources).toEqual(["sports"]);
+  });
+
+  it("setWidgetTickerRow places a widget id alongside channels in the same sources array", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }]);
+    const next = setWidgetTickerRow(prefs, "clock", 0);
+    expect(next.appearance.tickerLayout.rows[0].sources).toEqual([
+      "finance",
+      "clock",
+    ]);
+  });
+
+  it("does not mutate the original prefs object", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }]);
+    const before = JSON.stringify(prefs);
+    setSourceTickerRow(prefs, "finance", null);
+    expect(JSON.stringify(prefs)).toBe(before);
+  });
+
+  it("keeps the deprecated tickerRows field in sync after row mutations", () => {
+    // setTickerLayout (which setSourceTickerRow funnels through) clamps
+    // tickerRows to the row count. Round-tripping through the helper
+    // shouldn't drift this value.
+    const prefs = makePrefs([{ sources: [] }, { sources: [] }]);
+    const next = setSourceTickerRow(prefs, "finance", 1);
+    expect(next.appearance.tickerRows).toBe(2);
   });
 });

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -1105,4 +1105,159 @@ export function updateWidgetPrefs(
   };
 }
 
+// ── Unified ticker row selector helpers ─────────────────────────
+//
+// Stream 3 of Batch D collapses three duplicate ticker visibility
+// surfaces (tray Channels submenu, feed page Eye/EyeOff button,
+// Settings source picker) into a single mental model:
+//
+//     "Where should this source appear?  Off / Row 1 / Row 2 / Row 3"
+//
+// The new RowSelector UI calls these helpers. They keep BOTH data
+// layers in sync:
+//   - `tickerLayout.rows[i].sources[]` (client-side prefs) — controls
+//     per-row inclusion. Source of truth for which row a source
+//     appears on.
+//   - `Channel.ticker_enabled` (server-side) — controls the master
+//     gate via App.tsx's filter on `ch.enabled && isChannelTickerEnabled`.
+//     Set to true when row != null, false when row == null. Callers
+//     issue `channelsApi.update` separately; these helpers only mutate
+//     the client-side AppPreferences.
+//
+// Widgets only have the client-side layer (no server-side ticker_enabled),
+// so `setWidgetTickerRow` is just an alias to the source-id-based helper.
+// See docs/superpowers/specs/2026-04-28-batch-d-…-design.md §Stream 3.
+
+/** Minimal shape of a Channel record used by `getChannelTickerRow`. */
+interface ChannelTickerInfo {
+  channel_type: string;
+  ticker_enabled?: boolean;
+  /** @deprecated server-side legacy alias for ticker_enabled. */
+  visible?: boolean;
+}
+
+/**
+ * Read the row index where this source currently appears, or null if off.
+ *
+ * Resolution order:
+ *   1. If `sourceId` appears in any `tickerLayout.rows[i].sources[]`,
+ *      return that row index `i`.
+ *   2. Else, if `channelInfo` is provided and its `ticker_enabled` flag
+ *      is true (legacy default), return 0.
+ *   3. Else return null (off).
+ *
+ * `channelInfo` is optional because widgets don't have a server-side
+ * ticker_enabled flag — pass `null` for widget IDs.
+ */
+export function getSourceTickerRow(
+  prefs: AppPreferences,
+  channelInfo: ChannelTickerInfo | null,
+  sourceId: string,
+): number | null {
+  // Step 1: explicit assignment in tickerLayout
+  const rows = prefs.appearance.tickerLayout?.rows ?? [];
+  for (let i = 0; i < rows.length; i++) {
+    if ((rows[i]?.sources ?? []).includes(sourceId)) {
+      return i;
+    }
+  }
+
+  // Step 2: legacy fallback via Channel.ticker_enabled (channels only)
+  if (!channelInfo) return null;
+  const tickerEnabled =
+    typeof channelInfo.ticker_enabled === "boolean"
+      ? channelInfo.ticker_enabled
+      : typeof channelInfo.visible === "boolean"
+        ? channelInfo.visible
+        : true;
+  return tickerEnabled ? 0 : null;
+}
+
+/**
+ * Convenience wrapper around `getSourceTickerRow` for channels — accepts
+ * a Channel-like object (with `channel_type` + `ticker_enabled`).
+ */
+export function getChannelTickerRow(
+  prefs: AppPreferences,
+  channel: ChannelTickerInfo,
+): number | null {
+  return getSourceTickerRow(prefs, channel, channel.channel_type);
+}
+
+/**
+ * Convenience wrapper around `getSourceTickerRow` for widgets — widgets
+ * only check the client-side `tickerLayout.rows[i].sources[]` layer.
+ */
+export function getWidgetTickerRow(
+  prefs: AppPreferences,
+  widgetId: string,
+): number | null {
+  return getSourceTickerRow(prefs, null, widgetId);
+}
+
+/**
+ * Move a source to the given row, removing it from any other row first.
+ *
+ * - `row = null` removes the source from every row (off).
+ * - `row = 0..(rows.length-1)` puts the source in that row exclusively.
+ * - Out-of-bounds row returns `prefs` unchanged (caller must ensure the
+ *   row exists per tier limits).
+ *
+ * Pure: returns a new AppPreferences. Does NOT issue any API calls;
+ * channel-level callers must additionally invoke `channelsApi.update`
+ * to flip `ticker_enabled` server-side (true if row !== null).
+ *
+ * `tickerRows` is kept in sync via `setTickerLayout`.
+ */
+export function setSourceTickerRow(
+  prefs: AppPreferences,
+  sourceId: string,
+  row: number | null,
+): AppPreferences {
+  const rows = prefs.appearance.tickerLayout?.rows ?? [];
+
+  if (row !== null && (row < 0 || row >= rows.length)) {
+    return prefs;
+  }
+
+  // Remove sourceId from every row's sources array
+  const cleanedRows: TickerRowConfig[] = rows.map((r) => ({
+    ...r,
+    sources: (r.sources ?? []).filter((s) => s !== sourceId),
+  }));
+
+  if (row !== null) {
+    cleanedRows[row] = {
+      ...cleanedRows[row],
+      sources: [...cleanedRows[row].sources, sourceId],
+    };
+  }
+
+  return setTickerLayout(prefs, { rows: cleanedRows });
+}
+
+/**
+ * Move a channel to the given row. See `setSourceTickerRow`. Caller is
+ * responsible for the matching `channelsApi.update({ ticker_enabled })`
+ * call to keep the server-side flag in sync.
+ */
+export function setChannelTickerRow(
+  prefs: AppPreferences,
+  channelType: string,
+  row: number | null,
+): AppPreferences {
+  return setSourceTickerRow(prefs, channelType, row);
+}
+
+/**
+ * Move a widget to the given row. Widgets have no server-side
+ * ticker_enabled — only the client-side layer is touched.
+ */
+export function setWidgetTickerRow(
+  prefs: AppPreferences,
+  widgetId: string,
+  row: number | null,
+): AppPreferences {
+  return setSourceTickerRow(prefs, widgetId, row);
+}
 

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -8,8 +8,6 @@
 import { useState, useMemo, useCallback } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
-  Eye,
-  EyeOff,
   Pencil,
   Check,
   ChevronRight,
@@ -18,6 +16,7 @@ import {
 import clsx from "clsx";
 import RouteError from "../components/RouteError";
 import Tooltip from "../components/Tooltip";
+import RowSelector from "../components/RowSelector";
 import { useShell, useShellData } from "../shell-context";
 import { CHANNEL_ORDER } from "../channels/registry";
 import { WIDGET_ORDER } from "../widgets/registry";
@@ -32,7 +31,13 @@ import {
   LS_WEATHER_UNIT,
   LS_SYSMON_DATA,
 } from "../constants";
-import { isChannelTickerEnabled } from "../api/client";
+import {
+  setChannelTickerRow,
+  setWidgetTickerRow,
+  getChannelTickerRow,
+  getWidgetTickerRow,
+} from "../preferences";
+import { getMaxTickerRows } from "../tierLimits";
 import type { ChannelType, Channel } from "../api/client";
 import type {
   ChannelManifest,
@@ -63,13 +68,12 @@ function HomePage() {
     allWidgets,
     authenticated,
     onToggleChannelTicker,
-    onToggleWidgetTicker,
     onLogin,
   } = shell;
 
   const enabledWidgets = shell.prefs.widgets.enabledWidgets;
-  const widgetsOnTicker = shell.prefs.widgets.widgetsOnTicker;
   const homePreview = shell.prefs.homePreview;
+  const maxRows = getMaxTickerRows(shell.tier);
 
   const setHomePreview = useCallback(
     (channelType: string, keys: string[]) => {
@@ -77,6 +81,31 @@ function HomePage() {
       shell.onPrefsChange({ ...shell.prefs, homePreview: next });
     },
     [homePreview, shell],
+  );
+
+  // ── Unified ticker row selector handlers ────────────────────────
+  // Channel row change updates BOTH layers atomically:
+  //   1. tickerLayout.rows[i].sources[]   (client-side prefs)
+  //   2. Channel.ticker_enabled            (server-side master gate)
+  // See preferences.ts §"Unified ticker row selector helpers".
+  const handleChannelRowChange = useCallback(
+    (channelType: ChannelType, row: number | null) => {
+      const nextPrefs = setChannelTickerRow(shell.prefs, channelType, row);
+      shell.onPrefsChange(nextPrefs);
+      // Server-side flag: enable when assigned to any row, disable for "off".
+      // onToggleChannelTicker is async but fire-and-forget here — the existing
+      // handler shows a toast on failure and re-syncs from the dashboard refetch.
+      onToggleChannelTicker(channelType, row !== null);
+    },
+    [shell, onToggleChannelTicker],
+  );
+
+  const handleWidgetRowChange = useCallback(
+    (widgetId: string, row: number | null) => {
+      const nextPrefs = setWidgetTickerRow(shell.prefs, widgetId, row);
+      shell.onPrefsChange(nextPrefs);
+    },
+    [shell],
   );
 
   const orderedChannels = useMemo(
@@ -143,18 +172,17 @@ function HomePage() {
         const channelData = dashboard?.data?.[ch.channel_type];
         const hasData = Array.isArray(channelData) && channelData.length > 0;
         const targetTab = hasData ? "feed" : "configuration";
+        const currentRow = getChannelTickerRow(shell.prefs, ch);
         return (
           <ChannelSection
             key={ch.channel_type}
             channel={ch}
             manifest={manifest}
             data={dashboard?.data}
-            tickerEnabled={isChannelTickerEnabled(ch)}
-            onToggleTicker={() =>
-              onToggleChannelTicker(
-                ch.channel_type as ChannelType,
-                !isChannelTickerEnabled(ch),
-              )
+            currentRow={currentRow}
+            maxRows={maxRows}
+            onRowChange={(next) =>
+              handleChannelRowChange(ch.channel_type as ChannelType, next)
             }
             selectedKeys={homePreview[ch.channel_type] ?? []}
             onSelectionChange={(keys) =>
@@ -186,8 +214,9 @@ function HomePage() {
       {orderedWidgets.length > 0 && (
         <WidgetStrip
           widgets={orderedWidgets}
-          widgetsOnTicker={widgetsOnTicker}
-          onToggleTicker={onToggleWidgetTicker}
+          maxRows={maxRows}
+          getWidgetRow={(id) => getWidgetTickerRow(shell.prefs, id)}
+          onWidgetRowChange={handleWidgetRowChange}
           onNavigate={(id) =>
             navigate({
               to: "/widget/$id/$tab",
@@ -240,8 +269,12 @@ interface ChannelSectionProps {
   channel: Channel;
   manifest: ChannelManifest;
   data: Record<string, unknown> | undefined;
-  tickerEnabled: boolean;
-  onToggleTicker: () => void;
+  /** Currently assigned ticker row, or null for off. */
+  currentRow: number | null;
+  /** Max rows the user's tier allows (1, 2, or 3). */
+  maxRows: number;
+  /** Called when the user picks a different row or "Off". */
+  onRowChange: (row: number | null) => void;
   selectedKeys: string[];
   onSelectionChange: (keys: string[]) => void;
   onViewAll: () => void;
@@ -253,8 +286,9 @@ function ChannelSection({
   channel,
   manifest,
   data,
-  tickerEnabled,
-  onToggleTicker,
+  currentRow,
+  maxRows,
+  onRowChange,
   selectedKeys,
   onSelectionChange,
   onViewAll,
@@ -310,25 +344,20 @@ function ChannelSection({
           </Tooltip>
         )}
 
-        {/* Eye toggle */}
-        <Tooltip content={tickerEnabled ? "Hide from ticker" : "Show on ticker"}>
-          <button
-            onClick={onToggleTicker}
-            aria-label={
-              tickerEnabled
-                ? `Hide ${manifest.name} from ticker`
-                : `Show ${manifest.name} on ticker`
-            }
-            className={clsx(
-              "w-7 h-7 flex items-center justify-center rounded-lg transition-colors",
-              tickerEnabled
-                ? "text-fg-3 hover:text-fg hover:bg-surface-hover"
-                : "text-fg-4/60 hover:text-fg-2 hover:bg-surface-hover",
-            )}
-          >
-            {tickerEnabled ? <Eye size={14} /> : <EyeOff size={14} />}
-          </button>
-        </Tooltip>
+        {/* Row selector — replaces the legacy Eye/EyeOff toggle so users
+            can pick exactly which ticker row a channel appears on (Off /
+            Row 1 / 2 / 3) instead of a binary visibility flip that
+            silently fought with the Settings source picker. */}
+        <RowSelector
+          value={currentRow}
+          maxRows={maxRows}
+          disabled={!channel.enabled}
+          disabledHint={
+            !channel.enabled ? "Enable from the Catalog first" : undefined
+          }
+          onChange={onRowChange}
+          ariaLabel={`${manifest.name} ticker row`}
+        />
 
         {/* View all */}
         {!editing && (
@@ -670,15 +699,20 @@ function EmptyDataRow({
 
 interface WidgetStripProps {
   widgets: WidgetManifest[];
-  widgetsOnTicker: string[];
-  onToggleTicker: (id: string) => void;
+  /** Max rows the user's tier allows. */
+  maxRows: number;
+  /** Read the row a widget is currently assigned to (null = off). */
+  getWidgetRow: (id: string) => number | null;
+  /** Move a widget to the given row (null = off). */
+  onWidgetRowChange: (id: string, row: number | null) => void;
   onNavigate: (id: string) => void;
 }
 
 function WidgetStrip({
   widgets,
-  widgetsOnTicker,
-  onToggleTicker,
+  maxRows,
+  getWidgetRow,
+  onWidgetRowChange,
   onNavigate,
 }: WidgetStripProps) {
   return (
@@ -694,8 +728,9 @@ function WidgetStrip({
           <WidgetChip
             key={widget.id}
             widget={widget}
-            tickerEnabled={widgetsOnTicker.includes(widget.id)}
-            onToggleTicker={() => onToggleTicker(widget.id)}
+            currentRow={getWidgetRow(widget.id)}
+            maxRows={maxRows}
+            onRowChange={(row) => onWidgetRowChange(widget.id, row)}
             onClick={() => onNavigate(widget.id)}
           />
         ))}
@@ -706,23 +741,38 @@ function WidgetStrip({
 
 interface WidgetChipProps {
   widget: WidgetManifest;
-  tickerEnabled: boolean;
-  onToggleTicker: () => void;
+  currentRow: number | null;
+  maxRows: number;
+  onRowChange: (row: number | null) => void;
   onClick: () => void;
 }
 
 function WidgetChip({
   widget,
-  tickerEnabled,
-  onToggleTicker,
+  currentRow,
+  maxRows,
+  onRowChange,
   onClick,
 }: WidgetChipProps) {
   const Icon = widget.icon;
   const value = getWidgetValue(widget.id);
 
+  // Note: this used to be a single <button> wrapping the whole chip, but
+  // the RowSelector is a radiogroup of <button>s — nesting buttons is
+  // invalid HTML. The outer container is now a div with role="button"
+  // + tabIndex so the chip body still acts as a click target while the
+  // RowSelector renders cleanly inside it.
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       className="group rounded-lg border bg-base-200/40 border-edge/20 hover:bg-base-200/60 p-3 transition-colors text-left cursor-pointer w-full"
     >
       <div className="flex items-center gap-2 mb-1.5">
@@ -732,41 +782,22 @@ function WidgetChip({
         <span className="text-xs font-medium text-fg truncate flex-1">
           {widget.tabLabel}
         </span>
-
-        {/* Eye toggle */}
-        <Tooltip content={tickerEnabled ? "Hide from ticker" : "Show on ticker"}>
-          <div
-            role="switch"
-            aria-checked={tickerEnabled}
-            aria-label={tickerEnabled ? "Hide from ticker" : "Show on ticker"}
-            tabIndex={0}
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleTicker();
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                e.stopPropagation();
-                onToggleTicker();
-              }
-            }}
-            className={clsx(
-              "w-6 h-6 flex items-center justify-center rounded transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0",
-              tickerEnabled
-                ? "text-fg-3 hover:text-fg hover:bg-surface-hover"
-                : "text-fg-4/60 hover:text-fg-2 hover:bg-surface-hover",
-            )}
-          >
-            {tickerEnabled ? <Eye size={12} /> : <EyeOff size={12} />}
-          </div>
-        </Tooltip>
       </div>
 
-      <p className="text-sm font-medium text-fg-2 tabular-nums truncate">
+      <p className="text-sm font-medium text-fg-2 tabular-nums truncate mb-2">
         {value}
       </p>
-    </button>
+
+      {/* Row selector — replaces the legacy Eye/EyeOff toggle. Click events
+          inside the radiogroup are stopPropagation'd by RowSelector itself
+          so they don't trigger the chip's navigate-on-click. */}
+      <RowSelector
+        value={currentRow}
+        maxRows={maxRows}
+        onChange={onRowChange}
+        ariaLabel={`${widget.tabLabel} ticker row`}
+      />
+    </div>
   );
 }
 

--- a/docs/superpowers/specs/2026-04-28-batch-d-account-and-ticker-rework-design.md
+++ b/docs/superpowers/specs/2026-04-28-batch-d-account-and-ticker-rework-design.md
@@ -1,0 +1,139 @@
+# Batch D — Account Expansion + GitHub Sweep + Ticker Rework
+
+**Date:** 2026-04-28 (later same evening as Batch C)
+**Status:** Plan locked, executing
+**Spec/plan:** combined in this single doc (compact, since the three streams have minimal cross-coupling)
+
+## Why this batch
+
+Three separate concerns surfaced in the post-Batch-C session:
+
+1. **Account management gaps**: super_user not rendering correctly on website /account; no inline name/email/password edit on either platform; username should be locked everywhere.
+2. **GitHub redirect cleanup**: marketing site sends users to `github.com/.../discussions` for support paths; should route to `/support` now that it exists (Batch C shipped that route).
+3. **Ticker visibility intuition**: three surfaces (tray right-click, feed page Eye/EyeOff toggle, Settings multi-deck source picker) all controlling overlapping state with different mental models — needs a single coherent UX.
+
+Decisions locked from m1108 (full text in compressed block b6).
+
+## Stream 1 — Account expansion
+
+### Backend
+
+New file `api/core/handlers_account.go`:
+- `HandleUpdateProfile` — `PUT /users/me/profile`, body `{ name?, email? }`. Calls existing `updateUserIdentity` and/or `updateUserProfile` from `invite.go`. Rejects username changes with 403 (defense-in-depth on top of Logto admin lock).
+- `HandleRequestPasswordReset` — `POST /users/me/password/reset`. Triggers Logto's standard forgot-password flow with the user's email pre-filled. Returns 204.
+
+`api/core/server.go`: register both routes with `LogtoAuth`. Invalidate overview cache after profile updates.
+
+### Marketing site
+
+- `myscrollr.com/src/api/client.ts:14` — add `'super_user'` to `subscription_tier` union.
+- New `userApi.updateProfile(payload)` and `userApi.requestPasswordReset()`.
+- `SubscriptionStatus.tsx:149-164` — add super_user branch BEFORE the early-return-to-FreeTier path. Render dedicated "Super User" badge with no upgrade/cancel actions.
+- `account.tsx:458` — pass `overview.tier` down to SubscriptionStatus (drops redundant `getPreferences()` call).
+- New inline edit forms for name + email next to the identity row.
+- New "Send password reset" button under a Security section.
+
+### Desktop
+
+- `desktop/src/api/client.ts` — add `userApi.updateProfile(payload)` and `userApi.requestPasswordReset()`.
+- `AccountSettings.tsx` — new inline edit-in-place forms for name + email + "Send password reset" button under a new Security section.
+
+### Manual one-time admin (post-merge)
+
+- Logto admin → Sign-in experience → User profile → set Username field to read-only. API also rejects username PUT requests as defense-in-depth.
+
+## Stream 2 — GitHub redirect sweep
+
+14 mechanical edits across 9 files.
+
+**Link href swaps (6):**
+- `myscrollr.com/src/components/landing/CallToAction.tsx:302` — `discussions` → `<Link to="/support">`
+- `myscrollr.com/src/components/landing/TrustSection.tsx:265` — same
+- `myscrollr.com/src/components/landing/TrustSection.tsx:548` — `discussions/categories/integration-requests` → `/support`
+- `myscrollr.com/src/routes/channels.tsx:404` — same path → `/support`
+- `myscrollr.com/src/routes/account.tsx:66` — `releases/latest` → `<Link to="/download">` (better path)
+- `myscrollr.com/src/routes/legal.tsx:435` — repo link in "Questions about this document?" → `<Link to="/support">` (also update visible text "GitHub" → "Support")
+
+**Legal copy text changes (6 in `documents.ts`):** lines 130, 217, 284, 552, 769, 871. All currently say "reach out via our GitHub repository or community channels"; change to "reach out via our Support page or community Discord server". Plain-text replacement.
+
+**Edge case at line 806 (security disclosure):** keep GHSA path (security researchers expect it), ADD /support as the primary general-feedback path.
+
+**npm `bugs` metadata (2):**
+- `myscrollr.com/package.json:14` — `bugs` → `https://myscrollr.com/support`
+- `desktop/package.json:14` — same
+
+**Untouched:** Footer GitHub social icon, all "Star/Fork/View on GitHub/View Source/Build Your Own" CTAs (these are legitimate source-code references), `getDownloadInfo.ts` release-asset host, `tauri.conf.json` updater manifest, `useGitHubStats.ts` star/fork fetcher, GitHub Actions widget files, CSP allowlist, factual mentions ("source on GitHub", "manifest from GitHub releases").
+
+## Stream 3 — Ticker rework
+
+### Mental model
+"Where should this channel appear?" → **Off / Row 1 / Row 2 / Row 3**
+
+### Data model "Path Z"
+Keep both existing layers; new UI writes to both atomically:
+1. `Channel.ticker_enabled` (server-side, controls master gate via `App.tsx:99` filter)
+2. `tickerLayout.rows[i].sources[]` (client-side, controls per-row inclusion)
+
+### New helpers in `desktop/src/preferences.ts`
+
+```ts
+// row: 0..2 means "include in row N"; null means "off"
+export function setChannelTickerRow(
+  prefs: AppPreferences,
+  channelType: ChannelType,
+  row: number | null,
+): AppPreferences
+
+export function getChannelTickerRow(
+  prefs: AppPreferences,
+  dashboard: DashboardResponse | null,
+  channelType: ChannelType,
+): number | null
+```
+
+`set` writes BOTH `Channel.ticker_enabled` (via dashboard mutation) AND `tickerLayout.rows[i].sources[]` (replace channel's row membership atomically).
+
+`get` reads first from `tickerLayout.rows[].sources` (explicit assignment); if not found, falls back to `Channel.ticker_enabled` to determine row 0 vs off.
+
+### New `desktop/src/components/RowSelector.tsx`
+Reusable segmented control `[Off] [1] [2] [3]`. Tier-aware: hides rows above `tierLimits.maxTickerRows`. Disabled state for channels with `enabled === false` with hint "Enable from the Catalog first".
+
+### Surfaces updated
+
+- `routes/feed.tsx:243-329` (ChannelSection) — replace Eye/EyeOff button with RowSelector.
+- `routes/feed.tsx:697-761` (WidgetSection) — same pattern.
+- `App.tsx:480-506` (tray Channels submenu) — each channel becomes a Submenu with radio MenuItems for Off / Row 1 / Row 2 / Row 3.
+- Tray Widgets submenu — same.
+- `components/settings/TickerSettings.tsx` — source picker stays as bulk-edit alternative.
+
+### Edge cases
+
+1. Free tier (max 1 row): selector shows only `[Off] [1]`.
+2. Tier downgrade: existing tier-clamp in `loadPrefs` collapses higher rows; add toast "Your ticker layout was simplified to 1 row".
+3. Empty `sources: []` materializes to explicit list when modified via selector.
+4. Channel with `enabled === false`: disabled selector with hint.
+
+## Branch + PR
+
+- Branch: `feature/batch-d-account-and-ticker-rework`
+- 3 commits (one per stream)
+- Single squash-mergeable PR.
+
+## Acceptance criteria
+
+- `go vet ./...` clean across all Go modules
+- `go test ./core/...` clean
+- `npx tsc --noEmit` clean (desktop)
+- `npx vitest run` passes (178/178 baseline, +new tests where added)
+- `npm run build` clean (desktop + marketing)
+- `cargo check` clean (desktop tauri)
+- `npm run check` clean (marketing — Prettier + ESLint)
+- Manual smoke after merge: super_user shows correct badge on web /account, password reset email arrives, channel row reassignment works across all three surfaces
+
+## Out of scope (deferred)
+
+- Embedded change-password form (Option B from m1108 — chose C instead)
+- Desktop-side delete-account UI (per user — stays website-only)
+- Dedicated "Channel suggestion" form category (per user — use Feature request)
+- Markdown-link support in legal-doc renderer (per user — plain text)
+- Removing `Channel.ticker_enabled` field from server (kept as derived; future cleanup)

--- a/myscrollr.com/package.json
+++ b/myscrollr.com/package.json
@@ -11,7 +11,7 @@
     "directory": "myscrollr.com"
   },
   "homepage": "https://myscrollr.com",
-  "bugs": "https://github.com/brandon-relentnet/myscrollr/issues",
+  "bugs": "https://myscrollr.com/support",
   "type": "module",
   "scripts": {
     "predev": "node scripts/fetch-latest-version.mjs",

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -11,7 +11,12 @@ export interface UserPreferences {
   feed_enabled: boolean
   enabled_sites: Array<string>
   disabled_sites: Array<string>
-  subscription_tier: 'free' | 'uplink' | 'uplink_pro' | 'uplink_ultimate'
+  subscription_tier:
+    | 'free'
+    | 'uplink'
+    | 'uplink_pro'
+    | 'uplink_ultimate'
+    | 'super_user'
   updated_at: string
 }
 
@@ -489,10 +494,51 @@ export interface UserOverview {
   links: UserOverviewLinks
 }
 
+export interface UpdateProfileResponse {
+  status: string
+  name?: string
+  email?: string
+}
+
 export const userApi = {
   /** Unified read for the /account hub — identity, tier, channels, GDPR, fantasy. */
   overview: (getToken: () => Promise<string | null>) =>
     authenticatedFetch<UserOverview>('/users/me/overview', {}, getToken),
+
+  /** Update display name and/or primary email via Logto Management API. */
+  updateProfile: (
+    payload: { name?: string; email?: string },
+    getToken: () => Promise<string | null>,
+  ) =>
+    authenticatedFetch<UpdateProfileResponse>(
+      '/users/me/profile',
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      },
+      getToken,
+    ),
+
+  /** Trigger a password-reset email pointing at the Logto sign-in page. */
+  requestPasswordReset: async (getToken: () => Promise<string | null>) => {
+    const token = await getToken()
+    const headers: HeadersInit = {}
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`
+    }
+    const response = await fetch(`${API_BASE}/users/me/password/reset`, {
+      method: 'POST',
+      headers,
+      credentials: 'include',
+    })
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ error: 'Request failed' }))
+      throw new Error(error.error || 'Request failed')
+    }
+  },
 }
 
 // ── Invite API ───────────────────────────────────────────────────

--- a/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
+++ b/myscrollr.com/src/components/billing/SubscriptionStatus.tsx
@@ -9,6 +9,7 @@ import {
   Infinity as InfinityIcon,
   Loader2,
   ShieldAlert,
+  Sparkles,
   Zap,
 } from 'lucide-react'
 import type { SubscriptionStatus as SubStatus } from '@/api/client'
@@ -16,6 +17,9 @@ import { billingApi, getPreferences } from '@/api/client'
 
 interface SubscriptionStatusProps {
   getToken: () => Promise<string | null>
+  /** Optional tier hint from the parent's overview fetch — short-circuits
+   *  the internal `getPreferences` round-trip when supplied. */
+  tier?: string
 }
 
 const PLAN_LABELS: Record<string, string> = {
@@ -60,9 +64,10 @@ const STATUS_LABELS: Partial<Record<string, { label: string; color: string }>> =
 
 export default function SubscriptionStatus({
   getToken,
+  tier: tierProp,
 }: SubscriptionStatusProps) {
   const [subscription, setSubscription] = useState<SubStatus | null>(null)
-  const [tier, setTier] = useState<string>('free')
+  const [tier, setTier] = useState<string>(tierProp ?? 'free')
   const [loading, setLoading] = useState(true)
   const [canceling, setCanceling] = useState(false)
   const [openingPortal, setOpeningPortal] = useState(false)
@@ -78,16 +83,24 @@ export default function SubscriptionStatus({
     subscription?.plan === 'pro_monthly' ||
     subscription?.plan === 'pro_annual'
 
+  // Re-runs when the parent passes a new tier hint (e.g. once the
+  // overview fetch settles). loadSubscription is intentionally not in
+  // the deps array — it's stable per render and capturing it would
+  // cause an infinite refetch loop.
   useEffect(() => {
     loadSubscription()
-  }, [])
+    if (tierProp) setTier(tierProp)
+  }, [tierProp])
 
   async function loadSubscription() {
     try {
       setLoading(true)
+      // Skip the prefs round-trip when the parent already supplied a tier.
       const [sub, prefs] = await Promise.all([
         billingApi.getSubscription(getToken),
-        getPreferences(getToken).catch(() => null),
+        tierProp
+          ? Promise.resolve(null)
+          : getPreferences(getToken).catch(() => null),
       ])
       setSubscription(sub)
       if (prefs?.subscription_tier) setTier(prefs.subscription_tier)
@@ -142,6 +155,24 @@ export default function SubscriptionStatus({
       <div className="flex items-center gap-2 py-6">
         <AlertTriangle size={16} className="text-error" />
         <span className="text-sm text-error">{error}</span>
+      </div>
+    )
+  }
+
+  // Super users get a dedicated card — no upgrade/cancel CTAs, no tie
+  // to a Stripe subscription. The tier is granted via Logto role and
+  // unlocks every cap the system enforces.
+  if (tier === 'super_user') {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Sparkles size={16} className="text-success" />
+          <span className="text-sm font-semibold text-success">Super User</span>
+        </div>
+        <p className="text-sm text-base-content/40 leading-relaxed">
+          You have full access to every feature as a thank-you for early-access
+          testing. No subscription required.
+        </p>
       </div>
     )
   }

--- a/myscrollr.com/src/components/landing/CallToAction.tsx
+++ b/myscrollr.com/src/components/landing/CallToAction.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { motion, useInView, useMotionValue, useSpring } from 'motion/react'
+import { Link } from '@tanstack/react-router'
 import { GitFork, Github, Globe, MessageSquare, Star, Zap } from 'lucide-react'
 import type {
   BackdropBeam,
@@ -298,15 +299,13 @@ export function CallToAction() {
             </a>
 
             {/* Discussions */}
-            <a
-              href="https://github.com/brandon-relentnet/myscrollr/discussions"
-              target="_blank"
-              rel="noreferrer"
+            <Link
+              to="/support"
               className="group flex items-center gap-2 px-4 py-2.5 rounded-xl border border-base-300/20 bg-base-200/30 text-accent/50 hover:text-accent hover:border-accent/20 hover:bg-accent/[0.04] transition-[color,border-color,background-color] duration-200"
             >
               <MessageSquare className="size-4" />
               <span className="text-sm font-bold">Discuss</span>
-            </a>
+            </Link>
           </motion.div>
 
           {/* ── Bottom links ────────────────────────────────────────────── */}

--- a/myscrollr.com/src/components/landing/TrustSection.tsx
+++ b/myscrollr.com/src/components/landing/TrustSection.tsx
@@ -261,15 +261,13 @@ function GitHubFooter({ stats }: { stats: GitHubStats | null }) {
                     {stats.forks.toLocaleString()}
                   </span>
                 </a>
-                <a
-                  href={`https://github.com/${REPO}/discussions`}
-                  target="_blank"
-                  rel="noreferrer"
+                <Link
+                  to="/support"
                   className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs text-accent/50 hover:text-accent hover:bg-accent/[0.06] transition-[color,background-color] duration-200"
                 >
                   <MessageSquare className="size-3.5" />
                   <span className="font-semibold">Discuss</span>
-                </a>
+                </Link>
               </div>
             )}
 
@@ -544,10 +542,8 @@ export function TrustSection() {
                     className="opacity-0 group-hover/link:opacity-100 transition-opacity"
                   />
                 </a>
-                <a
-                  href="https://github.com/brandon-relentnet/myscrollr/discussions/categories/integration-requests"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <Link
+                  to="/support"
                   className="group/link inline-flex items-center gap-2 text-[11px] font-semibold text-base-content/30 hover:text-info transition-colors"
                 >
                   Propose an Idea
@@ -555,7 +551,7 @@ export function TrustSection() {
                     size={12}
                     className="opacity-0 group-hover/link:opacity-100 transition-opacity"
                   />
-                </a>
+                </Link>
               </div>
             </div>
           </motion.div>

--- a/myscrollr.com/src/components/legal/documents.ts
+++ b/myscrollr.com/src/components/legal/documents.ts
@@ -127,7 +127,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
       {
         heading: 'Contact',
         content: [
-          'If you have questions about these Terms, please reach out via our GitHub repository or community channels listed on the Platform.',
+          'If you have questions about these Terms, please reach out via our Support page or community Discord server.',
         ],
       },
     ],
@@ -214,7 +214,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
       {
         heading: 'Contact',
         content: [
-          'For privacy-related inquiries, please reach out via our GitHub repository or community Discord server. Links to both are available on the Platform.',
+          'For privacy-related inquiries, please reach out via our Support page or community Discord server.',
         ],
       },
     ],
@@ -281,7 +281,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
       {
         heading: 'Data Deletion',
         content: [
-          'You can delete all locally stored data by uninstalling the application or by using the "Reset all settings" option on the Account page. Server-side data (channel configurations, account preferences) can be deleted by contacting us through our GitHub repository or community Discord.',
+          'You can delete all locally stored data by uninstalling the application or by using the "Reset all settings" option on the Account page. Server-side data (channel configurations, account preferences) can be deleted by contacting us through our Support page or community Discord server.',
         ],
       },
     ],
@@ -549,7 +549,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
       {
         heading: 'How to Request a Refund',
         content: [
-          'To request a refund, contact us through our community channels (GitHub or Discord) with your account email and the reason for your request. We will process eligible refunds within 5-10 business days to your original payment method.',
+          'To request a refund, contact us through our Support page or community Discord server with your account email and the reason for your request. We will process eligible refunds within 5-10 business days to your original payment method.',
         ],
       },
       {
@@ -766,7 +766,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
       {
         heading: 'Designated Agent',
         content: [
-          'DMCA notices should be sent to the project maintainers via the contact methods listed on the Platform (GitHub or community channels). We will designate a formal DMCA agent and update this section with their contact information.',
+          'DMCA notices should be sent to the project maintainers via our Support page or community Discord server. We will designate a formal DMCA agent and update this section with their contact information.',
         ],
       },
       {
@@ -803,7 +803,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         heading: 'Responsible Disclosure',
         content: [
           'If you discover a security vulnerability in Scrollr, we appreciate your help in disclosing it to us responsibly. Please do NOT publicly disclose the vulnerability until we have had a chance to address it.',
-          "To report a vulnerability, please contact us through our GitHub repository's security advisory feature, or reach out via our community Discord server with a private message to a maintainer.",
+          "To report a vulnerability, please contact us through our Support page (category: bug), our GitHub repository's security advisory feature, or reach out via our community Discord server with a private message to a maintainer.",
         ],
       },
       {
@@ -868,7 +868,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
       {
         heading: 'Feedback',
         content: [
-          'We welcome your feedback on the accessibility of the Scrollr platform. If you encounter accessibility barriers, please let us know through our GitHub repository or community Discord server. We take accessibility feedback seriously and will work to address issues promptly.',
+          'We welcome your feedback on the accessibility of the Scrollr platform. If you encounter accessibility barriers, please let us know through our Support page or community Discord server. We take accessibility feedback seriously and will work to address issues promptly.',
         ],
       },
       {

--- a/myscrollr.com/src/routes/account.tsx
+++ b/myscrollr.com/src/routes/account.tsx
@@ -63,7 +63,7 @@ const HUB_CARDS: Array<HubCardDef> = [
   {
     title: 'Desktop App',
     desc: 'Download the Scrollr desktop app',
-    href: 'https://github.com/brandon-relentnet/myscrollr/releases/latest',
+    to: '/download',
     Icon: BarChart3,
     hex: HEX.primary,
     WatermarkIcon: BarChart3,

--- a/myscrollr.com/src/routes/account.tsx
+++ b/myscrollr.com/src/routes/account.tsx
@@ -3,13 +3,19 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   ArrowRight,
   BarChart3,
+  Check,
   Crown,
   Globe,
+  KeyRound,
+  Loader2,
   Lock,
+  Pencil,
   Radio,
   Settings,
   TrendingUp,
+  User,
   Wifi,
+  X,
 } from 'lucide-react'
 import { motion } from 'motion/react'
 import type { ComponentType } from 'react'
@@ -266,6 +272,58 @@ function AccountHub() {
           </motion.div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* Identity & Security Card */}
+            <motion.div
+              className="relative bg-base-200/40 border border-base-300/25 rounded-xl p-8 overflow-hidden lg:col-span-2"
+              style={{ opacity: 0 }}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-80px' }}
+              transition={{ duration: 0.6, ease: EASE }}
+            >
+              <div
+                className="absolute top-0 left-0 right-0 h-px"
+                style={{
+                  background: `linear-gradient(90deg, transparent, ${HEX.info} 50%, transparent)`,
+                }}
+              />
+              <div
+                className="absolute top-0 right-0 w-20 h-20 opacity-[0.04] text-base-content"
+                style={{
+                  backgroundImage:
+                    'radial-gradient(circle, currentColor 1px, transparent 1px)',
+                  backgroundSize: '8px 8px',
+                }}
+              />
+
+              <div className="flex items-center gap-3 mb-6">
+                <div
+                  className="w-11 h-11 rounded-xl flex items-center justify-center"
+                  style={{
+                    background: `${HEX.info}15`,
+                    boxShadow: `0 0 20px ${HEX.info}15, 0 0 0 1px ${HEX.info}20`,
+                  }}
+                >
+                  <User size={20} className="text-base-content/80" />
+                </div>
+                <h3 className="text-lg font-black tracking-tight text-base-content">
+                  Identity &amp; Security
+                </h3>
+              </div>
+
+              <IdentityEditor
+                getToken={getToken}
+                overview={overview}
+                onUpdated={fetchOverview}
+              />
+
+              <Lock
+                size={130}
+                strokeWidth={0.4}
+                className="absolute -bottom-4 -right-4 text-base-content/[0.025] pointer-events-none"
+              />
+            </motion.div>
+
             {/* System Status Link Card */}
             <motion.div
               style={{ opacity: 0 }}
@@ -455,7 +513,10 @@ function AccountHub() {
                 </h3>
               </div>
 
-              <SubscriptionStatus getToken={getToken} />
+              <SubscriptionStatus
+                getToken={getToken}
+                tier={overview?.tier.current}
+              />
 
               <Link
                 to="/uplink"
@@ -484,6 +545,223 @@ function AccountHub() {
         onDeletionChange={fetchOverview}
       />
     </motion.main>
+  )
+}
+
+// ── Identity Editor ─────────────────────────────────────────────
+//
+// Inline-edit pattern for display name + primary email, plus a
+// password-reset trigger. The reset button doesn't reveal a token —
+// it asks the API to email the user a link to the Logto sign-in page
+// where they can use the standard "Forgot password?" flow. The
+// username row is read-only (immutable).
+
+interface IdentityEditorProps {
+  getToken: () => Promise<string | null>
+  overview: UserOverview | null
+  onUpdated: () => void | Promise<void>
+}
+
+function IdentityEditor({
+  getToken,
+  overview,
+  onUpdated,
+}: IdentityEditorProps) {
+  const [resetState, setResetState] = useState<
+    'idle' | 'sending' | 'sent' | 'error'
+  >('idle')
+  const [resetError, setResetError] = useState<string | null>(null)
+
+  async function handleSendReset() {
+    try {
+      setResetState('sending')
+      setResetError(null)
+      await userApi.requestPasswordReset(getToken)
+      setResetState('sent')
+    } catch (err) {
+      setResetError(err instanceof Error ? err.message : 'Failed to send')
+      setResetState('error')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <EditableField
+        label="Display name"
+        value={overview?.identity.name ?? ''}
+        placeholder="Add a display name"
+        onSave={async (next) => {
+          await userApi.updateProfile({ name: next }, getToken)
+          await onUpdated()
+        }}
+      />
+      <EditableField
+        label="Email"
+        type="email"
+        value={overview?.identity.email ?? ''}
+        placeholder="you@example.com"
+        onSave={async (next) => {
+          await userApi.updateProfile({ email: next }, getToken)
+          await onUpdated()
+        }}
+      />
+      <div className="flex items-center justify-between gap-3 py-2">
+        <div className="min-w-0">
+          <div className="text-xs uppercase tracking-wide text-base-content/40 mb-1">
+            Username
+          </div>
+          <div className="text-sm text-base-content/70 font-mono truncate">
+            {overview?.identity.username || '—'}
+          </div>
+        </div>
+        <span className="text-[10px] uppercase tracking-wider text-base-content/30 px-2 py-1 rounded-md bg-base-content/5 shrink-0">
+          Immutable
+        </span>
+      </div>
+
+      <div className="pt-3 border-t border-base-300/30">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-xs uppercase tracking-wide text-base-content/40 mb-1">
+              Password
+            </div>
+            <div className="text-sm text-base-content/60 leading-relaxed">
+              We&apos;ll email you a link to reset it from the sign-in page.
+            </div>
+          </div>
+          <button
+            onClick={handleSendReset}
+            disabled={resetState === 'sending' || resetState === 'sent'}
+            className="shrink-0 flex items-center gap-1.5 px-3 py-2 text-xs font-semibold border border-base-content/10 rounded-lg text-base-content/60 hover:text-primary hover:border-primary/30 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            {resetState === 'sending' ? (
+              <>
+                <Loader2 size={12} className="animate-spin" /> Sending…
+              </>
+            ) : resetState === 'sent' ? (
+              <>
+                <Check size={12} /> Email sent
+              </>
+            ) : (
+              <>
+                <KeyRound size={12} /> Send reset email
+              </>
+            )}
+          </button>
+        </div>
+        {resetState === 'error' && resetError && (
+          <p className="mt-2 text-xs text-error/80">{resetError}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface EditableFieldProps {
+  label: string
+  value: string
+  placeholder?: string
+  type?: 'text' | 'email'
+  onSave: (next: string) => Promise<void>
+}
+
+function EditableField({
+  label,
+  value,
+  placeholder,
+  type = 'text',
+  onSave,
+}: EditableFieldProps) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Keep the draft in sync if the parent re-fetches the overview while
+  // we're not editing.
+  useEffect(() => {
+    if (!editing) setDraft(value)
+  }, [value, editing])
+
+  async function handleSave() {
+    const trimmed = draft.trim()
+    if (!trimmed || trimmed === value) {
+      setEditing(false)
+      setError(null)
+      return
+    }
+    try {
+      setSaving(true)
+      setError(null)
+      await onSave(trimmed)
+      setEditing(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="py-2">
+      <div className="text-xs uppercase tracking-wide text-base-content/40 mb-1.5">
+        {label}
+      </div>
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <input
+            type={type}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={placeholder}
+            disabled={saving}
+            autoFocus
+            className="flex-1 px-3 py-2 text-sm bg-base-300/50 border border-base-300/60 rounded-lg text-base-content focus:outline-none focus:border-primary/50 disabled:opacity-60"
+          />
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            aria-label="Save"
+            className="p-2 rounded-lg border border-primary/30 text-primary hover:bg-primary/10 disabled:opacity-60 transition-colors"
+          >
+            {saving ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Check size={14} />
+            )}
+          </button>
+          <button
+            onClick={() => {
+              setDraft(value)
+              setEditing(false)
+              setError(null)
+            }}
+            disabled={saving}
+            aria-label="Cancel"
+            className="p-2 rounded-lg border border-base-content/10 text-base-content/40 hover:text-base-content/70 disabled:opacity-60 transition-colors"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-sm text-base-content/80 truncate min-w-0">
+            {value || (
+              <span className="text-base-content/30 italic">
+                {placeholder ?? 'Not set'}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={() => setEditing(true)}
+            className="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-semibold text-base-content/40 hover:text-base-content/70 rounded-md transition-colors"
+          >
+            <Pencil size={12} /> Edit
+          </button>
+        </div>
+      )}
+      {error && <p className="mt-1.5 text-xs text-error/80">{error}</p>}
+    </div>
   )
 }
 

--- a/myscrollr.com/src/routes/channels.tsx
+++ b/myscrollr.com/src/routes/channels.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { Link, createFileRoute } from '@tanstack/react-router'
 import {
   ArrowUpRight,
   BookOpen,
@@ -400,33 +400,34 @@ function ChannelsPage() {
             ))}
 
             {/* Suggest card */}
-            <motion.a
-              href="https://github.com/brandon-relentnet/myscrollr/discussions/categories/integration-requests"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ opacity: 0 }}
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{
-                delay: COMING_SOON.length * 0.06,
-                duration: 0.5,
-                ease: EASE,
-              }}
-              className="group bg-primary/[0.03] border border-dashed border-primary/20 rounded-xl p-5 text-center hover:border-primary/40 hover:bg-primary/[0.06] transition-colors cursor-pointer"
-            >
-              <div className="h-10 w-10 rounded-lg bg-primary/8 border border-primary/15 flex items-center justify-center mx-auto mb-3 text-base-content/50 group-hover:text-base-content/70 transition-colors">
-                <Plus size={18} />
-              </div>
-              <p className="text-xs font-semibold text-primary/50 group-hover:text-primary/70 transition-colors">
-                Suggest
-              </p>
-              <p className="text-[9px] text-primary/30 mt-1">Your idea here</p>
-              <span className="inline-flex items-center gap-1 mt-3 px-2 py-0.5 text-[8px] font-bold uppercase tracking-wide text-primary/30 border border-primary/15 rounded-full group-hover:text-primary/50 group-hover:border-primary/25 transition-colors">
-                <Lightbulb size={8} />
-                Propose
-              </span>
-            </motion.a>
+            <Link to="/support" className="block">
+              <motion.div
+                style={{ opacity: 0 }}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{
+                  delay: COMING_SOON.length * 0.06,
+                  duration: 0.5,
+                  ease: EASE,
+                }}
+                className="group bg-primary/[0.03] border border-dashed border-primary/20 rounded-xl p-5 text-center hover:border-primary/40 hover:bg-primary/[0.06] transition-colors cursor-pointer"
+              >
+                <div className="h-10 w-10 rounded-lg bg-primary/8 border border-primary/15 flex items-center justify-center mx-auto mb-3 text-base-content/50 group-hover:text-base-content/70 transition-colors">
+                  <Plus size={18} />
+                </div>
+                <p className="text-xs font-semibold text-primary/50 group-hover:text-primary/70 transition-colors">
+                  Suggest
+                </p>
+                <p className="text-[9px] text-primary/30 mt-1">
+                  Your idea here
+                </p>
+                <span className="inline-flex items-center gap-1 mt-3 px-2 py-0.5 text-[8px] font-bold uppercase tracking-wide text-primary/30 border border-primary/15 rounded-full group-hover:text-primary/50 group-hover:border-primary/25 transition-colors">
+                  <Lightbulb size={8} />
+                  Propose
+                </span>
+              </motion.div>
+            </Link>
           </div>
         </div>
       </section>

--- a/myscrollr.com/src/routes/legal.tsx
+++ b/myscrollr.com/src/routes/legal.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
 import { AnimatePresence, motion } from 'motion/react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, BookOpen, ChevronDown, Info, List } from 'lucide-react'
@@ -431,14 +431,12 @@ function DocumentContent({ doc }: { doc: LegalDocument }) {
         </div>
         <p className="mt-3 text-xs text-base-content/25 leading-relaxed max-w-2xl">
           Questions about this document? Reach out via{' '}
-          <a
-            href="https://github.com/brandon-relentnet/myscrollr"
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            to="/support"
             className="text-primary/50 hover:text-primary transition-colors"
           >
-            GitHub
-          </a>{' '}
+            Support
+          </Link>{' '}
           or{' '}
           <a
             href="https://discord.gg/85b49TcGJa"


### PR DESCRIPTION
## Summary

Three independent concerns rolled into one PR.

### Stream 1 — Account expansion
- **Backend**: new `PUT /users/me/profile` (inline name/email edit; rejects `username` with 403 as defense-in-depth) and `POST /users/me/password/reset` (sends Resend email pointing at Logto sign-in's "Forgot password?" flow). Both invalidate the per-user overview cache.
- **Marketing site**: super_user union added to `subscription_tier`; `SubscriptionStatus` renders a dedicated "Super User" card before the Free-Tier early return; new `IdentityEditor` + `EditableField` components in `account.tsx`. Username displayed read-only with "Immutable" badge.
- **Desktop**: new Profile + Security sections in `AccountSettings` with edit-in-place name/email + Send-password-reset button; toast feedback via sonner; query invalidation after mutations.

### Stream 2 — GitHub redirect sweep
- 6 link href swaps (CallToAction, TrustSection ×2, channels, account, legal) — `discussions`/`issues`/`releases/latest` → `<Link to="/support">` (or `/download` for the Desktop App card).
- 6 plain-text copy edits in `documents.ts` (Terms, Privacy, Desktop privacy, Refund, DMCA, Accessibility) — replaced GitHub user-help mentions with "Support page or community Discord server".
- Security disclosure (line 806) keeps the GHSA path; ADDED /support as primary general path.
- Both `package.json` files now point `bugs` at `https://myscrollr.com/support`.
- Untouched: source-code/Star/Fork/View on GitHub CTAs, GitHub Actions widget, updater manifest, useGitHubStats fetcher, CSP allowlist, factual repo references.

### Stream 3 — Ticker rework
- Single mental model: "Where should this channel appear?" → Off / Row 1 / Row 2 / Row 3.
- New `RowSelector` component (radio-segmented control; collapses to `[Off][On]` for Free tier).
- New helpers in `preferences.ts`: `getChannelTickerRow`, `getWidgetTickerRow`, `setChannelTickerRow`, `setWidgetTickerRow` (+ `setSourceTickerRow` worker). Atomically update both data layers (`Channel.ticker_enabled` server-side via `channelsApi.update` + `tickerLayout.rows[i].sources[]` client-side).
- Wired into Feed page (ChannelSection + WidgetChip) and tray right-click menu (per-channel/per-widget submenus with radio CheckMenuItems).
- Settings → Ticker source picker stays as bulk-edit alternative.
- 15 new unit tests for the helpers (193 total, +15 from 178 baseline).

## Spec

`docs/superpowers/specs/2026-04-28-batch-d-account-and-ticker-rework-design.md`

## Verification

- Core API: `go vet ./...` clean, `go test ./core/` passes.
- Desktop: `npx tsc --noEmit` clean, `npx vitest run` 193/193 passing, `npm run build` clean, `cargo check` clean.
- Marketing: `npm run check` clean, `npm run build` clean.

## Post-merge user actions

1. **Logto admin** — Sign-in experience → User profile → set Username field to **read-only**. Defense-in-depth on top of the API's 403 reject.
2. **Production env vars** — confirm `RESEND_API_KEY` is set so password-reset emails actually deliver. Without it the endpoint returns 500.
3. **Smoke test on prod**:
   - Super_user account on /account renders the "Super User" card (not Free Tier).
   - Click "Send password reset email" → email arrives within seconds, link lands on Logto sign-in.
   - Edit name + save → reflected in overview within 30s (cache TTL).
   - On desktop: right-click tray → Channels submenu → reassign RSS to Row 2 → confirm Settings → Ticker source picker reflects the move.

## Out of scope (deferred)

- Embedded change-password form (chose Resend reset email instead — lower risk, no current-password verification surface to maintain).
- Desktop-side delete-account UI (stays website-only).
- TickerSettings source picker greyed-out state for `ticker_enabled=false` channels (data layers stay consistent already; UX polish for follow-up).
- Removing `Channel.ticker_enabled` field from server (kept as derived; future cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)