### PR TITLE
fix: super-user pre-launch sweep

### DIFF
--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -663,6 +663,8 @@ func HandleConfirmSubscription(c *fiber.Ctx) error {
 		trialEnd = &sub.TrialEnd
 	}
 
+	InvalidateOverviewCache(c.Context(), userID)
+
 	return c.JSON(SubscribeResponse{
 		SubscriptionID: sub.ID,
 		Status:         subStatus,
@@ -933,6 +935,7 @@ func HandleCancelSubscription(c *fiber.Ctx) error {
 		_ = RemoveUltimateRole(userID)
 
 		log.Printf("[Billing] Trial canceled immediately for %s", userID)
+		InvalidateOverviewCache(c.Context(), userID)
 		return c.JSON(fiber.Map{
 			"status":  "canceled",
 			"message": "Your trial has been ended",
@@ -962,6 +965,8 @@ func HandleCancelSubscription(c *fiber.Ctx) error {
 		 WHERE logto_sub = $1`,
 		userID, periodEnd,
 	)
+
+	InvalidateOverviewCache(c.Context(), userID)
 
 	return c.JSON(fiber.Map{
 		"status":             "canceling",
@@ -1072,6 +1077,8 @@ func HandleChangePlan(c *fiber.Ctx) error {
 		trialEnd := time.Unix(sub.TrialEnd, 0)
 		log.Printf("[Billing] Trial plan switched for %s: %s → %s (billing starts %s)", userID, currentPlan, newPlan, trialEnd.Format(time.RFC3339))
 
+		InvalidateOverviewCache(c.Context(), userID)
+
 		return c.JSON(SubscriptionResponse{
 			Plan:             newPlan,
 			Status:           "trialing",
@@ -1126,6 +1133,8 @@ func HandleChangePlan(c *fiber.Ctx) error {
 		)
 
 		log.Printf("[Billing] Plan upgraded for %s: %s → %s", userID, currentPlan, newPlan)
+
+		InvalidateOverviewCache(c.Context(), userID)
 
 		return c.JSON(SubscriptionResponse{
 			Plan:             newPlan,
@@ -1197,6 +1206,8 @@ func HandleChangePlan(c *fiber.Ctx) error {
 	}
 
 	log.Printf("[Billing] Downgrade scheduled for %s: %s → %s at %s", userID, currentPlan, newPlan, periodEnd.Format(time.RFC3339))
+
+	InvalidateOverviewCache(c.Context(), userID)
 
 	// Return current plan (unchanged until period end) with pending downgrade info
 	return c.JSON(SubscriptionResponse{

--- a/api/core/handlers_account.go
+++ b/api/core/handlers_account.go
@@ -8,12 +8,57 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/mail"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 )
+
+// ─────────────────────────────────────────────────────────────────────
+//  Per-user password-reset rate limit
+//
+//  Mirrors the supportRateMap pattern from support.go. Cap one reset
+//  request per user per hour. Resend is paid-per-send and these emails
+//  are user-triggered — without a cap, a malicious or buggy client
+//  could rack up bills and spam an inbox. The window starts on every
+//  successful send (recorded inside the handler after the email goes
+//  out) so a transient Resend failure doesn't trap the user.
+// ─────────────────────────────────────────────────────────────────────
+
+const passwordResetRateLimitWindow = time.Hour
+
+var (
+	passwordResetRateMu  sync.Mutex
+	passwordResetRateMap = make(map[string]time.Time)
+)
+
+// allowedByPasswordResetLimit returns whether the user may request a
+// new password-reset email. If they may not, retryAfter is the
+// remaining time on the cooldown window for the Retry-After header.
+func allowedByPasswordResetLimit(userID string) (allowed bool, retryAfter time.Duration) {
+	passwordResetRateMu.Lock()
+	defer passwordResetRateMu.Unlock()
+
+	if last, ok := passwordResetRateMap[userID]; ok {
+		elapsed := time.Since(last)
+		if elapsed < passwordResetRateLimitWindow {
+			return false, passwordResetRateLimitWindow - elapsed
+		}
+	}
+	return true, 0
+}
+
+// recordPasswordResetSent marks the user's most recent reset email,
+// starting the cooldown window. Called only after the Resend API
+// accepts the message.
+func recordPasswordResetSent(userID string) {
+	passwordResetRateMu.Lock()
+	defer passwordResetRateMu.Unlock()
+	passwordResetRateMap[userID] = time.Now()
+}
 
 // ─────────────────────────────────────────────────────────────────────
 //  Account self-service handlers
@@ -80,6 +125,57 @@ func HandleUpdateProfile(c *fiber.Ctx) error {
 			Status: "error",
 			Error:  "at least one of name or email is required",
 		})
+	}
+
+	// Validate email: format, length, and control characters. We do
+	// this before contacting Logto so a malformed value gets a precise
+	// 400 instead of bouncing off the upstream API.
+	if req.Email != nil {
+		email := strings.TrimSpace(*req.Email)
+		if email == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "email cannot be empty",
+			})
+		}
+		if len(email) > 254 {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "email exceeds maximum length",
+			})
+		}
+		if strings.ContainsAny(email, "\n\r\x00") {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "email contains invalid characters",
+			})
+		}
+		if _, err := mail.ParseAddress(email); err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "invalid email format",
+			})
+		}
+		// Persist the trimmed value for the Logto patch + response echo.
+		*req.Email = email
+	}
+
+	// Validate name: length cap and control-character rejection.
+	if req.Name != nil {
+		name := strings.TrimSpace(*req.Name)
+		if len(name) > 200 {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "name exceeds maximum length",
+			})
+		}
+		if strings.ContainsAny(name, "\n\r\x00") {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "name contains invalid characters",
+			})
+		}
+		*req.Name = name
 	}
 
 	cfg := getM2MConfig()
@@ -226,6 +322,14 @@ func HandleRequestPasswordReset(c *fiber.Ctx) error {
 		})
 	}
 
+	if allowed, retryAfter := allowedByPasswordResetLimit(userID); !allowed {
+		c.Set("Retry-After", fmt.Sprintf("%d", int(retryAfter.Seconds())))
+		return c.Status(fiber.StatusTooManyRequests).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Password reset already requested. Please try again later.",
+		})
+	}
+
 	signInURL := strings.TrimRight(os.Getenv("LOGTO_ENDPOINT"), "/")
 	if signInURL == "" {
 		signInURL = "https://auth.myscrollr.com"
@@ -238,6 +342,8 @@ func HandleRequestPasswordReset(c *fiber.Ctx) error {
 			Error:  "failed to send reset email",
 		})
 	}
+
+	recordPasswordResetSent(userID)
 
 	log.Printf("[PasswordReset] sent reset email to %s for user %s", email, userID)
 	return c.SendStatus(fiber.StatusNoContent)

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -108,7 +108,7 @@ export async function authFetch<T>(
 
   if (token) {
     (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
-  } else {
+  } else if (import.meta.env.DEV) {
     console.debug(
       "[authFetch] Token unavailable for authed endpoint; proceeding unauthenticated (may 401):",
       path,

--- a/desktop/src/components/onboarding/OnboardingWizard.tsx
+++ b/desktop/src/components/onboarding/OnboardingWizard.tsx
@@ -16,7 +16,6 @@ import StepChannels from "./StepChannels";
 import StepConfigureFinance from "./StepConfigureFinance";
 import StepConfigureSports from "./StepConfigureSports";
 import StepConfigureRss from "./StepConfigureRss";
-import StepConfigureFantasy from "./StepConfigureFantasy";
 import StepWidgets from "./StepWidgets";
 
 // ── Types ───────────────────────────────────────────────────────
@@ -37,7 +36,10 @@ interface OnboardingWizardProps {
 
 function buildSteps(selectedChannels: Set<ChannelType>): WizardStep[] {
   const steps: WizardStep[] = [{ kind: "channels" }];
-  const order: ChannelType[] = ["finance", "sports", "rss", "fantasy"];
+  // Note: 'fantasy' is intentionally omitted — Yahoo OAuth happens later from
+  // the Fantasy page itself. The wizard only collects the channel selection
+  // (which provisions the channel) but skips the connect step.
+  const order: ChannelType[] = ["finance", "sports", "rss"];
   for (const ch of order) {
     if (selectedChannels.has(ch)) {
       steps.push({ kind: "configure", channel: ch });
@@ -162,7 +164,6 @@ export default function OnboardingWizard({ prefs, tier, onComplete }: Onboarding
   const [financeSymbols, setFinanceSymbols] = useState<Set<string>>(new Set());
   const [sportsLeagues, setSportsLeagues] = useState<Set<string>>(new Set());
   const [rssFeeds, setRssFeeds] = useState<Set<string>>(new Set());
-  const [fantasyConnected, setFantasyConnected] = useState(false);
   const [selectedWidgets, setSelectedWidgets] = useState<Set<string>>(new Set(["weather", "clock"]));
   const [stepIndex, setStepIndex] = useState(0);
   const [busy, setBusy] = useState(false);
@@ -355,13 +356,6 @@ export default function OnboardingWizard({ prefs, tier, onComplete }: Onboarding
             return <StepConfigureSports selected={sportsLeagues} onToggle={toggleLeague} maxItems={maxItemsFor("sports")} />;
           case "rss":
             return <StepConfigureRss selected={rssFeeds} onToggle={toggleFeed} maxItems={maxItemsFor("rss")} />;
-          case "fantasy":
-            return (
-              <StepConfigureFantasy
-                connected={fantasyConnected}
-                onConnect={() => setFantasyConnected(true)}
-              />
-            );
           default:
             return null;
         }
@@ -380,7 +374,6 @@ export default function OnboardingWizard({ prefs, tier, onComplete }: Onboarding
           case "finance": return "Set Up Finance";
           case "sports": return "Set Up Sports";
           case "rss": return "Set Up RSS Feeds";
-          case "fantasy": return "Set Up Fantasy";
           default: return "Configure";
         }
       case "widgets": return "Pick Your Widgets";
@@ -396,7 +389,6 @@ export default function OnboardingWizard({ prefs, tier, onComplete }: Onboarding
           case "finance": return "Choose stocks and crypto to track.";
           case "sports": return "Select the leagues you follow.";
           case "rss": return "Pick news and blog feeds.";
-          case "fantasy": return "Connect your Yahoo Fantasy account.";
           default: return undefined;
         }
       case "widgets": return "Add utility widgets to your ticker.";

--- a/desktop/src/components/onboarding/curated-picks.ts
+++ b/desktop/src/components/onboarding/curated-picks.ts
@@ -46,7 +46,10 @@ export const POPULAR_LEAGUES: LeaguePick[] = [
   { id: "140", name: "La Liga", sport: "Soccer" },
   { id: "78", name: "Bundesliga", sport: "Soccer" },
   { id: "135", name: "Serie A", sport: "Soccer" },
-  { id: "2", name: "Champions League", sport: "Soccer" },
+  // Note: id "5" (not "2") because Champions League's natural id collides
+  // with NBA. These ids are React keys for the picker UI; the actual
+  // sport→league mapping happens server-side via channel config.
+  { id: "5", name: "Champions League", sport: "Soccer" },
   { id: "61", name: "Ligue 1", sport: "Soccer" },
 ];
 
@@ -58,7 +61,10 @@ export const RECOMMENDED_FEEDS: FeedPick[] = [
   // Business
   { url: "https://feeds.bloomberg.com/markets/news.rss", name: "Bloomberg Markets", category: "Business" },
   // News
-  { url: "https://rss.app/feeds/v1.1/tDBXCLAcqDjHBmtx.xml", name: "AP News", category: "News" },
+  // Direct AP feed instead of the rss.app proxy — the proxied URL
+  // started returning HTTP 400 ahead of launch. Same content, lower
+  // hop count, no third-party dependency.
+  { url: "https://feeds.apnews.com/rss/apf-topnews", name: "AP News", category: "News" },
   { url: "https://feeds.bbci.co.uk/news/rss.xml", name: "BBC News", category: "News" },
   { url: "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml", name: "NY Times", category: "News" },
   { url: "https://www.theguardian.com/world/rss", name: "The Guardian", category: "News" },

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-shell";
 import { toast } from "sonner";
@@ -113,6 +113,15 @@ export default function AccountSettings({
       );
     }
   }, []);
+
+  // Clear the "Email sent" sticky state after 30s so the user can re-trigger
+  // a reset if they didn't receive it. The button stays disabled while
+  // we're showing the confirmation, then snaps back to "Send reset email".
+  useEffect(() => {
+    if (resetState !== "sent") return;
+    const timer = setTimeout(() => setResetState("idle"), 30_000);
+    return () => clearTimeout(timer);
+  }, [resetState]);
 
   const handleOpenPortal = useCallback(async () => {
     try {

--- a/desktop/src/components/settings/ProfileField.tsx
+++ b/desktop/src/components/settings/ProfileField.tsx
@@ -48,6 +48,13 @@ export default function ProfileField({
       setError(null);
       return;
     }
+    // Lightweight client-side email validation. The server is the
+    // authoritative validator, but rejecting obviously malformed
+    // input here saves a round-trip and keeps the failure inline.
+    if (type === "email" && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setError("Invalid email address");
+      return;
+    }
     try {
       setSaving(true);
       setError(null);

--- a/desktop/src/components/settings/TickerSettings.tsx
+++ b/desktop/src/components/settings/TickerSettings.tsx
@@ -896,26 +896,25 @@ function RowCard({
         )}
       </div>
 
-      {/* Customize (Ultimate) — data path wired via rowConfig overrides.
-          Full per-row scroll-mode/direction/speed/mix UI is Phase 2
-          (spec §Rollout). For now we show a locked teaser so Ultimate
-          users discover the capability exists. */}
-      <div className="mt-3 pt-3 border-t border-edge/30">
-        <div
-          className={clsx(
-            "flex items-center justify-between text-[11px] font-mono",
-            canCustomize ? "text-fg-3" : "text-fg-4/60",
-          )}
-        >
-          <span className="flex items-center gap-1.5">
-            {!canCustomize && <Lock size={11} />}
-            Customize scroll
-          </span>
-          <span className="text-[10px] uppercase tracking-wider">
-            {canCustomize ? "Coming soon" : "Ultimate"}
-          </span>
+      {/* Customize (Ultimate) upsell teaser — only shown to tiers that
+          DON'T already have customization unlocked. Showing "Coming
+          soon" to Ultimate / super_user users implies a feature gap
+          where there isn't one (the Phase 2 UI hasn't shipped yet,
+          but tease pre-launch confused testers). Free / Uplink / Pro
+          continue to see the locked Ultimate upsell here. */}
+      {!canCustomize && (
+        <div className="mt-3 pt-3 border-t border-edge/30">
+          <div className="flex items-center justify-between text-[11px] font-mono text-fg-4/60">
+            <span className="flex items-center gap-1.5">
+              <Lock size={11} />
+              Customize scroll
+            </span>
+            <span className="text-[10px] uppercase tracking-wider">
+              Ultimate
+            </span>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -691,10 +691,15 @@ function clampTickerRows(n: number): TickerRows {
  *      `tickerRows`; sources default to [] = "show all visible tabs").
  *   2. Tier-clamp the row count — if the current tier allows fewer rows
  *      than stored, drop from the BOTTOM so row 0 is preserved.
+ *
+ * Returns a `changed` flag when the user lost pinned sources due to the
+ * tier-clamp (i.e. removed rows had non-empty `sources`). The caller is
+ * expected to surface a toast so the user understands why their layout
+ * shrank — silent data loss on tier downgrade is an UX trap.
  */
 function migrateTickerLayout(
   saved: Partial<AppearancePrefs> | undefined,
-): TickerLayout {
+): { layout: TickerLayout; changed: boolean } {
   const fallbackRowCount = clampTickerRows(
     typeof saved?.tickerRows === "number" ? saved.tickerRows : 1,
   );
@@ -732,17 +737,51 @@ function migrateTickerLayout(
     maxRows = 3;
   }
 
+  let changed = false;
+
   if (rows.length > maxRows) {
-    // eslint-disable-next-line no-console
-    console.info(
-      `[prefs] tickerLayout clamped from ${rows.length} to ${maxRows} rows (tier cap)`,
-    );
+    // Inspect the rows we're about to drop. Only flag the layout as
+    // "changed" if the user actually loses pinned sources — empty rows
+    // sliced off don't warrant a toast.
+    const dropped = rows.slice(maxRows);
+    const lostSources = dropped.some((r) => r.sources.length > 0);
+
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.info(
+        `[prefs] tickerLayout clamped from ${rows.length} to ${maxRows} rows (tier cap)`,
+      );
+    }
+
     rows = rows.slice(0, maxRows);
+    changed = lostSources;
   }
 
   if (rows.length === 0) rows = [{ sources: [] }];
 
-  return { rows };
+  return { layout: { rows }, changed };
+}
+
+// ── Transient signal: tickerLayout was clamped on the most recent load ──
+//
+// `loadPrefs` runs as a `useState` initializer in two places (the ticker
+// window and the main window). Returning a tuple from `loadPrefs` would
+// force both call sites to restructure for a flag only the main window
+// cares about. Instead we stash the flag here and let the main window
+// call `consumeTickerLayoutChanged()` once mounted, which reads and
+// clears it. The ticker window simply ignores the signal.
+
+let tickerLayoutChangedSignal = false;
+
+/**
+ * Returns true exactly once if the most recent `loadPrefs()` call clamped
+ * the ticker layout AND the dropped rows held pinned sources. Subsequent
+ * calls return false until the next `loadPrefs()` triggers another clamp.
+ */
+export function consumeTickerLayoutChanged(): boolean {
+  const v = tickerLayoutChangedSignal;
+  tickerLayoutChangedSignal = false;
+  return v;
 }
 
 // ── Channel display migrations (v1.0.2 venue-enum migration) ────
@@ -875,10 +914,20 @@ export function loadPrefs(): AppPreferences {
 
     // Deep merge with defaults so new keys are always present
     const savedDisplay = source.channelDisplay as Partial<ChannelDisplayPrefs> | undefined;
+    const layoutResult = migrateTickerLayout(
+      source.appearance as Partial<AppearancePrefs> | undefined,
+    );
+    // Latch the "user lost rows" signal for the main window to read
+    // once via consumeTickerLayoutChanged(). This must come before the
+    // function returns — see the helper's docs for why we don't pipe
+    // it through the return value.
+    if (layoutResult.changed) {
+      tickerLayoutChangedSignal = true;
+    }
     const mergedAppearance: AppearancePrefs = {
       ...DEFAULT_APPEARANCE,
       ...source.appearance,
-      tickerLayout: migrateTickerLayout(source.appearance as Partial<AppearancePrefs> | undefined),
+      tickerLayout: layoutResult.layout,
     };
     // Keep the deprecated `tickerRows` in lockstep with the layout so
     // legacy consumers (window-height math) keep working.

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -45,6 +45,7 @@ import {
   loadPref,
   loadPrefs,
   savePrefs,
+  consumeTickerLayoutChanged,
 } from "../preferences";
 import type { AppPreferences } from "../preferences";
 
@@ -188,6 +189,18 @@ function RootLayout() {
   const [prefs, setPrefs] = useState<AppPreferences>(loadPrefs);
   const [autostartOn, setAutostartOn] = useState(false);
   const enabledWidgets = prefs.widgets.enabledWidgets;
+
+  // Surface the tier-clamp toast once when loadPrefs() dropped pinned
+  // ticker rows (e.g. user downgraded Pro→Uplink and lost rows 2/3 of
+  // their layout). Empty rows getting sliced doesn't trigger this.
+  // See `migrateTickerLayout` and `consumeTickerLayoutChanged` in
+  // preferences.ts for why we use a transient module-level signal
+  // instead of plumbing a flag through the loadPrefs return value.
+  useEffect(() => {
+    if (consumeTickerLayoutChanged()) {
+      toast.info("Your ticker layout was simplified to fit your plan.");
+    }
+  }, []);
 
   const [appVersion, setAppVersion] = useState("");
   useEffect(() => {

--- a/myscrollr.com/public/sitemap.xml
+++ b/myscrollr.com/public/sitemap.xml
@@ -13,6 +13,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://myscrollr.com/support</loc>
+    <lastmod>2026-04-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://myscrollr.com/channels</loc>
     <lastmod>2026-04-24</lastmod>
     <changefreq>weekly</changefreq>

--- a/myscrollr.com/src/components/legal/documents.ts
+++ b/myscrollr.com/src/components/legal/documents.ts
@@ -917,7 +917,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         content: [
           'For as long as you remain in good standing under these Super User Terms and the general Terms of Service, your account will receive complimentary access at the Ultimate tier (or its equivalent successor tier, if Scrollr renames or restructures its tier system in the future).',
           'Tier access means access at the tier level. Specific features, limits, providers, and capabilities included in the Ultimate tier may change over time as the Platform evolves. We may add, remove, replace, or modify the features delivered at the Ultimate tier without prior notice. Your continued benefit is the equivalent tier-level access offered to paying Ultimate subscribers from time to time, not any specific feature or quota that exists at the moment of your invite.',
-          'This benefit is provided at no cost to you and is not refundable, exchangeable, or convertible to monetary value. Taxes, if any apply in your jurisdiction, are your responsibility.',
+          'This benefit is provided at no cost to you and is not refundable, exchangeable, or convertible to monetary value. This benefit is non-refundable; any separate paid purchase is governed by the standard Refund Policy. Taxes, if any apply in your jurisdiction, are your responsibility.',
         ],
       },
       {

--- a/myscrollr.com/src/hooks/useGitHubStats.ts
+++ b/myscrollr.com/src/hooks/useGitHubStats.ts
@@ -6,20 +6,65 @@ export interface GitHubStats {
   issues: number
 }
 
+const CACHE_KEY_PREFIX = 'gh-stats-cache:'
+const CACHE_TTL_MS = 10 * 60 * 1000
+
+interface CachedEntry {
+  stars: number
+  forks: number
+  issues: number
+  ts: number
+}
+
+function readCache(repo: string): GitHubStats | null {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY_PREFIX + repo)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as CachedEntry
+    if (Date.now() - parsed.ts > CACHE_TTL_MS) return null
+    return {
+      stars: parsed.stars,
+      forks: parsed.forks,
+      issues: parsed.issues,
+    }
+  } catch {
+    return null // private mode / disabled storage / malformed JSON
+  }
+}
+
+function writeCache(repo: string, stats: GitHubStats) {
+  try {
+    sessionStorage.setItem(
+      CACHE_KEY_PREFIX + repo,
+      JSON.stringify({ ...stats, ts: Date.now() } satisfies CachedEntry),
+    )
+  } catch {
+    // private mode / quota — silently skip
+  }
+}
+
 export function useGitHubStats(repo: string) {
   const [stats, setStats] = useState<GitHubStats | null>(null)
 
   useEffect(() => {
+    const cached = readCache(repo)
+    if (cached) {
+      setStats(cached)
+      return
+    }
+
     let cancelled = false
     fetch(`https://api.github.com/repos/${repo}`)
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (!cancelled && data?.stargazers_count != null) {
-          setStats({
+          const next: GitHubStats = {
             stars: data.stargazers_count as number,
             forks: data.forks_count as number,
             issues: data.open_issues_count as number,
-          })
+          }
+          setStats(next)
+          writeCache(repo, next)
         }
       })
       .catch(() => {})

--- a/myscrollr.com/src/routes/account.tsx
+++ b/myscrollr.com/src/routes/account.tsx
@@ -205,10 +205,10 @@ function AccountHub() {
             </p>
           </motion.div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="flex flex-col gap-6">
             {/* Identity & Security Card */}
             <motion.div
-              className="relative bg-base-200/40 border border-base-300/25 rounded-xl p-8 overflow-hidden lg:col-span-2"
+              className="relative bg-base-200/40 border border-base-300/25 rounded-xl p-8 overflow-hidden"
               style={{ opacity: 0 }}
               initial={{ opacity: 0, y: 30 }}
               whileInView={{ opacity: 1, y: 0 }}
@@ -326,7 +326,7 @@ function AccountHub() {
 
             {/* Subscription Status Card */}
             <motion.div
-              className="relative bg-base-200/40 border border-base-300/25 rounded-xl p-8 overflow-hidden group lg:col-span-2"
+              className="relative bg-base-200/40 border border-base-300/25 rounded-xl p-8 overflow-hidden group"
               style={{ opacity: 0 }}
               initial={{ opacity: 0, y: 30 }}
               whileInView={{ opacity: 1, y: 0 }}
@@ -446,7 +446,7 @@ function AccountHub() {
                 {visibleCards.map((card, i) => (
                   <div
                     key={card.title}
-                    className="w-full sm:w-[calc(50%-0.5rem)] lg:w-[calc(25%-0.75rem)] min-w-[220px] max-w-sm"
+                    className="flex-1 min-w-[220px] max-w-sm"
                   >
                     <HubCard card={card} index={i} />
                   </div>
@@ -491,6 +491,15 @@ function IdentityEditor({
     'idle' | 'sending' | 'sent' | 'error'
   >('idle')
   const [resetError, setResetError] = useState<string | null>(null)
+
+  // Auto-reset the "sent" confirmation back to idle after 30s so the
+  // button becomes actionable again (e.g. for users who don't receive
+  // the email or want to re-trigger).
+  useEffect(() => {
+    if (resetState !== 'sent') return
+    const timer = setTimeout(() => setResetState('idle'), 30_000)
+    return () => clearTimeout(timer)
+  }, [resetState])
 
   async function handleSendReset() {
     try {
@@ -608,6 +617,10 @@ function EditableField({
     if (!trimmed || trimmed === value) {
       setEditing(false)
       setError(null)
+      return
+    }
+    if (type === 'email' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setError('Please enter a valid email address')
       return
     }
     try {


### PR DESCRIPTION
## Summary

Pre-launch sweep before super-user wave 1. Three streams across backend, marketing, and desktop.

### Stream 1 — Backend hardening (commit `2ba548b`)
- **Rate limit on password reset**: 1 request/hour/user, mirrors `support.go` pattern. Returns 429 + `Retry-After` header. Prevents authed email-bomb vector.
- **Profile update validation**: email format (`mail.ParseAddress`), length caps (254 email / 200 name), null-byte and `\n\r` rejection. Trim and write back to request struct.
- **Overview cache invalidation in billing handlers**: `HandleConfirmSubscription` (1 path), `HandleCancelSubscription` (2 paths), `HandleChangePlan` (3 paths). No more stale tier display after subscribe/cancel/change.
- **Sitemap**: added `/support` URL with priority 0.7.

### Stream 2 — Marketing polish (commit `5660654`)
- **Email regex** in `EditableField.handleSave` for `type='email'` (existing inline error pattern reused).
- **Sticky reset state**: 30s timeout returns `IdentityEditor.resetState` from `'sent'` → `'idle'` so users can retry if email doesn't arrive.
- **Dashboard grid orphan fix**: switched `lg:grid-cols-2` → `flex-col` stack, removed `lg:col-span-2` modifiers. Identity / System Status / Subscription now all naturally full-width.
- **Quick Links 3-card layout**: `flex-1 min-w-[220px] max-w-sm` distributes evenly regardless of count.
- **GitHub stats sessionStorage cache**: 10-min TTL, graceful fallback in private mode.
- **Super User Terms refund clarification**: "This benefit is non-refundable; any separate paid purchase is governed by the standard Refund Policy."

### Stream 3 — Desktop polish (commit `9b072bf`)
- **Drop Yahoo connect step from onboarding wizard** (Option B): removed `'fantasy'` case from configure step, `StepConfigureFantasy` import, `fantasyConnected` state. Channel still provisions on Finish; Yahoo OAuth happens later from Fantasy page (which has clear connect CTAs).
- **Email regex in ProfileField.handleSave** matching marketing.
- **Sticky reset state in AccountSettings**: 30s timeout pattern.
- **migrateTickerLayout orphaned-channel detection**: refactored to return `{ layout, changed }`. Toast wired in `__root.tsx` via `consumeTickerLayoutChanged()` helper: "Your ticker layout was simplified to fit your plan."
- **Console gating**: `import.meta.env.DEV` guards on `[prefs] tickerLayout clamped` and `[authFetch] Token unavailable`.
- **RSS feed S5**: replaced broken rss.app feed (returned HTTP 400) with `https://feeds.apnews.com/rss/apf-topnews`.
- **League ID dedup**: Champions League `id: '2'` → `'5'` (was colliding with NBA).
- **Customize scroll teaser**: hidden entirely for Ultimate / super_user; lower tiers still see Ultimate upsell.

## Verification

- Core API: `go vet ./...` clean, `go test ./core/` passes.
- Desktop: `npx tsc --noEmit` clean, `npx vitest run` 189/189 passing (was 193 — wizard refactor removed 4 fantasy-step tests with the dropped code), `npm run build` clean, `cargo check` clean.
- Marketing: `npm run check` clean (Prettier + ESLint), `npm run build` clean.

## Manual checks deferred to user

1. **Logto admin** — set Username field to read-only (still pending from Batch D).
2. **Logto JWT script** — add `username` + `name` claims (still pending from Batch B).
3. **`www.myscrollr.com` redirect** — couldn't verify from agent's network (DNS resolved to 000 connection-failed). Confirm `www` → apex 301 is configured at Cloudflare/CDN before super-user emails go out.

## Out of scope (not in this PR)

- Channel shared-secret guard (defense-in-depth post-launch).
- K8s `:latest` → SHA pinning + PodDisruptionBudget (operational follow-up).
- Stripe `subscription.paused/.resumed` event handlers.
- Removing now-unreferenced `StepConfigureFantasy.tsx` (dead-code sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)