### PR TITLE
feat(support): AI triage + L2 approval flow for incoming tickets

### DIFF
--- a/api/core/ai_triage.go
+++ b/api/core/ai_triage.go
@@ -1,0 +1,325 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// =============================================================================
+// AI Support Triage — Anthropic Haiku integration
+// =============================================================================
+//
+// Best-effort categorization, summarization, dupe-detection, and reply
+// drafting for incoming support tickets. All functions in this file are
+// designed to fail soft: any error path returns nil so the support flow
+// continues with the legacy (no-AI) behavior. We never block ticket
+// creation on triage success.
+
+const (
+	anthropicAPIURL    = "https://api.anthropic.com/v1/messages"
+	anthropicModel     = "claude-haiku-4-5"
+	anthropicVersion   = "2023-06-01"
+	triageTimeout      = 10 * time.Second
+	maxTriageBodyChars = 8000 // truncate ticket body before sending to keep prompt size bounded
+)
+
+// TriageResult is the structured output from Claude. Fields use
+// lowercase JSON tags so we can unmarshal Claude's JSON response
+// directly. Confidence drives whether we override the user-picked
+// category.
+type TriageResult struct {
+	Category       string `json:"category"`
+	Channel        string `json:"channel,omitempty"`
+	Priority       string `json:"priority"`
+	Summary        string `json:"summary"`
+	DuplicateOf    string `json:"duplicate_of,omitempty"`
+	DraftReplyHTML string `json:"draft_reply_html"`
+	Confidence     string `json:"confidence"`
+}
+
+// TriageInput is what we pass to triageTicket. Builds the prompt
+// from these fields plus a small bundle of recent ticket summaries
+// pulled from Redis (for dupe detection) and a static FAQ snippet.
+type TriageInput struct {
+	UserCategory    string
+	UserEmail       string
+	UserName        string
+	Subject         string
+	Body            string
+	RecentSummaries []RecentTicketSummary
+	Channel         string // user-picked channel hint, if any
+}
+
+// RecentTicketSummary is what we cache in Redis for dupe-detection
+// context. Kept compact — this list is sent on every triage call.
+type RecentTicketSummary struct {
+	TicketNumber string `json:"ticket_number"`
+	Category     string `json:"category"`
+	Summary      string `json:"summary"`
+	CreatedAt    string `json:"created_at"`
+}
+
+// triageTicket calls Anthropic Haiku and returns a parsed TriageResult.
+// On any failure (network error, non-200, malformed JSON, missing
+// required fields) returns nil. Caller must handle nil gracefully —
+// AI triage is best-effort, never blocks the ticket flow.
+func triageTicket(ctx context.Context, input TriageInput) *TriageResult {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		log.Println("[Triage] ANTHROPIC_API_KEY not set; skipping triage")
+		return nil
+	}
+	if os.Getenv("AI_TRIAGE_ENABLED") == "false" {
+		return nil
+	}
+
+	body := input.Body
+	if len(body) > maxTriageBodyChars {
+		body = body[:maxTriageBodyChars] + "\n\n...[truncated]"
+	}
+
+	prompt := buildTriagePrompt(input, body)
+
+	reqBody := map[string]interface{}{
+		"model":      anthropicModel,
+		"max_tokens": 2048,
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+	}
+	reqBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		log.Printf("[Triage] marshal request: %v", err)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, triageTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicAPIURL, bytes.NewReader(reqBytes))
+	if err != nil {
+		log.Printf("[Triage] build request: %v", err)
+		return nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+
+	client := &http.Client{Timeout: triageTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("[Triage] HTTP request failed: %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("[Triage] read response: %v", err)
+		return nil
+	}
+
+	if resp.StatusCode >= 400 {
+		log.Printf("[Triage] Anthropic returned %d: %s", resp.StatusCode, string(respBody))
+		return nil
+	}
+
+	// Anthropic response: {content: [{type:"text", text:"..."}]}
+	var apiResp struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		log.Printf("[Triage] parse Anthropic response: %v", err)
+		return nil
+	}
+	if len(apiResp.Content) == 0 {
+		log.Printf("[Triage] empty content from Anthropic")
+		return nil
+	}
+
+	// Claude sometimes wraps JSON in markdown fences despite instructions.
+	rawJSON := strings.TrimSpace(apiResp.Content[0].Text)
+	rawJSON = strings.TrimPrefix(rawJSON, "```json")
+	rawJSON = strings.TrimPrefix(rawJSON, "```")
+	rawJSON = strings.TrimSuffix(rawJSON, "```")
+	rawJSON = strings.TrimSpace(rawJSON)
+
+	var result TriageResult
+	if err := json.Unmarshal([]byte(rawJSON), &result); err != nil {
+		log.Printf("[Triage] parse triage JSON: %v\nraw: %s", err, rawJSON)
+		return nil
+	}
+
+	// Sanity-check required fields
+	if result.Category == "" || result.Priority == "" || result.Summary == "" {
+		log.Printf("[Triage] incomplete result: %+v", result)
+		return nil
+	}
+
+	log.Printf("[Triage] OK: category=%s priority=%s confidence=%s summary=%q",
+		result.Category, result.Priority, result.Confidence, result.Summary)
+	return &result
+}
+
+// buildTriagePrompt constructs the user-message prompt sent to Claude.
+// Kept as a pure function for unit testing.
+func buildTriagePrompt(input TriageInput, body string) string {
+	recentJSON, _ := json.Marshal(input.RecentSummaries)
+	if len(recentJSON) == 0 {
+		recentJSON = []byte("[]")
+	}
+
+	channelHint := ""
+	if input.Channel != "" {
+		channelHint = fmt.Sprintf("Channel hint from user: %s\n", input.Channel)
+	}
+
+	return fmt.Sprintf(`You are a support triage assistant for Scrollr, a desktop ticker app for live financial markets, sports scores, news, and Yahoo Fantasy. Categorize incoming tickets and draft warm, direct replies grounded in the FAQ below.
+
+YOUR TASKS:
+1. Pick the best category from: bug, feature, feedback, billing, account, channel
+2. Pick a priority based on urgency signals (lost data / can't log in / can't pay → high or emergency; "love this app" / "would be cool if" → low)
+3. If category is "channel", identify which: finance, sports, rss, fantasy
+4. Generate a one-line summary (10 words max, no period at the end)
+5. If the ticket looks like a duplicate of one in RECENT TICKETS, output its ticket_number
+6. Draft a reply matching this voice:
+   - Warm, direct, lowercase first letter is fine, no corporate-speak
+   - Lead with brief acknowledgment, then action
+   - Reference FAQ if relevant; never make up fix steps
+   - 2-4 short paragraphs max
+   - Sign off "— the scrollr team"
+7. Output confidence: "high" if you're very sure of category/priority, "medium" if some ambiguity, "low" if you'd want a human to double-check
+
+OUTPUT EXACTLY THIS JSON (no markdown fences, no commentary):
+{
+  "category": "bug|feature|feedback|billing|account|channel",
+  "channel": "finance|sports|rss|fantasy" or null,
+  "priority": "low|normal|high|emergency",
+  "summary": "...",
+  "duplicate_of": "ticket-number" or null,
+  "draft_reply_html": "<p>...</p>",
+  "confidence": "high|medium|low"
+}
+
+RECENT TICKETS (for dupe-detection only):
+%s
+
+FAQ EXCERPTS:
+%s
+
+USER TICKET:
+Email: %s
+Name: %s
+User-picked category: %s
+%sSubject: %s
+Body:
+%s
+`,
+		string(recentJSON),
+		faqContextForTriage(),
+		input.UserEmail,
+		input.UserName,
+		input.UserCategory,
+		channelHint,
+		input.Subject,
+		body,
+	)
+}
+
+// faqContextForTriage returns a short FAQ snippet to ground Claude's
+// reply suggestions. Keep this small (<2000 chars) — it's sent on every
+// triage call. Update when the FAQ content evolves significantly.
+func faqContextForTriage() string {
+	return `# Scrollr FAQ — quick reference for triage replies
+
+## Connecting Yahoo Fantasy
+Open the Fantasy channel page in the desktop app, click "Connect Yahoo," walk through the OAuth flow. Leagues import automatically once connected.
+
+## Updating the desktop app
+Settings → General → Updates → Check for Updates. Auto-updates are also available; v1.0.4 is the latest as of April 2026.
+
+## Subscription & billing
+Manage all subscriptions through the Stripe portal: Account page → "Manage Subscription". Cancellation, payment-method updates, and invoices are all there. Super-users have permanent free Ultimate access (per the early-access program).
+
+## Resetting password
+Account page → "Send password reset email" — Logto handles the rest.
+
+## Reporting bugs
+The Contact Us form in the desktop app collects diagnostics automatically. Always include OS + Scrollr version (Settings → General → About).
+
+## Channel issues
+Finance: stocks/crypto via TwelveData. Sports: api-sports.io. News: RSS pull-based ingestion. Fantasy: Yahoo OAuth + cached league data.
+
+## Multi-row ticker
+Available on Pro (2 rows), Ultimate (3 rows), and super_user. Configure in Settings → Ticker → Rows. Per-channel row assignment in the Settings → Ticker source picker, or right-click the tray menu.
+
+## Channel.ticker_enabled / "missing channel"
+If a channel disappears from the ticker, it's likely the per-channel ticker toggle is off. Check the Home/Feed page → channel header → ticker icon.
+`
+}
+
+// applyTriageToBody prepends the AI summary and appends the duplicate
+// hint to the ticket body HTML. The drafted reply is appended as a
+// collapsible <details> block so the partner can copy it inside
+// osTicket. Returns the modified body.
+func applyTriageToBody(originalBody string, triage *TriageResult) string {
+	if triage == nil {
+		return originalBody
+	}
+
+	var prefix strings.Builder
+	prefix.WriteString(`<div style="background:#0f3a2c;border-left:4px solid #10b981;padding:12px;margin-bottom:16px;color:#a7f3d0;border-radius:4px;">`)
+	prefix.WriteString(fmt.Sprintf(`<strong>🤖 AI summary:</strong> %s`, escapeHTML(triage.Summary)))
+	prefix.WriteString(fmt.Sprintf(`<br><span style="font-size:11px;opacity:0.8;">priority=%s · category=%s · confidence=%s`,
+		escapeHTML(triage.Priority),
+		escapeHTML(triage.Category),
+		escapeHTML(triage.Confidence)))
+	if triage.Channel != "" {
+		prefix.WriteString(fmt.Sprintf(` · channel=%s`, escapeHTML(triage.Channel)))
+	}
+	prefix.WriteString(`</span></div>`)
+
+	body := prefix.String() + originalBody
+
+	if triage.DuplicateOf != "" {
+		body += fmt.Sprintf(`<div style="background:#3a2c0f;border-left:4px solid #f59e0b;padding:8px;margin-top:16px;color:#fde68a;border-radius:4px;font-size:13px;">🔗 <strong>Possibly related:</strong> ticket %s</div>`,
+			escapeHTML(triage.DuplicateOf))
+	}
+
+	if triage.DraftReplyHTML != "" {
+		body += fmt.Sprintf(`<details style="margin-top:16px;background:#1a1a2e;border:1px solid #2a2a3e;padding:12px;border-radius:4px;"><summary style="cursor:pointer;color:#10b981;font-weight:600;">💡 AI suggested reply (click to expand)</summary><div style="margin-top:8px;padding:8px;background:#0a0a1a;border-radius:4px;color:#e2e8f0;">%s</div></details>`,
+			triage.DraftReplyHTML)
+	}
+
+	return body
+}
+
+// mapTriagePriorityToOSTicket converts AI priority strings to osTicket's
+// expected priority IDs. osTicket's default priority IDs are 1=Low, 2=Normal,
+// 3=High, 4=Emergency. NOTE: this assumes default priority IDs; if the user's
+// osTicket install has custom IDs, this will need adjustment via env var.
+func mapTriagePriorityToOSTicket(priority string) string {
+	switch strings.ToLower(priority) {
+	case "low":
+		return "1"
+	case "normal":
+		return "2"
+	case "high":
+		return "3"
+	case "emergency":
+		return "4"
+	default:
+		return ""
+	}
+}

--- a/api/core/handlers_resend_webhook.go
+++ b/api/core/handlers_resend_webhook.go
@@ -1,0 +1,203 @@
+package core
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// =============================================================================
+// Resend webhook — capture outbound Message-IDs for ticket threading
+// =============================================================================
+//
+// osTicket sends auto-responses + agent replies via Resend. We need
+// each outbound Message-ID so the partner-approved AI replies can set
+// `In-Reply-To` correctly and thread back into osTicket. This handler
+// receives Resend's `email.sent` events, extracts the ticket number
+// from the subject, and persists the (ticket, message-id) pair.
+
+// ResendWebhookEvent is a minimal shape — Resend sends more fields,
+// but we only care about email.sent and the headers we need for
+// Message-ID extraction.
+type ResendWebhookEvent struct {
+	Type      string `json:"type"`
+	CreatedAt string `json:"created_at"`
+	Data      struct {
+		EmailID   string         `json:"email_id"`
+		From      string         `json:"from"`
+		To        []string       `json:"to"`
+		Subject   string         `json:"subject"`
+		Headers   []ResendHeader `json:"headers,omitempty"`
+		MessageID string         `json:"message_id,omitempty"`
+	} `json:"data"`
+}
+
+type ResendHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// ticketNumberInSubject extracts an osTicket-style ticket reference
+// from a subject line. osTicket's default outbound subject looks like
+// "Re: Your Scrollr ticket [#1247]" or "[#TKT-1247] Subject Here".
+// Returns "" if no [#…] reference is found.
+var ticketNumberRegex = regexp.MustCompile(`(?i)\[#\s*([A-Z]*-?\d+)\s*\]`)
+
+func ticketNumberInSubject(subject string) string {
+	m := ticketNumberRegex.FindStringSubmatch(subject)
+	if len(m) >= 2 {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+// HandleResendWebhook receives email lifecycle events from Resend.
+// Verifies the Svix-style signature against RESEND_WEBHOOK_SECRET, then
+// for `email.sent` / `email.delivered` events extracts the Message-ID
+// and ticket number from the subject and persists for later threading.
+//
+// Non-ticket emails (no [#…] in subject) are ignored silently. Other
+// event types (bounced, complained, …) are also ignored — they're
+// useful telemetry but not what this handler is for.
+func HandleResendWebhook(c *fiber.Ctx) error {
+	secret := os.Getenv("RESEND_WEBHOOK_SECRET")
+	if secret == "" {
+		log.Println("[ResendWebhook] RESEND_WEBHOOK_SECRET not set; rejecting")
+		return c.SendStatus(fiber.StatusServiceUnavailable)
+	}
+
+	body := c.Body()
+	if len(body) == 0 {
+		return c.SendStatus(fiber.StatusBadRequest)
+	}
+
+	// Resend uses Svix-style signing. The signature header is
+	// `svix-signature` with format "v1,<base64>". Verify HMAC-SHA256
+	// over `<svix-id>.<svix-timestamp>.<body>`.
+	sigHeader := c.Get("svix-signature")
+	svixID := c.Get("svix-id")
+	svixTimestamp := c.Get("svix-timestamp")
+
+	if sigHeader == "" || svixID == "" || svixTimestamp == "" {
+		// Allow no-sig in dev environments, but log loudly
+		if os.Getenv("RESEND_WEBHOOK_DEV") != "true" {
+			log.Println("[ResendWebhook] missing svix headers; rejecting")
+			return c.SendStatus(fiber.StatusUnauthorized)
+		}
+		log.Println("[ResendWebhook] DEV mode — bypassing signature check")
+	} else {
+		if !verifySvixSignature(secret, svixID, svixTimestamp, body, sigHeader) {
+			log.Println("[ResendWebhook] signature verification failed")
+			return c.SendStatus(fiber.StatusUnauthorized)
+		}
+	}
+
+	var ev ResendWebhookEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		log.Printf("[ResendWebhook] parse event: %v", err)
+		return c.SendStatus(fiber.StatusBadRequest)
+	}
+
+	if ev.Type != "email.sent" && ev.Type != "email.delivered" {
+		// Other event types (bounced, complained, etc.) — log but don't process
+		return c.SendStatus(fiber.StatusOK)
+	}
+
+	// Extract Message-ID from headers if present, else use email_id
+	var messageID string
+	for _, h := range ev.Data.Headers {
+		if strings.EqualFold(h.Name, "Message-ID") || strings.EqualFold(h.Name, "Message-Id") {
+			messageID = strings.Trim(h.Value, "<>")
+			break
+		}
+	}
+	if messageID == "" {
+		messageID = ev.Data.MessageID
+	}
+	if messageID == "" {
+		// Fallback: use Resend's internal email_id as the message reference
+		messageID = ev.Data.EmailID
+	}
+	if messageID == "" {
+		log.Println("[ResendWebhook] no Message-ID in event; skipping")
+		return c.SendStatus(fiber.StatusOK)
+	}
+
+	ticketNumber := ticketNumberInSubject(ev.Data.Subject)
+	if ticketNumber == "" {
+		// Not a ticket-related email; skip silently
+		return c.SendStatus(fiber.StatusOK)
+	}
+
+	recipient := ""
+	if len(ev.Data.To) > 0 {
+		recipient = ev.Data.To[0]
+	}
+
+	// Determine direction: if From contains the support address, it's
+	// outbound from osTicket (our partner's helpdesk). Anything else is
+	// flagged but still recorded for visibility.
+	direction := "outbound_osticket" // default — osTicket emails dominate
+	supportFrom := os.Getenv("OSTICKET_BCC_EMAIL")
+	if supportFrom == "" {
+		supportFrom = "support@myscrollr.com"
+	}
+	if !strings.Contains(strings.ToLower(ev.Data.From), strings.ToLower(supportFrom)) {
+		log.Printf("[ResendWebhook] unexpected from address: %s for ticket %s", ev.Data.From, ticketNumber)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := recordOSTicketMessageID(ctx, ticketNumber, messageID, recipient, direction); err != nil {
+		log.Printf("[ResendWebhook] persist failed: %v", err)
+		return c.SendStatus(fiber.StatusInternalServerError)
+	}
+
+	log.Printf("[ResendWebhook] captured ticket=%s msg-id=%s recipient=%s",
+		ticketNumber, messageID, recipient)
+	return c.SendStatus(fiber.StatusOK)
+}
+
+// verifySvixSignature validates the Svix HMAC-SHA256 signature header
+// against the configured webhook secret. Resend sends a space-separated
+// list of "v1,<base64>" entries; we accept the request if any entry
+// matches. The base64 in the header is *standard* (Svix uses standard
+// base64 padding), not URL-safe.
+//
+// secret is the value from the env var, possibly with the "whsec_"
+// prefix Svix prepends. The actual HMAC key is the bytes after the
+// prefix, decoded from standard base64 (Svix encodes its raw key into
+// the secret string).
+func verifySvixSignature(secret, svixID, svixTimestamp string, body []byte, header string) bool {
+	rawKey, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(secret, "whsec_"))
+	if err != nil {
+		// Some deployments may set the secret as raw bytes already; fall back to that.
+		rawKey = []byte(strings.TrimPrefix(secret, "whsec_"))
+	}
+
+	toSign := svixID + "." + svixTimestamp + "." + string(body)
+	mac := hmac.New(sha256.New, rawKey)
+	mac.Write([]byte(toSign))
+	expected := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	for _, sig := range strings.Split(header, " ") {
+		parts := strings.SplitN(sig, ",", 2)
+		if len(parts) != 2 || parts[0] != "v1" {
+			continue
+		}
+		if hmac.Equal([]byte(parts[1]), []byte(expected)) {
+			return true
+		}
+	}
+	return false
+}

--- a/api/core/handlers_support_approval.go
+++ b/api/core/handlers_support_approval.go
@@ -1,0 +1,326 @@
+package core
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// =============================================================================
+// Support approval URLs — partner-facing Send / Edit / Skip handlers
+// =============================================================================
+//
+// Each support draft generates three single-use, HMAC-signed URLs the
+// partner clicks from email. Tokens are tiny custom JWTs (header-less)
+// signed with HMAC-SHA256 — no JWT library dependency for what is a
+// 4-field claim set. Single-use enforcement lives in the DB
+// (markDraftDecided's `WHERE status = 'pending'`).
+
+// SupportApprovalToken is the signed claim set carried in the URL.
+// Field names are 1-letter to keep the encoded URL short.
+type SupportApprovalToken struct {
+	DraftID int64  `json:"d"`
+	Action  string `json:"a"` // "send" | "edit" | "skip"
+	Exp     int64  `json:"e"` // unix seconds
+	JTI     string `json:"j"` // unique nonce — useful for log correlation, not enforced
+}
+
+// supportApprovalSecret returns the HMAC key used to sign approval
+// tokens. Falls back to LOGTO_M2M_APP_SECRET so dev environments work
+// without an extra env var, but production should set
+// SUPPORT_APPROVAL_HMAC_SECRET to a high-entropy random value.
+func supportApprovalSecret() []byte {
+	s := os.Getenv("SUPPORT_APPROVAL_HMAC_SECRET")
+	if s == "" {
+		s = os.Getenv("LOGTO_M2M_APP_SECRET")
+	}
+	return []byte(s)
+}
+
+// signApprovalToken produces a base64url-encoded payload + signature
+// joined by ".". Format: <base64(json claims)>.<base64(hmac)>
+func signApprovalToken(t SupportApprovalToken) (string, error) {
+	if len(supportApprovalSecret()) == 0 {
+		return "", fmt.Errorf("SUPPORT_APPROVAL_HMAC_SECRET not configured")
+	}
+	body, err := json.Marshal(t)
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(body)
+	mac := hmac.New(sha256.New, supportApprovalSecret())
+	mac.Write([]byte(encoded))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return encoded + "." + sig, nil
+}
+
+// verifyApprovalToken parses + validates a token. Returns parsed
+// claims on success. Errors are intentionally generic so we don't
+// leak which step failed.
+func verifyApprovalToken(raw string) (*SupportApprovalToken, error) {
+	parts := strings.SplitN(raw, ".", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("malformed token")
+	}
+	mac := hmac.New(sha256.New, supportApprovalSecret())
+	mac.Write([]byte(parts[0]))
+	expected := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(parts[1]), []byte(expected)) {
+		return nil, fmt.Errorf("invalid signature")
+	}
+	body, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode body: %w", err)
+	}
+	var t SupportApprovalToken
+	if err := json.Unmarshal(body, &t); err != nil {
+		return nil, fmt.Errorf("parse claims: %w", err)
+	}
+	if t.Exp > 0 && time.Now().Unix() > t.Exp {
+		return nil, fmt.Errorf("token expired")
+	}
+	return &t, nil
+}
+
+// buildApprovalURLs returns the three URLs to embed in the partner
+// notification email. All three share the same expiry; one click on
+// any of them flips the draft's status, invalidating the other two
+// (single-use is enforced at the DB layer).
+func buildApprovalURLs(draftID int64) (sendURL, editURL, skipURL string, err error) {
+	base := os.Getenv("APPROVAL_BASE_URL")
+	if base == "" {
+		base = "https://api.myscrollr.com"
+	}
+	exp := time.Now().Add(24 * time.Hour).Unix()
+	mk := func(action string) (string, error) {
+		t, e := signApprovalToken(SupportApprovalToken{
+			DraftID: draftID,
+			Action:  action,
+			Exp:     exp,
+			JTI:     fmt.Sprintf("%d-%d", draftID, time.Now().UnixNano()),
+		})
+		if e != nil {
+			return "", e
+		}
+		return base + "/support/" + action + "?token=" + t, nil
+	}
+	if sendURL, err = mk("send"); err != nil {
+		return
+	}
+	if editURL, err = mk("edit"); err != nil {
+		return
+	}
+	if skipURL, err = mk("skip"); err != nil {
+		return
+	}
+	return
+}
+
+// HandleSupportSend (GET /support/send?token=...) — partner approves the AI's draft as-is.
+func HandleSupportSend(c *fiber.Ctx) error {
+	return handleApprovalAction(c, "send")
+}
+
+// HandleSupportSkip (GET /support/skip?token=...) — partner skips, no email sent.
+func HandleSupportSkip(c *fiber.Ctx) error {
+	return handleApprovalAction(c, "skip")
+}
+
+// HandleSupportEdit (GET /support/edit?token=...) — returns an HTML
+// form pre-filled with the draft body. The partner edits and POSTs to
+// /support/edit/submit, which falls into the Send path with the
+// edited body.
+func HandleSupportEdit(c *fiber.Ctx) error {
+	_, draft, err := loadAndVerifyApprovalToken(c, "edit")
+	if err != nil {
+		return errorHTMLResponse(c, fiber.StatusBadRequest, err.Error())
+	}
+
+	tokenRaw := c.Query("token")
+
+	// Build a small HTML editor page. Inline styling — no template
+	// engine dependency for a single-purpose form.
+	page := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Edit reply — Ticket %s</title>
+<style>
+  body { background:#0a0a0a; color:#e2e8f0; font-family:-apple-system,BlinkMacSystemFont,sans-serif; padding:24px; max-width:640px; margin:0 auto; }
+  h1 { color:#10b981; font-size:18px; margin:0 0 8px; }
+  p.meta { color:#888; font-size:13px; margin:0 0 16px; }
+  textarea { width:100%%; height:300px; background:#141414; color:#e2e8f0; border:1px solid #2a2a2a; border-radius:6px; padding:12px; font-family:ui-monospace,monospace; font-size:13px; resize:vertical; box-sizing:border-box; }
+  .actions { margin-top:16px; display:flex; gap:8px; }
+  button { padding:10px 16px; border:none; border-radius:6px; cursor:pointer; font-weight:600; font-size:14px; }
+  .send { background:#10b981; color:white; }
+  .cancel { background:#2a2a2a; color:#e2e8f0; }
+  .ai-note { background:#0f3a2c; padding:8px 12px; border-radius:4px; font-size:12px; color:#a7f3d0; margin-bottom:12px; }
+</style>
+</head>
+<body>
+<h1>Edit reply</h1>
+<p class="meta">Ticket <strong>%s</strong> · To <strong>%s</strong> · AI summary: %s</p>
+<div class="ai-note">You can edit the HTML below. Plain text is fine too — basic HTML tags will render in the user's email client.</div>
+<form method="POST" action="/support/edit/submit">
+  <input type="hidden" name="token" value="%s">
+  <textarea name="body">%s</textarea>
+  <div class="actions">
+    <button type="submit" class="send">Send edited reply</button>
+    <a href="/support/skip?token=%s" class="cancel" style="text-decoration:none;display:inline-block;line-height:36px;padding:0 16px;">Skip instead</a>
+  </div>
+</form>
+</body>
+</html>`,
+		html.EscapeString(draft.TicketNumber),
+		html.EscapeString(draft.TicketNumber),
+		html.EscapeString(draft.UserEmail),
+		html.EscapeString(draft.AISummary),
+		html.EscapeString(tokenRaw),
+		html.EscapeString(draft.DraftBodyHTML),
+		html.EscapeString(tokenRaw),
+	)
+
+	c.Set("Content-Type", "text/html; charset=utf-8")
+	return c.SendString(page)
+}
+
+// HandleSupportEditSubmit (POST /support/edit/submit) — partner submits the edited body.
+func HandleSupportEditSubmit(c *fiber.Ctx) error {
+	_, draft, err := loadAndVerifyApprovalToken(c, "edit")
+	if err != nil {
+		return errorHTMLResponse(c, fiber.StatusBadRequest, err.Error())
+	}
+
+	editedBody := strings.TrimSpace(c.FormValue("body"))
+	if editedBody == "" {
+		return errorHTMLResponse(c, fiber.StatusBadRequest, "Edit body cannot be empty")
+	}
+
+	// Mark as edited and send
+	if err := markDraftDecided(c.Context(), draft.ID, "edited", editedBody); err != nil {
+		if errors.Is(err, ErrAlreadyDecided) {
+			return errorHTMLResponse(c, fiber.StatusConflict, "This draft was already actioned")
+		}
+		log.Printf("[Approval] markDraftDecided: %v", err)
+		return errorHTMLResponse(c, fiber.StatusInternalServerError, "Failed to save decision")
+	}
+
+	if err := sendApprovedReply(c.Context(), draft, editedBody); err != nil {
+		markDraftFailed(c.Context(), draft.ID)
+		log.Printf("[Approval] sendApprovedReply (edited): %v", err)
+		return errorHTMLResponse(c, fiber.StatusBadGateway, "Failed to send reply")
+	}
+	markDraftSent(c.Context(), draft.ID)
+
+	return successHTMLResponse(c, "Edited reply sent — user will see it threaded into ticket "+draft.TicketNumber+".")
+}
+
+// handleApprovalAction handles the simple Send and Skip flows that
+// don't need a body editor. Both share verification + decision
+// transitions; only the Send path actually fires an outbound email.
+func handleApprovalAction(c *fiber.Ctx, action string) error {
+	_, draft, err := loadAndVerifyApprovalToken(c, action)
+	if err != nil {
+		return errorHTMLResponse(c, fiber.StatusBadRequest, err.Error())
+	}
+
+	switch action {
+	case "send":
+		if err := markDraftDecided(c.Context(), draft.ID, "approved", ""); err != nil {
+			if errors.Is(err, ErrAlreadyDecided) {
+				return errorHTMLResponse(c, fiber.StatusConflict, "This draft was already actioned")
+			}
+			log.Printf("[Approval] markDraftDecided: %v", err)
+			return errorHTMLResponse(c, fiber.StatusInternalServerError, "Failed to save decision")
+		}
+		if err := sendApprovedReply(c.Context(), draft, draft.DraftBodyHTML); err != nil {
+			markDraftFailed(c.Context(), draft.ID)
+			log.Printf("[Approval] sendApprovedReply: %v", err)
+			return errorHTMLResponse(c, fiber.StatusBadGateway, "Failed to send reply")
+		}
+		markDraftSent(c.Context(), draft.ID)
+		return successHTMLResponse(c, "Reply sent. The user will see it threaded into ticket "+draft.TicketNumber+".")
+	case "skip":
+		if err := markDraftDecided(c.Context(), draft.ID, "skipped", ""); err != nil {
+			if errors.Is(err, ErrAlreadyDecided) {
+				return errorHTMLResponse(c, fiber.StatusConflict, "This draft was already actioned")
+			}
+			return errorHTMLResponse(c, fiber.StatusInternalServerError, "Failed to save decision")
+		}
+		return successHTMLResponse(c, "Skipped. The ticket is open in osTicket; handle it manually.")
+	default:
+		return errorHTMLResponse(c, fiber.StatusBadRequest, "Unknown action")
+	}
+}
+
+// loadAndVerifyApprovalToken parses the token from the request, checks
+// signature/expiry, asserts the action matches the route, and loads
+// the underlying draft. expectedAction may be empty to skip the action
+// check.
+func loadAndVerifyApprovalToken(c *fiber.Ctx, expectedAction string) (*SupportApprovalToken, *SupportDraft, error) {
+	raw := c.Query("token")
+	if raw == "" {
+		raw = c.FormValue("token")
+	}
+	if raw == "" {
+		return nil, nil, fmt.Errorf("missing token")
+	}
+	t, err := verifyApprovalToken(raw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid token: %w", err)
+	}
+	if expectedAction != "" && t.Action != expectedAction {
+		return nil, nil, fmt.Errorf("token action mismatch")
+	}
+	draft, err := loadSupportDraft(c.Context(), t.DraftID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load draft: %w", err)
+	}
+	if draft == nil {
+		return nil, nil, fmt.Errorf("draft not found")
+	}
+	return t, draft, nil
+}
+
+func successHTMLResponse(c *fiber.Ctx, msg string) error {
+	c.Set("Content-Type", "text/html; charset=utf-8")
+	return c.SendString(fmt.Sprintf(`<!DOCTYPE html>
+<html><head><title>OK</title><style>body{background:#0a0a0a;color:#e2e8f0;font-family:-apple-system,sans-serif;padding:48px;text-align:center;}h1{color:#10b981;}p{color:#aaa;}</style></head>
+<body><h1>%s</h1></body></html>`, html.EscapeString(msg)))
+}
+
+func errorHTMLResponse(c *fiber.Ctx, status int, msg string) error {
+	c.Status(status)
+	c.Set("Content-Type", "text/html; charset=utf-8")
+	return c.SendString(fmt.Sprintf(`<!DOCTYPE html>
+<html><head><title>Error</title><style>body{background:#0a0a0a;color:#e2e8f0;font-family:-apple-system,sans-serif;padding:48px;text-align:center;}h1{color:#ef4444;}</style></head>
+<body><h1>%s</h1></body></html>`, html.EscapeString(msg)))
+}
+
+// sendApprovedReply is the seam used by the approval handlers to send
+// the partner-approved reply via Resend. Defined here as a variable so
+// support.go's handlers_support_approval.go and Phase 1D's body in
+// support_drafts.go can be wired without circular package init order.
+// Phase 1D rebinds this to the real implementation.
+//
+// Default no-op returns an explicit error so a Send click before
+// Phase 1D is wired up surfaces clearly in logs rather than silently
+// succeeding without an email.
+var sendApprovedReply = func(ctx context.Context, draft *SupportDraft, body string) error {
+	_ = ctx
+	_ = draft
+	_ = body
+	return fmt.Errorf("sendApprovedReply not wired (Phase 1D not yet applied)")
+}

--- a/api/core/handlers_support_public.go
+++ b/api/core/handlers_support_public.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
 	"strings"
 	"time"
 
@@ -118,46 +117,54 @@ func HandleSubmitPublicSupportTicket(c *fiber.Ctx) error {
 		}
 	}
 
-	// Resolve topic ID — reuse the per-category overrides the
-	// authenticated handler honors, so anonymous tickets land in the
-	// same OS Ticket queues as their authenticated equivalents.
-	topicID := os.Getenv("OSTICKET_TOPIC_ID")
-	switch req.Category {
-	case "feature":
-		if id := os.Getenv("OSTICKET_TOPIC_ID_FEATURE"); id != "" {
-			topicID = id
-		}
-	case "feedback":
-		if id := os.Getenv("OSTICKET_TOPIC_ID_FEEDBACK"); id != "" {
-			topicID = id
-		}
-	case "billing":
-		if id := os.Getenv("OSTICKET_TOPIC_ID_BILLING"); id != "" {
-			topicID = id
-		}
-	}
-
-	// Build OS Ticket payload. Match the same Message format the
-	// authenticated handler uses (data: URL with HTML body) so OS
-	// Ticket renders both submission types consistently.
-	bodyHTML := fmt.Sprintf(
+	// Run AI triage BEFORE building the final OS Ticket payload so
+	// high-confidence categorization can override the user's pick.
+	subjectFull := fmt.Sprintf("[%s] %s", categoryLabel, req.Subject)
+	originalBody := fmt.Sprintf(
 		"<h3>%s</h3><p>%s</p><hr/><p><em>Submitted anonymously from the marketing site (IP %s).</em></p>",
 		escapeHTML(categoryLabel),
 		escapeHTML(req.Message),
 		escapeHTML(redactIP(ip)),
 	)
 
+	recentSummaries := FetchRecentTicketSummaries(c.Context())
+	triage := triageTicket(c.Context(), TriageInput{
+		UserCategory:    req.Category,
+		UserEmail:       req.Email,
+		UserName:        fallbackName(req.Name, req.Email),
+		Subject:         subjectFull,
+		Body:            req.Message,
+		RecentSummaries: recentSummaries,
+	})
+
+	effectiveCategory := req.Category
+	if triage != nil && strings.EqualFold(triage.Confidence, "high") && triage.Category != "" {
+		effectiveCategory = triage.Category
+	}
+	topicID := resolveOSTicketTopicID(effectiveCategory)
+
+	// Build OS Ticket payload. Match the same Message format the
+	// authenticated handler uses (data: URL with HTML body) so OS
+	// Ticket renders both submission types consistently.
+	finalBody := applyTriageToBody(originalBody, triage)
+
 	payload := OSTicketPayload{
 		Name:    fallbackName(req.Name, req.Email),
 		Email:   req.Email,
-		Subject: fmt.Sprintf("[%s] %s", categoryLabel, req.Subject),
-		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", bodyHTML),
+		Subject: subjectFull,
+		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", finalBody),
 	}
 	if topicID != "" {
 		payload.TopicID = topicID
 	}
+	if triage != nil {
+		if pid := mapTriagePriorityToOSTicket(triage.Priority); pid != "" {
+			payload.PriorityID = pid
+		}
+	}
 
-	if err := forwardToOSTicket(c.Context(), payload); err != nil {
+	ticketNumber, err := forwardToOSTicket(c.Context(), payload)
+	if err != nil {
 		log.Printf("[PublicSupport] forwardToOSTicket failed for ip=%s email=%s: %v",
 			redactIP(ip), redactEmail(req.Email), err)
 		return c.Status(fiber.StatusBadGateway).JSON(ErrorResponse{
@@ -166,8 +173,12 @@ func HandleSubmitPublicSupportTicket(c *fiber.Ctx) error {
 		})
 	}
 
-	log.Printf("[PublicSupport] Ticket created from ip=%s email=%s category=%s",
-		redactIP(ip), redactEmail(req.Email), req.Category)
+	log.Printf("[PublicSupport] Ticket created from ip=%s email=%s category=%s osTicket=%s",
+		redactIP(ip), redactEmail(req.Email), req.Category, ticketNumber)
+
+	if triage != nil && ticketNumber != "" {
+		persistTriageSideEffects(ticketNumber, req.Email, fallbackName(req.Name, req.Email), subjectFull, originalBody, triage)
+	}
 
 	return c.JSON(fiber.Map{
 		"status":  "ok",

--- a/api/core/redis.go
+++ b/api/core/redis.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"os"
 
@@ -157,4 +158,53 @@ func RemoveSubscriberMulti(ctx context.Context, setKeys []string, userSub string
 	}
 	_, err := pipe.Exec(ctx)
 	return err
+}
+
+// --- AI Triage: Recent Ticket Summaries ---
+// Sliding window of the last N ticket summaries, used as context when
+// asking Claude to dupe-detect against recent submissions. Keyed by a
+// single global list; entries are LPUSHed and trimmed to the cap.
+
+const (
+	RedisRecentTicketsKey   = "support:recent_tickets"
+	RedisRecentTicketsLimit = 50
+)
+
+// PushRecentTicketSummary adds a summary to the head of the sliding
+// window. Atomic — uses LPUSH+LTRIM in a pipeline.
+func PushRecentTicketSummary(ctx context.Context, summary RecentTicketSummary) {
+	if Rdb == nil {
+		return
+	}
+	bytes, err := json.Marshal(summary)
+	if err != nil {
+		log.Printf("[Redis] marshal recent ticket: %v", err)
+		return
+	}
+	pipe := Rdb.Pipeline()
+	pipe.LPush(ctx, RedisRecentTicketsKey, string(bytes))
+	pipe.LTrim(ctx, RedisRecentTicketsKey, 0, int64(RedisRecentTicketsLimit-1))
+	if _, err := pipe.Exec(ctx); err != nil {
+		log.Printf("[Redis] push recent ticket: %v", err)
+	}
+}
+
+// FetchRecentTicketSummaries returns the last N summaries (most recent first).
+func FetchRecentTicketSummaries(ctx context.Context) []RecentTicketSummary {
+	if Rdb == nil {
+		return nil
+	}
+	rawList, err := Rdb.LRange(ctx, RedisRecentTicketsKey, 0, int64(RedisRecentTicketsLimit-1)).Result()
+	if err != nil {
+		log.Printf("[Redis] fetch recent tickets: %v", err)
+		return nil
+	}
+	out := make([]RecentTicketSummary, 0, len(rawList))
+	for _, s := range rawList {
+		var sum RecentTicketSummary
+		if err := json.Unmarshal([]byte(s), &sum); err == nil {
+			out = append(out, sum)
+		}
+	}
+	return out
 }

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -165,6 +165,7 @@ func (s *Server) setupRoutes() {
 	s.App.Get("/events/count", GetActiveViewers)
 	s.App.Post("/webhooks/sequin", HandleSequinWebhook)
 	s.App.Post("/webhooks/stripe", HandleStripeWebhook)
+	s.App.Post("/webhooks/resend", HandleResendWebhook)
 
 	// Extension auth proxy
 	s.App.Options("/extension/token", HandleExtensionAuthPreflight)

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -187,6 +187,13 @@ func (s *Server) setupRoutes() {
 	// hourly Redis counter inside the handler both protect this route.
 	s.App.Post("/support/ticket/public", HandleSubmitPublicSupportTicket)
 
+	// Partner-approval URLs for AI-drafted replies. No auth — these are
+	// HMAC-signed single-use tokens that the partner clicks from email.
+	s.App.Get("/support/send", HandleSupportSend)
+	s.App.Get("/support/edit", HandleSupportEdit)
+	s.App.Get("/support/skip", HandleSupportSkip)
+	s.App.Post("/support/edit/submit", HandleSupportEditSubmit)
+
 	// Invite (no auth — user isn't logged in yet, token-verified server-side)
 	s.App.Post("/invite/complete", HandleCompleteInvite)
 	s.App.Get("/invite/username-available", HandleCheckUsernameAvailable)

--- a/api/core/support.go
+++ b/api/core/support.go
@@ -51,6 +51,7 @@ type OSTicketPayload struct {
 	Subject     string                    `json:"subject"`
 	Message     string                    `json:"message"`
 	TopicID     string                    `json:"topicId,omitempty"`
+	PriorityID  string                    `json:"priorityId,omitempty"`
 	Attachments []osTicketAttachmentEntry `json:"attachments,omitempty"`
 }
 
@@ -233,9 +234,109 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 		}
 	}
 
-	// Resolve topic ID (per-category env vars override the default)
+	// Run AI triage BEFORE building the final OS Ticket payload so
+	// high-confidence categorization can override the user's pick (and
+	// thus route to a different osTicket topic). Triage is best-effort:
+	// nil result falls through to the legacy flow.
+	originalBody := body.String()
+	recentSummaries := FetchRecentTicketSummaries(c.Context())
+	triage := triageTicket(c.Context(), TriageInput{
+		UserCategory:    req.Category,
+		UserEmail:       email,
+		UserName:        name,
+		Subject:         subject,
+		Body:            originalBody,
+		RecentSummaries: recentSummaries,
+		Channel:         req.Channel,
+	})
+
+	// Resolve effective category — use AI's pick only on high confidence.
+	effectiveCategory := req.Category
+	if triage != nil && strings.EqualFold(triage.Confidence, "high") && triage.Category != "" {
+		effectiveCategory = triage.Category
+	}
+
+	topicID := resolveOSTicketTopicID(effectiveCategory)
+
+	// Augment body with triage summary / dupe hint / suggested reply
+	finalBody := applyTriageToBody(originalBody, triage)
+
+	// Build OS Ticket payload
+	payload := OSTicketPayload{
+		Name:    name,
+		Email:   email,
+		Subject: subject,
+		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", finalBody),
+	}
+
+	if topicID != "" {
+		payload.TopicID = topicID
+	}
+	if triage != nil {
+		if pid := mapTriagePriorityToOSTicket(triage.Priority); pid != "" {
+			payload.PriorityID = pid
+		}
+	}
+
+	// Forward attachments
+	for _, att := range req.Attachments {
+		payload.Attachments = append(payload.Attachments, osTicketAttachmentEntry{
+			Filename: att.Filename,
+			MimeType: att.MimeType,
+			Data:     att.Data,
+		})
+	}
+
+	ticketNumber, err := forwardToOSTicket(c.Context(), payload)
+	if err != nil {
+		// Distinguish "not configured" so we can keep the existing 500
+		// vs. upstream rejection (502).
+		if errors.Is(err, errOSTicketNotConfigured) {
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "Support ticket system is not configured",
+			})
+		}
+		if errors.Is(err, errOSTicketMarshal) {
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "Failed to prepare ticket",
+			})
+		}
+		return c.Status(fiber.StatusBadGateway).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Failed to submit bug report — support system rejected all API keys",
+		})
+	}
+
+	log.Printf("[Support] Ticket created for user %s (osTicket=%s)", userID, ticketNumber)
+	// Only record the submission AFTER OS Ticket confirms. If the
+	// request fails upstream the user isn't trapped in a cooldown
+	// they didn't earn — see allowedBySupportRateLimit.
+	recordSupportSubmission(userID)
+
+	// Side effects after successful ticket creation: persist the AI
+	// draft for partner approval, push to the recent-tickets sliding
+	// window, and notify the partner. All best-effort — failures here
+	// must not surface to the user, who has already gotten their
+	// success response logically.
+	if triage != nil && ticketNumber != "" {
+		persistTriageSideEffects(ticketNumber, email, name, subject, originalBody, triage)
+	}
+
+	return c.JSON(fiber.Map{
+		"status":  "ok",
+		"message": "Bug report submitted successfully",
+	})
+}
+
+// resolveOSTicketTopicID maps a category string to its osTicket topic
+// ID, honoring per-category env var overrides. Default falls back to
+// OSTICKET_TOPIC_ID. Extracted as a helper so both authenticated and
+// public handlers (and the AI override path) use one source of truth.
+func resolveOSTicketTopicID(category string) string {
 	topicID := os.Getenv("OSTICKET_TOPIC_ID")
-	switch req.Category {
+	switch category {
 	case "feature":
 		if id := os.Getenv("OSTICKET_TOPIC_ID_FEATURE"); id != "" {
 			topicID = id
@@ -257,58 +358,53 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 			topicID = id
 		}
 	}
+	return topicID
+}
 
-	// Build OS Ticket payload
-	payload := OSTicketPayload{
-		Name:    name,
-		Email:   email,
-		Subject: subject,
-		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", body.String()),
-	}
+// persistTriageSideEffects fans out the post-submit AI bookkeeping:
+// persists the draft, pushes a recent-summary entry to the sliding
+// window, and (in Phase 1D) fires the partner notification email.
+// Each step is logged on failure but never surfaced to the user.
+//
+// Runs in a background goroutine so it doesn't block the user's
+// response — the user has already had their ticket accepted by
+// osTicket at this point.
+func persistTriageSideEffects(ticketNumber, userEmail, userName, subject, originalBody string, triage *TriageResult) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
-	if topicID != "" {
-		payload.TopicID = topicID
-	}
-
-	// Forward attachments
-	for _, att := range req.Attachments {
-		payload.Attachments = append(payload.Attachments, osTicketAttachmentEntry{
-			Filename: att.Filename,
-			MimeType: att.MimeType,
-			Data:     att.Data,
+		// Save the draft (even if we don't end up notifying — useful for audit).
+		draft, err := createSupportDraft(ctx, &SupportDraft{
+			TicketNumber:    ticketNumber,
+			UserEmail:       userEmail,
+			UserName:        userName,
+			OriginalSubject: subject,
+			DraftBodyHTML:   triage.DraftReplyHTML,
+			AISummary:       triage.Summary,
+			AICategory:      triage.Category,
+			AIPriority:      triage.Priority,
+			AIChannel:       triage.Channel,
+			AIDuplicateOf:   triage.DuplicateOf,
+			AIConfidence:    triage.Confidence,
 		})
-	}
+		if err != nil {
+			log.Printf("[Support] createSupportDraft failed for ticket %s: %v", ticketNumber, err)
+		}
 
-	if err := forwardToOSTicket(c.Context(), payload); err != nil {
-		// Distinguish "not configured" so we can keep the existing 500
-		// vs. upstream rejection (502).
-		if errors.Is(err, errOSTicketNotConfigured) {
-			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
-				Status: "error",
-				Error:  "Support ticket system is not configured",
-			})
-		}
-		if errors.Is(err, errOSTicketMarshal) {
-			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
-				Status: "error",
-				Error:  "Failed to prepare ticket",
-			})
-		}
-		return c.Status(fiber.StatusBadGateway).JSON(ErrorResponse{
-			Status: "error",
-			Error:  "Failed to submit bug report — support system rejected all API keys",
+		// Recent-tickets sliding window for dupe detection on subsequent submissions.
+		PushRecentTicketSummary(ctx, RecentTicketSummary{
+			TicketNumber: ticketNumber,
+			Category:     triage.Category,
+			Summary:      triage.Summary,
+			CreatedAt:    time.Now().UTC().Format(time.RFC3339),
 		})
-	}
 
-	log.Printf("[Support] Ticket created for user %s", userID)
-	// Only record the submission AFTER OS Ticket confirms. If the
-	// request fails upstream the user isn't trapped in a cooldown
-	// they didn't earn — see allowedBySupportRateLimit.
-	recordSupportSubmission(userID)
-	return c.JSON(fiber.Map{
-		"status":  "ok",
-		"message": "Bug report submitted successfully",
-	})
+		// Partner notification — wired in Phase 1D once SendPartnerNotification exists.
+		if draft != nil {
+			notifyPartnerAfterDraft(ctx, draft)
+		}
+	}()
 }
 
 // ===== OS Ticket forwarding helper =====
@@ -338,12 +434,20 @@ var (
 // comma-separated API key in OSTICKET_API_KEY in order. OS Ticket ties
 // keys to source IPs and pods can land on different nodes, so a 401 on
 // one key just means try the next; any other non-2xx aborts the loop.
-func forwardToOSTicket(ctx context.Context, payload OSTicketPayload) error {
+//
+// Returns the ticket number on success along with nil error. osTicket's
+// REST API returns the bare ticket number as the response body on a
+// 201 Created (it is a plain string, not JSON, in default installs).
+// We trim whitespace and surrounding quotes defensively to tolerate
+// either form. Empty string + nil error is acceptable when osTicket
+// answers 201 with no body — caller treats missing ticket numbers as
+// non-fatal (no draft will be created, but the ticket itself succeeded).
+func forwardToOSTicket(ctx context.Context, payload OSTicketPayload) (string, error) {
 	osTicketURL := os.Getenv("OSTICKET_URL")
 	apiKeysRaw := os.Getenv("OSTICKET_API_KEY")
 	if osTicketURL == "" || apiKeysRaw == "" {
 		log.Println("[Support] OSTICKET_URL or OSTICKET_API_KEY not configured")
-		return errOSTicketNotConfigured
+		return "", errOSTicketNotConfigured
 	}
 
 	ticketURL := strings.TrimSuffix(osTicketURL, "/") + "/api/tickets.json"
@@ -351,7 +455,7 @@ func forwardToOSTicket(ctx context.Context, payload OSTicketPayload) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		log.Printf("[Support] Failed to marshal OS Ticket payload: %v", err)
-		return fmt.Errorf("%w: %v", errOSTicketMarshal, err)
+		return "", fmt.Errorf("%w: %v", errOSTicketMarshal, err)
 	}
 
 	apiKeys := strings.Split(apiKeysRaw, ",")
@@ -385,7 +489,7 @@ func forwardToOSTicket(ctx context.Context, payload OSTicketPayload) error {
 		lastBody = string(respBody)
 
 		if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
-			return nil
+			return parseOSTicketNumber(respBody), nil
 		}
 
 		// 401 (wrong IP for this key) — try next key.
@@ -400,7 +504,50 @@ func forwardToOSTicket(ctx context.Context, payload OSTicketPayload) error {
 	}
 
 	log.Printf("[Support] All API keys failed. Last status: %d, body: %s", lastStatus, lastBody)
-	return fmt.Errorf("%w: last status %d", errOSTicketAllKeysFailed, lastStatus)
+	return "", fmt.Errorf("%w: last status %d", errOSTicketAllKeysFailed, lastStatus)
+}
+
+// parseOSTicketNumber returns the ticket number from a successful
+// osTicket create response. Default osTicket installs return the bare
+// number as plain text; some versions / themes wrap it in JSON like
+// `{"id":1247}` or `{"number":"TKT-1247"}`. We try plain first, fall
+// back to JSON parsing on failure. Returns "" if neither yields a
+// usable value — caller is expected to treat that as non-fatal.
+func parseOSTicketNumber(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	s = strings.Trim(s, "\"")
+	if s == "" {
+		return ""
+	}
+	// If it parses as a JSON object, extract id/number/ticket_number.
+	if strings.HasPrefix(s, "{") {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(s), &obj); err == nil {
+			for _, k := range []string{"number", "ticket_number", "id"} {
+				if v, ok := obj[k]; ok {
+					switch t := v.(type) {
+					case string:
+						return strings.TrimSpace(t)
+					case float64:
+						return fmt.Sprintf("%d", int64(t))
+					}
+				}
+			}
+		}
+		return ""
+	}
+	return s
+}
+
+// notifyPartnerAfterDraft is the seam wired up in Phase 1D once
+// SendPartnerNotification exists. Defined here as an indirection so
+// support.go can compile through the phase boundary without referencing
+// a function that doesn't exist yet. Phase 1D replaces the body to
+// call SendPartnerNotification.
+var notifyPartnerAfterDraft = func(ctx context.Context, draft *SupportDraft) {
+	// no-op until Phase 1D wires in the email send
+	_ = ctx
+	_ = draft
 }
 
 // escapeHTML replaces < > & " with HTML entities.

--- a/api/core/support_drafts.go
+++ b/api/core/support_drafts.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // =============================================================================
@@ -76,4 +79,131 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 	}
 	draft.Status = "pending"
 	return draft, nil
+}
+
+// loadSupportDraft fetches a draft by primary key. Returns (nil, nil)
+// when the row doesn't exist so callers can distinguish "missing" from
+// "DB error".
+func loadSupportDraft(ctx context.Context, id int64) (*SupportDraft, error) {
+	const q = `
+		SELECT id, ticket_number, user_email, user_name, original_subject,
+			   draft_body_html, ai_summary, ai_category, ai_priority,
+			   ai_channel, ai_duplicate_of, ai_confidence, status,
+			   edited_body_html, decided_at, sent_at, created_at
+		FROM support_drafts WHERE id = $1
+	`
+	var d SupportDraft
+	var userName, summary, category, priority, channel, dupOf, confidence, editedBody *string
+	err := DBPool.QueryRow(ctx, q, id).Scan(
+		&d.ID, &d.TicketNumber, &d.UserEmail, &userName, &d.OriginalSubject,
+		&d.DraftBodyHTML, &summary, &category, &priority, &channel,
+		&dupOf, &confidence, &d.Status,
+		&editedBody, &d.DecidedAt, &d.SentAt, &d.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loadSupportDraft: %w", err)
+	}
+	if userName != nil {
+		d.UserName = *userName
+	}
+	if summary != nil {
+		d.AISummary = *summary
+	}
+	if category != nil {
+		d.AICategory = *category
+	}
+	if priority != nil {
+		d.AIPriority = *priority
+	}
+	if channel != nil {
+		d.AIChannel = *channel
+	}
+	if dupOf != nil {
+		d.AIDuplicateOf = *dupOf
+	}
+	if confidence != nil {
+		d.AIConfidence = *confidence
+	}
+	if editedBody != nil {
+		d.EditedBodyHTML = *editedBody
+	}
+	return &d, nil
+}
+
+// markDraftDecided atomically transitions a pending draft to the new
+// status if and only if it's still pending. This is the single-use
+// gate enforced for partner approval URLs — once a draft has been
+// actioned, all subsequent token redemptions return ErrAlreadyDecided.
+//
+// editedBody is persisted only when newStatus is 'edited'; pass an
+// empty string for other transitions. Empty editedBody is stored as
+// NULL via NULLIF($3,”).
+func markDraftDecided(ctx context.Context, id int64, newStatus string, editedBody string) error {
+	const q = `
+		UPDATE support_drafts
+		SET status = $2, edited_body_html = NULLIF($3,''), decided_at = NOW()
+		WHERE id = $1 AND status = 'pending'
+	`
+	tag, err := DBPool.Exec(ctx, q, id, newStatus, editedBody)
+	if err != nil {
+		return fmt.Errorf("markDraftDecided: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrAlreadyDecided
+	}
+	return nil
+}
+
+// markDraftSent records that the outbound reply email actually left
+// our gateway. Best-effort — failures here only affect the audit
+// trail, not user-visible behavior.
+func markDraftSent(ctx context.Context, id int64) {
+	if _, err := DBPool.Exec(ctx, `UPDATE support_drafts SET status='sent', sent_at=NOW() WHERE id=$1`, id); err != nil {
+		log.Printf("[Drafts] markDraftSent for %d failed: %v", id, err)
+	}
+}
+
+// markDraftFailed records that the Send path tried to send the reply
+// and got a hard error from Resend. The partner may need to retry
+// manually inside osTicket.
+func markDraftFailed(ctx context.Context, id int64) {
+	if _, err := DBPool.Exec(ctx, `UPDATE support_drafts SET status='failed' WHERE id=$1`, id); err != nil {
+		log.Printf("[Drafts] markDraftFailed for %d failed: %v", id, err)
+	}
+}
+
+// recordOSTicketMessageID stores a Message-ID we captured from a
+// Resend webhook event so we can later set In-Reply-To when sending
+// our AI reply. Idempotent via the UNIQUE(message_id) index.
+func recordOSTicketMessageID(ctx context.Context, ticketNumber, messageID, recipient, direction string) error {
+	const q = `
+		INSERT INTO osticket_message_ids (ticket_number, message_id, recipient_email, direction)
+		VALUES ($1,$2,$3,$4)
+		ON CONFLICT (message_id) DO NOTHING
+	`
+	_, err := DBPool.Exec(ctx, q, ticketNumber, messageID, recipient, direction)
+	return err
+}
+
+// fetchOSTicketMessageIDForReply returns the Message-ID of the most
+// recent osTicket-originated email for this ticket. Used when sending
+// our AI reply to set In-Reply-To correctly. Returns "" if none
+// (which is fine — the reply will still send, just without threading).
+func fetchOSTicketMessageIDForReply(ctx context.Context, ticketNumber string) string {
+	const q = `
+		SELECT message_id FROM osticket_message_ids
+		WHERE ticket_number = $1 AND direction = 'outbound_osticket'
+		ORDER BY captured_at DESC LIMIT 1
+	`
+	var id string
+	if err := DBPool.QueryRow(ctx, q, ticketNumber).Scan(&id); err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			log.Printf("[Drafts] fetchOSTicketMessageIDForReply: %v", err)
+		}
+		return ""
+	}
+	return id
 }

--- a/api/core/support_drafts.go
+++ b/api/core/support_drafts.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// =============================================================================
+// Support drafts — DB-backed state for the L2 (partner-approval) flow
+// =============================================================================
+//
+// Each incoming support ticket spawns a `support_drafts` row holding the
+// AI-generated draft reply plus its triage metadata. The partner's
+// approval URL handlers (handlers_support_approval.go) load this row,
+// transition its status, and — on Send — kick off the outbound email
+// via Resend (sendApprovedReply, defined below in Phase 1D).
+
+// SupportDraft mirrors the support_drafts table.
+type SupportDraft struct {
+	ID              int64
+	TicketNumber    string
+	UserEmail       string
+	UserName        string
+	OriginalSubject string
+	DraftBodyHTML   string
+	AISummary       string
+	AICategory      string
+	AIPriority      string
+	AIChannel       string
+	AIDuplicateOf   string
+	AIConfidence    string
+	Status          string
+	EditedBodyHTML  string
+	DecidedAt       *time.Time
+	SentAt          *time.Time
+	CreatedAt       time.Time
+}
+
+// ErrAlreadyDecided indicates a draft was already actioned (single-use enforcement).
+var ErrAlreadyDecided = errors.New("draft already decided")
+
+// createSupportDraft persists a new pending draft. The caller hands us
+// a fully-populated SupportDraft (other than ID/CreatedAt/Status) and
+// receives the row back with those fields filled in. Status is always
+// 'pending' on create; the partner-approval handlers transition it.
+func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft, error) {
+	if DBPool == nil {
+		return nil, fmt.Errorf("DB not initialized")
+	}
+
+	const q = `
+		INSERT INTO support_drafts
+			(ticket_number, user_email, user_name, original_subject,
+			 draft_body_html, ai_summary, ai_category, ai_priority,
+			 ai_channel, ai_duplicate_of, ai_confidence, status)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'pending')
+		RETURNING id, created_at
+	`
+	err := DBPool.QueryRow(ctx, q,
+		draft.TicketNumber,
+		draft.UserEmail,
+		draft.UserName,
+		draft.OriginalSubject,
+		draft.DraftBodyHTML,
+		draft.AISummary,
+		draft.AICategory,
+		draft.AIPriority,
+		draft.AIChannel,
+		draft.AIDuplicateOf,
+		draft.AIConfidence,
+	).Scan(&draft.ID, &draft.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("createSupportDraft: %w", err)
+	}
+	draft.Status = "pending"
+	return draft, nil
+}

--- a/api/core/support_drafts.go
+++ b/api/core/support_drafts.go
@@ -1,10 +1,17 @@
 package core
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
+	"io"
 	"log"
+	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -206,4 +213,199 @@ func fetchOSTicketMessageIDForReply(ctx context.Context, ticketNumber string) st
 		return ""
 	}
 	return id
+}
+
+// =============================================================================
+// Outbound replies + partner notifications via Resend
+// =============================================================================
+
+// doSendApprovedReply sends the partner-approved reply email via
+// Resend with proper In-Reply-To and References headers so osTicket
+// can thread it back into the original ticket. Also BCCs the support@
+// address so osTicket has its own copy of the agent reply via inbound
+// piping.
+//
+// We don't surface threading-failure as a hard error: if no
+// osTicket-side Message-ID has been captured yet, the reply still
+// goes out — the user just sees a fresh thread. Threading is
+// best-effort and depends on the Resend webhook having fired before
+// the partner clicks Send.
+func doSendApprovedReply(ctx context.Context, draft *SupportDraft, body string) error {
+	resendKey := os.Getenv("RESEND_API_KEY")
+	if resendKey == "" {
+		return fmt.Errorf("RESEND_API_KEY not set")
+	}
+	from := os.Getenv("SUPPORT_REPLY_FROM_EMAIL")
+	if from == "" {
+		from = "support@myscrollr.com"
+	}
+	bcc := os.Getenv("OSTICKET_BCC_EMAIL")
+	if bcc == "" {
+		bcc = "support@myscrollr.com"
+	}
+
+	osticketMsgID := fetchOSTicketMessageIDForReply(ctx, draft.TicketNumber)
+
+	var headers []map[string]string
+	if osticketMsgID != "" {
+		// Email standard requires Message-IDs to be wrapped in <>
+		wrappedID := osticketMsgID
+		if !strings.HasPrefix(wrappedID, "<") {
+			wrappedID = "<" + wrappedID + ">"
+		}
+		headers = append(headers,
+			map[string]string{"name": "In-Reply-To", "value": wrappedID},
+			map[string]string{"name": "References", "value": wrappedID},
+		)
+	}
+
+	subject := "Re: [#" + draft.TicketNumber + "] " + draft.OriginalSubject
+
+	payload := map[string]interface{}{
+		"from":    from,
+		"to":      []string{draft.UserEmail},
+		"bcc":     []string{bcc},
+		"subject": subject,
+		"html":    body,
+	}
+	if len(headers) > 0 {
+		payload["headers"] = headers
+	}
+
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.resend.com/emails", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+resendKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(respBytes))
+	}
+
+	log.Printf("[Drafts] reply sent for ticket=%s to=%s in-reply-to-set=%v",
+		draft.TicketNumber, draft.UserEmail, osticketMsgID != "")
+	return nil
+}
+
+// SendPartnerNotification emails the support agent (partner) with the
+// AI-drafted reply and three approval links. Sent via Resend.
+//
+// If SUPPORT_AGENT_EMAIL isn't configured, returns nil — the draft is
+// still persisted, the partner just won't get a notification email
+// for this round.
+func SendPartnerNotification(ctx context.Context, draft *SupportDraft) error {
+	agentEmail := os.Getenv("SUPPORT_AGENT_EMAIL")
+	if agentEmail == "" {
+		log.Println("[Drafts] SUPPORT_AGENT_EMAIL not set; skipping partner notification")
+		return nil
+	}
+
+	sendURL, editURL, skipURL, err := buildApprovalURLs(draft.ID)
+	if err != nil {
+		return fmt.Errorf("build approval URLs: %w", err)
+	}
+
+	// Local var name `htmlBody` to avoid shadowing the imported `html` package.
+	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,sans-serif;background:#f5f5f5;padding:24px;">
+<div style="max-width:600px;margin:0 auto;background:white;border-radius:8px;overflow:hidden;border:1px solid #e5e5e5;">
+<div style="padding:20px 24px;border-bottom:1px solid #e5e5e5;">
+  <h1 style="margin:0 0 4px;font-size:18px;color:#10b981;">New ticket — draft ready</h1>
+  <p style="margin:0;font-size:12px;color:#888;">Ticket #%s · From %s</p>
+</div>
+<div style="padding:20px 24px;">
+  <p style="margin:0 0 8px;font-size:14px;color:#333;"><strong>AI summary:</strong> %s</p>
+  <p style="margin:0 0 16px;font-size:11px;color:#666;">Category: %s · Priority: %s · Confidence: %s</p>
+  <div style="background:#f9f9f9;padding:12px;border-radius:6px;font-size:13px;color:#333;border-left:3px solid #10b981;">
+    %s
+  </div>
+</div>
+<div style="padding:20px 24px;border-top:1px solid #e5e5e5;">
+  <table cellpadding="0" cellspacing="0" border="0" style="width:100%%;">
+    <tr>
+      <td><a href="%s" style="display:inline-block;background:#10b981;color:white;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">Send</a></td>
+      <td><a href="%s" style="display:inline-block;background:#3b82f6;color:white;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">Edit</a></td>
+      <td align="right"><a href="%s" style="display:inline-block;background:#6b7280;color:white;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">Skip</a></td>
+    </tr>
+  </table>
+</div>
+<div style="padding:12px 24px;border-top:1px solid #e5e5e5;background:#fafafa;font-size:11px;color:#999;">
+  <p style="margin:0;">Subject: %s</p>
+  <p style="margin:0;">Links expire in 24h. Single-use.</p>
+</div>
+</div>
+</body></html>`,
+		html.EscapeString(draft.TicketNumber),
+		html.EscapeString(draft.UserEmail),
+		html.EscapeString(draft.AISummary),
+		html.EscapeString(draft.AICategory),
+		html.EscapeString(draft.AIPriority),
+		html.EscapeString(draft.AIConfidence),
+		draft.DraftBodyHTML, // already HTML, don't double-escape
+		sendURL, editURL, skipURL,
+		html.EscapeString(draft.OriginalSubject),
+	)
+
+	resendKey := os.Getenv("RESEND_API_KEY")
+	if resendKey == "" {
+		return fmt.Errorf("RESEND_API_KEY not set")
+	}
+	from := os.Getenv("RESEND_FROM_EMAIL")
+	if from == "" {
+		from = "noreply@myscrollr.com"
+	}
+
+	payload := map[string]interface{}{
+		"from":    from,
+		"to":      []string{agentEmail},
+		"subject": fmt.Sprintf("[#%s] Draft ready: %s", draft.TicketNumber, draft.AISummary),
+		"html":    htmlBody,
+	}
+	bodyBytes, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.resend.com/emails", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("build resend req: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+resendKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend send: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// init wires the Phase-1A/1C indirection seams to the real
+// implementations in this file. Keeping the bind here lets each phase
+// compile independently while still ending up with a single working
+// flow at deploy time.
+func init() {
+	sendApprovedReply = doSendApprovedReply
+	notifyPartnerAfterDraft = func(ctx context.Context, draft *SupportDraft) {
+		if err := SendPartnerNotification(ctx, draft); err != nil {
+			log.Printf("[Drafts] SendPartnerNotification for ticket %s failed: %v", draft.TicketNumber, err)
+		}
+	}
 }

--- a/api/migrations/000007_support_drafts.down.sql
+++ b/api/migrations/000007_support_drafts.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS osticket_message_ids;
+DROP TABLE IF EXISTS support_drafts;

--- a/api/migrations/000007_support_drafts.up.sql
+++ b/api/migrations/000007_support_drafts.up.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS support_drafts (
+  id BIGSERIAL PRIMARY KEY,
+  ticket_number TEXT NOT NULL,
+  user_email TEXT NOT NULL,
+  user_name TEXT,
+  original_subject TEXT NOT NULL,
+  draft_body_html TEXT NOT NULL,
+  ai_summary TEXT,
+  ai_category TEXT,
+  ai_priority TEXT,
+  ai_channel TEXT,
+  ai_duplicate_of TEXT,
+  ai_confidence TEXT,
+  status TEXT NOT NULL CHECK (status IN ('pending','approved','edited','skipped','sent','failed')),
+  edited_body_html TEXT,
+  decided_at TIMESTAMPTZ,
+  sent_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_support_drafts_status ON support_drafts(status);
+CREATE INDEX IF NOT EXISTS idx_support_drafts_ticket ON support_drafts(ticket_number);
+
+CREATE TABLE IF NOT EXISTS osticket_message_ids (
+  id BIGSERIAL PRIMARY KEY,
+  ticket_number TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  recipient_email TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('outbound_osticket','outbound_ai','inbound_user')),
+  captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(message_id)
+);
+CREATE INDEX IF NOT EXISTS idx_osticket_msgids_ticket ON osticket_message_ids(ticket_number);

--- a/docs/superpowers/specs/2026-04-29-ai-support-triage-design.md
+++ b/docs/superpowers/specs/2026-04-29-ai-support-triage-design.md
@@ -1,0 +1,208 @@
+# AI Support Triage — L2 Approval Flow
+
+**Date:** 2026-04-29
+**Status:** Approved, executing
+**Goal:** AI auto-categorizes, summarizes, dupe-detects, and drafts replies for incoming support tickets. Partner approves via one-click email links. Replies thread back into osTicket via standard email threading.
+
+## Decisions locked
+
+| Decision | Choice |
+|---|---|
+| Automation level | L2 — AI drafts every reply, partner approves via email Send/Edit/Skip |
+| AI model | Claude Haiku (cheap + fast; ~$0.001 per ticket) |
+| Approval surface | Email (no Slack, no custom UI) |
+| Override behavior | High-confidence AI categorization overrides user's pick; low-confidence keeps user's pick |
+| AI tone | Warm, direct, low on corporate-speak (matches Scrollr invite-email voice) |
+| Threading method | `In-Reply-To` + `References` headers (Path A) |
+| Message-ID capture | Resend webhook on outbound `email.sent` events |
+| osTicket inbound recognition | BCC to `support@myscrollr.com` with proper References chain |
+
+## Architecture
+
+### Flow on ticket creation
+
+1. User submits Contact Us → Scrollr API receives
+2. Scrollr API calls Claude Haiku with: ticket text, last 50 ticket summaries (Redis sliding window), and FAQ content
+3. Claude returns structured JSON: `{category, channel?, priority, summary, duplicate_of?, draft_reply, confidence}`
+4. Scrollr API applies triage to OSTicket payload:
+   - Override category if `confidence == "high"`
+   - Set priority field
+   - Prepend summary to body
+   - Append duplicate hint to body if applicable
+5. Scrollr API forwards to osTicket. osTicket creates ticket, returns ticket number.
+6. Scrollr API stores `support_drafts` row: `{ticket_number, user_email, original_subject, draft_body, status: 'pending'}`
+7. Scrollr API sends partner notification email via Resend with three JWT-signed URLs: Send / Edit / Skip
+8. osTicket sends auto-response to user via Resend → Resend webhook fires → Scrollr captures Message-ID, stores in `osticket_message_ids`
+
+### Flow on partner approval
+
+1. Partner clicks Send / Edit / Skip URL in their email
+2. Handler verifies JWT (signed, 24h TTL, single-use)
+3. **Send**: Backend looks up Message-ID for ticket, sends email FROM `support@myscrollr.com` TO user via Resend with:
+   - `In-Reply-To: <osticket-original-msg-id>`
+   - `References: <osticket-original-msg-id>`
+   - BCC to `support@myscrollr.com` so osTicket sees it via inbound piping → threads into ticket via `In-Reply-To`
+   - Body: AI draft (or partner's edited version)
+4. **Edit**: Returns small HTML page with draft pre-filled in textarea; partner edits, submits → falls into Send path with edited body
+5. **Skip**: Marks draft as skipped; no email sent. Ticket stays open in osTicket for partner to handle manually.
+
+### Flow on user reply
+
+1. User clicks Reply on the AI's email (or any subsequent email)
+2. Their email client sets:
+   - `In-Reply-To: <our-ai-reply-id>` (the most recent message they're replying to)
+   - `References: <osticket-original-id> <our-ai-reply-id>` (full chain)
+3. Email arrives at `support@myscrollr.com`
+4. osTicket sees References, walks the chain, finds the osTicket-known original Message-ID → threads correctly into the original ticket
+5. Triggers a new auto-response cycle if configured; loops back to AI triage if a new draft is needed
+
+## Components
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `api/core/ai_triage.go` | Anthropic API client + prompt + response parsing |
+| `api/core/handlers_resend_webhook.go` | Receives Resend `email.sent` webhook events; parses ticket # from subject; stores Message-ID |
+| `api/core/handlers_support_approval.go` | JWT-signed URL handlers: Send / Edit / Skip |
+| `api/core/support_drafts.go` | DB-backed draft state + Message-ID storage + outbound reply send via Resend |
+| `api/migrations/000007_support_drafts.up.sql` | New tables |
+| `api/migrations/000007_support_drafts.down.sql` | Rollback |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `api/core/support.go` | Hook AI triage into authenticated path; create draft after osTicket success; send partner notification |
+| `api/core/handlers_support_public.go` | Same hook for anonymous path |
+| `api/core/redis.go` | Sliding window helpers for recent ticket summaries |
+| `api/core/server.go` | Register `/webhooks/resend`, `/support/approve`, `/support/edit`, `/support/skip`, `/support/edit/submit` routes |
+| `k8s/configmap-core.yaml` | New env vars: `SUPPORT_AGENT_EMAIL`, `APPROVAL_BASE_URL`, `RESEND_WEBHOOK_SECRET`, `OSTICKET_BCC_EMAIL`, `AI_TRIAGE_ENABLED` |
+
+### Database schema
+
+```sql
+CREATE TABLE support_drafts (
+  id BIGSERIAL PRIMARY KEY,
+  ticket_number TEXT NOT NULL,
+  user_email TEXT NOT NULL,
+  user_name TEXT,
+  original_subject TEXT NOT NULL,
+  draft_body_html TEXT NOT NULL,
+  ai_summary TEXT,
+  ai_category TEXT,
+  ai_priority TEXT,
+  ai_channel TEXT,
+  ai_duplicate_of TEXT,
+  ai_confidence TEXT,
+  status TEXT NOT NULL CHECK (status IN ('pending','approved','edited','skipped','sent','failed')),
+  edited_body_html TEXT,
+  decided_at TIMESTAMPTZ,
+  sent_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_support_drafts_status ON support_drafts(status);
+CREATE INDEX idx_support_drafts_ticket ON support_drafts(ticket_number);
+
+CREATE TABLE osticket_message_ids (
+  id BIGSERIAL PRIMARY KEY,
+  ticket_number TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  recipient_email TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('outbound_osticket','outbound_ai','inbound_user')),
+  captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(message_id)
+);
+CREATE INDEX idx_osticket_msgids_ticket ON osticket_message_ids(ticket_number);
+```
+
+### Anthropic prompt structure (high-level)
+
+```
+SYSTEM: You are a support triage assistant for Scrollr (a desktop ticker app).
+Categorize incoming tickets and draft warm, direct replies grounded in our FAQ.
+
+TASK:
+1. Pick category: bug, feature, feedback, billing, account, channel
+2. Pick priority: low, normal, high, emergency  (use signals: "lost data" → high; "can't log in" → high; "feature request" → low; etc.)
+3. If category=channel, identify channel: finance, sports, rss, fantasy
+4. Generate a one-line summary (10 words max)
+5. Check for duplicates against the recent tickets list
+6. Draft a reply matching this voice:
+   - Warm, direct, lowercase first letter is ok
+   - Lead with acknowledgment, then action
+   - Reference FAQ if relevant; never make up fix steps
+   - 2-4 short paragraphs max
+   - Sign off "— the scrollr team"
+7. Output confidence: high (clear), medium (some ambiguity), low (need human)
+
+RECENT TICKETS:
+{json array of last 50 summaries with ticket #s}
+
+FAQ:
+{markdown of curated FAQ articles}
+
+USER TICKET:
+Email: {email}
+Category (user-picked): {category}
+Subject: {subject}
+Body: {body}
+
+OUTPUT exactly this JSON shape (no markdown fences):
+{
+  "category": "...",
+  "channel": "..." | null,
+  "priority": "...",
+  "summary": "...",
+  "duplicate_of": "ticket-number" | null,
+  "draft_reply_html": "<p>...</p>",
+  "confidence": "high" | "medium" | "low"
+}
+```
+
+## Approval URL design
+
+Each draft generates 3 signed URLs:
+
+```
+https://api.myscrollr.com/support/approve?token=<jwt>
+https://api.myscrollr.com/support/edit?token=<jwt>
+https://api.myscrollr.com/support/skip?token=<jwt>
+```
+
+JWT claims: `{draft_id, action, exp: now+24h, jti: unique}`. Backed by HMAC with a new secret `SUPPORT_APPROVAL_HMAC_SECRET`. Single-use enforced via `decided_at IS NULL` check.
+
+## Security model
+
+| Threat | Mitigation |
+|---|---|
+| Approval URL leaked via forwarded email | JWT 24h TTL + single-use enforcement |
+| Replay attack on approval URL | Single-use enforcement (checks `decided_at IS NULL`) |
+| Resend webhook spoofed | Verify Svix-style signature with `RESEND_WEBHOOK_SECRET` |
+| AI generates abusive/wrong reply | Partner approval gate (L2 default); confidence threshold for category override |
+| AI hallucinates fix steps | Prompt grounded in FAQ content; "if not in FAQ, escalate" instruction |
+| User's ticket text leaks to Anthropic | Documented in privacy policy update; attachments NOT sent |
+
+## Out of scope (deferred)
+
+- L3 auto-send (high-confidence direct send without partner approval) — can be added later by setting `auto_send_threshold` env var
+- Slack notifications instead of email — possible follow-up
+- AI assistance during partner reply composition — requires UI surface, not in this PR
+- Fine-tuning a model on Scrollr's tickets — not needed at current volume
+- Translation for non-English tickets — possible follow-up
+
+## Acceptance criteria
+
+- All Go modules: `go vet` clean, `go test` clean
+- Migration applies cleanly
+- New endpoints registered
+- Local dry-run: trigger a fake ticket via curl, see AI triage hit, see draft email arrive, click Send, verify outbound email composed correctly with In-Reply-To set
+- K8s deploy succeeds
+- Production smoke: real ticket → AI triage applied → partner notification arrives → click Send → user receives reply → osTicket threads correctly
+
+## Manual partner steps after merge
+
+1. Add Resend webhook endpoint pointing at `https://api.myscrollr.com/webhooks/resend` (in Resend dashboard → Webhooks). Subscribe to `email.sent` event. Capture signing secret.
+2. Add `RESEND_WEBHOOK_SECRET` and `ANTHROPIC_API_KEY` to K8s secrets.
+3. Verify osTicket's outbound subject format includes the ticket number in a way the webhook handler can parse (default osTicket format is fine, but worth testing once after deploy).
+4. Set `SUPPORT_AGENT_EMAIL` env var to partner's email.

--- a/k8s/configmap-core.yaml
+++ b/k8s/configmap-core.yaml
@@ -53,3 +53,15 @@ data:
   OSTICKET_TOPIC_ID_BILLING: "15"  # Billing & Subscriptions
   OSTICKET_TOPIC_ID_ACCOUNT: "16"  # Account Issues
   OSTICKET_TOPIC_ID_CHANNEL: "17"  # Channel Data Issues
+
+  # AI Triage (Phase: ai-support-triage)
+  #
+  # The following secrets MUST be added manually to k8s/secrets.yaml:
+  #   - ANTHROPIC_API_KEY              (Claude Haiku for triage; sk-ant-...)
+  #   - RESEND_WEBHOOK_SECRET          (Svix-style secret from Resend → Webhooks)
+  #   - SUPPORT_APPROVAL_HMAC_SECRET   (any high-entropy string ≥32 chars)
+  AI_TRIAGE_ENABLED: "true"                       # set "false" to bypass triage and fall back to legacy flow
+  SUPPORT_AGENT_EMAIL: "phil@myscrollr.com"       # CHANGEME — partner's email for approval notifications
+  APPROVAL_BASE_URL: "https://api.myscrollr.com"  # base URL embedded in Send/Edit/Skip links
+  OSTICKET_BCC_EMAIL: "support@myscrollr.com"     # the inbox osTicket polls for inbound piping
+  SUPPORT_REPLY_FROM_EMAIL: "support@myscrollr.com"


### PR DESCRIPTION
## Summary

End-to-end AI-driven support triage with email-based partner approval. Closes the loop on the "automate as much as possible" workflow you and your partner agreed on.

### What it does

When a support ticket comes in (authenticated or anonymous), Claude Haiku is called with the ticket text + last 50 ticket summaries from a Redis sliding window + a curated FAQ snippet. Claude returns structured JSON: category, priority, summary, channel (if applicable), duplicate_of, drafted reply HTML, and confidence.

That triage is applied to the osTicket payload before forwarding:
- High-confidence category overrides the user's pick (low-confidence keeps theirs)
- Priority field set on osTicket
- Summary prepended to ticket body inside a colored callout
- Duplicate hint appended if applicable
- AI's drafted reply embedded as a collapsible `<details>` block

After the ticket lands in osTicket, a `support_drafts` row is persisted, and the partner gets an email via Resend with three JWT-signed URLs: **Send** (approves the draft as-is), **Edit** (returns an HTML form with the draft pre-filled), and **Skip** (no email sent).

When the partner clicks Send (or submits an edit), backend sends the AI reply directly to the user via Resend with `In-Reply-To` and `References` headers pointing at the original osTicket auto-response Message-ID. The email is BCC'd to `support@myscrollr.com` so osTicket sees it via inbound piping and threads it into the original ticket via the `In-Reply-To` chain. User receives a properly threaded reply; if they reply, their reply naturally threads back to osTicket via standard email-threading rules.

Message-ID capture happens via a new `/webhooks/resend` endpoint that subscribes to Resend's `email.sent` and `email.delivered` events, parses the ticket number from the subject (`[#1247]` pattern), and persists Message-ID → ticket-number mappings.

## Spec

`docs/superpowers/specs/2026-04-29-ai-support-triage-design.md`

## Five commits, one per phase

| SHA | Phase |
|---|---|
| `c2c88d5` | 1A — AI triage on intake (Anthropic call, prompt, response parsing, body decoration) |
| `ea66db7` | 1B — `support_drafts` + `osticket_message_ids` tables, Resend webhook |
| `34c2a24` | 1C — JWT-signed approval URLs (Send/Edit/Skip) with HTML responses |
| `9eb631e` | 1D — Outbound AI replies + partner notification via Resend |
| `5e7dc38` | 1E — Configmap env vars |

Total: 1,795 insertions / 60 deletions across 12 files.

## Architecture notes (for review)

The subagent introduced two **package-level function variables** with no-op defaults to keep each phase independently compilable: `notifyPartnerAfterDraft` in `support.go` and `sendApprovedReply` in `handlers_support_approval.go`. Phase 1D's `init()` rebinds them to the real implementations. This is mildly unusual but gives clean rollback semantics if you ever revert just Phase 1D — the worst case is approvals returning errors and notifications skipping silently.

## Verification

- `go vet ./...` clean
- `go test ./core/` passes (existing tests still green; no new tests added — Anthropic API + Resend integrations are external and would require complex mocking)
- `go build` clean
- Migration files added at `api/migrations/000007_*.up.sql` / `.down.sql`

## Manual steps required after merge

**You (or your partner) must do these BEFORE the AI triage will fire on real tickets:**

1. **Add Resend webhook** in Resend dashboard → Webhooks → Add endpoint:
   - URL: `https://api.myscrollr.com/webhooks/resend`
   - Events: `email.sent`, `email.delivered`
   - Capture the signing secret it gives you

2. **Add three secrets to your K8s secret store** (do NOT commit them):
   - `ANTHROPIC_API_KEY` — your Anthropic console key
   - `RESEND_WEBHOOK_SECRET` — from step 1
   - `SUPPORT_APPROVAL_HMAC_SECRET` — generate with `openssl rand -base64 48`

3. **Verify configmap values** in `k8s/configmap-core.yaml`:
   - `SUPPORT_AGENT_EMAIL` defaults to `phil@myscrollr.com`. Change this if your partner's email differs.
   - `OSTICKET_BCC_EMAIL` defaults to `support@myscrollr.com`. Change if your osTicket inbox is at a different address.

4. **Optional smoke test** (after merge + deploy):
   - Submit a real ticket via the desktop Contact Us form
   - Confirm partner email arrives within ~30 seconds
   - Click Send button in partner email
   - User should receive a threaded reply within ~10 seconds
   - osTicket should show the reply on the original ticket's timeline

## Risks / things to watch

1. **Anthropic API cost**: ~$0.001 per ticket with Haiku. At 100 tickets/week, $0.10/week. If volume spikes unexpectedly, monitor your Anthropic console.
2. **Approval URL leak via email forwarding**: mitigated by 24h TTL + single-use enforcement (`status='pending'` check in `markDraftDecided`).
3. **AI hallucination in reply drafts**: prompt is grounded in FAQ; "if not in FAQ, escalate" instruction is explicit. Partner approval gate (L2) means every reply is human-approved before send.
4. **osTicket BCC threading**: depends on `In-Reply-To` standard email threading working in your osTicket install (you confirmed this works via your earlier test). If anything breaks here, fallback is the AI reply still goes to user; osTicket just doesn't see it threaded — partner would need to add a manual note.
5. **AI triage failure**: AI is best-effort. On Anthropic timeout, malformed response, etc., the ticket flow proceeds with the user's original category + no summary. Logged but never blocks the user.

## Rollback path

Set `AI_TRIAGE_ENABLED=false` in the configmap and roll. The Anthropic call is skipped; tickets flow through the legacy path unchanged. No code revert needed for emergency disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)