### PR TITLE
fix(support): AI triage polish (direction tagging, FROM address, prompt voice)

### DIFF
--- a/api/core/ai_triage.go
+++ b/api/core/ai_triage.go
@@ -194,11 +194,12 @@ YOUR TASKS:
 4. Generate a one-line summary (10 words max, no period at the end)
 5. If the ticket looks like a duplicate of one in RECENT TICKETS, output its ticket_number
 6. Draft a reply matching this voice:
-   - Warm, direct, lowercase first letter is fine, no corporate-speak
-   - Lead with brief acknowledgment, then action
-   - Reference FAQ if relevant; never make up fix steps
+   - Warm, direct, normal sentence-case capitalization (start every sentence with a capital letter), no corporate-speak
+   - NEVER use em dashes (—) or en dashes (–) anywhere in the reply. Use commas, periods, parentheses, or simple hyphens (-) instead. This is a hard rule.
+   - Lead with a brief acknowledgment, then action
+   - Reference the FAQ if relevant; never make up fix steps
    - 2-4 short paragraphs max
-   - Sign off "— the scrollr team"
+   - Sign off as: "the scrollr team" on its own line, with nothing before it
 7. Output confidence: "high" if you're very sure of category/priority, "medium" if some ambiguity, "low" if you'd want a human to double-check
 
 OUTPUT EXACTLY THIS JSON (no markdown fences, no commentary):
@@ -241,7 +242,7 @@ Body:
 // reply suggestions. Keep this small (<2000 chars) — it's sent on every
 // triage call. Update when the FAQ content evolves significantly.
 func faqContextForTriage() string {
-	return `# Scrollr FAQ — quick reference for triage replies
+	return `# Scrollr FAQ (quick reference for triage replies)
 
 ## Connecting Yahoo Fantasy
 Open the Fantasy channel page in the desktop app, click "Connect Yahoo," walk through the OAuth flow. Leagues import automatically once connected.
@@ -253,7 +254,7 @@ Settings → General → Updates → Check for Updates. Auto-updates are also av
 Manage all subscriptions through the Stripe portal: Account page → "Manage Subscription". Cancellation, payment-method updates, and invoices are all there. Super-users have permanent free Ultimate access (per the early-access program).
 
 ## Resetting password
-Account page → "Send password reset email" — Logto handles the rest.
+Account page, click "Send password reset email", and Logto handles the rest.
 
 ## Reporting bugs
 The Contact Us form in the desktop app collects diagnostics automatically. Always include OS + Scrollr version (Settings → General → About).

--- a/api/core/handlers_resend_webhook.go
+++ b/api/core/handlers_resend_webhook.go
@@ -143,17 +143,14 @@ func HandleResendWebhook(c *fiber.Ctx) error {
 		recipient = ev.Data.To[0]
 	}
 
-	// Determine direction: if From contains the support address, it's
-	// outbound from osTicket (our partner's helpdesk). Anything else is
-	// flagged but still recorded for visibility.
-	direction := "outbound_osticket" // default — osTicket emails dominate
-	supportFrom := os.Getenv("OSTICKET_BCC_EMAIL")
-	if supportFrom == "" {
-		supportFrom = "support@myscrollr.com"
-	}
-	if !strings.Contains(strings.ToLower(ev.Data.From), strings.ToLower(supportFrom)) {
-		log.Printf("[ResendWebhook] unexpected from address: %s for ticket %s", ev.Data.From, ticketNumber)
-	}
+	// Determine direction by inspecting the From address. osTicket's
+	// outbound mail comes from the support address; partner notifications
+	// and AI replies come from one of our own send addresses. Tagging
+	// these correctly matters because fetchOSTicketMessageIDForReply
+	// filters by direction='outbound_osticket' to find the In-Reply-To
+	// target. If we tag a partner notification as outbound_osticket, the
+	// AI reply ends up threaded against the wrong message.
+	direction := classifyMessageDirection(ev.Data.From)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -166,6 +163,65 @@ func HandleResendWebhook(c *fiber.Ctx) error {
 	log.Printf("[ResendWebhook] captured ticket=%s msg-id=%s recipient=%s",
 		ticketNumber, messageID, recipient)
 	return c.SendStatus(fiber.StatusOK)
+}
+
+// classifyMessageDirection inspects the from-address on a Resend
+// webhook event and decides which direction tag to store with the
+// captured Message-ID.
+//
+// Direction values:
+//
+//   - outbound_osticket: osTicket sent the email (auto-response or
+//     status update to the user). These are the only ones we want to
+//     pull when computing In-Reply-To headers for AI replies, so we
+//     can thread cleanly into the existing osTicket conversation.
+//   - outbound_partner_notification: our backend sent an internal
+//     notification to the support agent (the partner approval email).
+//     Recorded for visibility but excluded from In-Reply-To lookups.
+//   - outbound_ai: our backend sent an AI-drafted reply to the user.
+//     Recorded so we can still match if the user replies to that
+//     specific message.
+//   - unknown: anything we cannot classify. Recorded for diagnostic
+//     visibility but never used for threading.
+//
+// The set of "ours" addresses is read from env vars at runtime so the
+// classifier stays in sync with whatever Resend addresses we are
+// actually configured to send from.
+func classifyMessageDirection(fromAddress string) string {
+	from := strings.ToLower(fromAddress)
+
+	supportFrom := strings.ToLower(getenvOr("OSTICKET_BCC_EMAIL", "support@myscrollr.com"))
+	replyFrom := strings.ToLower(getenvOr("SUPPORT_REPLY_FROM_EMAIL", "support@myscrollr.com"))
+	notificationFrom := strings.ToLower(os.Getenv("RESEND_FROM_EMAIL"))
+
+	// AI reply check first because the reply-from address typically
+	// equals the support inbox address; we want the AI reply tag to
+	// win when both match (ours, going to user).
+	if replyFrom != "" && strings.Contains(from, replyFrom) && replyFrom != supportFrom {
+		return "outbound_ai"
+	}
+
+	// Partner notification: from address matches the global RESEND_FROM_EMAIL
+	// (commonly invites@myscrollr.com or similar) and is NOT the support inbox.
+	if notificationFrom != "" && strings.Contains(from, notificationFrom) && notificationFrom != supportFrom {
+		return "outbound_partner_notification"
+	}
+
+	// osTicket-originated email: from-address contains the support inbox.
+	if supportFrom != "" && strings.Contains(from, supportFrom) {
+		return "outbound_osticket"
+	}
+
+	log.Printf("[ResendWebhook] could not classify from address: %s", fromAddress)
+	return "unknown"
+}
+
+// getenvOr returns the value of env var key, or fallback if unset/empty.
+func getenvOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }
 
 // verifySvixSignature validates the Svix HMAC-SHA256 signature header

--- a/api/core/support_drafts.go
+++ b/api/core/support_drafts.go
@@ -364,9 +364,18 @@ func SendPartnerNotification(ctx context.Context, draft *SupportDraft) error {
 	if resendKey == "" {
 		return fmt.Errorf("RESEND_API_KEY not set")
 	}
-	from := os.Getenv("RESEND_FROM_EMAIL")
+	// Partner approval emails are sent FROM the support address so they
+	// match the rest of the support pipeline (osTicket auto-responses,
+	// AI replies, etc.) instead of the marketing/invites address. Reuse
+	// SUPPORT_REPLY_FROM_EMAIL since it already exists and points at
+	// support@. Fall back to the legacy RESEND_FROM_EMAIL only if the
+	// support-specific one is unset.
+	from := os.Getenv("SUPPORT_REPLY_FROM_EMAIL")
 	if from == "" {
-		from = "noreply@myscrollr.com"
+		from = os.Getenv("RESEND_FROM_EMAIL")
+	}
+	if from == "" {
+		from = "support@myscrollr.com"
 	}
 
 	payload := map[string]interface{}{

--- a/api/migrations/000008_widen_direction_enum.down.sql
+++ b/api/migrations/000008_widen_direction_enum.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE osticket_message_ids
+  DROP CONSTRAINT IF EXISTS osticket_message_ids_direction_check;
+
+ALTER TABLE osticket_message_ids
+  ADD CONSTRAINT osticket_message_ids_direction_check
+  CHECK (direction IN (
+    'outbound_osticket',
+    'outbound_ai',
+    'inbound_user'
+  ));

--- a/api/migrations/000008_widen_direction_enum.up.sql
+++ b/api/migrations/000008_widen_direction_enum.up.sql
@@ -1,0 +1,20 @@
+-- Widen the osticket_message_ids.direction enum to cover the new
+-- direction tags emitted by classifyMessageDirection in
+-- handlers_resend_webhook.go. The original migration restricted the
+-- column to {outbound_osticket, outbound_ai, inbound_user}; we now
+-- additionally need outbound_partner_notification (our internal
+-- approval emails to the support agent) and unknown (fallback when
+-- the from-address does not match any known address).
+
+ALTER TABLE osticket_message_ids
+  DROP CONSTRAINT IF EXISTS osticket_message_ids_direction_check;
+
+ALTER TABLE osticket_message_ids
+  ADD CONSTRAINT osticket_message_ids_direction_check
+  CHECK (direction IN (
+    'outbound_osticket',
+    'outbound_ai',
+    'outbound_partner_notification',
+    'inbound_user',
+    'unknown'
+  ));


### PR DESCRIPTION
## Summary

Three small fixes uncovered during the smoke-test runs of PR #131:

1. **Direction tagging on Message-ID capture** — partner notification emails were stored as `outbound_osticket`, which polluted the In-Reply-To lookup for AI replies. Now classified by from-address into `outbound_osticket`, `outbound_ai`, `outbound_partner_notification`, or `unknown`.
2. **Partner notification FROM address** — was using `RESEND_FROM_EMAIL` (which is set to `invites@myscrollr.com`). Now uses `SUPPORT_REPLY_FROM_EMAIL` (defaults to `support@myscrollr.com`) so the agent's approval emails come from the support address, matching the rest of the support pipeline.
3. **AI reply voice** — prompt updated to require normal sentence-case capitalization and explicitly forbid em dashes (—) and en dashes (–). Sign-off changed from `"— the scrollr team"` to `"the scrollr team"`. FAQ content also cleaned of stray em dashes.

## Verification (live smoke test from PR #131)

End-to-end pipeline confirmed working before this PR:
```
02:08:13  Ticket #374845 created in osTicket
02:08:14  Webhook captured osTicket auto-response Message-ID
02:08:15  Webhook captured partner notification Message-ID
02:12:33  Send clicked. Reply dispatched with in-reply-to-set=true
02:12:35  Webhook captured AI reply Message-ID (user + BCC)
```

Threading worked. The AI reply landed in the user's inbox properly threaded against osTicket's auto-response. This PR fixes the warts surfaced in that test.

## Files changed

| File | Purpose |
|---|---|
| `api/core/handlers_resend_webhook.go` | New `classifyMessageDirection` helper; replaces the default-and-warn pattern |
| `api/core/support_drafts.go` | Partner notification FROM address now uses `SUPPORT_REPLY_FROM_EMAIL` |
| `api/core/ai_triage.go` | Prompt voice updates: sentence-case capitalization, explicit em-dash ban; FAQ content cleaned |
| `api/migrations/000008_widen_direction_enum.up.sql` | Adds `outbound_partner_notification` and `unknown` to direction CHECK constraint |
| `api/migrations/000008_widen_direction_enum.down.sql` | Reverts |

5 files changed, +115 / -19 lines.

## Build / test

- `go vet ./...` clean
- `go test ./core/` passes
- `go build` clean

## Manual follow-up after merge

None. Migration 000008 runs automatically on core-api startup. No env var changes needed (uses existing `SUPPORT_REPLY_FROM_EMAIL` which is already set in the configmap to `support@myscrollr.com`).

## Rollback

Set `AI_TRIAGE_ENABLED=false` for the AI side, or revert this PR for the FROM/direction fixes. Migration 000008 down-script restores the original CHECK constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)