### PR TITLE
fix(osticket): plugin config_class + handler arg signature + instance requirement

### DIFF
--- a/osticket-plugins/scrollr-reply-api/README.md
+++ b/osticket-plugins/scrollr-reply-api/README.md
@@ -85,8 +85,34 @@ Adjust the `COPY` source path to wherever you stage the plugin during the build.
 2. You should see "Scrollr Reply API" in the list. Click it.
 3. Click **Enable** (or Install + Enable if it shows as not-yet-installed).
 4. Confirm the plugin status shows as Active.
+5. **Create at least one Plugin Instance** — this is critical and easy to miss. osTicket's `PluginManager::bootstrap()` only fires `Plugin::bootstrap()` for plugins with at least one ENABLED instance. A plugin can be installed and active in the database (`ost_plugin.isactive=1`) but if there are no enabled rows in `ost_plugin_instance`, the plugin's URL hooks never register.
+   - On the plugin's page, look for **Instances** or **Add a New Instance**.
+   - Create one with any name (e.g. "default"). The plugin has no per-instance config, so the form is effectively empty.
+   - Toggle the instance to **Enabled** and save.
+6. Restart the osTicket container/PHP-FPM so OPcache reloads the plugin classes.
 
 The endpoint is now live at `https://<osticket-host>/api/tickets/{number}/reply.json`.
+
+**Quick database verification** (skip if installing via admin UI worked first try):
+
+```sql
+SELECT id, name, install_path, isactive FROM ost_plugin
+  WHERE install_path LIKE '%scrollr-reply-api%';
+-- Expect: 1 row with isactive=1
+
+SELECT id, plugin_id, flags, name FROM ost_plugin_instance
+  WHERE plugin_id = (SELECT id FROM ost_plugin WHERE install_path LIKE '%scrollr-reply-api%');
+-- Expect: at least 1 row with flags=1 (FLAG_ENABLED)
+```
+
+If the second query returns 0 rows, no instance exists — bootstrap won't run. Add one via the admin UI, or directly:
+
+```sql
+INSERT INTO ost_plugin_instance (plugin_id, flags, name, notes, created, updated)
+VALUES (<plugin_id>, 1, 'default', '', NOW(), NOW());
+```
+
+Then restart the osTicket container.
 
 ### Verifying the install
 
@@ -167,11 +193,12 @@ For deeper debugging:
 osticket-plugins/scrollr-reply-api/
 ├── plugin.php                       # Manifest (osTicket-discoverable)
 ├── class.ScrollrReplyPlugin.php     # Plugin subclass; hooks Signal::connect('api', ...)
+├── config.php                       # Stub PluginConfig (required by osTicket bootstrap chain)
 ├── api.reply.php                    # ScrollrReplyController; wraps Ticket::postReply()
 └── README.md                        # This file
 ```
 
-The implementation is ~150 lines of PHP across three files. No external dependencies beyond osTicket itself.
+The implementation is ~200 lines of PHP across four files. No external dependencies beyond osTicket itself.
 
 ## Future work
 

--- a/osticket-plugins/scrollr-reply-api/api.reply.php
+++ b/osticket-plugins/scrollr-reply-api/api.reply.php
@@ -82,7 +82,7 @@ class ScrollrReplyController extends ApiController {
      * Endpoint handler. URL pattern in the dispatcher captures {number}
      * which is delivered through $args by the framework.
      */
-    function reply($args) {
+    function reply($number) {
         // 1. Auth — same as TicketApiController::create. Validates
         //    X-API-Key header AND the api key's bound IP. 401 on either
         //    failure.
@@ -100,10 +100,13 @@ class ScrollrReplyController extends ApiController {
         $this->validate($data, 'json');
 
         // 3. Look up the ticket by number from the URL.
-        if (!isset($args['number']) || !preg_match('/^[\w-]+$/', $args['number'])) {
+        // osTicket's UrlMatcher::dispatch strips named captures and passes
+        // remaining captures as positional args via call_user_func_array,
+        // so $number is the bare ticket-number string from the URL.
+        if (!is_string($number) || !preg_match('/^[\w-]+$/', $number)) {
             return $this->exerr(400, __('Invalid ticket number in URL'));
         }
-        $ticket = Ticket::lookupByNumber($args['number']);
+        $ticket = Ticket::lookupByNumber($number);
         if (!$ticket) {
             return $this->exerr(404, __('Ticket not found'));
         }

--- a/osticket-plugins/scrollr-reply-api/class.ScrollrReplyPlugin.php
+++ b/osticket-plugins/scrollr-reply-api/class.ScrollrReplyPlugin.php
@@ -7,16 +7,19 @@
  * URL pattern that maps to ScrollrReplyController::reply().
  *
  * The plugin has no admin-configurable options for now — auth is the
- * same X-API-Key the rest of the API already uses. If you need to
- * configure a default staff agent here later (instead of resolving from
- * the request payload), add a getOptions() method and a config form.
+ * same X-API-Key the rest of the API already uses. We still must
+ * declare a config class because osTicket's PluginInstance::bootstrap()
+ * short-circuits when getConfig() returns null (the && chain at line
+ * ~1159 of class.plugin.php). See config.php for the stub class.
  */
 
 require_once INCLUDE_DIR . 'class.plugin.php';
+require_once dirname(__FILE__) . '/config.php';
 
 class ScrollrReplyPlugin extends Plugin {
 
-    var $config_class = null; // No config UI — auth + agent come from request
+    var $config_class = "ScrollrReplyPluginConfig";
+    var $config;
 
     function bootstrap() {
         // Load the controller class up-front so it's available when

--- a/osticket-plugins/scrollr-reply-api/config.php
+++ b/osticket-plugins/scrollr-reply-api/config.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Stub PluginConfig for Scrollr Reply API.
+ *
+ * The plugin has no admin-configurable options — auth and the staff
+ * agent both come from the request payload, not from per-instance
+ * config. Despite that, osTicket REQUIRES every plugin to declare a
+ * config class for `Plugin::bootstrap()` to actually fire.
+ *
+ * Specifically: `PluginInstance::bootstrap()` (in class.plugin.php
+ * around line 1159 on osTicket 1.18) reads:
+ *
+ *     if ($this->isEnabled()
+ *             && ($plugin = $this->getPlugin())
+ *             && ($plugin->getConfig($this)))    // <-- short-circuits here
+ *         return $plugin->bootstrap();
+ *
+ * `Plugin::getConfig()` in turn returns null when the plugin's
+ * `$config_class` is null. So without a config class declared, the
+ * outer `bootstrap()` chain short-circuits and the plugin's own
+ * `bootstrap()` never runs — meaning Signal::connect('api', ...) is
+ * never registered, meaning the new URL pattern never gets appended,
+ * meaning the route returns "URL not supported".
+ *
+ * Returning an empty `getOptions()` produces a configure dialog with
+ * no fields, which is fine — the admin just clicks "Save" once.
+ */
+
+require_once INCLUDE_DIR . 'class.plugin.php';
+
+class ScrollrReplyPluginConfig extends PluginConfig {
+    function getOptions() {
+        return array();
+    }
+}


### PR DESCRIPTION
## Summary

The plugin shipped in PR #133 didn't actually register its API route in production. Two bugs in the plugin code and one missing-step in the install flow. All three fixed and verified end-to-end against ticket #239171 in the live osTicket instance.

## What was broken

### Bug 1 — `var $config_class = null` short-circuited Plugin::bootstrap()

osTicket's `PluginInstance::bootstrap()` (`include/class.plugin.php:1159`) gates `Plugin::bootstrap()` behind:

```php
if ($this->isEnabled()
        && ($plugin = $this->getPlugin())
        && ($plugin->getConfig($this)))    // <-- null short-circuits
    return $plugin->bootstrap();
```

`Plugin::getConfig()` returns null when `$config_class` is null, so the && chain short-circuits, the plugin's own `bootstrap()` never runs, and `Signal::connect('api', ...)` never registers the URL pattern. The route returned osTicket's stock "URL not supported" 400.

**Fix**: ship a stub `ScrollrReplyPluginConfig extends PluginConfig` with empty `getOptions()` (new `config.php`), and reference it via `var $config_class = "ScrollrReplyPluginConfig";`.

### Bug 2 — Handler signature expected captures as a hash, got positional args

osTicket's `UrlMatcher::dispatch()` (`include/class.dispatcher.php:~120`) explicitly strips named captures and passes the remaining numeric captures as **positional args via `call_user_func_array`**:

```php
# Remove named values from the match array
$f = array_filter(array_keys($this->matches), 'is_numeric');
$this->matches = array_intersect_key($this->matches, array_flip($f));
// ...
return call_user_func_array($func, $args);
```

My handler `function reply($args)` was treating `$args` as a single array (`$args['number']`) — instead it was receiving the bare ticket-number string as the first positional argument.

**Fix**: `function reply($number)` — receives the captured value directly.

### Operational issue — Plugin Instance row required

Even after both code bugs were fixed, the route still didn't register because there was no row in `ost_plugin_instance` for the plugin. osTicket's `PluginManager::bootstrap()` iterates `getActiveInstances()` for each plugin — with zero enabled instances, the inner `bootstrap()` loop never executes.

This is non-obvious because the admin UI's Plugins page shows "Active" once you click Install + Enable, but doesn't auto-create an instance for plugins without configurable options. The user has to separately create an Instance.

**Fix**: documented in README.md as install step 5, with SQL verification queries and a direct `INSERT INTO ost_plugin_instance` fallback.

## Verification

Smoke-tested in production against `support.myscrollr.com` ticket #239171:

```
=== Test 1: signal_alert=false ===
{"status":"ok","ticket_number":"239171","ticket_id":78,
 "entry_id":95,"alert_sent":false,"staff_id":1,
 "staff_name":"Admin istrator"}
HTTP_CODE: 200

=== Test 2: signal_alert=true ===
{"status":"ok","ticket_number":"239171","ticket_id":78,
 "entry_id":96,"alert_sent":true,"staff_id":1,
 "staff_name":"Admin istrator"}
HTTP_CODE: 200
```

DB verification:
```
id   type  staff_id  poster           created
95   R     1         Admin istrator   2026-05-01 04:31:05
96   R     1         Admin istrator   2026-05-01 04:31:42

ticket 239171: lastupdate=..., isanswered=1
```

Both entries are `type='R'` (proper agent Response, not a Note). Ticket flipped to `isanswered=1`. Both `Ticket::postReply()` paths (alert/no-alert) work as designed.

## What this PR does NOT do

- Refactor the Scrollr core API to USE this endpoint. That's still the follow-up PR (Stream C from the original AI-triage plan): swap `support_drafts.go::sendApprovedReply` from Resend-BCC pattern to the plugin endpoint, drop the Resend webhook handler, drop `osticket_message_ids` table writes. ~150 lines of Go change. Will ship as a separate PR now that the plugin is verified working in prod.

## Files changed

```
config.php                       NEW    Stub PluginConfig
class.ScrollrReplyPlugin.php     +5 -3  Wire config_class
api.reply.php                    +5 -2  function reply(\$number)
README.md                        +28 -1 Plugin Instance install step
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)