### PR TITLE
feat(triage): clean thread + comprehensive KB + user message in partner email

### DIFF
--- a/api/core/ai_triage.go
+++ b/api/core/ai_triage.go
@@ -338,73 +338,20 @@ Body:
 	)
 }
 
-// faqContextForTriage returns a short FAQ snippet to ground Claude's
-// reply suggestions. Keep this small (<2000 chars) — it's sent on every
-// triage call. Update when the FAQ content evolves significantly.
+// faqContextForTriage delegates to the canonical knowledge base in
+// support_kb.go. Kept as a wrapper so the prompt-building call site
+// doesn't need to change every time the KB structure evolves.
 func faqContextForTriage() string {
-	return `# Scrollr FAQ (quick reference for triage replies)
-
-## Connecting Yahoo Fantasy
-Open the Fantasy channel page in the desktop app, click "Connect Yahoo," walk through the OAuth flow. Leagues import automatically once connected.
-
-## Updating the desktop app
-Settings → General → Updates → Check for Updates. Auto-updates are also available; v1.0.4 is the latest as of April 2026.
-
-## Subscription & billing
-Manage all subscriptions through the Stripe portal: Account page → "Manage Subscription". Cancellation, payment-method updates, and invoices are all there. Super-users have permanent free Ultimate access (per the early-access program).
-
-## Resetting password
-Account page, click "Send password reset email", and Logto handles the rest.
-
-## Reporting bugs
-The Contact Us form in the desktop app collects diagnostics automatically. Always include OS + Scrollr version (Settings → General → About).
-
-## Channel issues
-Finance: stocks/crypto via TwelveData. Sports: api-sports.io. News: RSS pull-based ingestion. Fantasy: Yahoo OAuth + cached league data.
-
-## Multi-row ticker
-Available on Pro (2 rows), Ultimate (3 rows), and super_user. Configure in Settings → Ticker → Rows. Per-channel row assignment in the Settings → Ticker source picker, or right-click the tray menu.
-
-## Channel.ticker_enabled / "missing channel"
-If a channel disappears from the ticker, it's likely the per-channel ticker toggle is off. Check the Home/Feed page → channel header → ticker icon.
-`
+	return supportKnowledgeBase()
 }
 
-// applyTriageToBody prepends the AI summary and appends the duplicate
-// hint to the ticket body HTML. The drafted reply is appended as a
-// collapsible <details> block so the partner can copy it inside
-// osTicket. Returns the modified body.
-func applyTriageToBody(originalBody string, triage *TriageResult) string {
-	if triage == nil {
-		return originalBody
-	}
-
-	var prefix strings.Builder
-	prefix.WriteString(`<div style="background:#0f3a2c;border-left:4px solid #10b981;padding:12px;margin-bottom:16px;color:#a7f3d0;border-radius:4px;">`)
-	prefix.WriteString(fmt.Sprintf(`<strong>🤖 AI summary:</strong> %s`, escapeHTML(triage.Summary)))
-	prefix.WriteString(fmt.Sprintf(`<br><span style="font-size:11px;opacity:0.8;">priority=%s · category=%s · confidence=%s`,
-		escapeHTML(triage.Priority),
-		escapeHTML(triage.Category),
-		escapeHTML(triage.Confidence)))
-	if triage.Channel != "" {
-		prefix.WriteString(fmt.Sprintf(` · channel=%s`, escapeHTML(triage.Channel)))
-	}
-	prefix.WriteString(`</span></div>`)
-
-	body := prefix.String() + originalBody
-
-	if triage.DuplicateOf != "" {
-		body += fmt.Sprintf(`<div style="background:#3a2c0f;border-left:4px solid #f59e0b;padding:8px;margin-top:16px;color:#fde68a;border-radius:4px;font-size:13px;">🔗 <strong>Possibly related:</strong> ticket %s</div>`,
-			escapeHTML(triage.DuplicateOf))
-	}
-
-	if triage.DraftReplyHTML != "" {
-		body += fmt.Sprintf(`<details style="margin-top:16px;background:#1a1a2e;border:1px solid #2a2a3e;padding:12px;border-radius:4px;"><summary style="cursor:pointer;color:#10b981;font-weight:600;">💡 AI suggested reply (click to expand)</summary><div style="margin-top:8px;padding:8px;background:#0a0a1a;border-radius:4px;color:#e2e8f0;">%s</div></details>`,
-			triage.DraftReplyHTML)
-	}
-
-	return body
-}
+// applyTriageToBody was removed in 2026-05-01 — it used to prepend an
+// "AI summary" banner and append the drafted reply as a <details> block
+// to the ticket body, but those decorations were visible to users when
+// they viewed the ticket via the portal. AI metadata now lives in the
+// support_drafts row and the partner-notification email only. The
+// user-visible thread is whatever the user wrote and whatever the
+// agent answers — nothing else.
 
 // mapTriagePriorityToOSTicket converts AI priority strings to osTicket's
 // expected priority IDs. osTicket's default priority IDs are 1=Low, 2=Normal,

--- a/api/core/handlers_osticket_webhook.go
+++ b/api/core/handlers_osticket_webhook.go
@@ -180,6 +180,7 @@ func processReplyTriageAsync(ev osTicketThreadMessageEvent) {
 		UserEmail:             ev.UserEmail,
 		UserName:              userName,
 		OriginalSubject:       ev.Subject,
+		UserMessageHTML:       ev.MessageHTML,
 		DraftBodyHTML:         triage.DraftReplyHTML,
 		AISummary:             triage.Summary,
 		AICategory:            triage.Category,

--- a/api/core/handlers_support_public.go
+++ b/api/core/handlers_support_public.go
@@ -143,16 +143,15 @@ func HandleSubmitPublicSupportTicket(c *fiber.Ctx) error {
 	}
 	topicID := resolveOSTicketTopicID(effectiveCategory)
 
-	// Build OS Ticket payload. Match the same Message format the
-	// authenticated handler uses (data: URL with HTML body) so OS
-	// Ticket renders both submission types consistently.
-	finalBody := applyTriageToBody(originalBody, triage)
-
+	// Post the user's CLEAN body to osTicket. AI metadata (summary,
+	// drafted reply, confidence, etc.) lives in the support_drafts row
+	// and the partner-notification email — never in the user-visible
+	// thread. See support.go for the rationale.
 	payload := OSTicketPayload{
 		Name:    fallbackName(req.Name, req.Email),
 		Email:   req.Email,
 		Subject: subjectFull,
-		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", finalBody),
+		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", originalBody),
 	}
 	if topicID != "" {
 		payload.TopicID = topicID

--- a/api/core/support.go
+++ b/api/core/support.go
@@ -258,15 +258,19 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 
 	topicID := resolveOSTicketTopicID(effectiveCategory)
 
-	// Augment body with triage summary / dupe hint / suggested reply
-	finalBody := applyTriageToBody(originalBody, triage)
-
-	// Build OS Ticket payload
+	// Post the user's CLEAN body to osTicket. AI metadata (summary,
+	// drafted reply, confidence, etc.) lives in the support_drafts row
+	// and the partner-notification email — never in the user-visible
+	// thread. Earlier versions decorated the body with an "AI summary"
+	// banner + a <details> block containing the drafted reply, but
+	// that was visible to users when they viewed the ticket via the
+	// portal. Cleaner architecture: thread is what the user wrote and
+	// what the agent answered, nothing else.
 	payload := OSTicketPayload{
 		Name:    name,
 		Email:   email,
 		Subject: subject,
-		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", finalBody),
+		Message: fmt.Sprintf("data:text/html;charset=utf-8,%s", originalBody),
 	}
 
 	if topicID != "" {
@@ -380,6 +384,7 @@ func persistTriageSideEffects(ticketNumber, userEmail, userName, subject, origin
 			UserEmail:       userEmail,
 			UserName:        userName,
 			OriginalSubject: subject,
+			UserMessageHTML: originalBody,
 			DraftBodyHTML:   triage.DraftReplyHTML,
 			AISummary:       triage.Summary,
 			AICategory:      triage.Category,

--- a/api/core/support_drafts.go
+++ b/api/core/support_drafts.go
@@ -36,6 +36,7 @@ type SupportDraft struct {
 	UserEmail             string
 	UserName              string
 	OriginalSubject       string
+	UserMessageHTML       string // The user's actual message body (for partner-email context). Separate from DraftBodyHTML which is the AI-drafted reply.
 	DraftBodyHTML         string
 	AISummary             string
 	AICategory            string
@@ -67,10 +68,11 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 	const q = `
 		INSERT INTO support_drafts
 			(ticket_number, user_email, user_name, original_subject,
+			 user_message_html,
 			 draft_body_html, ai_summary, ai_category, ai_priority,
 			 ai_channel, ai_duplicate_of, ai_confidence, status,
 			 osticket_thread_entry_id, should_close)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'pending',$12,$13)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'pending',$13,$14)
 		RETURNING id, created_at
 	`
 	// 0 → NULL via NULLIF so the partial unique index doesn't reject
@@ -79,11 +81,20 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 	if draft.OSTicketThreadEntryID > 0 {
 		entryID = &draft.OSTicketThreadEntryID
 	}
+	// user_message_html is nullable for back-compat with old rows; we
+	// always populate it on new writes but use NULL when the field is
+	// empty so the column reads as the absence of a message rather
+	// than an empty string.
+	var userMsg *string
+	if draft.UserMessageHTML != "" {
+		userMsg = &draft.UserMessageHTML
+	}
 	err := DBPool.QueryRow(ctx, q,
 		draft.TicketNumber,
 		draft.UserEmail,
 		draft.UserName,
 		draft.OriginalSubject,
+		userMsg,
 		draft.DraftBodyHTML,
 		draft.AISummary,
 		draft.AICategory,
@@ -107,6 +118,7 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 func loadSupportDraft(ctx context.Context, id int64) (*SupportDraft, error) {
 	const q = `
 		SELECT id, ticket_number, user_email, user_name, original_subject,
+			   user_message_html,
 			   draft_body_html, ai_summary, ai_category, ai_priority,
 			   ai_channel, ai_duplicate_of, ai_confidence, status,
 			   edited_body_html, decided_at, sent_at, created_at,
@@ -114,9 +126,10 @@ func loadSupportDraft(ctx context.Context, id int64) (*SupportDraft, error) {
 		FROM support_drafts WHERE id = $1
 	`
 	var d SupportDraft
-	var userName, summary, category, priority, channel, dupOf, confidence, editedBody *string
+	var userName, userMsg, summary, category, priority, channel, dupOf, confidence, editedBody *string
 	err := DBPool.QueryRow(ctx, q, id).Scan(
 		&d.ID, &d.TicketNumber, &d.UserEmail, &userName, &d.OriginalSubject,
+		&userMsg,
 		&d.DraftBodyHTML, &summary, &category, &priority, &channel,
 		&dupOf, &confidence, &d.Status,
 		&editedBody, &d.DecidedAt, &d.SentAt, &d.CreatedAt,
@@ -130,6 +143,9 @@ func loadSupportDraft(ctx context.Context, id int64) (*SupportDraft, error) {
 	}
 	if userName != nil {
 		d.UserName = *userName
+	}
+	if userMsg != nil {
+		d.UserMessageHTML = *userMsg
 	}
 	if summary != nil {
 		d.AISummary = *summary
@@ -324,6 +340,22 @@ func SendPartnerNotification(ctx context.Context, draft *SupportDraft) error {
 		return fmt.Errorf("build approval URLs: %w", err)
 	}
 
+	// Build the "what the user wrote" block. Hidden when we don't have
+	// the body (legacy rows). User-supplied HTML is rendered verbatim
+	// inside a styled container; the upstream Contact Us form already
+	// goes through escapeHTML when triage builds the prompt, so what's
+	// in user_message_html is safe-ish HTML already. We still wrap it
+	// so it's visually distinct from the AI's draft.
+	userMessageBlock := ""
+	if draft.UserMessageHTML != "" {
+		userMessageBlock = fmt.Sprintf(`<div style="padding:0 24px 20px;">
+  <p style="margin:0 0 6px;font-size:11px;color:#888;text-transform:uppercase;letter-spacing:0.5px;">What the user wrote</p>
+  <div style="background:#fafafa;padding:12px;border-radius:6px;font-size:13px;color:#444;border-left:3px solid #6b7280;line-height:1.5;">
+    %s
+  </div>
+</div>`, draft.UserMessageHTML)
+	}
+
 	// Local var name `htmlBody` to avoid shadowing the imported `html` package.
 	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
 <html><head><meta charset="utf-8"></head>
@@ -336,7 +368,11 @@ func SendPartnerNotification(ctx context.Context, draft *SupportDraft) error {
 <div style="padding:20px 24px;">
   <p style="margin:0 0 8px;font-size:14px;color:#333;"><strong>AI summary:</strong> %s</p>
   <p style="margin:0 0 16px;font-size:11px;color:#666;">Category: %s · Priority: %s · Confidence: %s</p>
-  <div style="background:#f9f9f9;padding:12px;border-radius:6px;font-size:13px;color:#333;border-left:3px solid #10b981;">
+</div>
+%s
+<div style="padding:0 24px 20px;">
+  <p style="margin:0 0 6px;font-size:11px;color:#888;text-transform:uppercase;letter-spacing:0.5px;">AI-drafted reply</p>
+  <div style="background:#f9f9f9;padding:12px;border-radius:6px;font-size:13px;color:#333;border-left:3px solid #10b981;line-height:1.5;">
     %s
   </div>
 </div>
@@ -361,6 +397,7 @@ func SendPartnerNotification(ctx context.Context, draft *SupportDraft) error {
 		html.EscapeString(draft.AICategory),
 		html.EscapeString(draft.AIPriority),
 		html.EscapeString(draft.AIConfidence),
+		userMessageBlock,    // empty string when no user message available; otherwise the styled block
 		draft.DraftBodyHTML, // already HTML, don't double-escape
 		sendURL, editURL, skipURL,
 		html.EscapeString(draft.OriginalSubject),

--- a/api/core/support_kb.go
+++ b/api/core/support_kb.go
@@ -1,0 +1,224 @@
+package core
+
+// SupportKnowledgeBase is the canonical product reference passed to the
+// AI triage prompt on every ticket. Keep this AUTHORITATIVE — Claude
+// will treat anything stated here as ground truth and may parrot it
+// verbatim in user-facing replies. If a number, name, or behavior in
+// this file is wrong, AI replies will be wrong.
+//
+// Editing rules (for whoever owns this file next):
+//
+//  1. Tier names are CANONICAL: "Free", "Uplink", "Uplink Pro",
+//     "Uplink Ultimate", "Super User". Never use "Premium", "Plus",
+//     "Pro Max", or any other variant.
+//  2. List ALL FOUR tier-tiers (Free, Uplink, Pro, Ultimate) any time
+//     pricing or limits come up — do NOT skip Uplink Ultimate. The AI
+//     has skipped it in past replies because it inferred "Pro" was the
+//     top tier from incomplete context. The KB is now explicit.
+//  3. Never quote prices the AI wouldn't be confident about. If pricing
+//     drift is a concern, point users at /uplink on the marketing site
+//     instead of citing dollar amounts directly.
+//  4. Channel-specific troubleshooting goes in its own section so the
+//     AI can quote the relevant block when triaging that category.
+//  5. When you add new product features, add them HERE in the same edit
+//     as the feature ships. The KB drift between ship and update is
+//     where wrong-answer replies come from.
+//
+// Size budget: keep this under ~6 KB to leave room for recent-ticket
+// context + the user's actual ticket body in Claude's context window.
+// At ~6 KB this is sent verbatim on every triage call (~thousands per
+// month at scale); at 20 KB it would noticeably impact token cost.
+//
+// Last updated: 2026-05-01
+func supportKnowledgeBase() string {
+	return `# Scrollr Knowledge Base — authoritative reference for support replies
+
+## Product overview
+Scrollr is a desktop ticker application that streams real-time data
+across the top of your screen. Channels: Finance (TwelveData), Sports
+(api-sports.io), News (RSS), and Fantasy (Yahoo OAuth). Available for
+macOS, Windows, and Linux. Current desktop version: v1.0.4 (April 2026).
+Source code is publicly available on GitHub under AGPL-3.0; the
+Scrollr-hosted infrastructure (auth, billing, channel APIs) is the
+product users pay for.
+
+## Tiers — canonical names + limits
+There are FOUR paid tier-tiers and one early-access program tier.
+ALWAYS list all four when discussing pricing or limits:
+
+### Free
+- 5 finance symbols
+- 1 RSS feed
+- 0 fantasy leagues
+- 1 ticker row
+- Polling-based updates (no real-time streaming)
+- No multi-row customisation
+
+### Uplink (entry paid tier)
+- 25 finance symbols
+- 25 RSS feeds (1 custom)
+- 1 fantasy league
+- 2 ticker rows
+- Polling-based updates
+
+### Uplink Pro
+- 75 finance symbols
+- 100 RSS feeds (3 custom)
+- 3 fantasy leagues
+- 3 ticker rows
+- Polling-based updates
+
+### Uplink Ultimate (top paid tier)
+- Unlimited finance symbols
+- Unlimited RSS feeds (10 custom)
+- 10 fantasy leagues
+- 3 ticker rows + per-row scroll customisation
+- REAL-TIME SSE streaming (no polling — instant data)
+- Priority support
+
+### Super User (early-access program)
+- Same caps as Uplink Ultimate (unlimited everything, real-time SSE,
+  3 rows + customisation).
+- Permanent and free for life as part of the early-access program.
+- Granted by invite only via the Scrollr team.
+- Not refundable, transferable, or convertible to monetary value
+  (per the Super User Early Access Terms).
+
+When users ask "what tier am I on" or "what do I get", refer them to
+the Account page → Subscription card. When users ask "how do I upgrade"
+or "what does X cost", point them at https://myscrollr.com/uplink for
+the current pricing — don't quote dollar amounts in replies (pricing
+shifts; the marketing page is the source of truth).
+
+## Authentication & account management
+- Auth provider: Logto (auth.myscrollr.com). Sign-in via email +
+  password, Google OAuth, or magic-link invite.
+- Username is IMMUTABLE — set once at sign-up, never editable. Tell
+  users this directly when they ask.
+- Display name + primary email ARE editable: Settings → Account on
+  the desktop app, or myscrollr.com/account in the browser. Inline
+  edit-in-place fields, save and the change propagates within ~30s.
+- Password reset: Account page → "Send password reset email". Triggers
+  a Logto-driven flow; user gets an email and resets via Logto's
+  hosted page. We do not have an embedded "type new password" form
+  by design — the Logto reset flow is the source of truth.
+- Account deletion is website-only: myscrollr.com/account → Danger
+  Zone → Delete Account. 30-day grace period during which the user can
+  cancel via the same UI. Desktop intentionally does NOT have this
+  affordance (avoids accidental clicks on a destructive action).
+- Two-factor auth, passkeys, social-login linking: managed via Logto's
+  hosted Account Center. The /account hub card "Security Node" links
+  to it.
+
+## Billing
+- Stripe is the payment processor. Checkout flow for new subscriptions
+  and the customer portal for changes are both at the Account page.
+- Cancel: in-app on the website (account page → "Cancel Subscription").
+  Desktop sends users to the Stripe portal — no in-app cancel on
+  desktop by design.
+- Refund policy: 7-day refund window for monthly + annual paid plans
+  (per Refund Policy doc). Lifetime is non-refundable. Super User is
+  free → not refundable.
+- Trial: 7-day free trial for new paid plans. During trial the user
+  has full Ultimate-tier access regardless of which plan they trial.
+- Payment method updates / invoice history: Stripe portal → linked
+  from "Manage Subscription" on the Account page.
+
+## Channels — common issues by channel
+
+### Finance
+- Provider: TwelveData via WebSocket on Ultimate, polling on lower
+  tiers. Crypto + stocks both supported.
+- "Stocks not updating" → first check if the user is on a tier that
+  supports the data they want. Free + Uplink + Pro use polling
+  (intervals of 60-30-10 seconds respectively); Ultimate uses
+  real-time SSE.
+- Symbol limit hit: tell them which tier upgrade unblocks their use
+  case (Pro for 75, Ultimate for unlimited).
+- "AAPL missing" or specific symbol not present: TwelveData covers all
+  major exchanges; if a specific niche symbol is missing, that's a
+  TwelveData coverage gap and should be flagged as a feature request.
+
+### Sports
+- Provider: api-sports.io. Major leagues only (NFL, NBA, MLB, NHL,
+  Premier League, La Liga, Serie A, Bundesliga, Ligue 1, Champions
+  League). College sports NOT supported as of April 2026.
+- "Wrong score" → very rarely a real bug; usually api-sports.io is
+  catching up. Ask user for the game ID + their local timestamp; we
+  can look up the source.
+- "Game missing" → confirm the league is supported (above list); if
+  not, feature request.
+
+### News (RSS)
+- Pull-based polling against arbitrary RSS feeds. Default feeds curated
+  by tier; custom feeds counted separately.
+- "Feed broken" → diagnose by URL. Some feeds rotate URLs without
+  redirecting. We log fetch errors in the channel service; if a feed
+  has been failing for 24h+ we'll flag it for the user.
+- Custom feed URL must be a valid RSS or Atom feed; HTML pages are
+  not supported (we don't scrape).
+
+### Fantasy
+- Yahoo OAuth only. ESPN + Sleeper + CBS Fantasy NOT supported (most
+  common feature request — flag as such).
+- Connect: open the Fantasy channel page → "Connect Yahoo" → walk
+  through OAuth in the browser. Leagues import automatically once
+  connected. Token refreshed every ~30 days; if expired, the channel
+  shows a "Reconnect" prompt.
+- League limits: Free 0, Uplink 1, Pro 3, Ultimate 10. Super User
+  unlimited.
+- "Leagues not showing up" → check (1) Yahoo session not expired,
+  (2) leagues are visible to the connected Yahoo account, (3) league
+  is for a sport we support (NFL primarily; NBA/MLB/NHL also work).
+
+## Multi-row ticker (the visual layout feature)
+- Free: 1 row only.
+- Uplink: 2 rows.
+- Pro + Ultimate + Super User: 3 rows.
+- Per-row source assignment: tray right-click → channel name → row
+  picker. Or Settings → Ticker → multi-row source picker.
+- Ultimate + Super User additionally get per-row scroll customisation
+  (different speeds / directions per row). Lower tiers see a
+  "Customize scroll — Ultimate only" teaser.
+
+## "Channel disappeared from the ticker"
+By far the most common confusion. The per-channel "ticker_enabled"
+toggle on the Home/Feed page (eye icon next to each channel header)
+is independent of the channel being enabled. If the user has a
+channel enabled in Settings but it's not on the ticker, that toggle
+is the answer 95% of the time.
+
+## Updating the desktop app
+- Settings → General → Updates → Check for Updates.
+- Auto-update prompts on launch when a new version is available.
+- v1.0.4 is the current latest (April 2026).
+- Windows: MSI + NSIS installers. macOS: .dmg + .app.tar.gz (universal
+  arm64; Intel Macs not supported as of v1.0.4 — we may add a build
+  later).
+- Linux: AppImage, .deb, .rpm.
+
+## Bug-report etiquette
+When users report a bug, the desktop's Contact Us form auto-collects
+diagnostics (OS, Scrollr version, redacted system metadata). Always
+include those in the ticket — they're auto-filled, the user just
+needs to submit. If a user reports a bug WITHOUT diagnostics, ask
+politely for OS + Scrollr version (Settings → General → About).
+
+## What to do if you don't know
+If a user asks something that isn't covered by this KB:
+- Don't guess. The reply will be visible to the user and partner.
+- Acknowledge the question, say you'll look into it, and indicate the
+  partner will follow up. The partner can edit the reply via the
+  approval link before sending.
+- Set confidence: low. The partner is more likely to edit a low-
+  confidence draft.
+
+## What to NEVER say in replies
+- Specific dollar amounts (point at /uplink instead — pricing drifts).
+- Promised feature delivery dates (we don't commit to dates publicly).
+- Internal infrastructure details (Logto, Sequin, Coolify, K8s — all
+  opaque to users).
+- Anything contradicting this KB. If your training data and this KB
+  disagree, the KB wins.
+`
+}

--- a/api/migrations/000011_support_drafts_user_message.down.sql
+++ b/api/migrations/000011_support_drafts_user_message.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE support_drafts DROP COLUMN IF EXISTS user_message_html;

--- a/api/migrations/000011_support_drafts_user_message.up.sql
+++ b/api/migrations/000011_support_drafts_user_message.up.sql
@@ -1,0 +1,11 @@
+-- Persist the user's original message body alongside each support
+-- draft. This is the body the user actually wrote (after stripping/
+-- sanitising), separate from the AI's drafted reply
+-- (draft_body_html). We surface it in the partner-notification email
+-- so the partner can compare what the user wrote vs. what the AI
+-- proposes — much faster triage than clicking through to osTicket.
+--
+-- Nullable for back-compat with rows created before this column
+-- existed. New writes always populate it.
+ALTER TABLE support_drafts
+  ADD COLUMN IF NOT EXISTS user_message_html TEXT;


### PR DESCRIPTION
## Summary

Four refinements based on user feedback after PR #137 went live ('its working really fucking well, now its time to refine it').

### Concern 1 — AI metadata leaking into user-visible thread

**Before:** `applyTriageToBody` prepended an 'AI summary' banner and appended a `<details>` block containing the drafted reply to the user's first message. Both were visible to the user when they opened the ticket via the portal.

**After:** Removed `applyTriageToBody` calls from both `/support/ticket` and `/support/ticket/public` handlers. The user's clean original body goes to osTicket as the initial thread entry. AI metadata lives in `support_drafts` rows and the partner-notification email only.

### Concern 2 — Wrong tier info (skipped Ultimate)

**Before:** The 25-line FAQ in `ai_triage.go` only mentioned tiers in passing ('Super-users have permanent free Ultimate access') without listing them. Claude inferred 'Pro' was the top tier and gave at least one user a reply that skipped Ultimate entirely.

**After:** New `api/core/support_kb.go` with a 200+ line authoritative knowledge base. Tier section explicitly lists all four (Free, Uplink, Uplink Pro, Uplink Ultimate) plus Super User, with exact symbol/feed/league/row caps for each, plus an explicit instruction:

> List ALL FOUR tier-tiers (Free, Uplink, Pro, Ultimate) any time pricing or limits come up — do NOT skip Uplink Ultimate.

### Concern 3 — User's message not in partner approval email

**Before:** Partner email showed AI summary + drafted reply but not what the user actually wrote. Partner had to click through to osTicket to compare them.

**After:**
- New `user_message_html` column on `support_drafts` (migration 000011, nullable for back-compat with old rows)
- Plumbed through `SupportDraft` struct + `createSupportDraft` + `loadSupportDraft`
- Both ticket creation paths populate it (`/support/ticket` with the original body; `/support/ticket/public` likewise; reply-loop webhook with the user's reply body)
- Partner email now shows a 'What the user wrote' section with a distinct gray border-left, side-by-side with the green-bordered 'AI-drafted reply' section. Partner can compare them at a glance.

### Concern 4 — Richer knowledgebase

**Before:** 25-line FAQ. Drift-prone.

**After:** Comprehensive KB in `api/core/support_kb.go` with:
- All four tiers + Super User with exact caps
- Per-channel troubleshooting (Finance, Sports, News, Fantasy)
- Auth + account management (immutable username, password reset, GDPR)
- Multi-row ticker per-tier behavior
- The 'channel disappeared from ticker' issue (the most-asked-about confusion)
- Update + platform support
- 'What to never say' guardrails (no specific dollar amounts, no promised dates)

Editing rules and size budget are documented inline so the next contributor knows how to maintain it.

## Files changed

| File | Change |
|---|---|
| `api/core/support_kb.go` | NEW — canonical product knowledge base |
| `api/core/ai_triage.go` | `faqContextForTriage()` delegates to `supportKnowledgeBase()`; `applyTriageToBody` removed |
| `api/core/support.go` | Drop `applyTriageToBody` call in `HandleSubmitSupportTicket`; pass `originalBody` to `createSupportDraft` |
| `api/core/handlers_support_public.go` | Drop `applyTriageToBody` call in `HandleSubmitPublicSupportTicket` |
| `api/core/handlers_osticket_webhook.go` | Pass `ev.MessageHTML` to `createSupportDraft` |
| `api/core/support_drafts.go` | `SupportDraft.UserMessageHTML` field; SQL INSERT/SELECT updated; partner email template adds 'What the user wrote' block |
| `api/migrations/000011_support_drafts_user_message.{up,down}.sql` | NEW — adds nullable `user_message_html TEXT` column |

## Verification

- ` + "`go vet ./...`" + ` clean
- ` + "`go build`" + ` clean
- ` + "`go test ./core/`" + ` passing (no regressions)
- Migration runs cleanly: ` + "`ALTER TABLE support_drafts ADD COLUMN IF NOT EXISTS user_message_html TEXT`" + ` is idempotent and back-compat
- KB size: ~6 KB (well under the ~10 KB self-imposed budget for prompt context)

## No new env vars or secrets

No infrastructure changes. Plugin code untouched. Migration is a single column add.

## Post-merge verification

After K8s deploy, the next ticket triaged should show:
1. Clean user-visible thread (no AI summary banner, no drafted-reply <details> block)
2. Partner email with both 'What the user wrote' AND 'AI-drafted reply' sections
3. AI replies that mention Uplink + Uplink Pro + Uplink Ultimate when discussing tier upgrades (no more skipped Ultimate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)