### PR TITLE
feat(triage): Discord-thread integration for support ticket approval

### DIFF
--- a/api/core/discord.go
+++ b/api/core/discord.go
@@ -1,0 +1,691 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// =============================================================================
+// Discord integration — REST client + signature verification
+// =============================================================================
+//
+// Scrollr's support-triage pipeline uses Discord as the partner-facing
+// UI for approving / editing / skipping AI-drafted replies. Today we ALSO
+// notify via email; Discord runs in addition for now.
+//
+// All Discord logic lives in core-api (no separate bot service). Two
+// directions of traffic:
+//
+//   Outbound (us → Discord): REST API calls authenticated with bot token
+//     - POST /api/v10/channels/{channel_id}/threads     (create thread)
+//     - POST /api/v10/channels/{thread_id}/messages     (post in thread)
+//     - PATCH /api/v10/channels/{thread_id}             (archive thread)
+//     - PUT /api/v10/applications/{app_id}/guilds/{guild_id}/commands
+//
+//   Inbound (Discord → us): HTTP POSTs to /webhooks/discord/interactions
+//     verified via Ed25519 signatures (DISCORD_PUBLIC_KEY).
+//
+// Failure mode is fail-open: if Discord calls fail, we log and continue.
+// The email notification path stays active as a backup.
+//
+// See docs/superpowers/specs/2026-05-01-discord-triage-integration-design.md
+
+const (
+	discordAPIBase     = "https://discord.com/api/v10"
+	discordHTTPTimeout = 10 * time.Second
+)
+
+// DiscordConfig groups the env-driven config in one struct so callers
+// can quick-check whether Discord integration is enabled (any missing
+// required field => disabled, log once at startup).
+type DiscordConfig struct {
+	BotToken         string // Bot token from Discord application
+	PublicKey        string // Hex-encoded Ed25519 public key for verifying inbound interactions
+	ApplicationID    string // Discord application snowflake ID
+	GuildID          string // Discord server (guild) snowflake ID
+	SupportChannelID string // Channel in which support threads are created
+}
+
+// loadDiscordConfig reads env vars and returns a config.
+// Returns (cfg, true) when ALL required fields are populated; otherwise
+// (zero-value, false). Callers should treat false as "Discord disabled".
+func loadDiscordConfig() (DiscordConfig, bool) {
+	cfg := DiscordConfig{
+		BotToken:         os.Getenv("DISCORD_BOT_TOKEN"),
+		PublicKey:        os.Getenv("DISCORD_PUBLIC_KEY"),
+		ApplicationID:    os.Getenv("DISCORD_APPLICATION_ID"),
+		GuildID:          os.Getenv("DISCORD_GUILD_ID"),
+		SupportChannelID: os.Getenv("DISCORD_SUPPORT_CHANNEL_ID"),
+	}
+	if cfg.BotToken == "" || cfg.PublicKey == "" ||
+		cfg.ApplicationID == "" || cfg.GuildID == "" ||
+		cfg.SupportChannelID == "" {
+		return DiscordConfig{}, false
+	}
+	return cfg, true
+}
+
+// notifyMode returns the SUPPORT_NOTIFY env var value. Defaults to
+// "both" so existing email notifications keep flowing during rollout.
+//
+// Returned values: "discord", "email", "both".
+func notifyMode() string {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("SUPPORT_NOTIFY")))
+	switch v {
+	case "discord", "email", "both":
+		return v
+	default:
+		return "both"
+	}
+}
+
+// shouldNotifyEmail returns true when we should send the email
+// notification for this draft (per SUPPORT_NOTIFY).
+func shouldNotifyEmail() bool {
+	m := notifyMode()
+	return m == "email" || m == "both"
+}
+
+// shouldNotifyDiscord returns true when Discord integration is enabled
+// AND the SUPPORT_NOTIFY mode includes Discord.
+func shouldNotifyDiscord() bool {
+	if _, ok := loadDiscordConfig(); !ok {
+		return false
+	}
+	m := notifyMode()
+	return m == "discord" || m == "both"
+}
+
+// =============================================================================
+// Outbound Discord REST helpers
+// =============================================================================
+
+// discordHTTPClient is shared across requests.
+var discordHTTPClient = &http.Client{Timeout: discordHTTPTimeout}
+
+// discordRequest performs an authenticated REST call to Discord.
+// Returns the response body bytes and HTTP status code.
+//
+// All callers should treat non-2xx as failure and log + continue (fail-open).
+func discordRequest(ctx context.Context, method, path string, body interface{}) ([]byte, int, error) {
+	cfg, ok := loadDiscordConfig()
+	if !ok {
+		return nil, 0, errors.New("discord not configured")
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, fmt.Errorf("marshal body: %w", err)
+		}
+		bodyReader = bytes.NewReader(buf)
+	}
+
+	url := discordAPIBase + path
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bot "+cfg.BotToken)
+	req.Header.Set("User-Agent", "ScrollrSupportBot (myscrollr.com, 1.0)")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := discordHTTPClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("discord request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read response: %w", err)
+	}
+	return respBody, resp.StatusCode, nil
+}
+
+// =============================================================================
+// Thread + message primitives
+// =============================================================================
+
+// DiscordThread is the minimal subset of Discord's Channel object we
+// need from thread-creation responses.
+type DiscordThread struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	GuildID  string `json:"guild_id"`
+	ParentID string `json:"parent_id"`
+}
+
+// discordCreateThread starts a public thread WITHOUT a starting message
+// in the support channel.
+//
+// Returns the new thread's ID. Discord's "thread without a message"
+// endpoint requires the `auto_archive_duration` field; 4320 = 3 days.
+func discordCreateThread(ctx context.Context, channelID, name string) (*DiscordThread, error) {
+	if len(name) > 100 {
+		// Discord's hard limit on thread names is 100 chars.
+		name = name[:100]
+	}
+	body := map[string]interface{}{
+		"name":                  name,
+		"type":                  11, // PUBLIC_THREAD
+		"auto_archive_duration": 4320,
+	}
+	respBody, status, err := discordRequest(ctx, http.MethodPost,
+		"/channels/"+channelID+"/threads", body)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 400 {
+		return nil, fmt.Errorf("discord create thread: status %d body %s", status, string(respBody))
+	}
+	var t DiscordThread
+	if err := json.Unmarshal(respBody, &t); err != nil {
+		return nil, fmt.Errorf("parse thread response: %w", err)
+	}
+	return &t, nil
+}
+
+// DiscordMessageButton is a minimal action-row button.
+type DiscordMessageButton struct {
+	Type     int    `json:"type"`  // 2 = Button
+	Style    int    `json:"style"` // 1=primary, 2=secondary, 3=success, 4=danger, 5=link
+	Label    string `json:"label"`
+	CustomID string `json:"custom_id,omitempty"` // for non-link buttons
+	Emoji    *struct {
+		Name string `json:"name"`
+	} `json:"emoji,omitempty"`
+}
+
+// DiscordActionRow groups buttons.
+type DiscordActionRow struct {
+	Type       int                    `json:"type"` // 1 = ACTION_ROW
+	Components []DiscordMessageButton `json:"components"`
+}
+
+// discordPostMessage posts a message in a channel or thread, optionally
+// with components (buttons). Returns the new message's ID.
+//
+// channelOrThreadID is either a channel ID or thread ID — Discord
+// treats threads as channels for the purpose of posting.
+func discordPostMessage(ctx context.Context, channelOrThreadID, content string, components []DiscordActionRow) (string, error) {
+	body := map[string]interface{}{
+		"content":          content,
+		"allowed_mentions": map[string]interface{}{"parse": []string{}}, // suppress @ mentions
+	}
+	if len(components) > 0 {
+		body["components"] = components
+	}
+	respBody, status, err := discordRequest(ctx, http.MethodPost,
+		"/channels/"+channelOrThreadID+"/messages", body)
+	if err != nil {
+		return "", err
+	}
+	if status >= 400 {
+		return "", fmt.Errorf("discord post message: status %d body %s", status, string(respBody))
+	}
+	var m struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &m); err != nil {
+		return "", fmt.Errorf("parse message response: %w", err)
+	}
+	return m.ID, nil
+}
+
+// discordArchiveThread sets `archived: true` on a thread. No-op if
+// thread doesn't exist (returns nil so callers don't crash on race).
+func discordArchiveThread(ctx context.Context, threadID string) error {
+	body := map[string]interface{}{
+		"archived": true,
+		"locked":   false, // locked threads can't be unarchived by activity
+	}
+	respBody, status, err := discordRequest(ctx, http.MethodPatch,
+		"/channels/"+threadID, body)
+	if err != nil {
+		return err
+	}
+	if status == http.StatusNotFound {
+		return nil
+	}
+	if status >= 400 {
+		return fmt.Errorf("discord archive thread: status %d body %s", status, string(respBody))
+	}
+	return nil
+}
+
+// =============================================================================
+// Slash command registration
+// =============================================================================
+
+// discordSlashCommand is the minimal payload for registering a guild
+// command. Discord's API supports many more options (subcommands,
+// autocomplete, etc.) — we only need the basics.
+type discordSlashCommand struct {
+	Name        string                      `json:"name"`
+	Description string                      `json:"description"`
+	Type        int                         `json:"type"` // 1 = CHAT_INPUT
+	Options     []discordSlashCommandOption `json:"options,omitempty"`
+}
+
+type discordSlashCommandOption struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        int    `json:"type"` // 3 = STRING
+	Required    bool   `json:"required,omitempty"`
+}
+
+// registerDiscordSlashCommands upserts our guild-scoped slash commands.
+// Discord's bulk-overwrite endpoint replaces the entire command set in
+// one call, which is what we want — runs idempotently on every startup.
+//
+// Guild-scoped commands appear instantly; global commands have a 1-hour
+// propagation delay. We use guild-scoped because we have one server.
+func registerDiscordSlashCommands(ctx context.Context) error {
+	cfg, ok := loadDiscordConfig()
+	if !ok {
+		return errors.New("discord not configured")
+	}
+
+	commands := []discordSlashCommand{
+		{
+			Name:        "inbox",
+			Description: "Show pending support drafts (most recent 5)",
+			Type:        1,
+		},
+		{
+			Name:        "ticket",
+			Description: "Show the latest draft for a ticket number",
+			Type:        1,
+			Options: []discordSlashCommandOption{
+				{
+					Name:        "number",
+					Description: "osTicket ticket number (e.g. 239171)",
+					Type:        3,
+					Required:    true,
+				},
+			},
+		},
+	}
+
+	path := fmt.Sprintf("/applications/%s/guilds/%s/commands",
+		cfg.ApplicationID, cfg.GuildID)
+	respBody, status, err := discordRequest(ctx, http.MethodPut, path, commands)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("register slash commands: status %d body %s", status, string(respBody))
+	}
+	return nil
+}
+
+// RegisterDiscordSlashCommandsAtBoot is the public boot hook called
+// from main.go. No-op when Discord isn't configured. Errors are logged
+// but never fatal — the API stays up either way.
+func RegisterDiscordSlashCommandsAtBoot(ctx context.Context) {
+	if _, ok := loadDiscordConfig(); !ok {
+		log.Println("[Discord] not configured; skipping slash command registration")
+		return
+	}
+	if err := registerDiscordSlashCommands(ctx); err != nil {
+		log.Printf("[Discord] register slash commands: %v", err)
+		return
+	}
+	log.Println("[Discord] slash commands registered (/inbox, /ticket)")
+}
+
+// =============================================================================
+// Inbound signature verification
+// =============================================================================
+
+// verifyDiscordSignature checks that a request from Discord is genuine.
+// Discord signs every interaction with Ed25519: the signing payload is
+// timestamp + body, signed with the application's signing key.
+//
+// Returns nil if the signature is valid; an error otherwise. Callers
+// should respond 401 to the HTTP request when this returns non-nil.
+//
+// The verification IS time-sensitive in that Discord includes a
+// timestamp, but we don't reject old requests by clock — Discord
+// retries with the same timestamp. The crypto verification is
+// sufficient.
+func verifyDiscordSignature(publicKeyHex, signatureHex, timestamp string, body []byte) error {
+	pubKey, err := hex.DecodeString(publicKeyHex)
+	if err != nil {
+		return fmt.Errorf("decode public key: %w", err)
+	}
+	if len(pubKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("public key wrong size: got %d want %d", len(pubKey), ed25519.PublicKeySize)
+	}
+
+	signature, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+	if len(signature) != ed25519.SignatureSize {
+		return fmt.Errorf("signature wrong size: got %d want %d", len(signature), ed25519.SignatureSize)
+	}
+
+	// The signed payload is timestamp + body, no separator.
+	signed := make([]byte, 0, len(timestamp)+len(body))
+	signed = append(signed, []byte(timestamp)...)
+	signed = append(signed, body...)
+
+	if !ed25519.Verify(pubKey, signed, signature) {
+		return errors.New("signature verification failed")
+	}
+	return nil
+}
+
+// =============================================================================
+// Thread persistence
+// =============================================================================
+
+// SupportTicketThread mirrors the support_ticket_threads table.
+type SupportTicketThread struct {
+	TicketNumber    string
+	DiscordThreadID string
+	ChannelID       string
+	Archived        bool
+	CreatedAt       time.Time
+}
+
+// upsertSupportTicketThread inserts or updates the ticket→thread
+// mapping. Idempotent on ticket_number (unique key).
+func upsertSupportTicketThread(ctx context.Context, t *SupportTicketThread) error {
+	const q = `
+		INSERT INTO support_ticket_threads
+			(ticket_number, discord_thread_id, channel_id, archived)
+		VALUES ($1, $2, $3, FALSE)
+		ON CONFLICT (ticket_number) DO UPDATE
+			SET discord_thread_id = EXCLUDED.discord_thread_id,
+				channel_id = EXCLUDED.channel_id,
+				archived = FALSE
+	`
+	_, err := DBPool.Exec(ctx, q, t.TicketNumber, t.DiscordThreadID, t.ChannelID)
+	if err != nil {
+		return fmt.Errorf("upsert ticket thread: %w", err)
+	}
+	return nil
+}
+
+// loadSupportTicketThread looks up the Discord thread ID for a ticket.
+// Returns (nil, nil) when no mapping exists.
+func loadSupportTicketThread(ctx context.Context, ticketNumber string) (*SupportTicketThread, error) {
+	const q = `
+		SELECT ticket_number, discord_thread_id, channel_id, archived, created_at
+		FROM support_ticket_threads
+		WHERE ticket_number = $1
+	`
+	var t SupportTicketThread
+	err := DBPool.QueryRow(ctx, q, ticketNumber).Scan(
+		&t.TicketNumber, &t.DiscordThreadID, &t.ChannelID, &t.Archived, &t.CreatedAt,
+	)
+	if err != nil {
+		// Return nil, nil for "not found" so callers can branch easily.
+		// Specifically: pgx returns ErrNoRows on no rows, which we
+		// translate here.
+		if strings.Contains(err.Error(), "no rows") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load ticket thread: %w", err)
+	}
+	return &t, nil
+}
+
+// markSupportTicketThreadArchived flips the archived flag for a ticket's
+// thread. Used after auto-close so we don't try to repost in archived
+// threads on subsequent user replies (we'll create a new thread instead).
+func markSupportTicketThreadArchived(ctx context.Context, ticketNumber string) error {
+	const q = `UPDATE support_ticket_threads SET archived = TRUE WHERE ticket_number = $1`
+	_, err := DBPool.Exec(ctx, q, ticketNumber)
+	return err
+}
+
+// =============================================================================
+// Notification entry point — called from notifyPartnerAfterDraft
+// =============================================================================
+
+// notifyDiscordForDraft posts a new ticket draft to Discord. Creates a
+// thread if one doesn't exist for this ticket, posts a follow-up
+// message if it does. Either way, the message includes the user's body,
+// the AI summary + drafted reply, and three action buttons.
+//
+// Fail-open: any error here is logged and swallowed. The email path
+// (if enabled) covers us.
+func notifyDiscordForDraft(ctx context.Context, draft *SupportDraft) {
+	if !shouldNotifyDiscord() {
+		return
+	}
+	cfg, _ := loadDiscordConfig() // ok already verified by shouldNotifyDiscord
+
+	threadID, err := getOrCreateThreadForTicket(ctx, cfg, draft)
+	if err != nil {
+		log.Printf("[Discord] getOrCreateThread for ticket %s: %v", draft.TicketNumber, err)
+		return
+	}
+
+	content := buildDraftMessageContent(draft)
+	components := buildDraftActionButtons(draft.ID)
+
+	if _, err := discordPostMessage(ctx, threadID, content, components); err != nil {
+		log.Printf("[Discord] post draft message for ticket %s: %v", draft.TicketNumber, err)
+		return
+	}
+}
+
+// getOrCreateThreadForTicket looks up an existing thread or creates a
+// new one. Threads that have been archived (via the close path) are
+// treated as not-existing and a new thread is created.
+func getOrCreateThreadForTicket(ctx context.Context, cfg DiscordConfig, draft *SupportDraft) (string, error) {
+	existing, err := loadSupportTicketThread(ctx, draft.TicketNumber)
+	if err != nil {
+		return "", fmt.Errorf("load existing thread: %w", err)
+	}
+	if existing != nil && !existing.Archived {
+		return existing.DiscordThreadID, nil
+	}
+
+	// Create a new thread.
+	subject := draft.OriginalSubject
+	if subject == "" {
+		subject = "support ticket"
+	}
+	// Truncate so the formatted name fits Discord's 100-char limit.
+	if len(subject) > 70 {
+		subject = subject[:70] + "..."
+	}
+	name := fmt.Sprintf("[#%s] %s", draft.TicketNumber, subject)
+
+	thread, err := discordCreateThread(ctx, cfg.SupportChannelID, name)
+	if err != nil {
+		return "", fmt.Errorf("create thread: %w", err)
+	}
+
+	// Persist the mapping.
+	if err := upsertSupportTicketThread(ctx, &SupportTicketThread{
+		TicketNumber:    draft.TicketNumber,
+		DiscordThreadID: thread.ID,
+		ChannelID:       cfg.SupportChannelID,
+	}); err != nil {
+		// Non-fatal — thread is created in Discord, we just couldn't
+		// persist the mapping. Next user reply will create yet another
+		// thread, which is bad UX but not a hard failure. Log and
+		// continue so the partner still gets the message in the new
+		// thread.
+		log.Printf("[Discord] persist thread mapping for ticket %s: %v", draft.TicketNumber, err)
+	}
+
+	return thread.ID, nil
+}
+
+// buildDraftMessageContent renders the user message + AI metadata +
+// drafted reply into Discord's text content. Discord supports basic
+// markdown (bold, blockquote, code) and a 2000-char limit per message.
+//
+// We trim aggressively so the content fits even with verbose user
+// bodies.
+func buildDraftMessageContent(draft *SupportDraft) string {
+	var b strings.Builder
+
+	header := fmt.Sprintf("**Ticket #%s** — `%s` · `%s` · confidence: `%s`",
+		draft.TicketNumber, draft.AICategory, draft.AIPriority, draft.AIConfidence)
+	b.WriteString(header)
+	b.WriteString("\n\n")
+
+	if draft.UserMessageHTML != "" {
+		b.WriteString("**What the user wrote:**\n")
+		b.WriteString(blockquoteText(htmlToPlain(draft.UserMessageHTML), 600))
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("**AI summary:** ")
+	b.WriteString(draft.AISummary)
+	b.WriteString("\n\n")
+
+	b.WriteString("**Drafted reply:**\n")
+	b.WriteString(blockquoteText(htmlToPlain(draft.DraftBodyHTML), 800))
+
+	// Reserve some headroom for Discord's hard 2000-char limit.
+	out := b.String()
+	if len(out) > 1900 {
+		out = out[:1900] + "\n\n_...truncated_"
+	}
+	return out
+}
+
+// buildDraftActionButtons returns the action-row components for a
+// pending draft.
+func buildDraftActionButtons(draftID int64) []DiscordActionRow {
+	send := DiscordMessageButton{
+		Type:     2,
+		Style:    3, // success / green
+		Label:    "Send",
+		CustomID: fmt.Sprintf("support_send:%d", draftID),
+	}
+	send.Emoji = &struct {
+		Name string `json:"name"`
+	}{Name: "✅"}
+	edit := DiscordMessageButton{
+		Type:     2,
+		Style:    1, // primary / blue
+		Label:    "Edit",
+		CustomID: fmt.Sprintf("support_edit:%d", draftID),
+	}
+	edit.Emoji = &struct {
+		Name string `json:"name"`
+	}{Name: "✏️"}
+	skip := DiscordMessageButton{
+		Type:     2,
+		Style:    2, // secondary / gray
+		Label:    "Skip",
+		CustomID: fmt.Sprintf("support_skip:%d", draftID),
+	}
+	skip.Emoji = &struct {
+		Name string `json:"name"`
+	}{Name: "⏭️"}
+
+	return []DiscordActionRow{
+		{
+			Type:       1,
+			Components: []DiscordMessageButton{send, edit, skip},
+		},
+	}
+}
+
+// =============================================================================
+// Plain-text helpers (Discord's text/markdown is much simpler than HTML)
+// =============================================================================
+
+// htmlToPlain strips HTML tags and decodes a few common entities so the
+// content reads cleanly in Discord's markdown. Not a full HTML parser —
+// the AI drafts and user messages are simple enough that a regex-style
+// strip is sufficient.
+func htmlToPlain(s string) string {
+	out := s
+
+	// Replace common block-ish tags with newlines so paragraphs stay
+	// readable in Discord.
+	replacements := []struct{ from, to string }{
+		{"<br/>", "\n"},
+		{"<br />", "\n"},
+		{"<br>", "\n"},
+		{"</p>", "\n\n"},
+		{"</div>", "\n"},
+		{"</li>", "\n"},
+		{"<li>", "• "},
+	}
+	for _, r := range replacements {
+		out = strings.ReplaceAll(out, r.from, r.to)
+		out = strings.ReplaceAll(out, strings.ToUpper(r.from), r.to)
+	}
+
+	// Strip remaining tags.
+	out = stripHTMLTags(out)
+
+	// Decode a few common entities.
+	entities := map[string]string{
+		"&nbsp;": " ",
+		"&amp;":  "&",
+		"&lt;":   "<",
+		"&gt;":   ">",
+		"&quot;": "\"",
+		"&#39;":  "'",
+	}
+	for from, to := range entities {
+		out = strings.ReplaceAll(out, from, to)
+	}
+
+	// Collapse 3+ newlines.
+	for strings.Contains(out, "\n\n\n") {
+		out = strings.ReplaceAll(out, "\n\n\n", "\n\n")
+	}
+	return strings.TrimSpace(out)
+}
+
+// stripHTMLTags removes everything between < and >. Naive but
+// sufficient for our trusted-input content.
+func stripHTMLTags(s string) string {
+	var out strings.Builder
+	out.Grow(len(s))
+	inTag := false
+	for _, r := range s {
+		switch {
+		case r == '<':
+			inTag = true
+		case r == '>':
+			inTag = false
+		case !inTag:
+			out.WriteRune(r)
+		}
+	}
+	return out.String()
+}
+
+// blockquoteText prefixes each line with `> ` so Discord renders it as
+// a quote block. Truncates to maxBytes (rough char count).
+func blockquoteText(s string, maxBytes int) string {
+	if len(s) > maxBytes {
+		s = s[:maxBytes] + "..."
+	}
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = "> " + line
+	}
+	return strings.Join(lines, "\n")
+}

--- a/api/core/handlers_discord_interactions.go
+++ b/api/core/handlers_discord_interactions.go
@@ -1,0 +1,642 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// =============================================================================
+// Discord interactions handler — POST /webhooks/discord/interactions
+// =============================================================================
+//
+// Discord POSTs all interaction events (slash commands, button clicks,
+// modal submissions) to a single endpoint. Each request is signed with
+// Ed25519 using the application's signing key. We verify the signature
+// before processing, respond inline.
+//
+// Interaction types we handle:
+//   - PING (1)               — Discord verifies the endpoint URL
+//   - APPLICATION_COMMAND (2) — slash commands (/inbox, /ticket)
+//   - MESSAGE_COMPONENT (3)   — button clicks (Send, Edit, Skip)
+//   - MODAL_SUBMIT (5)        — partner submitting an edited reply
+//
+// Response types we use:
+//   - PONG (1)                          — for PING
+//   - CHANNEL_MESSAGE_WITH_SOURCE (4)   — visible message
+//   - DEFERRED_CHANNEL_MESSAGE (5)      — "thinking..." placeholder
+//   - MODAL (9)                         — open a modal
+//   - UPDATE_MESSAGE (7)                — edit the message that triggered the interaction
+//
+// Discord docs: https://discord.com/developers/docs/interactions/receiving-and-responding
+
+// Discord interaction types.
+const (
+	discordInteractionPing               = 1
+	discordInteractionApplicationCommand = 2
+	discordInteractionMessageComponent   = 3
+	discordInteractionModalSubmit        = 5
+)
+
+// Discord interaction response types.
+const (
+	discordResponsePong                     = 1
+	discordResponseChannelMessageWithSource = 4
+	discordResponseDeferredChannelMessage   = 5
+	discordResponseUpdateMessage            = 7
+	discordResponseDeferredUpdateMessage    = 6
+	discordResponseModal                    = 9
+)
+
+// discordInteractionFlagEphemeral marks a response as visible only to
+// the user who triggered it. Used for confirmations and errors so we
+// don't clutter the channel.
+const discordInteractionFlagEphemeral = 64
+
+// discordInteraction is the part of Discord's interaction payload we
+// actually consume. The full schema has many more fields; we ignore them.
+type discordInteraction struct {
+	ID            string                  `json:"id"`
+	Type          int                     `json:"type"`
+	Token         string                  `json:"token"`
+	ApplicationID string                  `json:"application_id"`
+	GuildID       string                  `json:"guild_id"`
+	ChannelID     string                  `json:"channel_id"`
+	Member        *discordMember          `json:"member"`
+	Data          *discordInteractionData `json:"data"`
+}
+
+type discordMember struct {
+	User *discordUser `json:"user"`
+}
+
+type discordUser struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+type discordInteractionData struct {
+	// APPLICATION_COMMAND fields
+	Name    string                         `json:"name"`
+	Options []discordInteractionDataOption `json:"options,omitempty"`
+	// MESSAGE_COMPONENT fields
+	CustomID      string `json:"custom_id"`
+	ComponentType int    `json:"component_type"`
+	// MODAL_SUBMIT fields
+	Components []discordModalComponentRow `json:"components,omitempty"`
+}
+
+type discordInteractionDataOption struct {
+	Name  string `json:"name"`
+	Type  int    `json:"type"`
+	Value string `json:"value"`
+}
+
+type discordModalComponentRow struct {
+	Type       int                          `json:"type"`
+	Components []discordModalComponentInput `json:"components"`
+}
+
+type discordModalComponentInput struct {
+	Type     int    `json:"type"`
+	CustomID string `json:"custom_id"`
+	Value    string `json:"value"`
+}
+
+// HandleDiscordInteractions verifies the signature, dispatches by
+// interaction type, returns the appropriate response.
+func HandleDiscordInteractions(c *fiber.Ctx) error {
+	cfg, ok := loadDiscordConfig()
+	if !ok {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "discord not configured",
+		})
+	}
+
+	signature := c.Get("X-Signature-Ed25519")
+	timestamp := c.Get("X-Signature-Timestamp")
+	if signature == "" || timestamp == "" {
+		return c.Status(fiber.StatusUnauthorized).SendString("missing signature headers")
+	}
+
+	body := c.Body()
+	if err := verifyDiscordSignature(cfg.PublicKey, signature, timestamp, body); err != nil {
+		log.Printf("[DiscordInteraction] signature verify failed: %v", err)
+		return c.Status(fiber.StatusUnauthorized).SendString("invalid signature")
+	}
+
+	var interaction discordInteraction
+	if err := json.Unmarshal(body, &interaction); err != nil {
+		log.Printf("[DiscordInteraction] body parse: %v", err)
+		return c.Status(fiber.StatusBadRequest).SendString("malformed body")
+	}
+
+	switch interaction.Type {
+	case discordInteractionPing:
+		return c.JSON(fiber.Map{"type": discordResponsePong})
+	case discordInteractionApplicationCommand:
+		return handleDiscordSlashCommand(c, &interaction)
+	case discordInteractionMessageComponent:
+		return handleDiscordButtonClick(c, &interaction)
+	case discordInteractionModalSubmit:
+		return handleDiscordModalSubmit(c, &interaction)
+	default:
+		log.Printf("[DiscordInteraction] unknown type %d", interaction.Type)
+		return c.Status(fiber.StatusBadRequest).SendString("unknown interaction type")
+	}
+}
+
+// =============================================================================
+// Button clicks — Send / Edit / Skip
+// =============================================================================
+
+// handleDiscordButtonClick routes button presses by the action prefix
+// in their `custom_id`.
+//
+// custom_id format: "support_<action>:<draft_id>" where action is
+// send / edit / skip.
+func handleDiscordButtonClick(c *fiber.Ctx, ix *discordInteraction) error {
+	if ix.Data == nil {
+		return discordEphemeralResponse(c, "missing data")
+	}
+	customID := ix.Data.CustomID
+	parts := strings.SplitN(customID, ":", 2)
+	if len(parts) != 2 {
+		return discordEphemeralResponse(c, "malformed custom_id")
+	}
+	prefix, idStr := parts[0], parts[1]
+	draftID, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return discordEphemeralResponse(c, "malformed draft id")
+	}
+
+	switch prefix {
+	case "support_send":
+		return handleDiscordSendAction(c, ix, draftID)
+	case "support_edit":
+		return handleDiscordEditOpenModal(c, ix, draftID)
+	case "support_skip":
+		return handleDiscordSkipAction(c, ix, draftID)
+	default:
+		log.Printf("[DiscordInteraction] unknown button prefix %q", prefix)
+		return discordEphemeralResponse(c, "unknown action")
+	}
+}
+
+// handleDiscordSendAction calls the existing approve-and-send flow.
+func handleDiscordSendAction(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil {
+		log.Printf("[DiscordInteraction] load draft %d: %v", draftID, err)
+		return discordEphemeralResponse(c, "Could not load draft.")
+	}
+	if draft == nil {
+		return discordEphemeralResponse(c, "Draft not found (already actioned?).")
+	}
+	if draft.Status != "pending" {
+		return discordEphemeralResponse(c,
+			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
+	}
+
+	// Atomic decide → approved (no edits). Same call the email
+	// approval flow makes for the Send action.
+	if err := markDraftDecided(ctx, draftID, "approved", ""); err != nil {
+		log.Printf("[DiscordInteraction] markDraftDecided for %d: %v", draftID, err)
+		return discordEphemeralResponse(c, "Could not mark draft as approved.")
+	}
+	// Reload to get the post-mark state (status='approved').
+	draft, _ = loadSupportDraft(ctx, draftID)
+
+	// Fire-and-forget the actual reply send. body="" tells
+	// sendApprovedReply to use draft.DraftBodyHTML as-is. On success it
+	// will markDraftSent; on failure markDraftFailed.
+	go func() {
+		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer bgCancel()
+		if err := sendApprovedReply(bgCtx, draft, draft.DraftBodyHTML); err != nil {
+			log.Printf("[DiscordInteraction] sendApprovedReply for ticket %s: %v",
+				draft.TicketNumber, err)
+			return
+		}
+		// On close, archive the Discord thread.
+		if draft.ShouldClose {
+			if t, err := loadSupportTicketThread(bgCtx, draft.TicketNumber); err == nil && t != nil {
+				if err := discordArchiveThread(bgCtx, t.DiscordThreadID); err != nil {
+					log.Printf("[DiscordInteraction] archive thread for ticket %s: %v",
+						draft.TicketNumber, err)
+				} else {
+					_ = markSupportTicketThreadArchived(bgCtx, draft.TicketNumber)
+				}
+			}
+		}
+	}()
+
+	suffix := ""
+	if draft.ShouldClose {
+		suffix = " — ticket auto-closing"
+	}
+	return discordVisibleResponse(c, "✅ Sent to user"+suffix)
+}
+
+// handleDiscordEditOpenModal opens a modal so the partner can edit the
+// AI's draft before sending. The modal's text-area is pre-filled with
+// the current draft body (HTML stripped to plain text since Discord
+// modals are plain-text only).
+func handleDiscordEditOpenModal(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil {
+		log.Printf("[DiscordInteraction] load draft %d: %v", draftID, err)
+		return discordEphemeralResponse(c, "Could not load draft.")
+	}
+	if draft == nil {
+		return discordEphemeralResponse(c, "Draft not found.")
+	}
+	if draft.Status != "pending" {
+		return discordEphemeralResponse(c,
+			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
+	}
+
+	// Convert draft HTML to plain text for the modal's text area.
+	prefilled := htmlToPlain(draft.DraftBodyHTML)
+	if len(prefilled) > 4000 {
+		// Discord text-area max is 4000 chars.
+		prefilled = prefilled[:4000]
+	}
+
+	resp := fiber.Map{
+		"type": discordResponseModal,
+		"data": fiber.Map{
+			"custom_id": fmt.Sprintf("support_edit_modal:%d", draftID),
+			"title":     fmt.Sprintf("Edit reply for #%s", draft.TicketNumber),
+			"components": []fiber.Map{
+				{
+					"type": 1,
+					"components": []fiber.Map{
+						{
+							"type":        4,
+							"custom_id":   "edited_body",
+							"label":       "Reply body (plain text)",
+							"style":       2, // Paragraph
+							"value":       prefilled,
+							"min_length":  1,
+							"max_length":  4000,
+							"required":    true,
+							"placeholder": "Edit the reply...",
+						},
+					},
+				},
+			},
+		},
+	}
+	return c.JSON(resp)
+}
+
+// handleDiscordSkipAction marks the draft as skipped.
+func handleDiscordSkipAction(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil {
+		return discordEphemeralResponse(c, "Could not load draft.")
+	}
+	if draft == nil {
+		return discordEphemeralResponse(c, "Draft not found.")
+	}
+	if draft.Status != "pending" {
+		return discordEphemeralResponse(c,
+			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
+	}
+
+	if err := markDraftDecided(ctx, draftID, "skipped", ""); err != nil {
+		log.Printf("[DiscordInteraction] markDraftDecided (skipped) %d: %v", draftID, err)
+		return discordEphemeralResponse(c, "Could not skip draft.")
+	}
+
+	return discordVisibleResponse(c, "⏭️ Skipped — draft will not be sent")
+}
+
+// =============================================================================
+// Modal submit — partner submitted edited reply
+// =============================================================================
+
+// handleDiscordModalSubmit processes the modal-submit event from the
+// Edit flow. Reads the edited body out of the components array,
+// applies it to the draft, and dispatches the reply.
+func handleDiscordModalSubmit(c *fiber.Ctx, ix *discordInteraction) error {
+	if ix.Data == nil {
+		return discordEphemeralResponse(c, "missing data")
+	}
+	customID := ix.Data.CustomID
+	parts := strings.SplitN(customID, ":", 2)
+	if len(parts) != 2 || parts[0] != "support_edit_modal" {
+		return discordEphemeralResponse(c, "malformed modal custom_id")
+	}
+	draftID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return discordEphemeralResponse(c, "malformed draft id")
+	}
+
+	// Discord nests modal field values one level deep: components is
+	// a list of action rows, each containing one input component.
+	var editedBody string
+	for _, row := range ix.Data.Components {
+		for _, comp := range row.Components {
+			if comp.CustomID == "edited_body" {
+				editedBody = comp.Value
+			}
+		}
+	}
+	editedBody = strings.TrimSpace(editedBody)
+	if editedBody == "" {
+		return discordEphemeralResponse(c, "Edited body is empty.")
+	}
+
+	// Wrap plain-text in basic HTML so the email rendering path doesn't
+	// break. Existing pipeline expects HTML.
+	editedBodyHTML := plainToHTMLParagraphs(editedBody)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil || draft == nil {
+		return discordEphemeralResponse(c, "Draft not found.")
+	}
+	if draft.Status != "pending" {
+		return discordEphemeralResponse(c,
+			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
+	}
+
+	// Atomic decide → edited with the edited body persisted on the row.
+	if err := markDraftDecided(ctx, draftID, "edited", editedBodyHTML); err != nil {
+		log.Printf("[DiscordInteraction] markDraftDecided (edited) %d: %v", draftID, err)
+		return discordEphemeralResponse(c, "Could not save edits.")
+	}
+	draft, _ = loadSupportDraft(ctx, draftID)
+
+	go func() {
+		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer bgCancel()
+		if err := sendApprovedReply(bgCtx, draft, editedBodyHTML); err != nil {
+			log.Printf("[DiscordInteraction] sendApprovedReply (edited) for ticket %s: %v",
+				draft.TicketNumber, err)
+		}
+		if draft.ShouldClose {
+			if t, err := loadSupportTicketThread(bgCtx, draft.TicketNumber); err == nil && t != nil {
+				_ = discordArchiveThread(bgCtx, t.DiscordThreadID)
+				_ = markSupportTicketThreadArchived(bgCtx, draft.TicketNumber)
+			}
+		}
+	}()
+
+	return discordVisibleResponse(c, "✏️ Edited and sent")
+}
+
+// =============================================================================
+// Slash commands — /inbox and /ticket <number>
+// =============================================================================
+
+func handleDiscordSlashCommand(c *fiber.Ctx, ix *discordInteraction) error {
+	if ix.Data == nil {
+		return discordEphemeralResponse(c, "missing data")
+	}
+	switch ix.Data.Name {
+	case "inbox":
+		return handleDiscordInboxCommand(c, ix)
+	case "ticket":
+		return handleDiscordTicketCommand(c, ix)
+	default:
+		return discordEphemeralResponse(c,
+			fmt.Sprintf("Unknown command: %s", ix.Data.Name))
+	}
+}
+
+// handleDiscordInboxCommand lists the 5 most recent pending drafts.
+func handleDiscordInboxCommand(c *fiber.Ctx, ix *discordInteraction) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const q = `
+		SELECT id, ticket_number, ai_summary, ai_priority, created_at
+		FROM support_drafts
+		WHERE status = 'pending'
+		ORDER BY created_at DESC
+		LIMIT 5
+	`
+	rows, err := DBPool.Query(ctx, q)
+	if err != nil {
+		log.Printf("[DiscordInteraction] /inbox query: %v", err)
+		return discordEphemeralResponse(c, "Database query failed.")
+	}
+	defer rows.Close()
+
+	var lines []string
+	for rows.Next() {
+		var (
+			id           int64
+			ticketNumber string
+			summary      *string
+			priority     *string
+			createdAt    time.Time
+		)
+		if err := rows.Scan(&id, &ticketNumber, &summary, &priority, &createdAt); err != nil {
+			continue
+		}
+		summaryText := "(no summary)"
+		if summary != nil && *summary != "" {
+			summaryText = *summary
+		}
+		priorityText := ""
+		if priority != nil && *priority != "" {
+			priorityText = " · `" + *priority + "`"
+		}
+		age := time.Since(createdAt).Round(time.Minute)
+		lines = append(lines,
+			fmt.Sprintf("• **#%s**%s — %s _(%s ago)_",
+				ticketNumber, priorityText, summaryText, age))
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("[DiscordInteraction] /inbox rows: %v", err)
+	}
+
+	if len(lines) == 0 {
+		return discordEphemeralResponse(c, "📭 Inbox is empty — no pending drafts.")
+	}
+
+	content := "**Pending support drafts:**\n" + strings.Join(lines, "\n")
+	return discordEphemeralResponse(c, content)
+}
+
+// handleDiscordTicketCommand shows the latest draft for a specific
+// ticket number.
+func handleDiscordTicketCommand(c *fiber.Ctx, ix *discordInteraction) error {
+	if ix.Data == nil {
+		return discordEphemeralResponse(c, "missing data")
+	}
+	var ticketNumber string
+	for _, opt := range ix.Data.Options {
+		if opt.Name == "number" {
+			ticketNumber = strings.TrimSpace(opt.Value)
+		}
+	}
+	if ticketNumber == "" {
+		return discordEphemeralResponse(c, "Missing `number` option.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const q = `
+		SELECT id, ticket_number, user_email, user_name, original_subject,
+			   user_message_html, draft_body_html, ai_summary, ai_category,
+			   ai_priority, ai_channel, ai_duplicate_of, ai_confidence, status,
+			   edited_body_html, decided_at, sent_at, created_at, should_close
+		FROM support_drafts
+		WHERE ticket_number = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	var d SupportDraft
+	var userName, userMsg, summary, category, priority, channel, dupOf, confidence, editedBody *string
+	err := DBPool.QueryRow(ctx, q, ticketNumber).Scan(
+		&d.ID, &d.TicketNumber, &d.UserEmail, &userName, &d.OriginalSubject,
+		&userMsg, &d.DraftBodyHTML, &summary, &category, &priority, &channel,
+		&dupOf, &confidence, &d.Status, &editedBody,
+		&d.DecidedAt, &d.SentAt, &d.CreatedAt, &d.ShouldClose,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return discordEphemeralResponse(c,
+				fmt.Sprintf("No draft found for ticket #%s.", ticketNumber))
+		}
+		log.Printf("[DiscordInteraction] /ticket query: %v", err)
+		return discordEphemeralResponse(c, "Database query failed.")
+	}
+	// Hydrate
+	if userName != nil {
+		d.UserName = *userName
+	}
+	if userMsg != nil {
+		d.UserMessageHTML = *userMsg
+	}
+	if summary != nil {
+		d.AISummary = *summary
+	}
+	if category != nil {
+		d.AICategory = *category
+	}
+	if priority != nil {
+		d.AIPriority = *priority
+	}
+	if channel != nil {
+		d.AIChannel = *channel
+	}
+	if dupOf != nil {
+		d.AIDuplicateOf = *dupOf
+	}
+	if confidence != nil {
+		d.AIConfidence = *confidence
+	}
+
+	content := buildDraftMessageContent(&d) +
+		fmt.Sprintf("\n\n_Status: `%s`_", d.Status)
+
+	// Buttons only if still pending.
+	var components []DiscordActionRow
+	if d.Status == "pending" {
+		components = buildDraftActionButtons(d.ID)
+	}
+
+	resp := fiber.Map{
+		"type": discordResponseChannelMessageWithSource,
+		"data": fiber.Map{
+			"content":          content,
+			"components":       components,
+			"flags":            discordInteractionFlagEphemeral,
+			"allowed_mentions": fiber.Map{"parse": []string{}},
+		},
+	}
+	return c.JSON(resp)
+}
+
+// =============================================================================
+// Response helpers
+// =============================================================================
+
+// discordEphemeralResponse returns an ephemeral message (visible only
+// to the user who triggered the interaction).
+func discordEphemeralResponse(c *fiber.Ctx, content string) error {
+	return c.JSON(fiber.Map{
+		"type": discordResponseChannelMessageWithSource,
+		"data": fiber.Map{
+			"content":          content,
+			"flags":            discordInteractionFlagEphemeral,
+			"allowed_mentions": fiber.Map{"parse": []string{}},
+		},
+	})
+}
+
+// discordVisibleResponse posts a message visible to everyone in the
+// thread/channel where the interaction happened.
+func discordVisibleResponse(c *fiber.Ctx, content string) error {
+	return c.JSON(fiber.Map{
+		"type": discordResponseChannelMessageWithSource,
+		"data": fiber.Map{
+			"content":          content,
+			"allowed_mentions": fiber.Map{"parse": []string{}},
+		},
+	})
+}
+
+// plainToHTMLParagraphs converts user-typed plain text into very basic
+// HTML so the existing email-rendering path can handle it. Each
+// blank-line-separated block becomes a <p>; line-breaks within a block
+// become <br>.
+func plainToHTMLParagraphs(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	paragraphs := strings.Split(s, "\n\n")
+	var out strings.Builder
+	for _, p := range paragraphs {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// Escape minimal HTML so user text is rendered safely.
+		p = strings.ReplaceAll(p, "&", "&amp;")
+		p = strings.ReplaceAll(p, "<", "&lt;")
+		p = strings.ReplaceAll(p, ">", "&gt;")
+		p = strings.ReplaceAll(p, "\n", "<br>")
+		out.WriteString("<p>")
+		out.WriteString(p)
+		out.WriteString("</p>")
+	}
+	return out.String()
+}
+
+// readBody is a small helper to keep handlers symmetric. Currently
+// unused but kept for future modal-or-attachment paths that may need
+// raw body access.
+func readBody(c *fiber.Ctx) ([]byte, error) {
+	r := c.Context().RequestBodyStream()
+	if r == nil {
+		return c.Body(), nil
+	}
+	return io.ReadAll(r)
+}

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -101,15 +101,17 @@ func (s *Server) setupMiddleware() {
 
 	// Core paths always exempt from rate limiting
 	coreExemptPaths := map[string]bool{
-		"/health":                  true,
-		"/events":                  true,
-		"/webhooks/sequin":         true,
-		"/webhooks/stripe":         true,
-		"/channels":                true,
-		"/tier-limits":             true,
-		"/extension/token":         true,
-		"/extension/token/refresh": true,
-		"/support/ticket":          true,
+		"/health":                           true,
+		"/events":                           true,
+		"/webhooks/sequin":                  true,
+		"/webhooks/stripe":                  true,
+		"/webhooks/osticket/thread-message": true,
+		"/webhooks/discord/interactions":    true, // Discord retries on rate-limit and we want them to succeed
+		"/channels":                         true,
+		"/tier-limits":                      true,
+		"/extension/token":                  true,
+		"/extension/token/refresh":          true,
+		"/support/ticket":                   true,
 	}
 
 	// Stricter rate limiter for OAuth initiation endpoints (e.g. /yahoo/start).
@@ -166,6 +168,7 @@ func (s *Server) setupRoutes() {
 	s.App.Post("/webhooks/sequin", HandleSequinWebhook)
 	s.App.Post("/webhooks/stripe", HandleStripeWebhook)
 	s.App.Post("/webhooks/osticket/thread-message", HandleOSTicketThreadMessage)
+	s.App.Post("/webhooks/discord/interactions", HandleDiscordInteractions)
 
 	// Extension auth proxy
 	s.App.Options("/extension/token", HandleExtensionAuthPreflight)

--- a/api/core/support_drafts.go
+++ b/api/core/support_drafts.go
@@ -455,9 +455,18 @@ func SendPartnerNotification(ctx context.Context, draft *SupportDraft) error {
 // flow at deploy time.
 func init() {
 	sendApprovedReply = doSendApprovedReply
+	// notifyPartnerAfterDraft fires both the email path AND the Discord
+	// path, gated by SUPPORT_NOTIFY (defaults to "both"). Either or both
+	// can fail without preventing the other — fully fail-open.
 	notifyPartnerAfterDraft = func(ctx context.Context, draft *SupportDraft) {
-		if err := SendPartnerNotification(ctx, draft); err != nil {
-			log.Printf("[Drafts] SendPartnerNotification for ticket %s failed: %v", draft.TicketNumber, err)
+		if shouldNotifyEmail() {
+			if err := SendPartnerNotification(ctx, draft); err != nil {
+				log.Printf("[Drafts] SendPartnerNotification for ticket %s failed: %v",
+					draft.TicketNumber, err)
+			}
+		}
+		if shouldNotifyDiscord() {
+			notifyDiscordForDraft(ctx, draft)
 		}
 	}
 }

--- a/api/main.go
+++ b/api/main.go
@@ -50,6 +50,10 @@ func main() {
 	// pods otherwise grow this table unboundedly between restarts.
 	core.StartWebhookEventsPruner(ctx)
 
+	// Register Discord slash commands (idempotent on every boot when
+	// configured). No-op if Discord env vars aren't set.
+	core.RegisterDiscordSlashCommandsAtBoot(ctx)
+
 	// Build and start the gateway server
 	srv := core.NewServer()
 	srv.Setup()

--- a/api/migrations/000012_support_ticket_threads.down.sql
+++ b/api/migrations/000012_support_ticket_threads.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS support_ticket_threads;

--- a/api/migrations/000012_support_ticket_threads.up.sql
+++ b/api/migrations/000012_support_ticket_threads.up.sql
@@ -1,0 +1,20 @@
+-- Map osTicket ticket numbers to Discord thread IDs.
+--
+-- Why a separate table (vs. a column on support_drafts): a ticket has
+-- many drafts (initial + each user reply), but ONE Discord thread.
+-- Keying by ticket_number cleanly expresses the 1:1 ticket-to-thread
+-- relationship without duplicating thread IDs across draft rows.
+--
+-- Nullable channel_id field is the channel the thread lives under;
+-- stored explicitly so we can reconstruct the thread URL or move
+-- a thread later if needed (e.g., per-category routing in v2).
+CREATE TABLE IF NOT EXISTS support_ticket_threads (
+    ticket_number      TEXT PRIMARY KEY,
+    discord_thread_id  TEXT NOT NULL,
+    channel_id         TEXT NOT NULL,
+    archived           BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS support_ticket_threads_thread_id_idx
+    ON support_ticket_threads(discord_thread_id);

--- a/docs/superpowers/specs/2026-05-01-discord-triage-integration-design.md
+++ b/docs/superpowers/specs/2026-05-01-discord-triage-integration-design.md
@@ -1,0 +1,242 @@
+# Discord-thread support triage integration — design
+
+**Status:** approved (m1727), executing
+**Owner:** Scrollr core
+**Last updated:** 2026-05-01
+
+## Decisions locked
+
+| # | Question | Choice |
+|---|---|---|
+| 1 | Email kill / keep / both | **Both** (toggleable later via env) |
+| 2 | Channels | **Single channel** for all support threads |
+| 3 | Thread lifecycle on close | **Auto-archive** when ticket closes |
+| 4 | Privacy | Channel is team-only (user-confirmed) |
+| 5 | Slash commands | **Yes** — include `/inbox` + `/ticket <number>` |
+| 6 | Edit UX | **Discord modal** (text-area, pre-filled draft) |
+| 7 | Error handling | **Fail-open** — Discord errors don't block ticket creation; email is the safety net |
+| 8 | Rate limits | Acceptable at current volume |
+
+## Why this exists
+
+The user's stated workflow lives in Discord more than email. Today the AI triage pipeline notifies the partner (Phil / Doni / etc.) via an HTML email with three buttons: Send, Edit, Skip. Email is async, easy to miss on mobile, and doesn't support multi-team-member collaboration well. Discord threads do.
+
+## Architectural insight: no separate bot service required
+
+Discord supports two patterns:
+
+1. **Gateway bots** — long-running websocket connection, event-driven. Required for things like `MESSAGE_CREATE` events, voice, presence.
+2. **HTTP-only bots** — outbound REST + inbound interaction webhooks. No persistent connection.
+
+For this use case (post threads, post messages, handle button + modal interactions, slash commands), HTTP-only is sufficient. Discord POSTs button clicks and modal submits to a webhook URL we host. We respond inline. No daemon, no gateway, no separate service.
+
+**All Discord logic lives in core-api.** No new K8s deployment.
+
+## Endpoint contract
+
+### Outbound (core-api → Discord REST API)
+
+Authenticated via `Authorization: Bot <DISCORD_BOT_TOKEN>` header.
+
+- `POST /api/v10/channels/{channel_id}/threads` — create a public thread for a new ticket
+- `POST /api/v10/channels/{thread_id}/messages` — post initial message + buttons, post reply messages, post confirmations
+- `PATCH /api/v10/channels/{thread_id}` — archive thread on ticket close
+- `POST /api/v10/applications/{application_id}/guilds/{guild_id}/commands` — register slash commands (one-time on startup)
+
+### Inbound (Discord → core-api)
+
+Single endpoint: `POST /webhooks/discord/interactions`
+
+All Discord interaction types funnel through here:
+- `PING` (Discord verification handshake) — respond `{"type": 1}`
+- `APPLICATION_COMMAND` — slash commands (`/inbox`, `/ticket <number>`)
+- `MESSAGE_COMPONENT` — button clicks (Send/Edit/Skip)
+- `MODAL_SUBMIT` — partner submitting an edited reply
+
+Authenticated via Ed25519 signature verification using `DISCORD_PUBLIC_KEY`. Discord signs every request with `X-Signature-Ed25519` + `X-Signature-Timestamp` headers.
+
+## Data model
+
+New table `support_ticket_threads` mapping ticket numbers to their Discord threads:
+
+```sql
+CREATE TABLE support_ticket_threads (
+    ticket_number      TEXT PRIMARY KEY,
+    discord_thread_id  TEXT NOT NULL,
+    channel_id         TEXT NOT NULL,
+    archived           BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX support_ticket_threads_thread_id_idx
+    ON support_ticket_threads(discord_thread_id);
+```
+
+Why a separate table instead of a column on `support_drafts`: a single ticket has many drafts (initial + each user reply), but ONE Discord thread. Keying by ticket_number cleanly expresses 1:1 ticket-to-thread.
+
+## Flow walkthrough
+
+### A. New ticket arrives
+
+1. User submits via `/support/ticket` → osTicket creates ticket → core-api triages → `support_drafts` row created (unchanged from today)
+2. `notifyPartnerAfterDraft` fires:
+   - **Always** sends partner-notification email (today's behavior, retained as fallback)
+   - **Additionally** calls Discord:
+     - `POST /api/v10/channels/{channel_id}/threads` — create thread named `[#{ticket_number}] {subject_preview}`
+     - `POST /api/v10/channels/{thread_id}/messages` — post initial message with content blocks + 3 buttons
+     - `INSERT INTO support_ticket_threads` mapping ticket number to thread ID
+3. If Discord call fails: log warning, continue (email already sent, fail-open)
+
+### Initial Discord message structure
+
+```
+**Ticket #239171** — bug · normal · medium confidence
+
+> What the user wrote:
+> [user's message body, quoted]
+
+**AI summary:** Stocks not updating after sleep
+
+**Drafted reply:**
+[AI's drafted reply body]
+
+[ Send ✅ ]   [ Edit ✏️ ]   [ Skip ⏭️ ]
+```
+
+Buttons carry the draft ID in their `custom_id`:
+- `support_send:{draft_id}`
+- `support_edit:{draft_id}`
+- `support_skip:{draft_id}`
+
+### B. Partner clicks "Send"
+
+1. Discord POSTs `MESSAGE_COMPONENT` interaction to `/webhooks/discord/interactions`
+2. core-api verifies Ed25519 signature
+3. Parses `custom_id`, extracts action = `send`, draft_id
+4. Calls existing `doSendApprovedReply(ctx, draft_id)` — which hits the osTicket plugin, sends user reply, optionally closes ticket
+5. Responds to Discord interaction with type 4 (`CHANNEL_MESSAGE_WITH_SOURCE`): "✅ Sent to user"
+6. If close-ticket flag: archive the Discord thread via `PATCH /channels/{thread_id}` with `archived: true`
+
+### C. Partner clicks "Edit"
+
+1. Discord POSTs `MESSAGE_COMPONENT` interaction (action = edit)
+2. core-api responds with type 9 (`MODAL`): a modal with one text-area input pre-filled with the AI's draft
+3. Partner edits, clicks Submit → Discord POSTs `MODAL_SUBMIT` interaction
+4. core-api verifies signature, extracts edited body + draft_id from modal `custom_id`
+5. Calls existing edit-then-send path — `markDraftSent(ctx, draft_id, edited_body)` then `doSendApprovedReply`
+6. Confirmation in thread: "✏️ Edited and sent"
+
+### D. Partner clicks "Skip"
+
+1. Discord POSTs interaction (action = skip)
+2. core-api calls `markDraftSkipped(ctx, draft_id)`
+3. Confirmation in thread: "⏭️ Skipped"
+4. Optionally archive the thread (skipping is effectively closing)
+
+### E. User replies via email
+
+1. osTicket fetches inbound email → plugin's `notify.message.php` fires signal → POSTs to `/webhooks/osticket/thread-message`
+2. core-api creates new `support_draft` (existing flow, unchanged)
+3. core-api looks up `support_ticket_threads` for this ticket_number
+4. If thread exists: post a new message in that thread with the user's reply + new approval buttons
+5. If thread doesn't exist (e.g., the original was archived): create a new thread, persist the mapping
+6. Email also gets sent (fallback)
+
+### F. Slash commands
+
+- `/inbox` — list 5 most recent pending drafts (status = pending). Posts in the channel with thread links.
+- `/ticket <number>` — fetch latest draft for that ticket and post it in the current channel/thread with action buttons.
+
+Slash commands are registered once at core-api startup via the `POST /applications/{app_id}/guilds/{guild_id}/commands` endpoint (idempotent — Discord upserts by command name).
+
+## Configuration
+
+### New env vars (in `scrollr-secrets`)
+
+| Name | Type | Required | Purpose |
+|---|---|---|---|
+| `DISCORD_BOT_TOKEN` | secret | yes | Outbound REST auth |
+| `DISCORD_PUBLIC_KEY` | secret | yes | Inbound interaction signature verification |
+| `DISCORD_APPLICATION_ID` | secret | yes | Slash command registration |
+| `DISCORD_GUILD_ID` | secret | yes | Server (guild) ID |
+| `DISCORD_SUPPORT_CHANNEL_ID` | secret | yes | Channel where threads get created |
+| `SUPPORT_NOTIFY` | env | optional | `discord`, `email`, or `both` (default `both` per Q1) |
+
+Discord public key + bot token are sensitive and go in K8s secret. Other IDs are technically not secret but kept consistent with the secrets pattern.
+
+### Discord application setup (one-time, manual)
+
+User does this in the Discord developer portal:
+1. New application → Bot → copy bot token, application ID, public key
+2. OAuth2 → URL Generator:
+   - Scopes: `bot`, `applications.commands`
+   - Bot Permissions: `View Channels`, `Send Messages`, `Embed Links`, `Create Public Threads`, `Send Messages in Threads`, `Manage Threads`, `Read Message History`, `Use Application Commands`
+3. Use the generated URL to install in the support server
+4. In Discord application settings, set "Interactions Endpoint URL" → `https://api.myscrollr.com/webhooks/discord/interactions`
+5. Discord will verify the URL via a PING interaction; core-api must respond correctly
+
+## Failure modes & fail-open contract
+
+| Scenario | Behavior |
+|---|---|
+| Discord REST 5xx on thread creation | Log error, continue. Email partner notification still goes out. |
+| Discord REST 5xx on reply posting | Same — log + continue, email backup. |
+| Ed25519 signature verification fails on inbound | Reject with 401. Discord retries automatically up to 3x. |
+| Bot token revoked / invalid | All outbound REST calls fail; logs flood; email path is unaffected. Detect via 401 from Discord, log loudly, ops should rotate token. |
+| Thread archived before partner can act | Buttons in archived threads are still actionable. Discord auto-restores the thread on user activity. |
+| Partner deletes a draft message | No-op for core-api. Action buttons still work via the JWT-signed `custom_id`. |
+
+## Slash command schemas
+
+```json
+[
+  {
+    "name": "inbox",
+    "description": "Show pending support drafts (most recent 5)",
+    "type": 1
+  },
+  {
+    "name": "ticket",
+    "description": "Show the latest draft for a ticket number",
+    "type": 1,
+    "options": [
+      {
+        "name": "number",
+        "description": "osTicket ticket number (e.g. 239171)",
+        "type": 3,
+        "required": true
+      }
+    ]
+  }
+]
+```
+
+Registered via guild-scoped command endpoint so they appear instantly (vs. global which has 1-hour cache).
+
+## Out of scope for v1
+
+These are easy follow-ups but explicitly NOT in the initial PR:
+
+- Per-category channel routing (#support-bugs vs #support-billing) — single channel per Q2
+- Reaction-based actions (👍 = send, ✏️ = edit, ❌ = skip) — buttons are clearer
+- Voice notification of new ticket — not requested
+- Web dashboard for partner — Discord IS the dashboard
+- Bot mentions / @ai-bot prompts to draft a custom reply — interesting but later
+
+## Verification plan
+
+After deploy, end-to-end test:
+
+1. Submit a fresh test ticket → thread appears in #support-tickets within seconds
+2. Initial message contains user body + AI summary + drafted reply + 3 buttons
+3. Click Send → user receives email reply (osTicket plugin path) → thread shows "✅ Sent"
+4. Submit another ticket → click Edit → modal opens with pre-filled draft → edit → Submit → user receives EDITED reply → thread shows "✏️ Edited and sent"
+5. Submit another → click Skip → thread shows "⏭️ Skipped" → no email sent to user
+6. User replies to one of the sent tickets → new message + buttons appear in same thread
+7. Run `/inbox` → bot lists pending drafts
+8. Run `/ticket 239171` → bot posts that ticket's draft with action buttons
+
+## Migration & rollout
+
+- Backend deploys with `SUPPORT_NOTIFY=both` by default. Email path is unchanged. Discord notifications are additional.
+- Once partner is confident Discord is working, can flip to `SUPPORT_NOTIFY=discord` to suppress redundant emails.
+- Rolling back is just unsetting the Discord secrets — code paths fail-open and email path takes over.

--- a/k8s/configmap-core.yaml
+++ b/k8s/configmap-core.yaml
@@ -94,3 +94,39 @@ data:
   # default Admin agent in the tiredofit/osticket image. Look up other
   # agent IDs in osTicket admin → Agents if you want a dedicated AI bot.
   SUPPORT_AGENT_STAFF_ID: "1"
+
+  # Support notification routing (Phase: discord-triage-integration)
+  #
+  # Controls where partner-approval notifications are sent for new
+  # AI-drafted replies and reply-loop drafts:
+  #   "email"   — only the existing Resend email path
+  #   "discord" — only the Discord-thread path
+  #   "both"    — both (default during rollout for graceful migration)
+  #
+  # When "both", every new draft creates a Discord thread AND sends an
+  # email. Once the team is confident in the Discord workflow, flip
+  # this to "discord" to suppress redundant emails.
+  #
+  # If Discord env vars below are unset, "discord" and "both" silently
+  # fall back to email-only — no error, no startup failure.
+  SUPPORT_NOTIFY: "both"
+
+  # Discord integration. The following secrets MUST be added manually
+  # to k8s/secrets.yaml (none are configmap-safe):
+  #   - DISCORD_BOT_TOKEN          (from Discord developer portal → Bot)
+  #   - DISCORD_PUBLIC_KEY         (from Discord developer portal → General Information)
+  #   - DISCORD_APPLICATION_ID     (from Discord developer portal → General Information)
+  #   - DISCORD_GUILD_ID           (right-click your server → Copy Server ID; needs Developer Mode)
+  #   - DISCORD_SUPPORT_CHANNEL_ID (right-click the support channel → Copy Channel ID)
+  #
+  # The bot must be installed in the server with these permissions:
+  #   View Channels, Send Messages, Embed Links, Create Public Threads,
+  #   Send Messages in Threads, Manage Threads, Read Message History,
+  #   Use Application Commands.
+  #
+  # Discord verifies the interactions endpoint via a signed PING during
+  # bot setup. Set the Interactions Endpoint URL in the Discord
+  # application config to:
+  #   https://api.myscrollr.com/webhooks/discord/interactions
+  # Discord will reject the URL if it doesn't get a valid PONG within
+  # ~3 seconds, so make sure the API is up and reachable when saving.


### PR DESCRIPTION
## Summary

Adds a Discord layer to the support-triage pipeline so the team can approve / edit / skip AI-drafted replies in a Discord thread instead of (or alongside) the existing email approval flow.

**No separate bot service needed.** All Discord logic lives in core-api — outbound REST calls + inbound HTTP-only interactions. No websocket gateway, no daemon, no new K8s deployment.

## Decisions locked (from m1727)

| # | Question | Choice |
|---|---|---|
| 1 | Email kill / keep / both | **Both** — toggleable via `SUPPORT_NOTIFY` env (default `both`) |
| 2 | Channels | **Single channel** for all support threads |
| 3 | Thread lifecycle on close | **Auto-archive** when ticket closes |
| 4 | Privacy | Channel will be team-only (user-confirmed) |
| 5 | Slash commands | **Yes** — `/inbox` + `/ticket <number>` |
| 6 | Edit UX | **Discord modal** with text-area pre-filled |
| 7 | Error handling | **Fail-open** — Discord errors don't block ticket creation |
| 8 | Rate limits | Acceptable at current volume |

## What ships

- `api/core/discord.go` — REST client, Ed25519 signature verification, thread + message + archive helpers, slash-command registration, draft-message rendering with Discord-flavored markdown
- `api/core/handlers_discord_interactions.go` — signature-verified endpoint at `POST /webhooks/discord/interactions` handling all 4 interaction types (PING, APPLICATION_COMMAND, MESSAGE_COMPONENT, MODAL_SUBMIT)
- `api/migrations/000012_support_ticket_threads.{up,down}.sql` — new table mapping ticket_number → discord_thread_id (1:1 since multiple drafts share one thread)
- Wired into existing `notifyPartnerAfterDraft` indirection so reply-loop messages also post into the existing thread automatically
- `api/main.go` registers slash commands at startup (idempotent bulk-overwrite)
- `api/core/server.go` registers the new route + adds it to the rate-limit-exempt list
- `k8s/configmap-core.yaml` documents the 5 new secrets + Discord application setup steps

## Architecture

### Outbound (us → Discord)

REST API calls authenticated with `Authorization: Bot $DISCORD_BOT_TOKEN`:

- `POST /channels/{id}/threads` — create thread per ticket
- `POST /channels/{thread_id}/messages` — post draft + buttons / reply messages / confirmations
- `PATCH /channels/{thread_id}` — archive on ticket auto-close
- `PUT /applications/{id}/guilds/{id}/commands` — register slash commands

### Inbound (Discord → us)

Single endpoint `POST /webhooks/discord/interactions` with Ed25519 signature verification using `DISCORD_PUBLIC_KEY`:

- **PING (1)** — Discord URL verification handshake → respond `{type: 1}`
- **APPLICATION_COMMAND (2)** — slash commands `/inbox` + `/ticket`
- **MESSAGE_COMPONENT (3)** — Send / Edit / Skip button clicks
- **MODAL_SUBMIT (5)** — partner submitting an edited reply

Buttons reuse the existing `markDraftDecided` + `sendApprovedReply` internal seams (the same code path the email approval handlers call). Edit opens a Discord modal pre-filled with the AI draft (plain-text); submit dispatches as edited reply.

## Slash commands

- `/inbox` — list 5 most recent pending drafts (ephemeral, only visible to caller)
- `/ticket <number>` — show specific ticket's latest draft with action buttons (ephemeral)

## Failure modes

Fully fail-open:

| Scenario | Behavior |
|---|---|
| Discord REST 5xx on thread creation | Log + continue; email backup still goes out |
| Discord REST 5xx on reply posting | Same |
| Bot token revoked | All outbound REST calls fail loudly in logs; API stays up; email path unaffected |
| Inbound signature verification fails | Return 401; Discord retries up to 3x automatically |
| Thread archived before partner acts | Buttons in archived threads still work; Discord auto-restores on user activity |

## What didn't change

- Email approval flow unchanged — works alongside Discord during rollout
- osTicket plugin unchanged
- Reply-loop pipeline unchanged at the outer layer; the only difference is reply drafts now post into the EXISTING Discord thread (via thread mapping lookup) instead of creating a fresh email-only notification

## Required manual setup (post-merge)

1. Create Discord application + bot in https://discord.com/developers/applications
2. Copy Bot Token, Public Key, Application ID
3. Enable Discord Developer Mode (Discord client → Settings → Advanced) → right-click your server + support channel to copy IDs
4. Install bot in server. OAuth2 URL Generator → scopes `bot` + `applications.commands`. Bot Permissions: View Channels, Send Messages, Embed Links, Create Public Threads, Send Messages in Threads, Manage Threads, Read Message History, Use Application Commands
5. Set Interactions Endpoint URL to `https://api.myscrollr.com/webhooks/discord/interactions` in Discord application config (Discord verifies via signed PING — must be live + reachable when saving)
6. Add 5 secrets to `k8s/secrets.yaml`:
   - `DISCORD_BOT_TOKEN`
   - `DISCORD_PUBLIC_KEY`
   - `DISCORD_APPLICATION_ID`
   - `DISCORD_GUILD_ID`
   - `DISCORD_SUPPORT_CHANNEL_ID`
7. `SUPPORT_NOTIFY` defaults to `both` in configmap; flip to `discord` once you've verified Discord works for a few real tickets

## Verification

- `go vet ./...` clean
- `go build` clean
- `go test ./core/` passing
- Migration 000012 runs cleanly on startup; idempotent via `IF NOT EXISTS`
- KB unchanged so AI replies maintain quality

## Spec

`docs/superpowers/specs/2026-05-01-discord-triage-integration-design.md` (committed in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)