### PR TITLE
feat(api+ci): auto-close osTicket tickets on merged PR via [fixes #N] tags

### DIFF
--- a/.github/workflows/auto-close-osticket.yml
+++ b/.github/workflows/auto-close-osticket.yml
@@ -1,0 +1,126 @@
+name: Auto-close osTicket on merged PR
+
+# When a PR is merged with a `[fixes #NNNNNN]` or `[closes #NNNNNN]`
+# tag in its title or body (case-insensitive), this workflow extracts
+# every referenced osTicket ticket number and POSTs them to the Scrollr
+# core API. The core API then proxies a templated reply through the
+# scrollr-reply-api plugin, which lands the reply in the user's inbox
+# AND closes the ticket.
+#
+# Why this hits core-api instead of osTicket directly: osTicket API
+# keys are bound to ONE IP each. GitHub Actions runners use hundreds
+# of rotating IPs. core-api has the right IP for the existing
+# OSTICKET_API_KEY, so we proxy.
+#
+# Auth: shared secret in `OSTICKET_PR_WEBHOOK_SECRET` GitHub Secret;
+# core-api validates with constant-time compare against
+# GITHUB_PR_WEBHOOK_SECRET env var.
+#
+# Strict syntax:
+#   [fixes #239171]      # case-insensitive
+#   [closes #716831]
+#
+# Loose mentions like `see #239171` or `(ref #239171)` are IGNORED to
+# avoid false-positive closes.
+#
+# Best-effort: if the close call fails (osTicket down, ticket not
+# found, etc.), the workflow logs and continues. Never blocks PR
+# merges.
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close-tickets:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract ticket numbers from PR title + body
+        id: tickets
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Combine title + body, search for [fixes #N] or [closes #N]
+          # patterns. -P enables PCRE for the case-insensitive flag.
+          # -o prints just the matched text (one match per line).
+          PR_TEXT="${PR_TITLE}"$'\n'"${PR_BODY}"
+
+          # Two-step extract: first pull the bracketed expressions, then
+          # extract just the numbers. This way we ignore stray `#NNNNN`
+          # mentions that aren't inside the bracketed `[fixes/closes #...]`
+          # pattern.
+          #
+          # The regex matches `[fixes #N]` or `[closes #N]` with optional
+          # whitespace and case-insensitivity. Numbers must be 1-12 digits.
+          BRACKETED=$(printf '%s' "$PR_TEXT" | grep -oiP '\[\s*(fixes|closes)\s*#\s*[0-9]{1,12}\s*\]' || true)
+          if [ -z "$BRACKETED" ]; then
+            echo "No [fixes #N] or [closes #N] tags found in PR title/body. Skipping close."
+            echo "tickets=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Pull the numbers, dedup, comma-separate.
+          NUMBERS=$(printf '%s' "$BRACKETED" | grep -oP '[0-9]{1,12}' | sort -u | paste -sd, -)
+
+          echo "Found ticket numbers: $NUMBERS"
+          echo "tickets=$NUMBERS" >> "$GITHUB_OUTPUT"
+
+      - name: POST to Scrollr core API for ticket close
+        if: steps.tickets.outputs.tickets != ''
+        env:
+          TICKETS_CSV: ${{ steps.tickets.outputs.tickets }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          API_BASE: ${{ vars.SCROLLR_API_BASE_URL }}
+          WEBHOOK_SECRET: ${{ secrets.OSTICKET_PR_WEBHOOK_SECRET }}
+        run: |
+          if [ -z "$WEBHOOK_SECRET" ]; then
+            echo "::warning::OSTICKET_PR_WEBHOOK_SECRET not set as a repo/org secret; skipping close."
+            exit 0
+          fi
+
+          API="${API_BASE:-https://api.myscrollr.com}"
+
+          # Convert "239171,716831" to JSON array ["239171","716831"]
+          TICKETS_JSON=$(printf '%s' "$TICKETS_CSV" | jq -R -c 'split(",")')
+
+          # Build payload via jq to handle JSON escaping cleanly. Avoids
+          # bash quoting nightmares with PR titles containing quotes,
+          # backslashes, or newlines.
+          PAYLOAD=$(jq -n \
+            --argjson tickets "$TICKETS_JSON" \
+            --argjson pr_number "$PR_NUMBER" \
+            --arg pr_title "$PR_TITLE" \
+            --arg pr_url "$PR_URL" \
+            '{ticket_numbers: $tickets, pr_number: $pr_number, pr_title: $pr_title, pr_url: $pr_url}')
+
+          # Best-effort POST. We log + exit 0 on failure; the workflow
+          # should not block PR merges.
+          set +e
+          RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Webhook-Secret: $WEBHOOK_SECRET" \
+            -d "$PAYLOAD" \
+            "$API/webhooks/github/pr-closed")
+          CURL_EXIT=$?
+          set -e
+
+          BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+          HTTP_CODE=$(printf '%s' "$RESPONSE" | tail -n1)
+
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "::warning::curl failed with exit code $CURL_EXIT — tickets not closed. PR merge unaffected."
+            exit 0
+          fi
+
+          if [ "$HTTP_CODE" -ge 400 ]; then
+            echo "::warning::Core API returned HTTP $HTTP_CODE — tickets not closed. PR merge unaffected."
+            echo "Response: $BODY"
+            exit 0
+          fi
+
+          echo "Successfully queued $(printf '%s' "$TICKETS_CSV" | tr ',' '\n' | wc -l) ticket(s) for close:"
+          echo "Response: $BODY"

--- a/api/core/handlers_github_webhook.go
+++ b/api/core/handlers_github_webhook.go
@@ -1,0 +1,281 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// =============================================================================
+// GitHub PR-merge webhook — auto-close osTicket tickets on PR merge
+// =============================================================================
+//
+// When a PR is merged, the GitHub Action at
+// .github/workflows/auto-close-osticket.yml extracts ticket numbers
+// from the PR title + body via the syntax `[fixes #NNNNNN]` or
+// `[closes #NNNNNN]` (case-insensitive), then POSTs them here.
+//
+// Why this lives in core-api instead of the GitHub Action calling
+// osTicket directly: osTicket API keys are bound to ONE IP each
+// (exact-match enforced; no CIDR support). GitHub Actions runners use
+// hundreds of rotating IPs from documented-but-large ranges. Trying
+// to maintain an osTicket API key bound to "any GitHub Actions IP" is
+// fragile. Instead, the Action authenticates to core-api via shared
+// secret, and core-api proxies the close call to osTicket using the
+// existing OSTICKET_API_KEY (which IS bound to core-api's egress IP
+// and works fine).
+//
+// For each ticket: posts a templated agent reply via the existing
+// scrollr-reply-api plugin's /api/tickets/{number}/reply.json
+// endpoint with close_ticket=true and signal_alert=true. That gives
+// us:
+//   - Reply lands in the user's inbox via osTicket's mailer (the
+//     standard outbound user-notification flow)
+//   - Ticket flips to closed status
+//   - Discord thread auto-archives (existing flow on close)
+//   - Single source of truth for "this PR fixed that ticket"
+//
+// On any failure (osTicket down, plugin missing, ticket already
+// closed) we log and continue — closing is best-effort. The Action
+// itself never fails the workflow on close errors so a flaky osTicket
+// doesn't block PR merges.
+
+// githubPRClosedEvent is the payload the Action sends. Ticket numbers
+// are strings (osTicket numbers can have leading zeros).
+type githubPRClosedEvent struct {
+	TicketNumbers []string `json:"ticket_numbers"`
+	PRNumber      int      `json:"pr_number"`
+	PRTitle       string   `json:"pr_title"`
+	PRURL         string   `json:"pr_url"`
+}
+
+// HandleGitHubPRClosed receives the webhook from the auto-close Action
+// when a PR merges. Validates secret, parses payload, and asynchronously
+// closes each referenced ticket via the existing osTicket reply plugin.
+func HandleGitHubPRClosed(c *fiber.Ctx) error {
+	// 1. Auth — constant-time secret comparison. Mirrors
+	//    HandleOSTicketThreadMessage's pattern.
+	expected := os.Getenv("GITHUB_PR_WEBHOOK_SECRET")
+	if expected == "" {
+		log.Println("[GitHubWebhook] GITHUB_PR_WEBHOOK_SECRET not set; rejecting")
+		return c.Status(fiber.StatusServiceUnavailable).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "webhook secret not configured",
+		})
+	}
+	provided := c.Get("X-GitHub-Webhook-Secret")
+	if provided == "" || subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+		log.Println("[GitHubWebhook] missing or invalid X-GitHub-Webhook-Secret")
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Status: "unauthorized",
+			Error:  "invalid webhook secret",
+		})
+	}
+
+	// 2. Parse event payload.
+	var ev githubPRClosedEvent
+	if err := json.Unmarshal(c.Body(), &ev); err != nil {
+		log.Printf("[GitHubWebhook] body parse error: %v", err)
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "invalid JSON body",
+		})
+	}
+
+	if len(ev.TicketNumbers) == 0 {
+		// Empty list isn't an error — Action may have submitted with
+		// nothing to close (e.g. PR with no fix-tags). 200 + log.
+		log.Printf("[GitHubWebhook] PR #%d submitted with empty ticket list; nothing to do", ev.PRNumber)
+		return c.JSON(fiber.Map{
+			"status":  "ok",
+			"closed":  0,
+			"errors":  0,
+			"message": "no tickets in payload",
+		})
+	}
+
+	// Cap to a sane limit so a malformed PR title with 200 spurious
+	// numbers doesn't trigger 200 osTicket calls.
+	const maxTicketsPerPR = 20
+	if len(ev.TicketNumbers) > maxTicketsPerPR {
+		log.Printf("[GitHubWebhook] PR #%d has %d ticket numbers; capping at %d", ev.PRNumber, len(ev.TicketNumbers), maxTicketsPerPR)
+		ev.TicketNumbers = ev.TicketNumbers[:maxTicketsPerPR]
+	}
+
+	// 3. Fire-and-forget close calls. We respond 200 to the Action
+	//    immediately so a slow osTicket doesn't time out the
+	//    GitHub workflow.
+	go closePRReferencedTickets(ev)
+
+	return c.JSON(fiber.Map{
+		"status":    "accepted",
+		"queued":    len(ev.TicketNumbers),
+		"pr_number": ev.PRNumber,
+		"message":   "tickets queued for close",
+	})
+}
+
+// closePRReferencedTickets calls the existing scrollr-reply-api plugin
+// reply endpoint for each ticket number, with close_ticket=true and a
+// templated message body. Any individual close failure is logged but
+// not retried — this is best-effort cleanup, not a guaranteed delivery.
+func closePRReferencedTickets(ev githubPRClosedEvent) {
+	osticketURL := strings.TrimRight(os.Getenv("OSTICKET_URL"), "/")
+	osticketKey := os.Getenv("OSTICKET_API_KEY")
+	if osticketURL == "" || osticketKey == "" {
+		log.Println("[GitHubWebhook] OSTICKET_URL or OSTICKET_API_KEY missing; cannot close tickets")
+		return
+	}
+
+	staffIDStr := os.Getenv("SUPPORT_AGENT_STAFF_ID")
+	staffEmail := os.Getenv("SUPPORT_AGENT_EMAIL")
+	if staffIDStr == "" && staffEmail == "" {
+		log.Println("[GitHubWebhook] neither SUPPORT_AGENT_STAFF_ID nor SUPPORT_AGENT_EMAIL set; replies cannot be attributed")
+		return
+	}
+
+	// Build the reply body once — same template for every ticket.
+	replyHTML := buildAutoCloseReplyHTML(ev)
+
+	successes := 0
+	failures := 0
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	for _, num := range ev.TicketNumbers {
+		num = strings.TrimSpace(num)
+		if num == "" {
+			continue
+		}
+
+		if err := callPluginReplyAndClose(ctx, osticketURL, osticketKey, num, staffIDStr, staffEmail, replyHTML, ev.PRNumber); err != nil {
+			log.Printf("[GitHubWebhook] close ticket #%s for PR #%d failed: %v", num, ev.PRNumber, err)
+			failures++
+			continue
+		}
+		successes++
+		log.Printf("[GitHubWebhook] closed ticket #%s for PR #%d", num, ev.PRNumber)
+	}
+
+	log.Printf("[GitHubWebhook] PR #%d auto-close complete: %d closed, %d failed", ev.PRNumber, successes, failures)
+}
+
+// callPluginReplyAndClose POSTs to the scrollr-reply-api plugin to send
+// a reply and close the ticket atomically. Returns an error on
+// transport, auth, or upstream failure.
+func callPluginReplyAndClose(
+	ctx context.Context,
+	osticketURL, apiKey, ticketNumber, staffID, staffEmail, replyHTML string,
+	prNumber int,
+) error {
+	body := map[string]interface{}{
+		"reply_html":   replyHTML,
+		"signal_alert": true,
+		"close_ticket": true,
+		"title":        fmt.Sprintf("Re: Fixed in PR #%d", prNumber),
+	}
+	if staffID != "" {
+		// staff_id is an int in the plugin schema; pass numeric value.
+		// We accept the ENV var as a string for compatibility with the
+		// existing configmap layout.
+		body["staff_id"] = atoiOrZero(staffID)
+	} else {
+		body["staff_email"] = staffEmail
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal body: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/tickets/%s/reply.json", osticketURL, ticketNumber)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("plugin call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("plugin returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// buildAutoCloseReplyHTML is the templated message that goes out to the
+// user when a PR closes their ticket. Branded tone matches existing AI
+// reply voice (sentence-case, no em dashes, "Best Regards, Scrollr
+// Support" sign-off — same as supportKnowledgeBase() guidance).
+func buildAutoCloseReplyHTML(ev githubPRClosedEvent) string {
+	// PR URL is optional (some Action invocations may not have it).
+	prLink := ""
+	if ev.PRURL != "" {
+		prLink = fmt.Sprintf(`<a href="%s" style="color:#10b981;">PR #%d</a>`, htmlEscape(ev.PRURL), ev.PRNumber)
+	} else {
+		prLink = fmt.Sprintf("PR #%d", ev.PRNumber)
+	}
+
+	// PR title quoted to give the user some context. Empty title falls
+	// back to "the linked pull request".
+	titleClause := "the linked pull request"
+	if ev.PRTitle != "" {
+		titleClause = fmt.Sprintf(`"%s"`, htmlEscape(ev.PRTitle))
+	}
+
+	return fmt.Sprintf(
+		`<p>Hi,</p>`+
+			`<p>We shipped a fix for this issue. It's part of %s (%s) which has been merged.</p>`+
+			`<p>The fix will be in the next desktop release. Please update your app via Settings &rarr; General &rarr; Updates &rarr; Check for Updates and let us know if you still see the issue.</p>`+
+			`<p>Closing this ticket. You can reply any time to reopen it.</p>`+
+			`<p>Best Regards,<br>Scrollr Support</p>`,
+		prLink,
+		titleClause,
+	)
+}
+
+// atoiOrZero is a tiny helper for parsing the staff-id string env var.
+// Returns 0 on parse failure, which the plugin handles by falling
+// through to the staff_email or assigned-agent path.
+func atoiOrZero(s string) int {
+	var n int
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return 0
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n
+}
+
+// htmlEscape is a minimal HTML escaper for inserting URLs + titles
+// into the reply template. Avoids pulling in html/template just for
+// this one use case (and keeps the body as a plain string for the
+// JSON marshal step).
+func htmlEscape(s string) string {
+	r := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&#39;",
+	)
+	return r.Replace(s)
+}

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -107,6 +107,7 @@ func (s *Server) setupMiddleware() {
 		"/webhooks/stripe":                  true,
 		"/webhooks/osticket/thread-message": true,
 		"/webhooks/discord/interactions":    true, // Discord retries on rate-limit and we want them to succeed
+		"/webhooks/github/pr-closed":        true, // GitHub Action calls this when a PR with [fixes #N] tags merges
 		"/channels":                         true,
 		"/tier-limits":                      true,
 		"/extension/token":                  true,
@@ -169,6 +170,7 @@ func (s *Server) setupRoutes() {
 	s.App.Post("/webhooks/stripe", HandleStripeWebhook)
 	s.App.Post("/webhooks/osticket/thread-message", HandleOSTicketThreadMessage)
 	s.App.Post("/webhooks/discord/interactions", HandleDiscordInteractions)
+	s.App.Post("/webhooks/github/pr-closed", HandleGitHubPRClosed)
 
 	// Extension auth proxy
 	s.App.Options("/extension/token", HandleExtensionAuthPreflight)

--- a/k8s/configmap-core.yaml
+++ b/k8s/configmap-core.yaml
@@ -67,6 +67,15 @@ data:
   #     plugin can sign outbound webhooks. If they don't match, the
   #     webhook handler returns 401 and reply-loop AI triage doesn't
   #     run for follow-up user messages.
+  #   - GITHUB_PR_WEBHOOK_SECRET       (any high-entropy string ≥32 chars)
+  #     used to authenticate the auto-close webhook from the
+  #     "Auto-close osTicket on merged PR" GitHub Action. The SAME
+  #     value must also be set as a GitHub repository secret named
+  #     OSTICKET_PR_WEBHOOK_SECRET (see
+  #     .github/workflows/auto-close-osticket.yml). If they don't
+  #     match, the workflow logs an unauthorized error and merged PRs
+  #     don't auto-close their referenced tickets — falls back to
+  #     manual close via the osTicket admin panel.
   #
   # Approved AI replies post directly to osTicket via the
   # scrollr-reply-api plugin (POST /api/tickets/{number}/reply.json).


### PR DESCRIPTION
## Summary

When a PR merges with a `[fixes #NNNNNN]` or `[closes #NNNNNN]` tag in its title or body (case-insensitive), this triggers an automatic agent reply + ticket close in osTicket. Closes the loop between "engineer fixed it" and "user gets the resolution email + the ticket disappears from the bugs queue".

Companion to PR #142 (which shipped the `bugs`/`bug` CLI for browsing the queue). Together they make osTicket a viable single-source todo list:

- Submit bugs in osTicket agent panel
- `bugs` to see the queue at the start of a dev session  
- `bug <number>` for full context on a specific ticket
- Tag PR with `[fixes #239171]`, merge it → ticket auto-closes with a templated reply

## Architecture

GitHub Action → core-api → osTicket plugin reply endpoint → user.

We can't have the Action call osTicket directly: osTicket API keys are bound to ONE IP each (exact-match, no CIDR). GitHub Actions runners use hundreds of rotating IPs. core-api's egress IP is bound on the existing `OSTICKET_API_KEY` and works fine, so we proxy through it. Same architectural pattern as the existing `SCROLLR_WEBHOOK_SECRET` flow (osTicket plugin → core-api).

## Files added

### `.github/workflows/auto-close-osticket.yml`

- Triggers on `pull_request.closed` where `merged=true`
- Extracts ticket numbers via case-insensitive PCRE matching of `[fixes #N]` or `[closes #N]` patterns inside square brackets
- Loose mentions like `see #239171` or `(ref #239171)` are **ignored** to avoid false-positive closes
- Builds JSON payload via `jq` (clean handling of PR titles with quotes/backslashes/newlines)
- POSTs to `${SCROLLR_API_BASE_URL}/webhooks/github/pr-closed` (defaults to `https://api.myscrollr.com`)
- **Best-effort**: any close failure logs to the workflow but never fails the run, so PR merges aren't blocked by a flaky osTicket

### `api/core/handlers_github_webhook.go`

- `HandleGitHubPRClosed` validates `X-GitHub-Webhook-Secret` against `GITHUB_PR_WEBHOOK_SECRET` env var (constant-time)
- Caps payload at 20 tickets — defends against malformed PR titles with hundreds of spurious numbers
- Returns 200 immediately and fires close calls asynchronously so a slow osTicket doesn't time out the GitHub workflow
- `closePRReferencedTickets` calls the existing `scrollr-reply-api` plugin's `POST /api/tickets/{number}/reply.json` endpoint with `close_ticket: true`, `signal_alert: true`, and a templated branded reply body
- Reply tone matches the rest of the support voice: sentence-case, no em dashes, "Best Regards, Scrollr Support" sign-off (consistent with `supportKnowledgeBase()` guidance)
- Reuses `SUPPORT_AGENT_STAFF_ID` from configmap for attribution; falls back to `SUPPORT_AGENT_EMAIL`

## Files modified

- `api/core/server.go` — registers `POST /webhooks/github/pr-closed` and adds it to the rate-limit-exempt list (legitimate Action traffic should always succeed)
- `k8s/configmap-core.yaml` — documents the new `GITHUB_PR_WEBHOOK_SECRET` requirement alongside the existing `SCROLLR_WEBHOOK_SECRET` docs

## Templated reply body

When a ticket auto-closes, the user gets:

> Hi,
>
> We shipped a fix for this issue. It's part of PR #145 ("fix: ticker freeze after sleep") which has been merged.
>
> The fix will be in the next desktop release. Please update your app via Settings → General → Updates → Check for Updates and let us know if you still see the issue.
>
> Closing this ticket. You can reply any time to reopen it.
>
> Best Regards,
> Scrollr Support

PR title is HTML-escaped before insertion. PR URL becomes a clickable link in the email.

## Verification

- `go vet ./...` clean
- `go build` clean
- `go test ./core/` passing (no regressions)
- YAML valid (parsed by Ruby's `YAML.load_file`)

## Manual setup post-merge

1. Generate webhook secret:
   ```sh
   openssl rand -base64 48
   ```
2. K8s: patch `scrollr-secrets` with `GITHUB_PR_WEBHOOK_SECRET=<value>`:
   ```sh
   kubectl patch secret scrollr-secrets -n scrollr \
     --type='json' \
     -p="[{\"op\": \"add\", \"path\": \"/data/GITHUB_PR_WEBHOOK_SECRET\", \"value\": \"$(echo -n '<your-secret>' | base64)\"}]"
   ```
3. GitHub repo: **Settings → Secrets and variables → Actions → New repository secret**:
   - Name: `OSTICKET_PR_WEBHOOK_SECRET`
   - Value: same value as step 2
4. (Optional) GitHub repo: add a repo **variable** (not secret) named `SCROLLR_API_BASE_URL` if your API base differs from `https://api.myscrollr.com`. Default works for Scrollr's setup.
5. Restart core-api pod so it picks up the new env var:
   ```sh
   kubectl rollout restart deploy/core-api -n scrollr
   ```
6. Smoke test: open a tiny test PR with `[fixes #<some-test-ticket-number>]` in the title, merge it, watch the ticket close + reply land in the user's inbox.

## Strict syntax — supported patterns

The Action ONLY closes tickets on these exact patterns (case-insensitive):

| Pattern | Closes? |
|---|---|
| `[fixes #239171]` | yes |
| `[closes #239171]` | yes |
| `[FIXES #239171]` | yes (case-insensitive) |
| `[ closes #239171 ]` | yes (whitespace tolerated) |
| `fixes #239171` (no brackets) | no — too easy to false-positive |
| `see #239171` | no |
| `(ref #239171)` | no |
| GitHub-native `Fixes #N` (without brackets) | no — those reference GitHub Issues, different namespace |

Multiple ticket references in one PR work; deduped by number:

```
fix(ticker): repaint after wake from sleep

[fixes #239171]
[fixes #716832]
```

## What this PR does NOT do

- Doesn't auto-merge AI-generated PRs (still humans-only)
- Doesn't post intermediate updates while a PR is in-flight (only on merge)
- Doesn't reopen tickets if a fix gets reverted (manual close + reopen if needed)
- Doesn't handle reverts smartly — if you revert PR #145 that closed ticket #239171, the ticket stays closed (would need manual reopen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)