### PR TITLE
fix(rss): per-user custom feeds + broken-feed auto-cleanup + is_custom server derivation

### DIFF
--- a/api/core/curated_feeds_cache.go
+++ b/api/core/curated_feeds_cache.go
@@ -1,0 +1,113 @@
+package core
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+)
+
+// Curated-feed URL cache.
+//
+// `tier_limits.go::ValidateChannelConfig` uses this to derive the
+// `is_custom` flag server-side instead of trusting the client's
+// `is_custom` field. A URL is custom iff it does NOT appear in the
+// curated set (tracked_feeds.is_default = true).
+//
+// The cache holds a snapshot of curated URLs and refreshes lazily.
+// It returns nil when the cache is empty AND a refresh fails (or DB
+// is uninitialized — common in unit tests). Callers must handle the
+// nil case by falling back to client-asserted `is_custom`. This
+// fall-through is intentional: the pre-derivation behavior was to
+// trust the client, so we never DEGRADE on cache failure.
+//
+// Why a package-level cache instead of a parameter passed through
+// the call stack: ValidateChannelConfig is called from multiple
+// places and is also covered by tests that don't have a context or
+// DB. Adding parameters would force breaking signature changes
+// across the codebase + tests. The cache+fallback is invisible to
+// existing callers and safe in test mode.
+
+const curatedFeedURLsCacheTTL = 5 * time.Minute
+
+// curatedFeedURLsCacheTimeout is the per-query timeout for refreshing
+// the curated set. Generous because this is a tiny SELECT against a
+// small table and we'd rather wait than fall back to client-trust.
+const curatedFeedURLsCacheTimeout = 3 * time.Second
+
+var (
+	curatedFeedURLsMu      sync.RWMutex
+	curatedFeedURLsCache   map[string]bool // nil = unloaded
+	curatedFeedURLsExpires time.Time       // zero = always refresh
+)
+
+// getCuratedFeedURLs returns the cached set of curated feed URLs.
+//
+// On a hit (cache present and unexpired): returns the cached map.
+// On a miss (expired or never loaded): refreshes synchronously and
+// returns the new map. If the refresh fails, returns the previous
+// cached value (could be nil).
+//
+// Returning nil signals "no curated set available — fall back to
+// client-asserted is_custom". Tests run with DBPool == nil so they
+// always get nil, which preserves the legacy client-trust behavior
+// without test changes.
+//
+// Uses a 3-second per-query timeout so a slow DB doesn't wedge
+// channel-update requests.
+func getCuratedFeedURLs() map[string]bool {
+	curatedFeedURLsMu.RLock()
+	if !curatedFeedURLsExpires.IsZero() && time.Now().Before(curatedFeedURLsExpires) {
+		cache := curatedFeedURLsCache
+		curatedFeedURLsMu.RUnlock()
+		return cache
+	}
+	curatedFeedURLsMu.RUnlock()
+
+	if DBPool == nil {
+		// Test or pre-init mode — no DB available. Fall through to
+		// client-asserted is_custom in callers.
+		return nil
+	}
+
+	curatedFeedURLsMu.Lock()
+	defer curatedFeedURLsMu.Unlock()
+
+	// Double-check after acquiring the write lock — another goroutine
+	// may have refreshed while we were waiting.
+	if !curatedFeedURLsExpires.IsZero() && time.Now().Before(curatedFeedURLsExpires) {
+		return curatedFeedURLsCache
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), curatedFeedURLsCacheTimeout)
+	defer cancel()
+
+	rows, err := DBPool.Query(ctx, "SELECT url FROM tracked_feeds WHERE is_default = true")
+	if err != nil {
+		log.Printf("[TierLimits] curated URL refresh failed: %v (using stale cache=%v)", err, curatedFeedURLsCache != nil)
+		// Don't bump the expiry on failure; let the next call retry.
+		return curatedFeedURLsCache
+	}
+	defer rows.Close()
+
+	urls := make(map[string]bool, 256)
+	for rows.Next() {
+		var url string
+		if scanErr := rows.Scan(&url); scanErr == nil {
+			urls[url] = true
+		}
+	}
+
+	curatedFeedURLsCache = urls
+	curatedFeedURLsExpires = time.Now().Add(curatedFeedURLsCacheTTL)
+	return urls
+}
+
+// invalidateCuratedFeedURLs forces the next getCuratedFeedURLs call
+// to refresh from DB. Useful from tests; rarely needed in prod since
+// the curated set changes infrequently and a 5-min TTL is acceptable.
+func invalidateCuratedFeedURLs() {
+	curatedFeedURLsMu.Lock()
+	curatedFeedURLsExpires = time.Time{}
+	curatedFeedURLsMu.Unlock()
+}

--- a/api/core/tier_limits.go
+++ b/api/core/tier_limits.go
@@ -140,15 +140,24 @@ func ValidateChannelConfig(tier, channelType string, config map[string]any) erro
 		// RSS caps both total feeds and user-added ("custom") feeds.
 		// The custom cap is tighter than the total cap, so the natural
 		// error mode is custom-first when both are breached.
+		//
+		// `is_custom` is determined SERVER-SIDE in production: a URL is
+		// considered custom iff it's NOT in the curated catalog
+		// (tracked_feeds.is_default = true). Falling back to the
+		// client-asserted `is_custom` flag when the curated set is
+		// unavailable (e.g. running without DB in unit tests) keeps
+		// tests deterministic without weakening prod safety.
 		feedsRaw, _ := config["feeds"].([]any)
 		totalFeeds := len(feedsRaw)
+		curated := getCuratedFeedURLs() // nil when DB unavailable / test mode
 		customCount := 0
 		for _, item := range feedsRaw {
 			m, ok := item.(map[string]any)
 			if !ok {
 				continue
 			}
-			if isCustom, _ := m["is_custom"].(bool); isCustom {
+			isCustom := isCustomFeed(m, curated)
+			if isCustom {
 				customCount++
 			}
 		}
@@ -172,6 +181,30 @@ func ValidateChannelConfig(tier, channelType string, config map[string]any) erro
 		}
 	}
 	return nil
+}
+
+// isCustomFeed decides whether a feeds[] item is a user-added (custom)
+// feed.
+//
+// Resolution order:
+//
+//  1. If a curated URL set is provided AND the item has a non-empty
+//     URL, the answer is server-derived: custom iff URL not in curated.
+//     This is the production path.
+//
+//  2. Otherwise, fall back to the client-asserted `is_custom` flag.
+//     This is the test path (no DBPool, so no curated set) and the
+//     graceful-degradation path (DB query failed, so we trust the
+//     client; this is no worse than the pre-derivation behavior).
+//
+// Returning true means "counts against the custom_feeds tier cap".
+func isCustomFeed(item map[string]any, curated map[string]bool) bool {
+	urlStr, _ := item["url"].(string)
+	if curated != nil && urlStr != "" {
+		return !curated[urlStr]
+	}
+	flag, _ := item["is_custom"].(bool)
+	return flag
 }
 
 // validateArrayCap counts entries in an array-shaped JSONB value and

--- a/channels/rss/api/janitor.go
+++ b/channels/rss/api/janitor.go
@@ -1,0 +1,260 @@
+// Package main — RSS auto-cleanup janitor.
+//
+// The janitor runs in a background goroutine on every RSS API pod. Its
+// job is to recognise feeds that are definitively broken and remove
+// them from the system (and from each subscribing user's config) so
+// users aren't stuck with dead URLs in their personal feed list.
+//
+// "Definitively broken" means one of:
+//
+//   - last_success_at older than 7 days (LastSuccessStaleThreshold)
+//   - never successfully polled AND created_at older than 7 days
+//   - consecutive_failures >= 100 (~8 hours of 5-min polling failures —
+//     more aggressive than the 24h Rust-side quarantine threshold of 288)
+//
+// Cleanup behavior depends on whether the feed is curated or custom:
+//
+//   - Custom feeds (is_default = false) are FULLY REMOVED:
+//     - user_custom_feeds rows for the URL are deleted
+//     - tracked_feeds row is deleted (cascades rss_items)
+//     - The subscriber Redis set is deleted
+//     - For each subscribing user, their user_channels.config.feeds[]
+//       JSONB array has the broken URL removed
+//
+//   - Curated feeds (is_default = true) are operator-managed; the
+//     janitor only marks is_enabled = false and logs a warning. Hands-on
+//     removal is the operator's call, not automatic.
+//
+// The janitor runs on startup AND every JanitorInterval (6 hours).
+// All operations are idempotent — running it twice in a row produces
+// no different end-state than running it once.
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+const (
+	// LastSuccessStaleThreshold is how old `last_success_at` is allowed
+	// to be before the janitor classifies the feed as broken. 7 days
+	// catches truly-dead feeds while tolerating a week-long outage of
+	// an otherwise-good source.
+	LastSuccessStaleThreshold = "7 days"
+
+	// MaxConsecutiveFailuresJanitor is the failure-count threshold for
+	// auto-removal. 100 cycles × 5 min = ~8h. More aggressive than the
+	// Rust-side quarantine at 288 (~24h) because the janitor's threshold
+	// is for AUTO-REMOVAL while quarantine just stops polling.
+	MaxConsecutiveFailuresJanitor = 100
+
+	// JanitorInterval is how often the cleanup runs. 6 hours is
+	// frequent enough to catch broken feeds within a quarter-day
+	// without spamming logs.
+	JanitorInterval = 6 * time.Hour
+
+	// JanitorRunTimeout caps how long a single janitor cycle can run
+	// before being cancelled. Set generously: a typical run touches
+	// only a handful of broken-feed URLs, but if the prod DB is slow
+	// or there's a thundering herd of recently-broken feeds we don't
+	// want the janitor to wedge.
+	JanitorRunTimeout = 5 * time.Minute
+)
+
+// startJanitor launches the auto-cleanup loop in a goroutine. Returns
+// immediately so the caller can continue with the rest of startup.
+//
+// The loop runs once on launch (after a brief sleep so other startup
+// machinery completes first) and then every JanitorInterval. It uses
+// a child context derived from rootCtx; when the root is cancelled
+// (e.g. SIGTERM during pod termination) the janitor exits cleanly.
+func (a *App) startJanitor(rootCtx context.Context) {
+	go func() {
+		// Wait briefly so DB pool warmup, channel registration, etc.
+		// complete before the first janitor pass.
+		select {
+		case <-time.After(30 * time.Second):
+		case <-rootCtx.Done():
+			return
+		}
+
+		log.Printf("[RSS Janitor] starting; interval=%s, last-success-threshold=%s, max-failures=%d",
+			JanitorInterval, LastSuccessStaleThreshold, MaxConsecutiveFailuresJanitor)
+
+		for {
+			a.runJanitorOnce(rootCtx)
+
+			select {
+			case <-time.After(JanitorInterval):
+				continue
+			case <-rootCtx.Done():
+				log.Printf("[RSS Janitor] stopping (root context cancelled)")
+				return
+			}
+		}
+	}()
+}
+
+// runJanitorOnce performs a single cleanup pass. Idempotent.
+//
+// Wraps the entire pass in JanitorRunTimeout. Any error in a sub-step
+// is logged but doesn't abort the whole pass — partial cleanup is
+// better than no cleanup, and the next cycle will pick up whatever this
+// one missed.
+func (a *App) runJanitorOnce(parent context.Context) {
+	ctx, cancel := context.WithTimeout(parent, JanitorRunTimeout)
+	defer cancel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[RSS Janitor] PANIC during cleanup pass: %v", r)
+		}
+	}()
+
+	// Step 1 — disable broken curated feeds (operator action required
+	// for actual removal; we just stop showing them in catalogs).
+	disabled, err := a.disableBrokenCuratedFeeds(ctx)
+	if err != nil {
+		log.Printf("[RSS Janitor] disable curated step failed: %v", err)
+	} else if disabled > 0 {
+		log.Printf("[RSS Janitor] disabled %d broken curated feed(s) — operator action recommended", disabled)
+	}
+
+	// Step 2 — remove broken custom feeds (full cleanup).
+	removed, err := a.removeBrokenCustomFeeds(ctx)
+	if err != nil {
+		log.Printf("[RSS Janitor] remove custom step failed: %v", err)
+	} else if removed > 0 {
+		log.Printf("[RSS Janitor] removed %d broken custom feed(s) and pruned subscriber configs", removed)
+	}
+
+	if disabled > 0 || removed > 0 {
+		// Some catalogs may have stale content. Drop every cached
+		// user catalog so next read sees the new state.
+		a.invalidateAllCatalogCaches(ctx)
+	}
+}
+
+// disableBrokenCuratedFeeds flips is_enabled = false on curated feeds
+// (is_default = true) that have crossed the broken threshold. Returns
+// the count of rows updated. The feeds are NOT removed — operators
+// decide whether the curated catalog should drop them entirely.
+func (a *App) disableBrokenCuratedFeeds(ctx context.Context) (int, error) {
+	const q = `
+		UPDATE tracked_feeds
+		   SET is_enabled = false,
+		       last_error = COALESCE(last_error, '') || ' [auto-disabled by janitor at ' || NOW()::text || ']'
+		 WHERE is_default = true
+		   AND is_enabled = true
+		   AND (
+			   (last_success_at IS NULL AND created_at < NOW() - INTERVAL '` + LastSuccessStaleThreshold + `')
+			OR last_success_at < NOW() - INTERVAL '` + LastSuccessStaleThreshold + `'
+			OR consecutive_failures >= $1
+		   )
+	`
+	cmd, err := a.db.Exec(ctx, q, MaxConsecutiveFailuresJanitor)
+	if err != nil {
+		return 0, err
+	}
+	return int(cmd.RowsAffected()), nil
+}
+
+// removeBrokenCustomFeeds finds custom feeds (is_default = false) that
+// have crossed the broken threshold and removes them everywhere:
+//
+//  1. Lists their URLs (the union of broken-by-staleness or
+//     broken-by-failure-count).
+//  2. For each URL, prunes user_channels.config.feeds[] for every
+//     subscribing user so the URL no longer appears in their pinned
+//     feed list.
+//  3. Deletes user_custom_feeds rows for the URL.
+//  4. Deletes the tracked_feeds row (rss_items cascades via FK).
+//  5. Drops the per-URL Redis subscriber set.
+//
+// Returns the count of unique URLs removed.
+//
+// Per-step errors are logged but don't halt the pass — partial cleanup
+// is still useful, and the next cycle will pick up whatever was missed.
+func (a *App) removeBrokenCustomFeeds(ctx context.Context) (int, error) {
+	// Step 1 — find the URLs.
+	const findQ = `
+		SELECT url FROM tracked_feeds
+		 WHERE is_default = false
+		   AND (
+			   (last_success_at IS NULL AND created_at < NOW() - INTERVAL '` + LastSuccessStaleThreshold + `')
+			OR last_success_at < NOW() - INTERVAL '` + LastSuccessStaleThreshold + `'
+			OR consecutive_failures >= $1
+		   )
+	`
+	rows, err := a.db.Query(ctx, findQ, MaxConsecutiveFailuresJanitor)
+	if err != nil {
+		return 0, err
+	}
+	urls := make([]string, 0)
+	for rows.Next() {
+		var url string
+		if scanErr := rows.Scan(&url); scanErr == nil {
+			urls = append(urls, url)
+		}
+	}
+	rows.Close()
+
+	if len(urls) == 0 {
+		return 0, nil
+	}
+
+	for _, url := range urls {
+		// Step 2 — prune user_channels.config.feeds[] for each
+		// subscribing user. The JSONB filter at the bottom of the
+		// CASE expression rebuilds the feeds array minus the broken
+		// URL, then writes it back. Users with no rss row aren't
+		// affected.
+		//
+		// We use jsonb_set + jsonb_agg + jsonb_array_elements; the
+		// COALESCE handles the case where filtering produces an empty
+		// set (jsonb_agg returns NULL on empty input, but config.feeds
+		// must be a JSON array, not null).
+		if _, pruneErr := a.db.Exec(ctx, `
+			UPDATE user_channels
+			   SET config = jsonb_set(
+				   config,
+				   '{feeds}',
+				   COALESCE(
+				       (SELECT jsonb_agg(item)
+				        FROM jsonb_array_elements(config->'feeds') item
+				        WHERE item->>'url' != $2),
+				       '[]'::jsonb
+				   )
+			   )
+			 WHERE channel_type = 'rss'
+			   AND config ? 'feeds'
+			   AND config->'feeds' @> jsonb_build_array(jsonb_build_object('url', $2::text))
+		`, MaxConsecutiveFailuresJanitor, url); pruneErr != nil {
+			log.Printf("[RSS Janitor] prune user_channels for %s failed: %v", url, pruneErr)
+			// Continue — better to remove tracked_feeds with a few
+			// stale user configs than skip the URL entirely.
+		}
+
+		// Step 3 — drop user_custom_feeds rows for the URL. Removes
+		// every user's tenancy claim on this URL.
+		if _, ucfErr := a.db.Exec(ctx,
+			"DELETE FROM user_custom_feeds WHERE url = $1", url); ucfErr != nil {
+			log.Printf("[RSS Janitor] delete user_custom_feeds for %s failed: %v", url, ucfErr)
+		}
+
+		// Step 4 — drop the tracked_feeds row. rss_items cascades.
+		// Guard `is_default = false` defensively even though the find
+		// query already filtered to customs.
+		if _, tfErr := a.db.Exec(ctx,
+			"DELETE FROM tracked_feeds WHERE url = $1 AND is_default = false", url); tfErr != nil {
+			log.Printf("[RSS Janitor] delete tracked_feeds for %s failed: %v", url, tfErr)
+		}
+
+		// Step 5 — drop the subscriber set in Redis.
+		a.rdb.Del(ctx, RedisRSSSubscribersPrefix+url)
+	}
+
+	return len(urls), nil
+}

--- a/channels/rss/api/main.go
+++ b/channels/rss/api/main.go
@@ -146,6 +146,14 @@ func main() {
 	fiberApp.Get("/rss/health", app.healthHandler)
 
 	// -------------------------------------------------------------------------
+	// Start the auto-cleanup janitor (background goroutine)
+	// -------------------------------------------------------------------------
+	// Removes definitively-broken custom feeds (and prunes them from
+	// each subscriber's user_channels.config), and disables broken
+	// curated feeds for operator follow-up. See janitor.go.
+	app.startJanitor(ctx)
+
+	// -------------------------------------------------------------------------
 	// Start server with graceful shutdown
 	// -------------------------------------------------------------------------
 	port := os.Getenv("PORT")
@@ -194,7 +202,11 @@ func startRegistration(ctx context.Context, rdb *redis.Client) {
 		Capabilities: []string{"cdc_handler", "dashboard_provider", "channel_lifecycle", "health_checker"},
 		CDCTables:    []string{"rss_items"},
 		Routes: []registrationRoute{
-			{Method: "GET", Path: "/rss/feeds", Auth: false},
+			// /rss/feeds is now Auth: true — the catalog is per-user
+			// (curated defaults + the requesting user's own custom feeds
+			// only). The pre-isolation public endpoint leaked custom
+			// feeds across users.
+			{Method: "GET", Path: "/rss/feeds", Auth: true},
 			{Method: "DELETE", Path: "/rss/feeds", Auth: true},
 			{Method: "GET", Path: "/rss/health", Auth: false},
 		},

--- a/channels/rss/api/rss.go
+++ b/channels/rss/api/rss.go
@@ -61,16 +61,47 @@ type App struct {
 // Public Routes (proxied by core gateway)
 // =============================================================================
 
-// getRSSFeedCatalog returns all enabled tracked feeds for the dashboard
-// catalog browser.
+// getRSSFeedCatalog returns the per-user feed catalog used by the
+// desktop UI's "add feeds" picker.
+//
+// The catalog is the union of:
+//   - Curated default feeds (tracked_feeds.is_default = true) — same for
+//     every user
+//   - The requesting user's own custom feeds (user_custom_feeds.logto_sub
+//     = X-User-Sub) — joined to tracked_feeds for health metadata
+//
+// User A's custom feeds are NOT included in user B's catalog. This is
+// the multi-tenancy guarantee that the pre-isolation catalog endpoint
+// (which returned ALL tracked_feeds rows globally) violated.
+//
+// Health filters in default mode:
+//   - is_enabled = true (operator-disabled curated feeds are hidden)
+//   - consecutive_failures < MaxConsecutiveFailures (3, ~15 min of failures)
+//   - last_success_at within 7 days OR feed was added < 24 hours ago (grace
+//     for newly-added custom feeds whose first poll hasn't completed)
+//
+// include_failing=true bypasses the health filters so the desktop's My
+// Feeds view can compute health badges for already-subscribed feeds.
+//
+// X-User-Sub is required (the route is now Auth: true on the gateway —
+// see main.go discovery payload). Returns 401 if absent.
 func (a *App) getRSSFeedCatalog(c *fiber.Ctx) error {
 	ctx := c.Context()
 	includeFailing := c.Query("include_failing") == "true"
 
-	// Use separate cache keys so the two variants don't collide
-	cacheKey := CacheKeyRSSCatalog
+	userSub := c.Get("X-User-Sub")
+	if userSub == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+			Status: "unauthorized",
+			Error:  "Authentication required",
+		})
+	}
+
+	// Per-user cache key. The catalog content depends on which custom
+	// feeds the user owns, so user A and user B can't share an entry.
+	cacheKey := CacheKeyRSSCatalog + ":" + userSub
 	if includeFailing {
-		cacheKey = CacheKeyRSSCatalog + ":all"
+		cacheKey += ":all"
 	}
 
 	var catalog []TrackedFeed
@@ -81,27 +112,9 @@ func (a *App) getRSSFeedCatalog(c *fiber.Ctx) error {
 
 	// Singleflight: collapse concurrent cache-miss requests into one DB query
 	result, err, _ := a.sfGroup.Do(cacheKey, func() (interface{}, error) {
-		query := "SELECT url, name, category, is_default, consecutive_failures, last_error, last_success_at FROM tracked_feeds WHERE is_enabled = true"
-		var rows pgx.Rows
-		var qErr error
-		if includeFailing {
-			rows, qErr = a.db.Query(ctx, query+" ORDER BY category, name")
-		} else {
-			rows, qErr = a.db.Query(ctx, query+" AND consecutive_failures < $1 ORDER BY category, name", MaxConsecutiveFailures)
-		}
+		feeds, qErr := a.queryUserCatalog(ctx, userSub, includeFailing)
 		if qErr != nil {
 			return nil, qErr
-		}
-		defer rows.Close()
-
-		var feeds []TrackedFeed
-		for rows.Next() {
-			var f TrackedFeed
-			if err := rows.Scan(&f.URL, &f.Name, &f.Category, &f.IsDefault, &f.ConsecutiveFailures, &f.LastError, &f.LastSuccessAt); err != nil {
-				log.Printf("[RSS] Catalog scan error: %v", err)
-				continue
-			}
-			feeds = append(feeds, f)
 		}
 		return feeds, nil
 	})
@@ -122,9 +135,147 @@ func (a *App) getRSSFeedCatalog(c *fiber.Ctx) error {
 	return c.JSON(catalog)
 }
 
-// deleteCustomFeed removes a non-default feed from the catalog.
+// queryUserCatalog runs the actual UNION query that backs the catalog
+// endpoint. Split out so it's testable independent of the HTTP wrapper.
+//
+// The query is a UNION ALL of two halves:
+//
+//  1. Curated defaults — pulled by every user identically. Health
+//     filters apply (when !includeFailing).
+//
+//  2. The requesting user's custom feeds — joined to tracked_feeds for
+//     health metadata via LEFT JOIN. Some custom feeds may not yet
+//     have a tracked_feeds row at the moment of the query (rare race
+//     between user_custom_feeds insert and tracked_feeds insert in
+//     syncRSSFeedsToTracked); in that case the LEFT JOIN yields NULL
+//     health columns, treated as healthy by the COALESCE logic below.
+//
+// Both halves apply the same staleness threshold:
+//
+//	last_success_at IS NULL  -- never polled OR
+//	last_success_at > NOW() - 7 days  -- recently successful OR
+//	created_at > NOW() - 24 hours  -- 24h grace for newly-added
+//
+// This filters out feeds that "look healthy" (consecutive_failures = 0)
+// but haven't actually returned valid content in weeks (e.g. a feed that
+// returns 200 with empty body — the failure counter resets on each
+// "successful" empty response).
+func (a *App) queryUserCatalog(ctx context.Context, userSub string, includeFailing bool) ([]TrackedFeed, error) {
+	const healthFilter = `
+		AND consecutive_failures < $2
+		AND (
+			last_success_at IS NULL
+			OR last_success_at > NOW() - INTERVAL '7 days'
+			OR created_at > NOW() - INTERVAL '24 hours'
+		)
+	`
+	const customFeedHealthFilter = `
+		AND (tf.consecutive_failures IS NULL OR tf.consecutive_failures < $2)
+		AND (
+			tf.last_success_at IS NULL
+			OR tf.last_success_at > NOW() - INTERVAL '7 days'
+			OR ucf.created_at > NOW() - INTERVAL '24 hours'
+		)
+	`
+
+	curatedClauses := "WHERE is_default = true AND is_enabled = true"
+	customClauses := "WHERE ucf.logto_sub = $1 AND (tf.is_enabled IS NULL OR tf.is_enabled = true)"
+	if !includeFailing {
+		curatedClauses += healthFilter
+		customClauses += customFeedHealthFilter
+	}
+
+	// $1 = userSub (used in the custom-feeds half)
+	// $2 = MaxConsecutiveFailures (used by both halves when !includeFailing)
+	query := `
+		SELECT url, name, category, is_default, consecutive_failures, last_error, last_success_at
+		FROM tracked_feeds
+		` + curatedClauses + `
+
+		UNION ALL
+
+		SELECT
+			ucf.url,
+			ucf.name,
+			ucf.category,
+			false AS is_default,
+			COALESCE(tf.consecutive_failures, 0) AS consecutive_failures,
+			tf.last_error,
+			tf.last_success_at
+		FROM user_custom_feeds ucf
+		LEFT JOIN tracked_feeds tf ON tf.url = ucf.url
+		` + customClauses + `
+
+		ORDER BY is_default DESC, category, name
+	`
+
+	var rows pgx.Rows
+	var qErr error
+	if includeFailing {
+		rows, qErr = a.db.Query(ctx, query, userSub, MaxConsecutiveFailures)
+	} else {
+		rows, qErr = a.db.Query(ctx, query, userSub, MaxConsecutiveFailures)
+	}
+	if qErr != nil {
+		return nil, qErr
+	}
+	defer rows.Close()
+
+	var feeds []TrackedFeed
+	for rows.Next() {
+		var f TrackedFeed
+		if err := rows.Scan(&f.URL, &f.Name, &f.Category, &f.IsDefault, &f.ConsecutiveFailures, &f.LastError, &f.LastSuccessAt); err != nil {
+			log.Printf("[RSS] Catalog scan error: %v", err)
+			continue
+		}
+		feeds = append(feeds, f)
+	}
+	return feeds, nil
+}
+
+// invalidateUserCatalogCache drops the per-user catalog cache entries so
+// the next read sees fresh data. Called after any operation that mutates
+// the user's custom-feed set (add, delete, janitor cleanup).
+func (a *App) invalidateUserCatalogCache(ctx context.Context, userSub string) {
+	if userSub == "" {
+		return
+	}
+	a.rdb.Del(ctx, CacheKeyRSSCatalog+":"+userSub)
+	a.rdb.Del(ctx, CacheKeyRSSCatalog+":"+userSub+":all")
+}
+
+// invalidateAllCatalogCaches drops every per-user cache entry. Used on
+// curated-feed mutations (rare — operator action) or the broad janitor
+// cleanup. Implemented as a SCAN+DEL so we don't rely on knowing which
+// users currently have cached entries.
+func (a *App) invalidateAllCatalogCaches(ctx context.Context) {
+	prefix := CacheKeyRSSCatalog + ":"
+	// SCAN with a match pattern. Cursor-based to avoid blocking Redis.
+	iter := a.rdb.Scan(ctx, 0, prefix+"*", 0).Iterator()
+	for iter.Next(ctx) {
+		a.rdb.Del(ctx, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		log.Printf("[RSS] catalog cache scan-delete failed: %v", err)
+	}
+}
+
+// deleteCustomFeed removes a custom feed for the requesting user.
 // The core gateway sets X-User-Sub header for authenticated requests.
-// Only the user who added the feed (added_by) can delete it.
+//
+// Behavior:
+//   - Drops the (logto_sub, url) row from user_custom_feeds. After this
+//     the feed no longer appears in the user's catalog.
+//   - If no other user still subscribes to this URL via user_custom_feeds
+//     AND the URL is not a curated default, also drops the tracked_feeds
+//     row and the rss_items it owned. Rust ingestion stops polling.
+//   - If other users still subscribe (or it's a curated default), the
+//     tracked_feeds row stays — only the requesting user's tenancy row
+//     is removed.
+//
+// This is the architecturally-correct multi-tenant deletion: per-user
+// removal of the user's own subscription, with global cleanup only when
+// the last subscriber is gone.
 func (a *App) deleteCustomFeed(c *fiber.Ctx) error {
 	ctx := c.Context()
 
@@ -146,33 +297,21 @@ func (a *App) deleteCustomFeed(c *fiber.Ctx) error {
 		})
 	}
 
+	// Don't allow deletion of curated defaults — those are operator-owned.
 	var isDefault bool
-	var addedBy *string
-	err := a.db.QueryRow(ctx,
-		"SELECT is_default, added_by FROM tracked_feeds WHERE url = $1", req.URL).Scan(&isDefault, &addedBy)
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(ErrorResponse{
-			Status: "error",
-			Error:  "Feed not found in catalog",
-		})
+	if err := a.db.QueryRow(ctx,
+		"SELECT is_default FROM tracked_feeds WHERE url = $1", req.URL).Scan(&isDefault); err == nil {
+		if isDefault {
+			return c.Status(fiber.StatusForbidden).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "Cannot delete a built-in default feed",
+			})
+		}
 	}
-	if isDefault {
-		return c.Status(fiber.StatusForbidden).JSON(ErrorResponse{
-			Status: "error",
-			Error:  "Cannot delete a built-in default feed",
-		})
-	}
-	// Only the user who added the feed can delete it
-	if addedBy != nil && *addedBy != userSub {
-		return c.Status(fiber.StatusForbidden).JSON(ErrorResponse{
-			Status: "error",
-			Error:  "You can only delete feeds that you added",
-		})
-	}
+	// Note: we don't 404 if the URL isn't in tracked_feeds — the user_custom_feeds
+	// row could exist without a corresponding tracked_feeds row in rare race
+	// scenarios. Proceed to the user-scoped delete.
 
-	// Wrap both deletes in a transaction so a failure partway through
-	// cannot leave rss_items gone while tracked_feeds still points at a
-	// now-empty feed row. Rollback is always safe to call after Commit.
 	tx, err := a.db.Begin(ctx)
 	if err != nil {
 		log.Printf("[RSS] Failed to begin delete transaction for feed %s: %v", req.URL, err)
@@ -183,20 +322,49 @@ func (a *App) deleteCustomFeed(c *fiber.Ctx) error {
 	}
 	defer tx.Rollback(ctx)
 
-	if _, err := tx.Exec(ctx, "DELETE FROM rss_items WHERE feed_url = $1", req.URL); err != nil {
-		log.Printf("[RSS] Failed to delete items for feed %s: %v", req.URL, err)
-		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
-			Status: "error",
-			Error:  "Failed to delete feed items",
-		})
-	}
-
-	if _, err := tx.Exec(ctx, "DELETE FROM tracked_feeds WHERE url = $1 AND is_default = false", req.URL); err != nil {
-		log.Printf("[RSS] Failed to delete custom feed %s: %v", req.URL, err)
+	// 1. Remove the requesting user's tenancy row. If the user wasn't
+	//    subscribed in the first place, this is a no-op (0 rows affected,
+	//    not an error — caller may be retrying).
+	cmd, err := tx.Exec(ctx,
+		"DELETE FROM user_custom_feeds WHERE logto_sub = $1 AND url = $2",
+		userSub, req.URL)
+	if err != nil {
+		log.Printf("[RSS] Failed to delete user_custom_feeds row (%s, %s): %v", userSub, req.URL, err)
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
 			Status: "error",
 			Error:  "Failed to delete feed",
 		})
+	}
+	rowsAffected := cmd.RowsAffected()
+
+	// 2. Check whether ANY user still subscribes to this URL. If yes,
+	//    keep tracked_feeds + rss_items intact (some other user is
+	//    reading this feed). If no, this URL is now orphaned — drop
+	//    tracked_feeds (which cascades to rss_items via FK).
+	var otherSubscribers int
+	if err := tx.QueryRow(ctx,
+		"SELECT COUNT(*) FROM user_custom_feeds WHERE url = $1",
+		req.URL).Scan(&otherSubscribers); err != nil {
+		log.Printf("[RSS] Failed to count remaining subscribers for %s: %v", req.URL, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Failed to delete feed",
+		})
+	}
+
+	orphaned := otherSubscribers == 0
+	if orphaned {
+		// rss_items has FK on tracked_feeds.url with ON DELETE CASCADE,
+		// so dropping tracked_feeds cleans up rss_items in the same statement.
+		if _, err := tx.Exec(ctx,
+			"DELETE FROM tracked_feeds WHERE url = $1 AND is_default = false",
+			req.URL); err != nil {
+			log.Printf("[RSS] Failed to delete orphaned tracked_feeds row %s: %v", req.URL, err)
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+				Status: "error",
+				Error:  "Failed to delete feed",
+			})
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -207,12 +375,20 @@ func (a *App) deleteCustomFeed(c *fiber.Ctx) error {
 		})
 	}
 
-	a.rdb.Del(ctx, RedisRSSSubscribersPrefix+req.URL)
-	a.rdb.Del(ctx, CacheKeyRSSCatalog)
-	a.rdb.Del(ctx, CacheKeyRSSCatalog+":all")
+	// Cache invalidation: drop the requesting user's catalog cache, and
+	// drop the per-feed-URL subscriber set if the URL was orphaned.
+	a.invalidateUserCatalogCache(ctx, userSub)
+	if orphaned {
+		a.rdb.Del(ctx, RedisRSSSubscribersPrefix+req.URL)
+	}
 
-	log.Printf("[RSS] User %s deleted custom feed: %s", userSub, req.URL)
-	return c.JSON(fiber.Map{"status": "ok", "message": "Custom feed deleted"})
+	log.Printf("[RSS] User %s deleted custom feed %s (rows=%d, orphaned=%t)",
+		userSub, req.URL, rowsAffected, orphaned)
+	return c.JSON(fiber.Map{
+		"status":   "ok",
+		"message":  "Custom feed deleted",
+		"orphaned": orphaned,
+	})
 }
 
 // healthHandler proxies a health check to the internal Rust RSS ingestion service.
@@ -562,6 +738,13 @@ func (a *App) syncRSSFeedsToTracked(userSub string, config map[string]interface{
 			name = feed.URL
 		}
 
+		// Insert into the global tracked_feeds (the polling-target
+		// table). We deduplicate on URL — two users adding the same
+		// URL still get one row here, which is correct: the Rust
+		// service polls each unique URL once. The added_by column
+		// records whoever was first, kept for backwards-compat with
+		// the legacy DELETE auth check; the user-tenancy concern is
+		// now solved by the user_custom_feeds row below.
 		_, err := a.db.Exec(ctx, `
 			INSERT INTO tracked_feeds (url, name, category, is_default, is_enabled, added_by)
 			VALUES ($1, $2, 'Custom', false, true, $3)
@@ -569,12 +752,30 @@ func (a *App) syncRSSFeedsToTracked(userSub string, config map[string]interface{
 		`, feed.URL, name, userSub)
 		if err != nil {
 			log.Printf("[RSS] Failed to sync feed %s to tracked_feeds: %v", feed.URL, err)
+			continue
+		}
+
+		// Insert into the per-user user_custom_feeds. This is the
+		// per-user-visibility row that the catalog endpoint reads.
+		// Each user owns their own (name, category) for a given URL —
+		// user A and user B can have different display names for the
+		// same URL. ON CONFLICT updates the name to handle the case
+		// where the user is renaming a feed they already added.
+		_, err = a.db.Exec(ctx, `
+			INSERT INTO user_custom_feeds (logto_sub, url, name, category)
+			VALUES ($1, $2, $3, 'Custom')
+			ON CONFLICT (logto_sub, url) DO UPDATE SET name = EXCLUDED.name
+		`, userSub, feed.URL, name)
+		if err != nil {
+			log.Printf("[RSS] Failed to sync feed %s to user_custom_feeds for %s: %v", feed.URL, userSub, err)
 		}
 	}
 
-	// Invalidate the catalog cache so new custom feeds appear
-	a.rdb.Del(ctx, CacheKeyRSSCatalog)
-	a.rdb.Del(ctx, CacheKeyRSSCatalog+":all")
+	// Invalidate this user's catalog cache so their new custom feeds
+	// appear immediately. Other users' caches are untouched (they
+	// shouldn't have been seeing this user's feeds anyway after the
+	// per-user split).
+	a.invalidateUserCatalogCache(ctx, userSub)
 }
 
 // =============================================================================

--- a/channels/rss/service/migrations/130000000001_user_custom_feeds.down.sql
+++ b/channels/rss/service/migrations/130000000001_user_custom_feeds.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_user_custom_feeds_logto_sub;
+DROP INDEX IF EXISTS idx_user_custom_feeds_url;
+DROP TABLE IF EXISTS user_custom_feeds;

--- a/channels/rss/service/migrations/130000000001_user_custom_feeds.up.sql
+++ b/channels/rss/service/migrations/130000000001_user_custom_feeds.up.sql
@@ -1,0 +1,46 @@
+-- Per-user custom feed registry, introduced 2026-05-06.
+--
+-- Why this exists: until now `tracked_feeds` (the polling-target table)
+-- was the SOLE store for both curated/default feeds and user-added
+-- custom feeds, distinguished only by `is_default`. The catalog
+-- endpoint that powers the desktop UI's "add feeds" picker read from
+-- `tracked_feeds` with no per-user filter, so user A's custom feeds
+-- showed up in user B's catalog. Multi-tenant data leak.
+--
+-- The fix is structural: split per-user metadata into this table.
+-- `tracked_feeds` continues to be the single polling target (the Rust
+-- ingestion service still polls each unique URL once regardless of
+-- how many users subscribe), but the catalog endpoint now joins
+-- `tracked_feeds` (for curated defaults + health columns) with
+-- `user_custom_feeds` (for the requesting user's customs only).
+--
+-- Each user owns their own (name, category) for a given URL — two
+-- users adding the same URL get two rows here with potentially
+-- different display names. The `tracked_feeds` row deduplicates the
+-- URL for polling purposes only.
+CREATE TABLE IF NOT EXISTS user_custom_feeds (
+    logto_sub  TEXT NOT NULL,
+    url        TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    category   TEXT NOT NULL DEFAULT 'Custom',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (logto_sub, url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_custom_feeds_url
+  ON user_custom_feeds(url);
+
+CREATE INDEX IF NOT EXISTS idx_user_custom_feeds_logto_sub
+  ON user_custom_feeds(logto_sub);
+
+-- Backfill from existing tracked_feeds rows that were custom feeds
+-- with a recorded `added_by`. Rows where `added_by IS NULL` are
+-- pre-`added_by`-migration legacy and are intentionally left orphaned
+-- in tracked_feeds; the auto-cleanup janitor introduced in this same
+-- batch will eventually remove them when they hit broken thresholds.
+INSERT INTO user_custom_feeds (logto_sub, url, name, category, created_at)
+SELECT added_by, url, name, category, COALESCE(created_at, NOW())
+FROM tracked_feeds
+WHERE is_default = false
+  AND added_by IS NOT NULL
+ON CONFLICT (logto_sub, url) DO NOTHING;

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -397,10 +397,19 @@ export interface TrackedFeed {
 }
 
 export const rssApi = {
-  /** Fetch the public feed catalog. Pass includeFailing to see quarantined feeds. */
+  /**
+   * Fetch the per-user feed catalog. The catalog returns curated
+   * default feeds plus the requesting user's own custom feeds — never
+   * other users' custom feeds.
+   *
+   * Endpoint is now Auth: true on the gateway (was Auth: false before
+   * the multi-tenant fix); use authFetch so the X-User-Sub header is
+   * applied. Pass includeFailing to see broken feeds (used by My
+   * Feeds for health badges on already-subscribed feeds).
+   */
   getCatalog: (opts?: { includeFailing?: boolean }) => {
     const params = opts?.includeFailing ? "?include_failing=true" : "";
-    return request<Array<TrackedFeed>>(`/rss/feeds${params}`);
+    return authFetch<Array<TrackedFeed>>(`/rss/feeds${params}`);
   },
 
   /** Delete a custom (non-default) feed from the catalog */


### PR DESCRIPTION
## Summary

Three coupled RSS fixes in one PR. User reported (m2124):
> some of the rss feeds are broken yet they still are available for selection in the user interface and any custom feeds anyone adds show up for all users im pretty sure

Investigation surfaced a related hardening item that lives in the same code path; bundled.

### Issue 1 — broken feeds remain selectable
The catalog query filtered by `is_enabled = true AND consecutive_failures < 3` but never checked `last_success_at`. A feed that returns 200-with-empty-body intermittently resets `consecutive_failures = 0` and stays in the catalog despite never legitimately succeeding in weeks.

### Issue 2 — multi-tenant data leak (severe, the urgent one)
ONE global `tracked_feeds` table held both curated AND user-added feeds. Primary key on `url` deduplicated across users. The `/rss/feeds` endpoint returned ALL `is_enabled` rows globally — no per-user filter. User A's custom feeds appeared in user B's catalog. Cache-poisoning vector too: first user to add a URL won the `name` field forever for everyone.

### Issue 3 — client-asserted `is_custom`
Tier validation counted `is_custom` from client-supplied JSON. A malicious client could send `is_custom: false` for a user-supplied URL to bypass the customFeeds tier cap (bounded only by total feeds).

## What changed (structural)

1. **New `user_custom_feeds (logto_sub, url, name, category, created_at)` table** with composite PK. Each user owns their own (name, category) for a URL.

2. **`tracked_feeds` continues to be the polling-target table** — Rust ingestion polls each unique URL once. Only the user-tenancy layer is split.

3. **Catalog endpoint becomes user-aware.** UNION ALL of curated defaults + the requesting user's own custom feeds (joined to `tracked_feeds` for health columns). Plus stale-filter `last_success_at > 7 days ago OR created_at > 24h ago` (24h grace for newly-added feeds).

4. **`/rss/feeds` flips Auth: false → Auth: true.** Desktop client updated `request<>` → `authFetch<>`.

5. **Custom-feed-add (`syncRSSFeedsToTracked`) writes to BOTH tables**: tracked_feeds (deduped global polling target) + user_custom_feeds (per-user tenancy with user-specific name).

6. **Custom-feed-delete (`deleteCustomFeed`) is now per-user**: drops the requesting user's `user_custom_feeds` row, cascades cleanup of `tracked_feeds` + `rss_items` ONLY when the URL has zero remaining subscribers across all users.

7. **New auto-cleanup janitor** (`channels/rss/api/janitor.go`) runs every 6 hours + on startup. For broken-threshold feeds (`last_success_at > 7 days` OR `consecutive_failures >= 100`):
   - **Custom feeds**: fully removed (user_custom_feeds rows dropped, tracked_feeds + rss_items dropped via FK cascade, each subscriber's `user_channels.config.feeds[]` pruned of the URL via JSONB update).
   - **Curated defaults**: marked `is_enabled = false` for operator follow-up. Janitor doesn't auto-remove operator-managed catalog entries.

8. **Server-side `is_custom` derivation** in `tier_limits.go` via a curated-URL set cache (5-min TTL, 3s query timeout). When DB is unavailable (tests) or refresh fails, gracefully falls back to the client-asserted flag — never DEGRADES on cache failure.

## Files changed

| File | Change |
|---|---|
| `channels/rss/service/migrations/130000000001_user_custom_feeds.{up,down}.sql` | NEW — table + backfill |
| `channels/rss/api/rss.go` | Catalog refactor + per-user delete + `is_custom` plumbing |
| `channels/rss/api/janitor.go` | NEW — auto-cleanup janitor |
| `channels/rss/api/main.go` | Wire janitor into startup; flip route Auth: false→true |
| `api/core/tier_limits.go` | Server-side `is_custom` derivation |
| `api/core/curated_feeds_cache.go` | NEW — curated-URL set cache for tier validation |
| `desktop/src/api/client.ts` | `rssApi.getCatalog` now uses `authFetch` |

## Migration

`130000000001_user_custom_feeds.up.sql` (rss `13*` prefix per the service-range convention):

1. Creates `user_custom_feeds` with composite PK + URL + logto_sub indices
2. Backfills from `tracked_feeds WHERE is_default = false AND added_by IS NOT NULL`
3. Pre-`added_by` legacy rows (where `added_by IS NULL`) are intentionally NOT backfilled — they're orphaned and the janitor will clean them up when they hit broken thresholds

## Defaults (encoded as Go constants — easy to tune later)

```go
LastSuccessStaleThreshold      = "7 days"
MaxConsecutiveFailuresJanitor  = 100  // ~8h of 5-min polls
JanitorInterval                = 6 * time.Hour
```

## Auto-cleanup behavior on user configs

When the janitor removes a broken custom feed, it ALSO updates each subscribing user's `user_channels.config.feeds[]` JSONB to drop the broken URL. Users will see the feed simply disappear from their feed list — silent removal in v1 per user directive (m2127: "the server should be able to recognize it and remove it"). Future work could surface "N broken feeds were removed from your config" on next desktop launch if desired.

## Verification

- `go vet ./...` clean (rss api + core)
- `go build` clean (rss api + core)
- `go test ./core/` 100% passing — `is_custom` server derivation preserves test behavior because tests run with `DBPool == nil`, falling through to the client-asserted flag
- `cargo check` clean (rss service)
- `cargo test --test migration_versions` 2/2 passing — new migration uses the rss-reserved `13*` prefix range
- `npx tsc --noEmit` clean (desktop)
- `npx vitest run` 189/189 passing (desktop)
- `npm run build` clean (desktop)

## How to verify after merge

1. **Multi-tenant isolation**: from two different signed-in accounts, add different custom feeds. Each account should see ONLY their own customs in the catalog (plus curated defaults). User A's feed should not appear in user B's `/rss/feeds` response.

2. **Broken feed cleanup**: insert a feed with `last_success_at` set to 8 days ago. Wait for the janitor cycle (max 6h after pod start), then verify the feed is removed from `tracked_feeds` and from any subscribing user's `user_channels.config.feeds[]`. Logs will show `[RSS Janitor] removed N broken custom feed(s)`.

3. **Stale-filter on catalog**: a feed with `consecutive_failures = 0` but `last_success_at = NOW() - INTERVAL '8 days'` should NOT appear in the catalog. (Previously it would have appeared as healthy.)

4. **Auth check**: hit `/rss/feeds` without an X-User-Sub header; expect 401 (was 200 globally).

5. **Migration backfill**: `SELECT COUNT(*) FROM user_custom_feeds` should equal `SELECT COUNT(*) FROM tracked_feeds WHERE is_default = false AND added_by IS NOT NULL` immediately after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)