### PR TITLE
fix(k8s): include www.myscrollr.com in TLS cert + add routing rule

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -21,11 +21,36 @@ spec:
   tls:
     - hosts:
         - myscrollr.com
+        - www.myscrollr.com
         - api.myscrollr.com
       secretName: scrollr-tls
   rules:
     # Marketing website
     - host: myscrollr.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: website
+                port:
+                  number: 3000
+
+    # www variant — same backend as apex. Required for cert-manager's
+    # HTTP-01 challenge to validate www.myscrollr.com (without a route
+    # for this hostname, Let's Encrypt cannot reach
+    # /.well-known/acme-challenge/... and the cert request would hang
+    # indefinitely, blocking renewal of the existing cert too).
+    #
+    # Visitors who hit www directly will see the same site as apex.
+    # If you'd prefer a 301 redirect www → apex at the K8s layer
+    # instead of serving content here, split this rule into a separate
+    # Ingress with the annotation:
+    #   nginx.ingress.kubernetes.io/permanent-redirect: https://myscrollr.com$request_uri
+    # (per-rule annotations are not supported by nginx-ingress, hence
+    # the need for a separate Ingress object if you want the redirect.)
+    - host: www.myscrollr.com
       http:
         paths:
           - path: /


### PR DESCRIPTION
## Summary

Adds www.myscrollr.com to the K8s ingress TLS cert + adds an HTTP routing rule for the hostname.

Before this change, https://www.myscrollr.com hit a cert mismatch (browsers showed NET::ERR_CERT_COMMON_NAME_INVALID) because scrollr-tls only covered apex + api.

## Already applied to production

The ingress change has already been applied via kubectl. The commit syncs the source-of-truth back to git so the change persists through future deploys.

End-to-end verification before opening this PR:
- Cert-manager triggered re-issue immediately on the spec change (SecretMismatch reason)
- All 3 ACME HTTP-01 challenges (apex, www, api) resolved within 60s
- New cert covers all three: \`DNS:api.myscrollr.com, DNS:myscrollr.com, DNS:www.myscrollr.com\`
- New cert valid until 2026-08-04 (re-issue restarted the 90-day Let's Encrypt clock)
- \`curl -sI https://www.myscrollr.com/\` returns HTTP 200 with SSL verify result 0

## Why a routing rule was needed

cert-manager uses HTTP-01 challenge (per \`k8s/cert-manager.yaml\`). For Let's Encrypt to validate ownership of www.myscrollr.com, it must reach \`http://www.myscrollr.com/.well-known/acme-challenge/...\` — which requires a routing rule for that hostname on the ingress. Without it, the cert request would hang and could also block renewal of the existing cert when its 30-day-before-expiry window opens.

DNS for www already pointed to the K8s LB IP (\`129.212.151.228\`) so the challenge had a clear path to land on our ingress. No DNS changes needed.

## www → apex redirect: not in this commit

www currently serves the same content as apex (both routes hit the website service). If we'd prefer a 301 redirect at the K8s layer, that requires splitting the www rule into a separate Ingress object with:

\`\`\`yaml
nginx.ingress.kubernetes.io/permanent-redirect: https://myscrollr.com\$request_uri
\`\`\`

Per-rule annotations are not supported by nginx-ingress, hence the need for a separate Ingress. Easy follow-up if/when desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)