### PR TITLE
feat(macos): wire Apple code signing + notarization

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -179,6 +179,15 @@ jobs:
       # the GitHub release, and assembles latest.json across all platforms.
       # Logto desktop app must allow callback http://127.0.0.1:19284/callback
       # and API resource https://api.myscrollr.com for production releases.
+      #
+      # Apple secrets (APPLE_*) are only consumed by macOS builds. tauri-action
+      # imports the .p12 into a temporary keychain, codesigns the .app bundle,
+      # then submits to notarytool for Apple notarization. Other matrix targets
+      # (Windows, Linux) ignore them. If any APPLE_* secret is missing on a
+      # macOS build, tauri-action skips signing and produces an unsigned bundle
+      # (the build still succeeds, just without notarization). We don't fail
+      # the workflow on missing Apple secrets so the Linux/Windows builds keep
+      # working during initial rollout / cert renewal.
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:
@@ -187,6 +196,13 @@ jobs:
           VITE_API_URL: ${{ secrets.DESKTOP_VITE_API_URL }}
           VITE_AUTH_ENDPOINT: ${{ secrets.DESKTOP_VITE_AUTH_ENDPOINT }}
           VITE_LOGTO_APP_ID: ${{ secrets.DESKTOP_VITE_LOGTO_APP_ID }}
+          # Apple code-signing + notarization (macOS only; ignored on other runners)
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           projectPath: desktop
           tauriScript: npx tauri

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -18,7 +18,13 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "minimumSystemVersion": "10.15",
+      "exceptionDomain": "",
+      "frameworks": [],
+      "entitlements": null
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
## Summary

Configures macOS desktop builds to use Apple Developer ID code signing + notarization. Without this, Mac users have to right-click + Open to bypass Gatekeeper warnings; with it, the standard double-click works and the auto-updater path is more reliable.

## Two file changes

### `desktop/src-tauri/tauri.conf.json`
Adds a `bundle.macOS` section:
- `minimumSystemVersion: "10.15"` (Catalina; minimum for hardened runtime + notarization)
- `signingIdentity` intentionally not set — Tauri reads it from `APPLE_SIGNING_IDENTITY` env when omitted, keeping team-specific values out of the public repo

### `.github/workflows/desktop-release.yml`
Passes 6 new APPLE_* secrets to the existing `tauri-action` build step. macOS builds consume them; Windows/Linux runners ignore them. Workflow does not fail when secrets are missing (so non-macOS releases keep working during initial setup or cert renewal).

## Required GitHub secrets (manual, post-merge)

Repo Settings → Secrets and variables → Actions → New repository secret:

| Name | Value source |
|---|---|
| `APPLE_CERTIFICATE` | base64-encoded .p12 file (`base64 -i scrollr_dev_id.p12 \| pbcopy`) |
| `APPLE_CERTIFICATE_PASSWORD` | the passphrase set when exporting the .p12 |
| `APPLE_SIGNING_IDENTITY` | `Developer ID Application: Scrollr, LLC (4S6F56VHMZ)` |
| `APPLE_ID` | Apple ID email |
| `APPLE_PASSWORD` | app-specific password from appleid.apple.com (NOT Apple ID password) |
| `APPLE_TEAM_ID` | `4S6F56VHMZ` |

## What happens after merge

If secrets are configured before the next macOS build triggers:
1. tauri-action imports the .p12 into a temporary GitHub Actions keychain
2. Codesigns .app + .dmg with the Developer ID Application cert
3. Submits to notarytool for Apple notarization (~5-15 min)
4. Staples the notarization ticket to the .dmg
5. Uploads as a draft release as usual

Build time goes from ~5-7 min to ~15-25 min on macOS due to notarization wait. Other platforms unaffected.

## Why we don't fail the workflow on missing Apple secrets

The Linux/Windows builds are independent and shouldn't be blocked by macOS-specific config issues during initial setup. If APPLE_* secrets are missing, the macOS build still succeeds — just produces an unsigned bundle (current behavior). This means:
- Initial rollout is non-blocking (set up secrets when ready)
- Cert renewal in 2027 won't surprise-break Linux/Windows releases if Apple Developer Program lapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)