### PR TITLE
fix(website): auto-refresh download link on desktop release publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,16 @@ on:
       - "myscrollr.com/**"
       - "k8s/**"
       - ".github/workflows/deploy.yml"
+  # When a desktop release is published (drafts -> published), rebuild the
+  # website so the download button picks up the new version. The site bakes
+  # `LATEST_DESKTOP_VERSION` at build time from `releases/latest` (see
+  # myscrollr.com/scripts/fetch-latest-version.mjs). Without this trigger,
+  # a desktop-only release would leave the marketing site advertising the
+  # previous version until the next unrelated commit to myscrollr.com/**.
+  # Filtered to desktop-v* tags inside the manual step so non-desktop
+  # releases (if any are added later) don't trigger pointless rebuilds.
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       services:
@@ -39,7 +49,29 @@ jobs:
 
       - name: Resolve manual service selection
         id: manual
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          # The `release: types: [published]` trigger rebuilds only the
+          # website, and only for `desktop-v*` tags. Other releases (none
+          # exist today, but future-proof) are ignored.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            for svc in core-api website finance-api finance-service sports-api sports-service rss-api rss-service fantasy-api k8s; do
+              echo "${svc}=false" >> $GITHUB_OUTPUT
+            done
+
+            case "$RELEASE_TAG" in
+              desktop-v*)
+                echo "Desktop release $RELEASE_TAG published; rebuilding website to refresh LATEST_DESKTOP_VERSION"
+                echo "website=true" >> $GITHUB_OUTPUT
+                ;;
+              *)
+                echo "Release $RELEASE_TAG is not a desktop release; skipping rebuild"
+                ;;
+            esac
+            exit 0
+          fi
+
           if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
             exit 0
           fi
@@ -72,7 +104,7 @@ jobs:
 
       - uses: dorny/paths-filter@v3
         id: changes
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name == 'push'
         with:
           filters: |
             core-api:

--- a/myscrollr.com/scripts/fetch-latest-version.mjs
+++ b/myscrollr.com/scripts/fetch-latest-version.mjs
@@ -15,55 +15,99 @@
  * at build time (one fetch per deploy, no CORS at all because Node
  * is not a browser) is the simplest correct path.
  *
- * The generated file is gitignored. Build pipelines that need
- * deterministic output without a network call can set
- * SCROLLR_LATEST_VERSION=1.0.3 in the environment to skip the fetch.
+ * Cache-busting: the marketing site is rebuilt automatically when a
+ * desktop release is *published* (see .github/workflows/deploy.yml,
+ * `release: types: [published]` trigger). That is what keeps the
+ * download button current without manual intervention.
+ *
+ * Failure modes:
+ *   - SCROLLR_LATEST_VERSION env var set -> use it, no network call.
+ *   - CI=true and API call fails -> hard fail. We refuse to ship a
+ *     production build advertising a stale FALLBACK_VERSION; better
+ *     to fail the deploy and retry than silently ship a bad link.
+ *   - Local dev (CI unset) and API call fails -> warn and use
+ *     FALLBACK_VERSION so `npm run dev` works offline.
+ *
+ * The generated file is gitignored.
  */
 
 import { writeFile, mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
 const REPO = 'brandon-relentnet/myscrollr'
-const FALLBACK_VERSION = '1.0.3'
+// Updated whenever we bump in production. Used only as a last-resort
+// fallback for local dev when the network is unavailable; CI builds
+// hard-fail instead of falling back.
+const FALLBACK_VERSION = '1.0.9'
 const OUTPUT_PATH = new URL(
   '../src/lib/latestVersion.generated.ts',
   import.meta.url,
 )
+// Treat any standard CI signal as "production build, fail loudly".
+const IS_CI = process.env.CI === 'true' || process.env.CI === '1'
 
-let version = process.env.SCROLLR_LATEST_VERSION ?? FALLBACK_VERSION
-let source = process.env.SCROLLR_LATEST_VERSION ? 'env' : 'fallback'
-
-if (!process.env.SCROLLR_LATEST_VERSION) {
-  try {
-    const res = await fetch(
-      `https://api.github.com/repos/${REPO}/releases/latest`,
-      {
-        headers: { 'User-Agent': 'myscrollr.com prebuild' },
-        signal: AbortSignal.timeout(10_000),
-      },
+async function fetchLatestVersionFromGitHub() {
+  const res = await fetch(
+    `https://api.github.com/repos/${REPO}/releases/latest`,
+    {
+      headers: { 'User-Agent': 'myscrollr.com prebuild' },
+      signal: AbortSignal.timeout(10_000),
+    },
+  )
+  if (!res.ok) {
+    throw new Error(`GitHub API returned ${res.status} ${res.statusText}`)
+  }
+  const data = await res.json()
+  if (
+    typeof data.tag_name !== 'string' ||
+    !data.tag_name.startsWith('desktop-v')
+  ) {
+    throw new Error(
+      `release tag_name not in expected form, got "${data.tag_name}"`,
     )
-    if (res.ok) {
-      const data = await res.json()
-      if (
-        typeof data.tag_name === 'string' &&
-        data.tag_name.startsWith('desktop-v')
-      ) {
-        version = data.tag_name.slice('desktop-v'.length)
-        source = 'github-api'
-      } else {
-        console.warn(
-          `[prebuild] release tag_name not in expected form, got "${data.tag_name}"; using fallback ${FALLBACK_VERSION}`,
-        )
-      }
-    } else {
+  }
+  return data.tag_name.slice('desktop-v'.length)
+}
+
+let version
+let source
+
+if (process.env.SCROLLR_LATEST_VERSION) {
+  version = process.env.SCROLLR_LATEST_VERSION
+  source = 'env'
+} else {
+  // One retry on transient failure (rate-limit window, brief network
+  // hiccup). Two attempts total, ~10s timeout each.
+  let lastErr
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      version = await fetchLatestVersionFromGitHub()
+      source = 'github-api'
+      break
+    } catch (err) {
+      lastErr = err
       console.warn(
-        `[prebuild] GitHub API returned ${res.status}; using fallback ${FALLBACK_VERSION}`,
+        `[prebuild] attempt ${attempt}/2 failed: ${err?.message ?? err}`,
       )
+      if (attempt < 2) await new Promise((r) => setTimeout(r, 1500))
     }
-  } catch (err) {
+  }
+
+  if (!version) {
+    if (IS_CI) {
+      console.error(
+        `[prebuild] FATAL: could not resolve latest version from GitHub in CI. ` +
+          `Refusing to ship a build that would advertise the fallback (${FALLBACK_VERSION}). ` +
+          `Last error: ${lastErr?.message ?? lastErr}. ` +
+          `If you need to force a specific version, set SCROLLR_LATEST_VERSION.`,
+      )
+      process.exit(1)
+    }
     console.warn(
-      `[prebuild] failed to reach GitHub API (${err?.message ?? err}); using fallback ${FALLBACK_VERSION}`,
+      `[prebuild] using fallback ${FALLBACK_VERSION} (local dev only; CI would have failed)`,
     )
+    version = FALLBACK_VERSION
+    source = 'fallback'
   }
 }
 


### PR DESCRIPTION
## Summary
- Marketing site download button now auto-updates whenever a desktop release is published, no manual touch needed.
- Hardens the prebuild script so a transient GitHub API failure in CI fails the deploy loudly instead of silently shipping a build that points at the stale `FALLBACK_VERSION`.

## Why
The site bakes `LATEST_DESKTOP_VERSION` at build time by hitting `GET /releases/latest` (`myscrollr.com/scripts/fetch-latest-version.mjs`). The current `deploy.yml` only rebuilds the website when files under `myscrollr.com/**` change. So a pure desktop release left the marketing site advertising the previous version until some unrelated commit happened to touch the website tree.

The site is currently advertising the right version (1.0.9) only because previous releases happened to coincide with website commits. Going forward we want this to be guaranteed.

## What changed

### `.github/workflows/deploy.yml`
Subscribe to `release: types: [published]`. When you click **Publish** on a draft `desktop-v*` release, the `manual` step sets `website=true` and everything else `=false`, so only the website rebuilds. Non-desktop tags (none today, future-proof) are explicitly ignored.

The existing `paths-filter` step is now gated to `event_name == 'push'` so it doesn't run on `release` events.

### `myscrollr.com/scripts/fetch-latest-version.mjs`
- `FALLBACK_VERSION` bumped from stale `1.0.3` → `1.0.9`.
- One retry on transient API failure (1.5s delay between attempts, 10s timeout each).
- **CI hard-fail**: if `CI=true` and both attempts fail, `process.exit(1)`. Better to fail the deploy and retry than silently ship a build with a wrong download link.
- Local dev (no `CI` env var) keeps the soft fallback so `npm run dev` works offline.

## How the flow looks now
1. Push to `main` touching `desktop/**` → `desktop-release.yml` builds + creates a draft release.
2. Click **Publish** in the GitHub UI (unchanged manual step — `releaseDraft: true` left as-is so you keep QA control over the in-app updater).
3. GitHub fires `release: published` → `deploy.yml` runs → website rebuilds with the new `LATEST_DESKTOP_VERSION`.
4. Site is current within ~5 min, fully automatic.

## Verification
- `deploy.yml` parses as valid YAML. Triggers = `[push, release, workflow_dispatch]`. `release.types = [published]`.
- Prebuild script tested in three modes locally:
  - `SCROLLR_LATEST_VERSION=9.9.9` → uses env value.
  - Default → fetches `1.0.9` from GitHub API (`source: github-api`).
  - `CI=true` + simulated API failure → `process.exit(1)` with a clear error message.
- `npm run check` (prettier + eslint) passes.

## Notes / non-goals
- `releaseDraft: true` in `desktop-release.yml` is unchanged. The trigger fires on publish, not on draft creation, so you keep manual control.
- The `deploy` job's smoke test still runs on every release event. That's a free production health check; not removing it.