### PR TITLE
feat(desktop): live-preview Display panels for Sports, RSS, Fantasy (v1.0.11)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4013,7 +4013,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "futures-util",
  "log",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/channels/fantasy/DisplayPanel.tsx
+++ b/desktop/src/channels/fantasy/DisplayPanel.tsx
@@ -1,0 +1,491 @@
+/**
+ * Fantasy display preferences — the "/channel/fantasy/display" page.
+ *
+ * Mirrors the Finance/Sports/RSS DisplayPanel shape (2026-05-09 IA refactor)
+ * with two notable differences:
+ *
+ *   1. Fantasy has 14 venue toggles spread across 4 groups
+ *      (Score & status / Standings / Roster / Player stats). All 14
+ *      flow through the shared `DisplayItemsGrid` widget, which
+ *      handles the section sub-headers automatically.
+ *
+ *   2. Feed-side rendering of the Fantasy channel uses dedicated
+ *      sub-views (MatchupHero, StandingsView, RosterView etc.) which
+ *      do NOT currently honor the per-item Venue.feed booleans —
+ *      they always show their full layout. Only the ticker side
+ *      reads the per-item visibility (via FantasyStatChip). The
+ *      Feed preview here therefore renders the canonical
+ *      MatchupHero card statically and the helper text spells out
+ *      this asymmetry. Fixing it is a follow-up that would propagate
+ *      `shouldShowOnFeed` reads through MatchupHero — out of scope
+ *      for the live-preview rollout.
+ *
+ * Sample league:
+ *   1. Prefer the user's first dashboard league
+ *   2. Fall back to a hardcoded "Sunday Funday" NFL sample with a
+ *      live week-5 matchup, full standings entry, and a roster that
+ *      lights up every player-stats segment (top scorer, worst
+ *      starter, top bench, two injuries) so the user can see every
+ *      Display item respond when toggled.
+ *
+ * Persisted shape unchanged: `Venue` enum (off|feed|ticker|both) +
+ * `FantasyDisplayPrefs` legacy boolean fields untouched.
+ */
+import { useMemo } from "react";
+import { Eye, Tv } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { fantasyLeaguesOptions } from "../../api/queries";
+import { useShell } from "../../shell-context";
+import {
+  Section,
+  SegmentedRow,
+  ToggleRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+import DisplayItemsGrid from "../../components/settings/DisplayItemsGrid";
+import type { DisplayItemsSection } from "../../components/settings/DisplayItemsGrid";
+import FollowedPlayersPicker from "../../components/settings/FollowedPlayersPicker";
+import type { FantasyDisplayPrefs, Venue } from "../../preferences";
+import type { LeagueResponse } from "./types";
+import { MatchupHero } from "./MatchupHero";
+import FantasyStatChip from "../../components/chips/FantasyStatChip";
+
+// ── Constants ────────────────────────────────────────────────────
+
+const DEFAULTS: FantasyDisplayPrefs = {
+  matchupScore: "both",
+  winProbability: "both",
+  matchupStatus: "both",
+  projectedPoints: "both",
+  week: "both",
+  record: "both",
+  standingsPosition: "both",
+  streak: "both",
+  injuryCount: "both",
+  topScorer: "both",
+  topThreeScorers: "both",
+  worstStarter: "both",
+  benchOpportunity: "both",
+  injuryDetail: "both",
+  // Followed players are user picks — reset clears them.
+  followedPlayerKeys: [],
+  showStandings: true,
+  showMatchups: true,
+  defaultSort: "name",
+  defaultSubTab: "overview",
+  primaryLeagueKey: null,
+  enabledLeagueKeys: [],
+};
+
+const SUB_TAB_OPTIONS = [
+  { value: "overview", label: "Overview" },
+  { value: "matchup", label: "Matchup" },
+  { value: "standings", label: "Standings" },
+  { value: "roster", label: "Roster" },
+];
+
+// Keys on FantasyDisplayPrefs that are venue-typed.
+type FantasyVenueKey =
+  | "matchupScore"
+  | "winProbability"
+  | "matchupStatus"
+  | "projectedPoints"
+  | "week"
+  | "record"
+  | "standingsPosition"
+  | "streak"
+  | "injuryCount"
+  | "topScorer"
+  | "topThreeScorers"
+  | "worstStarter"
+  | "benchOpportunity"
+  | "injuryDetail";
+
+interface FantasyVenueRow {
+  key: FantasyVenueKey;
+  label: string;
+  description: string;
+}
+
+interface FantasyVenueGroup {
+  title: string;
+  rows: FantasyVenueRow[];
+}
+
+// Visual sub-grouping inside the grid. Three "feeds" + one player-
+// stats group match the user's mental model of which segments are
+// about live game state, season-wide rank, and roster health.
+const FANTASY_VENUE_GROUPS: FantasyVenueGroup[] = [
+  {
+    title: "Score & status",
+    rows: [
+      { key: "matchupScore", label: "Matchup score", description: "Your team vs. opponent, live or final" },
+      { key: "winProbability", label: "Win probability", description: "62% chance to win" },
+      { key: "matchupStatus", label: "Matchup status", description: "LIVE / FINAL / PRE badge" },
+      { key: "projectedPoints", label: "Projected points", description: "Your projected total this week" },
+      { key: "week", label: "Week number", description: "Current matchup week label" },
+    ],
+  },
+  {
+    title: "Standings",
+    rows: [
+      { key: "record", label: "Team record", description: "Season wins / losses (optionally ties)" },
+      { key: "standingsPosition", label: "Standings position", description: "3rd of 10" },
+      { key: "streak", label: "Current streak", description: "W3 / L2 badge" },
+    ],
+  },
+  {
+    title: "Roster",
+    rows: [
+      { key: "injuryCount", label: "Injury count", description: "Count of IR / DTD players on your roster" },
+      { key: "topScorer", label: "Top scorer", description: "Highest-scoring active player on your team" },
+    ],
+  },
+  {
+    title: "Player stats",
+    rows: [
+      {
+        key: "topThreeScorers",
+        label: "Top 3 starters",
+        description: "Mahomes 32, Hill 18, CMC 14 — each as its own segment",
+      },
+      {
+        key: "worstStarter",
+        label: "Lowest starter",
+        description: "↓ Andrews 0 — the dud you couldn't sit (red)",
+      },
+      {
+        key: "benchOpportunity",
+        label: "Bench leader",
+        description: "BN Pacheco 18 — points your bench is producing",
+      },
+      {
+        key: "injuryDetail",
+        label: "Injury report",
+        description: "🚨 Saquon OUT, Mixon DTD — names + status (max 2 + overflow)",
+      },
+    ],
+  },
+];
+
+// Hardcoded sample league. Engineered so every player-stats
+// segment has data: 4 starters with declining scores (so top3,
+// top, worst all resolve), 1 bench player with points, 2 injured
+// players (one OUT, one DTD).
+function buildSampleLeague(): LeagueResponse {
+  const teamKey = "preview.sample.team";
+  const oppKey = "preview.sample.opp";
+  return {
+    league_key: "preview.sample.league",
+    name: "Sunday Funday",
+    game_code: "nfl",
+    season: "2025",
+    team_key: teamKey,
+    team_name: "Field Goal Punters",
+    data: {
+      num_teams: 10,
+      is_finished: false,
+      current_week: 5,
+      scoring_type: "head",
+    },
+    standings: [
+      {
+        team_key: teamKey,
+        name: "Field Goal Punters",
+        team_logo: "",
+        manager_name: "You",
+        rank: 3,
+        wins: 3,
+        losses: 1,
+        ties: 0,
+        points_for: "512.4",
+        streak_type: "win",
+        streak_value: 2,
+        playoff_seed: 3,
+        clinched_playoffs: false,
+        waiver_priority: 7,
+      },
+    ],
+    matchups: [
+      {
+        week: 5,
+        status: "midevent",
+        is_playoffs: false,
+        winner_team_key: null,
+        teams: [
+          {
+            team_key: teamKey,
+            name: "Field Goal Punters",
+            team_logo: "",
+            manager_name: "You",
+            points: 89.4,
+            projected_points: 121.6,
+          },
+          {
+            team_key: oppKey,
+            name: "Trick or Cleat",
+            team_logo: "",
+            manager_name: "Sam",
+            points: 76.2,
+            projected_points: 108.4,
+          },
+        ],
+      },
+    ],
+    rosters: [
+      {
+        team_key: teamKey,
+        data: {
+          team_key: teamKey,
+          team_name: "Field Goal Punters",
+          players: [
+            {
+              player_key: "preview.qb",
+              name: { full: "Patrick Mahomes", first: "Patrick", last: "Mahomes" },
+              editorial_team_abbr: "KC",
+              display_position: "QB",
+              selected_position: "QB",
+              image_url: "",
+              status: null,
+              status_full: null,
+              injury_note: null,
+              player_points: 32.4,
+            },
+            {
+              player_key: "preview.wr1",
+              name: { full: "Tyreek Hill", first: "Tyreek", last: "Hill" },
+              editorial_team_abbr: "MIA",
+              display_position: "WR",
+              selected_position: "WR",
+              image_url: "",
+              status: null,
+              status_full: null,
+              injury_note: null,
+              player_points: 18.2,
+            },
+            {
+              player_key: "preview.rb",
+              name: { full: "Christian McCaffrey", first: "Christian", last: "McCaffrey" },
+              editorial_team_abbr: "SF",
+              display_position: "RB",
+              selected_position: "RB",
+              image_url: "",
+              status: null,
+              status_full: null,
+              injury_note: null,
+              player_points: 14.7,
+            },
+            {
+              player_key: "preview.te",
+              name: { full: "Mark Andrews", first: "Mark", last: "Andrews" },
+              editorial_team_abbr: "BAL",
+              display_position: "TE",
+              selected_position: "TE",
+              image_url: "",
+              status: null,
+              status_full: null,
+              injury_note: null,
+              player_points: 0.0,
+            },
+            {
+              player_key: "preview.bn1",
+              name: { full: "Isiah Pacheco", first: "Isiah", last: "Pacheco" },
+              editorial_team_abbr: "KC",
+              display_position: "RB",
+              selected_position: "BN",
+              image_url: "",
+              status: null,
+              status_full: null,
+              injury_note: null,
+              player_points: 17.8,
+            },
+            {
+              player_key: "preview.ir1",
+              name: { full: "Saquon Barkley", first: "Saquon", last: "Barkley" },
+              editorial_team_abbr: "PHI",
+              display_position: "RB",
+              selected_position: "IR",
+              image_url: "",
+              status: "OUT",
+              status_full: "Out — Hamstring",
+              injury_note: null,
+              player_points: null,
+            },
+            {
+              player_key: "preview.dtd",
+              name: { full: "Joe Mixon", first: "Joe", last: "Mixon" },
+              editorial_team_abbr: "HOU",
+              display_position: "RB",
+              selected_position: "BN",
+              image_url: "",
+              status: "DTD",
+              status_full: "Day-to-day",
+              injury_note: null,
+              player_points: 6.1,
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export default function FantasyDisplayPanel() {
+  const { prefs, onPrefsChange } = useShell();
+  const dp = prefs.channelDisplay.fantasy;
+
+  // Pull a real league from the user's data so the preview shows
+  // something they recognise. Falls back to the engineered sample.
+  const { data: leaguesData } = useQuery(fantasyLeaguesOptions());
+  const previewLeague: LeagueResponse = useMemo(() => {
+    const leagues = leaguesData?.leagues ?? [];
+    if (leagues.length === 0) return buildSampleLeague();
+    // Prefer leagues with an active matchup so the chip's segments
+    // have data; otherwise return the first.
+    return leagues.find((l) => l.matchups && l.matchups.length > 0) ?? leagues[0];
+  }, [leaguesData?.leagues]);
+
+  // ── Patch helpers ──────────────────────────────────────────────
+
+  function patch(next: Partial<FantasyDisplayPrefs>) {
+    onPrefsChange({
+      ...prefs,
+      channelDisplay: {
+        ...prefs.channelDisplay,
+        fantasy: { ...dp, ...next },
+      },
+    });
+  }
+
+  function applyDisplayChanges(changes: Record<string, Venue>) {
+    patch(changes as Partial<FantasyDisplayPrefs>);
+  }
+
+  function toggle(
+    key: keyof Pick<FantasyDisplayPrefs, "showStandings" | "showMatchups">,
+  ) {
+    patch({ [key]: !dp[key] } as Partial<FantasyDisplayPrefs>);
+  }
+
+  function handleReset() {
+    patch(DEFAULTS);
+  }
+
+  // ── Display-items grid model ──────────────────────────────────
+
+  const sections: DisplayItemsSection[] = FANTASY_VENUE_GROUPS.map((group) => ({
+    title: group.title,
+    rows: group.rows.map((row) => ({
+      key: row.key,
+      label: row.label,
+      description: row.description,
+      value: dp[row.key],
+    })),
+  }));
+
+  // ── Render ─────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6 pb-8">
+      {/* ── Live preview ─────────────────────────────────────────── */}
+      <Section title="Live preview">
+        <div className="px-3 pb-1 space-y-3">
+          <p className="text-[11px] text-fg-4 leading-snug">
+            The Ticker chip on the right responds in real time to every
+            Display item below — toggle a row to see it appear or
+            disappear. The Feed always shows the canonical matchup card
+            (Display items currently affect the Ticker only).
+          </p>
+
+          <div className="grid grid-cols-2 gap-3">
+            <PreviewSurface label="Feed" icon={Eye}>
+              <div className="w-full">
+                <MatchupHero league={previewLeague} compact />
+              </div>
+            </PreviewSurface>
+            <PreviewSurface label="Ticker" icon={Tv}>
+              <FantasyStatChip
+                league={previewLeague}
+                prefs={dp}
+                comfort={false}
+                colorMode="channel"
+              />
+            </PreviewSurface>
+          </div>
+        </div>
+      </Section>
+
+      {/* ── Display items grid ───────────────────────────────────── */}
+      <DisplayItemsGrid sections={sections} onChange={applyDisplayChanges} />
+
+      {/* ── Followed players ─────────────────────────────────────── */}
+      <Section title="Followed players">
+        <p className="text-[11px] text-fg-4 px-3 pb-2 leading-snug">
+          Pick specific players from your rosters to track on the ticker.
+          Each player gets their own chip showing their name, team, and
+          current points.
+        </p>
+        <FollowedPlayersPicker
+          followedPlayerKeys={dp.followedPlayerKeys}
+          onChange={(next) => patch({ followedPlayerKeys: next })}
+        />
+      </Section>
+
+      {/* ── Feed layout ─────────────────────────────────────────── */}
+      <Section title="Feed layout">
+        <SegmentedRow
+          label="Default view"
+          description="Which sub-tab opens when you enter the Fantasy feed"
+          value={dp.defaultSubTab}
+          options={SUB_TAB_OPTIONS}
+          onChange={(value) =>
+            patch({
+              defaultSubTab: value as FantasyDisplayPrefs["defaultSubTab"],
+            })
+          }
+        />
+        <ToggleRow
+          label="Show standings section"
+          checked={dp.showStandings}
+          onChange={() => toggle("showStandings")}
+        />
+        <ToggleRow
+          label="Show matchups section"
+          checked={dp.showMatchups}
+          onChange={() => toggle("showMatchups")}
+        />
+      </Section>
+
+      {/* ── Footer reset ─────────────────────────────────────────── */}
+      <div className="flex items-center justify-end pt-2">
+        <ResetButton label="Reset display settings" onClick={handleReset} />
+      </div>
+    </div>
+  );
+}
+
+// ── Preview surface card ────────────────────────────────────────
+
+interface PreviewSurfaceProps {
+  label: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  children: React.ReactNode;
+}
+
+function PreviewSurface({ label, icon: Icon, children }: PreviewSurfaceProps) {
+  return (
+    <div className="rounded-lg border border-edge/40 bg-base-200/40 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 border-b border-edge/40 bg-surface-2/30">
+        <Icon size={11} className="text-fg-4" />
+        <span className="text-[10px] font-mono font-semibold uppercase tracking-wider text-fg-4">
+          {label}
+        </span>
+      </div>
+      <div className="p-2.5 min-h-[120px] flex items-center justify-center overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/channels/rss/DisplayPanel.tsx
+++ b/desktop/src/channels/rss/DisplayPanel.tsx
@@ -1,0 +1,332 @@
+/**
+ * RSS display preferences — the "/channel/rss/display" page.
+ *
+ * Mirrors the Finance/Sports DisplayPanel shape (2026-05-09 IA refactor):
+ *   1. Live preview        — sample article on the Feed and a chip on
+ *                            the Ticker, side by side. Both update in
+ *                            real time as the toggles change.
+ *   2. Display items grid  — shared `DisplayItemsGrid` widget with
+ *                            column-headers-as-bulk-toggles.
+ *   3. Feed behavior       — `articlesPerSource` segmented row
+ *                            (structural, not a Venue toggle).
+ *   4. Footer reset        — restore defaults.
+ *
+ * Sample article selection:
+ *   1. Prefer the user's first dashboard article so the preview shows
+ *      something they recognise
+ *   2. Fall back to a hardcoded sample (a fictional tech newsletter
+ *      article) so the preview always has content
+ *
+ * Persisted shape unchanged: `Venue` enum (off|feed|ticker|both)
+ * converted at the UI boundary via the shared `DisplayItemsGrid`.
+ */
+import { useMemo } from "react";
+import { Eye, Tv } from "lucide-react";
+import { clsx } from "clsx";
+import { motion } from "motion/react";
+import { useQuery } from "@tanstack/react-query";
+import { dashboardQueryOptions } from "../../api/queries";
+import { useShell } from "../../shell-context";
+import type { RssItem } from "../../types";
+import type { RssDisplayPrefs, Venue } from "../../preferences";
+import { useNow } from "../../hooks/useNow";
+import { relativeTime, truncate } from "../../utils/format";
+import RssChip from "../../components/chips/RssChip";
+import DisplayItemsGrid from "../../components/settings/DisplayItemsGrid";
+import type { DisplayItemsSection } from "../../components/settings/DisplayItemsGrid";
+import {
+  Section,
+  SegmentedRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+
+// ── Constants ────────────────────────────────────────────────────
+
+const DEFAULTS: RssDisplayPrefs = {
+  showDescription: "both",
+  showSource: "both",
+  showTimestamps: "both",
+  articlesPerSource: 4,
+};
+
+const ARTICLES_PER_SOURCE_OPTIONS = [
+  { value: "2", label: "2" },
+  { value: "4", label: "4" },
+  { value: "6", label: "6" },
+  { value: "10", label: "10" },
+  { value: "0", label: "All" },
+];
+
+// Hardcoded sample article. Used when the user has no feeds yet (or
+// the dashboard hasn't loaded). Plausible-looking tech newsletter
+// content with non-trivial title length so truncation behavior is
+// visible in compact mode.
+function buildSampleArticle(): RssItem {
+  const now = new Date();
+  const tenMinutesAgo = new Date(now.getTime() - 10 * 60_000).toISOString();
+  return {
+    id: -1,
+    feed_url: "https://example.com/feed.xml",
+    guid: "preview-sample",
+    title: "WebKit ships native CSS scroll-driven animations in Safari 26",
+    link: "",
+    description:
+      "Apple's browser team landed support for the View Timeline API, " +
+      "letting developers tie keyframe progress directly to scroll position " +
+      "without JavaScript. The implementation matches the Chromium build.",
+    source_name: "TechCrunch",
+    published_at: tenMinutesAgo,
+    created_at: tenMinutesAgo,
+    updated_at: tenMinutesAgo,
+  };
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export default function RssDisplayPanel() {
+  const { prefs, onPrefsChange } = useShell();
+  const dp = prefs.channelDisplay.rss;
+
+  // Pull a real article from the dashboard so the preview shows
+  // something the user recognises. Falls back to the sample.
+  const { data: dashboard } = useQuery(dashboardQueryOptions());
+  const previewItem: RssItem = useMemo(() => {
+    const items = (dashboard?.data?.rss as RssItem[] | undefined) ?? [];
+    if (items.length > 0) return items[0];
+    return buildSampleArticle();
+  }, [dashboard?.data?.rss]);
+
+  // ── Patch helpers ──────────────────────────────────────────────
+
+  function patch(next: Partial<RssDisplayPrefs>) {
+    onPrefsChange({
+      ...prefs,
+      channelDisplay: {
+        ...prefs.channelDisplay,
+        rss: { ...dp, ...next },
+      },
+    });
+  }
+
+  function applyDisplayChanges(changes: Record<string, Venue>) {
+    patch(changes as Partial<RssDisplayPrefs>);
+  }
+
+  function setArticlesPerSource(value: string) {
+    patch({ articlesPerSource: Number(value) });
+  }
+
+  function handleReset() {
+    patch(DEFAULTS);
+  }
+
+  // ── Booleans the preview reads from ───────────────────────────
+
+  const feedShowDescription = isOn(dp.showDescription, "feed");
+  const feedShowSource = isOn(dp.showSource, "feed");
+  const feedShowTimestamps = isOn(dp.showTimestamps, "feed");
+  const tickerShowSource = isOn(dp.showSource, "ticker");
+  const tickerShowTimestamps = isOn(dp.showTimestamps, "ticker");
+
+  // ── Display-items grid model ──────────────────────────────────
+
+  const sections: DisplayItemsSection[] = [
+    {
+      rows: [
+        {
+          key: "showDescription",
+          label: "Article description",
+          description: "Snippet beneath the headline (Feed only)",
+          value: dp.showDescription,
+        },
+        {
+          key: "showSource",
+          label: "Source name",
+          description: "Publisher / feed name",
+          value: dp.showSource,
+        },
+        {
+          key: "showTimestamps",
+          label: "Timestamps",
+          description: "Relative publish time on each item",
+          value: dp.showTimestamps,
+        },
+      ],
+    },
+  ];
+
+  // ── Render ─────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6 pb-8">
+      {/* ── Live preview ─────────────────────────────────────────── */}
+      <Section title="Live preview">
+        <div className="px-3 pb-1 space-y-3">
+          <p className="text-[11px] text-fg-4 leading-snug">
+            Toggle items below to see the Feed article and Ticker chip
+            update in real time.
+          </p>
+
+          <div className="grid grid-cols-2 gap-3">
+            <PreviewSurface label="Feed" icon={Eye}>
+              <RssFeedPreview
+                item={previewItem}
+                showDescription={feedShowDescription}
+                showSource={feedShowSource}
+                showTimestamps={feedShowTimestamps}
+              />
+            </PreviewSurface>
+            <PreviewSurface label="Ticker" icon={Tv}>
+              <RssTickerPreview
+                item={previewItem}
+                showSource={tickerShowSource}
+                showTimestamps={tickerShowTimestamps}
+              />
+            </PreviewSurface>
+          </div>
+        </div>
+      </Section>
+
+      {/* ── Display items grid ───────────────────────────────────── */}
+      <DisplayItemsGrid sections={sections} onChange={applyDisplayChanges} />
+
+      {/* ── Feed behavior ────────────────────────────────────────── */}
+      <Section title="Feed behavior">
+        <SegmentedRow
+          label="Articles per source"
+          description="Limit how many articles appear from each feed"
+          value={String(dp.articlesPerSource)}
+          options={ARTICLES_PER_SOURCE_OPTIONS}
+          onChange={setArticlesPerSource}
+        />
+      </Section>
+
+      {/* ── Footer reset ─────────────────────────────────────────── */}
+      <div className="flex items-center justify-end pt-2">
+        <ResetButton label="Reset display settings" onClick={handleReset} />
+      </div>
+    </div>
+  );
+}
+
+// Local helper: read a single Venue's surface boolean. Inlined to
+// avoid an extra import dance — every preview component does the
+// same conversion.
+function isOn(venue: Venue, surface: "feed" | "ticker"): boolean {
+  if (venue === "both") return true;
+  return venue === surface;
+}
+
+// ── Preview surface card ────────────────────────────────────────
+
+interface PreviewSurfaceProps {
+  label: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  children: React.ReactNode;
+}
+
+function PreviewSurface({ label, icon: Icon, children }: PreviewSurfaceProps) {
+  return (
+    <div className="rounded-lg border border-edge/40 bg-base-200/40 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 border-b border-edge/40 bg-surface-2/30">
+        <Icon size={11} className="text-fg-4" />
+        <span className="text-[10px] font-mono font-semibold uppercase tracking-wider text-fg-4">
+          {label}
+        </span>
+      </div>
+      <div className="p-2.5 min-h-[88px] flex items-center justify-center overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ── Feed preview — mini comfort article row ─────────────────────
+//
+// Doesn't reuse the production `RssArticle` because that component
+// is link-anchored (`<a>` with target="_blank") and renders inside
+// a strict grid layout. The preview wants a dense, click-inert
+// representation that still respects the same visibility prefs.
+
+interface RssFeedPreviewProps {
+  item: RssItem;
+  showDescription: boolean;
+  showSource: boolean;
+  showTimestamps: boolean;
+}
+
+function RssFeedPreview({
+  item,
+  showDescription,
+  showSource,
+  showTimestamps,
+}: RssFeedPreviewProps) {
+  const now = useNow();
+  const ago = showTimestamps
+    ? relativeTime(item.published_at, now)
+    : null;
+
+  return (
+    <motion.div
+      key={`${showDescription}-${showSource}-${showTimestamps}`}
+      initial={{ opacity: 0, scale: 0.98 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.2, ease: [0.22, 0.61, 0.36, 1] }}
+      className={clsx(
+        "w-full px-3 py-2 bg-surface rounded-md border-l-2 border-l-accent/30",
+      )}
+    >
+      <span className="block text-[12px] font-medium text-fg leading-snug line-clamp-2">
+        {item.title}
+      </span>
+      {showDescription && item.description && (
+        <p className="mt-1 text-[11px] text-fg-2 leading-relaxed line-clamp-2">
+          {truncate(item.description, 140)}
+        </p>
+      )}
+      {(showSource || ago) && (
+        <div className="flex items-center gap-1.5 mt-1.5">
+          {showSource && (
+            <span className="text-[9px] font-mono font-bold text-accent/80 uppercase tracking-wider">
+              {item.source_name}
+            </span>
+          )}
+          {showSource && ago && (
+            <span className="text-fg-4 text-[9px]" aria-hidden>
+              &middot;
+            </span>
+          )}
+          {ago && (
+            <span className="text-[9px] font-mono text-fg-4 tabular-nums">
+              {ago}
+            </span>
+          )}
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+// ── Ticker preview — a real RssChip ─────────────────────────────
+
+interface RssTickerPreviewProps {
+  item: RssItem;
+  showSource: boolean;
+  showTimestamps: boolean;
+}
+
+function RssTickerPreview({
+  item,
+  showSource,
+  showTimestamps,
+}: RssTickerPreviewProps) {
+  return (
+    <RssChip
+      item={item}
+      comfort={false}
+      colorMode="channel"
+      showSource={showSource}
+      showTimestamps={showTimestamps}
+    />
+  );
+}

--- a/desktop/src/channels/sports/DisplayPanel.tsx
+++ b/desktop/src/channels/sports/DisplayPanel.tsx
@@ -1,0 +1,276 @@
+/**
+ * Sports display preferences — the "/channel/sports/display" page.
+ *
+ * Mirrors the Finance DisplayPanel shape (2026-05-09 IA refactor):
+ *   1. Live preview        — a sample game card on the Feed and a
+ *                            chip on the Ticker, side by side. Both
+ *                            update in real time as the toggles below
+ *                            change.
+ *   2. Display items grid  — shared `DisplayItemsGrid` widget with
+ *                            column-headers-as-bulk-toggles. Two
+ *                            sub-groups: "Card chrome" (logos / clock)
+ *                            and "Game filters" (upcoming / final).
+ *   3. Footer reset        — restore defaults.
+ *
+ * Why one preview card and not one-per-state:
+ *   The two filter toggles (showUpcoming / showFinal) gate which
+ *   *games* appear, not how an individual card looks. Showing three
+ *   stub cards (pre / live / final) would imply the filters control
+ *   layout. A single live sample with the filter rows labelled
+ *   clearly in the grid keeps the visual contract honest: the
+ *   preview is for chrome (logos + clock); filters are described in
+ *   their row text.
+ *
+ * Sample-game selection:
+ *   1. Prefer a live game from the user's dashboard data
+ *   2. Fall back to any game from the dashboard
+ *   3. Fall back to a hardcoded in-progress sample so the preview
+ *      always has something concrete to render
+ *
+ * Persisted shape unchanged: `Venue` enum (off|feed|ticker|both)
+ * converted at the UI boundary via enumToBools / boolsToEnum inside
+ * the shared `DisplayItemsGrid`.
+ */
+import { useMemo } from "react";
+import { Eye, Tv } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { dashboardQueryOptions } from "../../api/queries";
+import { useSportsConfig } from "../../hooks/useSportsConfig";
+import type { SportsDisplayPrefs } from "../../hooks/useSportsConfig";
+import type { Game } from "../../types";
+import { enumToBools, type Venue } from "../../preferences";
+import DisplayItemsGrid from "../../components/settings/DisplayItemsGrid";
+import type { DisplayItemsSection } from "../../components/settings/DisplayItemsGrid";
+import { Section, ResetButton } from "../../components/settings/SettingsControls";
+import { isLive } from "../../utils/gameHelpers";
+import { GameItem } from "./GameItem";
+import GameChip from "../../components/chips/GameChip";
+
+// ── Constants ────────────────────────────────────────────────────
+
+const DEFAULTS: SportsDisplayPrefs = {
+  showUpcoming: "both",
+  showFinal: "both",
+  showLogos: "both",
+  showTimer: "both",
+};
+
+// Hardcoded in-progress sample. Used when the user has no tracked
+// leagues yet (or the dashboard hasn't loaded). Mirrors the shape of
+// a real Game — a generic NBA-like matchup, mid-game.
+function buildSampleGame(): Game {
+  return {
+    id: "preview-sample",
+    league: "NBA",
+    sport: "basketball",
+    external_game_id: "preview-sample",
+    link: "",
+    home_team_name: "Los Angeles Lakers",
+    home_team_logo: "",
+    home_team_score: 88,
+    home_team_code: "LAL",
+    away_team_name: "Boston Celtics",
+    away_team_logo: "",
+    away_team_score: 91,
+    away_team_code: "BOS",
+    start_time: new Date(Date.now() - 90 * 60_000).toISOString(),
+    state: "in_progress",
+    status_short: "Q3 4:32",
+    status_long: "3rd Quarter 4:32",
+    timer: "Q3 4:32",
+  };
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export default function SportsDisplayPanel() {
+  const { display, setDisplay } = useSportsConfig();
+
+  // Pull a real game from the dashboard so the preview shows
+  // something the user recognises. Prefers live games (most visually
+  // interesting); falls back to any game; then to a hardcoded sample.
+  const { data: dashboard } = useQuery(dashboardQueryOptions());
+  const previewGame: Game = useMemo(() => {
+    const games = (dashboard?.data?.sports as Game[] | undefined) ?? [];
+    if (games.length === 0) return buildSampleGame();
+    return games.find(isLive) ?? games[0];
+  }, [dashboard?.data?.sports]);
+
+  // ── Patch helpers ──────────────────────────────────────────────
+
+  function applyDisplayChanges(changes: Record<string, Venue>) {
+    setDisplay(changes as Partial<SportsDisplayPrefs>);
+  }
+
+  function handleReset() {
+    setDisplay(DEFAULTS);
+  }
+
+  // ── Booleans the preview reads from ───────────────────────────
+
+  const feedShowLogos = enumToBools(display.showLogos).feed;
+  const feedShowTimer = enumToBools(display.showTimer).feed;
+  const tickerShowLogos = enumToBools(display.showLogos).ticker;
+  const tickerShowTimer = enumToBools(display.showTimer).ticker;
+
+  // ── Display-items grid model ──────────────────────────────────
+
+  const sections: DisplayItemsSection[] = [
+    {
+      title: "Card chrome",
+      rows: [
+        {
+          key: "showLogos",
+          label: "Team logos",
+          description: "Show team logos on cards and ticker chips",
+          value: display.showLogos,
+        },
+        {
+          key: "showTimer",
+          label: "Game clock / status",
+          description: "Quarter, period, or final-time indicator",
+          value: display.showTimer,
+        },
+      ],
+    },
+    {
+      title: "Game filters",
+      rows: [
+        {
+          key: "showUpcoming",
+          label: "Upcoming games",
+          description: "Pre-event games (scheduled but not yet started)",
+          value: display.showUpcoming,
+        },
+        {
+          key: "showFinal",
+          label: "Final scores",
+          description: "Completed games",
+          value: display.showFinal,
+        },
+      ],
+    },
+  ];
+
+  // ── Render ─────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6 pb-8">
+      {/* ── Live preview ─────────────────────────────────────────── */}
+      <Section title="Live preview">
+        <div className="px-3 pb-1 space-y-3">
+          <p className="text-[11px] text-fg-4 leading-snug">
+            Toggle items below to see the Feed card and Ticker chip update
+            in real time. Game filters control which games appear in the
+            full Feed.
+          </p>
+
+          <div className="grid grid-cols-2 gap-3">
+            <PreviewSurface label="Feed" icon={Eye}>
+              <SportsFeedPreview
+                game={previewGame}
+                showLogos={feedShowLogos}
+                showTimer={feedShowTimer}
+              />
+            </PreviewSurface>
+            <PreviewSurface label="Ticker" icon={Tv}>
+              <SportsTickerPreview
+                game={previewGame}
+                showLogos={tickerShowLogos}
+                showTimer={tickerShowTimer}
+              />
+            </PreviewSurface>
+          </div>
+        </div>
+      </Section>
+
+      {/* ── Display items grid ───────────────────────────────────── */}
+      <DisplayItemsGrid sections={sections} onChange={applyDisplayChanges} />
+
+      {/* ── Footer reset ─────────────────────────────────────────── */}
+      <div className="flex items-center justify-end pt-2">
+        <ResetButton label="Reset display settings" onClick={handleReset} />
+      </div>
+    </div>
+  );
+}
+
+// ── Preview surface card ────────────────────────────────────────
+// Same chrome as the Finance DisplayPanel — kept inline rather than
+// extracted because each channel's preview has channel-specific
+// padding / min-height nuances and a shared component would just
+// take a className prop, which is barely an abstraction.
+
+interface PreviewSurfaceProps {
+  label: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  children: React.ReactNode;
+}
+
+function PreviewSurface({ label, icon: Icon, children }: PreviewSurfaceProps) {
+  return (
+    <div className="rounded-lg border border-edge/40 bg-base-200/40 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 border-b border-edge/40 bg-surface-2/30">
+        <Icon size={11} className="text-fg-4" />
+        <span className="text-[10px] font-mono font-semibold uppercase tracking-wider text-fg-4">
+          {label}
+        </span>
+      </div>
+      <div className="p-2.5 min-h-[88px] flex items-center justify-center overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ── Feed preview — a real GameItem in compact mode ──────────────
+// Reusing the actual production component means the preview is
+// exactly what the user will see in the Feed. Any future GameItem
+// changes propagate here for free.
+
+interface SportsFeedPreviewProps {
+  game: Game;
+  showLogos: boolean;
+  showTimer: boolean;
+}
+
+function SportsFeedPreview({
+  game,
+  showLogos,
+  showTimer,
+}: SportsFeedPreviewProps) {
+  return (
+    <div className="w-full">
+      <GameItem
+        game={game}
+        mode="compact"
+        showLogos={showLogos}
+        showTimer={showTimer}
+      />
+    </div>
+  );
+}
+
+// ── Ticker preview — a real GameChip ────────────────────────────
+
+interface SportsTickerPreviewProps {
+  game: Game;
+  showLogos: boolean;
+  showTimer: boolean;
+}
+
+function SportsTickerPreview({
+  game,
+  showLogos,
+  showTimer,
+}: SportsTickerPreviewProps) {
+  return (
+    <GameChip
+      game={game}
+      comfort={false}
+      colorMode="channel"
+      showLogos={showLogos}
+      showTimer={showTimer}
+    />
+  );
+}

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -289,6 +289,7 @@ export default function ScrollrTicker({
           // only channels; read each field through shouldShowOnTicker.
           const sportsConfig = getSportsDisplayConfig(dashboard);
           const showLogos = shouldShowOnTicker(sportsConfig.showLogos ?? "both");
+          const showTimer = shouldShowOnTicker(sportsConfig.showTimer ?? "both");
           const sorted = selectSportsForTicker(data as Game[], sportsConfig);
           for (const game of sorted) {
             bucket.push(
@@ -298,6 +299,7 @@ export default function ScrollrTicker({
                   comfort={comfort}
                   colorMode={chipColorMode}
                   showLogos={showLogos}
+                  showTimer={showTimer}
                   onClick={() => onChipClick?.("sports", game.id, chipUrlForSports(game))}
                 />
               )

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -14,6 +14,13 @@ interface GameChipProps {
   comfort?: boolean;
   colorMode?: ChipColorMode;
   showLogos?: boolean;
+  /**
+   * Hide the per-game status (Q3 4:32, Final, in 2h) when false.
+   * Matches the ticker-side `showTimer` Venue toggle. Defaults to
+   * true to preserve existing behavior for callers that don't pass
+   * the prop explicitly.
+   */
+  showTimer?: boolean;
   onClick?: () => void;
 }
 
@@ -24,6 +31,7 @@ const GameChip = memo(function GameChip({
   comfort,
   colorMode = "channel",
   showLogos = true,
+  showTimer = true,
   onClick,
 }: GameChipProps) {
   const c = getChipColors(colorMode, "sports");
@@ -116,7 +124,7 @@ const GameChip = memo(function GameChip({
         )}
 
         {/* Status (compact only) */}
-        {!comfort && status && (
+        {!comfort && showTimer && status && (
           <span
             className={clsx(
               "flex items-center gap-1 text-[11px] uppercase tracking-wider ml-0.5",
@@ -142,7 +150,7 @@ const GameChip = memo(function GameChip({
           {game.league && (
             <span className="uppercase font-semibold">{game.league}</span>
           )}
-          {status && (
+          {showTimer && status && (
             <>
               <span className="text-fg-4">&middot;</span>
               <span
@@ -172,6 +180,7 @@ const GameChip = memo(function GameChip({
   prev.comfort === next.comfort &&
   prev.colorMode === next.colorMode &&
   prev.showLogos === next.showLogos &&
+  prev.showTimer === next.showTimer &&
   prev.onClick === next.onClick &&
   prev.game.id === next.game.id &&
   prev.game.sport === next.game.sport &&

--- a/desktop/src/routes/channel.$type.$tab.tsx
+++ b/desktop/src/routes/channel.$type.$tab.tsx
@@ -22,15 +22,11 @@ import ChannelConfigPanel from "../channels/ChannelConfigPanel";
 import FinanceDisplayPanel from "../channels/finance/DisplayPanel";
 import SportsDisplayPanel from "../channels/sports/DisplayPanel";
 import RssDisplayPanel from "../channels/rss/DisplayPanel";
+import FantasyDisplayPanel from "../channels/fantasy/DisplayPanel";
 import { useShell } from "../shell-context";
-import { Section, ToggleRow, ResetButton, SegmentedRow } from "../components/settings/SettingsControls";
-import DisplayItemsGrid from "../components/settings/DisplayItemsGrid";
-import type { DisplayItemsSection } from "../components/settings/DisplayItemsGrid";
-import FollowedPlayersPicker from "../components/settings/FollowedPlayersPicker";
 import { loadPref } from "../preferences";
 import type { Channel, ChannelType } from "../api/client";
 import type { DashboardResponse, DeliveryMode } from "../types";
-import type { FantasyDisplayPrefs, Venue } from "../preferences";
 
 export const Route = createFileRoute("/channel/$type/$tab")({
   loader: ({ context: { queryClient } }) =>
@@ -180,206 +176,10 @@ function ChannelDisplayTab({ type }: { type: string }) {
     case "rss":
       return <RssDisplayPanel />;
     case "fantasy":
-      return <FantasyDisplay />;
+      return <FantasyDisplayPanel />;
     default:
       return null;
   }
-}
-
-// Keys on FantasyDisplayPrefs that are venue-typed. Drives the per-item
-// rows below — adding a new venue-typed field here and in the interface
-// is all it takes to expose it on the Display page.
-type FantasyVenueKey =
-  | "matchupScore"
-  | "winProbability"
-  | "matchupStatus"
-  | "projectedPoints"
-  | "week"
-  | "record"
-  | "standingsPosition"
-  | "streak"
-  | "injuryCount"
-  | "topScorer"
-  // Phase 1 player-stats (2026-04-25):
-  | "topThreeScorers"
-  | "worstStarter"
-  | "benchOpportunity"
-  | "injuryDetail";
-
-interface FantasyVenueRow {
-  key: FantasyVenueKey;
-  label: string;
-  description: string;
-}
-
-interface FantasyVenueGroup {
-  title: string;
-  rows: FantasyVenueRow[];
-}
-
-// Visual sub-grouping inside the grid. The Display tab has 10 venue
-// items; flat-listing them is overwhelming. Three groups (Score &
-// status / Standings / Roster) match the user's mental model of which
-// feeds are about live game state, season-wide rank, and roster health.
-const FANTASY_VENUE_GROUPS: FantasyVenueGroup[] = [
-  {
-    title: "Score & status",
-    rows: [
-      { key: "matchupScore", label: "Matchup score", description: "Your team vs. opponent, live or final" },
-      { key: "winProbability", label: "Win probability", description: "62% chance to win" },
-      { key: "matchupStatus", label: "Matchup status", description: "LIVE / FINAL / PRE badge" },
-      { key: "projectedPoints", label: "Projected points", description: "Your projected total this week" },
-      { key: "week", label: "Week number", description: "Current matchup week label" },
-    ],
-  },
-  {
-    title: "Standings",
-    rows: [
-      { key: "record", label: "Team record", description: "Season wins / losses (optionally ties)" },
-      { key: "standingsPosition", label: "Standings position", description: "3rd of 10" },
-      { key: "streak", label: "Current streak", description: "W3 / L2 badge" },
-    ],
-  },
-  {
-    title: "Roster",
-    rows: [
-      { key: "injuryCount", label: "Injury count", description: "Count of IR / DTD players on your roster" },
-      { key: "topScorer", label: "Top scorer", description: "Highest-scoring active player on your team" },
-    ],
-  },
-  {
-    title: "Player stats",
-    rows: [
-      {
-        key: "topThreeScorers",
-        label: "Top 3 starters",
-        description: "Mahomes 32, Hill 18, CMC 14 — each as its own segment",
-      },
-      {
-        key: "worstStarter",
-        label: "Lowest starter",
-        description: "↓ Andrews 0 — the dud you couldn't sit (red)",
-      },
-      {
-        key: "benchOpportunity",
-        label: "Bench leader",
-        description: "BN Pacheco 18 — points your bench is producing",
-      },
-      {
-        key: "injuryDetail",
-        label: "Injury report",
-        description: "🚨 Saquon OUT, Mixon DTD — names + status (max 2 + overflow)",
-      },
-    ],
-  },
-];
-
-function FantasyDisplay() {
-  const { prefs, onPrefsChange } = useShell();
-  const dp = prefs.channelDisplay.fantasy;
-
-  function patch(next: Partial<FantasyDisplayPrefs>) {
-    onPrefsChange({
-      ...prefs,
-      channelDisplay: {
-        ...prefs.channelDisplay,
-        fantasy: { ...dp, ...next },
-      },
-    });
-  }
-
-  function toggle(key: keyof Pick<FantasyDisplayPrefs, "showStandings" | "showMatchups">) {
-    patch({ [key]: !dp[key] } as Partial<FantasyDisplayPrefs>);
-  }
-
-  function handleReset() {
-    onPrefsChange({
-      ...prefs,
-      channelDisplay: {
-        ...prefs.channelDisplay,
-        fantasy: {
-          matchupScore: "both",
-          winProbability: "both",
-          matchupStatus: "both",
-          projectedPoints: "both",
-          week: "both",
-          record: "both",
-          standingsPosition: "both",
-          streak: "both",
-          injuryCount: "both",
-          topScorer: "both",
-          // Phase 1 player-stats — same default as the rest.
-          topThreeScorers: "both",
-          worstStarter: "both",
-          benchOpportunity: "both",
-          injuryDetail: "both",
-          // Phase 2 followed players — reset clears the list.
-          // Users explicitly picked these; resetting display settings
-          // shouldn't preserve them, otherwise "reset" wouldn't fully
-          // restore defaults.
-          followedPlayerKeys: [],
-          showStandings: true,
-          showMatchups: true,
-          defaultSort: "name",
-          defaultSubTab: "overview",
-          primaryLeagueKey: null,
-          enabledLeagueKeys: [],
-        },
-      },
-    });
-  }
-
-  const SUB_TAB_OPTIONS = [
-    { value: "overview", label: "Overview" },
-    { value: "matchup", label: "Matchup" },
-    { value: "standings", label: "Standings" },
-    { value: "roster", label: "Roster" },
-  ];
-
-  const sections: DisplayItemsSection[] = FANTASY_VENUE_GROUPS.map((group) => ({
-    title: group.title,
-    rows: group.rows.map((row) => ({
-      key: row.key,
-      label: row.label,
-      description: row.description,
-      value: dp[row.key],
-    })),
-  }));
-
-  function applyDisplayChanges(changes: Record<string, Venue>) {
-    patch(changes as Partial<FantasyDisplayPrefs>);
-  }
-
-  return (
-    <div className="space-y-6 pb-8">
-      <DisplayItemsGrid sections={sections} onChange={applyDisplayChanges} />
-      <Section title="Followed players">
-        <p className="text-[11px] text-fg-4 px-3 pb-2 leading-snug">
-          Pick specific players from your rosters to track on the ticker.
-          Each player gets their own chip showing their name, team, and
-          current points.
-        </p>
-        <FollowedPlayersPicker
-          followedPlayerKeys={dp.followedPlayerKeys}
-          onChange={(next) => patch({ followedPlayerKeys: next })}
-        />
-      </Section>
-      <Section title="Feed layout">
-        <SegmentedRow
-          label="Default view"
-          description="Which sub-tab opens when you enter the Fantasy feed"
-          value={dp.defaultSubTab}
-          options={SUB_TAB_OPTIONS}
-          onChange={(value) => patch({ defaultSubTab: value as FantasyDisplayPrefs["defaultSubTab"] })}
-        />
-        <ToggleRow label="Show standings section" checked={dp.showStandings} onChange={() => toggle("showStandings")} />
-        <ToggleRow label="Show matchups section" checked={dp.showMatchups} onChange={() => toggle("showMatchups")} />
-      </Section>
-      <div className="flex items-center justify-end pt-2">
-        <ResetButton label="Reset display settings" onClick={handleReset} />
-      </div>
-    </div>
-  );
 }
 
 function ChannelPending() {

--- a/desktop/src/routes/channel.$type.$tab.tsx
+++ b/desktop/src/routes/channel.$type.$tab.tsx
@@ -20,17 +20,16 @@ import { getChannel, getAllChannels } from "../channels/registry";
 import { dashboardQueryOptions } from "../api/queries";
 import ChannelConfigPanel from "../channels/ChannelConfigPanel";
 import FinanceDisplayPanel from "../channels/finance/DisplayPanel";
-import { useShell, useShellData } from "../shell-context";
+import SportsDisplayPanel from "../channels/sports/DisplayPanel";
+import { useShell } from "../shell-context";
 import { Section, ToggleRow, ResetButton, SegmentedRow } from "../components/settings/SettingsControls";
 import DisplayItemsGrid from "../components/settings/DisplayItemsGrid";
 import type { DisplayItemsSection } from "../components/settings/DisplayItemsGrid";
 import FollowedPlayersPicker from "../components/settings/FollowedPlayersPicker";
-import { useSportsConfig } from "../hooks/useSportsConfig";
 import { loadPref } from "../preferences";
 import type { Channel, ChannelType } from "../api/client";
 import type { DashboardResponse, DeliveryMode } from "../types";
 import type { RssDisplayPrefs, FantasyDisplayPrefs, Venue } from "../preferences";
-import type { SportsDisplayPrefs } from "../hooks/useSportsConfig";
 
 export const Route = createFileRoute("/channel/$type/$tab")({
   loader: ({ context: { queryClient } }) =>
@@ -176,7 +175,7 @@ function ChannelDisplayTab({ type }: { type: string }) {
     case "finance":
       return <FinanceDisplayPanel />;
     case "sports":
-      return <SportsDisplay />;
+      return <SportsDisplayPanel />;
     case "rss":
       return <RssDisplay />;
     case "fantasy":
@@ -184,49 +183,6 @@ function ChannelDisplayTab({ type }: { type: string }) {
     default:
       return null;
   }
-}
-
-function SportsDisplay() {
-  const { display, setDisplay } = useSportsConfig();
-
-  function applyDisplayChanges(changes: Record<string, Venue>) {
-    setDisplay(changes as Partial<SportsDisplayPrefs>);
-  }
-
-  function handleReset() {
-    setDisplay({
-      showUpcoming: "both",
-      showFinal: "both",
-      showLogos: "both",
-      showTimer: "both",
-    });
-  }
-
-  const sections: DisplayItemsSection[] = [
-    {
-      title: "Card chrome",
-      rows: [
-        { key: "showLogos", label: "Team logos", description: "Show team logos on cards and ticker chips", value: display.showLogos },
-        { key: "showTimer", label: "Game clock / status", description: "Quarter, period, or final-time indicator", value: display.showTimer },
-      ],
-    },
-    {
-      title: "Game filters",
-      rows: [
-        { key: "showUpcoming", label: "Upcoming games", description: "Pre-event games (scheduled but not yet started)", value: display.showUpcoming },
-        { key: "showFinal", label: "Final scores", description: "Completed games", value: display.showFinal },
-      ],
-    },
-  ];
-
-  return (
-    <div className="space-y-6 pb-8">
-      <DisplayItemsGrid sections={sections} onChange={applyDisplayChanges} />
-      <div className="flex items-center justify-end pt-2">
-        <ResetButton label="Reset display settings" onClick={handleReset} />
-      </div>
-    </div>
-  );
 }
 
 function RssDisplay() {

--- a/desktop/src/routes/channel.$type.$tab.tsx
+++ b/desktop/src/routes/channel.$type.$tab.tsx
@@ -21,6 +21,7 @@ import { dashboardQueryOptions } from "../api/queries";
 import ChannelConfigPanel from "../channels/ChannelConfigPanel";
 import FinanceDisplayPanel from "../channels/finance/DisplayPanel";
 import SportsDisplayPanel from "../channels/sports/DisplayPanel";
+import RssDisplayPanel from "../channels/rss/DisplayPanel";
 import { useShell } from "../shell-context";
 import { Section, ToggleRow, ResetButton, SegmentedRow } from "../components/settings/SettingsControls";
 import DisplayItemsGrid from "../components/settings/DisplayItemsGrid";
@@ -29,7 +30,7 @@ import FollowedPlayersPicker from "../components/settings/FollowedPlayersPicker"
 import { loadPref } from "../preferences";
 import type { Channel, ChannelType } from "../api/client";
 import type { DashboardResponse, DeliveryMode } from "../types";
-import type { RssDisplayPrefs, FantasyDisplayPrefs, Venue } from "../preferences";
+import type { FantasyDisplayPrefs, Venue } from "../preferences";
 
 export const Route = createFileRoute("/channel/$type/$tab")({
   loader: ({ context: { queryClient } }) =>
@@ -177,83 +178,12 @@ function ChannelDisplayTab({ type }: { type: string }) {
     case "sports":
       return <SportsDisplayPanel />;
     case "rss":
-      return <RssDisplay />;
+      return <RssDisplayPanel />;
     case "fantasy":
       return <FantasyDisplay />;
     default:
       return null;
   }
-}
-
-function RssDisplay() {
-  const { prefs, onPrefsChange } = useShell();
-  const dp = prefs.channelDisplay.rss;
-
-  function applyDisplayChanges(changes: Record<string, Venue>) {
-    onPrefsChange({
-      ...prefs,
-      channelDisplay: {
-        ...prefs.channelDisplay,
-        rss: { ...dp, ...(changes as Partial<RssDisplayPrefs>) },
-      },
-    });
-  }
-
-  function setArticlesPerSource(value: string) {
-    onPrefsChange({
-      ...prefs,
-      channelDisplay: {
-        ...prefs.channelDisplay,
-        rss: { ...dp, articlesPerSource: Number(value) },
-      },
-    });
-  }
-
-  function handleReset() {
-    onPrefsChange({
-      ...prefs,
-      channelDisplay: {
-        ...prefs.channelDisplay,
-        rss: { showDescription: "both", showSource: "both", showTimestamps: "both", articlesPerSource: 4 },
-      },
-    });
-  }
-
-  const ARTICLES_PER_SOURCE_OPTIONS = [
-    { value: "2", label: "2" },
-    { value: "4", label: "4" },
-    { value: "6", label: "6" },
-    { value: "10", label: "10" },
-    { value: "0", label: "All" },
-  ];
-
-  const sections: DisplayItemsSection[] = [
-    {
-      rows: [
-        { key: "showDescription", label: "Article description", description: "Snippet beneath the headline", value: dp.showDescription },
-        { key: "showSource", label: "Source name", description: "Publisher / feed name", value: dp.showSource },
-        { key: "showTimestamps", label: "Timestamps", description: "Relative publish time on each item", value: dp.showTimestamps },
-      ],
-    },
-  ];
-
-  return (
-    <div className="space-y-6 pb-8">
-      <DisplayItemsGrid sections={sections} onChange={applyDisplayChanges} />
-      <Section title="Feed behavior">
-        <SegmentedRow
-          label="Articles per source"
-          description="Limit how many articles appear from each feed"
-          value={String(dp.articlesPerSource)}
-          options={ARTICLES_PER_SOURCE_OPTIONS}
-          onChange={setArticlesPerSource}
-        />
-      </Section>
-      <div className="flex items-center justify-end pt-2">
-        <ResetButton label="Reset display settings" onClick={handleReset} />
-      </div>
-    </div>
-  );
 }
 
 // Keys on FantasyDisplayPrefs that are venue-typed. Drives the per-item

--- a/docs/superpowers/handoffs/backlog.md
+++ b/docs/superpowers/handoffs/backlog.md
@@ -4,12 +4,28 @@
 - (none)
 
 ### Pending
-- [ ] Optional: switch to API-key notarization (`APPLE_API_KEY` / `APPLE_API_ISSUER` / `APPLE_API_KEY_ID`) instead of Apple-ID + app-specific password. Cleaner credential rotation; no user-facing benefit. Both `tauri-bundler` and `xcrun notarytool` support this auth mode.
-- [ ] Optional: split notarize into its own retryable job after the main build. With `continue-on-error: true` + an explicit retry step, a runner-network flake costs ~5 min and one click instead of ~25 min and a full re-build. Defer until the timeout cap proves insufficient.
+- [ ] Apply Finance live-preview pattern to Sports / RSS / Fantasy Display tabs. They currently use the shared `DisplayItemsGrid` (column-headers-as-bulk-toggles, minimal cells) but lack a per-channel preview surface like Finance's `FeedPreview` + `TickerPreview`. Each needs its own sample card shape (Sports: GameItem, RSS: feed row, Fantasy: matchup card).
+- [ ] Onboarding pre-enable defaults: spec says new accounts should default `tickerEnabled: true` so the ticker self-demonstrates after first source add. Verify this is wired in `preferences.ts` defaults — check `DEFAULT_TICKER.showTicker`.
+- [ ] Filter-layer cleanup: `Channel.ticker_enabled` server flag should derive from row membership client-side. Currently dual-tracked. Spec says deferred to follow-up.
+- [ ] Optional: switch macOS notarization to API-key auth (`APPLE_API_KEY` / `APPLE_API_ISSUER` / `APPLE_API_KEY_ID`) instead of Apple-ID + app-specific password.
+- [ ] Optional: split notarize into its own retryable job after the main build.
 
 ### Done
-- [x] Diagnosed run #25578604859 — macos-14 runner lost network mid-poll on notarytool (`NSURLErrorDomain -1009`, `_NSURLErrorNWPathKey=unsatisfied`). Not an Apple notary issue.
-- [x] Added `timeout-minutes: 25` to the desktop-release build job. Bounds notarize-poll hangs to ~25 min vs. the 51-min run that killed PR throughput.
-- [x] Reverted the broken `notarize` workflow_dispatch toggle (run #25605423069: `Team ID must be at least 3 characters`). Tauri's bundler gates notarize on env-var *presence*, not value; GitHub Actions' `env:` map sets vars even when values are `''`.
-- [x] Verified `Scrollr.app` notarization end-to-end: `spctl --assess --type exec` → `accepted, source=Notarized Developer ID`; `xcrun stapler validate` → `The validate action worked!`.
-- [x] Added `Notarize and staple DMG` step to close the unnotarized-DMG-container gap. Verified against published `Scrollr_1.0.9_aarch64.dmg`: `spctl --assess --type install` → `accepted, source=Notarized Developer ID`. Zero Gatekeeper warnings on download.
+- [x] **IA refactor v1.0.10 shipped** — PR #153, merged to main as `8622750`. 30 commits squashed. 66 files changed (+5598/-4234).
+- [x] TopBar with brand mark + Spotify-style forward/back + page-identity breadcrumb dropdown. Replaces fragmented sidebar logo / control strip / page header layout.
+- [x] PageLayout chassis with `noContentPadding` and `fillHeight` options.
+- [x] PageContext — routes publish title/subtitle/menuItems; last breadcrumb segment becomes a dropdown.
+- [x] OverflowMenu (floating-ui) — accessible dropdown used as the breadcrumb dropdown across every primary route.
+- [x] Unified configure managers: `SymbolManager` (Finance), `LeagueManager` (Sports), `FeedManager` (RSS). Replaced two-pane catalog+watchlist split. ~3000 lines deleted.
+- [x] Finance `DisplayPanel` with live preview (Feed row + Ticker chip). New prefs: `feedDensity`, `tickerDirectionMarker`.
+- [x] Shared `DisplayItemsGrid` — column-headers-as-bulk-toggles, minimal cells, shared grid template. Used by Sports/RSS/Fantasy.
+- [x] Settings + Catalog ditch in-page tab bands; use breadcrumb dropdowns.
+- [x] Animation polish: motion-studio springs, `active:scale` press feedback, `layoutId` for active-state indicators (sidebar nav, page tabs, breadcrumb chevrons).
+- [x] Bug fixes rolled in: toast unstyled flash, theme default `dark`→`system`, stale router redirects, wizard removed (replaced with hero card on empty Home).
+- [x] Source-page Feed view renders flush (`noContentPadding=true` on `feed` tab); Configure/Display keep padded narrow column.
+- [x] Home page padding cleaned: nested-card on ticker preview removed, dangling `mb-6` margins → unified `space-y-5`.
+- [x] Diagnosed run #25578604859 — macos-14 runner lost network mid-poll on notarytool (`NSURLErrorDomain -1009`).
+- [x] Added `timeout-minutes: 25` to the desktop-release build job.
+- [x] Reverted the broken `notarize` workflow_dispatch toggle (Tauri bundler gates on env-var *presence*, not value).
+- [x] Verified `Scrollr.app` + `Scrollr_*.dmg` notarization end-to-end (`spctl --assess` → accepted, `xcrun stapler validate` → worked).
+- [x] Added `Notarize and staple DMG` step to close the unnotarized-DMG-container gap.

--- a/docs/superpowers/handoffs/current.md
+++ b/docs/superpowers/handoffs/current.md
@@ -3,52 +3,103 @@
 ## Repo State
 - Branch: `main`
 - Worktree: clean
-- Last commit: `6e274d8 ci(desktop): notarize and staple macOS DMG so Gatekeeper accepts the download silently`
+- Last commit: `8622750 refactor(desktop): IA overhaul + chrome polish (v1.0.10) (#153)`
+- Version: **1.0.10** (`desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `desktop/src-tauri/Cargo.toml`)
 
 ## Active Task
-None. macOS notarization pipeline is fully working end-to-end.
+None. PR #153 merged. Branch `refactor/desktop-ia` deleted.
 
-## What's Working Now
-Every push to `main` touching `desktop/**` produces:
-- Signed + notarized + stapled `Scrollr.app`
-- Signed + notarized + stapled `Scrollr_*_aarch64.dmg`
-- Working updater bundle (`Scrollr_aarch64.app.tar.gz`)
+## What Just Shipped (v1.0.10)
 
-User-visible result: zero Gatekeeper warnings on download, mount, install, or first launch.
+A comprehensive desktop IA refactor across ~30 commits squashed into one merge commit. The whole app now uses one navigation idiom, one chassis, one motion vocabulary.
 
-## Verified (run #25607445470, 2026-05-09)
-```
-spctl --assess --type install Scrollr_1.0.9_aarch64.dmg
-  → accepted, source=Notarized Developer ID
-xcrun stapler validate Scrollr_1.0.9_aarch64.dmg
-  → The validate action worked!
-```
-- `.app` notarize submission `bcdc4591-…` accepted in ~25s.
-- DMG notarize submission `4c24a6ba-…` accepted in ~24s.
-- macOS job total: 7m43s (was 6m07s; +96s for the second notarize submission).
+### Foundation primitives (live and ready to consume)
+- **`<TopBar>`** (`desktop/src/components/TopBar.tsx`) — full-width chrome row. Owns brand mark, Spotify-style ←/→ buttons (powered by `useNavHistory`), page identity breadcrumb (read from `usePageIdentity`), ambient ticker/pin/connection toggles. Always mounted in `__root.tsx` for authenticated users.
+- **`<PageLayout>`** (`desktop/src/components/layout/PageLayout.tsx`) — universal page chassis. Props: `title`, `subtitle`, `parentLabel`, `onParentClick`, `onTitleClick`, `menuItems`, `menuLabel`, `entityAction` (legacy), `tabs` (legacy — prefer menuItems), `width: "narrow" | "wide"`, `fillHeight`, `noContentPadding`, `footer`. Internally publishes identity to PageContext; the TopBar reads it.
+- **`<OverflowMenu>`** (`desktop/src/components/OverflowMenu.tsx`) — floating-ui-based accessible dropdown. Accepts `items: OverflowMenuItem[]`, optional `trigger` element (custom-trigger uses cloneElement pattern). Built-in keyboard nav, typeahead, focus-lock, theme-correct portal (`#app-shell`).
+- **`<DisplayItemsGrid>`** (`desktop/src/components/settings/DisplayItemsGrid.tsx`) — shared Feed/Ticker visibility grid with column-headers-as-bulk-toggles. Used by Sports/RSS/Fantasy Display tabs.
+- **`PageContext` / `useRegisterPageIdentity` / `usePageIdentity`** (`desktop/src/components/layout/page-context.tsx`).
+- **`useNavHistory`** (`desktop/src/hooks/useNavHistory.ts`) — wraps `useCanGoBack` + reads `__TSR_index` from `router.history.location.state` for `canForward`. Subscribes directly to `router.history.subscribe` so it updates on every PUSH/BACK/FORWARD/GO.
 
-## Workflow Configuration (`.github/workflows/desktop-release.yml`)
-- `timeout-minutes: 25` on the build job — bounds the notarize-poll hang from
-  run #25578604859 (macos-14 runner network drop, NSURLErrorDomain -1009).
-- Apple secrets unconditionally passed to `tauri-action` — Tauri's bundler
-  gates notarize on env-var *presence*, not value, so any toggle that
-  passes `''` triggers notarize-with-empty-creds and fails at notarytool
-  validation (run #25605423069, "Team ID must be at least 3 characters").
-- New `Notarize and staple DMG` step after `Build Tauri app`, gated on
-  `matrix.platform == 'macos-14'`, with `continue-on-error: true` so a
-  runner-network flake doesn't block the pipeline.
+### Per-channel managers (foundation for Display previews if extended)
+- **`SymbolManager`** (`desktop/src/channels/finance/SymbolManager.tsx`) — Finance configure. Unified scrollable list, click rows to add/remove.
+- **`LeagueManager`** (`desktop/src/channels/sports/LeagueManager.tsx`) — Sports configure. Same shape + favorite-team picker per tracked league.
+- **`FeedManager`** (`desktop/src/channels/rss/FeedManager.tsx`) — RSS configure. Same shape + custom-feed inline form (animated AnimatePresence height collapse).
+- **`FinanceDisplayPanel`** (`desktop/src/channels/finance/DisplayPanel.tsx`) — showcase Display panel with live `FeedPreview` + `TickerPreview` side by side. Updates in real time as toggles change. **Template for the next Pending item.**
 
-## Operator Note
-The user wanted "fucking notarization that works." Delivered.
+### Animation vocabulary (apply consistently in any new code)
+- `active:scale-[0.97]` for nav items / large surfaces
+- `active:scale-95` for standard buttons
+- `active:scale-90` for small icon buttons (≤28px)
+- `type:"spring", stiffness: 380-500, damping: 22-32` for icon swaps
+- `layoutId` for elements that move between positions (active underlines, accent bars)
+- `0.18-0.25s ease-[0.22,0.61,0.36,1]` for content fades
+- 40-50ms stagger delays for entrance reveals
+- CSS easing tokens in `style.css`: `--ease-snap`, `--ease-pop`, `--ease-out-soft`
+
+### Lessons learned (do NOT re-learn next session)
+1. **Tauri bundler gates notarize on env-var *presence*, not value.** Don't try to toggle by passing `''`. (Caused run #25605423069 fail.)
+2. **floating-ui's `getReferenceProps()` injects `aria-expanded`** which `cloneElement` merges into the trigger. Read it for chevron flip animations — no extra state needed.
+3. **floating-ui's `useListNavigation` overrides sibling onClick** — pass click handlers INTO `getItemProps({ onClick })` so they merge instead of getting overwritten.
+4. **`FloatingPortal` mounts at `<body>` by default** — outside the `#app-shell[data-theme=...]` selector. Pass `root={portalRoot}` (resolved via useEffect) so menus inherit the active theme.
+5. **TanStack memory history's current index is `__TSR_index` on `history.location.state`** — not `history.state?.index`. Subscribe to `router.history.subscribe` directly for live forward-state recompute (router's `onResolved` is too late).
+6. **Tailwind grid-cols class must be string-literal**, not template-literal. JIT can't see runtime classes. Share the same literal between header rows and body rows so column tracks align.
+7. **`PageLayout` content cross-fade keys on `title+subtitle+activeKey`** — set `subtitle` to the active section/filter label so Settings/Catalog tab swaps animate.
+8. **The persisted `Venue` enum stays unchanged** (`off | feed | ticker | both`) — convert at UI boundary via `enumToBools` / `boolsToEnum` from `preferences.ts`.
+9. **`useNow()` takes no args** (singleton interval). Don't pass a polling interval.
+10. **Sonner CSS must ship in the entry bundle** (`app-main.tsx`), not the route chunk, or toasts paint unstyled until the chunk loads.
+11. **Pre-paint theme**: inline script in `app.html` reads `scrollr:theme-mirror` from localStorage + `prefers-color-scheme`. `useTheme` writes the mirror on every change. Don't try to read Tauri store synchronously.
+
+### Plan deviations carried forward (do NOT undo)
+- Finance is the reference Display panel with live preview. Sports/RSS/Fantasy Display tabs use the shared `DisplayItemsGrid` only — they'll get previews per the next Pending item.
+- Source page Feed view uses `noContentPadding={true}` (flush rendering); Configure/Display keep the padded narrow column.
+- Home uses `noContentPadding` + its own `space-y-5` wrapper.
+- Settings + Catalog use breadcrumb dropdowns (`menuItems` on PageLayout) — NOT in-page tab bands.
+- Channel removal still uses `ConfirmDialog`; widgets use `useUndoableAction` toast. Asymmetric on purpose (channel deletion is server-side).
+- `Channel.ticker_enabled` is still dual-tracked client+server. Deferred derivation to a follow-up — don't cut over without reasoning about other clients.
+- Sidebar has no Home or Catalog nav items (TopBar brand mark + `+ Add source` button cover those).
+
+### Spec
+`docs/superpowers/specs/2026-05-09-desktop-ia-refactor-design.md` — the full IA refactor design doc. 289 lines. Includes mental model (Library/Source/Ticker), unified page chassis, canonical-home-per-verb table, file-level impact, implementation phases.
 
 ## Risks / Open Questions
-- Existing release `desktop-v1.0.9` has been re-uploaded with the stapled
-  DMG. Future version bumps will produce stapled DMGs from the start.
-- If `continue-on-error: true` ever masks a silent stapling failure, the
-  only thing that catches it is the post-deploy `spctl` check. No alerting
-  on the GitHub Actions side.
+- The Finance `DisplayPanel` live preview pattern is bespoke. Sports/RSS/Fantasy need analogous preview components — Sports needs a sample `GameItem`, RSS needs a sample feed row, Fantasy needs a sample matchup card. Each will be ~150 lines following the `FeedPreview`/`TickerPreview` shape.
+- Bundle size warning persists (`style-*.js` ~580kb). Pre-existing, not introduced by this PR. Code-splitting follow-up if needed.
 
-## Reference
-- Failed runs: #25578604859 (runner-network hang, 58m), #25605423069 (broken toggle, 8m50s)
-- Working runs: #25607083776 (revert verified), #25607445470 (DMG notarize verified)
-- Tauri bundler gating: `crates/tauri-bundler/src/bundle/macos/sign.rs::notarize_auth`
+## Next Best Action
+
+Start the next pending item: apply the Finance live-preview pattern to **Sports** Display first (Fantasy is the most complex; Sports is the smallest scope, good shakedown).
+
+```
+You're picking up the Scrollr desktop IA refactor on `main`. The big v1.0.10 ship landed (PR #153, commit 8622750) — full IA + chrome polish across ~30 commits. Read `docs/superpowers/handoffs/current.md` first for the complete operational state, including foundation primitives (TopBar, PageLayout, OverflowMenu, DisplayItemsGrid, PageContext, useNavHistory), animation vocabulary, and lessons learned that you must NOT re-learn (e.g. Tailwind grid-cols can't be runtime-assembled; floating-ui `getItemProps` merge contract; persisted `Venue` enum boundary helpers).
+
+**Repo**: `/Users/doni/code/myscrollr` — desktop app at `desktop/`. Branch `main`, clean. Version 1.0.10.
+
+**Spec for full context**: `docs/superpowers/specs/2026-05-09-desktop-ia-refactor-design.md`.
+
+**Next task**: Apply the Finance live-preview pattern to the **Sports** Display tab (`desktop/src/routes/channel.$type.$tab.tsx` → `SportsDisplay` function). Currently uses the shared `DisplayItemsGrid` only; needs a side-by-side live preview surface like Finance has.
+
+**Reference implementation**: `desktop/src/channels/finance/DisplayPanel.tsx` — the showcase. It has `FeedPreview` and `TickerPreview` components inline that render an actual sample card with the user's current toggle state, updating in real time. Mirror this shape:
+1. Create `desktop/src/channels/sports/DisplayPanel.tsx`.
+2. Build `SportsFeedPreview` (sample of a `GameItem`-shaped card) and `SportsTickerPreview` (sample chip — see `desktop/src/components/chips/GameChip.tsx`).
+3. Pull the user's first tracked league + a sample game from the dashboard if available; fall back to a hardcoded sample.
+4. Surface the existing Display toggles (`showLogos`, `showTimer`, `showUpcoming`, `showFinal` Venue enums) using the same `DisplayItemsGrid` you have now.
+5. Wire `<SportsDisplay />` in `channel.$type.$tab.tsx` to render the new panel.
+
+**After Sports**: do RSS (sample feed row from `desktop/src/channels/rss/FeedTab.tsx`), then Fantasy (`MatchupHero` is the natural sample — but Fantasy has 14 venue toggles in 4 groups, more complex).
+
+**Workflow**: implement, typecheck (`cd desktop && npx tsc --noEmit`), build (`npm run build`), commit each channel separately. After all three are done, bump to 1.0.11 in `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `desktop/src-tauri/Cargo.toml`, then create PR via `gh pr create` and squash-merge.
+
+**Foundations available** (don't recreate):
+- `<DisplayItemsGrid>` — column-headers-as-bulk-toggles grid widget
+- `Section`, `ToggleRow`, `SegmentedRow`, `ResetButton` from `desktop/src/components/settings/SettingsControls`
+- `enumToBools` / `boolsToEnum` from `desktop/src/preferences.ts`
+- `useShell` for prefs access
+
+**Plan deviations carried forward — do NOT undo**:
+- Source page Feed view uses `noContentPadding=true`; Configure/Display keep the padded narrow column. The Display panel renders inside `width="narrow"` PageLayout, so layout your component to fit there.
+- Animation vocabulary is established — use `active:scale-95` press feedback and motion-studio springs that already exist in style.css (`--ease-snap`, `--ease-pop`).
+- Persisted `Venue` enum is unchanged. Use `enumToBools(value)` to read .feed and .ticker booleans.
+
+**No blocking issues. Begin with Sports Display panel.**
+```


### PR DESCRIPTION
## Summary

Applies the live-preview pattern from the v1.0.10 Finance Display
panel to the remaining three channels — **Sports**, **RSS**, and
**Fantasy**. Each `/channel/{type}/display` page now shows a
side-by-side Feed card + Ticker chip that update in real time as the
user toggles the visibility prefs below them.

Bumps desktop to **1.0.11**.

## Channels shipped

### Sports — `desktop/src/channels/sports/DisplayPanel.tsx`
- Reuses `<GameItem mode="compact">` for the Feed preview and `<GameChip>` for the Ticker preview, so the preview is byte-identical to what users see in production.
- Sample game prefers a live game from the user's dashboard, falling back to any game, then to a hardcoded NBA in-progress sample.
- **Bonus fix**: `GameChip` now honors `showTimer` (default true, fully backward compatible). The persisted `showTimer.ticker` venue boolean had no visual effect prior to this — `ScrollrTicker` only read `showLogos`. The preview surfaced the gap; this PR closes it. `ScrollrTicker.tsx:286-307` now passes `showTimer` through.

### RSS — `desktop/src/channels/rss/DisplayPanel.tsx`
- Hand-rolled compact article row for the Feed preview (the production `RssArticle` is a strict link-anchored component); reuses `<RssChip>` for the Ticker preview.
- Sample article prefers the user's first dashboard item, falling back to a hardcoded TechCrunch-style piece.

### Fantasy — `desktop/src/channels/fantasy/DisplayPanel.tsx`
- The most complex of the four: 14 venue toggles split across Score & status / Standings / Roster / Player stats groups, plus a followed-players picker and feed-layout segmented controls.
- Sample league ("Sunday Funday", week-5 NFL live matchup) is engineered so every player-stats segment lights up at once — top scorer, worst starter, top bench, two injuries — so the user can verify each toggle does something the moment they flip it.
- **Asymmetry note**: the Ticker chip (`FantasyStatChip`) already honors all 14 venue toggles via `shouldShowOnTicker`, while the Feed-side rendering goes through dedicated sub-views (`MatchupHero`, `StandingsView`, etc.) that don't yet read the `.feed` boolean. The Feed preview shows `<MatchupHero>` statically and the helper text spells out that toggles currently affect the Ticker only. Propagating `shouldShowOnFeed` into the Feed sub-views is a follow-up out of scope for this rollout.

## Refactoring

- Inline `SportsDisplay`, `RssDisplay`, and `FantasyDisplay` functions removed from `desktop/src/routes/channel.$type.$tab.tsx`. Imports of `Section`, `ToggleRow`, `SegmentedRow`, `ResetButton`, `DisplayItemsGrid`, `DisplayItemsSection`, `FollowedPlayersPicker`, `FantasyDisplayPrefs`, `Venue`, `useShellData`, and `useSportsConfig` all gone from that file — they're now contained in the per-channel panels where they belong.

## Foundations reused, not recreated

- `<DisplayItemsGrid>` (column-headers-as-bulk-toggles)
- `Section`, `SegmentedRow`, `ToggleRow`, `ResetButton` from `SettingsControls`
- `enumToBools` / `boolsToEnum` (Venue boundary helpers)
- `useShell` for prefs access
- `dashboardQueryOptions` / `fantasyLeaguesOptions` for live data

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — clean (existing 580kb style chunk warning unchanged)
- `npx vitest run` — 249/249 tests passing across 15 files
- Cargo.lock auto-regenerated by the build to reflect the version bump

## Files changed

- 3 new: `channels/sports/DisplayPanel.tsx`, `channels/rss/DisplayPanel.tsx`, `channels/fantasy/DisplayPanel.tsx`
- 5 modified: `routes/channel.$type.$tab.tsx`, `components/chips/GameChip.tsx`, `components/ScrollrTicker.tsx`, plus version-file trio (`package.json` / `tauri.conf.json` / `Cargo.toml` / `Cargo.lock`)

## Commit history (squash-merge target)

```
cc6ee14 chore(desktop): bump to 1.0.11
72e810f feat(desktop/fantasy): live preview on Display tab
327bda6 feat(desktop/rss): live preview on Display tab
b9efe92 feat(desktop/sports): live preview on Display tab + wire showTimer to ticker
12717e8 chore: session handoff — IA refactor v1.0.10 shipped
```