### PR TITLE
fix(fantasy): content-negotiate /yahoo/start so the desktop OAuth flow works

### DIFF
--- a/channels/fantasy/api/user_handlers.go
+++ b/channels/fantasy/api/user_handlers.go
@@ -29,6 +29,15 @@ import (
 // session before proxying here. The old `?logto_sub=` query fallback was
 // removed because it allowed an attacker to bind their own Yahoo
 // credentials to an arbitrary victim's Scrollr account.
+//
+// Response shape is content-negotiated:
+//   - `Accept: application/json` (or `?response=json`) → 200 with
+//     {"redirect_url": "<yahoo consent url>"}. The desktop app uses
+//     this so it can call /yahoo/start with a Bearer header (which the
+//     system browser cannot carry) and then `shell::open` the returned
+//     URL externally.
+//   - Otherwise (HTML / wildcard) → 307 redirect to Yahoo. Used when a
+//     logged-in browser session hits the URL directly.
 func (a *App) YahooStart(c *fiber.Ctx) error {
 	logtoSub := GetUserSub(c)
 	if logtoSub == "" {
@@ -63,6 +72,16 @@ func (a *App) YahooStart(c *fiber.Ctx) error {
 	// Force Yahoo to show the login screen every time so the user can pick
 	// the correct Yahoo account.
 	authURL := a.yahooConfig.AuthCodeURL(state, oauth2.SetAuthURLParam("prompt", "login"))
+
+	// Content negotiation: JSON for programmatic callers (desktop app),
+	// 307 redirect for browser navigations.
+	wantsJSON := c.Query("response") == "json" ||
+		strings.Contains(strings.ToLower(c.Get(fiber.HeaderAccept)), "application/json")
+	if wantsJSON {
+		log.Printf("[YahooStart] Returning JSON consent URL (state=%s…) redirect_uri=%s", state[:8], a.yahooConfig.RedirectURL)
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{"redirect_url": authURL})
+	}
+
 	log.Printf("[YahooStart] Redirecting to Yahoo OAuth (state=%s…) redirect_uri=%s", state[:8], a.yahooConfig.RedirectURL)
 	return c.Redirect(authURL, fiber.StatusTemporaryRedirect)
 }

--- a/channels/fantasy/manifest.json
+++ b/channels/fantasy/manifest.json
@@ -5,7 +5,7 @@
   "capabilities": ["cdc_handler", "dashboard_provider", "health_checker"],
   "cdc_tables": ["yahoo_leagues", "yahoo_standings", "yahoo_matchups", "yahoo_rosters"],
   "routes": [
-    { "method": "GET", "path": "/yahoo/start", "auth": false },
+    { "method": "GET", "path": "/yahoo/start", "auth": true },
     { "method": "GET", "path": "/yahoo/callback", "auth": false },
     { "method": "GET", "path": "/yahoo/health", "auth": false },
     { "method": "GET", "path": "/users/me/yahoo-status", "auth": true },


### PR DESCRIPTION
## Summary

- Fixes the \"unauthorized\" error users hit when clicking **Connect Yahoo Account** in the desktop app.
- Makes `/yahoo/start` return JSON `{redirect_url}` when called with `Accept: application/json` (or `?response=json`), so the desktop client can request it with its Bearer token and then `shell::open` the Yahoo consent URL externally.
- Browser callers (cookie session, manual navigation, support docs) still receive the 307 redirect — fully backward-compatible.
- Brings `channels/fantasy/manifest.json` in sync with the actual `Auth: true` registration in `main.go:326` (the manifest was stale doc).

## Why this is the bug

`/yahoo/start` was promoted to `Auth: true` as part of the account-binding/CSRF hardening. After that, the desktop's `shell::open(\"${API_BASE}/yahoo/start?logto_sub=...\")` started failing because:

1. `shell::open` launches the system browser, which carries no `Authorization` header.
2. The core gateway proxy calls `ValidateAuth` for any `Auth: true` route before forwarding (see `api/core/proxy.go:56-61`).
3. `ValidateAuth` returns 401 `{\"status\":\"unauthorized\",\"error\":\"Missing authentication\"}` because there's no Bearer / no `access_token` cookie.
4. `YahooStart` is never reached. Polling times out after 5 minutes; user sees \"Yahoo sign-in timed out\".

The TODO at `desktop/src/channels/fantasy/ConfigPanel.tsx:261-267` and the v1 checklist line 271 both pre-flagged this exact failure mode and proposed exactly this fix.

## Changes

- **`channels/fantasy/api/user_handlers.go`** — `YahooStart` now content-negotiates. When `Accept: application/json` (or `?response=json`), returns `200 {\"redirect_url\": \"<yahoo url>\"}`. Otherwise unchanged: 307 redirect.
- **`channels/fantasy/manifest.json`** — `/yahoo/start` documented as `auth: true` (matches `main.go:326`).

## Out of scope for this PR

The desktop counterpart (`desktop/src/channels/fantasy/ConfigPanel.tsx`) — calling `authFetch` with `Accept: application/json` and then `shell::open` on the returned URL — will ship in the next desktop release. The server change is forward- and backward-compatible: old desktop clients still get the 307 (which they will then fail to follow because they have no auth header — same broken state as today, no regression), and new desktop clients will see JSON.

## Verification

- `go vet ./...` and `go test ./...` in `channels/fantasy/api/` — pass
- Manual: hitting `/yahoo/start?response=json` with a valid JWT will return the JSON shape; without a JWT the gateway 401s before reaching the handler (existing behavior).

## Risk

Low. Strictly additive on the server. The only behavior change is for callers explicitly opting into JSON via `Accept:` header or `?response=json` query param — neither is sent by anything in the wild today.