### PR TITLE
fix(desktop/fantasy): config panel scroll + home page leagues display

### DIFF
--- a/desktop/src/channels/fantasy/ConfigPanel.tsx
+++ b/desktop/src/channels/fantasy/ConfigPanel.tsx
@@ -319,8 +319,19 @@ export default function FantasyConfigPanel({
 
   // ── Render ─────────────────────────────────────────────────────
 
+  // Configure tab is rendered inside PageLayout's `fillHeight` mode,
+  // which disables outer scrolling and expects the child to provide
+  // its own scroll panel (see desktop/src/components/layout/PageLayout.tsx).
+  // Without this wrapper the page becomes uncroppable when the picker
+  // (or ConnectedView with several leagues) grows past the viewport.
+  // Mirrors the Finance/Sports/RSS Manager pattern.
   return (
-    <div className="w-full max-w-2xl mx-auto">
+    <div className="h-full min-h-0 flex flex-col">
+    {/* Inner wrapper handles its own scroll because PageLayout is in
+        fillHeight mode (see comment block above). Indentation is
+        intentionally one level shallower to avoid re-indenting the
+        rest of this large render. */}
+    <div className="w-full max-w-2xl mx-auto flex-1 min-h-0 overflow-y-auto scrollbar-thin pb-5">
       {/* Header */}
       <div className="flex items-center gap-3 mb-6 px-3">
         <div
@@ -488,6 +499,7 @@ export default function FantasyConfigPanel({
           onDisconnect={handleYahooDisconnect}
         />
       )}
+    </div>
     </div>
   );
 }

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -247,8 +247,17 @@ function HomePage() {
           page reveals its data instead of slamming everything in
           at once. */}
       {orderedChannels.map(({ ch, manifest }, idx) => {
-        const channelData = dashboard?.data?.[ch.channel_type];
-        const hasData = Array.isArray(channelData) && channelData.length > 0;
+        // Normalize the dashboard payload to a flat array per channel.
+        // Most channels are already arrays; Fantasy is { leagues: [...] }
+        // because each league entry carries matchups/standings/rosters at
+        // the top level. Without this unwrap the Home dashboard would
+        // think Fantasy is empty even when leagues are imported, while
+        // the standalone Feed view (which unwraps correctly) shows them.
+        const channelData = normalizeChannelData(
+          ch.channel_type,
+          dashboard?.data?.[ch.channel_type],
+        );
+        const hasData = channelData.length > 0;
         const targetTab = hasData ? "feed" : "configuration";
         const currentRow = getChannelTickerRow(shell.prefs, ch);
         return (
@@ -334,6 +343,33 @@ function HomePage() {
   );
 }
 
+// ── Dashboard payload normalizer ────────────────────────────────
+
+/**
+ * Coerce a per-channel `/dashboard` payload to a flat array.
+ *
+ * Most channels (`finance`, `sports`, `rss`) return an array directly.
+ * Fantasy returns `{ leagues: [...] }` because each league entry
+ * carries matchups/standings/rosters/standings at the top level and
+ * the wrapper leaves room for additional sibling metadata in the
+ * future.
+ *
+ * Other Fantasy consumers (`ScrollrTicker`, `FantasyFeedTab`,
+ * `FollowedPlayersPicker`, `FantasyDisplayPanel`) already do this
+ * unwrap. The Home dashboard used to treat the payload as a flat
+ * array uniformly, which produced a "No leagues imported yet" empty
+ * state even when the user had connected leagues. Centralizing the
+ * unwrap here keeps all Home-side consumers (group extractors, row
+ * renderers, hasData checks) consistent.
+ */
+function normalizeChannelData(type: string, raw: unknown): unknown[] {
+  if (type === "fantasy") {
+    const obj = raw as { leagues?: unknown } | undefined;
+    return Array.isArray(obj?.leagues) ? (obj.leagues as unknown[]) : [];
+  }
+  return Array.isArray(raw) ? (raw as unknown[]) : [];
+}
+
 // ── Group key extractors ────────────────────────────────────────
 
 function getGroups(type: string, data: unknown): string[] {
@@ -416,7 +452,12 @@ function ChannelSection({
   const [editing, setEditing] = useState(false);
   const Icon = manifest.icon;
   const type = channel.channel_type;
-  const channelData = data?.[type];
+  // Same normalize as the home loop — Fantasy is `{ leagues: [...] }`,
+  // every other channel is a flat array. See normalizeChannelData.
+  const channelData = useMemo(
+    () => normalizeChannelData(type, data?.[type]),
+    [type, data],
+  );
   const groups = useMemo(() => getGroups(type, channelData), [type, channelData]);
   const hasSelections = selectedKeys.length > 0;
 


### PR DESCRIPTION
## Summary

Two bugs surfaced after dogfooding Fantasy at the default 960x640 window size with imported leagues. Both diagnosed and verified live via the MCP-driven dev session against the production API.

### 1. FantasyConfigPanel didn't scroll at default window height

The Configure tab is mounted inside `PageLayout`'s `fillHeight` mode (`SourcePageLayout` passes `fillHeight={activeTab === \"configuration\"}`), which disables outer scrolling and explicitly expects the child to provide its own scroll panel — see [`PageLayout.tsx:84-86`](desktop/src/components/layout/PageLayout.tsx#L84-L86). Finance, Sports, and RSS all do this correctly with the canonical `h-full flex flex-col gap-3 pb-5 min-h-0` root + `flex-1 min-h-0 overflow-y-auto scrollbar-thin` child idiom (`SymbolManager:248`, `LeagueManager:179`, `FeedManager:257`).

`FantasyConfigPanel` just stacked content under a passive `<div className=\"w-full max-w-2xl mx-auto\">` — when the LeaguePicker (or a populated ConnectedView with several leagues) grew taller than the viewport, the submit button was clipped and there was no way to reach it without manually resizing the window.

**Fix:** wrap the existing render in the canonical `fillHeight` idiom. Affects all four phases (disconnected, picking, importing, connected).

### 2. Home page Fantasy section showed \"No leagues imported yet\" when leagues ARE imported

`/dashboard` returns `data.fantasy = { leagues: [...] }` (object) but every other channel returns `data.<channel> = [...]` (flat array). The Home page (`routes/feed.tsx`) treated every channel uniformly with `Array.isArray(channelData)` checks, which evaluated false for Fantasy even when leagues were populated. Result: empty state rendered, the Edit-preview pencil button was hidden, and the home loop's `targetTab` calc forced \"configuration\" instead of \"feed\" for Fantasy even when data was present.

Other Fantasy consumers (`ScrollrTicker`, `FantasyFeedTab`, `FollowedPlayersPicker`, `FantasyDisplayPanel`) already unwrap `.leagues` correctly — the standalone Fantasy Feed view shows the same data that Home was claiming was missing. Hence \"inconsistent with the feed\".

**Fix:** introduce a small `normalizeChannelData(type, raw)` helper at the top of `feed.tsx` and apply it at the two consumer sites (the home loop at line 250 and the inner `ChannelSection` at line 419). The downstream `getGroups`, `getGroupLabel`, `FantasyRows` already defended themselves with `Array.isArray`; they now always pass through to the array branch.

## Verification

- `npm run build` (desktop) — clean (typecheck + vite build)
- `npm test` (desktop) — 15 files / 249 tests passing
- MCP-driven live check at 960x640 against production API:
  - **Home page**: Fantasy section now lists \"Stanton Again A Fuck League\" and \"Scrollr League\" with the Edit-preview pencil button visible (was missing before because `groups.length === 0`).
  - **Channel/Fantasy/Configure**: panel scrolls cleanly. \"Disconnect Yahoo\" button at the bottom is reachable without resizing the window. Verified inner scroll panel exists (`max-w-2xl mx-auto flex-1 min-h-0 overflow-y-auto scrollbar-thin pb-5`) with the right scrollHeight/clientHeight ratio.

## Risk

- Both changes are local to client-side rendering. No API changes.
- The `normalizeChannelData` helper preserves existing behavior for non-Fantasy channels (`Array.isArray(raw) ? raw : []`) and only changes the Fantasy path.
- The scroll wrapper around `FantasyConfigPanel` mirrors the established Finance/Sports/RSS pattern. The inner content is unchanged.

Files: 2 changed, +57 / -4.