### PR TITLE
fix(desktop/fantasy): rebuild Display preview to be honest and legible

### DIFF
--- a/desktop/src/channels/fantasy/DisplayPanel.tsx
+++ b/desktop/src/channels/fantasy/DisplayPanel.tsx
@@ -32,7 +32,7 @@
  * `FantasyDisplayPrefs` legacy boolean fields untouched.
  */
 import { useMemo } from "react";
-import { Eye, Tv } from "lucide-react";
+import { Tv } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { fantasyLeaguesOptions } from "../../api/queries";
 import { useShell } from "../../shell-context";
@@ -47,7 +47,6 @@ import type { DisplayItemsSection } from "../../components/settings/DisplayItems
 import FollowedPlayersPicker from "../../components/settings/FollowedPlayersPicker";
 import type { FantasyDisplayPrefs, Venue } from "../../preferences";
 import type { LeagueResponse } from "./types";
-import { MatchupHero } from "./MatchupHero";
 import FantasyStatChip from "../../components/chips/FantasyStatChip";
 
 // ── Constants ────────────────────────────────────────────────────
@@ -390,30 +389,34 @@ export default function FantasyDisplayPanel() {
   return (
     <div className="space-y-6 pb-8">
       {/* ── Live preview ─────────────────────────────────────────── */}
+      {/* Renders the same FantasyStatChip in `comfort` mode the home
+          dashboard / channel feed uses. The previous design had a
+          side-by-side Feed + Ticker preview, but the Feed preview
+          (a MatchupHero card) didn't honor any of the 14 venue
+          toggles below — it was structurally static — and the
+          Ticker preview rendered the chip at its rail-native ~838px
+          width inside a ~340px surface, hiding the entire left half
+          (league name, week, score). Both failures made the preview
+          actively misleading. Single full-width comfort chip is
+          honest: it represents what the user actually sees in the
+          ticker rail and home dashboard, and reacts in real time to
+          every toggle below. */}
       <Section title="Live preview">
         <div className="px-3 pb-1 space-y-3">
           <p className="text-[11px] text-fg-4 leading-snug">
-            The Ticker chip on the right responds in real time to every
-            Display item below — toggle a row to see it appear or
-            disappear. The Feed always shows the canonical matchup card
-            (Display items currently affect the Ticker only).
+            Toggle any Display item below to see it appear or disappear
+            in the chip. The Fantasy Feed view always shows the full
+            matchup card and is unaffected by these toggles.
           </p>
 
-          <div className="grid grid-cols-2 gap-3">
-            <PreviewSurface label="Feed" icon={Eye}>
-              <div className="w-full">
-                <MatchupHero league={previewLeague} compact />
-              </div>
-            </PreviewSurface>
-            <PreviewSurface label="Ticker" icon={Tv}>
-              <FantasyStatChip
-                league={previewLeague}
-                prefs={dp}
-                comfort={false}
-                colorMode="channel"
-              />
-            </PreviewSurface>
-          </div>
+          <PreviewSurface label="Ticker chip" icon={Tv}>
+            <FantasyStatChip
+              league={previewLeague}
+              prefs={dp}
+              comfort
+              colorMode="channel"
+            />
+          </PreviewSurface>
         </div>
       </Section>
 
@@ -483,7 +486,12 @@ function PreviewSurface({ label, icon: Icon, children }: PreviewSurfaceProps) {
           {label}
         </span>
       </div>
-      <div className="p-2.5 min-h-[120px] flex items-center justify-center overflow-hidden">
+      {/* `overflow-x-auto` instead of `overflow-hidden` so any future chip
+          that exceeds the surface width is pannable rather than silently
+          clipped (the previous bug). `justify-start` keeps the chip flush
+          left so its head segments stay visible by default. The vertical
+          padding still centers a normal-height chip nicely. */}
+      <div className="p-2.5 min-h-[64px] flex items-center justify-start overflow-x-auto scrollbar-thin">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary

The Fantasy Display preferences page had two structural preview bugs that made the panel actively misleading at the default 960x640 window size. Both were caught dogfooding live via the MCP-driven dev session.

### What was broken

**1. Feed preview was structurally dishonest.** It rendered `MatchupHero`, the same card the standalone Fantasy Feed uses, but `MatchupHero` doesn't honor any of the 14 venue toggles below it — the panel's own disclaimer admitted as much. Toggling Display items did literally nothing to the Feed preview, despite the column being labelled \"Feed\". Users would naturally assume the toggles drove what they were seeing; they didn't. As a bonus, at ~320px preview width the team-name truncation broke and \"Pasquatch & the Beaned Up Boyz\" overlapped \"Big Dumps\" in the centre of the matchup card.

**2. Ticker preview was structurally illegible.** `FantasyStatChip` in non-comfort (rail) mode is 838px wide with all venues enabled, inside a 340px surface with `overflow-hidden`. The user only saw the right tail of the chip — every head segment (league name, week, score, win-prob) was clipped off-screen. Toggling those head-side venues produced no visible reaction in the preview, making the panel feel broken even when the underlying reactivity was correct.

### What's fixed

- **Drop the side-by-side Feed + Ticker layout.** Replace with a single full-width preview surface labelled \"Ticker chip\" rendering `FantasyStatChip` in `comfort` mode.
- Comfort mode is the same shape the chip uses in the home dashboard's Fantasy section and the channel Feed view's chip rows. It naturally fits the surface (two stacked rows, ~50px tall), no clipping, every segment readable. The chip continues to react in real time to every Display item below.
- **Update the disclaimer to be honest:** the toggles control the live ticker chip; the Fantasy Feed view always shows the full matchup card and is unaffected by these toggles.
- **Defence in depth:** change `PreviewSurface` inner overflow from `overflow-hidden` to `overflow-x-auto scrollbar-thin`, drop the 120px min-height (overprovisioned), and switch from `justify-center` to `justify-start` so any future chip that does grow stays head-visible and pannable rather than silently clipped.

### Verification

- `npx tsc --noEmit` (desktop) — clean
- `npm test` (desktop) — 15 files / 249 tests passing
- MCP-driven live check at default 960x612:
  - All chip segments visible without clipping at default window size
  - Toggling head segments (league name, score, win-prob) is now reflected visibly in the preview (was hidden off-screen before)
  - Toggling tail segments (record, standings, injuries) still works
  - Reactivity preserved: every venue checkbox flips its segment

### Risk

Local to this one panel. No data, API, or shared-component changes — `FantasyStatChip`, `MatchupHero`, and `DisplayItemsGrid` are unmodified. Other channels (Finance, Sports, RSS) have their own DisplayPanel files and are unaffected.

Files: 1 changed, +30 / -22.