### PR TITLE
chore(desktop): bump version to 1.0.12

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4013,7 +4013,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "futures-util",
  "log",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Bumps all three desktop version strings (`desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `desktop/src-tauri/Cargo.toml`) and `Cargo.lock` from **1.0.11** to **1.0.12**.

## What's in this release

Bundles four PRs landed since 1.0.11:

- **#155** \u2014 `fix(fantasy): content-negotiate /yahoo/start so the desktop OAuth flow works` *(server, already deployed)*
- **#156** \u2014 `chore(desktop): readability pass + MCP dev tooling + Yahoo desktop counterpart`
- **#157** \u2014 `fix(desktop/fantasy): config panel scroll + home page leagues display`
- **#158** \u2014 `fix(desktop/fantasy): rebuild Display preview to be honest and legible`

## After merge

Tag `desktop-v1.0.12` to trigger the cross-platform release build via `.github/workflows/desktop-release.yml`. The marketing site's download link auto-refreshes via the `release: types: [published]` hook in `deploy.yml`.

```sh
git tag desktop-v1.0.12
git push origin desktop-v1.0.12
```

## Verification

- `npm run build` (desktop): clean.
- All four bundled PRs were verified live via the MCP-driven dev session against the production API before merge.

## Risk

Trivial \u2014 four single-line version bumps. Cargo.lock regeneration kept tightly scoped (only the `scrollr-desktop` package version line changed; the rest of the lockfile is byte-identical).