### PR TITLE
feat(desktop/fantasy): split player-stats into individual ticker chips

### DIFF
--- a/desktop/src/channels/fantasy/DisplayPanel.tsx
+++ b/desktop/src/channels/fantasy/DisplayPanel.tsx
@@ -48,6 +48,14 @@ import FollowedPlayersPicker from "../../components/settings/FollowedPlayersPick
 import type { FantasyDisplayPrefs, Venue } from "../../preferences";
 import type { LeagueResponse } from "./types";
 import FantasyStatChip from "../../components/chips/FantasyStatChip";
+import FollowedPlayerChip from "../../components/chips/FollowedPlayerChip";
+import {
+  findTopN,
+  findTopBench,
+  findWorstStarter,
+  findInjuredPlayers,
+} from "./playerStats";
+import { shouldShowOnTicker } from "../../preferences";
 
 // ── Constants ────────────────────────────────────────────────────
 
@@ -372,6 +380,87 @@ export default function FantasyDisplayPanel() {
     patch(DEFAULTS);
   }
 
+  // ── Preview player chips ──────────────────────────────────────
+  // Mirrors the fantasy bucket builder in ScrollrTicker so the
+  // preview shows exactly what'll appear on the rail. Each enabled
+  // "Player stats" venue spawns one chip per derived player. Memoized
+  // on the league data + prefs so toggling a venue checkbox produces
+  // an immediate visual response without re-deriving on every render.
+
+  const previewPlayerChips = useMemo<
+    Array<{
+      key: string;
+      playerKey: string;
+      accent: "top" | "worst" | "bench" | "injury";
+    }>
+  >(() => {
+    const userTeam = previewLeague.rosters?.find(
+      (r) => r.team_key === previewLeague.team_key,
+    );
+    if (!userTeam) return [];
+    const players = userTeam.data.players;
+    const out: Array<{
+      key: string;
+      playerKey: string;
+      accent: "top" | "worst" | "bench" | "injury";
+    }> = [];
+
+    if (shouldShowOnTicker(dp.topThreeScorers)) {
+      const top3 = findTopN(players, 3, { startersOnly: true });
+      const startIdx =
+        shouldShowOnTicker(dp.topScorer) && top3.length > 0 ? 1 : 0;
+      for (let i = startIdx; i < top3.length; i++) {
+        out.push({
+          key: `top-${top3[i].player_key}`,
+          playerKey: top3[i].player_key,
+          accent: "top",
+        });
+      }
+    }
+
+    if (shouldShowOnTicker(dp.worstStarter)) {
+      const worst = findWorstStarter(players);
+      if (worst) {
+        out.push({
+          key: `worst-${worst.player_key}`,
+          playerKey: worst.player_key,
+          accent: "worst",
+        });
+      }
+    }
+
+    if (shouldShowOnTicker(dp.benchOpportunity)) {
+      const topBench = findTopBench(players);
+      if (topBench) {
+        out.push({
+          key: `bench-${topBench.player_key}`,
+          playerKey: topBench.player_key,
+          accent: "bench",
+        });
+      }
+    }
+
+    if (shouldShowOnTicker(dp.injuryDetail)) {
+      const injured = findInjuredPlayers(players);
+      for (const p of injured) {
+        out.push({
+          key: `inj-${p.player_key}`,
+          playerKey: p.player_key,
+          accent: "injury",
+        });
+      }
+    }
+
+    return out;
+  }, [
+    previewLeague,
+    dp.topThreeScorers,
+    dp.topScorer,
+    dp.worstStarter,
+    dp.benchOpportunity,
+    dp.injuryDetail,
+  ]);
+
   // ── Display-items grid model ──────────────────────────────────
 
   const sections: DisplayItemsSection[] = FANTASY_VENUE_GROUPS.map((group) => ({
@@ -389,33 +478,42 @@ export default function FantasyDisplayPanel() {
   return (
     <div className="space-y-6 pb-8">
       {/* ── Live preview ─────────────────────────────────────────── */}
-      {/* Renders the same FantasyStatChip in `comfort` mode the home
-          dashboard / channel feed uses. The previous design had a
-          side-by-side Feed + Ticker preview, but the Feed preview
-          (a MatchupHero card) didn't honor any of the 14 venue
-          toggles below — it was structurally static — and the
-          Ticker preview rendered the chip at its rail-native ~838px
-          width inside a ~340px surface, hiding the entire left half
-          (league name, week, score). Both failures made the preview
-          actively misleading. Single full-width comfort chip is
-          honest: it represents what the user actually sees in the
-          ticker rail and home dashboard, and reacts in real time to
-          every toggle below. */}
+      {/* Mirrors what ScrollrTicker actually renders for this league:
+          the league summary chip, then per-player chips for each
+          enabled "Player stats" venue. Each row of chips reacts in
+          real time as toggles flip — enabling Top 3 starters spawns
+          three chips, etc. PreviewSurface scrolls horizontally if
+          there are more chips than fit. */}
       <Section title="Live preview">
         <div className="px-3 pb-1 space-y-3">
           <p className="text-[11px] text-fg-4 leading-snug">
-            Toggle any Display item below to see it appear or disappear
-            in the chip. The Fantasy Feed view always shows the full
+            Toggle any Display item below to watch it appear on the
+            ticker. The four "Player stats" venues each spawn their own
+            chip(s) so you can scan them individually as the rail
+            scrolls. The Fantasy Feed view always shows the full
             matchup card and is unaffected by these toggles.
           </p>
 
-          <PreviewSurface label="Ticker chip" icon={Tv}>
-            <FantasyStatChip
-              league={previewLeague}
-              prefs={dp}
-              comfort
-              colorMode="channel"
-            />
+          <PreviewSurface label="Ticker chips" icon={Tv}>
+            <div className="flex items-center gap-2">
+              <FantasyStatChip
+                league={previewLeague}
+                prefs={dp}
+                comfort
+                colorMode="channel"
+              />
+              {previewPlayerChips.map(({ key, playerKey, accent }) => (
+                <FollowedPlayerChip
+                  key={key}
+                  playerKey={playerKey}
+                  leagueKey={previewLeague.league_key}
+                  leagues={[previewLeague]}
+                  comfort
+                  colorMode="channel"
+                  accent={accent}
+                />
+              ))}
+            </div>
           </PreviewSurface>
         </div>
       </Section>

--- a/desktop/src/channels/fantasy/playerStats.ts
+++ b/desktop/src/channels/fantasy/playerStats.ts
@@ -1,0 +1,152 @@
+/**
+ * Per-player selection helpers shared between the league summary chip
+ * (FantasyStatChip) and the ticker rail composer (ScrollrTicker).
+ *
+ * The "Player stats" venue toggles in Display preferences each emit a
+ * specific player or set of players from the user's roster. These
+ * helpers pick those players using the same rules as the legacy inline
+ * segments did, so the output is identical between the old summary-
+ * embedded display and the new individual-chip display.
+ *
+ * Each function:
+ *   - Returns null / [] when there's no meaningful pick (e.g. roster
+ *     all-zero, single-starter team, healthy roster).
+ *   - Filters out players with null `player_points` because they
+ *     haven't recorded yet — including them as 0 would mislead.
+ *   - Treats bench positions consistently with `isBenchPosition`.
+ */
+import { isBenchPosition, type RosterPlayer } from "./types";
+
+/**
+ * Top-N players by `player_points`, descending. Ties broken by Yahoo's
+ * natural roster order. Filters out null-points players. When
+ * `startersOnly: true`, bench positions are excluded.
+ */
+export function findTopN(
+  players: RosterPlayer[],
+  n: number,
+  opts: { startersOnly?: boolean } = {},
+): RosterPlayer[] {
+  const candidates = players.filter((p) => {
+    if (p.player_points === null || p.player_points === undefined) return false;
+    if (opts.startersOnly && isBenchPosition(p.selected_position)) return false;
+    return true;
+  });
+  candidates.sort((a, b) => (b.player_points ?? 0) - (a.player_points ?? 0));
+  return candidates.slice(0, n);
+}
+
+/**
+ * Highest-`player_points` active-roster (non-bench) player. Surfaces
+ * the user's MVP for the current matchup.
+ */
+export function findTopScorer(players: RosterPlayer[]): RosterPlayer | null {
+  let best: RosterPlayer | null = null;
+  let bestPoints = -Infinity;
+  for (const p of players) {
+    if (isBenchPosition(p.selected_position)) continue;
+    if (p.player_points === null || p.player_points === undefined) continue;
+    if (p.player_points > bestPoints) {
+      best = p;
+      bestPoints = p.player_points;
+    }
+  }
+  return best;
+}
+
+/**
+ * Lowest-`player_points` active-roster (non-bench) player. Returns
+ * null when there are fewer than 2 starters with scores — at that
+ * point "worst" overlaps with `topScorer` and is redundant noise.
+ */
+export function findWorstStarter(
+  players: RosterPlayer[],
+): RosterPlayer | null {
+  const starters = players.filter(
+    (p) =>
+      !isBenchPosition(p.selected_position) &&
+      p.player_points !== null &&
+      p.player_points !== undefined,
+  );
+  if (starters.length < 2) return null;
+  starters.sort((a, b) => (a.player_points ?? 0) - (b.player_points ?? 0));
+  return starters[0];
+}
+
+/**
+ * Highest-`player_points` REAL bench player (BN only — explicitly NOT
+ * IR/IL/NA). Used to surface sit/start regret: "you could have started
+ * this benched player instead." Injured-reserve slots aren't sittable
+ * in the conventional sense, so including them in the comparison would
+ * mislead. Returns null when no eligible bench player has a positive
+ * score.
+ */
+export function findTopBench(players: RosterPlayer[]): RosterPlayer | null {
+  let best: RosterPlayer | null = null;
+  let bestPoints = -Infinity;
+  for (const p of players) {
+    if (!isStrictBench(p.selected_position)) continue;
+    if (p.player_points === null || p.player_points === undefined) continue;
+    if (p.player_points > bestPoints) {
+      best = p;
+      bestPoints = p.player_points;
+    }
+  }
+  if (!best || (best.player_points ?? 0) <= 0) return null;
+  return best;
+}
+
+/**
+ * All injured (or otherwise unavailable) players on the roster, in
+ * Yahoo's natural roster order. Caller decides how many to render
+ * (e.g. cap at 2 with overflow message, or render every one as its
+ * own chip). Returns [] when the roster is healthy.
+ */
+export function findInjuredPlayers(players: RosterPlayer[]): RosterPlayer[] {
+  return players.filter((p) => isInjured(p.status));
+}
+
+// ── Position helpers ─────────────────────────────────────────────
+
+/**
+ * Stricter than `isBenchPosition` — returns true only for actual bench
+ * slots ("BN"), not injured-reserve / not-active slots. Use this when
+ * the question is "could the user have started this player?"
+ */
+export function isStrictBench(pos: string): boolean {
+  return pos.toUpperCase() === "BN";
+}
+
+// ── Status helpers ───────────────────────────────────────────────
+
+/**
+ * Yahoo injury-status strings indicating the player isn't fully
+ * available. Matches what users see in the UI: OUT, DTD, IR, IR-R,
+ * PUP, NA, SUSP, etc. Empty / null = healthy.
+ */
+export function isInjured(status: string | null | undefined): boolean {
+  if (!status) return false;
+  const s = status.trim().toUpperCase();
+  if (s === "" || s === "HEALTHY" || s === "P") return false;
+  return true;
+}
+
+/**
+ * Squash long Yahoo status codes (IR-R, IR-LT, NA, etc) into the
+ * short form users recognize. Unknown values pass through unchanged.
+ */
+export function shortStatus(status: string | null | undefined): string {
+  if (!status) return "";
+  const s = status.trim().toUpperCase();
+  if (s.startsWith("IR")) return "IR";
+  return s;
+}
+
+/**
+ * Compact one-decimal fixed-point that matches `fmtPlayerPoints` for
+ * individual-player segments. Centralized so all per-player segments
+ * format identically.
+ */
+export function formatPts(points: number): string {
+  return points.toFixed(1);
+}

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -24,6 +24,12 @@ import { selectRssForTicker } from "../channels/rss/view";
 import { selectFinanceForTicker } from "../channels/finance/view";
 import { selectFantasyForTicker } from "../channels/fantasy/view";
 import { selectSportsForTicker, getSportsDisplayConfig } from "../channels/sports/view";
+import {
+  findTopN,
+  findTopBench,
+  findWorstStarter,
+  findInjuredPlayers,
+} from "../channels/fantasy/playerStats";
 import { buildYahooLeagueUrl, buildYahooPlayerUrl, chipUrlForFinance, chipUrlForSports, chipUrlForRss } from "../utils/chipUrl";
 
 // ── Module-level constants ───────────────────────────────────────
@@ -236,6 +242,8 @@ export default function ScrollrTicker({
 
         const ranked = selectFantasyForTicker(leagues, fantasyPrefs);
         for (const league of ranked) {
+          // 1. The league summary chip itself (matchup-level: score,
+          //    week, win-prob, record, standings, top scorer, etc).
           bucket.push(
             wrap(`fan-${league.league_key}`,
               <FantasyStatChip
@@ -247,6 +255,99 @@ export default function ScrollrTicker({
               />
             )
           );
+
+          // 2. Per-player chips derived from the user's roster in this
+          //    league. Each "Player stats" venue toggle that's enabled
+          //    on the ticker spawns one FollowedPlayerChip per derived
+          //    player. Render order mirrors the Display prefs grouping:
+          //    top scorers (top3), worst starter, bench leader,
+          //    injury report.
+          //
+          //    Skip this whole block if the league has no roster (rare
+          //    pre-import or partial-sync state).
+          const userTeam = league.rosters?.find((r) => r.team_key === league.team_key);
+          if (!userTeam) continue;
+          const players = userTeam.data.players;
+
+          if (shouldShowOnTicker(fantasyPrefs.topThreeScorers)) {
+            const top3 = findTopN(players, 3, { startersOnly: true });
+            // Skip top1 if topScorer is also enabled — it's already on
+            // the league chip as "★ Mahomes 32" and would duplicate.
+            const startIdx = shouldShowOnTicker(fantasyPrefs.topScorer) && top3.length > 0 ? 1 : 0;
+            for (let i = startIdx; i < top3.length; i++) {
+              const p = top3[i];
+              bucket.push(
+                wrap(`fan-${league.league_key}-top-${p.player_key}`,
+                  <FollowedPlayerChip
+                    playerKey={p.player_key}
+                    leagueKey={league.league_key}
+                    leagues={leagues}
+                    comfort={comfort}
+                    colorMode={chipColorMode}
+                    accent="top"
+                    onClick={() => onChipClick?.("fantasy", p.player_key, buildYahooPlayerUrl(p.player_key, league.game_code))}
+                  />
+                )
+              );
+            }
+          }
+
+          if (shouldShowOnTicker(fantasyPrefs.worstStarter)) {
+            const worst = findWorstStarter(players);
+            if (worst) {
+              bucket.push(
+                wrap(`fan-${league.league_key}-worst-${worst.player_key}`,
+                  <FollowedPlayerChip
+                    playerKey={worst.player_key}
+                    leagueKey={league.league_key}
+                    leagues={leagues}
+                    comfort={comfort}
+                    colorMode={chipColorMode}
+                    accent="worst"
+                    onClick={() => onChipClick?.("fantasy", worst.player_key, buildYahooPlayerUrl(worst.player_key, league.game_code))}
+                  />
+                )
+              );
+            }
+          }
+
+          if (shouldShowOnTicker(fantasyPrefs.benchOpportunity)) {
+            const topBench = findTopBench(players);
+            if (topBench) {
+              bucket.push(
+                wrap(`fan-${league.league_key}-bench-${topBench.player_key}`,
+                  <FollowedPlayerChip
+                    playerKey={topBench.player_key}
+                    leagueKey={league.league_key}
+                    leagues={leagues}
+                    comfort={comfort}
+                    colorMode={chipColorMode}
+                    accent="bench"
+                    onClick={() => onChipClick?.("fantasy", topBench.player_key, buildYahooPlayerUrl(topBench.player_key, league.game_code))}
+                  />
+                )
+              );
+            }
+          }
+
+          if (shouldShowOnTicker(fantasyPrefs.injuryDetail)) {
+            const injured = findInjuredPlayers(players);
+            for (const p of injured) {
+              bucket.push(
+                wrap(`fan-${league.league_key}-inj-${p.player_key}`,
+                  <FollowedPlayerChip
+                    playerKey={p.player_key}
+                    leagueKey={league.league_key}
+                    leagues={leagues}
+                    comfort={comfort}
+                    colorMode={chipColorMode}
+                    accent="injury"
+                    onClick={() => onChipClick?.("fantasy", p.player_key, buildYahooPlayerUrl(p.player_key, league.game_code))}
+                  />
+                )
+              );
+            }
+          }
         }
 
         // Only push the bucket when something is actually in it (no

--- a/desktop/src/components/chips/FantasyStatChip.tsx
+++ b/desktop/src/components/chips/FantasyStatChip.tsx
@@ -8,7 +8,6 @@ import {
   countInjuries,
   estimateWinProbability,
   fmtPlayerPoints,
-  isBenchPosition,
   isMatchupFinal,
   isMatchupLive,
   streakLabel,
@@ -17,6 +16,7 @@ import {
   userRoster,
   userStanding,
 } from "../../channels/fantasy/types";
+import { findTopScorer } from "../../channels/fantasy/playerStats";
 import { getChipColors, chipBaseClasses } from "./chipColors";
 
 interface FantasyStatChipProps {
@@ -56,18 +56,21 @@ interface StatSegment {
  *   - `streak` — "W3"
  *   Roster-derived:
  *   - `injuryCount` — "2 IR"
- *   - `topScorer` — "LeBron 42.3"
- *   Player-stats (Phase 1, 2026-04-25):
- *   - `topThreeScorers` — "Mahomes 32 · Hill 18 · CMC 14"
- *   - `worstStarter` — "Worst: Andrews 0.0"
- *   - `benchOpportunity` — "Bench: Pacheco 18.0"
- *   - `injuryDetail` — "🚨 Saquon OUT, Mixon DTD"
+ *   - `topScorer` — "★ LeBron 42.3"
  *
  * Segments render only when their data is available for this league
  * (e.g. `standingsPosition` skips pre-season; `topScorer` skips rosters
  * with all-zero points). A league with ZERO ticker-enabled items
  * collapses to a name-only chip so the user still sees something
  * meaningful per-league.
+ *
+ * The 4 "Player stats" venues (`topThreeScorers`, `worstStarter`,
+ * `benchOpportunity`, `injuryDetail`) used to render here as inline
+ * segments. They are now emitted as standalone chips on the rail by
+ * `ScrollrTicker`'s fantasy bucket builder, using `FollowedPlayerChip`
+ * with an `accent` prop. This keeps the league chip focused on
+ * matchup-level context while letting per-player stats stand on their
+ * own where they're easier to scan.
  */
 export default function FantasyStatChip({
   league,
@@ -183,56 +186,10 @@ export default function FantasyStatChip({
       }
     }
 
-    // ── Phase 1 player-stats — each as its own visual segment ──
-    // Splitting top3 into 3 separate segments (rather than one
-    // "A · B · C" blob) gives each player a colored chip-within-the-
-    // chip, scannable in a scrolling ticker. Each degrades silently
-    // when its data is meaningless (pre-kickoff zeros, healthy
-    // roster, single-starter teams).
-
-    if (shouldShowOnTicker(prefs.topThreeScorers)) {
-      const top3 = findTopN(roster.data.players, 3, { startersOnly: true });
-      // Skip the FIRST entry if topScorer is also enabled — it would
-      // be a duplicate. The user opted in to both prefs but they
-      // shouldn't see "★ Mahomes 32 · Mahomes 32 · Hill 18 · CMC 14".
-      const startIdx = shouldShowOnTicker(prefs.topScorer) && top3.length > 0 ? 1 : 0;
-      for (let i = startIdx; i < top3.length; i++) {
-        const p = top3[i];
-        secondarySegments.push({
-          key: `top${i + 1}`,
-          text: `${p.name.last} ${formatPts(p.player_points!)}`,
-          tone: "up",
-        });
-      }
-    }
-
-    if (shouldShowOnTicker(prefs.worstStarter)) {
-      const worst = findWorstStarter(roster.data.players);
-      if (worst) {
-        secondarySegments.push({
-          key: "worst",
-          text: `↓ ${worst.name.last} ${formatPts(worst.player_points!)}`,
-          tone: "down",
-        });
-      }
-    }
-
-    if (shouldShowOnTicker(prefs.benchOpportunity)) {
-      const topBench = findTopBench(roster.data.players);
-      if (topBench && (topBench.player_points ?? 0) > 0) {
-        secondarySegments.push({
-          key: "bench",
-          text: `BN ${topBench.name.last} ${formatPts(topBench.player_points!)}`,
-        });
-      }
-    }
-
-    if (shouldShowOnTicker(prefs.injuryDetail)) {
-      const injuredText = formatInjuryList(roster.data.players, 2);
-      if (injuredText) {
-        secondarySegments.push({ key: "injd", text: `🚨 ${injuredText}`, tone: "down" });
-      }
-    }
+    // The four "Player stats" venues (topThreeScorers, worstStarter,
+    // benchOpportunity, injuryDetail) USED to render here as inline
+    // segments. They are now emitted as standalone chips on the rail
+    // by ScrollrTicker — see the fantasy bucket builder there.
   }
 
   // In compact mode (single-line ticker), pour everything into a
@@ -306,129 +263,12 @@ export default function FantasyStatChip({
 }
 
 // ── Helpers ──────────────────────────────────────────────────
-
-type Player = ReturnType<typeof userRoster> extends infer R
-  ? R extends null | undefined
-    ? never
-    : R extends { data: { players: infer P } }
-      ? P extends (infer Elt)[]
-        ? Elt
-        : never
-      : never
-  : never;
-
-/** Highest-`player_points` active-roster player with a non-null score. */
-function findTopScorer(players: Player[]): Player | null {
-  let best: Player | null = null;
-  let bestPoints = -Infinity;
-  for (const p of players) {
-    if (isBenchPosition(p.selected_position)) continue;
-    if (p.player_points === null || p.player_points === undefined) continue;
-    if (p.player_points > bestPoints) {
-      best = p;
-      bestPoints = p.player_points;
-    }
-  }
-  return best;
-}
-
-/** Top-N players by `player_points`, descending. Ties broken by
- *  the order they appear in the roster (Yahoo's natural sort).
- *  Filters out players with null `player_points`. When
- *  `startersOnly: true`, bench positions are excluded. */
-function findTopN(
-  players: Player[],
-  n: number,
-  opts: { startersOnly?: boolean } = {},
-): Player[] {
-  const candidates = players.filter((p) => {
-    if (p.player_points === null || p.player_points === undefined) return false;
-    if (opts.startersOnly && isBenchPosition(p.selected_position)) return false;
-    return true;
-  });
-  candidates.sort((a, b) => (b.player_points ?? 0) - (a.player_points ?? 0));
-  return candidates.slice(0, n);
-}
-
-/** Lowest-`player_points` active-roster (non-bench) player. Returns
- *  null when there are fewer than 2 starters with scores — at that
- *  point "worst" overlaps with `topScorer` and is redundant noise. */
-function findWorstStarter(players: Player[]): Player | null {
-  const starters = players.filter(
-    (p) =>
-      !isBenchPosition(p.selected_position) &&
-      p.player_points !== null &&
-      p.player_points !== undefined,
-  );
-  if (starters.length < 2) return null;
-  starters.sort((a, b) => (a.player_points ?? 0) - (b.player_points ?? 0));
-  return starters[0];
-}
-
-/** Highest-`player_points` REAL bench player (BN only — explicitly NOT
- *  IR/IL/NA). Used to surface sit/start regret: "you could have started
- *  this benched player instead." Injured-reserve slots aren't sittable
- *  in the conventional sense, so including them in the comparison
- *  would mislead. Returns null when there are no eligible bench players
- *  or none have valid scores. */
-function findTopBench(players: Player[]): Player | null {
-  let best: Player | null = null;
-  let bestPoints = -Infinity;
-  for (const p of players) {
-    if (!isStrictBench(p.selected_position)) continue;
-    if (p.player_points === null || p.player_points === undefined) continue;
-    if (p.player_points > bestPoints) {
-      best = p;
-      bestPoints = p.player_points;
-    }
-  }
-  return best;
-}
-
-/** Stricter than `isBenchPosition` — returns true only for actual bench
- *  slots ("BN"), not injured-reserve / not-active slots. Use this when
- *  the question is "could the user have started this player?" */
-function isStrictBench(pos: string): boolean {
-  return pos.toUpperCase() === "BN";
-}
-
-/** Compose a comma-separated list of injured players up to `cap` names,
- *  with "+N more" overflow when the cap is exceeded. Returns "" when
- *  no players have an injury status (so the caller can skip rendering
- *  the whole segment). */
-function formatInjuryList(players: Player[], cap: number): string {
-  const injured = players.filter((p) => isInjured(p.status));
-  if (injured.length === 0) return "";
-  const head = injured.slice(0, cap).map((p) => `${p.name.last} ${shortStatus(p.status)}`);
-  const overflow = injured.length - cap;
-  return overflow > 0 ? `${head.join(", ")}, +${overflow} more` : head.join(", ");
-}
-
-/** Yahoo injury-status strings indicating the player isn't fully
- *  available. Matches what users see in the UI: OUT, DTD, IR, IR-R,
- *  PUP, NA, SUSP, etc. Empty / null = healthy. */
-function isInjured(status: string | null | undefined): boolean {
-  if (!status) return false;
-  const s = status.trim().toUpperCase();
-  if (s === "" || s === "HEALTHY" || s === "P") return false;
-  return true;
-}
-
-/** Squash long Yahoo status codes (IR-R, IR-LT, NA, etc) into the
- *  short form users recognize. Unknown values pass through unchanged. */
-function shortStatus(status: string | null | undefined): string {
-  if (!status) return "";
-  const s = status.trim().toUpperCase();
-  if (s.startsWith("IR")) return "IR";
-  return s;
-}
-
-/** Compact one-decimal fixed-point that matches `fmtPlayerPoints` for
- *  individual-player segments. Centralized so all per-player segments
- *  format identically. */
-function formatPts(points: number): string {
-  return points.toFixed(1);
-}
+//
+// Per-player selection helpers (findTopN / findWorstStarter /
+// findTopBench / findInjuredPlayers / shortStatus / formatPts) used to
+// live here. They moved to ../../channels/fantasy/playerStats.ts when
+// the player-stat segments were extracted to standalone ticker chips
+// — both this file and ScrollrTicker now share them.
 
 function ordinal(n: number): string {
   const s = ["th", "st", "nd", "rd"];

--- a/desktop/src/components/chips/FollowedPlayerChip.tsx
+++ b/desktop/src/components/chips/FollowedPlayerChip.tsx
@@ -27,24 +27,66 @@ import type {
 } from "../../channels/fantasy/types";
 import { getChipColors, chipBaseClasses } from "./chipColors";
 
+/**
+ * Why this player is on the rail. Drives a small leading mark before
+ * the position pill so the user can scan-distinguish chip purposes:
+ *
+ *   - `top`     — top-N starter highlight (e.g. top 3 scorers). "↑"
+ *   - `worst`   — lowest-scoring starter ("↓", down tone forced)
+ *   - `bench`   — sit/start regret: bench player who outscored a
+ *                 starter ("BN")
+ *   - `injury`  — injury report. The injury status badge already shows
+ *                 the player's condition; we just force down tone.
+ *
+ * When omitted, the chip behaves identically to the legacy
+ * "Followed players" mode (user-selected, no contextual lead).
+ */
+export type FollowedPlayerAccent =
+  | "top"
+  | "worst"
+  | "bench"
+  | "injury";
+
 interface FollowedPlayerChipProps {
   /** Yahoo player_key, e.g. "nfl.p.30977". */
   playerKey: string;
   /** All leagues from the dashboard so we can locate this player. */
   leagues: LeagueResponse[];
+  /**
+   * Optional league_key constraint. When set, the lookup prefers the
+   * matching league's roster — important because Yahoo player_keys are
+   * global, so the same NFL/MLB player can appear in BOTH of the
+   * user's leagues if they own them in each. Without this hint, the
+   * chip walks leagues in array order and returns the first match,
+   * which produces wrong owner / score / league context. The
+   * follower-list chip path doesn't set this (a user-followed player
+   * is intentionally context-free), but the per-league player-stat
+   * chips emitted by ScrollrTicker always do.
+   */
+  leagueKey?: string;
   comfort?: boolean;
   colorMode?: ChipColorMode;
+  /**
+   * Optional reason this chip exists on the rail — drives a small
+   * leading badge so the user can tell at a glance whether they're
+   * looking at "my followed Mahomes" vs "this league's MVP" vs "the
+   * worst-scoring starter on my Stanton roster". Omit for a plain
+   * Followed-players chip.
+   */
+  accent?: FollowedPlayerAccent;
   onClick?: () => void;
 }
 
 export default function FollowedPlayerChip({
   playerKey,
   leagues,
+  leagueKey,
   comfort,
   colorMode = "channel",
+  accent,
   onClick,
 }: FollowedPlayerChipProps) {
-  const found = findPlayerByKey(playerKey, leagues);
+  const found = findPlayerByKey(playerKey, leagues, leagueKey);
   if (!found) return null;
 
   const { player, leagueName, ownerTeamName } = found;
@@ -52,8 +94,18 @@ export default function FollowedPlayerChip({
   const points = player.player_points;
   const hasPoints = points !== null && points !== undefined;
   const injured = isInjuredStatus(player.status);
+  // `accent` overrides the default tone calculation so worst/injury chips
+  // feel emphatically down even when the player has positive points.
   const tone: "up" | "down" | "neutral" =
-    injured ? "down" : hasPoints && points > 0 ? "up" : "neutral";
+    accent === "worst" || accent === "injury"
+      ? "down"
+      : accent === "top"
+        ? "up"
+        : injured
+          ? "down"
+          : hasPoints && points > 0
+            ? "up"
+            : "neutral";
 
   const positionBadge = positionLabel(player.selected_position, player.display_position);
   const teamAbbr = player.editorial_team_abbr || "";
@@ -67,6 +119,7 @@ export default function FollowedPlayerChip({
       title={`${player.name.full}${teamAbbr ? ` (${teamAbbr})` : ""}`}
     >
       <div className={clsx("flex items-center gap-2", comfort && "text-ui-body")}>
+        {accent && <AccentBadge accent={accent} colorClass={c.textDim} />}
         <span
           className={clsx(
             "inline-flex items-center justify-center px-1 py-0 rounded text-ui-chip font-semibold uppercase tracking-wide tabular-nums",
@@ -133,6 +186,46 @@ export default function FollowedPlayerChip({
   );
 }
 
+// ── Accent badge ─────────────────────────────────────────────────
+
+const ACCENT_GLYPH: Record<FollowedPlayerAccent, string> = {
+  top: "↑",
+  worst: "↓",
+  bench: "BN",
+  injury: "🚨",
+};
+
+const ACCENT_TITLE: Record<FollowedPlayerAccent, string> = {
+  top: "Top scorer this week",
+  worst: "Lowest-scoring starter",
+  bench: "Bench player outscoring a starter",
+  injury: "Injured / unavailable",
+};
+
+function AccentBadge({
+  accent,
+  colorClass,
+}: {
+  accent: FollowedPlayerAccent;
+  colorClass: string;
+}) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center justify-center px-1 py-0 rounded text-ui-chip font-semibold uppercase tracking-wide",
+        // Injury accent uses the emoji glyph natively; the rest get the
+        // shared chip text-dim color so they read as quiet metadata.
+        accent !== "injury" && colorClass,
+        accent !== "injury" && "bg-fg-3/15",
+      )}
+      title={ACCENT_TITLE[accent]}
+      aria-label={ACCENT_TITLE[accent]}
+    >
+      {ACCENT_GLYPH[accent]}
+    </span>
+  );
+}
+
 // ── Helpers ──────────────────────────────────────────────────────
 
 interface PlayerLookup {
@@ -143,17 +236,35 @@ interface PlayerLookup {
   ownerTeamName: string;
 }
 
-/** Walk every league's roster looking for the given player_key. The
- *  first match wins — a player typically only appears in one league
- *  per user, so collisions don't happen in practice. Returns the
- *  league context AND the owning fantasy-team name so callers can
- *  surface "this player is on Big Thumps in Stanton League" in chip
- *  comfort mode. */
+/** Walk every league's roster looking for the given player_key. When
+ *  `preferLeagueKey` is provided, that league is searched first; this
+ *  matters because Yahoo player_keys are global — a real player like
+ *  "469.p.9590" (Byron Buxton) can sit in BOTH of the user's MLB
+ *  leagues with totally different owners, scores, and roster slots
+ *  per league. The per-league player-stat chips emitted by
+ *  ScrollrTicker always pass `preferLeagueKey` so they show the data
+ *  from the league that derived them. The user-followed chip path
+ *  doesn't (a followed player is intentionally context-free).
+ *
+ *  Returns the league context AND the owning fantasy-team name so
+ *  callers can surface "this player is on Big Thumps in Stanton
+ *  League" in chip comfort mode. */
 export function findPlayerByKey(
   playerKey: string,
   leagues: LeagueResponse[],
+  preferLeagueKey?: string,
 ): PlayerLookup | null {
-  for (const league of leagues) {
+  // Two-pass: when preferLeagueKey is set, search that league first.
+  // Falls through to the global walk if the player isn't there (defensive
+  // — caller may pass a stale leagueKey if the dashboard is mid-refresh).
+  const ordered = preferLeagueKey
+    ? [
+        ...leagues.filter((l) => l.league_key === preferLeagueKey),
+        ...leagues.filter((l) => l.league_key !== preferLeagueKey),
+      ]
+    : leagues;
+
+  for (const league of ordered) {
     if (!league.rosters) continue;
     for (const roster of league.rosters) {
       for (const player of roster.data.players) {


### PR DESCRIPTION
## Summary

The four "Player stats" venues — Top 3 starters, Lowest starter, Bench leader, Injury report — used to render as inline `<span>` segments inside the league summary chip. Crammed in there with up to 9 other matchup/standings segments, the chip became an 800px+ horizontal blob that was hard to scan as the rail scrolled past.

Now each enabled venue spawns its own standalone ticker chip:

| Venue | Output |
|---|---|
| `topThreeScorers` | up to 3 `↑`-accent chips per league |
| `worstStarter`    | 1 `↓`-accent chip per league |
| `benchOpportunity`| 1 `BN`-accent chip per league |
| `injuryDetail`    | 1 `\ud83d\udea8`-accent chip per injured player per league |

The league summary chip keeps its matchup-level segments (score, week, record, standings, win-prob, top-scorer star, injury count). Chip order on the rail per league: **league chip → top scorers → worst → bench leader → injuries**.

## Implementation

- **New `desktop/src/channels/fantasy/playerStats.ts`** houses the shared selection helpers (`findTopN`, `findTopScorer`, `findWorstStarter`, `findTopBench`, `findInjuredPlayers`, `shortStatus`, `formatPts`, `isInjured`, `isStrictBench`). They moved out of `FantasyStatChip`'s private file scope so `ScrollrTicker` can drive the same logic.

- **`FollowedPlayerChip` gains an optional `accent` prop** (`"top" | "worst" | "bench" | "injury"`) that renders a small leading glyph badge (`↑` / `↓` / `BN` / `\ud83d\udea8`) and forces the chip's tone for `worst` / `injury` so they read emphatically down. The legacy user-followed path (no accent) behaves identically to before.

- **`FollowedPlayerChip` ALSO gains an optional `leagueKey` constraint** on its lookup. Yahoo player_keys are global \u2014 Buxton can sit in BOTH of the user's MLB leagues with totally different owners and scores. Without the constraint, the chip would attribute every Buxton derivation to whichever league appeared first in the array (which it WAS doing in my first pass \u2014 verified live and fixed). `ScrollrTicker` passes `leagueKey` for every per-league chip so the owner / score / context match where the player was actually picked from. The user-followed path keeps the constraint optional (a followed player is intentionally context-free \u2014 first match wins).

- **`FantasyStatChip`** drops the four segment generators and the helper functions that supported them. The chip still renders all matchup / standings / roster summary segments unchanged. Docstring updated.

- **`DisplayPanel` preview** adds a horizontal flex of league chip + spawned player-stat chips so the user can see exactly what their toggles produce. PreviewSurface already pans horizontally (PR #158) so the preview gracefully handles long player lists.

- **Top-1 dedup preserved**: when both `topScorer` (league chip's `\u2605 Mahomes 32` segment) and `topThreeScorers` are enabled, the player-chip output skips top1 so the user doesn't see Mahomes twice.

## Verification (live, MCP-driven, against production API)

- **Stanton league** (no game data yet): produced **5 standalone \ud83d\udea8 injury chips** for Lawlar / Marte / De Paula / Brown / Steele. Screenshot confirms chips render with red \ud83d\udea8 badge, position pill, last name, team, and IL/NA status. League chip retains matchup/standings segments only.
- **Scrollr League** (live data, 583.1-601.9): produced league chip + `\u2191 OF Buxton MIN 67.7` (top3 #2) + `\u2191 SP Skenes PIT 50.4` (top3 #3) + `\u2193 P Valdez DET -18.6 SUSP` (worst) + `BN BN Riley ATL 16.8` (bench) + 4 \ud83d\udea8 injury chips. All show "Stealing Philip \u00b7 Scrollr League" owner context (was being misattributed to Stanton before the `leagueKey` fix).
- `npx tsc --noEmit` clean
- `npm test` 15 files / 249 tests passing
- `npm run build` clean

## Risk

- All changes localized to the Fantasy channel ticker rendering path. No API changes, no schema changes, no database changes.
- Behavioral change is opt-in per toggle: a user with all four venues `off` sees no behavior change at all. A user with all four `on` sees more (clearer) chips than before \u2014 the visual difference is the point.
- The `leagueKey` lookup constraint on `FollowedPlayerChip` is backward compatible: omitting it preserves the legacy first-match-wins behavior used by user-followed players.

Files: 5 changed (+512 / \u2212210). One new file (`playerStats.ts`).