### PR TITLE
fix(desktop/fantasy): trim player-stat chip bottom row for tighter rail

### DIFF
--- a/desktop/src/components/chips/FollowedPlayerChip.tsx
+++ b/desktop/src/components/chips/FollowedPlayerChip.tsx
@@ -158,12 +158,21 @@ export default function FollowedPlayerChip({
           </span>
         )}
       </div>
-      {comfort && (
-        // Bottom row in comfort mode shows owner context — useful when
-        // following players from multiple leagues / multiple friends'
-        // teams. Format: "OwnerTeam · LeagueName · NFL Team Full Name".
-        // The position badge already lives on the top row, so the
-        // bottom row's job is "where does this player come from?"
+      {comfort && accent ? (
+        // Per-league player-stat chips: the league chip sits immediately
+        // before us in the rail, so league name / owner / real-team are
+        // all redundant context. Use the bottom row to label WHY this
+        // chip exists ("Top scorer", "Bench leader", etc) so the accent
+        // glyph isn't the only hint. ~70-110px instead of ~368px.
+        <div className={clsx("text-ui-chip uppercase tracking-wider", c.textFaint)}>
+          {ACCENT_LABEL[accent]}
+        </div>
+      ) : comfort ? (
+        // User-followed-players chip: no surrounding league context,
+        // so the user picked this player without that visual anchor.
+        // Show full owner / league / real-team context to disambiguate
+        // when the user follows players across multiple leagues or
+        // friends' teams. Format: "OwnerTeam · LeagueName · NFL Team Full Name".
         <div className={clsx("flex items-center gap-1.5 text-ui-chip", c.textFaint)}>
           <span className="truncate max-w-[140px]" title={ownerTeamName}>
             {ownerTeamName}
@@ -181,7 +190,7 @@ export default function FollowedPlayerChip({
             </>
           )}
         </div>
-      )}
+      ) : null}
     </button>
   );
 }
@@ -200,6 +209,18 @@ const ACCENT_TITLE: Record<FollowedPlayerAccent, string> = {
   worst: "Lowest-scoring starter",
   bench: "Bench player outscoring a starter",
   injury: "Injured / unavailable",
+};
+
+/** Short ALL-CAPS bottom-row label for per-league player-stat chips.
+ *  The accent glyph (↑ / ↓ / BN / 🚨) on the top row is the primary
+ *  signal; this label is the redundant-but-clear secondary signal so
+ *  users who haven't memorized the glyphs still know what each chip
+ *  represents. Kept terse to keep chip width tight on the rail. */
+const ACCENT_LABEL: Record<FollowedPlayerAccent, string> = {
+  top: "Top scorer",
+  worst: "Worst starter",
+  bench: "Bench leader",
+  injury: "Injured",
 };
 
 function AccentBadge({


### PR DESCRIPTION
## Summary

After #160 split player-stats into individual ticker chips, each per-league accent chip was ~395px wide because the bottom row repeated context the user already had — owner team, league name, and the player's real-life team's full name — most of which is implied by the league chip sitting directly to its left in the rail or by the team-abbr pill on the chip's own top row. The bottom row was 368px when the actual data on the top row was only 190px.

When the chip has an `accent` (per-league player-stat chip), the bottom row now shows just a short uppercase label that mirrors the glyph:

| Accent | Glyph | Bottom-row label |
|---|---|---|
| top    | ↑      | "Top scorer"     |
| worst  | ↓      | "Worst starter"  |
| bench  | BN     | "Bench leader"   |
| injury | \ud83d\udea8 | "Injured"   |

Width drops 40-50%. The accent glyph is still the primary visual signal; the label is the backup so users who haven't memorized the glyphs still know what each chip represents.

The **legacy user-followed path** (accent omitted) keeps the full `OwnerTeam · LeagueName · NFL Team Full Name` bottom row unchanged \u2014 that context IS valuable when you follow players across multiple leagues / friends' teams without a surrounding league chip to anchor them.

## Verification (live, MCP-driven, against production API)

Per-league accent chips on the live ticker, all width now ~190-240px (was ~395):

| Chip | Bottom | Width |
|---|---|---|
| `\ud83d\udea8 IL Lawlar AZ \u2014 IL60`     | "Injured"       | 217px |
| `\ud83d\udea8 NA Marte CIN \u2014 NA`       | "Injured"       | 202px |
| `\u2191 OF Buxton MIN 67.7`              | "Top scorer"    | 194px |
| `\u2191 SP Skenes PIT 50.4`              | "Top scorer"    | 194px |
| `\u2193 P Valdez DET -18.6 SUSP`         | "Worst starter" | 240px |
| `BN BN Riley ATL 16.8`                   | "Bench leader"  | 193px |

User-followed chip (CJ Abrams, briefly re-followed to verify): preserved its 475px width and the original "I am Shohei Right Now (batter) · Stanton Again A Fuck League · Washington Nationals" bottom row.

- `npx tsc --noEmit` clean
- `npm test` 15 files / 249 tests passing
- `npm run build` clean

## Risk

Trivial. Single file (28 / -7), pure visual change inside one component's render path. The new branch is gated on `accent` being present, which is opt-in per chip and only set by the per-league composer in ScrollrTicker. Anything passing `<FollowedPlayerChip />` without `accent` (= the user-followed picker path) sees identical behavior to before.