### PR TITLE
fix(desktop/sports): stable engagement sort to stop random ticker jank

### DIFF
--- a/desktop/src/channels/sports/view.test.ts
+++ b/desktop/src/channels/sports/view.test.ts
@@ -94,28 +94,42 @@ describe("gameEngagement", () => {
     expect(gameEngagement(g)).toBe(80);
   });
 
-  it("returns 60 for pre-game within 1 hour", () => {
+  it("returns 60 for any pre-game regardless of how far out it is", () => {
+    // Engagement is state-only — no time bucketing — so a pre-game's
+    // sort priority doesn't flip on dashboard refetches as it drifts
+    // across clock thresholds. Continuous time-of-day priority is
+    // applied via the start_time tie-break in selectSportsForTicker.
     expect(gameEngagement(preGame(1, 30 * 60_000))).toBe(60);
+    expect(gameEngagement(preGame(2, 6 * 3_600_000))).toBe(60);
+    expect(gameEngagement(preGame(3, 48 * 3_600_000))).toBe(60);
   });
 
-  it("returns 40 for pre-game within 24 hours", () => {
-    expect(gameEngagement(preGame(1, 6 * 3_600_000))).toBe(40);
-  });
-
-  it("returns 20 for pre-game more than 24 hours away", () => {
-    expect(gameEngagement(preGame(1, 48 * 3_600_000))).toBe(20);
-  });
-
-  it("returns 30 for final within 2 hours", () => {
+  it("returns 30 for any final game regardless of how long ago it ended", () => {
+    // Same rationale as pre-games — engagement is state-only, recency
+    // is handled by the start_time tie-break in the selector.
     expect(gameEngagement(finalGame(1, 30 * 60_000))).toBe(30);
-  });
-
-  it("returns 10 for final more than 2 hours ago", () => {
-    expect(gameEngagement(finalGame(1, 5 * 3_600_000))).toBe(10);
+    expect(gameEngagement(finalGame(2, 5 * 3_600_000))).toBe(30);
+    expect(gameEngagement(finalGame(3, 48 * 3_600_000))).toBe(30);
   });
 
   it("returns 0 for games in unknown states", () => {
     expect(gameEngagement(mk({ id: 1, state: "postponed" }))).toBe(0);
+  });
+
+  it("is stable across simulated time drift", () => {
+    // The fix's core invariant: a game's engagement must not change
+    // simply because wall-clock time has advanced. This is what the
+    // old time-bucketed implementation got wrong, producing the
+    // 4000-9000px marquee transform jumps on every dashboard refetch.
+    const upcoming = preGame(1, 90 * 60_000); // 90 minutes away
+    const recent = finalGame(2, 30 * 60_000); // finished 30 minutes ago
+    const before = { upcoming: gameEngagement(upcoming), recent: gameEngagement(recent) };
+
+    // Advance system clock past every old time-bucket boundary.
+    vi.setSystemTime(new Date(NOW.getTime() + 6 * 3_600_000)); // +6 hours
+    const after = { upcoming: gameEngagement(upcoming), recent: gameEngagement(recent) };
+
+    expect(after).toEqual(before);
   });
 });
 
@@ -181,5 +195,51 @@ describe("selectSportsForTicker", () => {
 
   it("returns [] for empty input", () => {
     expect(selectSportsForTicker([], null)).toEqual([]);
+  });
+
+  it("breaks ties between pre-games by soonest start_time first", () => {
+    // Two upcoming games at the same engagement bucket (60). The one
+    // starting sooner should sort first — same intuitive priority the
+    // old "within-1-hour > within-24h" buckets encoded discretely,
+    // now expressed continuously.
+    const games = [
+      preGame(1, 6 * 3_600_000), // starts in 6h
+      preGame(2, 30 * 60_000),   // starts in 30m
+      preGame(3, 12 * 3_600_000), // starts in 12h
+    ];
+    const result = selectSportsForTicker(games, null);
+    expect(result.map((g) => g.id)).toEqual([2, 1, 3]);
+  });
+
+  it("breaks ties between final games by most-recently-finished first", () => {
+    // Two finished games at the same engagement bucket (30). The one
+    // that ended more recently should sort first.
+    const games = [
+      finalGame(1, 5 * 3_600_000),   // finished 5h ago
+      finalGame(2, 30 * 60_000),      // finished 30m ago
+      finalGame(3, 12 * 3_600_000),   // finished 12h ago
+    ];
+    const result = selectSportsForTicker(games, null);
+    expect(result.map((g) => g.id)).toEqual([2, 1, 3]);
+  });
+
+  it("produces the same order on repeated calls (stable across refetches)", () => {
+    // Regression test for the marquee-snap bug: dashboard refetches
+    // every ~30s would re-evaluate the time-bucketed engagement and
+    // produce a different order, causing the rail to snap.
+    const games = [
+      preGame(1, 90 * 60_000),  // crosses old 1h boundary as time advances
+      preGame(2, 30 * 60_000),  // already inside old 1h boundary
+      liveGame(3),
+      finalGame(4, 90 * 60_000), // crosses old 2h boundary as time advances
+      finalGame(5, 30 * 60_000), // already inside old 2h boundary
+    ];
+    const orderAtT0 = selectSportsForTicker(games, null).map((g) => g.id);
+
+    // Advance past every old boundary.
+    vi.setSystemTime(new Date(NOW.getTime() + 3 * 3_600_000));
+    const orderAtT1 = selectSportsForTicker(games, null).map((g) => g.id);
+
+    expect(orderAtT1).toEqual(orderAtT0);
   });
 });

--- a/desktop/src/channels/sports/view.ts
+++ b/desktop/src/channels/sports/view.ts
@@ -29,19 +29,28 @@ export interface SportsDisplayConfig {
 
 // ── Pure: engagement score ──────────────────────────────────────
 
+/**
+ * Coarse priority bucket for ranking games on the ticker.
+ *
+ * **Stable across consecutive renders / refetches** — the score for any
+ * given game only changes when its `state` transitions (pre → live →
+ * final) or its `isCloseGame` status flips. It is NOT a function of
+ * `Date.now()`, so dashboard refetches that bring back the same data
+ * produce the same sort order, which keeps the ticker rail from
+ * snapping every ~30 seconds as games drift across arbitrary clock
+ * thresholds (within-1-hour, within-24-hours, within-2-hours-ago).
+ *
+ * The previous time-bucketed implementation produced 4000-9000px
+ * marquee transform jumps on every dashboard refetch when any game
+ * crossed a threshold, which the user observed as "weird movement".
+ * Continuous time-of-day priority (sooner pre-games surface, more
+ * recent finals surface) is now expressed via the secondary sort in
+ * `selectSportsForTicker` instead — same UX, no jank.
+ */
 export function gameEngagement(g: Game): number {
   if (isLive(g)) return isCloseGame(g) ? 100 : 80;
-  if (g.state === "pre") {
-    const until = new Date(g.start_time).getTime() - Date.now();
-    if (until < 3_600_000) return 60; // within 1 hour
-    if (until < 86_400_000) return 40; // within 24 hours
-    return 20;
-  }
-  if (g.state === "final") {
-    const ago = Date.now() - new Date(g.start_time).getTime();
-    if (ago < 7_200_000) return 30; // finished within 2 hours
-    return 10;
-  }
+  if (g.state === "pre") return 60;
+  if (g.state === "final") return 30;
   return 0;
 }
 
@@ -50,11 +59,22 @@ export function gameEngagement(g: Game): number {
 /**
  * Baseline pipeline used by the ticker: applies `showUpcoming`/`showFinal`
  * filters from the channel config.display blob, then sorts by engagement
- * (live/close-game games float to the top).
+ * (live games first, then upcoming, then finals) with a deterministic
+ * tie-break on `start_time` so the ticker rail stays stable across
+ * dashboard refetches.
  *
  * Filters only apply when the venue is `off` or ticker-only-excluded
  * ("feed"). `both` and `ticker` both permit the category to show on the
  * ticker.
+ *
+ * Tie-break direction is per-state:
+ *   - pre/live   → start_time ASC (sooner / more in-progress first)
+ *   - final      → start_time DESC (most recently finished first)
+ *
+ * This preserves the continuous "closer games matter more" priority the
+ * old time-bucketed engagement encoded discretely, without producing a
+ * different sort order on every refetch as games drift across clock
+ * thresholds.
  */
 export function selectSportsForTicker(
   games: Game[],
@@ -70,7 +90,16 @@ export function selectSportsForTicker(
     return true;
   });
 
-  return filtered.sort((a, b) => gameEngagement(b) - gameEngagement(a));
+  return filtered.sort((a, b) => {
+    const eDiff = gameEngagement(b) - gameEngagement(a);
+    if (eDiff !== 0) return eDiff;
+    // Same engagement bucket — break ties by start_time. Finals sort
+    // newest-first; everything else sorts soonest-first.
+    const aT = new Date(a.start_time).getTime();
+    const bT = new Date(b.start_time).getTime();
+    if (a.state === "final" && b.state === "final") return bT - aT;
+    return aT - bT;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

The user reported the ticker "randomly moving in weird ways" with a hunch that sports updates were the trigger. Confirmed via 2 minutes of live MCP-driven instrumentation against the running ticker window:

| Metric | Before fix | After fix |
|---|---|---|
| Transform jumps (>300px in <50ms) | **68** | **0** |
| Chip-set mutation events           | 120  | 81 (-33%) |
| Fantasy chip count drift           | 0    | 0 ✓ |

Largest pre-fix transform jump: **9782 px in 17 ms** (~575 px/ms vs the marquee's normal 0.05-0.15 px/ms — about 4000× normal speed). That snap is exactly the visible "weird movement" the user described.

## Root cause

`selectSportsForTicker` sorts by `gameEngagement(g)`. The old engagement function read `Date.now()` to bucket games:

```ts
if (g.state === "pre") {
  const until = new Date(g.start_time).getTime() - Date.now();
  if (until < 3_600_000) return 60;   // within 1 hour
  if (until < 86_400_000) return 40;  // within 24 hours
  return 20;
}
if (g.state === "final") {
  const ago = Date.now() - new Date(g.start_time).getTime();
  if (ago < 7_200_000) return 30;     // finished within 2 hours
  return 10;
}
```

Every dashboard refetch (≈32s interval) re-evaluated those buckets against the current wall clock, so any game drifting across a threshold flipped its sort key — causing `filtered.sort()` to return a different order on consecutive calls against the same data. React reconciled the new order, the `motion-plus` `Ticker` recomputed accumulated chip widths, and snapped the marquee transform 4-9k px to keep visible content roughly contiguous.

Bursts clustered at t=7s, 19s, 39s, 71s, 103s, 135s, 167s — perfectly at the React-Query refetch interval. Fantasy chips never reordered (no time-dependent sort) — the user correctly identified sports as the culprit.

## The fix

Classify games by state only — no `Date.now()` inside `gameEngagement`:

```ts
export function gameEngagement(g: Game): number {
  if (isLive(g)) return isCloseGame(g) ? 100 : 80;
  if (g.state === "pre") return 60;
  if (g.state === "final") return 30;
  return 0;
}
```

The intuitive "closer / recent games surface first" priority that the time buckets encoded discretely is now expressed continuously via a deterministic `start_time` tie-break in `selectSportsForTicker`:

- pre / live games → `start_time` ASC (sooner / more in-progress first)
- final games → `start_time` DESC (most recently finished first)

A given game's sort key now only changes when its **actual state transitions** (pre → live → final) — which IS a moment that should reorder the rail.

## Tests

- Existing time-bucket `gameEngagement` tests collapsed to "any pre-game returns 60" / "any final returns 30" with a new regression test asserting engagement is invariant under simulated time drift (advances `vi.setSystemTime` past every old boundary, asserts engagement values are identical).
- New tests covering the `start_time` tie-break for both pre and final games.
- New regression test for the full pipeline: calls `selectSportsForTicker` twice with the system clock advanced 3 hours between calls, asserts the returned order is identical.
- **250 tests pass** (was 249; +3 new, -2 collapsed).

## Verification (live, MCP-driven)

Re-ran the same `MutationObserver` + `requestAnimationFrame` transform-jump probe for another 2 minutes after the fix landed via HMR. Transform jumps dropped from **68 → 0**. Chip-set mutations dropped 33% — the remaining are normal React reconciliation on refetch, but they no longer change order, so the marquee does not snap and the user does not see them.

## Risk

- Single file (`view.ts`) + tests. No API changes, no shared component changes.
- The behavioral change is "ticker order stays stable across refetches when nothing meaningful happened" — a strict improvement. The sort still places live > pre > final and still surfaces sooner / more-recent games first.