### PR TITLE
feat(desktop): community theme families with light/dark/system modes

### DIFF
--- a/desktop/app.html
+++ b/desktop/app.html
@@ -5,36 +5,89 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Scrollr</title>
     <script>
-      // Pre-paint theme resolution to prevent dark-flash on light-system users.
+      // Pre-paint theme resolution to prevent dark-flash on light-system users
+      // AND to honour the user's chosen theme family (Catppuccin, Dracula, …).
       //
-      // Reads a tiny mirror of the user's theme preference written to
-      // localStorage by useTheme on every theme change. Falls back to
-      // OS preference (system) if no mirror exists yet (first launch).
-      // Sets data-theme on <html> before React or any stylesheet paints.
+      // Reads a small mirror written to localStorage by useTheme on every
+      // theme change. Two formats are tolerated:
+      //
+      //   1. Current format (multi-theme):
+      //        { family: "catppuccin", mode: "system" }
+      //   2. Legacy format (pre-multi-theme):
+      //        "light" | "dark" | "system"
+      //
+      // Falls back to Scrollr + system if no mirror exists yet (first launch).
+      // Sets data-theme on <html> before React or any stylesheet paints so
+      // the body background matches the resolved theme.
       (function () {
-        var resolved = "dark";
+        var KNOWN_FAMILIES = [
+          "scrollr",
+          "catppuccin",
+          "dracula",
+          "tokyo-night",
+          "nord",
+          "gruvbox",
+          "solarized",
+          "rose-pine",
+          "one",
+          "everforest",
+        ];
+
+        function resolveMode(mode) {
+          if (mode === "light" || mode === "dark") return mode;
+          // mode === "system" or anything else -> use OS preference
+          return window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+        }
+
+        var family = "scrollr";
+        var mode = "system";
         try {
           var saved = localStorage.getItem("scrollr:theme-mirror");
-          // saved is "light" | "dark" | "system" | null
-          if (saved === "light" || saved === "dark") {
-            resolved = saved;
-          } else {
-            // saved === "system" or null -> use OS preference
-            resolved = window.matchMedia("(prefers-color-scheme: dark)").matches
-              ? "dark"
-              : "light";
+          if (saved) {
+            if (saved.charAt(0) === "{") {
+              // New JSON format.
+              var parsed = JSON.parse(saved);
+              if (parsed && typeof parsed === "object") {
+                if (KNOWN_FAMILIES.indexOf(parsed.family) !== -1) {
+                  family = parsed.family;
+                }
+                if (
+                  parsed.mode === "light" ||
+                  parsed.mode === "dark" ||
+                  parsed.mode === "system"
+                ) {
+                  mode = parsed.mode;
+                }
+              }
+            } else if (saved === "light" || saved === "dark" || saved === "system") {
+              // Legacy format from pre-multi-theme builds.
+              mode = saved;
+            }
           }
         } catch (e) {
-          // Defensive: any failure -> dark default (matches legacy behavior)
+          // Defensive: any failure -> Scrollr + system default.
         }
-        document.documentElement.setAttribute("data-theme", resolved);
+
+        var resolvedMode = resolveMode(mode);
+        document.documentElement.setAttribute(
+          "data-theme",
+          family + "-" + resolvedMode,
+        );
+        // Also expose the resolved mode separately so the inline style
+        // block below can paint the correct background colour without
+        // having to enumerate every family.
+        document.documentElement.setAttribute("data-mode", resolvedMode);
       })();
     </script>
     <style>
-      /* Prevent flash on load — match the resolved data-theme above */
+      /* Prevent flash on load — paint a sane background that matches the
+         resolved mode. Per-family backgrounds are applied by style.css
+         once the stylesheet loads; this just covers the brief gap. */
       html, body { margin: 0; padding: 0; }
-      html[data-theme="dark"], html[data-theme="dark"] body { background: #141420; }
-      html[data-theme="light"], html[data-theme="light"] body { background: #ffffff; }
+      html[data-mode="dark"], html[data-mode="dark"] body { background: #141420; }
+      html[data-mode="light"], html[data-mode="light"] body { background: #ffffff; }
     </style>
   </head>
   <body>

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -4,9 +4,77 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Scrollr</title>
+    <script>
+      // Pre-paint theme resolution for the ticker window. Mirrors the
+      // pre-paint script in app.html — both windows share the same
+      // `scrollr:theme-mirror` localStorage key so the ticker picks up
+      // the same theme family + mode the main app last applied.
+      (function () {
+        var KNOWN_FAMILIES = [
+          "scrollr",
+          "catppuccin",
+          "dracula",
+          "tokyo-night",
+          "nord",
+          "gruvbox",
+          "solarized",
+          "rose-pine",
+          "one",
+          "everforest",
+        ];
+
+        function resolveMode(mode) {
+          if (mode === "light" || mode === "dark") return mode;
+          return window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+        }
+
+        var family = "scrollr";
+        var mode = "system";
+        try {
+          var saved = localStorage.getItem("scrollr:theme-mirror");
+          if (saved) {
+            if (saved.charAt(0) === "{") {
+              var parsed = JSON.parse(saved);
+              if (parsed && typeof parsed === "object") {
+                if (KNOWN_FAMILIES.indexOf(parsed.family) !== -1) {
+                  family = parsed.family;
+                }
+                if (
+                  parsed.mode === "light" ||
+                  parsed.mode === "dark" ||
+                  parsed.mode === "system"
+                ) {
+                  mode = parsed.mode;
+                }
+              }
+            } else if (saved === "light" || saved === "dark" || saved === "system") {
+              mode = saved;
+            }
+          }
+        } catch (e) {
+          // Defensive default.
+        }
+
+        var resolvedMode = resolveMode(mode);
+        document.documentElement.setAttribute(
+          "data-theme",
+          family + "-" + resolvedMode,
+        );
+        document.documentElement.setAttribute("data-mode", resolvedMode);
+      })();
+    </script>
     <style>
-      /* Prevent white flash on load */
-      html, body { background: #141420; margin: 0; padding: 0; overflow: hidden; }
+      /* Prevent white flash on load — paint a sane mode-aware background.
+         The per-family styles in style.css take over once it loads. */
+      html, body {
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
+      html[data-mode="dark"], html[data-mode="dark"] body { background: #141420; }
+      html[data-mode="light"], html[data-mode="light"] body { background: #ffffff; }
     </style>
   </head>
   <body>

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -301,7 +301,8 @@ export default function App() {
   // ── Theme + UI scale (shared hook) ────────────────────────────
   useTheme({
     shellId: "desktop-shell",
-    theme: prefs.appearance.theme,
+    themeFamily: prefs.appearance.themeFamily,
+    themeMode: prefs.appearance.themeMode,
     uiScale: prefs.appearance.uiScale,
     fontWeight: prefs.appearance.fontWeight,
     highContrast: prefs.appearance.highContrast,

--- a/desktop/src/components/settings/GeneralSettings.tsx
+++ b/desktop/src/components/settings/GeneralSettings.tsx
@@ -25,12 +25,15 @@ interface PendingUpdate {
 import type {
   AppearancePrefs,
   WindowPrefs,
-  Theme,
+  ThemeMode,
+  ThemeFamily,
 } from "../../preferences";
+import { THEME_FAMILIES, THEME_FAMILY_LABELS } from "../../preferences";
 import {
   Section,
   ToggleRow,
   SegmentedRow,
+  SelectRow,
   DisplayRow,
   ResetButton,
 } from "./SettingsControls";
@@ -61,11 +64,17 @@ interface GeneralSettingsProps {
 
 // ── Options ─────────────────────────────────────────────────────
 
-const THEME_OPTIONS: { value: Theme; label: string }[] = [
+const THEME_MODE_OPTIONS: { value: ThemeMode; label: string }[] = [
   { value: "light", label: "Light" },
   { value: "dark", label: "Dark" },
   { value: "system", label: "Auto" },
 ];
+
+const THEME_FAMILY_OPTIONS: { value: ThemeFamily; label: string }[] =
+  THEME_FAMILIES.map((family) => ({
+    value: family,
+    label: THEME_FAMILY_LABELS[family],
+  }));
 
 const SCALE_PRESETS: { value: string; label: string }[] = [
   { value: "85", label: "85%" },
@@ -235,12 +244,19 @@ export default function GeneralSettings({
   return (
     <div>
       <Section title="Appearance">
+        <SelectRow
+          label="Theme"
+          description="Pick a color palette"
+          value={appearance.themeFamily}
+          options={THEME_FAMILY_OPTIONS}
+          onChange={(v) => setApp("themeFamily", v)}
+        />
         <SegmentedRow
           label="Color mode"
-          description="Choose light or dark colors"
-          value={appearance.theme}
-          options={THEME_OPTIONS}
-          onChange={(v) => setApp("theme", v)}
+          description="Light, dark, or follow the system"
+          value={appearance.themeMode}
+          options={THEME_MODE_OPTIONS}
+          onChange={(v) => setApp("themeMode", v)}
         />
         <SegmentedRow
           label="Display size"

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -136,6 +136,56 @@ export function SegmentedRow<T extends string>({
   );
 }
 
+// ── Select row ──────────────────────────────────────────────────
+// A labeled dropdown for picking one of many string options. Used by
+// the Appearance panel for the 10-entry theme family selector, where a
+// segmented control would overflow the row.
+
+interface SelectRowProps<T extends string> {
+  label: string;
+  description?: string;
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (value: T) => void;
+}
+
+export function SelectRow<T extends string>({
+  label,
+  description,
+  value,
+  options,
+  onChange,
+}: SelectRowProps<T>) {
+  return (
+    <div className="flex items-center justify-between px-3 py-2.5 rounded-lg">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-ui-muted leading-tight">{label}</span>
+        {description && (
+          <span className="text-ui-meta leading-tight">{description}</span>
+        )}
+      </div>
+      <select
+        aria-label={label}
+        value={value}
+        onChange={(e) => onChange(e.target.value as T)}
+        className="shrink-0 ml-4 px-2.5 py-1 text-ui-chip font-medium rounded-md bg-base-200 border border-edge/40 text-fg focus:outline-none focus:border-accent/60 transition-colors cursor-pointer appearance-none pr-7 bg-no-repeat bg-right"
+        style={{
+          backgroundImage:
+            "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 4.5l3 3 3-3' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>\")",
+          backgroundPosition: "right 6px center",
+          backgroundSize: "12px",
+        }}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
 // ── Venue row ───────────────────────────────────────────────────
 // @deprecated as of 2026-04-25.
 // Use `<DisplayLocationGrid>` instead — it renders the same persisted

--- a/desktop/src/hooks/useTheme.ts
+++ b/desktop/src/hooks/useTheme.ts
@@ -1,30 +1,65 @@
 /**
- * Apply theme, UI scale, font weight, and contrast to a shell element.
+ * Apply theme family + color mode, UI scale, font weight, and contrast
+ * to a shell element.
  *
- * Shared between the app window (#app-shell) and ticker window (#desktop-shell).
- * Handles dark/light/system themes with smooth transitions and prefers-color-scheme
- * media query listening for system mode.
+ * Shared between the app window (#app-shell) and ticker window
+ * (#desktop-shell). Handles the multi-theme color system:
  *
- * UI scale uses Tauri's native webview zoom API, which scales the entire
- * rendering layer uniformly. This avoids the coordinate mismatches that
- * CSS `zoom` causes with portal-based components (tooltips, toasts, modals).
+ *   - `themeFamily` picks the palette identity (Scrollr, Catppuccin,
+ *     Dracula, …). One of `THEME_FAMILIES`.
+ *   - `themeMode` is the light/dark/system selector. "system" resolves
+ *     via prefers-color-scheme and stays reactive to OS changes.
+ *
+ * Together they form the `data-theme` attribute applied to the shell
+ * and the document element, e.g. `data-theme="catppuccin-dark"`.
+ *
+ * UI scale uses Tauri's native webview zoom API, which scales the
+ * entire rendering layer uniformly. This avoids the coordinate
+ * mismatches that CSS `zoom` causes with portal-based components
+ * (tooltips, toasts, modals).
  */
 import { useEffect } from "react";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import { resolveTheme } from "../preferences";
-import type { Theme, FontWeight } from "../preferences";
+import { resolveThemeMode, resolveThemeName } from "../preferences";
+import type { ThemeFamily, ThemeMode, FontWeight } from "../preferences";
 
 interface UseThemeOptions {
   shellId: string;
-  theme: Theme;
+  themeFamily: ThemeFamily;
+  themeMode: ThemeMode;
   uiScale: number;
   fontWeight: FontWeight;
   highContrast: boolean;
 }
 
+/**
+ * Mirror written to localStorage so the pre-paint script in app.html
+ * (and index.html for the ticker) can resolve the user's saved theme
+ * synchronously before React mounts. Both the family and the unresolved
+ * mode are stored so "system" stays responsive to OS changes between
+ * launches.
+ */
+const THEME_MIRROR_KEY = "scrollr:theme-mirror";
+
+interface ThemeMirror {
+  family: ThemeFamily;
+  mode: ThemeMode;
+}
+
+function writeMirror(family: ThemeFamily, mode: ThemeMode): void {
+  try {
+    const payload: ThemeMirror = { family, mode };
+    localStorage.setItem(THEME_MIRROR_KEY, JSON.stringify(payload));
+  } catch {
+    // localStorage may be unavailable in some webview contexts —
+    // pre-paint will fall back to Scrollr dark.
+  }
+}
+
 export function useTheme({
   shellId,
-  theme,
+  themeFamily,
+  themeMode,
   uiScale,
   fontWeight,
   highContrast,
@@ -34,31 +69,27 @@ export function useTheme({
     const shell = document.getElementById(shellId);
     if (!shell) return;
 
-    const resolved = resolveTheme(theme);
+    const resolvedMode = resolveThemeMode(themeMode);
+    const dataTheme = resolveThemeName(themeFamily, resolvedMode);
+
     shell.classList.add("theme-transition");
-    shell.dataset.theme = resolved;
-    // Mirror the user's pref to localStorage so the pre-paint script
-    // in app.html can read it synchronously on next launch and avoid
-    // the dark-flash for light-system users. Stores the *unresolved*
-    // pref so "system" stays responsive to OS changes between launches.
-    try {
-      localStorage.setItem("scrollr:theme-mirror", theme);
-    } catch {
-      // localStorage may be unavailable in some webview contexts —
-      // pre-paint will fall back to OS preference.
-    }
-    // Also ensure <html> stays in sync with the shell so the pre-paint
-    // background colors don't fight us once the React tree has mounted.
-    document.documentElement.setAttribute("data-theme", resolved);
+    shell.dataset.theme = dataTheme;
+    // Mirror the user's pref so the pre-paint script can read it on
+    // next launch and avoid a theme flash for non-default families.
+    writeMirror(themeFamily, themeMode);
+    // Also ensure <html> stays in sync with the shell so the
+    // pre-paint background colors don't fight us once React mounts.
+    document.documentElement.setAttribute("data-theme", dataTheme);
     const timer = setTimeout(
       () => shell.classList.remove("theme-transition"),
       350,
     );
 
-    if (theme === "system") {
+    if (themeMode === "system") {
       const mq = window.matchMedia("(prefers-color-scheme: dark)");
       const handler = (e: MediaQueryListEvent) => {
-        const next = e.matches ? "dark" : "light";
+        const nextMode = e.matches ? "dark" : "light";
+        const next = resolveThemeName(themeFamily, nextMode);
         shell.dataset.theme = next;
         document.documentElement.setAttribute("data-theme", next);
       };
@@ -70,7 +101,7 @@ export function useTheme({
     }
 
     return () => clearTimeout(timer);
-  }, [shellId, theme]);
+  }, [shellId, themeFamily, themeMode]);
 
   // ── UI scale via native webview zoom ─────────────────────────
   useEffect(() => {

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -28,6 +28,11 @@ import {
   setSourceTickerRow,
   setChannelTickerRow,
   setWidgetTickerRow,
+  migrateAppearanceTheme,
+  resolveThemeName,
+  isThemeFamily,
+  isThemeMode,
+  THEME_FAMILIES,
 } from "./preferences";
 import type { Venue, AppPreferences } from "./preferences";
 
@@ -471,5 +476,137 @@ describe("setSourceTickerRow / setChannelTickerRow / setWidgetTickerRow", () => 
     const prefs = makePrefs([{ sources: ["finance"] }]);
     const next = setSourceTickerRow(prefs, "finance", null);
     expect(next.appearance.tickerLayout.rows.length).toBe(1);
+  });
+});
+
+// ── Theme family + mode ─────────────────────────────────────────
+//
+// The multi-theme rollout split the single `appearance.theme` field
+// into `themeFamily` (palette identity) + `themeMode` (light/dark/system).
+// These tests pin down:
+//
+//   - The 10 supported families exist and the type guard accepts them.
+//   - The legacy `theme` field migrates into `themeMode` without losing
+//     the user's prior color-mode choice (`scrollr` family is assumed).
+//   - The new explicit fields take precedence over the legacy one when
+//     both are present (an unusual but plausible state during rollout).
+//   - Unknown families fall back to "scrollr" and unknown modes to
+//     "system" so a corrupted prefs file never breaks the UI.
+//   - resolveThemeName composes data-theme strings in the expected form.
+
+describe("isThemeFamily / isThemeMode", () => {
+  it("accepts every family in THEME_FAMILIES", () => {
+    for (const family of THEME_FAMILIES) {
+      expect(isThemeFamily(family)).toBe(true);
+    }
+  });
+
+  it("rejects unknown family strings", () => {
+    expect(isThemeFamily("monokai")).toBe(false);
+    expect(isThemeFamily("synthwave")).toBe(false);
+    expect(isThemeFamily("")).toBe(false);
+    expect(isThemeFamily(null)).toBe(false);
+    expect(isThemeFamily(undefined)).toBe(false);
+    expect(isThemeFamily(42)).toBe(false);
+  });
+
+  it("accepts the three valid modes", () => {
+    expect(isThemeMode("light")).toBe(true);
+    expect(isThemeMode("dark")).toBe(true);
+    expect(isThemeMode("system")).toBe(true);
+  });
+
+  it("rejects everything else as a mode", () => {
+    expect(isThemeMode("auto")).toBe(false);
+    expect(isThemeMode("")).toBe(false);
+    expect(isThemeMode(null)).toBe(false);
+    expect(isThemeMode(undefined)).toBe(false);
+  });
+});
+
+describe("migrateAppearanceTheme", () => {
+  it("returns Scrollr + system when nothing is saved", () => {
+    expect(migrateAppearanceTheme(undefined)).toEqual({
+      themeFamily: "scrollr",
+      themeMode: "system",
+    });
+    expect(migrateAppearanceTheme({})).toEqual({
+      themeFamily: "scrollr",
+      themeMode: "system",
+    });
+  });
+
+  it("folds legacy `theme: dark` into themeMode + scrollr family", () => {
+    expect(migrateAppearanceTheme({ theme: "dark" })).toEqual({
+      themeFamily: "scrollr",
+      themeMode: "dark",
+    });
+  });
+
+  it("folds legacy `theme: light` into themeMode + scrollr family", () => {
+    expect(migrateAppearanceTheme({ theme: "light" })).toEqual({
+      themeFamily: "scrollr",
+      themeMode: "light",
+    });
+  });
+
+  it("folds legacy `theme: system` into themeMode + scrollr family", () => {
+    expect(migrateAppearanceTheme({ theme: "system" })).toEqual({
+      themeFamily: "scrollr",
+      themeMode: "system",
+    });
+  });
+
+  it("keeps an explicit themeFamily + themeMode as-is", () => {
+    expect(
+      migrateAppearanceTheme({
+        themeFamily: "catppuccin",
+        themeMode: "dark",
+      }),
+    ).toEqual({ themeFamily: "catppuccin", themeMode: "dark" });
+  });
+
+  it("prefers the new themeMode field when both new and legacy are present", () => {
+    // Legacy theme=light vs new themeMode=dark — the new field wins
+    // so a partial migration (UI saved one field but not the other)
+    // resolves cleanly.
+    expect(
+      migrateAppearanceTheme({
+        theme: "light",
+        themeMode: "dark",
+        themeFamily: "dracula",
+      }),
+    ).toEqual({ themeFamily: "dracula", themeMode: "dark" });
+  });
+
+  it("falls back to scrollr for unknown themeFamily values", () => {
+    expect(
+      migrateAppearanceTheme({ themeFamily: "monokai", themeMode: "dark" }),
+    ).toEqual({ themeFamily: "scrollr", themeMode: "dark" });
+  });
+
+  it("falls back to system for unknown themeMode values", () => {
+    expect(
+      migrateAppearanceTheme({
+        themeFamily: "nord",
+        themeMode: "midnight",
+      }),
+    ).toEqual({ themeFamily: "nord", themeMode: "system" });
+  });
+
+  it("survives corrupted shapes without throwing", () => {
+    expect(
+      migrateAppearanceTheme({ themeFamily: 42, themeMode: true }),
+    ).toEqual({ themeFamily: "scrollr", themeMode: "system" });
+  });
+});
+
+describe("resolveThemeName", () => {
+  it("composes the data-theme attribute as `<family>-<mode>`", () => {
+    expect(resolveThemeName("scrollr", "dark")).toBe("scrollr-dark");
+    expect(resolveThemeName("scrollr", "light")).toBe("scrollr-light");
+    expect(resolveThemeName("catppuccin", "dark")).toBe("catppuccin-dark");
+    expect(resolveThemeName("tokyo-night", "light")).toBe("tokyo-night-light");
+    expect(resolveThemeName("rose-pine", "dark")).toBe("rose-pine-dark");
   });
 });

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -8,7 +8,74 @@ import { getMaxTickerRows } from "./tierLimits";
 
 // ── Types ────────────────────────────────────────────────────────
 
-export type Theme = "light" | "dark" | "system";
+/**
+ * Color mode controls light/dark resolution, independent of the
+ * selected theme family. "system" follows the OS preference.
+ *
+ * Historically this type was called `Theme` and lived on
+ * `appearance.theme`. As of the multi-theme refactor, the field is
+ * `appearance.themeMode` and is paired with `appearance.themeFamily`.
+ * The legacy `Theme` alias is kept as a deprecated export for any
+ * consumer that hasn't been migrated yet.
+ */
+export type ThemeMode = "light" | "dark" | "system";
+
+/** @deprecated Use `ThemeMode` instead. */
+export type Theme = ThemeMode;
+
+/**
+ * The ten built-in theme families. Each family carries its own light
+ * and dark palette in `style.css`, applied via
+ * `data-theme="<family>-<resolved-mode>"`.
+ */
+export type ThemeFamily =
+  | "scrollr"
+  | "catppuccin"
+  | "dracula"
+  | "tokyo-night"
+  | "nord"
+  | "gruvbox"
+  | "solarized"
+  | "rose-pine"
+  | "one"
+  | "everforest";
+
+export const THEME_FAMILIES: ThemeFamily[] = [
+  "scrollr",
+  "catppuccin",
+  "dracula",
+  "tokyo-night",
+  "nord",
+  "gruvbox",
+  "solarized",
+  "rose-pine",
+  "one",
+  "everforest",
+];
+
+export const THEME_MODES: ThemeMode[] = ["light", "dark", "system"];
+
+/** Display label for the theme family selector. */
+export const THEME_FAMILY_LABELS: Record<ThemeFamily, string> = {
+  scrollr: "Scrollr",
+  catppuccin: "Catppuccin",
+  dracula: "Dracula",
+  "tokyo-night": "Tokyo Night",
+  nord: "Nord",
+  gruvbox: "Gruvbox",
+  solarized: "Solarized",
+  "rose-pine": "Rose Pine",
+  one: "One",
+  everforest: "Everforest",
+};
+
+export function isThemeFamily(value: unknown): value is ThemeFamily {
+  return typeof value === "string" && (THEME_FAMILIES as string[]).includes(value);
+}
+
+export function isThemeMode(value: unknown): value is ThemeMode {
+  return value === "light" || value === "dark" || value === "system";
+}
 type TaskbarHeight = "compact" | "default" | "comfortable";
 export type TickerGap = "tight" | "normal" | "spacious";
 export type TickerMode = "compact" | "comfort";
@@ -43,7 +110,18 @@ export interface TickerLayout {
 }
 
 export interface AppearancePrefs {
-  theme: Theme;
+  /**
+   * Color mode for the active theme family. `system` follows the OS.
+   * Renamed from the legacy `theme` field; see migration in
+   * `loadPrefs` / `migrateAppearance`.
+   */
+  themeMode: ThemeMode;
+  /**
+   * Selected theme family (color palette identity). Combines with
+   * `themeMode` at runtime to form the `data-theme` attribute, e.g.
+   * `data-theme="catppuccin-dark"`.
+   */
+  themeFamily: ThemeFamily;
   uiScale: number; // 75–150, default 100
   /**
    * Source of truth for the multi-row ticker layout. The number of
@@ -421,7 +499,8 @@ const DEFAULT_TICKER_LAYOUT: TickerLayout = {
 };
 
 const DEFAULT_APPEARANCE: AppearancePrefs = {
-  theme: "system",
+  themeFamily: "scrollr",
+  themeMode: "system",
   uiScale: 100,
   tickerLayout: { rows: [{ sources: [] }] },
   fontWeight: "normal",
@@ -1025,14 +1104,34 @@ export function loadPrefs(): AppPreferences {
     // truth; persisting a derived scalar alongside it caused the
     // Home/Settings drift this refactor was written to kill.
     const savedAppearance = source.appearance as
-      | (Partial<AppearancePrefs> & { tickerRows?: unknown })
+      | (Partial<AppearancePrefs> & {
+          tickerRows?: unknown;
+          theme?: unknown;
+        })
       | undefined;
-    const { tickerRows: _legacyTickerRows, ...appearanceRest } =
-      savedAppearance ?? {};
+    // Strip legacy fields:
+    //  - `tickerRows` was a derived scalar from pre-multi-row builds.
+    //  - `theme` was the pre-multi-theme color-mode field; the
+    //    migration helper below folds it into themeMode + themeFamily.
+    const {
+      tickerRows: _legacyTickerRows,
+      theme: _legacyTheme,
+      themeFamily: _savedFamily,
+      themeMode: _savedMode,
+      ...appearanceRest
+    } = savedAppearance ?? {};
     void _legacyTickerRows; // intentionally discarded
+    void _legacyTheme; // folded into themeMode below
+    void _savedFamily; // re-applied via migrateAppearanceTheme
+    void _savedMode; // re-applied via migrateAppearanceTheme
+    const { themeFamily, themeMode } = migrateAppearanceTheme(
+      savedAppearance as Record<string, unknown> | undefined,
+    );
     const mergedAppearance: AppearancePrefs = {
       ...DEFAULT_APPEARANCE,
       ...appearanceRest,
+      themeFamily,
+      themeMode,
       tickerLayout: layoutResult.layout,
     };
     const merged: AppPreferences = {
@@ -1127,15 +1226,71 @@ export function resetAll(): AppPreferences {
 
 // ── Theme resolution ────────────────────────────────────────
 
-/** Resolve the effective theme from a Theme preference value.
+/** Resolve a `ThemeMode` to a concrete light/dark value.
  *  "system" follows the OS preference; otherwise returns as-is. */
-export function resolveTheme(theme: Theme): "light" | "dark" {
-  if (theme === "system") {
+export function resolveThemeMode(mode: ThemeMode): "light" | "dark" {
+  if (mode === "system") {
     return window.matchMedia("(prefers-color-scheme: dark)").matches
       ? "dark"
       : "light";
   }
-  return theme;
+  return mode;
+}
+
+/**
+ * Build the `data-theme` attribute value for a family + resolved mode.
+ *
+ *   resolveThemeName("catppuccin", "dark") → "catppuccin-dark"
+ *   resolveThemeName("scrollr", "light")   → "scrollr-light"
+ */
+export function resolveThemeName(
+  family: ThemeFamily,
+  resolvedMode: "light" | "dark",
+): string {
+  return `${family}-${resolvedMode}`;
+}
+
+/**
+ * @deprecated Use `resolveThemeMode` instead.
+ * Kept as a thin alias so older imports continue to compile during
+ * the multi-theme rollout. Will be removed once all call sites are
+ * migrated.
+ */
+export function resolveTheme(mode: ThemeMode): "light" | "dark" {
+  return resolveThemeMode(mode);
+}
+
+/**
+ * Migrate a saved appearance blob to the new themeFamily + themeMode
+ * shape. Existing builds wrote `{ theme: "light" | "dark" | "system" }`;
+ * the new shape splits that into `themeFamily` + `themeMode`.
+ *
+ * Rules:
+ *   - Legacy `theme` → `themeMode`, `themeFamily` defaults to "scrollr"
+ *   - Unknown / missing `themeFamily` → "scrollr"
+ *   - Unknown / missing `themeMode`   → "system"
+ *
+ * This function only normalizes the theme fields; the caller is still
+ * responsible for merging the rest of AppearancePrefs (tickerLayout,
+ * uiScale, fontWeight, highContrast) against DEFAULT_APPEARANCE.
+ */
+export function migrateAppearanceTheme(
+  saved: Record<string, unknown> | undefined,
+): { themeFamily: ThemeFamily; themeMode: ThemeMode } {
+  if (!saved) {
+    return { themeFamily: "scrollr", themeMode: "system" };
+  }
+  const family = isThemeFamily(saved.themeFamily)
+    ? saved.themeFamily
+    : "scrollr";
+  // Prefer the new field; fall back to the legacy `theme` field.
+  let mode: ThemeMode = "system";
+  if (isThemeMode(saved.themeMode)) {
+    mode = saved.themeMode;
+  } else if (isThemeMode(saved.theme)) {
+    mode = saved.theme;
+  }
+  return { themeFamily: family, themeMode: mode };
 }
 
 // ── Derived values ──────────────────────────────────────────────

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -50,7 +50,7 @@ import {
   loadPrefs,
   savePrefs,
   consumeTickerLayoutChanged,
-  resolveTheme,
+  resolveThemeMode,
 } from "../preferences";
 import type { AppPreferences } from "../preferences";
 import {
@@ -468,7 +468,8 @@ function RootLayout() {
   // Apply theme + UI scale
   useTheme({
     shellId: "app-shell",
-    theme: prefs.appearance.theme,
+    themeFamily: prefs.appearance.themeFamily,
+    themeMode: prefs.appearance.themeMode,
     uiScale: prefs.appearance.uiScale,
     fontWeight: prefs.appearance.fontWeight,
     highContrast: prefs.appearance.highContrast,
@@ -611,14 +612,21 @@ function RootLayout() {
         return;
       }
 
-      // Ctrl+Shift+T → cycle theme
+      // Ctrl+Shift+T → cycle color mode (theme family stays put)
       if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "T") {
         e.preventDefault();
-        const cycle: Record<string, string> = { dark: "light", light: "system", system: "dark" };
-        const nextTheme = cycle[prefs.appearance.theme] ?? "dark";
+        const cycle: Record<string, "light" | "dark" | "system"> = {
+          dark: "light",
+          light: "system",
+          system: "dark",
+        };
+        const nextMode = cycle[prefs.appearance.themeMode] ?? "dark";
         const next = {
           ...prefs,
-          appearance: { ...prefs.appearance, theme: nextTheme as AppPreferences["appearance"]["theme"] },
+          appearance: {
+            ...prefs.appearance,
+            themeMode: nextMode,
+          },
         };
         setPrefs(next);
         savePrefs(next);
@@ -728,9 +736,10 @@ function RootLayout() {
 
   // ── Render ──────────────────────────────────────────────────
 
-  // Resolve theme for portal-based components (Toaster) that don't
-  // inherit the shell's data-theme attribute.
-  const resolvedToasterTheme = resolveTheme(prefs.appearance.theme);
+  // Resolve color mode for portal-based components (Toaster) that
+  // don't inherit the shell's data-theme attribute. Toasts only need
+  // light/dark, not the full family — Sonner uses neutral surfaces.
+  const resolvedToasterTheme = resolveThemeMode(prefs.appearance.themeMode);
 
   return (
     <div

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -86,12 +86,38 @@
   --ease-out-soft: cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
-/* ── Light theme ──────────────────────────────────────────────── */
-/* Dark is the default @theme. Light overrides via data-theme attribute.
-   Color palette matches the website's light mode. */
+/* ── Theme palettes ─────────────────────────────────────────────
+   Default @theme above is the Scrollr Dark palette. Each named theme
+   family overrides the surface / fg / accent / shadow tokens via
+   `[data-theme="<family>-<mode>"]`. All palettes share the same token
+   set so components never have to know which theme is active.
 
-#desktop-shell[data-theme="light"],
-#app-shell[data-theme="light"] {
+   Naming:
+     scrollr-dark   (default, identical to @theme)
+     scrollr-light
+     catppuccin-dark   (Mocha)
+     catppuccin-light  (Latte)
+     dracula-dark      (canonical Dracula)
+     dracula-light     (Scrollr-adapted; Dracula is dark-first)
+     tokyo-night-dark  (Tokyo Night)
+     tokyo-night-light (Tokyo Night Day)
+     nord-dark
+     nord-light
+     gruvbox-dark      (Gruvbox Dark Medium)
+     gruvbox-light     (Gruvbox Light Medium)
+     solarized-dark
+     solarized-light
+     rose-pine-dark    (Rose Pine)
+     rose-pine-light   (Rose Pine Dawn)
+     one-dark          (Atom One Dark)
+     one-light         (Atom One Light)
+     everforest-dark   (Everforest Dark Medium)
+     everforest-light  (Everforest Light Medium)
+*/
+
+/* ── Scrollr Light ───────────────────────────────────────────── */
+#desktop-shell[data-theme="scrollr-light"],
+#app-shell[data-theme="scrollr-light"] {
   --color-surface: #ffffff;
   --color-surface-2: #f6f7fb;
   --color-surface-hover: #eef0f6;
@@ -124,6 +150,735 @@
   --shadow-soft-md: 0 2px 6px rgba(0, 0, 0, 0.04), 0 4px 16px rgba(0, 0, 0, 0.08);
 }
 
+/* ── Catppuccin Mocha (dark) ─────────────────────────────────── */
+#desktop-shell[data-theme="catppuccin-dark"],
+#app-shell[data-theme="catppuccin-dark"] {
+  --color-surface: #1e1e2e;          /* base */
+  --color-surface-2: #181825;        /* mantle */
+  --color-surface-hover: #313244;    /* surface0 */
+  --color-surface-3: #11111b;        /* crust */
+
+  --color-base-100: #1e1e2e;
+  --color-base-150: #181825;
+  --color-base-200: #313244;
+  --color-base-250: #45475a;         /* surface1 */
+  --color-base-300: #585b70;         /* surface2 */
+  --color-base-350: #6c7086;         /* overlay0 */
+  --color-base-400: #7f849c;         /* overlay1 */
+  --color-base-content: #cdd6f4;
+
+  --color-edge: #313244;
+  --color-edge-2: #45475a;
+
+  --color-primary: #a6e3a1;          /* green */
+  --color-accent: #a6e3a1;
+  --color-secondary: #f38ba8;        /* red */
+  --color-info: #89dceb;             /* sky */
+  --color-accent-purple: #cba6f7;    /* mauve */
+
+  --color-fg: #cdd6f4;               /* text */
+  --color-fg-2: #bac2de;             /* subtext1 */
+  --color-fg-3: #a6adc8;             /* subtext0 */
+  --color-fg-4: #7f849c;             /* overlay1 */
+
+  --color-up: #a6e3a1;
+  --color-down: #f38ba8;
+  --color-success: #a6e3a1;
+  --color-error: #f38ba8;
+  --color-live: #f38ba8;
+  --color-warn: #f9e2af;
+  --color-warning: #f9e2af;
+}
+
+/* ── Catppuccin Latte (light) ────────────────────────────────── */
+#desktop-shell[data-theme="catppuccin-light"],
+#app-shell[data-theme="catppuccin-light"] {
+  --color-surface: #eff1f5;          /* base */
+  --color-surface-2: #e6e9ef;        /* mantle */
+  --color-surface-hover: #ccd0da;    /* surface0 */
+  --color-surface-3: #dce0e8;        /* crust */
+
+  --color-base-100: #eff1f5;
+  --color-base-150: #e6e9ef;
+  --color-base-200: #ccd0da;
+  --color-base-250: #bcc0cc;         /* surface1 */
+  --color-base-300: #acb0be;         /* surface2 */
+  --color-base-350: #9ca0b0;         /* overlay0 */
+  --color-base-400: #8c8fa1;         /* overlay1 */
+  --color-base-content: #4c4f69;
+
+  --color-edge: #ccd0da;
+  --color-edge-2: #bcc0cc;
+
+  --color-primary: #40a02b;          /* green */
+  --color-accent: #40a02b;
+  --color-secondary: #d20f39;        /* red */
+  --color-info: #04a5e5;             /* sky */
+  --color-accent-purple: #8839ef;    /* mauve */
+
+  --color-fg: #4c4f69;               /* text */
+  --color-fg-2: #5c5f77;             /* subtext1 */
+  --color-fg-3: #6c6f85;             /* subtext0 */
+  --color-fg-4: #8c8fa1;             /* overlay1 */
+
+  --color-up: #40a02b;
+  --color-down: #d20f39;
+  --color-success: #40a02b;
+  --color-error: #d20f39;
+  --color-live: #d20f39;
+  --color-warn: #df8e1d;
+  --color-warning: #df8e1d;
+}
+
+/* ── Dracula (dark) ──────────────────────────────────────────── */
+#desktop-shell[data-theme="dracula-dark"],
+#app-shell[data-theme="dracula-dark"] {
+  --color-surface: #282a36;          /* background */
+  --color-surface-2: #21222c;
+  --color-surface-hover: #44475a;    /* current line */
+  --color-surface-3: #1e1f29;
+
+  --color-base-100: #282a36;
+  --color-base-150: #21222c;
+  --color-base-200: #44475a;
+  --color-base-250: #565973;
+  --color-base-300: #6272a4;         /* comment */
+  --color-base-350: #7783b4;
+  --color-base-400: #8c95c2;
+  --color-base-content: #f8f8f2;
+
+  --color-edge: #44475a;
+  --color-edge-2: #6272a4;
+
+  --color-primary: #50fa7b;          /* green */
+  --color-accent: #50fa7b;
+  --color-secondary: #ff5555;        /* red */
+  --color-info: #8be9fd;             /* cyan */
+  --color-accent-purple: #bd93f9;    /* purple */
+
+  --color-fg: #f8f8f2;               /* foreground */
+  --color-fg-2: #d8d8d2;
+  --color-fg-3: #a8a8a2;
+  --color-fg-4: #6272a4;             /* comment */
+
+  --color-up: #50fa7b;
+  --color-down: #ff5555;
+  --color-success: #50fa7b;
+  --color-error: #ff5555;
+  --color-live: #ff5555;
+  --color-warn: #f1fa8c;
+  --color-warning: #f1fa8c;
+}
+
+/* ── Dracula (light, Scrollr-adapted) ────────────────────────── */
+#desktop-shell[data-theme="dracula-light"],
+#app-shell[data-theme="dracula-light"] {
+  --color-surface: #f8f8f2;
+  --color-surface-2: #efefe6;
+  --color-surface-hover: #e4e4d8;
+  --color-surface-3: #ececdf;
+
+  --color-base-100: #f8f8f2;
+  --color-base-150: #efefe6;
+  --color-base-200: #e4e4d8;
+  --color-base-250: #d4d4c5;
+  --color-base-300: #c2c2b2;
+  --color-base-350: #a8a89a;
+  --color-base-400: #8e8e82;
+  --color-base-content: #282a36;
+
+  --color-edge: #c2c2b2;
+  --color-edge-2: #a8a89a;
+
+  --color-primary: #2a9d6f;
+  --color-accent: #2a9d6f;
+  --color-secondary: #c43a3a;
+  --color-info: #2a8aa5;
+  --color-accent-purple: #7a52d8;
+
+  --color-fg: #282a36;
+  --color-fg-2: #44475a;
+  --color-fg-3: #6272a4;
+  --color-fg-4: #828bbc;
+
+  --color-up: #2a9d6f;
+  --color-down: #c43a3a;
+  --color-success: #2a9d6f;
+  --color-error: #c43a3a;
+  --color-live: #c43a3a;
+  --color-warn: #b88c1a;
+  --color-warning: #b88c1a;
+}
+
+/* ── Tokyo Night (dark) ──────────────────────────────────────── */
+#desktop-shell[data-theme="tokyo-night-dark"],
+#app-shell[data-theme="tokyo-night-dark"] {
+  --color-surface: #1a1b26;
+  --color-surface-2: #16161e;
+  --color-surface-hover: #24283b;
+  --color-surface-3: #13131a;
+
+  --color-base-100: #1a1b26;
+  --color-base-150: #16161e;
+  --color-base-200: #24283b;
+  --color-base-250: #2f334d;
+  --color-base-300: #414868;
+  --color-base-350: #545c7e;
+  --color-base-400: #737aa2;
+  --color-base-content: #c0caf5;
+
+  --color-edge: #2f334d;
+  --color-edge-2: #414868;
+
+  --color-primary: #7aa2f7;          /* blue */
+  --color-accent: #7aa2f7;
+  --color-secondary: #f7768e;        /* red */
+  --color-info: #7dcfff;             /* cyan */
+  --color-accent-purple: #bb9af7;    /* magenta */
+
+  --color-fg: #c0caf5;
+  --color-fg-2: #a9b1d6;
+  --color-fg-3: #9aa5ce;
+  --color-fg-4: #565f89;
+
+  --color-up: #9ece6a;
+  --color-down: #f7768e;
+  --color-success: #9ece6a;
+  --color-error: #f7768e;
+  --color-live: #f7768e;
+  --color-warn: #e0af68;
+  --color-warning: #e0af68;
+}
+
+/* ── Tokyo Night Day (light) ─────────────────────────────────── */
+#desktop-shell[data-theme="tokyo-night-light"],
+#app-shell[data-theme="tokyo-night-light"] {
+  --color-surface: #e1e2e7;
+  --color-surface-2: #d5d6dc;
+  --color-surface-hover: #c4c8da;
+  --color-surface-3: #cbcdd4;
+
+  --color-base-100: #e1e2e7;
+  --color-base-150: #d5d6dc;
+  --color-base-200: #c4c8da;
+  --color-base-250: #b4b8cf;
+  --color-base-300: #a1a6c5;
+  --color-base-350: #8990af;
+  --color-base-400: #6c728c;
+  --color-base-content: #3760bf;
+
+  --color-edge: #c4c8da;
+  --color-edge-2: #b4b8cf;
+
+  --color-primary: #2e7de9;
+  --color-accent: #2e7de9;
+  --color-secondary: #f52a65;
+  --color-info: #007197;
+  --color-accent-purple: #9854f1;
+
+  --color-fg: #3760bf;
+  --color-fg-2: #4c5079;
+  --color-fg-3: #6172b0;
+  --color-fg-4: #848cb5;
+
+  --color-up: #587539;
+  --color-down: #f52a65;
+  --color-success: #587539;
+  --color-error: #f52a65;
+  --color-live: #f52a65;
+  --color-warn: #8c6c3e;
+  --color-warning: #8c6c3e;
+}
+
+/* ── Nord (dark) ─────────────────────────────────────────────── */
+#desktop-shell[data-theme="nord-dark"],
+#app-shell[data-theme="nord-dark"] {
+  --color-surface: #2e3440;          /* nord0 */
+  --color-surface-2: #292e39;
+  --color-surface-hover: #3b4252;    /* nord1 */
+  --color-surface-3: #242933;
+
+  --color-base-100: #2e3440;
+  --color-base-150: #292e39;
+  --color-base-200: #3b4252;
+  --color-base-250: #434c5e;         /* nord2 */
+  --color-base-300: #4c566a;         /* nord3 */
+  --color-base-350: #5e6779;
+  --color-base-400: #6f7889;
+  --color-base-content: #eceff4;
+
+  --color-edge: #3b4252;
+  --color-edge-2: #4c566a;
+
+  --color-primary: #88c0d0;          /* nord8 */
+  --color-accent: #88c0d0;
+  --color-secondary: #bf616a;        /* nord11 */
+  --color-info: #81a1c1;             /* nord9 */
+  --color-accent-purple: #b48ead;    /* nord15 */
+
+  --color-fg: #eceff4;               /* nord6 */
+  --color-fg-2: #e5e9f0;             /* nord5 */
+  --color-fg-3: #d8dee9;             /* nord4 */
+  --color-fg-4: #8d96a8;
+
+  --color-up: #a3be8c;               /* nord14 */
+  --color-down: #bf616a;
+  --color-success: #a3be8c;
+  --color-error: #bf616a;
+  --color-live: #bf616a;
+  --color-warn: #ebcb8b;             /* nord13 */
+  --color-warning: #ebcb8b;
+}
+
+/* ── Nord (light, Snow Storm) ────────────────────────────────── */
+#desktop-shell[data-theme="nord-light"],
+#app-shell[data-theme="nord-light"] {
+  --color-surface: #eceff4;          /* nord6 */
+  --color-surface-2: #e5e9f0;        /* nord5 */
+  --color-surface-hover: #d8dee9;    /* nord4 */
+  --color-surface-3: #dfe3ec;
+
+  --color-base-100: #eceff4;
+  --color-base-150: #e5e9f0;
+  --color-base-200: #d8dee9;
+  --color-base-250: #c8d0dd;
+  --color-base-300: #b6bfce;
+  --color-base-350: #9aa3b4;
+  --color-base-400: #7d8595;
+  --color-base-content: #2e3440;
+
+  --color-edge: #d8dee9;
+  --color-edge-2: #c8d0dd;
+
+  --color-primary: #5e81ac;          /* nord10 */
+  --color-accent: #5e81ac;
+  --color-secondary: #bf616a;
+  --color-info: #5d8eaf;
+  --color-accent-purple: #9c6c8d;
+
+  --color-fg: #2e3440;
+  --color-fg-2: #434c5e;
+  --color-fg-3: #4c566a;
+  --color-fg-4: #6f7889;
+
+  --color-up: #6a8857;
+  --color-down: #bf616a;
+  --color-success: #6a8857;
+  --color-error: #bf616a;
+  --color-live: #bf616a;
+  --color-warn: #b08d3b;
+  --color-warning: #b08d3b;
+}
+
+/* ── Gruvbox Dark Medium ─────────────────────────────────────── */
+#desktop-shell[data-theme="gruvbox-dark"],
+#app-shell[data-theme="gruvbox-dark"] {
+  --color-surface: #282828;          /* bg0 */
+  --color-surface-2: #1d2021;        /* bg0_h */
+  --color-surface-hover: #3c3836;    /* bg1 */
+  --color-surface-3: #1d2021;
+
+  --color-base-100: #282828;
+  --color-base-150: #32302f;
+  --color-base-200: #3c3836;
+  --color-base-250: #504945;         /* bg2 */
+  --color-base-300: #665c54;         /* bg3 */
+  --color-base-350: #7c6f64;         /* bg4 */
+  --color-base-400: #928374;         /* gray */
+  --color-base-content: #ebdbb2;
+
+  --color-edge: #3c3836;
+  --color-edge-2: #504945;
+
+  --color-primary: #b8bb26;          /* bright green */
+  --color-accent: #b8bb26;
+  --color-secondary: #fb4934;        /* bright red */
+  --color-info: #83a598;             /* bright blue */
+  --color-accent-purple: #d3869b;    /* bright purple */
+
+  --color-fg: #ebdbb2;               /* fg */
+  --color-fg-2: #d5c4a1;             /* fg2 */
+  --color-fg-3: #bdae93;             /* fg3 */
+  --color-fg-4: #a89984;             /* fg4 */
+
+  --color-up: #b8bb26;
+  --color-down: #fb4934;
+  --color-success: #b8bb26;
+  --color-error: #fb4934;
+  --color-live: #fb4934;
+  --color-warn: #fabd2f;             /* bright yellow */
+  --color-warning: #fabd2f;
+}
+
+/* ── Gruvbox Light Medium ────────────────────────────────────── */
+#desktop-shell[data-theme="gruvbox-light"],
+#app-shell[data-theme="gruvbox-light"] {
+  --color-surface: #fbf1c7;          /* bg0 */
+  --color-surface-2: #f9f5d7;        /* bg0_h */
+  --color-surface-hover: #ebdbb2;    /* bg1 */
+  --color-surface-3: #f2e5bc;
+
+  --color-base-100: #fbf1c7;
+  --color-base-150: #f2e5bc;
+  --color-base-200: #ebdbb2;
+  --color-base-250: #d5c4a1;         /* bg2 */
+  --color-base-300: #bdae93;         /* bg3 */
+  --color-base-350: #a89984;         /* bg4 */
+  --color-base-400: #928374;         /* gray */
+  --color-base-content: #3c3836;
+
+  --color-edge: #ebdbb2;
+  --color-edge-2: #d5c4a1;
+
+  --color-primary: #79740e;          /* faded green */
+  --color-accent: #79740e;
+  --color-secondary: #9d0006;        /* faded red */
+  --color-info: #076678;             /* faded blue */
+  --color-accent-purple: #8f3f71;    /* faded purple */
+
+  --color-fg: #3c3836;
+  --color-fg-2: #504945;
+  --color-fg-3: #665c54;
+  --color-fg-4: #7c6f64;
+
+  --color-up: #79740e;
+  --color-down: #9d0006;
+  --color-success: #79740e;
+  --color-error: #9d0006;
+  --color-live: #9d0006;
+  --color-warn: #b57614;             /* faded yellow */
+  --color-warning: #b57614;
+}
+
+/* ── Solarized (dark) ────────────────────────────────────────── */
+#desktop-shell[data-theme="solarized-dark"],
+#app-shell[data-theme="solarized-dark"] {
+  --color-surface: #002b36;          /* base03 */
+  --color-surface-2: #073642;        /* base02 */
+  --color-surface-hover: #094352;
+  --color-surface-3: #00212b;
+
+  --color-base-100: #002b36;
+  --color-base-150: #03303b;
+  --color-base-200: #073642;
+  --color-base-250: #0e4250;
+  --color-base-300: #586e75;         /* base01 */
+  --color-base-350: #657b83;         /* base00 */
+  --color-base-400: #839496;         /* base0 */
+  --color-base-content: #fdf6e3;
+
+  --color-edge: #073642;
+  --color-edge-2: #586e75;
+
+  --color-primary: #2aa198;          /* cyan */
+  --color-accent: #2aa198;
+  --color-secondary: #dc322f;        /* red */
+  --color-info: #268bd2;             /* blue */
+  --color-accent-purple: #6c71c4;    /* violet */
+
+  --color-fg: #93a1a1;               /* base1 */
+  --color-fg-2: #839496;             /* base0 */
+  --color-fg-3: #657b83;             /* base00 */
+  --color-fg-4: #586e75;             /* base01 */
+
+  --color-up: #859900;               /* green */
+  --color-down: #dc322f;
+  --color-success: #859900;
+  --color-error: #dc322f;
+  --color-live: #dc322f;
+  --color-warn: #b58900;             /* yellow */
+  --color-warning: #b58900;
+}
+
+/* ── Solarized (light) ───────────────────────────────────────── */
+#desktop-shell[data-theme="solarized-light"],
+#app-shell[data-theme="solarized-light"] {
+  --color-surface: #fdf6e3;          /* base3 */
+  --color-surface-2: #eee8d5;        /* base2 */
+  --color-surface-hover: #e6e0cc;
+  --color-surface-3: #f5efdc;
+
+  --color-base-100: #fdf6e3;
+  --color-base-150: #f5efdc;
+  --color-base-200: #eee8d5;
+  --color-base-250: #ddd6c1;
+  --color-base-300: #93a1a1;         /* base1 */
+  --color-base-350: #839496;         /* base0 */
+  --color-base-400: #657b83;         /* base00 */
+  --color-base-content: #002b36;
+
+  --color-edge: #eee8d5;
+  --color-edge-2: #93a1a1;
+
+  --color-primary: #2aa198;
+  --color-accent: #2aa198;
+  --color-secondary: #dc322f;
+  --color-info: #268bd2;
+  --color-accent-purple: #6c71c4;
+
+  --color-fg: #586e75;               /* base01 */
+  --color-fg-2: #657b83;             /* base00 */
+  --color-fg-3: #839496;             /* base0 */
+  --color-fg-4: #93a1a1;             /* base1 */
+
+  --color-up: #859900;
+  --color-down: #dc322f;
+  --color-success: #859900;
+  --color-error: #dc322f;
+  --color-live: #dc322f;
+  --color-warn: #b58900;
+  --color-warning: #b58900;
+}
+
+/* ── Rose Pine (dark, "main") ────────────────────────────────── */
+/* Palette verified against rose-pine/neovim lua/rose-pine/palette.lua */
+#desktop-shell[data-theme="rose-pine-dark"],
+#app-shell[data-theme="rose-pine-dark"] {
+  --color-surface: #191724;          /* base */
+  --color-surface-2: #1f1d2e;        /* surface */
+  --color-surface-hover: #26233a;    /* overlay */
+  --color-surface-3: #16141f;        /* _nc */
+
+  --color-base-100: #191724;         /* base */
+  --color-base-150: #1f1d2e;         /* surface */
+  --color-base-200: #26233a;         /* overlay */
+  --color-base-250: #21202e;         /* highlight_low */
+  --color-base-300: #403d52;         /* highlight_med */
+  --color-base-350: #524f67;         /* highlight_high */
+  --color-base-400: #6e6a86;         /* muted */
+  --color-base-content: #e0def4;     /* text */
+
+  --color-edge: #26233a;             /* overlay */
+  --color-edge-2: #403d52;           /* highlight_med */
+
+  --color-primary: #c4a7e7;          /* iris */
+  --color-accent: #c4a7e7;
+  --color-secondary: #eb6f92;        /* love */
+  --color-info: #9ccfd8;             /* foam */
+  --color-accent-purple: #c4a7e7;
+
+  --color-fg: #e0def4;               /* text */
+  --color-fg-2: #908caa;             /* subtle */
+  --color-fg-3: #6e6a86;             /* muted */
+  --color-fg-4: #524f67;             /* highlight_high */
+
+  --color-up: #31748f;               /* pine */
+  --color-down: #eb6f92;             /* love */
+  --color-success: #31748f;
+  --color-error: #eb6f92;
+  --color-live: #eb6f92;
+  --color-warn: #f6c177;             /* gold */
+  --color-warning: #f6c177;
+}
+
+/* ── Rose Pine Dawn (light) ──────────────────────────────────── */
+/* Palette verified against rose-pine/neovim lua/rose-pine/palette.lua
+   (Dawn variant). `fg` uses the website spec value #575279 rather than
+   the neovim port's darker #464261 — the lighter shade preserves our
+   fg-2/fg-3/fg-4 hierarchy. */
+#desktop-shell[data-theme="rose-pine-light"],
+#app-shell[data-theme="rose-pine-light"] {
+  --color-surface: #faf4ed;          /* base */
+  --color-surface-2: #fffaf3;        /* surface */
+  --color-surface-hover: #f2e9e1;    /* overlay */
+  --color-surface-3: #f8f0e7;        /* _nc */
+
+  --color-base-100: #faf4ed;         /* base */
+  --color-base-150: #fffaf3;         /* surface */
+  --color-base-200: #f2e9e1;         /* overlay */
+  --color-base-250: #f4ede8;         /* highlight_low */
+  --color-base-300: #dfdad9;         /* highlight_med */
+  --color-base-350: #cecacd;         /* highlight_high */
+  --color-base-400: #9893a5;         /* muted */
+  --color-base-content: #575279;     /* text */
+
+  --color-edge: #f2e9e1;             /* overlay */
+  --color-edge-2: #dfdad9;           /* highlight_med */
+
+  --color-primary: #907aa9;          /* iris */
+  --color-accent: #907aa9;
+  --color-secondary: #b4637a;        /* love */
+  --color-info: #56949f;             /* foam */
+  --color-accent-purple: #907aa9;
+
+  --color-fg: #575279;               /* text (website spec) */
+  --color-fg-2: #797593;             /* subtle */
+  --color-fg-3: #9893a5;             /* muted */
+  --color-fg-4: #b5b0c4;             /* between muted + highlight_high */
+
+  --color-up: #286983;               /* pine */
+  --color-down: #b4637a;             /* love */
+  --color-success: #286983;
+  --color-error: #b4637a;
+  --color-live: #b4637a;
+  --color-warn: #ea9d34;             /* gold */
+  --color-warning: #ea9d34;
+}
+
+/* ── One Dark (Atom) ─────────────────────────────────────────── */
+#desktop-shell[data-theme="one-dark"],
+#app-shell[data-theme="one-dark"] {
+  --color-surface: #282c34;
+  --color-surface-2: #21252b;
+  --color-surface-hover: #2c313a;
+  --color-surface-3: #1d2025;
+
+  --color-base-100: #282c34;
+  --color-base-150: #23272e;
+  --color-base-200: #2c313a;
+  --color-base-250: #353b45;
+  --color-base-300: #3e4451;
+  --color-base-350: #4b5263;
+  --color-base-400: #5c6370;
+  --color-base-content: #abb2bf;
+
+  --color-edge: #3e4451;
+  --color-edge-2: #4b5263;
+
+  --color-primary: #61afef;          /* blue */
+  --color-accent: #61afef;
+  --color-secondary: #e06c75;        /* red */
+  --color-info: #56b6c2;             /* cyan */
+  --color-accent-purple: #c678dd;    /* purple */
+
+  --color-fg: #abb2bf;
+  --color-fg-2: #9da5b4;
+  --color-fg-3: #828997;
+  --color-fg-4: #5c6370;
+
+  --color-up: #98c379;               /* green */
+  --color-down: #e06c75;
+  --color-success: #98c379;
+  --color-error: #e06c75;
+  --color-live: #e06c75;
+  --color-warn: #e5c07b;             /* yellow */
+  --color-warning: #e5c07b;
+}
+
+/* ── One Light (Atom) ────────────────────────────────────────── */
+#desktop-shell[data-theme="one-light"],
+#app-shell[data-theme="one-light"] {
+  --color-surface: #fafafa;
+  --color-surface-2: #f0f0f1;
+  --color-surface-hover: #e5e5e6;
+  --color-surface-3: #f4f4f5;
+
+  --color-base-100: #fafafa;
+  --color-base-150: #f4f4f5;
+  --color-base-200: #f0f0f1;
+  --color-base-250: #e5e5e6;
+  --color-base-300: #d4d4d6;
+  --color-base-350: #b8b8ba;
+  --color-base-400: #a0a1a7;
+  --color-base-content: #383a42;
+
+  --color-edge: #e5e5e6;
+  --color-edge-2: #d4d4d6;
+
+  --color-primary: #4078f2;          /* blue */
+  --color-accent: #4078f2;
+  --color-secondary: #e45649;        /* red */
+  --color-info: #0184bc;             /* cyan */
+  --color-accent-purple: #a626a4;    /* purple */
+
+  --color-fg: #383a42;
+  --color-fg-2: #4d4f57;
+  --color-fg-3: #696c77;
+  --color-fg-4: #a0a1a7;
+
+  --color-up: #50a14f;               /* green */
+  --color-down: #e45649;
+  --color-success: #50a14f;
+  --color-error: #e45649;
+  --color-live: #e45649;
+  --color-warn: #c18401;             /* yellow */
+  --color-warning: #c18401;
+}
+
+/* ── Everforest Dark Medium ──────────────────────────────────── */
+/* Palette verified against sainnhe/everforest autoload/everforest.vim
+   (background = 'medium'). */
+#desktop-shell[data-theme="everforest-dark"],
+#app-shell[data-theme="everforest-dark"] {
+  --color-surface: #2d353b;          /* bg0 */
+  --color-surface-2: #232a2e;        /* bg_dim */
+  --color-surface-hover: #343f44;    /* bg1 */
+  --color-surface-3: #232a2e;        /* bg_dim */
+
+  --color-base-100: #2d353b;         /* bg0 */
+  --color-base-150: #232a2e;         /* bg_dim */
+  --color-base-200: #343f44;         /* bg1 */
+  --color-base-250: #3d484d;         /* bg2 */
+  --color-base-300: #475258;         /* bg3 */
+  --color-base-350: #4f585e;         /* bg4 */
+  --color-base-400: #56635f;         /* bg5 */
+  --color-base-content: #d3c6aa;     /* fg */
+
+  --color-edge: #343f44;             /* bg1 */
+  --color-edge-2: #475258;           /* bg3 */
+
+  --color-primary: #a7c080;          /* green */
+  --color-accent: #a7c080;
+  --color-secondary: #e67e80;        /* red */
+  --color-info: #7fbbb3;             /* blue */
+  --color-accent-purple: #d699b6;    /* purple */
+
+  --color-fg: #d3c6aa;               /* fg */
+  --color-fg-2: #9da9a0;             /* grey2 (lightest grey) */
+  --color-fg-3: #859289;             /* grey1 */
+  --color-fg-4: #7a8478;             /* grey0 */
+
+  --color-up: #a7c080;               /* green */
+  --color-down: #e67e80;             /* red */
+  --color-success: #a7c080;
+  --color-error: #e67e80;
+  --color-live: #e67e80;
+  --color-warn: #dbbc7f;             /* yellow */
+  --color-warning: #dbbc7f;
+}
+
+/* ── Everforest Light Medium ─────────────────────────────────── */
+/* Palette verified against sainnhe/everforest autoload/everforest.vim
+   (background = 'medium'). */
+#desktop-shell[data-theme="everforest-light"],
+#app-shell[data-theme="everforest-light"] {
+  --color-surface: #fdf6e3;          /* bg0 */
+  --color-surface-2: #efebd4;        /* bg_dim */
+  --color-surface-hover: #f4f0d9;    /* bg1 */
+  --color-surface-3: #efebd4;        /* bg_dim */
+
+  --color-base-100: #fdf6e3;         /* bg0 */
+  --color-base-150: #efebd4;         /* bg_dim */
+  --color-base-200: #f4f0d9;         /* bg1 */
+  --color-base-250: #efebd4;         /* bg2 */
+  --color-base-300: #e6e2cc;         /* bg3 */
+  --color-base-350: #e0dcc7;         /* bg4 */
+  --color-base-400: #bdc3af;         /* bg5 */
+  --color-base-content: #5c6a72;     /* fg */
+
+  --color-edge: #e6e2cc;             /* bg3 */
+  --color-edge-2: #e0dcc7;           /* bg4 */
+
+  --color-primary: #8da101;          /* green */
+  --color-accent: #8da101;
+  --color-secondary: #f85552;        /* red */
+  --color-info: #3a94c5;             /* blue */
+  --color-accent-purple: #df69ba;    /* purple */
+
+  --color-fg: #5c6a72;               /* fg */
+  --color-fg-2: #829181;             /* grey2 */
+  --color-fg-3: #939f91;             /* grey1 */
+  --color-fg-4: #a6b0a0;             /* grey0 */
+
+  --color-up: #8da101;               /* green */
+  --color-down: #f85552;             /* red */
+  --color-success: #8da101;
+  --color-error: #f85552;
+  --color-live: #f85552;
+  --color-warn: #dfa000;             /* yellow */
+  --color-warning: #dfa000;
+}
+
 /* ── Font weight boost ────────────────────────────────────────── */
 /* Applied via useTheme hook to the shell element */
 .font-weight-medium {
@@ -143,16 +898,17 @@
 }
 
 /* ── High contrast text ──────────────────────────────────────── */
-/* Bumps muted text tiers to be more readable */
-.high-contrast[data-theme="dark"] {
-  --color-fg-2: #d0d0dc;
-  --color-fg-3: #b4b4c4;
-  --color-fg-4: #9a9aac;
+/* Bumps muted text tiers to be more readable. Matches any theme family
+   by suffix: `*-dark` for dark variants, `*-light` for light variants. */
+.high-contrast[data-theme$="-dark"] {
+  --color-fg-2: color-mix(in srgb, var(--color-fg) 92%, white);
+  --color-fg-3: color-mix(in srgb, var(--color-fg) 80%, white);
+  --color-fg-4: color-mix(in srgb, var(--color-fg) 68%, white);
 }
 
-.high-contrast[data-theme="light"] {
-  --color-fg-3: #555568;
-  --color-fg-4: #6a6a7e;
+.high-contrast[data-theme$="-light"] {
+  --color-fg-3: color-mix(in srgb, var(--color-fg) 80%, black);
+  --color-fg-4: color-mix(in srgb, var(--color-fg) 65%, black);
 }
 
 /* ── Desktop type scale ────────────────────────────────────────── */
@@ -216,21 +972,23 @@
   transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease !important;
 }
 
-/* Light theme scrollbar */
-#desktop-shell[data-theme="light"] ::-webkit-scrollbar-thumb,
-#app-shell[data-theme="light"] ::-webkit-scrollbar-thumb {
+/* Light-mode scrollbar — applies to every theme family's light variant.
+   Dark scrollbars are already covered by the base ::-webkit-scrollbar
+   rule further down (which reads --color-base-300). */
+#desktop-shell[data-theme$="-light"] ::-webkit-scrollbar-thumb,
+#app-shell[data-theme$="-light"] ::-webkit-scrollbar-thumb {
   background: var(--color-base-350);
 }
 
-#desktop-shell[data-theme="light"] ::-webkit-scrollbar-thumb:hover,
-#app-shell[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
+#desktop-shell[data-theme$="-light"] ::-webkit-scrollbar-thumb:hover,
+#app-shell[data-theme$="-light"] ::-webkit-scrollbar-thumb:hover {
   background: var(--color-base-400);
 }
 
-/* Light theme selection */
-#desktop-shell[data-theme="light"] ::selection,
-#app-shell[data-theme="light"] ::selection {
-  background: rgba(52, 211, 153, 0.2);
+/* Light-mode selection — softer accent overlay than dark mode. */
+#desktop-shell[data-theme$="-light"] ::selection,
+#app-shell[data-theme$="-light"] ::selection {
+  background: color-mix(in srgb, var(--color-accent) 25%, transparent);
   color: var(--color-fg);
 }
 
@@ -256,13 +1014,13 @@ body {
 }
 
 ::selection {
-  background: rgba(52, 211, 153, 0.3);
+  background: color-mix(in srgb, var(--color-accent) 35%, transparent);
   color: var(--color-fg);
 }
 
 *:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(52, 211, 153, 0.5);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 55%, transparent);
 }
 
 /* ── Desktop window layout ────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Adds 10 curated community theme families to the desktop app — Scrollr, Catppuccin, Dracula, Tokyo Night, Nord, Gruvbox, Solarized, Rose Pine, One, Everforest — each with full light, dark, and system (OS-driven) color modes.

The legacy `appearance.theme` field is split into `themeFamily` + `themeMode` so users pick the palette and the lightness independently, like OpenCode does. Existing prefs migrate automatically on first load with no user intervention.

## Architecture

- **`themeFamily`** drives the palette identity (token values).
- **`themeMode`** drives light/dark resolution (`system` follows OS).
- The two combine into a `data-theme="<family>-<mode>"` attribute applied to both the app shell (`#app-shell`) and ticker shell (`#desktop-shell`). All existing component styles already read from tokenized CSS variables, so no per-component changes were needed.
- Pre-paint scripts in `app.html` and `index.html` read a small JSON mirror from localStorage and apply `data-theme` before React mounts, eliminating theme flash on launch for non-default families. The legacy plain-string mirror format is still tolerated for users upgrading.

## Palette Sources

Every palette is verified hex-for-hex against its upstream:

| Theme | Source |
|---|---|
| Catppuccin Mocha / Latte | `catppuccin/nvim/lua/catppuccin/palettes/{mocha,latte}.lua` |
| Dracula | `dracula/dracula-theme/README.md` color table |
| Tokyo Night / Day | `folke/tokyonight.nvim/lua/tokyonight/colors/night.lua` + `extras/lua/tokyonight_day.lua` |
| Nord | `nordtheme/nord/src/nord.css` |
| Gruvbox Dark/Light Medium | `morhetz/gruvbox/colors/gruvbox.vim` |
| Solarized | `altercation/solarized/vim-colors-solarized/colors/solarized.vim` |
| Rose Pine / Dawn | `rose-pine/neovim/lua/rose-pine/palette.lua` |
| One Dark/Light | `atom/atom/packages/one-{dark,light}-syntax/styles/colors.less` |
| Everforest Dark/Light Medium | `sainnhe/everforest/autoload/everforest.vim` |

## Changes

- `desktop/src/preferences.ts` — new `ThemeFamily` / `ThemeMode` types, `THEME_FAMILIES`, `THEME_FAMILY_LABELS`, type guards, `resolveThemeMode`, `resolveThemeName`, `migrateAppearanceTheme`. Legacy exports kept as `@deprecated` aliases.
- `desktop/src/hooks/useTheme.ts` — takes both family + mode, writes JSON mirror, applies `data-theme="<family>-<mode>"`.
- `desktop/src/components/settings/SettingsControls.tsx` — new `SelectRow` component for the 10-entry theme dropdown.
- `desktop/src/components/settings/GeneralSettings.tsx` — Theme dropdown + Mode segmented control.
- `desktop/src/routes/__root.tsx` + `App.tsx` — pass new fields into `useTheme`, `Ctrl+Shift+T` now cycles mode only.
- `desktop/app.html` + `desktop/index.html` — multi-theme pre-paint scripts.
- `desktop/src/style.css` — 20 palette blocks (10 families × 2 modes), keyed off `[data-theme="<family>-<mode>"]`. `high-contrast`, scrollbar, and selection rules switched to `[data-theme$="-light"]` / `-dark` so they apply across every family. Selection + focus ring read `var(--color-accent)` so they tint per theme.
- `desktop/src/preferences.test.ts` — 16 new tests for type guards, migration, legacy `theme` → `themeMode` folding, unknown fallbacks, corrupted-shape tolerance, and `resolveThemeName`.

## Verification

- `npm run test` — 266/266 pass (16 of those are new theme tests).
- `npm run build` — clean (vite + `tsc --noEmit`).
- Manual: every theme cycles cleanly in both windows; `Ctrl+Shift+T` cycles mode; settings dropdown wires through; pre-paint shows the right background on first frame.

## Migration

Existing users on `appearance.theme: "dark"` get `themeFamily: "scrollr", themeMode: "dark"` on next launch. No data loss.