### PR TITLE
feat(desktop): silent update check on startup with opt-out toggle

### DIFF
--- a/desktop/src/components/settings/GeneralSettings.tsx
+++ b/desktop/src/components/settings/GeneralSettings.tsx
@@ -25,6 +25,7 @@ interface PendingUpdate {
 import type {
   AppearancePrefs,
   WindowPrefs,
+  StartupPrefs,
   ThemeMode,
   ThemeFamily,
 } from "../../preferences";
@@ -54,8 +55,10 @@ type UpdateStatus =
 interface GeneralSettingsProps {
   appearance: AppearancePrefs;
   window_: WindowPrefs;
+  startup: StartupPrefs;
   onAppearanceChange: (prefs: AppearancePrefs) => void;
   onWindowChange: (prefs: WindowPrefs) => void;
+  onStartupChange: (prefs: StartupPrefs) => void;
   onReset: () => void;
   autostartEnabled: boolean;
   onAutostartChange: (enabled: boolean) => void;
@@ -94,8 +97,10 @@ const FONT_WEIGHT_OPTIONS: { value: string; label: string }[] = [
 export default function GeneralSettings({
   appearance,
   window_,
+  startup,
   onAppearanceChange,
   onWindowChange,
+  onStartupChange,
   onReset,
   autostartEnabled,
   onAutostartChange,
@@ -307,6 +312,12 @@ export default function GeneralSettings({
       </Section>
 
       <Section title="Updates">
+        <ToggleRow
+          label="Check for updates on startup"
+          description="Notify me when a new version is available shortly after launch"
+          checked={startup.autoCheckUpdates}
+          onChange={(v) => onStartupChange({ ...startup, autoCheckUpdates: v })}
+        />
         <UpdateRow
           status={status}
           onCheck={handleCheckForUpdates}

--- a/desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/desktop/src/hooks/useStartupUpdateCheck.ts
@@ -1,0 +1,172 @@
+// ── Startup update check ────────────────────────────────────────
+//
+// Runs a single update check shortly after the main window mounts.
+// On a real update it surfaces a sonner toast with a "Download &
+// install" action. On up-to-date or error it stays silent — the
+// manual button in Settings → General is the recovery path.
+//
+// The same-version pub_date suppression logic mirrors the manual
+// check in `components/settings/GeneralSettings.tsx`. Keep them in
+// sync if you change either one.
+//
+// We delay 4s so:
+//   1) Tauri webview, splash, and React hydration finish first.
+//   2) If we're going to toast, it lands after the first paint, not
+//      on top of it.
+//   3) Brief flaky-network races on launch get a chance to settle.
+
+import { useEffect, useRef } from "react";
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { toast } from "sonner";
+import { getStore, setStore } from "../lib/store";
+
+const STARTUP_DELAY_MS = 4_000;
+const TOAST_ID = "scrollr-startup-update";
+
+// Storage keys — MUST match GeneralSettings.tsx exactly. Both files
+// participate in the same pub_date reconciliation, so the keys are a
+// shared contract.
+const KEY_LAST_UPDATE_DATE = "scrollr:lastUpdateDate";
+const KEY_PENDING_UPDATE = "scrollr:pendingUpdate";
+
+interface PendingUpdate {
+  version: string;
+  date: string;
+}
+
+interface Options {
+  /** When false (user disabled it in Settings), the hook does nothing. */
+  enabled: boolean;
+  /** Current installed version, used to suppress same-version false positives. */
+  appVersion: string;
+}
+
+export function useStartupUpdateCheck({ enabled, appVersion }: Options) {
+  // Latch so the check runs at most once per mount, even if React strict
+  // mode double-invokes effects or props change after the first run.
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!appVersion) return;
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    let cancelled = false;
+
+    const timer = setTimeout(async () => {
+      try {
+        const update = await check();
+        if (cancelled || !update) return;
+
+        // Same-version patch suppression. If the remote version matches
+        // what's installed AND the pub_date matches what we last recorded
+        // (or there's no record yet, in which case we seed it), treat as
+        // up-to-date. Otherwise fall through to the toast — a genuine
+        // same-version rebuild has shipped.
+        if (update.version === appVersion) {
+          const storedDate = getStore<string | null>(KEY_LAST_UPDATE_DATE, null);
+          if (storedDate === null) {
+            setStore(KEY_LAST_UPDATE_DATE, update.date);
+            return;
+          }
+          if (update.date === storedDate) return;
+        }
+
+        showUpdateToast(update, appVersion);
+      } catch (err) {
+        // Startup check failures are silent. The user can always retry
+        // via Settings → General → Updates. We still log so devs can
+        // see what's going wrong during local development.
+        console.warn("[Scrollr] Startup update check failed:", err);
+      }
+    }, STARTUP_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [enabled, appVersion]);
+}
+
+// ── Toast flow ──────────────────────────────────────────────────
+//
+// Three states the toast walks through:
+//   1) Prompt — "Update available, [Update] [Not now]"
+//   2) Downloading — replaces the prompt with a progress message
+//   3) Done — "Restart to apply, [Restart now]"
+//
+// We use a single toast id (`TOAST_ID`) so sonner replaces the toast
+// in place rather than stacking new ones.
+
+function showUpdateToast(update: Update, appVersion: string) {
+  const isPatch = update.version === appVersion;
+  const description = isPatch
+    ? "A patched build of your current version is ready."
+    : `Version ${update.version} is ready to download.`;
+
+  toast.message("Update available", {
+    id: TOAST_ID,
+    description,
+    duration: Infinity,
+    action: {
+      label: "Update",
+      onClick: () => {
+        // Fire-and-forget. downloadAndInstall is async but sonner's
+        // action handler is sync — we just kick it off and let the
+        // toast updates drive UX from here.
+        void runDownloadAndInstall(update);
+      },
+    },
+    cancel: {
+      label: "Not now",
+      onClick: () => toast.dismiss(TOAST_ID),
+    },
+  });
+}
+
+async function runDownloadAndInstall(update: Update) {
+  toast.loading("Downloading update…", {
+    id: TOAST_ID,
+    description: "This may take a minute.",
+    duration: Infinity,
+  });
+
+  try {
+    await update.downloadAndInstall();
+
+    // Record pending state so the next launch can reconcile pub_date.
+    // See KEY_PENDING_UPDATE docs in GeneralSettings.tsx for why this
+    // is "pending" rather than "last".
+    if (update.version && update.date) {
+      const pending: PendingUpdate = {
+        version: update.version,
+        date: update.date,
+      };
+      setStore(KEY_PENDING_UPDATE, pending);
+    }
+
+    toast.success("Update installed", {
+      id: TOAST_ID,
+      description: "Restart to apply.",
+      duration: Infinity,
+      action: {
+        label: "Restart now",
+        onClick: () => {
+          void relaunch();
+        },
+      },
+      cancel: {
+        label: "Later",
+        onClick: () => toast.dismiss(TOAST_ID),
+      },
+    });
+  } catch (err) {
+    toast.error("Couldn't install update", {
+      id: TOAST_ID,
+      description: err instanceof Error ? err.message : String(err),
+      duration: 8_000,
+    });
+  }
+}

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -151,10 +151,17 @@ export interface TickerPrefs {
   stepPause: number; // seconds between transitions (1–10)
 }
 
-interface StartupPrefs {
+export interface StartupPrefs {
   defaultView: DefaultView;
   refreshInterval: number;
   autostart: boolean;
+  /**
+   * When true, the main window runs a single update check shortly after
+   * launch and surfaces a toast if a new version is available. The user
+   * confirms before any download happens — we never auto-install.
+   * Defaults to true; opt out via Settings → General → Updates.
+   */
+  autoCheckUpdates: boolean;
 }
 
 export type TickerPosition = "top" | "bottom";
@@ -525,6 +532,7 @@ const DEFAULT_STARTUP: StartupPrefs = {
   defaultView: "last",
   refreshInterval: 60_000,
   autostart: false,
+  autoCheckUpdates: true,
 };
 
 const DEFAULT_WINDOW: WindowPrefs = {
@@ -679,6 +687,7 @@ function migrateV1(saved: Record<string, unknown>): Partial<AppPreferences> {
       defaultView: general.defaultView ?? DEFAULT_STARTUP.defaultView,
       refreshInterval: general.refreshInterval ?? DEFAULT_STARTUP.refreshInterval,
       autostart: general.autostart ?? DEFAULT_STARTUP.autostart,
+      autoCheckUpdates: DEFAULT_STARTUP.autoCheckUpdates,
     };
     // smoothScroll and scrollSmoothness are dropped (removed)
   }

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -73,6 +73,7 @@ import { useDashboardCDC } from "../hooks/useDashboardCDC";
 import { useTauriListener } from "../hooks/useTauriListener";
 import { useDeliveryHealth } from "../hooks/useDeliveryHealth";
 import { useNavHistory } from "../hooks/useNavHistory";
+import { useStartupUpdateCheck } from "../hooks/useStartupUpdateCheck";
 import { weatherQueryOptions } from "../api/queries";
 import { fetchSubscription } from "../api/client";
 import { getValidToken } from "../auth";
@@ -274,6 +275,13 @@ function RootLayout() {
   useEffect(() => {
     getVersion().then(setAppVersion).catch(() => {});
   }, []);
+
+  // Silent update check on startup — toasts only if a real update is
+  // available. The user opts out via Settings → General → Updates.
+  useStartupUpdateCheck({
+    enabled: prefs.startup.autoCheckUpdates,
+    appVersion,
+  });
 
   // ── Undo snapshot GC ───────────────────────────────────────
   // Snapshots pushed by `useUndoableAction` live in a module-level

--- a/desktop/src/routes/settings.tsx
+++ b/desktop/src/routes/settings.tsx
@@ -115,11 +115,15 @@ function SettingsRoute() {
         <GeneralSettings
           appearance={prefs.appearance}
           window_={prefs.window}
+          startup={prefs.startup}
           onAppearanceChange={(appearance) =>
             onPrefsChange({ ...prefs, appearance })
           }
           onWindowChange={(window_) =>
             onPrefsChange({ ...prefs, window: window_ })
+          }
+          onStartupChange={(startup) =>
+            onPrefsChange({ ...prefs, startup })
           }
           onReset={() => {
             let next: AppPreferences = resetCategory(prefs, "appearance");


### PR DESCRIPTION
## Summary

- Adds a one-shot updater check ~4s after the main window mounts. When a real update is found, a sonner toast prompts the user with **Update** / **Not now** actions; downloading and the post-install relaunch are driven from the same toast.
- Up-to-date and error paths stay silent so the toast is only surfaced when there's something to act on.
- Same-version pub_date suppression mirrors the manual check in `GeneralSettings.tsx`, and `KEY_PENDING_UPDATE` continues to drive the reconcile-on-next-launch flow.
- Opt-out via **Settings → General → Updates → "Check for updates on startup"**, backed by `prefs.startup.autoCheckUpdates` (default `true`).

## Implementation

| File | Change |
|---|---|
| `desktop/src/preferences.ts` | Export `StartupPrefs`, add `autoCheckUpdates: boolean` (default `true`), include in v1 migration. |
| `desktop/src/hooks/useStartupUpdateCheck.ts` | New hook: delays 4s, runs `check()` once per mount, walks the toast through prompt → downloading → restart. |
| `desktop/src/routes/__root.tsx` | Invokes the hook with the current pref and `appVersion`. Main window only — ticker window has its own entry. |
| `desktop/src/components/settings/GeneralSettings.tsx` | Adds the toggle in the Updates section; takes new `startup` + `onStartupChange` props. |
| `desktop/src/routes/settings.tsx` | Plumbs `prefs.startup` and the setter through to `GeneralSettings`. |

## Verification

- `npx tsc --noEmit` — clean
- `npm run test` — 266 tests pass

## Notes

- We never auto-install; the user always confirms via the toast action.
- Errors during the startup check are logged with `console.warn` only — recovery is the existing manual button in Settings.
- The ticker window (`App.tsx`) does not invoke this hook, so the check fires exactly once per app launch.