### PR TITLE
fix(finance): refresh previous_close daily so change% stops drifting

### DIFF
--- a/channels/finance/service/src/lib.rs
+++ b/channels/finance/service/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{sync::Arc, time::Duration, fs};
 
+use chrono::{Timelike, Utc};
 use futures_util::future::join_all;
 use reqwest::Client;
 use tokio::{sync::Mutex, time::{self, sleep}};
@@ -50,6 +51,20 @@ pub async fn start_finance_services(pool: Arc<PgPool>, health_state: Arc<Mutex<F
             sleep(Duration::from_secs(86400)).await; // 24 hours
             info!("[ TwelveData ] Running background exchange metadata verification...");
             verify_exchange_metadata(bg_state.clone()).await;
+        }
+    });
+
+    // Spawn background task to refresh previous closes daily, shortly after
+    // the US market closes. We target 21:30 UTC (~16:30 ET / 17:30 EDT), which
+    // is comfortably after the 4:00pm ET close and after TwelveData's official
+    // previous_close values have settled. Without this, previous_close only
+    // refreshes when the pod restarts, causing the stale numbers users see.
+    let prev_close_state = state.clone();
+    tokio::spawn(async move {
+        loop {
+            sleep(duration_until_next_utc(21, 30)).await;
+            info!("[ TwelveData ] Running daily previous close refresh...");
+            update_all_previous_closes(prev_close_state.clone()).await;
         }
     });
 
@@ -129,6 +144,21 @@ pub async fn update_all_previous_closes(state: FinanceState) {
         join_all(futures).await;
     }
     info!("[ TwelveData ] Previous closes update complete.");
+}
+
+/// Returns the `Duration` until the next occurrence of `hour:minute` UTC.
+/// If the target time has already passed today, returns the duration until
+/// that time tomorrow.
+fn duration_until_next_utc(hour: u32, minute: u32) -> Duration {
+    let now = Utc::now();
+    let target_secs_of_day = (hour * 3600 + minute * 60) as i64;
+    let now_secs_of_day =
+        (now.hour() * 3600 + now.minute() * 60 + now.second()) as i64;
+    let mut delta = target_secs_of_day - now_secs_of_day;
+    if delta <= 0 {
+        delta += 86_400;
+    }
+    Duration::from_secs(delta as u64)
 }
 
 pub(crate) async fn get_quote(symbol: String, client: Arc<Client>, api_key: &str) -> anyhow::Result<QuoteResponse> {

--- a/channels/finance/service/src/websocket.rs
+++ b/channels/finance/service/src/websocket.rs
@@ -444,10 +444,12 @@ async fn process_single_trade(trade: TradeData, trades_map: Arc<HashMap<String, 
             }
         }
 
-        if determined_previous_close.is_none() {
-            warn!("Quote unavailable for {}, using live price fallback", symbol);
-            determined_previous_close = Some(price);
-        }
+        // Intentionally NO fallback to the current live price. Using the
+        // live tick as "previous close" produces a permanently-incorrect
+        // baseline that polluted change/percentage calculations for the
+        // lifetime of the pod. If TwelveData can't give us a real previous
+        // close right now, skip this trade — the daily refresh task in
+        // lib.rs::update_all_previous_closes will fill it in on its next run.
 
         if let Some(pc) = determined_previous_close {
             current_record.previous_close = pc;


### PR DESCRIPTION
## Summary

- `update_all_previous_closes` only ran once, at service startup. Between restarts, `previous_close` in the `trades` table stayed frozen, so `price_change` / `percentage_change` / `direction` drifted further from reality every trading day. This is what made the previous-close numbers in the UI look out of date.
- Spawn a new background task that re-runs `update_all_previous_closes` daily at **21:30 UTC** (~30 minutes after the US 4:00pm ET close, comfortably after TwelveData's official `previous_close` settles).
- Add a `duration_until_next_utc(hour, minute)` helper that sleeps to the next wall-clock occurrence of a UTC time (uses the already-vendored `chrono` crate).
- Remove the live-price fallback in `process_single_trade` that set `previous_close = current_price` when TwelveData `/quote` failed. That fallback produced a permanently-zero change% baseline until the next pod restart. Skip the trade instead and let the daily task fill it in correctly on the next run.

## Files

- `channels/finance/service/src/lib.rs` — daily scheduler + helper, new `chrono::{Timelike, Utc}` import.
- `channels/finance/service/src/websocket.rs` — drop the live-price fallback, leave a comment explaining why.

## Verification

- `cargo check` — clean.
- `cargo test` — 22/22 pass.
- No DB or HTTP contract changes; no migration required.

## What you'll see after deploy

- A one-time correction on the next pod restart (existing startup call still runs).
- From then on, previous closes refresh once per day at 21:30 UTC automatically.