### PR TITLE
fix: walkthrough pain points — auto-pin widgets, discoverable Options trigger, RSS dedup

### DIFF
--- a/channels/rss/api/rss.go
+++ b/channels/rss/api/rss.go
@@ -179,7 +179,13 @@ func (a *App) queryUserCatalog(ctx context.Context, userSub string, includeFaili
 	`
 
 	curatedClauses := "WHERE is_default = true AND is_enabled = true"
-	customClauses := "WHERE ucf.logto_sub = $1 AND (tf.is_enabled IS NULL OR tf.is_enabled = true)"
+	// Safety net: even if user_custom_feeds contains a row for a URL that's
+	// also a curated default (from the pre-fix bug, or any other path), we
+	// exclude it here so the UNION never returns the same URL twice. The
+	// runtime guard in syncRSSFeedsToTracked prevents new pollution; the
+	// 130000000002 cleanup migration drops historical pollution; this filter
+	// is defense in depth.
+	customClauses := "WHERE ucf.logto_sub = $1 AND (tf.is_enabled IS NULL OR tf.is_enabled = true) AND NOT EXISTS (SELECT 1 FROM tracked_feeds tf2 WHERE tf2.url = ucf.url AND tf2.is_default = true)"
 	if !includeFailing {
 		curatedClauses += healthFilter
 		customClauses += customFeedHealthFilter
@@ -729,6 +735,25 @@ func (a *App) syncRSSFeedsToTracked(userSub string, config map[string]interface{
 		return
 	}
 
+	// Preload the set of curated default URLs so we can skip writing
+	// duplicates into user_custom_feeds. Curated feeds already live in
+	// tracked_feeds with is_default=true and are visible to every user
+	// via the catalog UNION — writing them into user_custom_feeds would
+	// re-label them under "Custom" (the bug we're fixing).
+	curatedURLs := make(map[string]struct{})
+	curatedRows, curErr := a.db.Query(ctx, `SELECT url FROM tracked_feeds WHERE is_default = true`)
+	if curErr != nil {
+		log.Printf("[RSS] Failed to load curated URLs for sync (continuing without dedup): %v", curErr)
+	} else {
+		for curatedRows.Next() {
+			var u string
+			if scanErr := curatedRows.Scan(&u); scanErr == nil {
+				curatedURLs[u] = struct{}{}
+			}
+		}
+		curatedRows.Close()
+	}
+
 	for _, feed := range parsed.Feeds {
 		if feed.URL == "" {
 			continue
@@ -752,6 +777,15 @@ func (a *App) syncRSSFeedsToTracked(userSub string, config map[string]interface{
 		`, feed.URL, name, userSub)
 		if err != nil {
 			log.Printf("[RSS] Failed to sync feed %s to tracked_feeds: %v", feed.URL, err)
+			continue
+		}
+
+		// Skip the user_custom_feeds insert for URLs that are already
+		// curated defaults. Curated feeds are surfaced to every user
+		// via the catalog's curated half of the UNION; writing them
+		// here would cause queryUserCatalog to return the URL twice
+		// and FeedTab to re-label the row as "Custom".
+		if _, isCurated := curatedURLs[feed.URL]; isCurated {
 			continue
 		}
 

--- a/channels/rss/service/migrations/130000000002_cleanup_dup_user_custom_feeds.down.sql
+++ b/channels/rss/service/migrations/130000000002_cleanup_dup_user_custom_feeds.down.sql
@@ -1,0 +1,6 @@
+-- No-op: a cleanup migration cannot be meaningfully reversed. We don't know
+-- which (logto_sub, url, name) tuples were deleted, and re-creating "Custom"
+-- per-user rows for curated default URLs would re-introduce the bug.
+-- If you need to roll back the fix, also revert the rss.go runtime guard and
+-- queryUserCatalog filter — the down migration alone won't bring the data back.
+SELECT 1;

--- a/channels/rss/service/migrations/130000000002_cleanup_dup_user_custom_feeds.up.sql
+++ b/channels/rss/service/migrations/130000000002_cleanup_dup_user_custom_feeds.up.sql
@@ -1,0 +1,15 @@
+-- Cleanup: remove rows from user_custom_feeds whose URL is already a curated
+-- default in tracked_feeds. These rows were created by the pre-fix
+-- syncRSSFeedsToTracked path (channels/rss/api/rss.go), which blindly upserted
+-- every feed in a user's config — including curated defaults the user simply
+-- clicked in the picker — into user_custom_feeds with category='Custom'. The
+-- catalog UNION then returned the URL twice and FeedTab re-labeled the row to
+-- "Custom" when building its category map.
+--
+-- The runtime guard added in the same change prevents new pollution; this
+-- migration backfills existing accounts. The query filter in
+-- queryUserCatalog provides defense in depth.
+DELETE FROM user_custom_feeds
+WHERE url IN (
+    SELECT url FROM tracked_feeds WHERE is_default = true
+);

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -168,13 +168,24 @@ function RssFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
   );
 
   // Build category map: feed_url → category
+  //
+  // Defensive dedup: if the catalog returns the same URL twice (curated +
+  // "Custom" leftover from the pre-fix duplication bug), prefer the
+  // non-"Custom" category. The backend now filters these via
+  // queryUserCatalog's NOT EXISTS clause and the cleanup migration drops
+  // historical dupes, but this guard means a stale row anywhere upstream
+  // can never re-label a curated feed in the UI.
   const categoryMap = useMemo(() => {
     const map = new Map<string, string>();
     if (catalog) {
       for (const feed of catalog) {
-        if (feed.category) {
-          map.set(feed.url, feed.category);
+        if (!feed.category) continue;
+        const existing = map.get(feed.url);
+        // Don't overwrite a non-"Custom" category with "Custom".
+        if (existing && existing !== "Custom" && feed.category === "Custom") {
+          continue;
         }
+        map.set(feed.url, feed.category);
       }
     }
     return map;

--- a/desktop/src/components/SourcePageLayout.tsx
+++ b/desktop/src/components/SourcePageLayout.tsx
@@ -4,9 +4,9 @@
  * Renders through the universal `PageLayout`. Source pages no longer
  * have a visible tab band — Feed is the single visible page. All
  * secondary actions (Configure, Display preferences, Remove) live in
- * a contextual menu surfaced two ways in the TopBar: a visible
- * "Options" pill button AND the last breadcrumb segment (both open
- * the same menu).
+ * a contextual menu opened by the "Options" pill button in the
+ * TopBar. The breadcrumb segments are plain navigation text — the
+ * pill is the single, explicit menu trigger.
  *
  * The /feed, /configuration, and /display routes all still exist for
  * direct deeplinks, tray actions, and the Catalog "Open" → feed flow.
@@ -197,11 +197,11 @@ export default function SourcePageLayout({
         // their padding. Configure / Display keep the default padded
         // narrow column.
         noContentPadding={isFeed}
-        // Source pages get BOTH a discoverable "Options" pill in the
-        // TopBar AND the breadcrumb-as-trigger, both opening the same
-        // menu. menuKind="actions" tells TopBar to render the pill.
-        // Walkthrough fix 2026-05-11 — testers couldn't find the
-        // breadcrumb-only trigger.
+        // Source pages use the "Options" pill in the TopBar as the
+        // sole menu trigger. menuKind="actions" tells TopBar to render
+        // the pill and leave the breadcrumb as plain navigation text.
+        // Walkthrough fix 2026-05-11 — testers preferred the explicit
+        // pill over the discoverability-poor breadcrumb dropdown.
         menuItems={menuItems}
         menuLabel={`${name} options`}
         menuKind="actions"

--- a/desktop/src/components/SourcePageLayout.tsx
+++ b/desktop/src/components/SourcePageLayout.tsx
@@ -3,21 +3,29 @@
  *
  * Renders through the universal `PageLayout`. Source pages no longer
  * have a visible tab band — Feed is the single visible page. All
- * secondary actions (Configure, Display preferences, Manage on
- * ticker, Remove) live in a contextual menu whose trigger IS the
- * last breadcrumb segment in the TopBar.
+ * secondary actions (Configure, Display preferences, Remove) live in
+ * a contextual menu surfaced two ways in the TopBar: a visible
+ * "Options" pill button AND the last breadcrumb segment (both open
+ * the same menu).
  *
  * The /feed, /configuration, and /display routes all still exist for
  * direct deeplinks, tray actions, and the Catalog "Open" → feed flow.
  *
  * IA refactor 2026-05-09 — see
  * docs/superpowers/specs/2026-05-09-desktop-ia-refactor-design.md
+ * Walkthrough discoverability fix 2026-05-11.
  */
 import { useState } from "react";
 import { Settings as SettingsIcon, SlidersHorizontal, Tv, Trash2 } from "lucide-react";
 import ConfirmDialog from "./ConfirmDialog";
 import PageLayout from "./layout/PageLayout";
 import { type OverflowMenuItem } from "./OverflowMenu";
+
+// Note: "Manage on ticker" used to live in this menu but was removed in
+// the 2026-05-11 walkthrough fix — it navigated users away from the
+// source they were configuring to a global Settings panel, which testers
+// found jarring. Ticker configuration is still reachable from the main
+// Settings route. See AGENTS.md or the PR description for context.
 
 // ── Shared tab constants ────────────────────────────────────────
 //
@@ -69,8 +77,6 @@ interface SourcePageLayoutProps {
   /** Click handler for the parent breadcrumb in the TopBar
    *  (typically navigates back to /feed). */
   onBack: () => void;
-  /** Click handler for "Manage on ticker" — opens Settings → Ticker. */
-  onManageTicker: () => void;
   children: React.ReactNode;
 
   /** Source-level remove action. */
@@ -89,7 +95,6 @@ export default function SourcePageLayout({
   activeTab,
   onTabChange,
   onBack,
-  onManageTicker,
   children,
   onRemove,
   sourceKind,
@@ -107,8 +112,11 @@ export default function SourcePageLayout({
 
   // Build the menu items list. Order is intentional: when away from
   // Feed, "Back to feed" goes first so the menu always offers a
-  // canonical way out. Then Configure → Display → Manage on ticker,
-  // a divider, then destructive Remove at the bottom.
+  // canonical way out. Then Configure → Display, a divider, then
+  // destructive Remove at the bottom. (Pre-2026-05-11 this also
+  // included "Manage on ticker" — removed because it navigated users
+  // away from the source page to global ticker settings, which
+  // confused testers.)
   const menuItems: OverflowMenuItem[] = [];
 
   // Always offer "Back to feed" when not on the feed already. This
@@ -148,14 +156,6 @@ export default function SourcePageLayout({
       onSelect: () => onTabChange("display"),
     });
   }
-
-  menuItems.push({
-    key: "ticker",
-    label: "Manage on ticker",
-    hint: "Set rows, speed, and style",
-    icon: Tv,
-    onSelect: onManageTicker,
-  });
 
   if (onRemove) {
     menuItems.push({ key: "div-1", divider: true });
@@ -197,11 +197,14 @@ export default function SourcePageLayout({
         // their padding. Configure / Display keep the default padded
         // narrow column.
         noContentPadding={isFeed}
-        // The TopBar renders the last breadcrumb segment as the menu
-        // trigger when menuItems are present — no separate "Options"
-        // button competing with the breadcrumb.
+        // Source pages get BOTH a discoverable "Options" pill in the
+        // TopBar AND the breadcrumb-as-trigger, both opening the same
+        // menu. menuKind="actions" tells TopBar to render the pill.
+        // Walkthrough fix 2026-05-11 — testers couldn't find the
+        // breadcrumb-only trigger.
         menuItems={menuItems}
         menuLabel={`${name} options`}
+        menuKind="actions"
       >
         {children}
       </PageLayout>

--- a/desktop/src/components/SourcePageLayout.tsx
+++ b/desktop/src/components/SourcePageLayout.tsx
@@ -198,13 +198,11 @@ export default function SourcePageLayout({
         // narrow column.
         noContentPadding={isFeed}
         // Source pages use the "Options" pill in the TopBar as the
-        // sole menu trigger. menuKind="actions" tells TopBar to render
-        // the pill and leave the breadcrumb as plain navigation text.
+        // sole menu trigger; the breadcrumb is plain navigation text.
         // Walkthrough fix 2026-05-11 — testers preferred the explicit
-        // pill over the discoverability-poor breadcrumb dropdown.
+        // pill over the hidden breadcrumb dropdown.
         menuItems={menuItems}
         menuLabel={`${name} options`}
-        menuKind="actions"
       >
         {children}
       </PageLayout>

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -16,13 +16,16 @@
  * route's content area in a chunky 4-row header. It's now in the
  * TopBar, freeing the entire content area for actual content.
  */
-import { ArrowLeft, ArrowRight, Pin, Radio, RadioTower } from "lucide-react";
+import { forwardRef, useLayoutEffect, useRef, useState } from "react";
+import type { ButtonHTMLAttributes, Ref } from "react";
+import { ArrowLeft, ArrowRight, ChevronDown, Pin, Radio, RadioTower } from "lucide-react";
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";
 import Tooltip from "./Tooltip";
 import ConnectionIndicator from "./ConnectionIndicator";
 import ScrollLogo from "./ScrollLogo";
 import OverflowMenu from "./OverflowMenu";
+import type { OverflowMenuItem } from "./OverflowMenu";
 import { usePageIdentity, type PageTabStrip } from "./layout/page-context";
 import type { DeliveryHealth } from "../hooks/useDeliveryHealth";
 
@@ -180,16 +183,16 @@ export default function TopBar({
 
             {/* Inline tab strip — sibling navigation as a segmented
                 pill control. Renders only when the page publishes
-                `tabs`. Scrolls horizontally if it overflows so the
-                breadcrumb on the left and ambient toggles on the
-                right stay anchored. */}
-            {page.tabs && (
+                `tabs`. The strip itself takes flex-1 so it owns all
+                available space (which is also what the adaptive
+                overflow measurement needs to decide how many pills
+                fit). When there are no tabs, an empty spacer fills
+                the gap so Options pins to the right edge. */}
+            {page.tabs ? (
               <InlineTabStrip tabs={page.tabs} />
+            ) : (
+              <div className="flex-1 min-w-0" aria-hidden />
             )}
-
-            {/* Spacer pushes Options/entityAction to the right edge
-                of the breadcrumb area regardless of tab presence. */}
-            <div className="flex-1 min-w-0" aria-hidden />
 
             {/* "Options" pill — the sole trigger for page-level menus. */}
             {page.menuItems?.length ? (
@@ -278,46 +281,228 @@ export default function TopBar({
 // Catalog: All/Channels/Widgets, Support sections, etc.). Replaces the
 // full-width content-area tab band that wasted vertical space.
 //
-// The active pill renders with an animated background via shared
-// layoutId so switching tabs slides the highlight rather than fading
-// in place.
+// Adaptive overflow: when the available width can't fit every pill,
+// the tail collapses into a "More ▾" menu. The active tab is always
+// kept visible — if it would be in the overflow slice, earlier tabs
+// are pushed into overflow instead so users always see where they
+// currently are.
+//
+// Measurement uses an off-screen ghost row to learn each pill's
+// natural width, then walks the list deciding what fits. A
+// ResizeObserver on the container re-runs the calculation when the
+// window or the breadcrumb width changes.
 
 function InlineTabStrip({ tabs }: { tabs: PageTabStrip }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const ghostRef = useRef<HTMLDivElement | null>(null);
+
+  // Number of leading items currently rendered inline. The rest go
+  // into the overflow menu. Starts at items.length so the first
+  // render shows every pill; ResizeObserver immediately corrects it
+  // if there isn't enough room.
+  const [visibleCount, setVisibleCount] = useState(tabs.items.length);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const ghost = ghostRef.current;
+    if (!container || !ghost) return;
+
+    const recompute = () => {
+      const available = container.clientWidth;
+      if (available <= 0) return;
+
+      // Measure each ghost pill + the ghost "More" trigger.
+      const pillNodes = Array.from(
+        ghost.querySelectorAll<HTMLElement>("[data-pill-index]"),
+      );
+      const widths = pillNodes.map((n) => n.offsetWidth);
+      const moreNode = ghost.querySelector<HTMLElement>("[data-pill-more]");
+      const moreWidth = moreNode?.offsetWidth ?? 0;
+
+      // Gap between pills in the rendered strip (gap-0.5 = 2px).
+      const gap = 2;
+
+      // First, can everything fit without "More"?
+      const total = widths.reduce(
+        (sum, w, i) => sum + w + (i > 0 ? gap : 0),
+        0,
+      );
+      if (total <= available) {
+        setVisibleCount(widths.length);
+        return;
+      }
+
+      // Otherwise reserve room for the "More" trigger and pack from
+      // the left until the next pill won't fit.
+      let used = moreWidth + gap;
+      let fit = 0;
+      for (let i = 0; i < widths.length; i++) {
+        const next = widths[i] + (fit > 0 ? gap : 0);
+        if (used + next > available) break;
+        used += next;
+        fit += 1;
+      }
+
+      // Guarantee at least one inline pill so the strip never
+      // collapses entirely (the More menu would still work, but the
+      // user loses the visual anchor).
+      setVisibleCount(Math.max(1, fit));
+    };
+
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [tabs.items]);
+
+  // If the active tab would land in the overflow slice, shift the
+  // visible window so it stays in view. We do this by re-ordering:
+  // the displayed pills are the first `visibleCount` items, BUT we
+  // swap the active tab into that slice if it isn't there.
+  const activeIndex = tabs.items.findIndex((t) => t.key === tabs.activeKey);
+  const inlineSet = (() => {
+    const visible = tabs.items.slice(0, visibleCount);
+    if (activeIndex < 0 || activeIndex < visibleCount) {
+      return { visible, overflow: tabs.items.slice(visibleCount) };
+    }
+    // Active is in overflow — swap it with the last visible slot so
+    // the active pill is always rendered inline.
+    const swapped = visible.slice(0, -1);
+    swapped.push(tabs.items[activeIndex]);
+    const overflow = tabs.items.filter((t) => !swapped.includes(t));
+    return { visible: swapped, overflow };
+  })();
+
+  const overflowMenuItems: OverflowMenuItem[] = inlineSet.overflow.map((t) => ({
+    key: t.key,
+    label: t.label,
+    hint: t.description,
+    onSelect: () => tabs.onChange(t.key),
+  }));
+
   return (
-    <nav
-      aria-label={tabs.ariaLabel ?? "Page sections"}
-      className="flex items-center gap-0.5 h-7 px-0.5 rounded-md bg-surface-1/60 border border-edge/40 shrink-0 overflow-x-auto scrollbar-none"
+    <div
+      ref={containerRef}
+      className="relative flex items-center min-w-0 flex-1"
     >
-      {tabs.items.map((tab) => {
-        const isActive = tab.key === tabs.activeKey;
-        return (
-          <button
+      {/* Visible strip. */}
+      <nav
+        aria-label={tabs.ariaLabel ?? "Page sections"}
+        className="flex items-center gap-0.5 h-7 px-0.5 rounded-md bg-surface-1/60 border border-edge/40 max-w-full"
+      >
+        {inlineSet.visible.map((tab) => (
+          <TabPill
             key={tab.key}
-            type="button"
-            onClick={() => tabs.onChange(tab.key)}
-            aria-current={isActive ? "page" : undefined}
-            title={tab.description}
-            className={clsx(
-              "relative h-6 px-2.5 rounded text-[11px] font-medium transition-colors whitespace-nowrap",
-              isActive
-                ? "text-fg"
-                : "text-fg-3 hover:text-fg-2",
-            )}
+            label={tab.label}
+            description={tab.description}
+            isActive={tab.key === tabs.activeKey}
+            onSelect={() => tabs.onChange(tab.key)}
+          />
+        ))}
+        {inlineSet.overflow.length > 0 && (
+          <OverflowMenu
+            items={overflowMenuItems}
+            triggerLabel="More sections"
+            trigger={<MoreTabsTrigger />}
+            placement="bottom-end"
+          />
+        )}
+      </nav>
+
+      {/* Ghost row — off-screen, used only for width measurement.
+          Mirrors the styles of the real pills + trigger so widths
+          match. aria-hidden so AT doesn't see duplicates. */}
+      <div
+        ref={ghostRef}
+        aria-hidden
+        className="absolute left-0 top-0 invisible pointer-events-none flex items-center gap-0.5 h-7 px-0.5"
+        style={{ visibility: "hidden" }}
+      >
+        {tabs.items.map((tab, i) => (
+          <span
+            key={tab.key}
+            data-pill-index={i}
+            className="relative h-6 px-2.5 rounded text-[11px] font-medium whitespace-nowrap"
           >
-            {/* Sliding background — shared layoutId animates the
-                highlight between pills instead of fading in place. */}
-            {isActive && (
-              <motion.span
-                layoutId="topbar-tab-active"
-                transition={{ type: "spring", stiffness: 500, damping: 38 }}
-                className="absolute inset-0 rounded bg-surface-3 shadow-sm"
-              />
-            )}
-            <span className="relative">{tab.label}</span>
-          </button>
-        );
-      })}
-    </nav>
+            {tab.label}
+          </span>
+        ))}
+        <span
+          data-pill-more
+          className="flex items-center gap-1 h-6 px-2 rounded text-[11px] font-medium whitespace-nowrap"
+        >
+          More
+          <ChevronDown size={11} />
+        </span>
+      </div>
+    </div>
   );
 }
+
+// Single pill button. Extracted so the visible strip and the ghost
+// row can share the same dimensions without duplicating className.
+function TabPill({
+  label,
+  description,
+  isActive,
+  onSelect,
+}: {
+  label: string;
+  description?: string;
+  isActive: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={isActive ? "page" : undefined}
+      title={description}
+      className={clsx(
+        "relative h-6 px-2.5 rounded text-[11px] font-medium transition-colors whitespace-nowrap",
+        isActive ? "text-fg" : "text-fg-3 hover:text-fg-2",
+      )}
+    >
+      {isActive && (
+        <motion.span
+          layoutId="topbar-tab-active"
+          transition={{ type: "spring", stiffness: 500, damping: 38 }}
+          className="absolute inset-0 rounded bg-surface-3 shadow-sm"
+        />
+      )}
+      <span className="relative">{label}</span>
+    </button>
+  );
+}
+
+// "More ▾" trigger styled to match TabPill so it visually belongs to
+// the same segmented control. floating-ui injects a ref + handlers
+// via cloneElement, so this is a forwardRef-compatible button.
+const MoreTabsTrigger = forwardRef(function MoreTabsTrigger(
+  props: ButtonHTMLAttributes<HTMLButtonElement>,
+  ref: Ref<HTMLButtonElement>,
+) {
+  const isOpen =
+    props["aria-expanded"] === true || props["aria-expanded"] === "true";
+  return (
+    <button
+      ref={ref}
+      type="button"
+      {...props}
+      className={clsx(
+        "flex items-center gap-1 h-6 px-2 rounded text-[11px] font-medium transition-colors whitespace-nowrap",
+        isOpen ? "bg-surface-3 text-fg" : "text-fg-3 hover:text-fg-2",
+      )}
+    >
+      More
+      <ChevronDown
+        size={11}
+        style={{
+          transition: "transform 300ms var(--ease-snap)",
+          transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
+        }}
+      />
+    </button>
+  );
+});
 

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -207,6 +207,28 @@ export default function TopBar({
               )}
             </AnimatePresence>
 
+            {/* Discoverable "Options" pill for action menus (source
+                pages). Renders ONLY when menuKind === "actions" so the
+                Settings / Catalog tab switchers don't get a redundant
+                pill (their menu IS the breadcrumb-as-trigger).
+
+                The breadcrumb segment is ALSO still a menu trigger via
+                BreadcrumbMenuTrigger above — both open the same menu.
+                Two affordances, one menu. Discoverability + muscle
+                memory.
+
+                Walkthrough fix 2026-05-11: super-user testers couldn't
+                find the 11px-chevron-on-breadcrumb trigger; the pill
+                with "Options" label resolves that. */}
+            {page.menuItems?.length && page.menuKind === "actions" && (
+              <div className="shrink-0 ml-1">
+                <OverflowMenu
+                  items={page.menuItems}
+                  triggerLabel={page.menuLabel ?? "Page options"}
+                />
+              </div>
+            )}
+
             {/* Fallback non-menu action (rare). */}
             {page.entityAction && !page.menuItems?.length && (
               <div className="shrink-0 flex items-center gap-1 ml-1">

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -23,7 +23,7 @@ import Tooltip from "./Tooltip";
 import ConnectionIndicator from "./ConnectionIndicator";
 import ScrollLogo from "./ScrollLogo";
 import OverflowMenu from "./OverflowMenu";
-import { usePageIdentity } from "./layout/page-context";
+import { usePageIdentity, type PageTabStrip } from "./layout/page-context";
 import type { DeliveryHealth } from "../hooks/useDeliveryHealth";
 
 // ── Props ───────────────────────────────────────────────────────
@@ -113,72 +113,87 @@ export default function TopBar({
 
       <div className="w-px h-5 bg-edge/40 mx-1 shrink-0" />
 
-      {/* ── Page identity (breadcrumb) ──────────────────────────
-          Layout: parentLabel / title / subtitle
-
-          Breadcrumb segments are plain navigation text. Sub-route
-          titles become back-link buttons via onTitleClick. Page-level
-          menus are opened by the explicit "Options" pill at the end of
-          the breadcrumb area — the breadcrumb itself is never a menu
-          trigger. Walkthrough fix 2026-05-11: testers found the old
-          hidden chevron pattern undiscoverable. Pages with sibling
-          tabs (Settings, Catalog, Support sections) now use the
-          PageLayout `tabs` prop to render a visible in-page tab band
-          instead of hiding sibling navigation in a dropdown. */}
-      <div className="flex items-center gap-1.5 min-w-0 flex-1 overflow-hidden text-ui-meta">
+      {/* ── Page identity + inline tab strip ────────────────────
+          Layout in this row:
+            [parentLabel / title (/ subtitle)]  [tab pills]  [Options]
+          Breadcrumb segments are plain navigation text (sub-route
+          titles are back-link buttons via onTitleClick). Sibling-tab
+          nav is a compact segmented pill control inline in the bar
+          — no full-width tab band wasting vertical space. The
+          "Options" pill is the sole page-menu trigger. When tabs are
+          present, subtitle is suppressed (the active pill conveys the
+          same info). Walkthrough fix 2026-05-11 round 3. */}
+      <div className="flex items-center gap-2 min-w-0 flex-1 overflow-hidden text-ui-meta">
         {page && (
           <>
-            {page.parentLabel && page.onParentClick && (
-              <>
-                <button
-                  onClick={page.onParentClick}
-                  className="text-fg-3 hover:text-fg-2 transition-colors shrink-0"
-                >
-                  {page.parentLabel}
-                </button>
-                <span className="text-fg-4 shrink-0" aria-hidden>
-                  /
-                </span>
-              </>
-            )}
-
-            {page.onTitleClick ? (
-              <button
-                onClick={page.onTitleClick}
-                className="font-semibold text-fg-2 hover:text-fg truncate transition-colors"
-              >
-                {page.title}
-              </button>
-            ) : (
-              <span className="font-semibold text-fg truncate">
-                {page.title}
-              </span>
-            )}
-
-            {/* Subtitle segment — slides in when entering a sub-route
-                and out when leaving. Keyed on the subtitle text so
-                switching between Configure and Display also animates. */}
-            <AnimatePresence mode="popLayout" initial={false}>
-              {page.subtitle && (
-                <motion.div
-                  key={page.subtitle}
-                  initial={{ opacity: 0, x: -6, filter: "blur(2px)" }}
-                  animate={{ opacity: 1, x: 0, filter: "blur(0px)" }}
-                  exit={{ opacity: 0, x: -6, filter: "blur(2px)" }}
-                  transition={{ duration: 0.22, ease: [0.22, 0.61, 0.36, 1] }}
-                  className="flex items-center gap-1.5 min-w-0"
-                >
+            {/* Breadcrumb — always shrink-friendly. */}
+            <div className="flex items-center gap-1.5 min-w-0 shrink">
+              {page.parentLabel && page.onParentClick && (
+                <>
+                  <button
+                    onClick={page.onParentClick}
+                    className="text-fg-3 hover:text-fg-2 transition-colors shrink-0"
+                  >
+                    {page.parentLabel}
+                  </button>
                   <span className="text-fg-4 shrink-0" aria-hidden>
                     /
                   </span>
-                  <span className="text-fg-3 truncate">{page.subtitle}</span>
-                </motion.div>
+                </>
               )}
-            </AnimatePresence>
+
+              {page.onTitleClick ? (
+                <button
+                  onClick={page.onTitleClick}
+                  className="font-semibold text-fg-2 hover:text-fg truncate transition-colors"
+                >
+                  {page.title}
+                </button>
+              ) : (
+                <span className="font-semibold text-fg truncate">
+                  {page.title}
+                </span>
+              )}
+
+              {/* Subtitle slot — suppressed when tab pills are
+                  showing (the active pill is the subtitle). */}
+              <AnimatePresence mode="popLayout" initial={false}>
+                {page.subtitle && !page.tabs && (
+                  <motion.div
+                    key={page.subtitle}
+                    initial={{ opacity: 0, x: -6, filter: "blur(2px)" }}
+                    animate={{ opacity: 1, x: 0, filter: "blur(0px)" }}
+                    exit={{ opacity: 0, x: -6, filter: "blur(2px)" }}
+                    transition={{ duration: 0.22, ease: [0.22, 0.61, 0.36, 1] }}
+                    className="flex items-center gap-1.5 min-w-0"
+                  >
+                    <span className="text-fg-4 shrink-0" aria-hidden>
+                      /
+                    </span>
+                    <span className="text-fg-3 truncate">
+                      {page.subtitle}
+                    </span>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+
+            {/* Inline tab strip — sibling navigation as a segmented
+                pill control. Renders only when the page publishes
+                `tabs`. Scrolls horizontally if it overflows so the
+                breadcrumb on the left and ambient toggles on the
+                right stay anchored. */}
+            {page.tabs && (
+              <InlineTabStrip tabs={page.tabs} />
+            )}
+
+            {/* Spacer pushes Options/entityAction to the right edge
+                of the breadcrumb area regardless of tab presence. */}
+            <div className="flex-1 min-w-0" aria-hidden />
 
             {/* "Options" pill — the sole trigger for page-level menus. */}
             {page.menuItems?.length ? (
-              <div className="shrink-0 ml-1">
+              <div className="shrink-0">
                 <OverflowMenu
                   items={page.menuItems}
                   triggerLabel={page.menuLabel ?? "Page options"}
@@ -188,7 +203,7 @@ export default function TopBar({
 
             {/* Fallback non-menu action (rare). */}
             {page.entityAction && !page.menuItems?.length && (
-              <div className="shrink-0 flex items-center gap-1 ml-1">
+              <div className="shrink-0 flex items-center gap-1">
                 {page.entityAction}
               </div>
             )}
@@ -256,4 +271,53 @@ export default function TopBar({
   );
 }
 
+// ── Inline tab strip ─────────────────────────────────────────────
+//
+// Compact segmented pill control that lives inline in the TopBar to
+// expose sibling-tab navigation (Settings: Appearance/Ticker/Account,
+// Catalog: All/Channels/Widgets, Support sections, etc.). Replaces the
+// full-width content-area tab band that wasted vertical space.
+//
+// The active pill renders with an animated background via shared
+// layoutId so switching tabs slides the highlight rather than fading
+// in place.
+
+function InlineTabStrip({ tabs }: { tabs: PageTabStrip }) {
+  return (
+    <nav
+      aria-label={tabs.ariaLabel ?? "Page sections"}
+      className="flex items-center gap-0.5 h-7 px-0.5 rounded-md bg-surface-1/60 border border-edge/40 shrink-0 overflow-x-auto scrollbar-none"
+    >
+      {tabs.items.map((tab) => {
+        const isActive = tab.key === tabs.activeKey;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => tabs.onChange(tab.key)}
+            aria-current={isActive ? "page" : undefined}
+            title={tab.description}
+            className={clsx(
+              "relative h-6 px-2.5 rounded text-[11px] font-medium transition-colors whitespace-nowrap",
+              isActive
+                ? "text-fg"
+                : "text-fg-3 hover:text-fg-2",
+            )}
+          >
+            {/* Sliding background — shared layoutId animates the
+                highlight between pills instead of fading in place. */}
+            {isActive && (
+              <motion.span
+                layoutId="topbar-tab-active"
+                transition={{ type: "spring", stiffness: 500, damping: 38 }}
+                className="absolute inset-0 rounded bg-surface-3 shadow-sm"
+              />
+            )}
+            <span className="relative">{tab.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
 

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -115,10 +115,19 @@ export default function TopBar({
 
       {/* ── Page identity (breadcrumb) ──────────────────────────
           Layout: parentLabel / title / subtitle
-          The LAST segment (subtitle if any, otherwise title) becomes
-          the trigger for the page's contextual menu when menuItems is
-          provided. Breadcrumb segment IS the menu — no separate
-          "Options" button competing for attention. */}
+
+          Two menu patterns coexist:
+           - menuKind="tabs" (Settings, Catalog): the breadcrumb's last
+             segment IS the menu trigger — clicking it opens an
+             OverflowMenu of sibling tabs. The breadcrumb name is the
+             active tab; the menu lists the others. No separate pill
+             because the breadcrumb already carries the affordance.
+           - menuKind="actions" (source pages): the breadcrumb is plain
+             navigation text (clickable to go back on sub-routes); the
+             menu is opened by a dedicated "Options" pill rendered
+             after the breadcrumb. Walkthrough fix 2026-05-11 round 2 —
+             testers found the dual-trigger arrangement confusing and
+             preferred the pill as the single, obvious entry point. */}
       <div className="flex items-center gap-1.5 min-w-0 flex-1 overflow-hidden text-ui-meta">
         {page && (
           <>
@@ -136,18 +145,21 @@ export default function TopBar({
               </>
             )}
 
-            {/* Title segment — clickable when onTitleClick is set
-                AND it's not the last segment (which is reserved for
-                the menu trigger). */}
+            {/* Title segment.
+                - For "tabs" menus when title is the last breadcrumb
+                  segment AND there are menu items, render as the
+                  breadcrumb-menu trigger.
+                - Otherwise render as plain text (or as a back-link
+                  button when onTitleClick is set, e.g. on sub-routes
+                  of a source page). */}
             {(() => {
               const titleIsLast = !page.subtitle;
-              const titleIsMenuTrigger =
-                titleIsLast && Boolean(page.menuItems?.length);
+              const titleIsTabsMenuTrigger =
+                titleIsLast &&
+                Boolean(page.menuItems?.length) &&
+                page.menuKind === "tabs";
 
-              if (titleIsMenuTrigger) {
-                // Title is the menu trigger — render via OverflowMenu
-                // with a custom trigger that looks like a breadcrumb
-                // segment with a chevron.
+              if (titleIsTabsMenuTrigger) {
                 return (
                   <OverflowMenu
                     items={page.menuItems!}
@@ -175,7 +187,10 @@ export default function TopBar({
 
             {/* Subtitle segment — slides in when entering a sub-route
                 and out when leaving. Keyed on the subtitle text so
-                switching between Configure and Display also animates. */}
+                switching between Configure and Display also animates.
+
+                For "tabs" menus, the subtitle IS the menu trigger.
+                For "actions" menus, the subtitle is plain text. */}
             <AnimatePresence mode="popLayout" initial={false}>
               {page.subtitle && (
                 <motion.div
@@ -189,7 +204,7 @@ export default function TopBar({
                   <span className="text-fg-4 shrink-0" aria-hidden>
                     /
                   </span>
-                  {page.menuItems?.length ? (
+                  {page.menuItems?.length && page.menuKind === "tabs" ? (
                     <OverflowMenu
                       items={page.menuItems}
                       triggerLabel={page.menuLabel ?? "Page options"}
@@ -207,19 +222,10 @@ export default function TopBar({
               )}
             </AnimatePresence>
 
-            {/* Discoverable "Options" pill for action menus (source
-                pages). Renders ONLY when menuKind === "actions" so the
-                Settings / Catalog tab switchers don't get a redundant
-                pill (their menu IS the breadcrumb-as-trigger).
-
-                The breadcrumb segment is ALSO still a menu trigger via
-                BreadcrumbMenuTrigger above — both open the same menu.
-                Two affordances, one menu. Discoverability + muscle
-                memory.
-
-                Walkthrough fix 2026-05-11: super-user testers couldn't
-                find the 11px-chevron-on-breadcrumb trigger; the pill
-                with "Options" label resolves that. */}
+            {/* "Options" pill — the sole trigger for action menus.
+                Renders ONLY when menuKind === "actions" so Settings /
+                Catalog don't get a redundant pill alongside their
+                breadcrumb-as-trigger. */}
             {page.menuItems?.length && page.menuKind === "actions" && (
               <div className="shrink-0 ml-1">
                 <OverflowMenu

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -16,7 +16,7 @@
  * route's content area in a chunky 4-row header. It's now in the
  * TopBar, freeing the entire content area for actual content.
  */
-import { ArrowLeft, ArrowRight, ChevronDown, Pin, Radio, RadioTower } from "lucide-react";
+import { ArrowLeft, ArrowRight, Pin, Radio, RadioTower } from "lucide-react";
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";
 import Tooltip from "./Tooltip";
@@ -116,18 +116,15 @@ export default function TopBar({
       {/* ── Page identity (breadcrumb) ──────────────────────────
           Layout: parentLabel / title / subtitle
 
-          Two menu patterns coexist:
-           - menuKind="tabs" (Settings, Catalog): the breadcrumb's last
-             segment IS the menu trigger — clicking it opens an
-             OverflowMenu of sibling tabs. The breadcrumb name is the
-             active tab; the menu lists the others. No separate pill
-             because the breadcrumb already carries the affordance.
-           - menuKind="actions" (source pages): the breadcrumb is plain
-             navigation text (clickable to go back on sub-routes); the
-             menu is opened by a dedicated "Options" pill rendered
-             after the breadcrumb. Walkthrough fix 2026-05-11 round 2 —
-             testers found the dual-trigger arrangement confusing and
-             preferred the pill as the single, obvious entry point. */}
+          Breadcrumb segments are plain navigation text. Sub-route
+          titles become back-link buttons via onTitleClick. Page-level
+          menus are opened by the explicit "Options" pill at the end of
+          the breadcrumb area — the breadcrumb itself is never a menu
+          trigger. Walkthrough fix 2026-05-11: testers found the old
+          hidden chevron pattern undiscoverable. Pages with sibling
+          tabs (Settings, Catalog, Support sections) now use the
+          PageLayout `tabs` prop to render a visible in-page tab band
+          instead of hiding sibling navigation in a dropdown. */}
       <div className="flex items-center gap-1.5 min-w-0 flex-1 overflow-hidden text-ui-meta">
         {page && (
           <>
@@ -145,52 +142,22 @@ export default function TopBar({
               </>
             )}
 
-            {/* Title segment.
-                - For "tabs" menus when title is the last breadcrumb
-                  segment AND there are menu items, render as the
-                  breadcrumb-menu trigger.
-                - Otherwise render as plain text (or as a back-link
-                  button when onTitleClick is set, e.g. on sub-routes
-                  of a source page). */}
-            {(() => {
-              const titleIsLast = !page.subtitle;
-              const titleIsTabsMenuTrigger =
-                titleIsLast &&
-                Boolean(page.menuItems?.length) &&
-                page.menuKind === "tabs";
-
-              if (titleIsTabsMenuTrigger) {
-                return (
-                  <OverflowMenu
-                    items={page.menuItems!}
-                    triggerLabel={page.menuLabel ?? "Page options"}
-                    trigger={<BreadcrumbMenuTrigger label={page.title} />}
-                  />
-                );
-              }
-              if (page.onTitleClick) {
-                return (
-                  <button
-                    onClick={page.onTitleClick}
-                    className="font-semibold text-fg-2 hover:text-fg truncate transition-colors"
-                  >
-                    {page.title}
-                  </button>
-                );
-              }
-              return (
-                <span className="font-semibold text-fg truncate">
-                  {page.title}
-                </span>
-              );
-            })()}
+            {page.onTitleClick ? (
+              <button
+                onClick={page.onTitleClick}
+                className="font-semibold text-fg-2 hover:text-fg truncate transition-colors"
+              >
+                {page.title}
+              </button>
+            ) : (
+              <span className="font-semibold text-fg truncate">
+                {page.title}
+              </span>
+            )}
 
             {/* Subtitle segment — slides in when entering a sub-route
                 and out when leaving. Keyed on the subtitle text so
-                switching between Configure and Display also animates.
-
-                For "tabs" menus, the subtitle IS the menu trigger.
-                For "actions" menus, the subtitle is plain text. */}
+                switching between Configure and Display also animates. */}
             <AnimatePresence mode="popLayout" initial={false}>
               {page.subtitle && (
                 <motion.div
@@ -204,36 +171,20 @@ export default function TopBar({
                   <span className="text-fg-4 shrink-0" aria-hidden>
                     /
                   </span>
-                  {page.menuItems?.length && page.menuKind === "tabs" ? (
-                    <OverflowMenu
-                      items={page.menuItems}
-                      triggerLabel={page.menuLabel ?? "Page options"}
-                      trigger={
-                        <BreadcrumbMenuTrigger
-                          label={page.subtitle}
-                          muted
-                        />
-                      }
-                    />
-                  ) : (
-                    <span className="text-fg-3 truncate">{page.subtitle}</span>
-                  )}
+                  <span className="text-fg-3 truncate">{page.subtitle}</span>
                 </motion.div>
               )}
             </AnimatePresence>
 
-            {/* "Options" pill — the sole trigger for action menus.
-                Renders ONLY when menuKind === "actions" so Settings /
-                Catalog don't get a redundant pill alongside their
-                breadcrumb-as-trigger. */}
-            {page.menuItems?.length && page.menuKind === "actions" && (
+            {/* "Options" pill — the sole trigger for page-level menus. */}
+            {page.menuItems?.length ? (
               <div className="shrink-0 ml-1">
                 <OverflowMenu
                   items={page.menuItems}
                   triggerLabel={page.menuLabel ?? "Page options"}
                 />
               </div>
-            )}
+            ) : null}
 
             {/* Fallback non-menu action (rare). */}
             {page.entityAction && !page.menuItems?.length && (
@@ -305,60 +256,4 @@ export default function TopBar({
   );
 }
 
-// ── Breadcrumb-as-menu-trigger ──────────────────────────────────
-//
-// Renders a breadcrumb segment that doubles as the OverflowMenu
-// trigger. Clicking the segment opens the menu. Visually it looks
-// like the segment with a small chevron suffix, so the menu's
-// existence is discoverable but the segment still reads as page
-// identity rather than a separate "Options" button.
-//
-// React forwards arbitrary props (including the ref injected by
-// floating-ui's cloneElement) so this component must be a plain
-// element receiver — we build it as a button.
 
-interface BreadcrumbMenuTriggerProps {
-  label: string;
-  /** When true, renders in subtitle (muted) styling instead of title. */
-  muted?: boolean;
-}
-
-function BreadcrumbMenuTrigger({
-  label,
-  muted = false,
-  ...rest
-}: BreadcrumbMenuTriggerProps & React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  // floating-ui injects aria-expanded onto the trigger; we read it
-  // here to flip the chevron orientation so the trigger feels like a
-  // proper dropdown affordance.
-  const isOpen = rest["aria-expanded"] === true || rest["aria-expanded"] === "true";
-
-  return (
-    <button
-      type="button"
-      {...rest}
-      className={clsx(
-        "group flex items-center gap-1 px-1 -mx-1 rounded-md min-w-0 transition-colors",
-        "hover:bg-surface-hover",
-        isOpen && "bg-surface-hover",
-        muted ? "text-fg-3 hover:text-fg-2" : "font-semibold text-fg-2 hover:text-fg",
-      )}
-    >
-      <span className="truncate">{label}</span>
-      <ChevronDown
-        size={11}
-        // 500ms calculated duration on a snap spring — feels more
-        // satisfying than the default linear flip without dragging.
-        style={{
-          transition: "transform 500ms var(--ease-snap)",
-          transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
-        }}
-        className={clsx(
-          "shrink-0",
-          "text-fg-3",
-          "group-hover:text-fg-2 transition-colors",
-        )}
-      />
-    </button>
-  );
-}

--- a/desktop/src/components/layout/PageLayout.tsx
+++ b/desktop/src/components/layout/PageLayout.tsx
@@ -1,35 +1,25 @@
 /**
  * PageLayout — universal page chassis.
  *
- * Page identity (title, subtitle, parent breadcrumb, entity action)
- * is published to the TopBar via PageContext, NOT rendered here. The
- * old in-page header band is gone — the status bar is the single
- * canonical home for "where am I" identity across the whole app.
+ * Everything except the content stack itself lives in the TopBar via
+ * PageContext: title, parent breadcrumb, sibling-tab strip, entity
+ * action, and Options menu. The route just publishes its identity and
+ * renders its content.
  *
- * What stays inside the route's content area:
- *   1. Tab band — sub-navigation within this page (Feed / Configure)
- *   2. Content stack — children
- *   3. Footer — optional destructive/peripheral page-level actions
+ * The content area renders:
+ *   1. Content stack — children, cross-faded on tab/route changes
+ *   2. Footer — optional destructive/peripheral page-level actions
  *
  * IA refactor 2026-05-09 polish pass — see
  * docs/superpowers/specs/2026-05-09-desktop-ia-refactor-design.md
+ * Tab band hoisted into the TopBar on 2026-05-11 to reclaim vertical
+ * space and consolidate page chrome.
  */
 import type { ReactNode } from "react";
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";
-import { useRegisterPageIdentity } from "./page-context";
+import { useRegisterPageIdentity, type PageTabStrip } from "./page-context";
 import type { OverflowMenuItem } from "../OverflowMenu";
-
-// ── Tab type ────────────────────────────────────────────────────
-
-export interface PageTab {
-  /** URL-like identifier for the tab. */
-  key: string;
-  /** Human label rendered in the tab button. */
-  label: string;
-  /** Optional tooltip / aria description. */
-  description?: string;
-}
 
 // ── Props ───────────────────────────────────────────────────────
 
@@ -47,9 +37,8 @@ interface PageLayoutProps {
   onTitleClick?: () => void;
 
   /**
-   * Contextual menu items for this page. When present, the last
-   * breadcrumb segment in the TopBar (subtitle if any, otherwise
-   * title) becomes the menu trigger.
+   * Contextual menu items for this page. When present, the TopBar
+   * renders an "Options" pill button as the menu trigger.
    */
   menuItems?: OverflowMenuItem[];
   /** Aria label for the menu trigger. Default: 'Page options'. */
@@ -62,12 +51,13 @@ interface PageLayoutProps {
    */
   entityAction?: ReactNode;
 
-  /** Optional tab band rendered at the top of the content area. */
-  tabs?: {
-    items: PageTab[];
-    activeKey: string;
-    onChange: (key: string) => void;
-  };
+  /**
+   * Optional sibling-tab strip. Rendered as a compact segmented
+   * control inline in the TopBar (NOT a full-width band in the
+   * content area). Used by Settings, Catalog, and Support section
+   * views to expose sibling navigation.
+   */
+  tabs?: PageTabStrip;
 
   /** Page content. */
   children: ReactNode;
@@ -123,6 +113,7 @@ export default function PageLayout({
     parentLabel,
     onParentClick,
     onTitleClick,
+    tabs,
     menuItems,
     menuLabel,
     entityAction,
@@ -133,59 +124,19 @@ export default function PageLayout({
   // Key the content cross-fade on title+subtitle+active-tab so:
   //  - Source pages animate when switching feed/configure/display
   //    (subtitle changes).
-  //  - Settings/Catalog animate when switching tabs (activeKey
-  //    changes) even though title+subtitle stay the same.
+  //  - Settings/Catalog/Support animate when switching tab pills
+  //    (activeKey changes) even though title stays the same.
   const contentKey = `${title}::${subtitle ?? ""}::${tabs?.activeKey ?? ""}`;
 
   return (
     <div className="flex flex-col h-full">
-      {/* ── Tab band (only when route has sub-tabs) ────────── */}
-      {tabs && (
-        <div className="shrink-0 border-b border-edge/30 bg-surface">
-          <div className={clsx("mx-auto px-5", widthClass)}>
-            <nav
-              className="flex flex-wrap gap-0 -mb-px"
-              aria-label="Page sections"
-            >
-              {tabs.items.map((tab) => {
-                const isActive = tab.key === tabs.activeKey;
-                return (
-                  <button
-                    key={tab.key}
-                    onClick={() => tabs.onChange(tab.key)}
-                    aria-current={isActive ? "page" : undefined}
-                    title={tab.description}
-                    className={clsx(
-                      "relative px-3 py-2.5 text-[12px] font-medium transition-colors -mb-px",
-                      isActive
-                        ? "text-accent"
-                        : "text-fg-3 hover:text-fg-2",
-                    )}
-                  >
-                    {tab.label}
-                    {/* Animated underline — slides between tabs via
-                        layoutId instead of disappearing/reappearing. */}
-                    {isActive && (
-                      <motion.span
-                        layoutId="page-tab-underline"
-                        transition={{ type: "spring", stiffness: 400, damping: 32 }}
-                        className="absolute left-0 right-0 -bottom-px h-0.5 bg-accent rounded-full"
-                      />
-                    )}
-                  </button>
-                );
-              })}
-            </nav>
-          </div>
-        </div>
-      )}
-
       {/* ── Content stack ────────────────────────────────────
           Children are wrapped in an AnimatePresence + motion.div
-          keyed on title+subtitle so navigating between sub-routes
-          (e.g. Feed → Configure → Display on a source page) cross-
-          fades the content while the TopBar chrome and tab band
-          stay stable. The cross-fade uses 'wait' mode for a clean
+          keyed on title+subtitle+active-tab so navigating between
+          sub-routes (e.g. Feed → Configure → Display on a source
+          page) or sibling tabs (Appearance → Ticker → Account in
+          Settings) cross-fades the content while the TopBar chrome
+          stays stable. The cross-fade uses 'wait' mode for a clean
           one-at-a-time transition without overlap during route
           changes. */}
       {fillHeight ? (

--- a/desktop/src/components/layout/PageLayout.tsx
+++ b/desktop/src/components/layout/PageLayout.tsx
@@ -54,12 +54,6 @@ interface PageLayoutProps {
   menuItems?: OverflowMenuItem[];
   /** Aria label for the menu trigger. Default: 'Page options'. */
   menuLabel?: string;
-  /**
-   * Kind of menu. "actions" (default) renders a visible Options pill in
-   * the TopBar; "tabs" relies on the breadcrumb-as-trigger pattern.
-   * See PageContext for the full rationale.
-   */
-  menuKind?: "actions" | "tabs";
 
   /**
    * Fallback non-menu action rendered after the breadcrumb. Use
@@ -114,7 +108,6 @@ export default function PageLayout({
   onTitleClick,
   menuItems,
   menuLabel,
-  menuKind,
   entityAction,
   tabs,
   children,
@@ -132,7 +125,6 @@ export default function PageLayout({
     onTitleClick,
     menuItems,
     menuLabel,
-    menuKind,
     entityAction,
   });
 

--- a/desktop/src/components/layout/PageLayout.tsx
+++ b/desktop/src/components/layout/PageLayout.tsx
@@ -54,6 +54,12 @@ interface PageLayoutProps {
   menuItems?: OverflowMenuItem[];
   /** Aria label for the menu trigger. Default: 'Page options'. */
   menuLabel?: string;
+  /**
+   * Kind of menu. "actions" (default) renders a visible Options pill in
+   * the TopBar; "tabs" relies on the breadcrumb-as-trigger pattern.
+   * See PageContext for the full rationale.
+   */
+  menuKind?: "actions" | "tabs";
 
   /**
    * Fallback non-menu action rendered after the breadcrumb. Use
@@ -108,6 +114,7 @@ export default function PageLayout({
   onTitleClick,
   menuItems,
   menuLabel,
+  menuKind,
   entityAction,
   tabs,
   children,
@@ -125,6 +132,7 @@ export default function PageLayout({
     onTitleClick,
     menuItems,
     menuLabel,
+    menuKind,
     entityAction,
   });
 

--- a/desktop/src/components/layout/page-context.tsx
+++ b/desktop/src/components/layout/page-context.tsx
@@ -47,15 +47,16 @@ export interface PageIdentity {
   /** Aria label for the menu trigger. Default: 'Page options'. */
   menuLabel?: string;
   /**
-   * Kind of menu this is.
-   *  - "actions" (default): page-scoped actions like Configure, Remove
-   *    on source pages. The TopBar renders a visible "Options" pill
-   *    button in addition to the (still-clickable) breadcrumb so the
-   *    menu is discoverable.
-   *  - "tabs": the menu is a sibling-tab switcher (Settings, Catalog)
-   *    where the breadcrumb segment IS the affordance — no extra pill
-   *    needed because the user already sees the active section name
-   *    with a chevron, and the menu items are the other sections.
+   * Kind of menu this is. Controls which trigger TopBar renders.
+   *  - "actions": page-scoped actions like Configure, Remove on
+   *    source pages. The TopBar renders a visible "Options" pill
+   *    button as the SOLE menu trigger. Breadcrumb segments stay
+   *    plain navigation text.
+   *  - "tabs": the menu is a sibling-tab switcher (Settings,
+   *    Catalog). The last breadcrumb segment IS the trigger —
+   *    clicking it opens a menu of the OTHER tabs. No separate pill,
+   *    because the breadcrumb already names the active section and
+   *    the chevron signals "switch."
    */
   menuKind?: "actions" | "tabs";
   /**

--- a/desktop/src/components/layout/page-context.tsx
+++ b/desktop/src/components/layout/page-context.tsx
@@ -42,11 +42,22 @@ export interface PageIdentity {
    * Optional contextual menu items. When provided, the LAST breadcrumb
    * segment (subtitle if present, otherwise title) becomes the menu
    * trigger — clicking it opens an OverflowMenu with these items.
-   * Replaces the earlier separate "Options" button.
    */
   menuItems?: OverflowMenuItem[];
   /** Aria label for the menu trigger. Default: 'Page options'. */
   menuLabel?: string;
+  /**
+   * Kind of menu this is.
+   *  - "actions" (default): page-scoped actions like Configure, Remove
+   *    on source pages. The TopBar renders a visible "Options" pill
+   *    button in addition to the (still-clickable) breadcrumb so the
+   *    menu is discoverable.
+   *  - "tabs": the menu is a sibling-tab switcher (Settings, Catalog)
+   *    where the breadcrumb segment IS the affordance — no extra pill
+   *    needed because the user already sees the active section name
+   *    with a chevron, and the menu items are the other sections.
+   */
+  menuKind?: "actions" | "tabs";
   /**
    * Optional non-menu action rendered after the breadcrumb (e.g. a
    * raw Trash button on routes that don't otherwise have a menu).
@@ -103,6 +114,7 @@ export function useRegisterPageIdentity(identity: PageIdentity) {
     subtitle: identity.subtitle,
     parentLabel: identity.parentLabel,
     menuLabel: identity.menuLabel,
+    menuKind: identity.menuKind,
     menuKey,
   });
   useEffect(() => {

--- a/desktop/src/components/layout/page-context.tsx
+++ b/desktop/src/components/layout/page-context.tsx
@@ -1,27 +1,38 @@
 /**
  * PageContext — lets every route declare its identity (title, optional
- * subtitle, optional menu of contextual actions) so the TopBar can
- * render that identity as breadcrumb-style navigation.
+ * subtitle, optional tab strip, optional menu of contextual actions)
+ * so the TopBar can render all of it inline.
  *
- * The TopBar renders the breadcrumb as:
- *   parentLabel / title / subtitle
- * The LAST segment (subtitle if present, otherwise title) becomes the
- * trigger for the page's contextual menu when `menuItems` is provided.
- * That way the breadcrumb segment IS the menu — no separate "Options"
- * button competing with the breadcrumb for attention.
- *
- * Pre-polish-pass the page header lived inside the route's content
- * area. Now the page identity sits in the always-visible TopBar and
- * the route just publishes its title via this context.
+ * Layout in the TopBar:
+ *   [parentLabel / title]  [tab pills (if any)]  [Options pill / action]
+ * Sibling-tab navigation is rendered as a compact segmented control
+ * inside the bar itself — the breadcrumb area has plenty of slack and
+ * a separate full-width tab band wastes vertical space. Walkthrough
+ * fix 2026-05-11 round 3.
  */
 import { createContext, useContext, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import type { OverflowMenuItem } from "../OverflowMenu";
 
+export interface PageTabStrip {
+  /** Tab descriptors. */
+  items: Array<{
+    key: string;
+    label: string;
+    /** Optional tooltip / aria description. */
+    description?: string;
+  }>;
+  activeKey: string;
+  onChange: (key: string) => void;
+  /** Aria label for the tab strip nav. Default: "Page sections". */
+  ariaLabel?: string;
+}
+
 export interface PageIdentity {
   /** Page title, e.g. "Sports", "Settings", "Catalog". */
   title: string;
-  /** Optional 1-line subtitle / tagline. */
+  /** Optional 1-line subtitle / tagline. Suppressed when `tabs` is
+   *  set — the active tab pill carries the same information. */
   subtitle?: string;
   /**
    * For source pages, the parent breadcrumb label (e.g. "Home"). Used
@@ -39,13 +50,17 @@ export interface PageIdentity {
    */
   onTitleClick?: () => void;
   /**
+   * Optional sibling-tab navigation rendered inline in the TopBar as a
+   * compact segmented pill group. Used by Settings, Catalog, Support
+   * sections — anywhere a route has sibling views that should be
+   * one-click reachable.
+   */
+  tabs?: PageTabStrip;
+  /**
    * Optional contextual menu items. When provided, the TopBar renders
    * an "Options" pill button after the breadcrumb. Clicking the pill
    * opens an OverflowMenu of these items. The breadcrumb itself is
-   * never a menu trigger — it's always plain navigation text. Pages
-   * that need sibling-tab navigation should use PageLayout's `tabs`
-   * prop to render a visible in-page tab band instead of hiding it in
-   * a dropdown.
+   * never a menu trigger — it's always plain navigation text.
    */
   menuItems?: OverflowMenuItem[];
   /** Aria label for the menu trigger. Default: 'Page options'. */
@@ -101,12 +116,18 @@ export function useRegisterPageIdentity(identity: PageIdentity) {
         )
         .join("|")
     : "";
+  const tabsKey = identity.tabs
+    ? `${identity.tabs.activeKey}::${identity.tabs.items
+        .map((t) => `${t.key}:${t.label}`)
+        .join("|")}`
+    : "";
   const key = JSON.stringify({
     title: identity.title,
     subtitle: identity.subtitle,
     parentLabel: identity.parentLabel,
     menuLabel: identity.menuLabel,
     menuKey,
+    tabsKey,
   });
   useEffect(() => {
     ctx?.setIdentity(identity);
@@ -118,5 +139,6 @@ export function useRegisterPageIdentity(identity: PageIdentity) {
     identity.onParentClick,
     identity.onTitleClick,
     identity.menuItems,
+    identity.tabs,
   ]);
 }

--- a/desktop/src/components/layout/page-context.tsx
+++ b/desktop/src/components/layout/page-context.tsx
@@ -39,26 +39,17 @@ export interface PageIdentity {
    */
   onTitleClick?: () => void;
   /**
-   * Optional contextual menu items. When provided, the LAST breadcrumb
-   * segment (subtitle if present, otherwise title) becomes the menu
-   * trigger — clicking it opens an OverflowMenu with these items.
+   * Optional contextual menu items. When provided, the TopBar renders
+   * an "Options" pill button after the breadcrumb. Clicking the pill
+   * opens an OverflowMenu of these items. The breadcrumb itself is
+   * never a menu trigger — it's always plain navigation text. Pages
+   * that need sibling-tab navigation should use PageLayout's `tabs`
+   * prop to render a visible in-page tab band instead of hiding it in
+   * a dropdown.
    */
   menuItems?: OverflowMenuItem[];
   /** Aria label for the menu trigger. Default: 'Page options'. */
   menuLabel?: string;
-  /**
-   * Kind of menu this is. Controls which trigger TopBar renders.
-   *  - "actions": page-scoped actions like Configure, Remove on
-   *    source pages. The TopBar renders a visible "Options" pill
-   *    button as the SOLE menu trigger. Breadcrumb segments stay
-   *    plain navigation text.
-   *  - "tabs": the menu is a sibling-tab switcher (Settings,
-   *    Catalog). The last breadcrumb segment IS the trigger —
-   *    clicking it opens a menu of the OTHER tabs. No separate pill,
-   *    because the breadcrumb already names the active section and
-   *    the chevron signals "switch."
-   */
-  menuKind?: "actions" | "tabs";
   /**
    * Optional non-menu action rendered after the breadcrumb (e.g. a
    * raw Trash button on routes that don't otherwise have a menu).
@@ -115,7 +106,6 @@ export function useRegisterPageIdentity(identity: PageIdentity) {
     subtitle: identity.subtitle,
     parentLabel: identity.parentLabel,
     menuLabel: identity.menuLabel,
-    menuKind: identity.menuKind,
     menuKey,
   });
   useEffect(() => {

--- a/desktop/src/hooks/useWidgetActions.ts
+++ b/desktop/src/hooks/useWidgetActions.ts
@@ -6,7 +6,12 @@
  */
 import { useCallback } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { savePrefs, toggleWidgetOnTicker, toggleWidgetPin } from "../preferences";
+import {
+  defaultPinForNewWidget,
+  savePrefs,
+  toggleWidgetOnTicker,
+  toggleWidgetPin,
+} from "../preferences";
 import type { AppPreferences } from "../preferences";
 
 interface WidgetActions {
@@ -41,12 +46,23 @@ export function useWidgetActions(
       const nextOnTicker = isEnabled
         ? prefs.widgets.widgetsOnTicker.filter((id) => id !== widgetId)
         : [...prefs.widgets.widgetsOnTicker, widgetId];
+      // On enable, default-pin the widget to the right of the ticker so
+      // it lands in the static pinned zone. Preserve any existing pin
+      // config so a re-enable honors the user's last side/row choice.
+      // On disable, leave pinnedWidgets alone — keeping the entry means
+      // a re-enable later remembers where it was. Walkthrough fix
+      // 2026-05-11 — see preferences.ts:defaultPinForNewWidget.
+      const nextPinned = { ...prefs.widgets.pinnedWidgets };
+      if (!isEnabled && !nextPinned[widgetId]) {
+        nextPinned[widgetId] = defaultPinForNewWidget();
+      }
       const next: AppPreferences = {
         ...prefs,
         widgets: {
           ...prefs.widgets,
           enabledWidgets: nextEnabled,
           widgetsOnTicker: nextOnTicker,
+          pinnedWidgets: nextPinned,
         },
       };
       setPrefs(next);

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -1424,13 +1424,34 @@ export function disableWidget(prefs: AppPreferences, widgetId: string): AppPrefe
   };
 }
 
+/**
+ * Default pin config for a newly-added widget.
+ *
+ * Walkthrough fix 2026-05-11 — testers added widgets and saw nothing
+ * "happen" because the widget joined the scrolling ticker tape rather
+ * than appearing in the static pinned zone where they expected widget-
+ * style controls (clock, weather, etc.) to live. Defaulting to a
+ * right-side pin on row 0 means a newly-added widget appears in the
+ * pinned zone immediately. Users can still drag or re-pin to the left
+ * or unpin to make it scroll.
+ *
+ * Lives in one place so the catalog add path, the sidebar toggle path,
+ * and the first-time toggleWidgetPin default all stay consistent.
+ */
+export function defaultPinForNewWidget(): WidgetPinConfig {
+  return { side: "right", row: 0 };
+}
+
 /** Toggle a widget's pin state. Returns a new AppPreferences. */
 export function toggleWidgetPin(prefs: AppPreferences, widgetId: string): AppPreferences {
   const pinned = { ...prefs.widgets.pinnedWidgets };
   if (pinned[widgetId]) {
     delete pinned[widgetId];
   } else {
-    pinned[widgetId] = { side: "left" };
+    // First-time pin from the toggle uses the same default as a
+    // brand-new widget so the manual-pin path doesn't diverge from
+    // the auto-pin path.
+    pinned[widgetId] = defaultPinForNewWidget();
   }
   return {
     ...prefs,

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -6,6 +6,7 @@ import type { LucideIcon } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { toast } from "sonner";
 
+import { defaultPinForNewWidget } from "../preferences";
 import { getCatalogItems, CATEGORY_LABELS, CANONICAL_ORDER } from "../marketplace";
 import type { CatalogCategory, CatalogItem } from "../marketplace";
 import { channelsApi } from "../api/client";
@@ -188,9 +189,23 @@ function CatalogPage() {
       } else {
         const nextEnabled = [...prefs.widgets.enabledWidgets, item.id];
         const nextOnTicker = [...prefs.widgets.widgetsOnTicker, item.id];
+        // Auto-pin newly added widgets to the right side so they land
+        // in the static pinned zone instead of disappearing into the
+        // scrolling tape. Preserve any existing pin config (re-adding
+        // a previously-removed widget honors the user's last choice).
+        // Walkthrough fix 2026-05-11 — see preferences.ts:defaultPinForNewWidget.
+        const nextPinned = { ...prefs.widgets.pinnedWidgets };
+        if (!nextPinned[item.id]) {
+          nextPinned[item.id] = defaultPinForNewWidget();
+        }
         onPrefsChange({
           ...prefs,
-          widgets: { ...prefs.widgets, enabledWidgets: nextEnabled, widgetsOnTicker: nextOnTicker },
+          widgets: {
+            ...prefs.widgets,
+            enabledWidgets: nextEnabled,
+            widgetsOnTicker: nextOnTicker,
+            pinnedWidgets: nextPinned,
+          },
         });
         toast.success(`${item.name} added`);
         navigate({ to: "/widget/$id/$tab", params: { id: item.id, tab: "feed" } });
@@ -226,6 +241,7 @@ function CatalogPage() {
       width="wide"
       menuItems={menuItems}
       menuLabel="Catalog filter"
+      menuKind="tabs"
     >
       {dashboardError && (
         <div className="mb-4">

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -20,7 +20,7 @@ import RouteError from "../components/RouteError";
 import PageLayout from "../components/layout/PageLayout";
 import PageSection from "../components/layout/PageSection";
 import EmptySection from "../components/layout/EmptySection";
-import type { OverflowMenuItem } from "../components/OverflowMenu";
+
 
 export const Route = createFileRoute("/catalog")({
   component: CatalogPage,
@@ -36,14 +36,6 @@ const FILTER_TABS: { key: FilterTab; label: string; icon: LucideIcon; hint: stri
   { key: "channel", label: CATEGORY_LABELS["channel"], icon: Radio, hint: "Show only data channels" },
   { key: "widget", label: CATEGORY_LABELS["widget"], icon: Boxes, hint: "Show only utility widgets" },
 ];
-
-const TAB_BY_KEY: Record<FilterTab, (typeof FILTER_TABS)[number]> = FILTER_TABS.reduce(
-  (acc, t) => {
-    acc[t.key] = t;
-    return acc;
-  },
-  {} as Record<FilterTab, (typeof FILTER_TABS)[number]>,
-);
 
 // ── Sort order: enabled first, then canonical order ─────────────
 
@@ -214,34 +206,25 @@ function CatalogPage() {
     [navigate, queryClient, prefs, onPrefsChange],
   );
 
-  // ── Breadcrumb dropdown — switch the active filter ───────────
-
-  const menuItems: OverflowMenuItem[] = useMemo(() => {
-    const items: OverflowMenuItem[] = [];
-    for (const t of FILTER_TABS) {
-      if (t.key === filter) continue;
-      items.push({
-        key: t.key,
-        label: t.label,
-        hint: t.hint,
-        icon: t.icon,
-        onSelect: () => setFilter(t.key),
-      });
-    }
-    return items;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filter]);
-
   // ── Render ──────────────────────────────────────────────────
+  //
+  // Catalog uses an in-page tab band (All / Channels / Widgets) at the
+  // top of the content. Pre-2026-05-11 this lived in a hidden
+  // breadcrumb dropdown — testers couldn't find the filter switcher.
 
   return (
     <PageLayout
       title="Catalog"
-      subtitle={TAB_BY_KEY[filter].label}
       width="wide"
-      menuItems={menuItems}
-      menuLabel="Catalog filter"
-      menuKind="tabs"
+      tabs={{
+        items: FILTER_TABS.map((t) => ({
+          key: t.key,
+          label: t.label,
+          description: t.hint,
+        })),
+        activeKey: filter,
+        onChange: (key) => setFilter(key as FilterTab),
+      }}
     >
       {dashboardError && (
         <div className="mb-4">

--- a/desktop/src/routes/channel.$type.$tab.tsx
+++ b/desktop/src/routes/channel.$type.$tab.tsx
@@ -78,9 +78,6 @@ function ChannelRoute() {
         navigate({ to: "/channel/$type/$tab", params: { type, tab: t } })
       }
       onBack={() => navigate({ to: "/feed" })}
-      onManageTicker={() =>
-        navigate({ to: "/settings", search: { tab: "ticker" } })
-      }
       onRemove={() => {
         onDeleteChannel(type as ChannelType);
         navigate({ to: "/feed" });

--- a/desktop/src/routes/settings.tsx
+++ b/desktop/src/routes/settings.tsx
@@ -110,6 +110,7 @@ function SettingsRoute() {
       width="narrow"
       menuItems={menuItems}
       menuLabel="Settings sections"
+      menuKind="tabs"
     >
       {tab === "general" && (
         <GeneralSettings

--- a/desktop/src/routes/settings.tsx
+++ b/desktop/src/routes/settings.tsx
@@ -1,26 +1,21 @@
 /**
  * Settings route — consolidated settings page.
  *
- * Three tab-like areas (Appearance / Ticker / Account) but no in-page
- * tab band — the active area's name renders as the last breadcrumb
- * segment in the TopBar, and clicking it opens a dropdown to switch.
- * Mirrors the source-page Options pattern so Settings, Catalog, and
- * channel/widget pages all share one navigation idiom.
+ * Three tab areas (Appearance / Ticker / Account) rendered as an
+ * explicit in-page tab band at the top of the content. The hidden
+ * breadcrumb-dropdown pattern was confusing to walkthrough testers
+ * (2026-05-11) — tabs are now the single, obvious navigation.
  *
  * URL slug "general" retained for backward compat with billing
  * banners and existing routing; the user-facing label is "Appearance".
  */
-import { useMemo } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Settings as SettingsIcon, Sliders, User } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import RouteError from "../components/RouteError";
 import { useShell } from "../shell-context";
 import GeneralSettings from "../components/settings/GeneralSettings";
 import TickerSettings from "../components/settings/TickerSettings";
 import AccountSettings from "../components/settings/AccountSettings";
 import PageLayout from "../components/layout/PageLayout";
-import type { OverflowMenuItem } from "../components/OverflowMenu";
 import { resetCategory, resetAll, type AppPreferences } from "../preferences";
 
 // ── Types ───────────────────────────────────────────────────────
@@ -39,12 +34,6 @@ const TAB_DESCRIPTIONS: Record<SettingsTab, string> = {
   general: "Theme, scale, window, startup, and updates",
   ticker: "Ticker layout, style, and live preview",
   account: "Profile, subscription, plan, data, and reset",
-};
-
-const TAB_ICONS: Record<SettingsTab, LucideIcon> = {
-  general: SettingsIcon,
-  ticker: Sliders,
-  account: User,
 };
 
 // ── Route ───────────────────────────────────────────────────────
@@ -84,33 +73,19 @@ function SettingsRoute() {
     onPrefsChange(next);
   };
 
-  // The dropdown menu items are the OTHER tabs — clicking one
-  // switches. The currently-active tab is hidden from the menu since
-  // its label is already rendered as the trigger itself.
-  const menuItems: OverflowMenuItem[] = useMemo(() => {
-    const items: OverflowMenuItem[] = [];
-    for (const t of VALID_TABS) {
-      if (t === tab) continue;
-      items.push({
-        key: t,
-        label: TAB_LABELS[t],
-        hint: TAB_DESCRIPTIONS[t],
-        icon: TAB_ICONS[t],
-        onSelect: () => setTab(t),
-      });
-    }
-    return items;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab]);
-
   return (
     <PageLayout
       title="Settings"
-      subtitle={TAB_LABELS[tab]}
       width="narrow"
-      menuItems={menuItems}
-      menuLabel="Settings sections"
-      menuKind="tabs"
+      tabs={{
+        items: VALID_TABS.map((t) => ({
+          key: t,
+          label: TAB_LABELS[t],
+          description: TAB_DESCRIPTIONS[t],
+        })),
+        activeKey: tab,
+        onChange: (next) => setTab(next as SettingsTab),
+      }}
     >
       {tab === "general" && (
         <GeneralSettings

--- a/desktop/src/routes/support.tsx
+++ b/desktop/src/routes/support.tsx
@@ -1,3 +1,18 @@
+/**
+ * Support route — landing hub + section views.
+ *
+ * - Hub view: search + category cards. No tab band; the cards ARE the
+ *   navigation.
+ * - Section view: in-page tab band of sibling sections at the top so
+ *   users can hop between Getting Started / FAQ / Troubleshooting /
+ *   Guides / Billing / Contact without round-tripping through the hub.
+ *   The TopBar breadcrumb still shows "Support / <section>" with the
+ *   parent link returning to the hub.
+ *
+ * Walkthrough fix 2026-05-11 — testers had to keep going back to the
+ * hub to switch between Q&A surfaces; the tab band makes lateral
+ * movement obvious.
+ */
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import SupportHub from "../components/support/SupportHub";
@@ -16,7 +31,28 @@ export const Route = createFileRoute("/support")({
   errorComponent: RouteError,
 });
 
+// Ordered list — drives the tab band on section views. Keep the order
+// consistent with SupportHub's CATEGORIES so users see the same
+// progression whether they land via cards or via tabs.
+const SECTION_ORDER: SectionId[] = [
+  "getting-started",
+  "faq",
+  "troubleshooting",
+  "guides",
+  "billing",
+  "contact",
+];
+
 const SECTION_TITLES: Record<SectionId, string> = {
+  "getting-started": "Getting Started",
+  faq: "FAQ",
+  troubleshooting: "Troubleshooting",
+  guides: "Feature Guides",
+  billing: "Account & Billing",
+  contact: "Contact",
+};
+
+const SECTION_LONG_TITLES: Record<SectionId, string> = {
   "getting-started": "Getting Started",
   faq: "Frequently Asked Questions",
   troubleshooting: "Troubleshooting",
@@ -41,11 +77,12 @@ function SupportPage() {
     );
   }
 
-  // Section view — TopBar shows "Support / <section>" breadcrumb.
-  // Click "Support" in the breadcrumb to return to the hub.
+  // Section view — TopBar shows "Support / <section>" breadcrumb;
+  // an in-page tab band lets users switch laterally between sections
+  // without bouncing through the hub.
   return (
     <PageLayout
-      title={SECTION_TITLES[activeSection]}
+      title={SECTION_LONG_TITLES[activeSection]}
       subtitle={
         activeSection === "contact"
           ? "Report bugs, request features, or send feedback"
@@ -54,6 +91,14 @@ function SupportPage() {
       parentLabel="Support"
       onParentClick={() => setActiveSection(null)}
       width="wide"
+      tabs={{
+        items: SECTION_ORDER.map((id) => ({
+          key: id,
+          label: SECTION_TITLES[id],
+        })),
+        activeKey: activeSection,
+        onChange: (key) => setActiveSection(key as SectionId),
+      }}
     >
       {activeSection === "getting-started" && <GettingStartedSection />}
       {activeSection === "faq" && <FAQSection />}

--- a/desktop/src/routes/widget.$id.$tab.tsx
+++ b/desktop/src/routes/widget.$id.$tab.tsx
@@ -53,9 +53,6 @@ function WidgetRoute() {
         navigate({ to: "/widget/$id/$tab", params: { id, tab: t } })
       }
       onBack={() => navigate({ to: "/feed" })}
-      onManageTicker={() =>
-        navigate({ to: "/settings", search: { tab: "ticker" } })
-      }
       onRemove={() => {
         undoable(
           {


### PR DESCRIPTION
## Summary

Three pain points surfaced during fresh super-user walkthroughs:

1. **Widgets defaulted to scrolling in the ticker tape** instead of the static pinned zone, so testers added a widget and saw "nothing happen."
2. **The source-page dropdown was impossible to find** (11px chevron disguised as a breadcrumb segment) and mixed source-scoped actions with a global "Manage on ticker" link that yanked users away mid-task.
3. **RSS feed duplication** — clicking any curated feed silently re-labeled it as "Custom" because the backend was writing every feed into `user_custom_feeds` and the catalog query/UI didn't dedup.

All three fixed in one PR.

## Changes

### 1) Auto-pin new widgets to the right of the ticker

- New `defaultPinForNewWidget()` helper in `preferences.ts` (`{ side: "right", row: 0 }`).
- Used by the catalog "add widget" path (`routes/catalog.tsx`) and the sidebar toggle path (`hooks/useWidgetActions.ts`).
- `toggleWidgetPin()` first-time default now uses the same helper so manual-pin and auto-pin stay in lockstep.
- Existing widgets in user state are untouched; only widgets added after this change ship pinned. Re-enabling a previously-disabled widget honors its last side/row choice.

### 2) Discoverable "Options" pill + remove ticker settings from source menu

- New `menuKind: "actions" | "tabs"` field on `PageContext` / `PageLayout`.
- Source pages (channel + widget) declare `menuKind="actions"` → TopBar renders a visible "Options" pill (Settings2 icon + label + chevron) **in addition to** the existing breadcrumb-as-trigger. Both open the same menu.
- Settings + Catalog declare `menuKind="tabs"` → keep the breadcrumb-as-trigger pattern (the breadcrumb already shows the active section, which is appropriate for a sibling-tab switcher).
- Removed "Manage on ticker" from the source-page menu. It navigated users to `/settings?tab=ticker`, which testers found jarring. Ticker settings remain reachable from the main Settings route.
- Dropped the now-unused `onManageTicker` prop from `SourcePageLayout` and its two callers.

### 3) RSS feed duplication — defense in depth

**Root cause:** `syncRSSFeedsToTracked` in `channels/rss/api/rss.go` blindly upserted every feed in a user's config into `user_custom_feeds`, including URLs that were already curated defaults in `tracked_feeds`. The catalog query then `UNION ALL`'d both halves with no dedup, and `FeedTab.tsx`'s `categoryMap` overwrote the curated category with "Custom" when building its `url → category` map.

**Fixes (all three layers):**

- **Runtime guard** — `syncRSSFeedsToTracked` preloads the set of curated URLs once and skips the `user_custom_feeds` insert for them. Prevents new pollution.
- **Query filter** — `queryUserCatalog` adds `NOT EXISTS (SELECT 1 FROM tracked_feeds tf2 WHERE tf2.url = ucf.url AND tf2.is_default = true)` to the custom half of the UNION. Hides any historical bad rows that escaped the guard.
- **Cleanup migration** — new `130000000002_cleanup_dup_user_custom_feeds` in `channels/rss/service/migrations/` deletes `user_custom_feeds` rows whose URL is already a curated default. Runs automatically on RSS service startup. Migration version is in the rss `13*` prefix range and passes the `migration_versions` invariant test.
- **Frontend safety net** — `FeedTab.tsx` `categoryMap` prefers non-"Custom" categories when both exist for the same URL.

## Verification

- `npm run build` (desktop) → vite build + `tsc --noEmit` clean
- `go build ./...` + `go vet ./...` (rss/api) → clean
- `go build ./...` (api) → clean
- `cargo build` + `cargo test --test migration_versions` (rss/service) → 2 tests passing
- Migration `130000000002` is in the rss-reserved version range (`13*`).

## Manual test plan

1. Fresh account: add a widget from Catalog → appears in the right pinned zone of row 0 (not scrolling).
2. Existing account: open the app → widget layout unchanged.
3. Source page → both the "Options" pill and the breadcrumb segment open the same menu.
4. Source menu contains: Configure, Display preferences (channels only), Remove. No "Manage on ticker."
5. Add a curated RSS feed (e.g., Hacker News) → it appears under "News" category, not "Custom."
6. Add a custom URL → it appears under "Custom."
7. Existing affected user: previously-dup'd feeds now show correct curated category after migration.
8. `SELECT count(*) FROM user_custom_feeds ucf JOIN tracked_feeds tf ON tf.url = ucf.url WHERE tf.is_default = true;` returns 0 post-migration.