### PR TITLE
fix: update stale tips that referenced the old breadcrumb dropdown

### DIFF
--- a/desktop/src/channels/fantasy/FeedTab.tsx
+++ b/desktop/src/channels/fantasy/FeedTab.tsx
@@ -153,7 +153,6 @@ function FantasyFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
       <EmptyChannelState
         icon={Swords}
         noun="fantasy leagues"
-        channelName="Fantasy"
         hasConfig={!!feedContext.__hasConfig}
         dashboardLoaded={!!feedContext.__dashboardLoaded}
         loadingNoun="leagues"

--- a/desktop/src/channels/finance/FeedTab.tsx
+++ b/desktop/src/channels/finance/FeedTab.tsx
@@ -39,7 +39,7 @@ export const financeChannel: ChannelManifest = {
       "Track stocks, ETFs, and cryptocurrencies with live price updates. " +
       "Prices update automatically so your feed always shows the latest.",
     usage: [
-      "Add symbols from the Settings tab to start tracking.",
+      "Open Configure to add symbols and start tracking.",
       "Prices update automatically when connected.",
       "Click any symbol to view its chart on Google Finance.",
     ],
@@ -203,7 +203,6 @@ function FinanceFeedTab({ mode: callerMode, feedContext, onConfigure }: FeedTabP
       <EmptyChannelState
         icon={TrendingUp}
         noun="stocks or crypto"
-        channelName="Finance"
         hasConfig={!!feedContext.__hasConfig}
         dashboardLoaded={!!feedContext.__dashboardLoaded}
         loadingNoun="prices"

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -40,7 +40,7 @@ export const rssChannel: ChannelManifest = {
       "Collect articles from your favorite websites into one place. " +
       "New articles appear automatically as they are published.",
     usage: [
-      "Add news sources from the Settings tab.",
+      "Open Configure to add news sources.",
       "Articles are sorted by publish date, newest first.",
       "Click any article to open it in your browser.",
     ],
@@ -341,7 +341,6 @@ function RssFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
       <EmptyChannelState
         icon={Rss}
         noun="feeds"
-        channelName="RSS"
         hasConfig={!!feedContext.__hasConfig}
         dashboardLoaded={!!dashboardLoaded}
         loadingNoun="articles"

--- a/desktop/src/channels/sports/FeedTab.tsx
+++ b/desktop/src/channels/sports/FeedTab.tsx
@@ -38,7 +38,7 @@ export const sportsChannel: ChannelManifest = {
       "Follow live scores across NFL, NBA, MLB, NHL, MLS, and more. " +
       "Scores update automatically with a visual flash when they change.",
     usage: [
-      "Pick your leagues from the Settings tab.",
+      "Open Configure to pick your leagues.",
       "Live games show a pulsing indicator and scores update automatically.",
       "Final scores highlight the winning team in bold.",
     ],
@@ -223,7 +223,6 @@ function SportsFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
       <EmptyChannelState
         icon={Trophy}
         noun="leagues"
-        channelName="Sports"
         hasConfig={!!feedContext.__hasConfig}
         dashboardLoaded={!!feedContext.__dashboardLoaded}
         loadingNoun="scores"

--- a/desktop/src/components/EmptyChannelState.tsx
+++ b/desktop/src/components/EmptyChannelState.tsx
@@ -4,31 +4,25 @@
  * Replaces the repeated empty-state pattern in finance, sports, rss, and
  * fantasy feeds.
  *
- * Copy is pointed at the **breadcrumb dropdown in the TopBar** — the
- * channel name + chevron at the top of the window (e.g. "Sports ▾").
- * That dropdown is the ONLY sub-tab switcher on channel pages; there is
- * no horizontal tab strip and no "Settings" tab in the title bar. The
- * earlier copy said "Open the Settings tab" which was misleading — users
- * looked for a tab that doesn't exist.
+ * Copy is pointed at the **"Options" pill in the TopBar** — the
+ * Settings2 icon + "Options" label rendered next to the page title.
+ * That pill is the canonical menu trigger on source pages (channel +
+ * widget). The CTA button still jumps directly to the Configure sub-
+ * tab so the one-tap fix is preserved; the surrounding copy teaches
+ * the user where the menu lives so they can do it themselves next
+ * time.
  *
- * The CTA button still jumps directly to the Configure sub-tab so the
- * one-tap fix is preserved; the surrounding copy teaches the user where
- * the dropdown lives so they can do it themselves next time.
+ * Walkthrough fix 2026-05-11 — previously this tip pointed at a
+ * breadcrumb dropdown (channel name + chevron) which no longer exists
+ * after the source-page menu was consolidated under the Options pill.
  */
 import { clsx } from "clsx";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Settings2 } from "lucide-react";
 
 interface EmptyChannelStateProps {
   icon: React.ComponentType<{ size?: number; className?: string }>;
   /** What hasn't been added yet (e.g. "stocks or crypto", "leagues", "feeds"). */
   noun: string;
-  /**
-   * Display name of the channel itself, e.g. "Finance", "Sports", "RSS",
-   * "Fantasy". Used to label the breadcrumb dropdown trigger in the
-   * teaching copy. When omitted, the copy falls back to the generic
-   * "channel name" phrase.
-   */
-  channelName?: string;
   /** Whether the channel has config (i.e. user has picked items to track). */
   hasConfig: boolean;
   /** Whether the dashboard has loaded. */
@@ -41,7 +35,7 @@ interface EmptyChannelStateProps {
    * Navigate to the channel's Configure sub-tab. Wired in
    * `routes/channel.$type.$tab.tsx`. When provided, the hint becomes a
    * one-tap button; the surrounding copy still teaches the user the
-   * dropdown path so they can do it themselves next time.
+   * Options-pill path so they can do it themselves next time.
    */
   onConfigure?: () => void;
 }
@@ -49,15 +43,12 @@ interface EmptyChannelStateProps {
 export default function EmptyChannelState({
   icon: Icon,
   noun,
-  channelName,
   hasConfig,
   dashboardLoaded,
   loadingNoun,
   actionHint,
   onConfigure,
 }: EmptyChannelStateProps) {
-  const breadcrumbLabel = channelName ?? "channel name";
-
   return (
     <div
       className={clsx(
@@ -92,12 +83,13 @@ export default function EmptyChannelState({
             Tip: click{" "}
             <span
               className={clsx(
-                "inline-flex items-center gap-0.5 align-baseline",
+                "inline-flex items-center gap-1 align-baseline",
                 "px-1 py-px rounded",
                 "bg-fg-4/10 text-fg-2 font-semibold",
               )}
             >
-              {breadcrumbLabel}
+              <Settings2 size={9} strokeWidth={2.5} aria-hidden="true" />
+              Options
               <ChevronDown size={9} strokeWidth={2.5} aria-hidden="true" />
             </span>{" "}
             in the title bar to open this menu yourself next time.

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useEffect, useRef, useState, useCallback } from "react";
 import clsx from "clsx";
-import { ChevronDown, Plus } from "lucide-react";
+import { ChevronDown, Plus, Settings2 } from "lucide-react";
 import { Ticker } from "motion-plus/react";
 import { useMotionValue, animate, AnimatePresence, motion } from "motion/react";
 import type { DashboardResponse, Trade, Game, RssItem, WidgetTickerData } from "../types";
@@ -762,28 +762,29 @@ export default function ScrollrTicker({
               })}
             </div>
           </div>
-          {/* Secondary row: teaching tip pointing at the title-bar
-              breadcrumb dropdown. Hidden on the compact ticker (h-11
+          {/* Secondary row: teaching tip pointing at the "Options"
+              pill in the TopBar. Hidden on the compact ticker (h-11
               ≈ 44px) because there's no room for a second line without
               cramping; comfort mode (h-16 ≈ 64px) has plenty. The
               equivalent tip is also shown on every channel's empty
               feed (see EmptyChannelState.tsx), so users still discover
-              the dropdown there even when this row is suppressed. */}
+              the pill there even when this row is suppressed. */}
           {comfort && (
             <p className="text-[10px] text-fg-4/80 shrink-0 leading-tight hidden md:inline-flex items-center gap-1">
               <span className="text-fg-4">Tip:</span>
-              <span>click</span>
+              <span>open a source and click</span>
               <span
                 className={clsx(
-                  "inline-flex items-center gap-0.5 align-baseline",
+                  "inline-flex items-center gap-1 align-baseline",
                   "px-1 py-px rounded",
                   "bg-fg-4/10 text-fg-2 font-semibold",
                 )}
               >
-                a source name
+                <Settings2 size={8} strokeWidth={2.5} aria-hidden="true" />
+                Options
                 <ChevronDown size={8} strokeWidth={2.5} aria-hidden="true" />
               </span>
-              <span>in the title bar to open this menu yourself next time.</span>
+              <span>in the title bar to do this yourself next time.</span>
             </p>
           )}
         </div>

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -189,8 +189,8 @@ export default function Sidebar({
         />
 
         {/* Collapse toggle. Connection status + ticker status are now
-            in the ControlStrip (always-visible chrome below the title
-            bar) — see components/ControlStrip.tsx. The sidebar footer
+            in the TopBar (always-visible chrome at the top of the
+            window) — see components/TopBar.tsx. The sidebar footer
             stays minimal. */}
         <Tooltip content={collapsed ? "Expand sidebar" : "Collapse sidebar"} side="right">
           <button

--- a/desktop/src/components/support/support-content.ts
+++ b/desktop/src/components/support/support-content.ts
@@ -99,7 +99,7 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
       "Ticker shows empty slots where data should be",
     ],
     steps: [
-      "Open the channel's Settings tab and verify items are configured (symbols, leagues, or feeds).",
+      "Open the channel and click Options > Configure to verify items are added (symbols, leagues, or feeds).",
       "Check that you're signed in (Settings > Account).",
       "Try switching away from and back to the feed tab.",
       "Check your internet connection.",
@@ -227,7 +227,7 @@ export const GETTING_STARTED_STEPS: GettingStartedStep[] = [
     title: "Configure Your Feeds",
     iconName: "Settings",
     description:
-      "Each channel has a Settings tab where you pick what to track. Add stock symbols, select sports leagues, subscribe to news feeds, or connect your Yahoo account.",
+      "Each channel has a Configure view where you pick what to track. Open a channel, click Options in the title bar, then Configure source — add stock symbols, select sports leagues, subscribe to news feeds, or connect your Yahoo account.",
   },
   {
     title: "Customize the Ticker",

--- a/desktop/src/components/support/support-content.ts
+++ b/desktop/src/components/support/support-content.ts
@@ -41,7 +41,7 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "Can I customize the feed?",
     answer:
-      "Extensively. Position the ticker at the top or bottom of your screen, adjust rows and density, pin favorite sources to the sidebar, filter and sort within each channel, and toggle individual data points on or off in each channel's Display settings.",
+      "Extensively. Move the ticker to the top or bottom of the screen by right-clicking it (or using the up/down chevron in the hover toolbar). In Settings > Ticker you can change the detail level (Compact / Detailed), add ticker rows, and adjust speed. Within each channel you can filter, sort, and toggle individual data points on or off under Options > Display preferences.",
   },
   {
     question: "Is Scrollr open source?",
@@ -56,17 +56,17 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "Can I use Scrollr on multiple monitors?",
     answer:
-      "Yes. The ticker automatically spans the full width of your primary monitor. You can move it between monitors by changing the ticker position in Settings > Ticker.",
+      "Yes. The ticker spans the full width of whichever monitor the Scrollr window is currently on. To move it to a different monitor, drag the main window onto that monitor — the ticker follows. There's no monitor selector inside Settings; the ticker uses your OS's active-monitor placement.",
   },
   {
     question: "How does live data work vs. polling?",
     answer:
-      "Free and Uplink tiers use polling — the app fetches fresh data at regular intervals (60s for free, 30s for Uplink, 10s for Pro). Uplink Ultimate uses a persistent SSE connection for instant live updates as data changes on the server. You can see your current mode (Live or Polling) in the sidebar footer.",
+      "Free, Uplink, and Uplink Pro tiers use polling — the app fetches fresh data at regular intervals (60s on Free, 30s on Uplink, 10s on Uplink Pro). Uplink Ultimate uses a persistent SSE connection for instant live updates as data changes on the server. The current mode (Live or Polling) shows in the title bar next to the Pin button — a green dot means Live, a normal dot means Polling.",
   },
   {
     question: "What's the difference between Uplink tiers?",
     answer:
-      "Free: 5 symbols, 1 feed, 1 league. Uplink: 25 symbols, 25 feeds, 8 leagues, 30s polling. Uplink Pro: 75 symbols, 100 feeds, 20 leagues, 10s polling. Uplink Ultimate: unlimited everything, live streaming via SSE, priority support.",
+      "Free: 5 stock/crypto symbols, 1 news feed, 1 sports league, no fantasy leagues, 60s polling. Uplink: 25 symbols, 25 feeds, 8 sports leagues, 1 fantasy league, 30s polling. Uplink Pro: 75 symbols, 100 feeds, 20 sports leagues, 3 fantasy leagues, 10s polling. Uplink Ultimate: unlimited symbols/feeds/sports leagues, 10 fantasy leagues, live SSE streaming.",
   },
 ];
 
@@ -113,8 +113,9 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
     ],
     steps: [
       "Press Ctrl+T (Cmd+T on macOS) to toggle ticker visibility.",
-      "Or go to Settings > General and enable the \"Show Ticker\" toggle.",
-      "Right-click the system tray icon and check \"Toggle Ticker\".",
+      "Or go to Settings > Ticker and turn on \"Enable ticker\".",
+      "Or click the Ticker toggle in the title bar (next to the Pin button).",
+      "Or right-click the system tray icon and choose \"Toggle Ticker\".",
     ],
   },
   {
@@ -148,8 +149,8 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
       "Yesterday's games still showing as live",
     ],
     steps: [
-      "Scores update via polling based on your plan tier. Free: 60s, Uplink: 30s, Pro: 10s, Ultimate: live.",
-      "Check your current delivery mode in the sidebar footer (Live vs Polling).",
+      "Scores update via polling based on your plan tier. Free: 60s, Uplink: 30s, Uplink Pro: 10s, Uplink Ultimate: live SSE.",
+      "Check your current delivery mode in the title bar (next to the Pin button) — green dot is Live, normal dot is Polling.",
       "Try switching to a different tab and back.",
     ],
   },
@@ -171,7 +172,7 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
       "Some feeds show data but others don't",
     ],
     steps: [
-      "Check the feed's health indicator in Settings — green is healthy, amber is stale, red is failing.",
+      "Open the News channel, then Options > Configure source. Each tracked feed has a colored health dot — green is healthy, amber is stale, red is failing.",
       "Some feeds may be temporarily down. Try adding a different feed to verify your connection works.",
       "Custom feeds must be valid RSS or Atom URLs.",
     ],
@@ -233,7 +234,7 @@ export const GETTING_STARTED_STEPS: GettingStartedStep[] = [
     title: "Customize the Ticker",
     iconName: "Monitor",
     description:
-      "The ticker bar runs across your screen showing live data. Adjust its position (top/bottom), size (compact/comfort), and number of rows in Settings > Ticker.",
+      "The ticker bar runs across your screen showing live data. Open Settings > Ticker to change the detail level (Compact / Detailed), add ticker rows, and adjust speed. To move the ticker to the top or bottom of the screen, right-click it or use the up/down chevron in the hover toolbar.",
   },
   {
     title: "Explore Widgets",

--- a/desktop/src/hooks/useDeliveryHealth.ts
+++ b/desktop/src/hooks/useDeliveryHealth.ts
@@ -143,7 +143,7 @@ function descriptionFor(
     case "polling":
       return sseEligible
         ? "Realtime stream is reconnecting. Polling every minute meanwhile."
-        : "Polling every minute. Upgrade to Uplink Pro for realtime updates.";
+        : "Polling every minute. Upgrade to Uplink Ultimate for realtime SSE updates.";
     case "stale": {
       const ago = ageMs ? formatAge(ageMs) : "a while";
       return `No update in ${ago}. Data on screen may be slightly behind.`;

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -685,11 +685,11 @@ function RootLayout() {
     }
   }, []);
 
-  // ── ControlStrip handlers ───────────────────────────────────
-  // Two ambient toggles always visible below the title bar so users
-  // never have to dig into Settings → Ticker to toggle the entire
-  // product on/off. Same prefs as Settings → Ticker top toggle and
-  // Settings → Appearance → Always on top — single source of truth.
+  // ── TopBar ambient-toggle handlers ──────────────────────────
+  // Two ambient toggles always visible in the TopBar so users never
+  // have to dig into Settings → Ticker to toggle the entire product
+  // on/off. Same prefs as Settings → Ticker "Enable ticker" toggle
+  // and the Pin button — single source of truth.
   const handleTickerToggle = useCallback(() => {
     persistPrefs({
       ...prefs,

--- a/desktop/src/widgets/clock/FeedTab.tsx
+++ b/desktop/src/widgets/clock/FeedTab.tsx
@@ -42,9 +42,9 @@ export const clockWidget: WidgetManifest = {
       "countdown and stopwatch timer.",
     usage: [
       "Your local time appears on the ticker by default.",
-      "Turn on world clocks in the Settings tab to add more time zones.",
+      "Turn on world clocks in the Configure tab to add more time zones.",
       "Use the timer tab in the feed view to set countdowns or run a stopwatch.",
-      "Hide specific time zones from the ticker in the Settings tab.",
+      "Hide specific time zones from the ticker in the Configure tab.",
     ],
   },
   FeedTab: ClockFeedTab,

--- a/desktop/src/widgets/github/FeedTab.tsx
+++ b/desktop/src/widgets/github/FeedTab.tsx
@@ -43,7 +43,7 @@ export const githubWidget: WidgetManifest = {
       "Paste a GitHub repo URL to add it (e.g. https://github.com/org/repo).",
       "Each repo shows its latest GitHub Actions workflow run status.",
       "Click a repo row to open the workflow run on GitHub.",
-      "Hide specific repos from the ticker in the Settings tab.",
+      "Hide specific repos from the ticker in the Configure tab.",
     ],
   },
   FeedTab: GitHubFeedTab,

--- a/desktop/src/widgets/sysmon/FeedTab.tsx
+++ b/desktop/src/widgets/sysmon/FeedTab.tsx
@@ -309,9 +309,9 @@ export const sysmonWidget: WidgetManifest = {
       "The System Monitor widget shows live stats for your computer on the ticker, including CPU usage, memory, and GPU.",
     usage: [
       "CPU, memory, and GPU usage appear on the ticker.",
-      "Turn individual stats on or off in the Settings tab.",
+      "Turn individual stats on or off in the Configure tab.",
       "The feed view shows detailed real-time stats including temperatures and a full breakdown.",
-      "Keep the system monitor in a fixed spot on the ticker from the Settings tab.",
+      "Keep the system monitor in a fixed spot on the ticker from the Configure tab.",
     ],
   },
   desktopOnly: true,

--- a/desktop/src/widgets/uptime/FeedTab.tsx
+++ b/desktop/src/widgets/uptime/FeedTab.tsx
@@ -39,7 +39,7 @@ export const uptimeWidget: WidgetManifest = {
     usage: [
       "Paste your Uptime Kuma public status page URL to connect.",
       "All monitors from your status page appear with their current status.",
-      "Hide specific monitors from the ticker in the Settings tab.",
+      "Hide specific monitors from the ticker in the Configure tab.",
       "Configure the poll interval to control how often statuses refresh.",
     ],
   },

--- a/desktop/src/widgets/weather/FeedTab.tsx
+++ b/desktop/src/widgets/weather/FeedTab.tsx
@@ -34,7 +34,7 @@ export const weatherWidget: WidgetManifest = {
       "Search for a city in the feed view to add it to your weather locations.",
       "Each location appears on the ticker with temperature, conditions, and an icon.",
       "Add multiple cities to track weather across different locations.",
-      "Hide specific cities from the ticker in the Settings tab.",
+      "Hide specific cities from the ticker in the Configure tab.",
     ],
   },
   FeedTab: WeatherFeedTab,

--- a/myscrollr.com/src/components/support/support-content.ts
+++ b/myscrollr.com/src/components/support/support-content.ts
@@ -94,7 +94,7 @@ export const TROUBLESHOOTING_ARTICLES: Array<TroubleshootingArticle> = [
       'Ticker shows empty slots where data should be',
     ],
     steps: [
-      "Open the channel's Settings tab and verify items are configured (symbols, leagues, or feeds).",
+      'Open the channel and click Options > Configure to verify items are added (symbols, leagues, or feeds).',
       "Check that you're signed in (Settings > Account).",
       'Try switching away from and back to the feed tab.',
       'Check your internet connection.',
@@ -175,7 +175,7 @@ export const GETTING_STARTED_STEPS: Array<GettingStartedStep> = [
   {
     title: 'Configure Your Feeds',
     description:
-      'Each channel has a Settings tab where you pick what to track. Add stock symbols, select sports leagues, subscribe to news feeds, or connect your Yahoo account.',
+      'Each channel has a Configure view where you pick what to track. Open a channel, click Options in the title bar, then Configure source — add stock symbols, select sports leagues, subscribe to news feeds, or connect your Yahoo account.',
   },
   {
     title: 'Customize the Ticker',

--- a/myscrollr.com/src/components/support/support-content.ts
+++ b/myscrollr.com/src/components/support/support-content.ts
@@ -46,7 +46,7 @@ export const FAQ_ITEMS: Array<FAQItem> = [
   {
     question: 'Can I customize the feed?',
     answer:
-      "Extensively. Position the ticker at the top or bottom of your screen, adjust rows and density, pin favorite sources to the sidebar, filter and sort within each channel, and toggle individual data points on or off in each channel's Display settings.",
+      'Extensively. Move the ticker to the top or bottom of the screen by right-clicking it (or using the up/down chevron in the hover toolbar). In Settings > Ticker you can change the detail level (Compact / Detailed), add ticker rows, and adjust speed. Within each channel you can filter, sort, and toggle individual data points on or off under Options > Display preferences.',
   },
   {
     question: 'Is Scrollr open source?',
@@ -61,7 +61,12 @@ export const FAQ_ITEMS: Array<FAQItem> = [
   {
     question: 'How does live data work vs. polling?',
     answer:
-      'Free and Uplink tiers use polling — the app fetches fresh data at regular intervals (60s for free, 30s for Uplink, 10s for Pro). Uplink Ultimate uses a persistent SSE connection for instant live updates as data changes on the server.',
+      'Free, Uplink, and Uplink Pro tiers use polling — the app fetches fresh data at regular intervals (60s on Free, 30s on Uplink, 10s on Uplink Pro). Uplink Ultimate uses a persistent SSE connection for instant live updates as data changes on the server.',
+  },
+  {
+    question: "What's the difference between Uplink tiers?",
+    answer:
+      'Free: 5 stock/crypto symbols, 1 news feed, 1 sports league, no fantasy leagues, 60s polling. Uplink: 25 symbols, 25 feeds, 8 sports leagues, 1 fantasy league, 30s polling. Uplink Pro: 75 symbols, 100 feeds, 20 sports leagues, 3 fantasy leagues, 10s polling. Uplink Ultimate: unlimited symbols/feeds/sports leagues, 10 fantasy leagues, live SSE streaming.',
   },
 ]
 
@@ -108,8 +113,9 @@ export const TROUBLESHOOTING_ARTICLES: Array<TroubleshootingArticle> = [
     ],
     steps: [
       'Press Ctrl+T (Cmd+T on macOS) to toggle ticker visibility.',
-      'Or go to Settings > General and enable the "Show Ticker" toggle.',
-      'Right-click the system tray icon and check "Toggle Ticker".',
+      'Or go to Settings > Ticker and turn on "Enable ticker".',
+      'Or click the Ticker toggle in the title bar (next to the Pin button).',
+      'Or right-click the system tray icon and choose "Toggle Ticker".',
     ],
   },
   {
@@ -180,7 +186,7 @@ export const GETTING_STARTED_STEPS: Array<GettingStartedStep> = [
   {
     title: 'Customize the Ticker',
     description:
-      'The ticker bar runs across your screen showing live data. Adjust its position (top/bottom), size (compact/comfort), and number of rows in Settings > Ticker.',
+      'The ticker bar runs across your screen showing live data. Open Settings > Ticker to change the detail level (Compact / Detailed), add ticker rows, and adjust speed. To move the ticker to the top or bottom of the screen, right-click it or use the up/down chevron in the hover toolbar.',
   },
 ]
 


### PR DESCRIPTION
## Summary

Follow-up to #169. Several user-facing tips still pointed at the pre-walkthrough-fix breadcrumb dropdown (\"click the source name in the title bar\") and at a non-existent \"Settings tab.\" With the source-page menu now opened exclusively by the Options pill and the legacy in-page tab band gone, those tips were misleading.

## Changes

**Desktop**
- `EmptyChannelState` — the chip in the teaching tip now shows the \`[Settings2 icon] Options [chevron]\` affordance (matching the new TopBar pill) instead of the channel name + chevron. The unused `channelName` prop is dropped and the four FeedTab callers (Finance, Sports, RSS, Fantasy) updated.
- `ScrollrTicker` installed-but-off tip — same update, points at the Options pill.
- Channel feature-guide \`info.usage\` strings (finance / sports / rss) — say \"Open Configure to …\" instead of \"from the Settings tab.\"
- Widget feature-guide \`info.usage\` strings (clock, weather, sysmon, uptime, github) — say \"in the Configure tab\" instead of \"in the Settings tab.\"
- Support content (troubleshooting + Getting Started) — point at \"Options > Configure\" instead of \"the channel's Settings tab.\"

**Website (myscrollr.com)**
- Same two support-content edits in the marketing site's mirrored \`support-content.ts\`.

## Verification

- \`npm run build\` (desktop): vite build + \`tsc --noEmit\` clean
- \`npm run build\` (myscrollr.com): vite build + tsc clean