### PR TITLE
fix(sports): truthful catalog counts + full channel page shows all data

### DIFF
--- a/channels/sports/api/sports.go
+++ b/channels/sports/api/sports.go
@@ -46,10 +46,16 @@ const (
 	// Keys: sports:subscribers:league:{NFL}, sports:subscribers:league:{NBA}, etc.
 	SportsLeagueSubscribersPrefix = "sports:subscribers:league:"
 
-	// DefaultSportsLimit caps the number of games returned for the public route.
-	DefaultSportsLimit = 50
+	// DefaultSportsLimit caps the number of games returned for /sports
+	// (authenticated full channel page + public route). High enough to fit
+	// a week of MLB (~105 rows) plus other leagues with headroom. The full
+	// channel page disables per-league fair share at this limit so users
+	// see every game for every selected league.
+	DefaultSportsLimit = 200
 
-	// DashboardSportsLimit caps the number of games returned for dashboard.
+	// DashboardSportsLimit caps the number of games returned for the
+	// home-feed glanceable row. The fair-share allocator (MinPerLeagueShare)
+	// ensures every selected league gets visibility within this cap.
 	DashboardSportsLimit = 20
 
 	// PollingStaleThreshold is the maximum acceptable age of the last
@@ -122,40 +128,35 @@ type leagueStatus struct {
 // just those leagues (LEFT JOIN semantics in spirit — leagues with no games
 // simply don't appear in the map).
 //
-// `game_count` is intentionally NOT "all rows for this league." A user
-// scanning the catalog wants to know "how many games are happening today,"
-// not "how many fixtures has the ingestion service ever stored." Without
-// this filter, MLB shows ~100 (a full week × ~15/day) while Premier League
-// shows ~10 — visually wildly out of proportion with what's relevant.
-// The today-window is:
-//   - state = 'in'                                    (live right now)
-//   - state = 'pre' AND start_time < NOW() + 24h      (starting in next 24h)
-//   - state IN ('final','postponed') AND start_time > NOW() - 12h  (just finished)
+// `game_count` is the raw COUNT(*) over the games table — every row the
+// ingestion service has stored for this league, across all states. This
+// reflects what's actually in the database and is the truthful number to
+// surface to users. The catalog UI uses `live_count` and `next_game` as
+// the primary chips when they're meaningful; `game_count` is the fallback.
+//
+// An earlier version filtered this to a "today's window" (live + upcoming-24h
+// + just-finished-12h). That looked tidier but felt algorithmic — users
+// want to see the actual data, not our editorial summary of it.
 //
 // The query is intentionally batched so we run one round-trip per call,
 // not one query per league.
 func (a *App) loadLeagueStatus(ctx context.Context, names []string) (map[string]leagueStatus, error) {
 	statusMap := make(map[string]leagueStatus)
 
-	const countFilter = `
-		COUNT(*) FILTER (
-			WHERE state = 'in'
-			   OR (state = 'pre' AND start_time < NOW() + INTERVAL '24 hours')
-			   OR (state IN ('final','postponed') AND start_time > NOW() - INTERVAL '12 hours')
-		) AS game_count`
-
 	var rows pgx.Rows
 	var err error
 	if len(names) == 0 {
 		rows, err = a.db.Query(ctx, `
-			SELECT league,`+countFilter+`,
+			SELECT league,
+			       COUNT(*) AS game_count,
 			       COUNT(*) FILTER (WHERE state = 'in') AS live_count,
 			       MIN(start_time) FILTER (WHERE state = 'pre') AS next_game
 			FROM games
 			GROUP BY league`)
 	} else {
 		rows, err = a.db.Query(ctx, `
-			SELECT league,`+countFilter+`,
+			SELECT league,
+			       COUNT(*) AS game_count,
 			       COUNT(*) FILTER (WHERE state = 'in') AS live_count,
 			       MIN(start_time) FILTER (WHERE state = 'pre') AS next_game
 			FROM games
@@ -440,7 +441,9 @@ func (a *App) handleInternalDashboard(c *fiber.Ctx) error {
 	}
 
 	favoriteTeams := a.getUserFavoriteTeams(userSub)
-	games, err := a.queryGamesByLeagues(ctx, leagues, DashboardSportsLimit, favoriteTeams)
+	// Home dashboard uses fair-share so every selected league is visible
+	// within the 20-row glanceable preview, regardless of relative volume.
+	games, err := a.queryGamesByLeagues(ctx, leagues, DashboardSportsLimit, favoriteTeams, true)
 	if err != nil {
 		log.Printf("[Sports] Dashboard query failed: %v", err)
 		return c.JSON(fiber.Map{
@@ -649,72 +652,93 @@ func (a *App) queryGames(ctx context.Context, limit int, favoriteTeams map[strin
 }
 
 // MinPerLeagueShare is the minimum number of candidate games each selected
-// league gets before the global LIMIT applies. Prevents one high-volume
-// league (e.g. MLB with ~15 games/day) from monopolizing the response and
-// hiding leagues with fewer fixtures (e.g. Premier League, F1).
+// league gets before the global LIMIT applies. Used only in fair-share mode
+// (home dashboard). Prevents one high-volume league (e.g. MLB with ~15
+// games/day) from monopolizing the response and hiding leagues with fewer
+// fixtures (e.g. Premier League, F1).
 const MinPerLeagueShare = 2
 
-// queryGamesByLeagues fetches games for specific leagues with per-league
-// fair share. Each league gets max(MinPerLeagueShare, ceil(limit/N))
-// candidate rows ranked by the same priority (live > pre > final, favorites
-// first, soonest upcoming first). The global LIMIT trims the pool.
+// queryGamesByLeagues fetches games for specific leagues.
 //
-// Without the share cap, an SQL "ORDER BY priority LIMIT 20" query against a
-// games table dominated by one league (MLB during the season) returns 20
-// rows from that league exclusively. Premier League rows score lower on the
-// global ordering and never make it into the response — they then can't
-// appear in the frontend's "edit preview" dropdown either, because the
-// dropdown's group list is built from the games array.
+// When `fairShare` is true (used by /dashboard with limit=20): each league
+// gets max(MinPerLeagueShare, ceil(limit/N)) candidate rows via a window
+// function, ranked by the standard priority (live > pre > final, favorites
+// first, soonest upcoming first). The global LIMIT then trims. This keeps
+// every selected league visible on the glanceable home row.
 //
-// If favoriteTeams is provided, those teams' games are prioritized within
-// the per-league ranking.
-func (a *App) queryGamesByLeagues(ctx context.Context, leagues []string, limit int, favoriteTeams map[string]FavoriteTeam) ([]Game, error) {
+// When `fairShare` is false (used by /sports with limit=200 for the full
+// channel page): a simple ORDER BY priority LIMIT query, no per-league cap.
+// Users see every game for every selected league and can filter client-side
+// with the page's league/status chips. The user-controlled experience.
+//
+// If favoriteTeams is provided, those teams' games are prioritized.
+func (a *App) queryGamesByLeagues(ctx context.Context, leagues []string, limit int, favoriteTeams map[string]FavoriteTeam, fairShare bool) ([]Game, error) {
 	if len(leagues) == 0 {
 		return make([]Game, 0), nil
 	}
 
 	favNames := extractFavoriteTeamNames(favoriteTeams)
 
-	// Per-league candidate share. ceil(limit / N_leagues), capped below by
-	// MinPerLeagueShare so small leagues are always visible even when the
-	// user has many leagues selected.
-	perLeague := (limit + len(leagues) - 1) / len(leagues)
-	if perLeague < MinPerLeagueShare {
-		perLeague = MinPerLeagueShare
-	}
-
-	rows, err := a.db.Query(ctx, fmt.Sprintf(`
-		WITH ranked AS (
-			SELECT id, league, sport, external_game_id, link,
-				home_team_name, home_team_logo, home_team_score, home_team_code,
-				away_team_name, away_team_logo, away_team_score, away_team_code,
-				start_time, short_detail, state, status_short, status_long,
-				timer, venue, season,
-				ROW_NUMBER() OVER (
-					PARTITION BY league
-					ORDER BY
-						CASE state WHEN 'in' THEN 0 WHEN 'pre' THEN 1 ELSE 2 END,
-						CASE WHEN home_team_name = ANY($2) OR away_team_name = ANY($2) THEN 0 ELSE 1 END,
-						CASE WHEN state = 'pre' THEN start_time END ASC,
-						CASE WHEN state != 'pre' THEN start_time END DESC
-				) AS rn
+	var query string
+	if fairShare {
+		// Per-league candidate share. ceil(limit / N_leagues), floored by
+		// MinPerLeagueShare so small leagues are always visible.
+		perLeague := (limit + len(leagues) - 1) / len(leagues)
+		if perLeague < MinPerLeagueShare {
+			perLeague = MinPerLeagueShare
+		}
+		query = fmt.Sprintf(`
+			WITH ranked AS (
+				SELECT id, league, sport, external_game_id, link,
+					home_team_name, home_team_logo, home_team_score, home_team_code,
+					away_team_name, away_team_logo, away_team_score, away_team_code,
+					start_time, short_detail, state, status_short, status_long,
+					timer, venue, season,
+					ROW_NUMBER() OVER (
+						PARTITION BY league
+						ORDER BY
+							CASE state WHEN 'in' THEN 0 WHEN 'pre' THEN 1 ELSE 2 END,
+							CASE WHEN home_team_name = ANY($2) OR away_team_name = ANY($2) THEN 0 ELSE 1 END,
+							CASE WHEN state = 'pre' THEN start_time END ASC,
+							CASE WHEN state != 'pre' THEN start_time END DESC
+					) AS rn
+				FROM games
+				WHERE league = ANY($1)
+			)
+			SELECT id, league, COALESCE(sport, ''), external_game_id, COALESCE(link, ''),
+				home_team_name, COALESCE(home_team_logo, ''), COALESCE(home_team_score::text, ''), COALESCE(home_team_code, ''),
+				away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
+				start_time, COALESCE(short_detail, ''), state,
+				COALESCE(status_short, ''), COALESCE(status_long, ''),
+				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, '')
+			FROM ranked
+			WHERE rn <= %d
+			ORDER BY
+				CASE state WHEN 'in' THEN 0 WHEN 'pre' THEN 1 ELSE 2 END,
+				CASE WHEN home_team_name = ANY($2) OR away_team_name = ANY($2) THEN 0 ELSE 1 END,
+				CASE WHEN state = 'pre' THEN start_time END ASC,
+				CASE WHEN state != 'pre' THEN start_time END DESC
+			LIMIT %d`, perLeague, limit)
+	} else {
+		// No per-league cap. Show every game for every selected league.
+		query = fmt.Sprintf(`
+			SELECT id, league, COALESCE(sport, ''), external_game_id, COALESCE(link, ''),
+				home_team_name, COALESCE(home_team_logo, ''), COALESCE(home_team_score::text, ''), COALESCE(home_team_code, ''),
+				away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
+				start_time, COALESCE(short_detail, ''), state,
+				COALESCE(status_short, ''), COALESCE(status_long, ''),
+				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, '')
 			FROM games
 			WHERE league = ANY($1)
-		)
-		SELECT id, league, COALESCE(sport, ''), external_game_id, COALESCE(link, ''),
-			home_team_name, COALESCE(home_team_logo, ''), COALESCE(home_team_score::text, ''), COALESCE(home_team_code, ''),
-			away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
-			start_time, COALESCE(short_detail, ''), state,
-			COALESCE(status_short, ''), COALESCE(status_long, ''),
-			COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, '')
-		FROM ranked
-		WHERE rn <= %d
-		ORDER BY
-			CASE state WHEN 'in' THEN 0 WHEN 'pre' THEN 1 ELSE 2 END,
-			CASE WHEN home_team_name = ANY($2) OR away_team_name = ANY($2) THEN 0 ELSE 1 END,
-			CASE WHEN state = 'pre' THEN start_time END ASC,
-			CASE WHEN state != 'pre' THEN start_time END DESC
-		LIMIT %d`, perLeague, limit), leagues, favNames)
+			ORDER BY
+				CASE state WHEN 'in' THEN 0 WHEN 'pre' THEN 1 ELSE 2 END,
+				CASE WHEN home_team_name = ANY($2) OR away_team_name = ANY($2) THEN 0 ELSE 1 END,
+				CASE WHEN state = 'pre' THEN start_time END ASC,
+				CASE WHEN state != 'pre' THEN start_time END DESC
+			LIMIT %d`, limit)
+	}
+
+	rows, err := a.db.Query(ctx, query, leagues, favNames)
 	if err != nil {
 		return nil, fmt.Errorf("sports league query failed: %w", err)
 	}
@@ -756,7 +780,10 @@ func (a *App) getUserGames(c *fiber.Ctx, userSub string, limit int) error {
 	}
 
 	favoriteTeams := a.getUserFavoriteTeams(userSub)
-	games, err := a.queryGamesByLeagues(ctx, leagues, limit, favoriteTeams)
+	// /sports (full channel page) returns every game for every selected
+	// league. The page already has league + status filter chips for the
+	// user to narrow down — we surface all the data and let them control it.
+	games, err := a.queryGamesByLeagues(ctx, leagues, limit, favoriteTeams, false)
 	if err != nil {
 		log.Printf("[Sports] getUserGames query failed: %v", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{

--- a/desktop/src/api/queries.ts
+++ b/desktop/src/api/queries.ts
@@ -8,7 +8,7 @@ import { queryOptions } from "@tanstack/react-query";
 import { isAuthenticated, hasRefreshToken } from "../auth";
 import { authFetch, request, rssApi, fetchOverview } from "./client";
 import type { TrackedFeed, UserOverview } from "./client";
-import type { DashboardResponse } from "../types";
+import type { DashboardResponse, Game } from "../types";
 
 // ── Query Keys ───────────────────────────────────────────────────
 
@@ -180,6 +180,23 @@ export function sportsCatalogOptions() {
     queryKey: queryKeys.catalogs.sports,
     queryFn: () => request<TrackedLeague[]>("/sports/leagues"),
     staleTime: 5 * 60 * 1000, // 5 min — catalogs change infrequently
+  });
+}
+
+/**
+ * Full sports games payload — every game for the user's selected leagues,
+ * no per-league fair-share cap. Used by the full channel page
+ * (`/channel/sports/feed`), where the user has filter chips to narrow down
+ * by hand.
+ *
+ * The home feed reads from `dashboardQueryOptions` instead, which serves a
+ * 20-row fair-shared preview optimized for glanceable consumption.
+ */
+export function sportsFullQueryOptions() {
+  return queryOptions({
+    queryKey: ["sports", "full"] as const,
+    queryFn: () => authFetch<{ sports: Game[]; meta: SportsMeta }>("/sports"),
+    staleTime: 10_000,
   });
 }
 

--- a/desktop/src/channels/sports/FeedTab.tsx
+++ b/desktop/src/channels/sports/FeedTab.tsx
@@ -14,14 +14,14 @@ import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { clsx } from "clsx";
 import { Trophy, Filter } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { dashboardQueryOptions } from "../../api/queries";
+import { sportsFullQueryOptions } from "../../api/queries";
 import { useSportsConfig } from "../../hooks/useSportsConfig";
 import { ScoresTab } from "./ScoresTab";
 import { ScheduleTab } from "./ScheduleTab";
 import { StandingsTab } from "./StandingsTab";
 import EmptyChannelState from "../../components/EmptyChannelState";
 import FreshnessPill from "../../components/FreshnessPill";
-import type { Game, FeedTabProps, ChannelManifest } from "../../types";
+import type { FeedTabProps, ChannelManifest } from "../../types";
 import type { FavoriteTeam } from "../../hooks/useSportsConfig";
 
 // ── Channel manifest ─────────────────────────────────────────────
@@ -173,10 +173,14 @@ function SportsFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
   const [leagueFilter, setLeagueFilter] = useState<Set<string>>(new Set());
   const { leagues, display, favoriteTeams } = useSportsConfig();
 
-  const { data: dashboard } = useQuery(dashboardQueryOptions());
+  // Full channel page reads from /sports directly (not /dashboard), which
+  // returns every game for the user's selected leagues without per-league
+  // fair-share capping. The page's league + status filter chips let the
+  // user narrow down by hand — we surface all the data and let them control it.
+  const { data: sportsData } = useQuery(sportsFullQueryOptions());
   const games = useMemo(
-    () => (dashboard?.data?.sports as Game[] | undefined) ?? [],
-    [dashboard?.data?.sports],
+    () => sportsData?.sports ?? [],
+    [sportsData?.sports],
   );
 
   // Unique leagues from current games for the filter dropdown


### PR DESCRIPTION
## Summary

Two follow-ups to #172 based on user feedback that the catalog counts felt algorithmic and the full channel page didn't actually show more than the home preview.

### 1. Catalog counts back to truthful totals

\`loadLeagueStatus.game_count\` is back to a raw \`COUNT(*)\` over the games table. The "today-window" filter from #172 (live + upcoming-24h + just-finished-12h) was tidier but hid data the user expected to see.

- MLB shows **102** because there are 102 MLB rows ingested for the 7-day horizon.
- Premier League shows **10** because 10 is what's in the database.

The catalog UI's primary chip is still "N Live" or "Next: in Xh" when relevant — \`game_count\` is the fallback when neither applies.

### 2. Full channel page shows all data

\`queryGamesByLeagues\` now takes a \`fairShare bool\` parameter:

| Endpoint | Limit | fairShare | Behavior |
|---|---|---|---|
| \`/internal/dashboard\` | 20 | \`true\` | Per-league window function (#172 behavior). Every selected league visible on the glanceable home row. |
| \`/sports\` | 200 | \`false\` | Simple \`ORDER BY priority LIMIT 200\`. Every game for every selected league. |

\`DefaultSportsLimit\` bumped 50 → 200. A week of MLB (~105 rows) plus other leagues fits comfortably.

Desktop \`SportsFeedTab\` swaps its data source from \`dashboardQueryOptions\` to a new \`sportsFullQueryOptions\` that hits \`/sports\` directly. The page's existing league + status filter chips (and Scores/Schedule/Standings tabs) let the user narrow down by hand.

### What's not changing

- Home feed sports row: still 20-row fair-shared, still keeps Premier League visible alongside MLB.
- "View all" link in the top-right of the home row: already navigates to the full page; with this change, the full page actually has more data to show.
- DisplayPanel preview: still reads from \`/dashboard\` for one sample game.

## Test plan

1. **Catalog truthful counts.** Open Settings → Sports. MLB row should show ~100, Premier League ~10, F1 ~20. Numbers match what's in the database.
2. **Full page shows everything.** Open \`/channel/sports/feed\`. Should see every selected league's games (with the existing tab/filter UI), not just 20 fair-shared.
3. **Home unchanged.** Home feed sports row still shows 5 games via fair-share allocation. Premier League still appears alongside MLB.
4. **Filters work on full page.** Click a league chip to narrow; the chip still filters the full data set.

## Files changed

- \`channels/sports/api/sports.go\` (+88/−69) — revert count filter, add fairShare param, bump DefaultSportsLimit
- \`desktop/src/api/queries.ts\` (+18/−1) — add \`sportsFullQueryOptions\`
- \`desktop/src/channels/sports/FeedTab.tsx\` (+8/−6) — swap data source

## CI

All 8 Go + Rust checks expected to pass (no schema changes, no migration).

🤖 Generated with Claude Code via opencode