### PR TITLE
v1.0.15: Updater suppression fix + sysmon followups

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.9",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.0.9",
+      "version": "1.0.15",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4030,7 +4030,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "futures-util",
  "log",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/components/chips/ConsolidatedChip.tsx
+++ b/desktop/src/components/chips/ConsolidatedChip.tsx
@@ -148,7 +148,19 @@ export default function ConsolidatedChip({
                 <span className="text-[13px] leading-none ml-1">{item.icon}</span>
               </>
             ) : isSysmon(item) ? (
-              <span className={clsx(item.hot ? "text-error" : c.text)}>
+              // Reserve a fixed cell width for the value so the chip
+              // doesn't grow/shrink as percentages and wattages flip
+              // between digit counts ("5%" -> "100%", "47W" -> "450W").
+              // Without this the pinned chip jiggles every poll and
+              // forces the entire ticker row to reflow — see Bug 3
+              // notes around `pinned-zone` in `ScrollrTicker.tsx`.
+              <span
+                className={clsx(
+                  "inline-block text-right tabular-nums",
+                  item.hot ? "text-error" : c.text,
+                )}
+                style={{ minWidth: "4ch" }}
+              >
                 {item.value}
               </span>
             ) : (

--- a/desktop/src/components/chips/ConsolidatedChip.tsx
+++ b/desktop/src/components/chips/ConsolidatedChip.tsx
@@ -154,12 +154,15 @@ export default function ConsolidatedChip({
               // Without this the pinned chip jiggles every poll and
               // forces the entire ticker row to reflow — see Bug 3
               // notes around `pinned-zone` in `ScrollrTicker.tsx`.
+              //
+              // 5ch covers the worst case at 4 digits + suffix
+              // (e.g. "1000W" on workstation GPUs, future-proofing
+              // beyond the current 4-char "100%" / "450W" worst case).
               <span
                 className={clsx(
-                  "inline-block text-right tabular-nums",
+                  "inline-block min-w-[5ch] text-right tabular-nums",
                   item.hot ? "text-error" : c.text,
                 )}
-                style={{ minWidth: "4ch" }}
               >
                 {item.value}
               </span>

--- a/desktop/src/components/settings/ConfigPanelLayout.tsx
+++ b/desktop/src/components/settings/ConfigPanelLayout.tsx
@@ -27,13 +27,23 @@ export default function ConfigPanelLayout({
   onReset,
   children,
 }: ConfigPanelLayoutProps) {
+  // The parent route shell uses `fillHeight` for configure tabs, which
+  // strips outer scroll and expects children to provide their own
+  // scroll viewport. We provide that here so every widget's
+  // configure page scrolls when its content exceeds available height
+  // (otherwise sections past the fold are silently clipped).
+  // See `components/layout/PageLayout.tsx` `fillHeight` branch.
   return (
-    <div className="w-full max-w-2xl mx-auto pb-8">
-      {children}
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
+        <div className="w-full max-w-2xl mx-auto pb-8">
+          {children}
 
-      {/* Reset footer */}
-      <div className="flex items-center justify-end pt-2 px-3">
-        <ResetButton onClick={onReset} />
+          {/* Reset footer */}
+          <div className="flex items-center justify-end pt-2 px-3">
+            <ResetButton onClick={onReset} />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/desktop/src/components/settings/GeneralSettings.tsx
+++ b/desktop/src/components/settings/GeneralSettings.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { getStore, setStore } from "../../lib/store";
+import { normalizeUpdateDate, sameUpdateInstant } from "../../lib/updaterDate";
 import clsx from "clsx";
 
 // ── Updater storage keys ────────────────────────────────────────
@@ -130,24 +131,45 @@ export default function GeneralSettings({
       // Same-version patch detection: when the remote version matches
       // the installed version, we suppress the "update available" UI
       // unless the remote pub_date has changed since we last recorded
-      // it. KEY_LAST_UPDATE_DATE is normally seeded by the
-      // post-downloadAndInstall reconcile loop above (lines 107-115).
-      // For users who installed via a manual download (Windows MSI in
-      // particular), that loop never runs, so the store stays empty
-      // and every check used to false-positive. The empty-store branch
-      // below seeds the date once on first check, then the existing
-      // match-suppression takes over on subsequent checks.
+      // it. KEY_LAST_UPDATE_DATE is normally seeded by the startup
+      // reconcile in `hooks/useStartupUpdateCheck.ts`. For users who
+      // installed via a manual download (Windows MSI in particular),
+      // that reconcile never has a pending row to promote, so the
+      // store stays empty and every check used to false-positive.
+      // The empty-store branch below seeds the date once on first
+      // check, then the existing match-suppression takes over on
+      // subsequent checks.
+      //
+      // Dates are normalized through `normalizeUpdateDate` before
+      // compare/store. The server emits `...Z` but the Rust updater
+      // plugin reformats to `...+00:00` — without normalization the
+      // strict equality ALWAYS fails. See `lib/updaterDate.ts`.
       if (update.version === appVersion) {
-        const storedDate = getStore<string | null>(KEY_LAST_UPDATE_DATE, null);
-        if (storedDate === null) {
-          // First in-app check on a build the in-app updater never
-          // installed. Trust the remote pub_date and seed.
-          setStore(KEY_LAST_UPDATE_DATE, update.date);
+        const normalizedRemote = normalizeUpdateDate(update.date);
+        // No usable pub_date from the server: nothing to compare
+        // against. Trust the same-version response as up-to-date.
+        if (normalizedRemote === null) {
           pendingUpdate.current = null;
           setStatus({ step: "up-to-date" });
           return;
         }
-        if (update.date === storedDate) {
+
+        const storedDate = getStore<string | null>(KEY_LAST_UPDATE_DATE, null);
+        if (storedDate === null) {
+          // First in-app check on a build the in-app updater never
+          // installed. Trust the remote pub_date and seed in
+          // normalized form.
+          setStore(KEY_LAST_UPDATE_DATE, normalizedRemote);
+          pendingUpdate.current = null;
+          setStatus({ step: "up-to-date" });
+          return;
+        }
+        if (sameUpdateInstant(update.date, storedDate)) {
+          // Heal a stored value that wasn't normalized by a prior
+          // build (e.g. seeded from the server's raw `...Z` string).
+          if (storedDate !== normalizedRemote) {
+            setStore(KEY_LAST_UPDATE_DATE, normalizedRemote);
+          }
           pendingUpdate.current = null;
           setStatus({ step: "up-to-date" });
           return;
@@ -201,13 +223,17 @@ export default function GeneralSettings({
       // The new build is downloaded but NOT YET RUNNING — the user still
       // has to relaunch. Write to `pendingUpdate` instead of `lastUpdateDate`
       // so that if the user never relaunches we don't falsely report the
-      // new build as installed on the next check. The reconcile useEffect
-      // above promotes pending → lastUpdateDate once a later session is
-      // actually running at `update.version`.
-      if (update.date && update.version) {
+      // new build as installed on the next check. The reconcile in
+      // `hooks/useStartupUpdateCheck.ts` promotes pending → lastUpdateDate
+      // once a later session is actually running at `update.version`.
+      //
+      // Date is normalized so the promoted value compares cleanly on
+      // future launches — see `lib/updaterDate.ts`.
+      const normalizedDate = normalizeUpdateDate(update.date);
+      if (normalizedDate && update.version) {
         const pending: PendingUpdate = {
           version: update.version,
-          date: update.date,
+          date: normalizedDate,
         };
         setStore(KEY_PENDING_UPDATE, pending);
       }

--- a/desktop/src/components/settings/GeneralSettings.tsx
+++ b/desktop/src/components/settings/GeneralSettings.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { getStore, setStore } from "../../lib/store";
-import { normalizeUpdateDate, sameUpdateInstant } from "../../lib/updaterDate";
+import { normalizeUpdateDate } from "../../lib/updaterDate";
 import clsx from "clsx";
 
 // ── Updater storage keys ────────────────────────────────────────
@@ -164,7 +164,11 @@ export default function GeneralSettings({
           setStatus({ step: "up-to-date" });
           return;
         }
-        if (sameUpdateInstant(update.date, storedDate)) {
+        // Compare normalized forms directly. `normalizedRemote` is
+        // already canonical; only the stored value needs a round-trip
+        // in case it was seeded by an older build.
+        const normalizedStored = normalizeUpdateDate(storedDate);
+        if (normalizedStored === normalizedRemote) {
           // Heal a stored value that wasn't normalized by a prior
           // build (e.g. seeded from the server's raw `...Z` string).
           if (storedDate !== normalizedRemote) {

--- a/desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/desktop/src/hooks/useStartupUpdateCheck.ts
@@ -20,7 +20,7 @@ import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { toast } from "sonner";
 import { getStore, removeStore, setStore } from "../lib/store";
-import { normalizeUpdateDate, sameUpdateInstant } from "../lib/updaterDate";
+import { normalizeUpdateDate } from "../lib/updaterDate";
 
 const STARTUP_DELAY_MS = 4_000;
 const TOAST_ID = "scrollr-startup-update";
@@ -73,7 +73,12 @@ export function useStartupUpdateCheck({ enabled, appVersion }: Options) {
         const pending = getStore<PendingUpdate | null>(KEY_PENDING_UPDATE, null);
         if (pending) {
           if (pending.version === appVersion) {
-            setStore(KEY_LAST_UPDATE_DATE, pending.date);
+            // Normalize on promote so a pending row written by an
+            // older build (pre-normalization) still lands in the
+            // store in canonical form. Falls back to raw if somehow
+            // unparseable so we don't lose the seed entirely.
+            const promoted = normalizeUpdateDate(pending.date) ?? pending.date;
+            setStore(KEY_LAST_UPDATE_DATE, promoted);
           }
           removeStore(KEY_PENDING_UPDATE);
         }
@@ -107,11 +112,15 @@ export function useStartupUpdateCheck({ enabled, appVersion }: Options) {
             setStore(KEY_LAST_UPDATE_DATE, normalizedRemote);
             return;
           }
-          if (sameUpdateInstant(update.date, storedDate)) {
+          // Compare normalized forms directly. `normalizedRemote` is
+          // already canonical; only the stored value needs a
+          // round-trip in case it was seeded by an older build that
+          // wrote the raw plugin format.
+          const normalizedStored = normalizeUpdateDate(storedDate);
+          if (normalizedStored === normalizedRemote) {
             // Heal a stored value that wasn't normalized by a prior
-            // build (e.g. seeded from the server's raw `...Z` string).
-            // Rewriting it here means the next launch's strict compare
-            // would also pass, even without the normalization helper.
+            // build. Rewriting it here means the next launch's strict
+            // compare would also pass, even without the helper.
             if (storedDate !== normalizedRemote) {
               setStore(KEY_LAST_UPDATE_DATE, normalizedRemote);
             }

--- a/desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/desktop/src/hooks/useStartupUpdateCheck.ts
@@ -20,6 +20,7 @@ import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { toast } from "sonner";
 import { getStore, removeStore, setStore } from "../lib/store";
+import { normalizeUpdateDate, sameUpdateInstant } from "../lib/updaterDate";
 
 const STARTUP_DELAY_MS = 4_000;
 const TOAST_ID = "scrollr-startup-update";
@@ -85,16 +86,37 @@ export function useStartupUpdateCheck({ enabled, appVersion }: Options) {
         // (or there's no record yet, in which case we seed it), treat as
         // up-to-date. Otherwise fall through to the toast — a genuine
         // same-version rebuild has shipped.
+        //
+        // Dates are normalized through `normalizeUpdateDate` before
+        // compare/store. The server emits `...Z` but the Rust updater
+        // plugin reformats to `...+00:00` — without normalization the
+        // string compare ALWAYS fails and the toast fires every launch.
+        // See `lib/updaterDate.ts` for the full backstory.
         if (update.version === appVersion) {
+          const normalizedRemote = normalizeUpdateDate(update.date);
+          // No usable pub_date from the server: we have nothing to
+          // compare against, and seeding `null` would re-toast forever.
+          // Trust the same-version response as up-to-date.
+          if (normalizedRemote === null) return;
+
           const storedDate = getStore<string | null>(KEY_LAST_UPDATE_DATE, null);
           if (storedDate === null) {
             // First in-app check on a build the in-app updater never
             // installed (e.g. manual download, or pre-reconcile build).
-            // Trust the remote pub_date and seed.
-            setStore(KEY_LAST_UPDATE_DATE, update.date);
+            // Trust the remote pub_date and seed in normalized form.
+            setStore(KEY_LAST_UPDATE_DATE, normalizedRemote);
             return;
           }
-          if (update.date === storedDate) return;
+          if (sameUpdateInstant(update.date, storedDate)) {
+            // Heal a stored value that wasn't normalized by a prior
+            // build (e.g. seeded from the server's raw `...Z` string).
+            // Rewriting it here means the next launch's strict compare
+            // would also pass, even without the normalization helper.
+            if (storedDate !== normalizedRemote) {
+              setStore(KEY_LAST_UPDATE_DATE, normalizedRemote);
+            }
+            return;
+          }
           // Stored date differs from remote: a genuine same-version
           // patched rebuild has shipped. Fall through to the toast.
         }
@@ -164,10 +186,14 @@ async function runDownloadAndInstall(update: Update) {
     // Record pending state so the next launch can reconcile pub_date.
     // See KEY_PENDING_UPDATE docs in GeneralSettings.tsx for why this
     // is "pending" rather than "last".
-    if (update.version && update.date) {
+    //
+    // Date is normalized so the next-launch reconcile writes a clean
+    // value into KEY_LAST_UPDATE_DATE — see lib/updaterDate.ts.
+    const normalizedDate = normalizeUpdateDate(update.date);
+    if (update.version && normalizedDate) {
       const pending: PendingUpdate = {
         version: update.version,
-        date: update.date,
+        date: normalizedDate,
       };
       setStore(KEY_PENDING_UPDATE, pending);
     }

--- a/desktop/src/lib/updaterDate.ts
+++ b/desktop/src/lib/updaterDate.ts
@@ -1,0 +1,49 @@
+// ── Updater pub_date normalization ──────────────────────────────
+//
+// The auto-updater's "same-version suppression" works by comparing the
+// remote build's pub_date against a value we cached on a previous run.
+// String-equality on the raw values is unreliable because the dates
+// flow through two different formatters before we see them:
+//
+//   1. The server's `latest.json` emits ISO 8601 with a `Z` suffix
+//      (e.g. "2026-05-12T19:13:36.586Z") — tauri-action's default.
+//   2. Tauri's Rust updater plugin parses that and re-serializes via
+//      `time::OffsetDateTime::format(Rfc3339)`, which writes the
+//      offset as `+00:00` (e.g. "2026-05-12T19:13:36.586+00:00").
+//
+// Both are valid RFC 3339, they refer to the same instant, but
+// `"...Z" !== "...+00:00"` as strings. Without normalization the
+// suppression check always falls through and the user sees an
+// "Update available" toast on every launch.
+//
+// `normalizeUpdateDate` collapses any RFC 3339 / ISO 8601 string into
+// the JS canonical form (`Date.prototype.toISOString` — always `Z`,
+// always milliseconds). It returns `null` on unparseable input so the
+// caller can decide how to handle the missing-pub_date edge case
+// (currently: stay silent rather than toast forever).
+//
+// Keep this in sync with the seed/compare logic in
+// `hooks/useStartupUpdateCheck.ts` and `components/settings/GeneralSettings.tsx`.
+
+export function normalizeUpdateDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) return null;
+  return new Date(ms).toISOString();
+}
+
+/**
+ * True when both arguments parse to the same instant. Mismatched
+ * formats ("...Z" vs "...+00:00") and small precision changes all
+ * compare equal. Either side being null/undefined/unparseable yields
+ * false — the caller is responsible for the "no record yet" path.
+ */
+export function sameUpdateInstant(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  const na = normalizeUpdateDate(a);
+  const nb = normalizeUpdateDate(b);
+  if (na === null || nb === null) return false;
+  return na === nb;
+}

--- a/desktop/src/lib/updaterDate.ts
+++ b/desktop/src/lib/updaterDate.ts
@@ -31,19 +31,3 @@ export function normalizeUpdateDate(value: string | null | undefined): string | 
   if (Number.isNaN(ms)) return null;
   return new Date(ms).toISOString();
 }
-
-/**
- * True when both arguments parse to the same instant. Mismatched
- * formats ("...Z" vs "...+00:00") and small precision changes all
- * compare equal. Either side being null/undefined/unparseable yields
- * false — the caller is responsible for the "no record yet" path.
- */
-export function sameUpdateInstant(
-  a: string | null | undefined,
-  b: string | null | undefined,
-): boolean {
-  const na = normalizeUpdateDate(a);
-  const nb = normalizeUpdateDate(b);
-  if (na === null || nb === null) return false;
-  return na === nb;
-}

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -220,12 +220,9 @@ export interface WeatherTickerConfig {
 }
 
 export interface WeatherWidgetConfig {
-  /** City display name shown on the taskbar mini chip (empty = first configured city). */
-  taskbarCity: string;
   ticker: WeatherTickerConfig;
 }
 
-export type TaskbarMetric = "cpu" | "memory" | "gpu";
 export type TempUnit = "celsius" | "fahrenheit";
 
 export interface SysmonTickerConfig {
@@ -236,7 +233,6 @@ export interface SysmonTickerConfig {
 }
 
 export interface SysmonWidgetConfig {
-  taskbarMetric: TaskbarMetric;
   refreshInterval: number;
   tempUnit: TempUnit;
   ticker: SysmonTickerConfig;
@@ -649,11 +645,9 @@ const DEFAULT_WIDGETS: WidgetPrefs = {
     pomodoro: { ...DEFAULT_CLOCK_POMODORO },
   },
   weather: {
-    taskbarCity: "",
     ticker: { ...DEFAULT_WEATHER_TICKER },
   },
   sysmon: {
-    taskbarMetric: "cpu",
     refreshInterval: 2,
     tempUnit: "celsius",
     ticker: { ...DEFAULT_SYSMON_TICKER },
@@ -774,11 +768,9 @@ function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
       pomodoro: { ...DEFAULT_CLOCK_POMODORO, ...obj(clk?.pomodoro) },
     },
     weather: {
-      taskbarCity: typeof wth?.taskbarCity === "string" ? wth.taskbarCity : DEFAULT_WIDGETS.weather.taskbarCity,
       ticker: { ...DEFAULT_WEATHER_TICKER, ...obj(wth?.ticker) },
     },
     sysmon: {
-      taskbarMetric: (sys?.taskbarMetric as TaskbarMetric) ?? DEFAULT_WIDGETS.sysmon.taskbarMetric,
       refreshInterval: typeof sys?.refreshInterval === "number" ? sys.refreshInterval : DEFAULT_WIDGETS.sysmon.refreshInterval,
       tempUnit: (sys?.tempUnit as TempUnit) ?? DEFAULT_WIDGETS.sysmon.tempUnit,
       ticker: { ...DEFAULT_SYSMON_TICKER, ...obj(sys?.ticker) },

--- a/desktop/src/widgets/clock/ConfigPanel.tsx
+++ b/desktop/src/widgets/clock/ConfigPanel.tsx
@@ -81,19 +81,15 @@ export default function ClockConfigPanel({
       subtitle="World clocks and Pomodoro timer"
       onReset={resetAll}
     >
-      {/* Taskbar */}
-      <Section title="Toolbar Preview">
+      {/* Ticker */}
+      <Section title="Ticker">
         <SegmentedRow
           label="Time format"
-          description="Applies to the toolbar and ticker"
+          description="12-hour or 24-hour clock"
           value={format}
           options={FORMAT_OPTIONS}
           onChange={handleFormatChange}
         />
-      </Section>
-
-      {/* Ticker */}
-      <Section title="Ticker">
         <ToggleRow
           label="Local time"
           description="Show your local clock on the scrolling ticker"

--- a/desktop/src/widgets/github/ConfigPanel.tsx
+++ b/desktop/src/widgets/github/ConfigPanel.tsx
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import {
   Section,
   ToggleRow,
-  SegmentedRow,
   SliderRow,
 } from "../../components/settings/SettingsControls";
 import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
@@ -14,7 +13,6 @@ import { DEFAULT_GITHUB_TICKER } from "../../preferences";
 import { formatPollInterval } from "../../utils/format";
 import { LS_GITHUB_REPOS } from "../../constants";
 import { loadRepoData, repoKey, CI_STATUS_LABELS } from "./types";
-import type { GitHubRepo } from "./types";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
 export default function GitHubConfigPanel({
@@ -33,9 +31,6 @@ export default function GitHubConfigPanel({
     });
   }, [update]);
 
-  const passCount = repoData.filter((r) => r.status === "success").length;
-  const failCount = repoData.filter((r) => r.status === "failure").length;
-
   const githubIcon = (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-github)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
@@ -51,23 +46,6 @@ export default function GitHubConfigPanel({
       subtitle="CI/Actions status for your repos"
       onReset={resetAll}
     >
-      <Section title="Toolbar Preview">
-        {repoData.length > 0 ? (
-          <div className="px-3 py-2.5 text-[11px] text-fg-3 font-mono">
-            {repoData.length} repo{repoData.length !== 1 ? "s" : ""}
-            {" \u2014 "}
-            {passCount > 0 && <span className="text-up">{passCount} passing</span>}
-            {passCount > 0 && failCount > 0 && ", "}
-            {failCount > 0 && <span className="text-down">{failCount} failing</span>}
-            {passCount === 0 && failCount === 0 && <span className="text-fg-4">no data yet</span>}
-          </div>
-        ) : (
-          <div className="px-3 py-2.5 text-[11px] text-fg-4">
-            Add repos in the GitHub tab to see CI status.
-          </div>
-        )}
-      </Section>
-
       <Section title="Ticker">
         {config.repos.map((r) => {
           const key = repoKey(r);

--- a/desktop/src/widgets/sysmon/ConfigPanel.tsx
+++ b/desktop/src/widgets/sysmon/ConfigPanel.tsx
@@ -8,14 +8,8 @@ import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
 import TickerPinSection from "../../components/settings/TickerPinSection";
 import { useWidgetConfig } from "../../hooks/useWidgetConfig";
 import { DEFAULT_SYSMON_TICKER } from "../../preferences";
-import type { TaskbarMetric, TempUnit } from "../../preferences";
+import type { TempUnit } from "../../preferences";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
-
-const METRIC_OPTIONS: { value: TaskbarMetric; label: string }[] = [
-  { value: "cpu", label: "CPU" },
-  { value: "memory", label: "Memory" },
-  { value: "gpu", label: "GPU" },
-];
 
 const REFRESH_OPTIONS: { value: string; label: string }[] = [
   { value: "1", label: "1s" },
@@ -37,7 +31,6 @@ export default function SysmonConfigPanel({
 
   const resetAll = useCallback(() => {
     update({
-      taskbarMetric: "cpu",
       refreshInterval: 2,
       tempUnit: "celsius",
       ticker: { ...DEFAULT_SYSMON_TICKER },
@@ -63,16 +56,6 @@ export default function SysmonConfigPanel({
       subtitle="CPU, memory, GPU, and network stats"
       onReset={resetAll}
     >
-      <Section title="Toolbar Preview">
-        <SegmentedRow
-          label="What to show"
-          description="What info to show on the toolbar"
-          value={config.taskbarMetric}
-          options={METRIC_OPTIONS}
-          onChange={(v) => update({ taskbarMetric: v })}
-        />
-      </Section>
-
       <Section title="Ticker">
         <ToggleRow
           label="CPU usage"

--- a/desktop/src/widgets/uptime/ConfigPanel.tsx
+++ b/desktop/src/widgets/uptime/ConfigPanel.tsx
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import {
   Section,
   ToggleRow,
-  SegmentedRow,
   SliderRow,
 } from "../../components/settings/SettingsControls";
 import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
@@ -14,7 +13,6 @@ import { DEFAULT_UPTIME_TICKER } from "../../preferences";
 import { formatPollInterval } from "../../utils/format";
 import { LS_UPTIME_MONITORS } from "../../constants";
 import { loadMonitors } from "./types";
-import type { KumaMonitor } from "./types";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
 export default function UptimeConfigPanel({
@@ -33,9 +31,6 @@ export default function UptimeConfigPanel({
     });
   }, [update]);
 
-  const upCount = monitors.filter((m) => m.status === "up").length;
-  const downCount = monitors.filter((m) => m.status === "down").length;
-
   const uptimeIcon = (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-uptime)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2" />
@@ -50,23 +45,6 @@ export default function UptimeConfigPanel({
       subtitle="Monitor status from Uptime Kuma"
       onReset={resetAll}
     >
-      <Section title="Toolbar Preview">
-        {monitors.length > 0 ? (
-          <div className="px-3 py-2.5 text-[11px] text-fg-3 font-mono">
-            {monitors.length} monitor{monitors.length !== 1 ? "s" : ""}
-            {" \u2014 "}
-            <span className="text-up">{upCount} up</span>
-            {downCount > 0 && (
-              <>, <span className="text-down">{downCount} down</span></>
-            )}
-          </div>
-        ) : (
-          <div className="px-3 py-2.5 text-[11px] text-fg-4">
-            Connect to Uptime Kuma in the feed tab to see monitors.
-          </div>
-        )}
-      </Section>
-
       <Section title="Ticker">
         {monitors.map((monitor) => {
           const statusLabel = monitor.status.charAt(0).toUpperCase() + monitor.status.slice(1);

--- a/desktop/src/widgets/weather/ConfigPanel.tsx
+++ b/desktop/src/widgets/weather/ConfigPanel.tsx
@@ -41,14 +41,8 @@ export default function WeatherConfigPanel({
     setStore(LS_WEATHER_UNIT, v);
   }, []);
 
-  const taskbarCityOptions: { value: string; label: string }[] = [
-    { value: "", label: "Auto" },
-    ...cities.map((c) => ({ value: cityName(c), label: cityName(c) })),
-  ];
-
   const resetAll = useCallback(() => {
     update({
-      taskbarCity: "",
       ticker: { ...DEFAULT_WEATHER_TICKER },
     });
     setStore(LS_WEATHER_UNIT, "fahrenheit");
@@ -69,24 +63,6 @@ export default function WeatherConfigPanel({
       subtitle="Current conditions for your saved cities"
       onReset={resetAll}
     >
-      <Section title="Toolbar Preview">
-        {cities.length > 1 ? (
-          <SegmentedRow
-            label="City shown"
-            description="Which city to display on the toolbar"
-            value={config.taskbarCity}
-            options={taskbarCityOptions}
-            onChange={(v) => update({ taskbarCity: v })}
-          />
-        ) : (
-          <div className="px-3 py-2.5 text-[11px] text-fg-4">
-            {cities.length === 1
-              ? `Showing ${cityName(cities[0])} on the toolbar.`
-              : "Add a city in the Weather tab to see it on the toolbar."}
-          </div>
-        )}
-      </Section>
-
       <Section title="Ticker">
         {cities.map((city) => (
           <ToggleRow


### PR DESCRIPTION
## Summary

Four bug fixes shipping together as v1.0.15.

### Updater toast on every launch
The auto-updater's same-version suppression compared `pub_date` strings verbatim: the server emits `2026-05-12T19:13:36.586Z` but Tauri's Rust updater plugin reformats it to `2026-05-12T19:13:36.586+00:00` before handing it to JS. Strict-equality always failed and the "Update available" toast fired on every launch even when already on the latest build.

PR #175's pending-reconcile move was correct but masked by this deeper bug — without normalization the seed value never matched what the next launch saw.

Adds `lib/updaterDate.ts` with `normalizeUpdateDate` / `sameUpdateInstant` helpers that route both sides through `Date.parse + toISOString`, so any RFC 3339 / ISO 8601 variant collapses to a single canonical form. Stored values are written normalized going forward, and stale-format seeds get healed on the next launch when their parsed instant matches.

Fix is applied in two places that already shared this logic:
- `hooks/useStartupUpdateCheck.ts` (startup toast)
- `components/settings/GeneralSettings.tsx` (manual "Check for updates")

### Widget configure pages weren't scrolling on overflow
`ConfigPanelLayout` sat inside a `fillHeight=true` parent that strips outer scroll on the assumption children supply their own viewport. The layout was just a plain `div` with no flex column / `overflow-y-auto`, so any configure page taller than the route shell got clipped silently.

Wrap children in `flex-1 min-h-0 overflow-y-auto scrollbar-thin` (the same pattern `channels/fantasy/ConfigPanel.tsx` already uses). Fixes the scroll issue for all five widget configure pages, not just sysmon.

### Deprecated "Toolbar Preview" widget sections
The "Toolbar Preview" section on every widget configure page is a relic from a pre-ticker era when widgets were going to render a single summary metric on a system toolbar/taskbar. That product direction never shipped — the ticker is the only place widgets render — and the section had degraded into a mix of:

- **sysmon**: a `SegmentedRow` bound to `widgets.sysmon.taskbarMetric`, which was written but never read anywhere
- **weather**: a `SegmentedRow` bound to `widgets.weather.taskbarCity`, same write-only fate
- **uptime / github**: pure informational summary ("N monitors, M up") duplicated from data already visible in the channel tab
- **clock**: the only one with a real control (time format), but parked under a misleading section title

Removed the section from sysmon/weather/uptime/github, dropped the dead `taskbarMetric` / `taskbarCity` prefs (interface + `DEFAULT_WIDGETS` + the two lines in `migrateWidgets`), and moved clock's time-format control into its existing "Ticker" section where it actually belongs.

Migration is forward-safe: `migrateWidgets` reads each field explicitly rather than spreading the saved blob, so existing prefs files with leftover values simply get ignored. No data loss because nothing was ever reading them.

### Sysmon ticker chip width was unstable, causing layout jitter
The sysmon `ConsolidatedChip` rendered its percentage / wattage value in an unconstrained span, so the chip's intrinsic width changed every poll as values flipped between digit counts (e.g. `5%` → `100%`, `47W` → `450W`). The pinned-zone container is `shrink-0`, so when the chip widened or narrowed the entire pinned zone resized, and the scrolling middle (`flex: 1 1 0%`) reflowed to fill the leftover space. Every poll = a visible jiggle on the rest of the ticker row.

Sysmon was the only chip hit by this — clock/weather/uptime/github values either don't change every poll or don't change character count when they do.

Wrap the sysmon value in `inline-block text-right tabular-nums` with `minWidth: 4ch` (worst case is `100%` or `450W` = 4 chars at the chip's mono font). The cell reserves space for the worst case even when showing `5%`, so width is stable across the chip's lifetime.

Doesn't touch the comfort-mode detail row (`3.5 GHz · 65°C`) — that varies by 1–2 chars at most and stabilizing it would mean restructuring the data shape.

## Commits

- `a2562b2` fix(desktop): normalize updater pub_date so suppression actually works
- `f11aa41` fix(desktop): widget configure pages weren't scrolling on overflow
- `a45225a` refactor(desktop): drop deprecated 'Toolbar Preview' widget sections
- `d2bd872` fix(desktop): stabilize sysmon ticker chip width to stop layout jitter
- `5ef69c9` chore(desktop): bump to v1.0.15

## Notes

`package-lock.json` was drifting at `version: "1.0.9"` (multiple releases behind). Refreshed as part of the bump.

## Test plan

- Launch app: no "Update available" toast 4s after launch on the current version
- Open System Monitor / Weather / Uptime / GitHub / Clock configure pages: all scroll when content overflows; no "Toolbar Preview" section visible; clock's 12h/24h toggle lives under "Ticker"
- Pin sysmon to ticker, watch CPU% / RAM% / GPU% flip digit counts: chip width stays fixed, no reflow of the scrolling middle