### PR TITLE
feat(business): /business landing page + Resend-backed lead capture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,23 @@ INTERNAL_RSS_URL={{ environment.INTERNAL_RSS_URL }}
 
 # ── Yahoo Service ────────────────────────────────────────────────
 SYNC_INTERVAL_SECS={{ environment.SYNC_INTERVAL_SECS }}
+
+# ── Resend (transactional email) ─────────────────────────────────
+# Shared across password reset, support partner notifications, and
+# the /business-leads endpoint. The API key is required for ANY of
+# those flows to send mail.
+RESEND_API_KEY={{ environment.RESEND_API_KEY }}
+# Fallback From address for callers that don't set a pipeline-specific
+# one. Must be a verified sending domain in the Resend dashboard.
+RESEND_FROM_EMAIL={{ environment.RESEND_FROM_EMAIL }}
+# From address used by the support partner-notification + AI-draft path.
+SUPPORT_REPLY_FROM_EMAIL={{ environment.SUPPORT_REPLY_FROM_EMAIL }}
+
+# ── Business Leads (/business form on myscrollr.com) ─────────────
+# Internal recipient for new B2B inquiry notifications. Falls back to
+# enterprise@myscrollr.com if unset.
+BUSINESS_LEADS_TO_EMAIL={{ environment.BUSINESS_LEADS_TO_EMAIL }}
+# From address used for both the internal notification and the
+# auto-reply sent back to the lead. Falls back to RESEND_FROM_EMAIL,
+# then a literal default.
+BUSINESS_LEADS_FROM_EMAIL={{ environment.BUSINESS_LEADS_FROM_EMAIL }}

--- a/api/core/handlers_business_leads.go
+++ b/api/core/handlers_business_leads.go
@@ -1,0 +1,417 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// BusinessLeadRequest is the JSON body shape for POST /business-leads.
+// Anonymous endpoint — fields come straight from the marketing form
+// on myscrollr.com/business with no JWT identity attached.
+type BusinessLeadRequest struct {
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	Company string `json:"company"`
+	UseCase string `json:"use_case"`
+	Message string `json:"message"`
+}
+
+// businessLeadRateLimitKey scopes anonymous business-lead submissions
+// per source IP. Window: 1 hour.
+func businessLeadRateLimitKey(ip string) string {
+	return "business_leads:public:" + ip + ":hour"
+}
+
+const (
+	businessLeadMaxPerHour = 5
+	businessLeadRateWindow = time.Hour
+
+	businessLeadNameMax    = 120
+	businessLeadEmailMax   = 254
+	businessLeadCompanyMax = 200
+	businessLeadMessageMin = 10
+	businessLeadMessageMax = 5000
+)
+
+// allowedBusinessUseCases mirrors the dropdown options on the marketing
+// form. The map value is the human-friendly label that appears in the
+// internal notification email and the auto-reply subject — keeping it
+// here means the email copy stays in sync if we add/rename a use case.
+var allowedBusinessUseCases = map[string]string{
+	"sports-bars": "Sports bar / restaurant",
+	"brokerages":  "Brokerage / financial advisor",
+	"fantasy":     "Fantasy sports platform",
+	"sportsbooks": "Sportsbook / betting affiliate",
+	"crypto":      "Crypto exchange",
+	"news":        "News aggregator / publisher",
+	"other":       "Other",
+}
+
+// HandleSubmitBusinessLead accepts anonymous business-inquiry
+// submissions from myscrollr.com/business. Per-IP rate-limited via
+// Redis (5/hour) on top of the global IP limiter. Persists every
+// accepted submission to `business_leads` as the source of truth,
+// then best-effort dispatches two Resend emails:
+//
+//  1. Internal notification to BUSINESS_LEADS_TO_EMAIL (defaults
+//     enterprise@myscrollr.com) so sales sees the lead.
+//  2. Auto-reply to the lead's address so they get a confirmation
+//     beyond the on-screen success state.
+//
+// Email-send failures are LOGGED but do NOT change the 200 response —
+// the DB row is the durable record, and sales can backfill by scanning
+// the table for rows with `notified_at IS NULL`.
+func HandleSubmitBusinessLead(c *fiber.Ctx) error {
+	setCORSHeaders(c)
+
+	var req BusinessLeadRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Invalid request body",
+		})
+	}
+
+	// ── Normalise ─────────────────────────────────────────────────
+	req.Name = strings.TrimSpace(req.Name)
+	req.Email = strings.TrimSpace(req.Email)
+	req.Company = strings.TrimSpace(req.Company)
+	req.UseCase = strings.TrimSpace(strings.ToLower(req.UseCase))
+	req.Message = strings.TrimSpace(req.Message)
+
+	// ── Validate ──────────────────────────────────────────────────
+	if req.Name == "" || len(req.Name) > businessLeadNameMax {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Name required (max 120 chars)",
+		})
+	}
+	if req.Email == "" || !strings.Contains(req.Email, "@") || len(req.Email) > businessLeadEmailMax {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Valid email required",
+		})
+	}
+	if req.Company == "" || len(req.Company) > businessLeadCompanyMax {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Company required (max 200 chars)",
+		})
+	}
+	useCaseLabel, ok := allowedBusinessUseCases[req.UseCase]
+	if !ok {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Invalid use case",
+		})
+	}
+	if len(req.Message) < businessLeadMessageMin || len(req.Message) > businessLeadMessageMax {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  fmt.Sprintf("Message must be %d-%d characters", businessLeadMessageMin, businessLeadMessageMax),
+		})
+	}
+
+	// ── Rate limit ────────────────────────────────────────────────
+	// Soft-fail on Redis errors: accepting a lead is more valuable
+	// than losing one to a transient infra glitch. The outer Fiber IP
+	// limiter still caps total request rate.
+	ip := c.IP()
+	if Rdb != nil && ip != "" {
+		key := businessLeadRateLimitKey(ip)
+		count, err := Rdb.Incr(c.Context(), key).Result()
+		if err == nil {
+			if count == 1 {
+				_ = Rdb.Expire(c.Context(), key, businessLeadRateWindow).Err()
+			}
+			if count > businessLeadMaxPerHour {
+				return c.Status(fiber.StatusTooManyRequests).JSON(ErrorResponse{
+					Status: "error",
+					Error:  "Too many submissions; please try again in an hour",
+				})
+			}
+		} else {
+			log.Printf("[BusinessLeads] Redis INCR failed (continuing): %v", err)
+		}
+	}
+
+	ipRedacted := redactIP(ip)
+	userAgent := c.Get("User-Agent")
+	if len(userAgent) > 500 {
+		userAgent = userAgent[:500]
+	}
+
+	// ── Persist (must succeed) ────────────────────────────────────
+	// DBPool is the durable record. Email dispatches that come next
+	// are best-effort and don't roll back this row.
+	var leadID int64
+	err := DBPool.QueryRow(c.Context(), `
+		INSERT INTO business_leads
+		  (name, email, company, use_case, message, ip_redacted, user_agent)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id
+	`, req.Name, req.Email, req.Company, req.UseCase, req.Message, ipRedacted, userAgent).
+		Scan(&leadID)
+	if err != nil {
+		log.Printf("[BusinessLeads] DB insert failed for email=%s company=%s: %v",
+			redactEmail(req.Email), req.Company, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Failed to save submission; please try again",
+		})
+	}
+
+	log.Printf("[BusinessLeads] Lead #%d captured ip=%s email=%s company=%q use_case=%s",
+		leadID, ipRedacted, redactEmail(req.Email), req.Company, req.UseCase)
+
+	// ── Email dispatches (best-effort) ────────────────────────────
+	// Use a detached context so a fast client disconnect doesn't
+	// cancel the Resend calls mid-flight. We've already promised the
+	// user a response — finish the side effects.
+	bg, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := sendBusinessLeadNotification(bg, leadID, req, useCaseLabel, ipRedacted); err != nil {
+		log.Printf("[BusinessLeads] Notification email failed for lead #%d: %v", leadID, err)
+	} else {
+		if _, err := DBPool.Exec(bg,
+			"UPDATE business_leads SET notified_at = now() WHERE id = $1", leadID); err != nil {
+			log.Printf("[BusinessLeads] notified_at update failed for lead #%d: %v", leadID, err)
+		}
+	}
+
+	if err := sendBusinessLeadAutoReply(bg, req, useCaseLabel); err != nil {
+		log.Printf("[BusinessLeads] Auto-reply failed for lead #%d to %s: %v",
+			leadID, redactEmail(req.Email), err)
+	} else {
+		if _, err := DBPool.Exec(bg,
+			"UPDATE business_leads SET auto_replied_at = now() WHERE id = $1", leadID); err != nil {
+			log.Printf("[BusinessLeads] auto_replied_at update failed for lead #%d: %v", leadID, err)
+		}
+	}
+
+	return c.JSON(fiber.Map{
+		"status":  "ok",
+		"message": "Lead received",
+	})
+}
+
+// ══════════════════════════════════════════════════════════════════
+//  Resend dispatch
+// ══════════════════════════════════════════════════════════════════
+//
+// Both senders below issue a direct HTTPS POST to Resend rather than
+// using their Go SDK. This matches the inline pattern already used by
+// sendPasswordResetEmail (handlers_account.go) and the partner
+// notification path (support_drafts.go). When a third caller appears,
+// extracting a shared `resendSend()` helper becomes worth the churn —
+// for now, three near-identical 30-line blocks are cheaper than the
+// abstraction.
+
+// resendEndpoint is the Resend Emails API URL. Pulled into a const so
+// tests (when we add them) can swap it via a test double if needed.
+const resendEndpoint = "https://api.resend.com/emails"
+
+// businessLeadsFrom returns the From address used for both the
+// internal notification and the auto-reply. Resolution order:
+//
+//  1. BUSINESS_LEADS_FROM_EMAIL — explicit override for this pipeline
+//  2. RESEND_FROM_EMAIL — shared fallback used by other Resend callers
+//  3. A literal default — last resort so misconfigured envs still send
+//
+// The literal default uses `enterprise@myscrollr.com`. For Resend to
+// accept that From, myscrollr.com must be a verified sending domain in
+// the Resend dashboard (it already is — see existing support emails).
+func businessLeadsFrom() string {
+	if v := strings.TrimSpace(os.Getenv("BUSINESS_LEADS_FROM_EMAIL")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("RESEND_FROM_EMAIL")); v != "" {
+		return v
+	}
+	return "Scrollr Business <enterprise@myscrollr.com>"
+}
+
+// businessLeadsTo returns the internal notification recipient. Env-
+// configurable so non-prod environments can route notifications to a
+// test inbox without code changes.
+func businessLeadsTo() string {
+	if v := strings.TrimSpace(os.Getenv("BUSINESS_LEADS_TO_EMAIL")); v != "" {
+		return v
+	}
+	return "enterprise@myscrollr.com"
+}
+
+// sendBusinessLeadNotification sends the internal "new lead" email to
+// the sales address. Reply-To is set to the lead's email so a sales
+// rep hitting "reply" lands directly in the lead's inbox without
+// having to copy-paste an address out of the body.
+func sendBusinessLeadNotification(
+	ctx context.Context,
+	leadID int64,
+	req BusinessLeadRequest,
+	useCaseLabel string,
+	ipRedacted string,
+) error {
+	apiKey := strings.TrimSpace(os.Getenv("RESEND_API_KEY"))
+	if apiKey == "" {
+		return fmt.Errorf("RESEND_API_KEY not configured")
+	}
+
+	subject := fmt.Sprintf("New business lead: %s", req.Company)
+
+	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0b0d10;color:#e6e6e6;padding:24px;">
+  <div style="max-width:600px;margin:0 auto;background:#14181d;border:1px solid #1e252d;border-radius:12px;overflow:hidden;">
+    <div style="padding:24px 28px 12px;border-bottom:1px solid #1e252d;">
+      <p style="margin:0 0 4px;font-size:11px;color:#10b981;text-transform:uppercase;letter-spacing:1px;font-weight:600;">New business lead · #%d</p>
+      <h2 style="margin:0;font-size:20px;color:#fff;font-weight:700;">%s</h2>
+    </div>
+    <table cellpadding="0" cellspacing="0" border="0" style="width:100%%;padding:20px 28px;">
+      <tr><td style="padding:6px 0;font-size:11px;color:#7a7a7a;text-transform:uppercase;letter-spacing:0.5px;width:110px;vertical-align:top;">Name</td><td style="padding:6px 0;font-size:14px;color:#e6e6e6;">%s</td></tr>
+      <tr><td style="padding:6px 0;font-size:11px;color:#7a7a7a;text-transform:uppercase;letter-spacing:0.5px;vertical-align:top;">Email</td><td style="padding:6px 0;font-size:14px;color:#10b981;"><a href="mailto:%s" style="color:#10b981;text-decoration:none;">%s</a></td></tr>
+      <tr><td style="padding:6px 0;font-size:11px;color:#7a7a7a;text-transform:uppercase;letter-spacing:0.5px;vertical-align:top;">Company</td><td style="padding:6px 0;font-size:14px;color:#e6e6e6;">%s</td></tr>
+      <tr><td style="padding:6px 0;font-size:11px;color:#7a7a7a;text-transform:uppercase;letter-spacing:0.5px;vertical-align:top;">Use case</td><td style="padding:6px 0;font-size:14px;color:#e6e6e6;">%s</td></tr>
+    </table>
+    <div style="padding:8px 28px 24px;">
+      <p style="margin:0 0 8px;font-size:11px;color:#7a7a7a;text-transform:uppercase;letter-spacing:0.5px;">Message</p>
+      <div style="background:#0b0d10;border:1px solid #1e252d;border-radius:8px;padding:16px;font-size:14px;color:#d0d0d0;line-height:1.55;white-space:pre-wrap;">%s</div>
+    </div>
+    <div style="padding:14px 28px;background:#0b0d10;border-top:1px solid #1e252d;font-size:11px;color:#5a5a5a;">
+      <p style="margin:0;">Reply to this email to respond directly to %s.</p>
+      <p style="margin:6px 0 0;">Submitted from myscrollr.com/business · IP %s</p>
+    </div>
+  </div>
+</body>
+</html>`,
+		leadID,
+		html.EscapeString(req.Company),
+		html.EscapeString(req.Name),
+		html.EscapeString(req.Email),
+		html.EscapeString(req.Email),
+		html.EscapeString(req.Company),
+		html.EscapeString(useCaseLabel),
+		html.EscapeString(req.Message),
+		html.EscapeString(req.Email),
+		html.EscapeString(ipRedacted),
+	)
+
+	payload := map[string]any{
+		"from":     businessLeadsFrom(),
+		"to":       []string{businessLeadsTo()},
+		"reply_to": req.Email,
+		"subject":  subject,
+		"html":     htmlBody,
+	}
+
+	return postToResend(ctx, apiKey, payload)
+}
+
+// sendBusinessLeadAutoReply confirms receipt to the lead. Brand voice
+// matches the rest of the site: short, direct, no salesy fluff. Tells
+// them exactly what happens next so they're not left wondering.
+func sendBusinessLeadAutoReply(
+	ctx context.Context,
+	req BusinessLeadRequest,
+	useCaseLabel string,
+) error {
+	apiKey := strings.TrimSpace(os.Getenv("RESEND_API_KEY"))
+	if apiKey == "" {
+		return fmt.Errorf("RESEND_API_KEY not configured")
+	}
+
+	subject := fmt.Sprintf("Thanks — we got your note about %s", req.Company)
+
+	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0b0d10;color:#e6e6e6;padding:24px;">
+  <div style="max-width:560px;margin:0 auto;background:#14181d;border:1px solid #1e252d;border-radius:12px;padding:32px;">
+    <p style="margin:0 0 4px;font-size:11px;color:#10b981;text-transform:uppercase;letter-spacing:1px;font-weight:600;">Scrollr for business</p>
+    <h2 style="margin:0 0 20px;font-size:22px;color:#fff;font-weight:700;">Thanks, %s — we got your note.</h2>
+
+    <p style="margin:0 0 20px;line-height:1.6;color:#c8c8c8;font-size:15px;">
+      We received your inquiry about deploying Scrollr for <strong style="color:#e6e6e6;">%s</strong> (%s). Here&rsquo;s what happens next:
+    </p>
+
+    <ol style="margin:0 0 24px;padding-left:20px;line-height:1.7;color:#c8c8c8;font-size:14px;">
+      <li style="margin-bottom:6px;">Within one business day, a real human (probably Brandon) will reply to this thread.</li>
+      <li style="margin-bottom:6px;">If it&rsquo;s a fit, we&rsquo;ll schedule a 30-minute scoping call to understand your deployment.</li>
+      <li>Within three business days of that call, you&rsquo;ll have a written scope and quote.</li>
+    </ol>
+
+    <div style="border-top:1px solid #1e252d;margin:24px 0;padding-top:20px;">
+      <p style="margin:0 0 8px;font-size:13px;color:#8a8a8a;line-height:1.6;">
+        If you don&rsquo;t hear back within two business days, reply to this email and we&rsquo;ll fix it.
+      </p>
+      <p style="margin:0;font-size:13px;color:#8a8a8a;line-height:1.6;">
+        Want to sign an NDA before our call? Reply with yours, or ask for ours.
+      </p>
+    </div>
+
+    <p style="margin:0;color:#5a5a5a;font-size:12px;">&mdash; The Scrollr team</p>
+  </div>
+  <p style="text-align:center;margin-top:16px;color:#3a3a3a;font-size:11px;">
+    You received this because you submitted the form at myscrollr.com/business
+  </p>
+</body>
+</html>`,
+		html.EscapeString(req.Name),
+		html.EscapeString(req.Company),
+		html.EscapeString(useCaseLabel),
+	)
+
+	payload := map[string]any{
+		"from":     businessLeadsFrom(),
+		"to":       []string{req.Email},
+		"reply_to": businessLeadsTo(),
+		"subject":  subject,
+		"html":     htmlBody,
+	}
+
+	return postToResend(ctx, apiKey, payload)
+}
+
+// postToResend is the shared POST helper for the two senders above.
+// Returns nil on 2xx, an error containing Resend's response body on
+// anything else so logs are actionable. 15s timeout matches the
+// existing partner-notification sender — Resend is usually <500ms and
+// 15s is enough headroom for a slow upstream without trapping our
+// goroutines.
+func postToResend(ctx context.Context, apiKey string, payload map[string]any) error {
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal resend payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resendEndpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("build resend request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/api/core/handlers_business_leads.go
+++ b/api/core/handlers_business_leads.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/mail"
 	"os"
 	"strings"
 	"time"
@@ -42,6 +43,18 @@ const (
 	businessLeadCompanyMax = 200
 	businessLeadMessageMin = 10
 	businessLeadMessageMax = 5000
+
+	// companySubjectMax caps how much of the (200-char) Company string
+	// we splice into email subject lines. 80 keeps subjects readable
+	// in most mail clients without truncating mid-word on legitimate
+	// names like "Goldman Sachs Asset Management & Co." (38 chars).
+	companySubjectMax = 80
+
+	// businessLeadSideEffectsTimeout bounds the detached context used
+	// for the post-rate-limit DB insert AND both Resend dispatches.
+	// Two Resend calls at 15s apiece + a fast Postgres write leaves
+	// headroom; 45s avoids the worst-case 30s cliff.
+	businessLeadSideEffectsTimeout = 45 * time.Second
 )
 
 // allowedBusinessUseCases mirrors the dropdown options on the marketing
@@ -97,7 +110,19 @@ func HandleSubmitBusinessLead(c *fiber.Ctx) error {
 			Error:  "Name required (max 120 chars)",
 		})
 	}
-	if req.Email == "" || !strings.Contains(req.Email, "@") || len(req.Email) > businessLeadEmailMax {
+	if len(req.Email) == 0 || len(req.Email) > businessLeadEmailMax {
+		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
+			Status: "error",
+			Error:  "Valid email required",
+		})
+	}
+	// net/mail.ParseAddress catches the obvious garbage that
+	// `strings.Contains("@")` lets through ("a@b", "foo @ bar", names
+	// without local parts, etc.). It accepts RFC 5322 forms including
+	// the "Name <addr>" variant, so we narrow to the bare address by
+	// reading parsed.Address and requiring it equals the trimmed input.
+	parsedEmail, err := mail.ParseAddress(req.Email)
+	if err != nil || parsedEmail.Address != req.Email {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
 			Status: "error",
 			Error:  "Valid email required",
@@ -133,7 +158,13 @@ func HandleSubmitBusinessLead(c *fiber.Ctx) error {
 		count, err := Rdb.Incr(c.Context(), key).Result()
 		if err == nil {
 			if count == 1 {
-				_ = Rdb.Expire(c.Context(), key, businessLeadRateWindow).Err()
+				if expErr := Rdb.Expire(c.Context(), key, businessLeadRateWindow).Err(); expErr != nil {
+					// If TTL set fails, the key has no expiry and will
+					// permanently block submissions from this IP until
+					// manually cleared. Log loudly so we notice.
+					log.Printf("[BusinessLeads] Redis EXPIRE failed for key=%s (key has no TTL): %v",
+						key, expErr)
+				}
 			}
 			if count > businessLeadMaxPerHour {
 				return c.Status(fiber.StatusTooManyRequests).JSON(ErrorResponse{
@@ -152,18 +183,26 @@ func HandleSubmitBusinessLead(c *fiber.Ctx) error {
 		userAgent = userAgent[:500]
 	}
 
+	// ── Persist + side effects under a detached context ───────────
+	// `bg` outlives the request scope so a fast client disconnect
+	// doesn't cancel the durable INSERT or the post-insert Resend
+	// dispatches. The user already submitted the form — finish what
+	// we promised them. 45s budget covers a fast Postgres write plus
+	// both 15s Resend timeouts with headroom.
+	bg, cancel := context.WithTimeout(context.Background(), businessLeadSideEffectsTimeout)
+	defer cancel()
+
 	// ── Persist (must succeed) ────────────────────────────────────
 	// DBPool is the durable record. Email dispatches that come next
 	// are best-effort and don't roll back this row.
 	var leadID int64
-	err := DBPool.QueryRow(c.Context(), `
+	if err := DBPool.QueryRow(bg, `
 		INSERT INTO business_leads
 		  (name, email, company, use_case, message, ip_redacted, user_agent)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		RETURNING id
 	`, req.Name, req.Email, req.Company, req.UseCase, req.Message, ipRedacted, userAgent).
-		Scan(&leadID)
-	if err != nil {
+		Scan(&leadID); err != nil {
 		log.Printf("[BusinessLeads] DB insert failed for email=%s company=%s: %v",
 			redactEmail(req.Email), req.Company, err)
 		return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{
@@ -174,13 +213,6 @@ func HandleSubmitBusinessLead(c *fiber.Ctx) error {
 
 	log.Printf("[BusinessLeads] Lead #%d captured ip=%s email=%s company=%q use_case=%s",
 		leadID, ipRedacted, redactEmail(req.Email), req.Company, req.UseCase)
-
-	// ── Email dispatches (best-effort) ────────────────────────────
-	// Use a detached context so a fast client disconnect doesn't
-	// cancel the Resend calls mid-flight. We've already promised the
-	// user a response — finish the side effects.
-	bg, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 
 	if err := sendBusinessLeadNotification(bg, leadID, req, useCaseLabel, ipRedacted); err != nil {
 		log.Printf("[BusinessLeads] Notification email failed for lead #%d: %v", leadID, err)
@@ -269,7 +301,7 @@ func sendBusinessLeadNotification(
 		return fmt.Errorf("RESEND_API_KEY not configured")
 	}
 
-	subject := fmt.Sprintf("New business lead: %s", req.Company)
+	subject := fmt.Sprintf("New business lead: %s", truncateForSubject(req.Company))
 
 	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
 <html>
@@ -332,7 +364,7 @@ func sendBusinessLeadAutoReply(
 		return fmt.Errorf("RESEND_API_KEY not configured")
 	}
 
-	subject := fmt.Sprintf("Thanks — we got your note about %s", req.Company)
+	subject := fmt.Sprintf("Thanks — we got your note about %s", truncateForSubject(req.Company))
 
 	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
 <html>
@@ -381,6 +413,23 @@ func sendBusinessLeadAutoReply(
 	}
 
 	return postToResend(ctx, apiKey, payload)
+}
+
+// truncateForSubject trims a user-supplied string down to a length
+// that reads cleanly as part of an email subject. The DB allows up
+// to 200 characters of Company, but pasting all 200 into the subject
+// produces unreadable headers in most mail clients. We chop at a word
+// boundary when possible and append an ellipsis so the truncation is
+// visible to the recipient.
+func truncateForSubject(s string) string {
+	if len(s) <= companySubjectMax {
+		return s
+	}
+	cut := s[:companySubjectMax]
+	if idx := strings.LastIndexByte(cut, ' '); idx > companySubjectMax/2 {
+		cut = cut[:idx]
+	}
+	return cut + "\u2026"
 }
 
 // postToResend is the shared POST helper for the two senders above.

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -192,6 +192,12 @@ func (s *Server) setupRoutes() {
 	// hourly Redis counter inside the handler both protect this route.
 	s.App.Post("/support/ticket/public", HandleSubmitPublicSupportTicket)
 
+	// B2B lead capture from the marketing /business page. Same
+	// abuse-protection model as /support/ticket/public: Fiber IP
+	// limiter on the outside, per-IP hourly Redis counter inside
+	// the handler.
+	s.App.Post("/business-leads", HandleSubmitBusinessLead)
+
 	// Partner-approval URLs for AI-drafted replies. No auth — these are
 	// HMAC-signed single-use tokens that the partner clicks from email.
 	s.App.Get("/support/send", HandleSupportSend)

--- a/api/migrations/000013_business_leads.down.sql
+++ b/api/migrations/000013_business_leads.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS business_leads_email_idx;
+DROP INDEX IF EXISTS business_leads_created_at_idx;
+DROP TABLE IF EXISTS business_leads;

--- a/api/migrations/000013_business_leads.up.sql
+++ b/api/migrations/000013_business_leads.up.sql
@@ -1,0 +1,43 @@
+-- B2B lead-capture from the marketing /business page.
+--
+-- One row per submission. The handler validates + rate-limits the
+-- request, inserts here as the source of truth, then best-effort
+-- dispatches two Resend emails (internal notification + auto-reply).
+-- Email failures DO NOT roll back the row — the lead stays captured
+-- even if Resend is down, so sales can scan this table for missed
+-- notifications. `notified_at` / `auto_replied_at` get set only when
+-- their respective Resend call succeeds.
+--
+-- `ip_redacted` stores the abuse-investigation form (e.g. "192.168.1.x"
+-- or "2001:db8::/64") rather than the raw IP, mirroring what we put in
+-- log lines. We never need the host-bit precision for sales workflow,
+-- and dropping it keeps this table cheaper from a PII standpoint.
+--
+-- `replied_at` is forward-looking: not set by this code path. A future
+-- admin/CRM integration can backfill it when a human responds, so we
+-- can compute lead-response-time metrics without touching schema.
+
+CREATE TABLE IF NOT EXISTS business_leads (
+    id              BIGSERIAL PRIMARY KEY,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    name            TEXT NOT NULL,
+    email           TEXT NOT NULL,
+    company         TEXT NOT NULL,
+    use_case        TEXT NOT NULL,
+    message         TEXT NOT NULL,
+    ip_redacted     TEXT,
+    user_agent      TEXT,
+    notified_at     TIMESTAMPTZ,
+    auto_replied_at TIMESTAMPTZ,
+    replied_at      TIMESTAMPTZ
+);
+
+-- Hot query: "latest 50 leads" on an admin dashboard. DESC index keeps
+-- the scan cheap once the table grows.
+CREATE INDEX IF NOT EXISTS business_leads_created_at_idx
+    ON business_leads (created_at DESC);
+
+-- Email lookup: useful when a returning lead submits again and we want
+-- to thread them, or when investigating abuse from a known address.
+CREATE INDEX IF NOT EXISTS business_leads_email_idx
+    ON business_leads (email);

--- a/myscrollr.com/public/sitemap.xml
+++ b/myscrollr.com/public/sitemap.xml
@@ -37,6 +37,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://myscrollr.com/business</loc>
+    <lastmod>2026-05-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://myscrollr.com/architecture</loc>
     <lastmod>2026-04-24</lastmod>
     <changefreq>monthly</changefreq>

--- a/myscrollr.com/src/api/client.ts
+++ b/myscrollr.com/src/api/client.ts
@@ -644,6 +644,53 @@ export const supportApi = {
     }),
 }
 
+// ── Business Leads API ────────────────────────────────────────────
+//
+// Anonymous lead-capture endpoint backing the marketing /business
+// page. Server (api/core/handlers_business_leads.go) persists every
+// accepted submission to `business_leads` as the source of truth, then
+// best-effort dispatches a Resend notification to enterprise@ plus an
+// auto-reply to the lead. Per-IP rate-limited 5/hour.
+//
+// `use_case` values must match the keys in allowedBusinessUseCases on
+// the server. Drift is a 400 from the validator.
+
+export type BusinessUseCase =
+  | 'sports-bars'
+  | 'brokerages'
+  | 'fantasy'
+  | 'sportsbooks'
+  | 'crypto'
+  | 'news'
+  | 'other'
+
+export interface BusinessLeadPayload {
+  name: string
+  email: string
+  company: string
+  use_case: BusinessUseCase
+  message: string
+}
+
+export interface BusinessLeadResponse {
+  status: string
+  message: string
+}
+
+export const businessApi = {
+  /**
+   * Submit a B2B inquiry. Per-IP rate-limited (5/hour). Throws on
+   * validation or transport failure; the caller should surface the
+   * thrown message and let the user retry.
+   */
+  submit: (payload: BusinessLeadPayload) =>
+    request<BusinessLeadResponse>('/business-leads', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+}
+
 // ── GDPR Account Export + Delete ──────────────────────────────────
 //
 // 30-day soft-delete grace window. Users can cancel from the Account

--- a/myscrollr.com/src/components/Header.tsx
+++ b/myscrollr.com/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from '@tanstack/react-router'
 import {
+  Building2,
   ChevronRight,
   Download,
   House,
@@ -106,7 +107,12 @@ export default function Header() {
 
             <NavLink to="/uplink" activeOn="/uplink">
               <Satellite size={14} />
-              Uplink
+              Pricing
+            </NavLink>
+
+            <NavLink to="/business" activeOn="/business">
+              <Building2 size={14} />
+              Business
             </NavLink>
 
             <NavLink to="/download" activeOn="/download">
@@ -253,7 +259,15 @@ export default function Header() {
                   icon={<ChevronRight size={18} />}
                   onClick={() => setIsOpen(false)}
                 >
-                  Uplink
+                  Pricing
+                </MobileNavLink>
+
+                <MobileNavLink
+                  to="/business"
+                  icon={<ChevronRight size={18} />}
+                  onClick={() => setIsOpen(false)}
+                >
+                  Business
                 </MobileNavLink>
 
                 <MobileNavLink

--- a/myscrollr.com/src/components/landing/CallToAction.tsx
+++ b/myscrollr.com/src/components/landing/CallToAction.tsx
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { motion, useInView, useMotionValue, useSpring } from 'motion/react'
 import { Link } from '@tanstack/react-router'
-import { GitFork, Github, Globe, MessageSquare, Star, Zap } from 'lucide-react'
+import {
+  Building2,
+  GitFork,
+  Github,
+  Globe,
+  MessageSquare,
+  Star,
+  Zap,
+} from 'lucide-react'
 import type {
   BackdropBeam,
   BackdropParticle,
@@ -315,7 +323,7 @@ export function CallToAction() {
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
             transition={{ delay: 0.85, duration: 0.5, ease: EASE }}
-            className="mt-12 flex items-center gap-6"
+            className="mt-12 flex flex-wrap items-center justify-center gap-x-6 gap-y-3"
           >
             <a
               href="https://github.com/brandon-relentnet/myscrollr"
@@ -334,6 +342,14 @@ export function CallToAction() {
               <Globe className="size-4" aria-hidden />
               Explore Channels
             </a>
+            <span className="w-px h-4 bg-base-content/10" />
+            <Link
+              to="/business"
+              className="inline-flex items-center gap-2 text-sm text-base-content/40 hover:text-primary transition-[color] duration-200"
+            >
+              <Building2 className="size-4" aria-hidden />
+              Running a business?
+            </Link>
           </motion.div>
         </div>
       </div>

--- a/myscrollr.com/src/routeTree.gen.ts
+++ b/myscrollr.com/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as InviteRouteImport } from './routes/invite'
 import { Route as DownloadRouteImport } from './routes/download'
 import { Route as ChannelsRouteImport } from './routes/channels'
 import { Route as CallbackRouteImport } from './routes/callback'
+import { Route as BusinessRouteImport } from './routes/business'
 import { Route as ArchitectureRouteImport } from './routes/architecture'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as IndexRouteImport } from './routes/index'
@@ -63,6 +64,11 @@ const CallbackRoute = CallbackRouteImport.update({
   path: '/callback',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BusinessRoute = BusinessRouteImport.update({
+  id: '/business',
+  path: '/business',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ArchitectureRoute = ArchitectureRouteImport.update({
   id: '/architecture',
   path: '/architecture',
@@ -93,6 +99,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/architecture': typeof ArchitectureRoute
+  '/business': typeof BusinessRoute
   '/callback': typeof CallbackRoute
   '/channels': typeof ChannelsRoute
   '/download': typeof DownloadRoute
@@ -108,6 +115,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/architecture': typeof ArchitectureRoute
+  '/business': typeof BusinessRoute
   '/callback': typeof CallbackRoute
   '/channels': typeof ChannelsRoute
   '/download': typeof DownloadRoute
@@ -124,6 +132,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/architecture': typeof ArchitectureRoute
+  '/business': typeof BusinessRoute
   '/callback': typeof CallbackRoute
   '/channels': typeof ChannelsRoute
   '/download': typeof DownloadRoute
@@ -141,6 +150,7 @@ export interface FileRouteTypes {
     | '/'
     | '/account'
     | '/architecture'
+    | '/business'
     | '/callback'
     | '/channels'
     | '/download'
@@ -156,6 +166,7 @@ export interface FileRouteTypes {
     | '/'
     | '/account'
     | '/architecture'
+    | '/business'
     | '/callback'
     | '/channels'
     | '/download'
@@ -171,6 +182,7 @@ export interface FileRouteTypes {
     | '/'
     | '/account'
     | '/architecture'
+    | '/business'
     | '/callback'
     | '/channels'
     | '/download'
@@ -187,6 +199,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AccountRoute: typeof AccountRoute
   ArchitectureRoute: typeof ArchitectureRoute
+  BusinessRoute: typeof BusinessRoute
   CallbackRoute: typeof CallbackRoute
   ChannelsRoute: typeof ChannelsRoute
   DownloadRoute: typeof DownloadRoute
@@ -257,6 +270,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/business': {
+      id: '/business'
+      path: '/business'
+      fullPath: '/business'
+      preLoaderRoute: typeof BusinessRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/architecture': {
       id: '/architecture'
       path: '/architecture'
@@ -299,6 +319,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AccountRoute: AccountRoute,
   ArchitectureRoute: ArchitectureRoute,
+  BusinessRoute: BusinessRoute,
   CallbackRoute: CallbackRoute,
   ChannelsRoute: ChannelsRoute,
   DownloadRoute: DownloadRoute,

--- a/myscrollr.com/src/routes/business.tsx
+++ b/myscrollr.com/src/routes/business.tsx
@@ -1,0 +1,1803 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { motion, useInView, useMotionValue } from 'motion/react'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import {
+  AlertTriangle,
+  ArrowRight,
+  Bitcoin,
+  Briefcase,
+  Building2,
+  CheckCircle2,
+  Code2,
+  Copy,
+  Cpu,
+  Dice5,
+  Eye,
+  FileSignature,
+  GitFork,
+  Github,
+  Headphones,
+  LayoutGrid,
+  Loader2,
+  Mail,
+  MessageSquare,
+  MonitorPlay,
+  Newspaper,
+  Palette,
+  Radio,
+  Rocket,
+  Send,
+  Server,
+  Star,
+  Trophy,
+} from 'lucide-react'
+import type { FormEvent } from 'react'
+
+import type { BusinessUseCase } from '@/api/client'
+import type { FAQItem } from '@/components/landing/FAQSection'
+import type { BackdropBeam } from '@/components/landing/_ConvergenceBackdrop'
+import { businessApi } from '@/api/client'
+import { FAQSection } from '@/components/landing/FAQSection'
+import { ConvergenceBackdrop } from '@/components/landing/_ConvergenceBackdrop'
+import { usePageMeta } from '@/lib/usePageMeta'
+import { useGitHubStats } from '@/hooks/useGitHubStats'
+
+// ── Constants ───────────────────────────────────────────────────
+
+const EASE = [0.22, 1, 0.36, 1] as const
+const CONTACT_EMAIL = 'enterprise@myscrollr.com'
+const REPO = 'brandon-relentnet/myscrollr'
+
+// ── Route ───────────────────────────────────────────────────────
+
+export const Route = createFileRoute('/business')({
+  component: BusinessPage,
+})
+
+// ── Audience cards (3x2 grid) ───────────────────────────────────
+
+interface Audience {
+  id: string
+  icon: typeof MonitorPlay
+  name: string
+  copy: string
+  accent: {
+    text: string
+    ring: string
+    glow: string
+    gradient: string
+  }
+}
+
+const AUDIENCES: Array<Audience> = [
+  {
+    id: 'sports-bars',
+    icon: MonitorPlay,
+    name: 'Sports bars & restaurants',
+    copy: 'Every TV in the room runs live scores, news, and your branding. Better than ESPN scrollers, fully under your control.',
+    accent: {
+      text: 'text-primary',
+      ring: 'rgba(52,211,153,0.25)',
+      glow: 'rgba(52,211,153,0.12)',
+      gradient: 'rgba(52,211,153,0.06)',
+    },
+  },
+  {
+    id: 'brokerages',
+    icon: Briefcase,
+    name: 'Brokerages & financial advisors',
+    copy: 'A branded desktop ticker for clients. Real-time quotes, custom watchlists, your logo, your colors, your domain.',
+    accent: {
+      text: 'text-info',
+      ring: 'rgba(0,212,255,0.25)',
+      glow: 'rgba(0,212,255,0.12)',
+      gradient: 'rgba(0,212,255,0.06)',
+    },
+  },
+  {
+    id: 'fantasy',
+    icon: Trophy,
+    name: 'Fantasy sports platforms',
+    copy: 'White-label the Scrollr desktop app as your platform’s companion. Native ticker, your branding, your standings.',
+    accent: {
+      text: 'text-secondary',
+      ring: 'rgba(255,71,87,0.25)',
+      glow: 'rgba(255,71,87,0.12)',
+      gradient: 'rgba(255,71,87,0.06)',
+    },
+  },
+  {
+    id: 'sportsbooks',
+    icon: Dice5,
+    name: 'Sportsbooks & betting affiliates',
+    copy: 'Stay on a user’s desktop without a tab open. Odds, scores, and your offers — visible the moment they matter.',
+    accent: {
+      text: 'text-accent',
+      ring: 'rgba(167,139,250,0.25)',
+      glow: 'rgba(167,139,250,0.12)',
+      gradient: 'rgba(167,139,250,0.06)',
+    },
+  },
+  {
+    id: 'crypto',
+    icon: Bitcoin,
+    name: 'Crypto exchanges',
+    copy: 'A native desktop price ticker for power users. Custom symbol list, your exchange’s pairs, your branding.',
+    accent: {
+      text: 'text-warning',
+      ring: 'rgba(251,191,36,0.25)',
+      glow: 'rgba(251,191,36,0.12)',
+      gradient: 'rgba(251,191,36,0.06)',
+    },
+  },
+  {
+    id: 'news',
+    icon: Newspaper,
+    name: 'News aggregators & publishers',
+    copy: 'A desktop distribution channel for your headlines. Always on, always visible, never another tab to open.',
+    accent: {
+      text: 'text-success',
+      ring: 'rgba(45,212,191,0.25)',
+      glow: 'rgba(45,212,191,0.12)',
+      gradient: 'rgba(45,212,191,0.06)',
+    },
+  },
+]
+
+// ── "What you get" items ────────────────────────────────────────
+
+interface Capability {
+  icon: typeof Palette
+  title: string
+  body: string
+}
+
+const CAPABILITIES: Array<Capability> = [
+  {
+    icon: Palette,
+    title: 'Custom branding',
+    body: 'Logo, colors, fonts, domain. Down to the app icon.',
+  },
+  {
+    icon: LayoutGrid,
+    title: 'Multi-display deployment',
+    body: 'Fleet-wide config push. One bar, one brokerage, one set of TVs.',
+  },
+  {
+    icon: Server,
+    title: 'Self-hosted or managed',
+    body: 'Run the whole stack in your environment, or let us host it. Your call.',
+  },
+  {
+    icon: Headphones,
+    title: 'Dedicated support & SLA',
+    body: 'Direct Slack or email channel. Response times in writing.',
+  },
+  {
+    icon: Code2,
+    title: 'API access',
+    body: 'Programmatic read/write to your deployment. Integrate with your stack.',
+  },
+  {
+    icon: FileSignature,
+    title: 'NDA-friendly',
+    body: 'Mutual NDA before the scoping call. Yours or ours.',
+  },
+]
+
+// ── 3-step process ─────────────────────────────────────────────
+
+interface Step {
+  title: string
+  body: string
+}
+
+const STEPS: Array<Step> = [
+  {
+    title: 'Contact',
+    body: 'Tell us what you want to build. We respond within one business day.',
+  },
+  {
+    title: 'Scope',
+    body: 'A 30-minute call. We send a written scope and quote within three business days.',
+  },
+  {
+    title: 'Deploy',
+    body: 'Build, brand, ship. Most deployments go live in 2-4 weeks. We stay engaged for support and changes.',
+  },
+]
+
+// ── "Why Scrollr" trust principles ─────────────────────────────
+
+interface Principle {
+  icon: typeof Rocket
+  title: string
+  body: string
+  accent: {
+    text: string
+    ring: string
+    glow: string
+    gradient: string
+  }
+}
+
+const PRINCIPLES: Array<Principle> = [
+  {
+    icon: Rocket,
+    title: 'Already shipping',
+    body: 'Real consumers, real installs, real revenue. Not a prototype.',
+    accent: {
+      text: 'text-primary',
+      ring: 'rgba(52,211,153,0.25)',
+      glow: 'rgba(52,211,153,0.12)',
+      gradient: 'rgba(52,211,153,0.06)',
+    },
+  },
+  {
+    icon: Eye,
+    title: 'Open source, AGPL-3.0',
+    body: 'Audit every line. No black box, no hidden telemetry.',
+    accent: {
+      text: 'text-info',
+      ring: 'rgba(0,212,255,0.25)',
+      glow: 'rgba(0,212,255,0.12)',
+      gradient: 'rgba(0,212,255,0.06)',
+    },
+  },
+  {
+    icon: Cpu,
+    title: 'Native, not Electron',
+    body: 'Tauri-based. ~15MB binary, sub-100MB resident memory. Runs on macOS, Windows, Linux.',
+    accent: {
+      text: 'text-secondary',
+      ring: 'rgba(255,71,87,0.25)',
+      glow: 'rgba(255,71,87,0.12)',
+      gradient: 'rgba(255,71,87,0.06)',
+    },
+  },
+  {
+    icon: Radio,
+    title: 'Real-time by default',
+    body: 'Server-Sent Events backbone. Sub-second updates without polling.',
+    accent: {
+      text: 'text-accent',
+      ring: 'rgba(167,139,250,0.25)',
+      glow: 'rgba(167,139,250,0.12)',
+      gradient: 'rgba(167,139,250,0.06)',
+    },
+  },
+]
+
+// ── FAQ items ──────────────────────────────────────────────────
+
+const BUSINESS_FAQ: Array<FAQItem> = [
+  {
+    icon: Server,
+    question: 'Can we self-host?',
+    highlight:
+      'Yes — the full stack runs in your environment. We document it and help you stand it up.',
+    answer:
+      'The full stack — desktop app, Go API, Rust ingestion services, Postgres, Redis — runs in your environment. We hand you the keys: deployment scripts, Docker Compose files, runbooks, and a hand-off call. We stay reachable after the handover.',
+    accent: 'emerald',
+  },
+  {
+    icon: FileSignature,
+    question: 'Do you sign NDAs?',
+    highlight: 'Yes. Mutual NDA before scoping calls. Standard form or yours.',
+    answer:
+      'We sign mutual NDAs before the scoping call so you can speak freely about deployment plans, integrations, and customers. We have a standard one-page form, or we can sign yours. No legal back-and-forth before the first call.',
+    accent: 'sky',
+  },
+  {
+    icon: Headphones,
+    question: 'What’s the SLA?',
+    highlight:
+      'Discussed per contract. Response times, uptime targets, and a direct channel — in writing.',
+    answer:
+      'Typical engagements include defined response times for incidents (often P1 < 1hr, P2 < 4hrs business hours), monthly uptime targets, scheduled maintenance windows, and a direct Slack channel with the engineers building your deployment. We don’t pretend "enterprise-grade" means anything until it’s in writing.',
+    accent: 'violet',
+  },
+  {
+    icon: Palette,
+    question: 'Can we fully white-label?',
+    highlight:
+      'Yes. Logo, colors, fonts, app name, domain, icon — your brand, not ours.',
+    answer:
+      'Your customers see your brand, not ours. Logo, colors, fonts, app name, app icon, install bundle identity, custom domain on the API. The codebase is AGPL-3.0, so the white-label is delivered as a separately-licensed build under a commercial license that removes the copyleft requirement for distribution.',
+    accent: 'rose',
+  },
+  {
+    icon: Rocket,
+    question: 'How long does deployment take?',
+    highlight:
+      'Most engagements ship in 2-4 weeks. Timeline is committed in writing.',
+    answer:
+      'A typical managed deployment with custom branding, two channels, and basic integrations ships in 2-4 weeks from kickoff. Self-hosted or heavy customization (new data sources, custom UI components, complex SSO) can take 6-12 weeks. The exact timeline is committed in the scope document before you pay anything.',
+    accent: 'orange',
+  },
+  {
+    icon: Code2,
+    question: 'Do you offer perpetual or one-time licensing?',
+    highlight:
+      'Yes, for self-hosted. Monthly is the default for managed deployments.',
+    answer:
+      'For self-hosted deployments, we offer perpetual licenses with optional annual maintenance for updates and support. For managed deployments, monthly billing is the default because we’re running the infrastructure. We’re flexible — bring us your procurement constraints and we’ll work with them.',
+    accent: 'fuchsia',
+  },
+]
+
+// ── Use-case dropdown options ──────────────────────────────────
+
+const USE_CASE_OPTIONS = [
+  { value: '', label: 'Select your use case' },
+  { value: 'sports-bars', label: 'Sports bar / restaurant' },
+  { value: 'brokerages', label: 'Brokerage / financial advisor' },
+  { value: 'fantasy', label: 'Fantasy sports platform' },
+  { value: 'sportsbooks', label: 'Sportsbook / betting affiliate' },
+  { value: 'crypto', label: 'Crypto exchange' },
+  { value: 'news', label: 'News aggregator / publisher' },
+  { value: 'other', label: 'Other' },
+] as const
+
+// ── CTA Particles ──────────────────────────────────────────────
+
+const CTA_PARTICLES = Array.from({ length: 12 }, (_, i) => ({
+  id: i,
+  x: Math.random() * 100,
+  y: Math.random() * 100,
+  size: Math.random() * 3 + 1.5,
+  delay: Math.random() * 5,
+  duration: Math.random() * 6 + 8,
+  color: i % 2 === 0 ? '#34d399' : '#00b8db',
+}))
+
+/* ══════════════════════════════════════════════════════════════════
+   HERO
+   ══════════════════════════════════════════════════════════════════ */
+
+function BusinessHero() {
+  const scrollToForm = () => {
+    document
+      .getElementById('contact-form')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+  const scrollToAudiences = () => {
+    document
+      .getElementById('audiences')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  return (
+    <section className="relative pt-32 pb-24 lg:pt-40 lg:pb-32 overflow-hidden">
+      {/* ── Background system ───────────────────────────────── */}
+      <div className="absolute inset-0 pointer-events-none">
+        {/* Fine dot matrix */}
+        <div
+          className="absolute inset-0 opacity-[0.03]"
+          style={{
+            backgroundImage: `radial-gradient(circle at 1px 1px, var(--grid-dot-primary) 1px, transparent 0)`,
+            backgroundSize: '24px 24px',
+          }}
+        />
+
+        {/* Single primary orbital glow — institutional, not flashy */}
+        <motion.div
+          className="absolute top-[-15%] right-[-5%] w-[700px] h-[700px] rounded-full"
+          style={{
+            background:
+              'radial-gradient(circle, var(--glow-primary-subtle) 0%, transparent 70%)',
+          }}
+          animate={{
+            scale: [1, 1.06, 1],
+            opacity: [0.5, 0.9, 0.5],
+          }}
+          transition={{ duration: 9, repeat: Infinity, ease: 'easeInOut' }}
+        />
+      </div>
+
+      {/* Top border accent */}
+      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-primary/20 to-transparent" />
+
+      <div className="container relative z-10">
+        {/* Badge row */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: EASE }}
+          className="flex items-center gap-4 mb-10"
+        >
+          <span className="inline-flex items-center gap-2 px-3 py-1.5 bg-primary/8 text-primary text-[10px] font-bold rounded-lg border border-primary/15 uppercase tracking-wide">
+            <Building2 size={12} />
+            For business
+          </span>
+          <span className="h-px w-16 bg-gradient-to-r from-base-300 to-transparent" />
+          <span className="text-[10px] text-base-content/25">
+            Branded · Deployed · Supported
+          </span>
+        </motion.div>
+
+        {/* Two-column: text left, monitor grid right */}
+        <div className="flex flex-col-reverse lg:flex-row items-center gap-12 lg:gap-16">
+          {/* Left — headline + CTAs */}
+          <div className="flex-1 min-w-0 w-full">
+            <motion.h1
+              initial={{ opacity: 0, y: 30 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.7, delay: 0.15, ease: EASE }}
+              className="text-5xl sm:text-6xl lg:text-7xl xl:text-8xl font-black tracking-tight leading-[0.9] mb-8"
+            >
+              <span className="block">Scrollr for your</span>
+              <span className="relative inline-block">
+                <span className="text-gradient-primary">business.</span>
+                <motion.span
+                  className="absolute -bottom-2 left-0 right-0 h-[3px] bg-gradient-to-r from-primary via-primary/60 to-transparent origin-left"
+                  initial={{ scaleX: 0 }}
+                  animate={{ scaleX: 1 }}
+                  transition={{ duration: 0.8, delay: 0.8, ease: EASE }}
+                />
+              </span>
+            </motion.h1>
+
+            {/* Sub-copy */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.35, ease: EASE }}
+              className="flex items-start gap-3 mb-10 max-w-xl"
+            >
+              <span className="text-primary/30 font-mono text-sm mt-0.5 select-none shrink-0">
+                $
+              </span>
+              <p className="text-base sm:text-lg text-base-content/50 leading-relaxed">
+                The same real-time ticker thousands already run — branded,
+                deployed, and supported for your team, bar, brokerage, or
+                platform.
+              </p>
+            </motion.div>
+
+            {/* CTAs */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.5, ease: EASE }}
+              className="flex flex-wrap items-center gap-4"
+            >
+              <button
+                type="button"
+                onClick={scrollToForm}
+                className="btn btn-pulse btn-lg gap-2.5"
+              >
+                <Mail size={14} />
+                Talk to us
+              </button>
+
+              <button
+                type="button"
+                onClick={scrollToAudiences}
+                className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl border border-base-300 bg-base-200/50 px-6 py-3 text-sm font-semibold text-base-content hover:bg-base-300 transition-colors backdrop-blur-sm"
+              >
+                See what’s possible
+                <ArrowRight size={14} />
+              </button>
+            </motion.div>
+
+            {/* Trust microcopy */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.6, delay: 0.7, ease: EASE }}
+              className="mt-10 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-base-content/35"
+            >
+              {[
+                'One business day response',
+                'Mutual NDA on request',
+                'Self-hosted available',
+              ].map((item) => (
+                <span key={item} className="flex items-center gap-1.5">
+                  <span className="w-1.5 h-1.5 rounded-full bg-primary/40" />
+                  {item}
+                </span>
+              ))}
+            </motion.div>
+          </div>
+
+          {/* Right — deployment fan-out visual */}
+          <div className="hidden lg:flex items-center justify-center w-[420px] shrink-0">
+            <DeploymentFanout />
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom border */}
+      <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-base-300/50 to-transparent" />
+    </section>
+  )
+}
+
+/* ── Deployment fan-out: 2x2 monitor grid with central node ───────────
+ *
+ * Four stylized monitor screens arranged in a grid, each showing the same
+ * faint ticker bar but in a different accent color — suggesting the same
+ * Scrollr platform deployed under different brands. Subtle pulse animation
+ * radiates outward from the center node.
+ */
+function DeploymentFanout() {
+  const monitors = useMemo(
+    () => [
+      { x: 0, y: 0, accent: '#34d399', delay: 0.4 },
+      { x: 1, y: 0, accent: '#00b8db', delay: 0.55 },
+      { x: 0, y: 1, accent: '#a78bfa', delay: 0.7 },
+      { x: 1, y: 1, accent: '#fbbf24', delay: 0.85 },
+    ],
+    [],
+  )
+
+  return (
+    <div className="relative w-[360px] h-[360px]">
+      {/* Ambient orb behind everything */}
+      <motion.div
+        className="absolute inset-0 rounded-full pointer-events-none"
+        style={{
+          background:
+            'radial-gradient(circle at center, rgba(52,211,153,0.06) 0%, transparent 65%)',
+          filter: 'blur(20px)',
+        }}
+        animate={{ opacity: [0.5, 1, 0.5] }}
+        transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
+      />
+
+      {/* Center pulse rings */}
+      {[0, 1].map((i) => (
+        <motion.div
+          key={i}
+          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-primary/15 pointer-events-none"
+          style={{ width: 100, height: 100 }}
+          animate={{ scale: [0.6, 2.4], opacity: [0.4, 0] }}
+          transition={{
+            delay: 1 + i * 1.4,
+            duration: 3,
+            ease: 'easeOut',
+            repeat: Infinity,
+            repeatDelay: 1.2,
+          }}
+        />
+      ))}
+
+      {/* Monitor grid */}
+      <div className="absolute inset-0 grid grid-cols-2 grid-rows-2 gap-6 p-4">
+        {monitors.map((m, i) => (
+          <MonitorTile
+            key={i}
+            accent={m.accent}
+            delay={m.delay}
+            mirrorX={m.x === 1}
+            mirrorY={m.y === 1}
+          />
+        ))}
+      </div>
+
+      {/* Central hub icon */}
+      <motion.div
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        initial={{ scale: 0, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ delay: 0.25, duration: 0.6, ease: EASE }}
+      >
+        <div
+          className="relative w-14 h-14 rounded-2xl flex items-center justify-center backdrop-blur-md"
+          style={{
+            background: 'rgba(52,211,153,0.08)',
+            boxShadow:
+              '0 0 30px rgba(52,211,153,0.18), 0 0 0 1px rgba(52,211,153,0.25)',
+          }}
+        >
+          <Building2 size={22} className="text-primary/80" />
+
+          {/* Online indicator */}
+          <span className="absolute -top-1 -right-1 flex h-2.5 w-2.5">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
+            <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-primary" />
+          </span>
+        </div>
+      </motion.div>
+
+      {/* Corner labels — anchor the visual to the 'fleet' idea */}
+      <motion.span
+        className="absolute -top-2 left-1/2 -translate-x-1/2 text-[9px] font-bold uppercase tracking-widest text-base-content/30 bg-base-100/80 backdrop-blur-sm px-3 py-1 rounded-full border border-base-300/30"
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 1.3, duration: 0.5, ease: EASE }}
+      >
+        One platform · Many deployments
+      </motion.span>
+    </div>
+  )
+}
+
+function MonitorTile({
+  accent,
+  delay,
+  mirrorX,
+  mirrorY,
+}: {
+  accent: string
+  delay: number
+  mirrorX: boolean
+  mirrorY: boolean
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.8 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ delay, duration: 0.5, ease: EASE }}
+      className="relative rounded-lg border bg-base-200/40 overflow-hidden backdrop-blur-sm"
+      style={{
+        borderColor: `${accent}30`,
+        boxShadow: `0 0 24px ${accent}10, inset 0 0 12px ${accent}06`,
+      }}
+    >
+      {/* Title bar */}
+      <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-base-300/20">
+        <div
+          className="w-1.5 h-1.5 rounded-full opacity-40"
+          style={{ backgroundColor: accent }}
+        />
+        <div
+          className="w-1.5 h-1.5 rounded-full opacity-25"
+          style={{ backgroundColor: accent }}
+        />
+        <div
+          className="w-1.5 h-1.5 rounded-full opacity-15"
+          style={{ backgroundColor: accent }}
+        />
+      </div>
+
+      {/* Content lines */}
+      <div className="p-2.5 space-y-1.5">
+        <div
+          className="h-1 rounded"
+          style={{
+            backgroundColor: `${accent}25`,
+            width: mirrorX ? '60%' : '75%',
+          }}
+        />
+        <div
+          className="h-1 rounded bg-base-content/8"
+          style={{ width: mirrorY ? '45%' : '55%' }}
+        />
+        <div
+          className="h-1 rounded bg-base-content/5"
+          style={{ width: '40%' }}
+        />
+      </div>
+
+      {/* Ticker bar — pinned to bottom */}
+      <div
+        className="absolute bottom-0 left-0 right-0 border-t flex items-center gap-1.5 px-2 py-1.5"
+        style={{ borderColor: `${accent}25`, background: `${accent}08` }}
+      >
+        {/* Live dot */}
+        <motion.span
+          className="relative inline-flex h-1 w-1 rounded-full"
+          style={{ backgroundColor: accent }}
+          animate={{ opacity: [0.4, 1, 0.4] }}
+          transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
+        />
+        {/* Faux ticker chips */}
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-1.5 rounded-sm"
+            style={{
+              backgroundColor: `${accent}25`,
+              width: 12 + i * 4,
+            }}
+          />
+        ))}
+      </div>
+    </motion.div>
+  )
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   AUDIENCES — 6-card grid (3x2)
+   ══════════════════════════════════════════════════════════════════ */
+
+function AudiencesSection() {
+  return (
+    <section id="audiences" className="relative py-24 lg:py-32 scroll-mt-20">
+      <div className="container relative">
+        {/* Header */}
+        <motion.div
+          style={{ opacity: 0 }}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-80px' }}
+          transition={{ duration: 0.6, ease: EASE }}
+          className="flex flex-col items-center text-center mb-14 lg:mb-18"
+        >
+          <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-4">
+            Who it’s <span className="text-gradient-primary">for</span>
+          </h2>
+          <p className="text-base text-base-content/45 leading-relaxed max-w-lg">
+            Six places we already see Scrollr making sense. There are more.
+          </p>
+        </motion.div>
+
+        {/* 3x2 grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 max-w-6xl mx-auto">
+          {AUDIENCES.map((aud, i) => (
+            <AudienceCard key={aud.id} audience={aud} index={i} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function AudienceCard({
+  audience,
+  index,
+}: {
+  audience: Audience
+  index: number
+}) {
+  const Icon = audience.icon
+  const { accent } = audience
+
+  return (
+    <motion.div
+      style={{ opacity: 0 }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: '-40px' }}
+      transition={{
+        delay: 0.06 + (index % 3) * 0.08,
+        duration: 0.5,
+        ease: EASE,
+      }}
+      className="relative rounded-2xl bg-base-200/40 border border-base-300/25 p-6 sm:p-7 overflow-hidden h-full"
+    >
+      {/* Top accent line */}
+      <div
+        className="absolute top-0 left-6 right-6 h-px"
+        style={{
+          background: `linear-gradient(90deg, transparent, ${accent.ring} 50%, transparent)`,
+        }}
+      />
+
+      {/* Ambient gradient orb */}
+      <div
+        className="absolute -top-16 -right-16 w-48 h-48 rounded-full pointer-events-none blur-3xl"
+        style={{ background: accent.gradient }}
+      />
+
+      {/* Watermark icon */}
+      <Icon
+        size={130}
+        strokeWidth={0.4}
+        className="absolute -bottom-5 -right-5 text-base-content/[0.025] pointer-events-none select-none"
+      />
+
+      {/* Corner dot grid */}
+      <div
+        className="absolute bottom-4 right-4 w-14 h-14 pointer-events-none opacity-[0.04]"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle, currentColor 1px, transparent 1px)',
+          backgroundSize: '8px 8px',
+        }}
+      />
+
+      {/* Inline header — icon + title in a row */}
+      <div className="relative flex items-center gap-3 mb-4">
+        <div
+          className="w-11 h-11 rounded-xl flex items-center justify-center shrink-0"
+          style={{
+            background: accent.glow,
+            boxShadow: `0 0 20px ${accent.glow}, 0 0 0 1px ${accent.ring}`,
+          }}
+        >
+          <Icon size={20} className="text-base-content/80" />
+        </div>
+        <h3
+          className={`text-[15px] font-bold leading-snug ${accent.text} min-w-0`}
+        >
+          {audience.name}
+        </h3>
+      </div>
+
+      {/* Body */}
+      <p className="relative text-sm text-base-content/50 leading-relaxed">
+        {audience.copy}
+      </p>
+    </motion.div>
+  )
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   WHAT YOU GET — 6 B2B capabilities
+   ══════════════════════════════════════════════════════════════════ */
+
+function CapabilitiesSection() {
+  return (
+    <section className="relative py-24 lg:py-32">
+      {/* Background band */}
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-base-200/20 to-transparent pointer-events-none" />
+
+      <div className="container relative">
+        {/* Header */}
+        <motion.div
+          style={{ opacity: 0 }}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-80px' }}
+          transition={{ duration: 0.6, ease: EASE }}
+          className="flex flex-col items-center text-center mb-14 lg:mb-18"
+        >
+          <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-4">
+            What you <span className="text-gradient-primary">get</span>
+          </h2>
+          <p className="text-base text-base-content/45 leading-relaxed max-w-lg">
+            The features that matter when you’re deploying for a team, a venue,
+            or a customer base.
+          </p>
+        </motion.div>
+
+        {/* 2-col grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-5 max-w-5xl mx-auto">
+          {CAPABILITIES.map((cap, i) => (
+            <CapabilityRow key={cap.title} capability={cap} index={i} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CapabilityRow({
+  capability,
+  index,
+}: {
+  capability: Capability
+  index: number
+}) {
+  const Icon = capability.icon
+
+  return (
+    <motion.div
+      style={{ opacity: 0 }}
+      initial={{ opacity: 0, y: 15 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: '-40px' }}
+      transition={{
+        delay: 0.06 + index * 0.06,
+        duration: 0.5,
+        ease: EASE,
+      }}
+      className="relative flex items-start gap-4 rounded-xl bg-base-200/30 border border-base-300/20 p-5 sm:p-6 overflow-hidden"
+    >
+      {/* Icon badge */}
+      <div className="shrink-0">
+        <div className="w-10 h-10 rounded-lg bg-primary/8 border border-primary/15 flex items-center justify-center">
+          <Icon size={18} className="text-primary" />
+        </div>
+      </div>
+
+      {/* Text */}
+      <div className="flex-1 min-w-0">
+        <h3 className="text-sm font-bold text-base-content mb-1">
+          {capability.title}
+        </h3>
+        <p className="text-sm text-base-content/45 leading-relaxed">
+          {capability.body}
+        </p>
+      </div>
+    </motion.div>
+  )
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   HOW IT WORKS — 3 horizontal steps
+   ══════════════════════════════════════════════════════════════════ */
+
+function ProcessSection() {
+  return (
+    <section className="relative py-24 lg:py-32">
+      <div className="container relative">
+        {/* Header */}
+        <motion.div
+          style={{ opacity: 0 }}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-80px' }}
+          transition={{ duration: 0.6, ease: EASE }}
+          className="flex flex-col items-center text-center mb-14 lg:mb-18"
+        >
+          <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-4">
+            How it <span className="text-gradient-primary">works</span>
+          </h2>
+          <p className="text-base text-base-content/45 leading-relaxed max-w-lg">
+            Three steps from first email to live deployment.
+          </p>
+        </motion.div>
+
+        {/* Steps */}
+        <div className="relative max-w-5xl mx-auto">
+          {/* Horizontal connector line — desktop only */}
+          <div
+            className="hidden md:block absolute top-[44px] left-[15%] right-[15%] h-px pointer-events-none"
+            style={{
+              background:
+                'linear-gradient(90deg, transparent, var(--color-primary) 20%, var(--color-primary) 80%, transparent)',
+              opacity: 0.15,
+            }}
+          />
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 relative">
+            {STEPS.map((step, i) => (
+              <ProcessStep key={step.title} step={step} index={i} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ProcessStep({ step, index }: { step: Step; index: number }) {
+  return (
+    <motion.div
+      style={{ opacity: 0 }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: '-60px' }}
+      transition={{
+        delay: 0.1 + index * 0.12,
+        duration: 0.5,
+        ease: EASE,
+      }}
+      className="relative flex flex-col items-center text-center"
+    >
+      {/* Step number badge */}
+      <div className="relative z-10 mb-5">
+        <div
+          className="w-[88px] h-[88px] rounded-2xl bg-base-100 border-2 border-primary/20 flex items-center justify-center"
+          style={{
+            boxShadow:
+              '0 0 30px rgba(52,211,153,0.08), inset 0 0 20px rgba(52,211,153,0.04)',
+          }}
+        >
+          <span className="text-3xl font-black text-gradient-primary tabular-nums">
+            {String(index + 1).padStart(2, '0')}
+          </span>
+        </div>
+
+        {/* Pulse halo */}
+        <motion.div
+          className="absolute inset-0 rounded-2xl border-2 border-primary/15 pointer-events-none"
+          animate={{ scale: [1, 1.2], opacity: [0.5, 0] }}
+          transition={{
+            delay: index * 0.5,
+            duration: 2.5,
+            ease: 'easeOut',
+            repeat: Infinity,
+            repeatDelay: 1.5,
+          }}
+        />
+      </div>
+
+      {/* Title */}
+      <h3 className="text-lg sm:text-xl font-bold text-base-content mb-2">
+        {step.title}
+      </h3>
+
+      {/* Body */}
+      <p className="text-sm text-base-content/50 leading-relaxed max-w-xs">
+        {step.body}
+      </p>
+    </motion.div>
+  )
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   WHY SCROLLR — 4 trust principles + GitHub stats
+   ══════════════════════════════════════════════════════════════════ */
+
+function WhyScrollrSection() {
+  const stats = useGitHubStats(REPO)
+
+  return (
+    <section className="relative py-24 lg:py-32">
+      {/* Background band */}
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-base-200/20 to-transparent pointer-events-none" />
+
+      <div className="container relative">
+        {/* Header */}
+        <motion.div
+          style={{ opacity: 0 }}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-80px' }}
+          transition={{ duration: 0.6, ease: EASE }}
+          className="flex flex-col items-center text-center mb-14 lg:mb-18"
+        >
+          <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-4">
+            Why <span className="text-gradient-primary">Scrollr</span>
+          </h2>
+          <p className="text-base text-base-content/45 leading-relaxed max-w-lg">
+            Not a prototype, not a pitch deck — a real product with real users.
+          </p>
+        </motion.div>
+
+        {/* 4-up principle grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-5 max-w-6xl mx-auto mb-12 lg:mb-14">
+          {PRINCIPLES.map((p, i) => (
+            <PrincipleCard key={p.title} principle={p} index={i} />
+          ))}
+        </div>
+
+        {/* GitHub footer card */}
+        <motion.div
+          style={{ opacity: 0 }}
+          initial={{ opacity: 0, y: 12 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.35, duration: 0.5, ease: EASE }}
+          className="relative max-w-5xl mx-auto"
+        >
+          {/* Outer glow */}
+          <div
+            className="absolute -inset-3 rounded-2xl pointer-events-none blur-2xl"
+            style={{
+              background:
+                'radial-gradient(ellipse at center, var(--color-primary) 0%, transparent 70%)',
+              opacity: 0.04,
+            }}
+          />
+
+          <div className="relative rounded-xl border border-base-300/20 bg-base-200/30 overflow-hidden">
+            {/* Top accent */}
+            <div
+              className="absolute top-0 left-10 right-10 h-px"
+              style={{
+                background:
+                  'linear-gradient(90deg, transparent, rgba(52,211,153,0.15) 50%, transparent)',
+              }}
+            />
+
+            <div className="px-6 py-5 sm:px-8 flex flex-col sm:flex-row items-center justify-between gap-4">
+              {/* Left: message */}
+              <div className="flex items-center gap-3">
+                <div className="w-9 h-9 rounded-lg bg-primary/8 border border-primary/15 flex items-center justify-center">
+                  <Eye size={16} className="text-primary" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-base-content/70">
+                    Inspect every line before you commit
+                  </p>
+                  <p className="text-xs text-base-content/30">
+                    AGPL-3.0 · {REPO}
+                  </p>
+                </div>
+              </div>
+
+              {/* Right: stats + link */}
+              <div className="flex items-center gap-3">
+                {stats != null && (
+                  <div className="hidden sm:flex items-center gap-1">
+                    <a
+                      href={`https://github.com/${REPO}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      title="Star on GitHub"
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs text-warning/50 hover:text-warning hover:bg-warning/[0.06] transition-[color,background-color] duration-200"
+                    >
+                      <Star className="size-3.5" />
+                      <span className="font-semibold tabular-nums">
+                        {stats.stars.toLocaleString()}
+                      </span>
+                    </a>
+                    <a
+                      href={`https://github.com/${REPO}/forks`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs text-info/50 hover:text-info hover:bg-info/[0.06] transition-[color,background-color] duration-200"
+                    >
+                      <GitFork className="size-3.5" />
+                      <span className="font-semibold tabular-nums">
+                        {stats.forks.toLocaleString()}
+                      </span>
+                    </a>
+                  </div>
+                )}
+
+                <span className="hidden sm:block w-px h-6 bg-base-300/20" />
+
+                <a
+                  href={`https://github.com/${REPO}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-base-300/25 bg-base-200/40 text-sm font-semibold text-base-content/50 hover:text-primary hover:border-primary/25 transition-[color,border-color] duration-200"
+                >
+                  <Github className="size-4" />
+                  <span>View source</span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  )
+}
+
+function PrincipleCard({
+  principle,
+  index,
+}: {
+  principle: Principle
+  index: number
+}) {
+  const Icon = principle.icon
+  const { accent } = principle
+
+  return (
+    <motion.div
+      style={{ opacity: 0 }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: '-40px' }}
+      transition={{
+        delay: 0.08 + index * 0.08,
+        duration: 0.5,
+        ease: EASE,
+      }}
+      className="relative rounded-2xl bg-base-200/40 border border-base-300/25 p-6 overflow-hidden h-full"
+    >
+      {/* Top accent line */}
+      <div
+        className="absolute top-0 left-6 right-6 h-px"
+        style={{
+          background: `linear-gradient(90deg, transparent, ${accent.ring} 50%, transparent)`,
+        }}
+      />
+
+      {/* Ambient gradient orb */}
+      <div
+        className="absolute -top-14 -right-14 w-40 h-40 rounded-full pointer-events-none blur-3xl"
+        style={{ background: accent.gradient }}
+      />
+
+      {/* Inline header — icon + title in a row */}
+      <div className="relative flex items-center gap-2.5 mb-3">
+        <div
+          className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+          style={{
+            background: accent.glow,
+            boxShadow: `0 0 18px ${accent.glow}, 0 0 0 1px ${accent.ring}`,
+          }}
+        >
+          <Icon size={18} className="text-base-content/80" />
+        </div>
+        <h3 className={`text-sm font-bold leading-snug ${accent.text} min-w-0`}>
+          {principle.title}
+        </h3>
+      </div>
+
+      {/* Body */}
+      <p className="relative text-[13px] text-base-content/45 leading-relaxed">
+        {principle.body}
+      </p>
+    </motion.div>
+  )
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   PRICING + LEAD CAPTURE FORM
+   ══════════════════════════════════════════════════════════════════ */
+
+function PricingFormSection() {
+  return (
+    <section id="contact-form" className="relative py-24 lg:py-32 scroll-mt-20">
+      <div className="container relative">
+        {/* Pricing line */}
+        <motion.div
+          style={{ opacity: 0 }}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-80px' }}
+          transition={{ duration: 0.6, ease: EASE }}
+          className="flex flex-col items-center text-center mb-12 lg:mb-16"
+        >
+          <span className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-1.5 text-xs font-medium text-primary backdrop-blur-sm mb-6">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
+              <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary" />
+            </span>
+            Pricing
+          </span>
+
+          <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-3">
+            Starts at <span className="text-gradient-primary">$500/mo.</span>
+          </h2>
+          <p className="text-base sm:text-lg text-base-content/45 leading-relaxed max-w-lg">
+            Custom quote based on scope.
+          </p>
+        </motion.div>
+
+        {/* Form card */}
+        <motion.div
+          style={{ opacity: 0 }}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-60px' }}
+          transition={{ delay: 0.15, duration: 0.6, ease: EASE }}
+          className="max-w-2xl mx-auto"
+        >
+          <LeadForm />
+        </motion.div>
+      </div>
+    </section>
+  )
+}
+
+function LeadForm() {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [company, setCompany] = useState('')
+  const [useCase, setUseCase] = useState<BusinessUseCase | ''>('')
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [submittedEmail, setSubmittedEmail] = useState('')
+  const [emailCopied, setEmailCopied] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    const trimmedName = name.trim()
+    const trimmedEmail = email.trim()
+    const trimmedCompany = company.trim()
+    const trimmedMessage = message.trim()
+
+    if (!trimmedName) {
+      setError('Please enter your name.')
+      return
+    }
+    if (!trimmedEmail || !trimmedEmail.includes('@')) {
+      setError('Please enter a valid email address.')
+      return
+    }
+    if (!trimmedCompany) {
+      setError('Please tell us your company name.')
+      return
+    }
+    if (!useCase) {
+      setError('Please pick a use case.')
+      return
+    }
+    if (trimmedMessage.length < 10) {
+      setError('Please give us at least one sentence of context (10+ chars).')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await businessApi.submit({
+        name: trimmedName,
+        email: trimmedEmail,
+        company: trimmedCompany,
+        use_case: useCase,
+        message: trimmedMessage,
+      })
+      setSubmittedEmail(trimmedEmail)
+      setSubmitted(true)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Submission failed'
+      setError(msg)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleCopyEmail = async () => {
+    try {
+      await navigator.clipboard.writeText(CONTACT_EMAIL)
+      setEmailCopied(true)
+      setTimeout(() => setEmailCopied(false), 2000)
+    } catch {
+      // Clipboard blocked — user can still type it manually
+    }
+  }
+
+  if (submitted) {
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.35 }}
+        className="flex flex-col items-center gap-5 rounded-2xl border border-success/20 bg-success/5 p-8 sm:p-10 text-center"
+        role="status"
+      >
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-success/15 text-success">
+          <CheckCircle2 size={24} />
+        </div>
+        <div>
+          <h3 className="text-lg font-bold text-base-content">
+            Thanks — we got your note.
+          </h3>
+          <p className="mt-2 max-w-md text-sm text-base-content/55 leading-relaxed">
+            A confirmation email is on its way to{' '}
+            <span className="text-base-content/80 font-medium">
+              {submittedEmail}
+            </span>{' '}
+            with what to expect next. A real human will reply within one
+            business day.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-1">
+          <button
+            type="button"
+            onClick={handleCopyEmail}
+            className="inline-flex items-center gap-2 rounded-lg border border-base-300/50 bg-base-200/40 px-4 py-2 text-sm font-medium text-base-content/70 transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-primary cursor-pointer"
+          >
+            {emailCopied ? (
+              <>
+                <CheckCircle2 size={14} className="text-success" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy size={14} />
+                Copy {CONTACT_EMAIL}
+              </>
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
+              setSubmitted(false)
+              setSubmittedEmail('')
+              setError(null)
+              setName('')
+              setEmail('')
+              setCompany('')
+              setUseCase('')
+              setMessage('')
+            }}
+            className="text-sm text-base-content/40 hover:text-base-content/70 transition-colors cursor-pointer"
+          >
+            Send another
+          </button>
+        </div>
+      </motion.div>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-5 rounded-2xl border border-base-300/40 bg-base-200/30 p-6 sm:p-8"
+      noValidate
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <FormField label="Your name" htmlFor="biz-name" required>
+          <input
+            id="biz-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={submitting}
+            required
+            autoComplete="name"
+            maxLength={120}
+            className="biz-input"
+            placeholder="Alex Chen"
+          />
+        </FormField>
+
+        <FormField label="Email" htmlFor="biz-email" required>
+          <input
+            id="biz-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={submitting}
+            required
+            autoComplete="email"
+            maxLength={254}
+            className="biz-input"
+            placeholder="alex@company.com"
+          />
+        </FormField>
+      </div>
+
+      <FormField label="Company" htmlFor="biz-company" required>
+        <input
+          id="biz-company"
+          type="text"
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+          disabled={submitting}
+          required
+          autoComplete="organization"
+          maxLength={200}
+          className="biz-input"
+          placeholder="Acme Corp."
+        />
+      </FormField>
+
+      <FormField label="Use case" htmlFor="biz-use-case" required>
+        <select
+          id="biz-use-case"
+          value={useCase}
+          onChange={(e) => setUseCase(e.target.value as BusinessUseCase | '')}
+          disabled={submitting}
+          required
+          className="biz-input"
+        >
+          {USE_CASE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value} disabled={!opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </FormField>
+
+      <FormField
+        label="Tell us about your deployment"
+        htmlFor="biz-message"
+        required
+        counter={`${message.length}/5000`}
+      >
+        <textarea
+          id="biz-message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          disabled={submitting}
+          required
+          minLength={10}
+          maxLength={5000}
+          rows={6}
+          className="biz-input resize-y"
+          placeholder="How many displays / clients? What kind of branding? Self-hosted or managed? Anything else we should know."
+        />
+      </FormField>
+
+      {error ? (
+        <motion.div
+          initial={{ opacity: 0, y: -4 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-start gap-2 rounded-lg border border-error/20 bg-error/10 p-3"
+          role="alert"
+        >
+          <AlertTriangle
+            size={14}
+            className="mt-0.5 shrink-0 text-error"
+            aria-hidden="true"
+          />
+          <p className="text-xs text-error">{error}</p>
+        </motion.div>
+      ) : null}
+
+      <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-base-content/40">
+          We&rsquo;ll send a confirmation to your email and reply within one
+          business day.
+        </p>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-content transition-all hover:bg-primary/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? (
+            <>
+              <Loader2 size={15} className="animate-spin" />
+              Sending...
+            </>
+          ) : (
+            <>
+              <Send size={15} />
+              Send inquiry
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Local input styling — colocated, matches SupportContactForm pattern */}
+      <style>{`
+        .biz-input {
+          width: 100%;
+          background-color: color-mix(in oklab, var(--color-base-100) 85%, transparent);
+          border: 1px solid color-mix(in oklab, var(--color-base-300) 60%, transparent);
+          border-radius: 0.5rem;
+          padding: 0.55rem 0.75rem;
+          font-size: 0.875rem;
+          color: var(--color-base-content);
+          transition: border-color 0.15s ease, box-shadow 0.15s ease;
+        }
+        .biz-input:focus {
+          outline: none;
+          border-color: color-mix(in oklab, var(--color-primary) 60%, transparent);
+          box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 15%, transparent);
+        }
+        .biz-input:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+        .biz-input::placeholder {
+          color: color-mix(in oklab, var(--color-base-content) 35%, transparent);
+        }
+        .biz-input:invalid {
+          /* Don't paint invalid styling until the user actually interacts. */
+          box-shadow: none;
+        }
+      `}</style>
+    </form>
+  )
+}
+
+interface FormFieldProps {
+  label: string
+  htmlFor: string
+  required?: boolean
+  counter?: string
+  children: React.ReactNode
+}
+
+function FormField({
+  label,
+  htmlFor,
+  required,
+  counter,
+  children,
+}: FormFieldProps) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <label
+          htmlFor={htmlFor}
+          className="text-xs font-semibold tracking-wider text-base-content/70 uppercase"
+        >
+          {label}
+          {required ? <span className="ml-1 text-primary">*</span> : null}
+        </label>
+        {counter ? (
+          <span className="text-[11px] tabular-nums text-base-content/35">
+            {counter}
+          </span>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   BOTTOM CTA — heavy treatment with ConvergenceBackdrop
+   ══════════════════════════════════════════════════════════════════ */
+
+function BottomCTA() {
+  const sectionRef = useRef<HTMLElement>(null)
+  const isInView = useInView(sectionRef, { amount: 0.15 })
+
+  const mouseX = useMotionValue(0.5)
+  const mouseY = useMotionValue(0.5)
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      const rect = e.currentTarget.getBoundingClientRect()
+      mouseX.set((e.clientX - rect.left) / rect.width)
+      mouseY.set((e.clientY - rect.top) / rect.height)
+    },
+    [mouseX, mouseY],
+  )
+
+  const beams = useMemo<Array<BackdropBeam>>(
+    () => [
+      { angle: 35, color: '#34d399', delay: 0.3 },
+      { angle: 145, color: '#00b8db', delay: 0.45 },
+      { angle: 215, color: '#34d399', delay: 0.6 },
+      { angle: 325, color: '#00b8db', delay: 0.75 },
+    ],
+    [],
+  )
+
+  const handleScrollToForm = () => {
+    document
+      .getElementById('contact-form')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  return (
+    <section
+      ref={sectionRef}
+      className="relative overflow-clip py-32 lg:py-44"
+      onMouseMove={handleMouseMove}
+    >
+      <ConvergenceBackdrop
+        mouseX={mouseX}
+        mouseY={mouseY}
+        isInView={isInView}
+        particles={CTA_PARTICLES}
+        beams={beams}
+        pulseRingCount={3}
+        orbBackground="radial-gradient(circle, rgba(52,211,153,0.08) 0%, rgba(0,212,255,0.04) 40%, transparent 70%)"
+      />
+
+      <div
+        className="relative mx-auto px-5 sm:px-6 lg:px-8"
+        style={{ maxWidth: 1400 }}
+      >
+        <div className="flex flex-col items-center text-center">
+          {/* Pill */}
+          <motion.div
+            style={{ opacity: 0 }}
+            initial={{ opacity: 0, y: 15 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: '-80px' }}
+            transition={{ duration: 0.5, ease: EASE }}
+          >
+            <span className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-1.5 text-xs font-medium text-primary backdrop-blur-sm">
+              <Mail className="size-3" aria-hidden />
+              {CONTACT_EMAIL}
+            </span>
+          </motion.div>
+
+          {/* Headline */}
+          <motion.h2
+            style={{ opacity: 0 }}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: '-80px' }}
+            transition={{ delay: 0.1, duration: 0.6, ease: EASE }}
+            className="mt-8 text-5xl sm:text-6xl lg:text-7xl xl:text-8xl font-black tracking-tight leading-none"
+          >
+            <span className="block">Tell us what</span>
+            <span className="block mt-2">
+              you want <span className="text-gradient-primary">to build.</span>
+            </span>
+          </motion.h2>
+
+          {/* Sub-copy */}
+          <motion.span
+            style={{ opacity: 0 }}
+            initial={{ opacity: 0, y: 15 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.25, duration: 0.5, ease: EASE }}
+            className="block mt-6 text-lg sm:text-xl text-base-content/50 max-w-lg leading-relaxed"
+          >
+            One email kicks it off. We respond within a business day.
+          </motion.span>
+
+          {/* CTAs */}
+          <motion.div
+            className="relative mt-10"
+            style={{ opacity: 0 }}
+            initial={{ opacity: 0, scale: 0.95 }}
+            whileInView={{ opacity: 1, scale: 1 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.4, duration: 0.6, ease: EASE }}
+          >
+            {/* Central glow */}
+            <div
+              className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full pointer-events-none"
+              style={{
+                width: 240,
+                height: 240,
+                background:
+                  'radial-gradient(circle, rgba(52,211,153,0.15) 0%, transparent 70%)',
+                filter: 'blur(30px)',
+              }}
+            />
+
+            <div className="relative z-10 flex flex-wrap items-center justify-center gap-4">
+              <button
+                type="button"
+                onClick={handleScrollToForm}
+                className="btn btn-pulse gap-2 text-base px-8 py-5 shadow-2xl"
+              >
+                <MessageSquare size={14} />
+                Send an inquiry
+              </button>
+              <a
+                href={`mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent('Scrollr for Business')}`}
+                className="btn btn-outline gap-2 px-6 py-4"
+              >
+                <Mail size={14} />
+                Or email directly
+              </a>
+            </div>
+          </motion.div>
+
+          {/* Trust signals */}
+          <motion.div
+            style={{ opacity: 0 }}
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.6, duration: 0.5, ease: EASE }}
+            className="mt-6 flex flex-wrap items-center justify-center gap-4 text-xs text-base-content/30"
+          >
+            {[
+              'One business day response',
+              'Mutual NDA on request',
+              'Self-hosted available',
+            ].map((item) => (
+              <span key={item} className="flex items-center gap-1.5">
+                <span className="w-1.5 h-1.5 rounded-full bg-primary/40" />
+                {item}
+              </span>
+            ))}
+          </motion.div>
+        </div>
+      </div>
+
+      {/* Bottom horizon glow */}
+      <div className="absolute bottom-0 left-0 right-0 h-px pointer-events-none">
+        <motion.div
+          className="absolute inset-0"
+          style={{
+            background:
+              'linear-gradient(90deg, transparent, var(--color-primary), var(--color-info), var(--color-primary), transparent)',
+            opacity: 0,
+          }}
+          animate={isInView ? { opacity: [0, 0.4, 0.2] } : {}}
+          transition={{ delay: 1.5, duration: 2 }}
+        />
+        <motion.div
+          className="absolute bottom-0 left-1/2 -translate-x-1/2"
+          style={{
+            width: '60%',
+            height: 120,
+            background:
+              'radial-gradient(ellipse at bottom, rgba(52,211,153,0.08) 0%, transparent 70%)',
+            opacity: 0,
+          }}
+          animate={isInView ? { opacity: 1 } : {}}
+          transition={{ delay: 1.8, duration: 1.5 }}
+        />
+      </div>
+    </section>
+  )
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   PAGE
+   ══════════════════════════════════════════════════════════════════ */
+
+function BusinessPage() {
+  usePageMeta({
+    title: 'Business — Scrollr',
+    description:
+      'Scrollr for business: branded desktop deployments for teams, brokerages, sports venues, fantasy platforms, crypto exchanges, and news publishers. Custom branding, multi-display, self-hosted, dedicated support. Starts at $500/mo.',
+    canonicalUrl: 'https://myscrollr.com/business',
+  })
+
+  return (
+    <div className="min-h-screen">
+      <BusinessHero />
+      <AudiencesSection />
+      <CapabilitiesSection />
+      <ProcessSection />
+      <WhyScrollrSection />
+      <PricingFormSection />
+
+      {/* FAQ — reuses the homepage FAQSection with B2B items */}
+      <FAQSection
+        items={BUSINESS_FAQ}
+        title="Honest"
+        titleHighlight="Answers"
+        subtitle="No legalese, no salesy hand-waving."
+      />
+
+      <BottomCTA />
+    </div>
+  )
+}

--- a/myscrollr.com/src/routes/business.tsx
+++ b/myscrollr.com/src/routes/business.tsx
@@ -1267,7 +1267,11 @@ function LeadForm() {
       setError('Please enter your name.')
       return
     }
-    if (!trimmedEmail || !trimmedEmail.includes('@')) {
+    // Frontend email check mirrors the backend's net/mail.ParseAddress
+    // gate: catch obvious garbage before the round-trip. The backend
+    // is still authoritative — this just saves a network roundtrip
+    // for "a@b" / "foo @ bar" / unfinished input.
+    if (!trimmedEmail || !/^\S+@\S+\.\S+$/.test(trimmedEmail)) {
       setError('Please enter a valid email address.')
       return
     }


### PR DESCRIPTION
## Summary

New `/business` marketing route for inbound B2B inquiries, plus the backend pipeline to capture and route leads. The page targets six buyer types we already see organic interest from: sports bars & restaurants, brokerages & financial advisors, fantasy sports platforms, sportsbooks & affiliates, crypto exchanges, news aggregators & publishers.

The page deliberately **does not sell** — pricing is a single line (`Starts at $500/mo. Custom quote based on scope.`) and the conversion target is the lead-capture form. Scope and quote happen offline per engagement.

## What's in the page

Eight sections, route-local in `myscrollr.com/src/routes/business.tsx`:

1. **Hero** — dot-matrix + single orbital glow, deployment fan-out SVG (2×2 monitor grid suggesting white-label deployment under different brands)
2. **Who it's for** — 6 audience cards in a 3×2 grid, inline icon+title layout, rotating accent palette (primary/info/secondary/accent/warning/success)
3. **What you get** — 6-item capability list (custom branding, multi-display, self-hosted, SLA, API access, NDA-friendly)
4. **How it works** — 3 horizontal steps with numbered badges and connector line
5. **Why Scrollr** — 4 principle cards + live GitHub stats card via existing `useGitHubStats` hook
6. **Pricing + form** — the single pricing line, then the lead-capture form
7. **FAQ** — reuses existing `FAQSection` component with B2B-specific items prop
8. **Bottom CTA** — heavy treatment with shared `ConvergenceBackdrop`, form-primary / email-fallback CTAs

## Backend (api/core)

- **`POST /business-leads`** in `handlers_business_leads.go`
  - Validates payload (name, email, company, allowlisted `use_case`, 10-5000 char message)
  - Per-IP rate limit via Redis (5/hour) on top of Fiber's global IP limiter
  - **DB insert is the source of truth** — must succeed or we 500. The lead is captured before any email send.
  - Two best-effort Resend dispatches in a detached 30s context:
    - **Notification** to ` BUSINESS_LEADS_TO_EMAIL` (defaults to `enterprise@myscrollr.com`), with `Reply-To: <lead-email>` so hitting reply lands in the lead's inbox
    - **Auto-reply** to the lead with `Reply-To: <sales-inbox>` so their reply routes back to sales
  - Failed sends log but don't roll back the row — `notified_at` / `auto_replied_at` stay NULL so we can scan for missed notifications later
- **`000013_business_leads`** migration creates the table with `id`, `created_at`, `name`, `email`, `company`, `use_case`, `message`, `ip_redacted`, `user_agent`, `notified_at`, `auto_replied_at`, `replied_at` columns, plus indexes on `created_at DESC` and `email`. Runs automatically on startup via golang-migrate.
- Route registered alongside the public support handler in `server.go`

## Other changes

- **Nav rename**: "Uplink" → "Pricing" in `Header.tsx` desktop + mobile (URL stays `/uplink` — URLs are forever, label change removes friction for first-time visitors)
- **Homepage cross-link**: "Running a business?" added to `CallToAction.tsx` footer next to "View Source" and "Explore Channels"
- **Sitemap**: `/business` added with priority 0.7
- **`.env.example`**: documented `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `SUPPORT_REPLY_FROM_EMAIL`, plus new `BUSINESS_LEADS_TO_EMAIL` and `BUSINESS_LEADS_FROM_EMAIL` (the existing Resend vars were in use by password reset + support but never written down)

## Env vars required to go live

| Variable | Required | Default |
|---|---|---|
| `RESEND_API_KEY` | Yes (or no emails send) | — |
| `BUSINESS_LEADS_TO_EMAIL` | No | `enterprise@myscrollr.com` |
| `BUSINESS_LEADS_FROM_EMAIL` | No | falls back to `RESEND_FROM_EMAIL`, then `Scrollr Business <enterprise@myscrollr.com>` |

`myscrollr.com` already verified as a sending domain in the Resend dashboard (used by support + password reset), so this should just work post-deploy.

## Patterns followed

- Route-local single-file architecture (matches `uplink.tsx`)
- Easing `[0.22, 1, 0.36, 1]` everywhere
- `whileInView` + `viewport={{ once: true, margin: '-80px' }}` section reveals
- Inline icon+title card pattern (matches `TrustSection`'s "Create a Channel" card)
- Local `biz-input` utility class block at bottom of file (matches `SupportContactForm`'s `input-base` colocation)
- Resend HTTP send inlined per existing convention (`sendPasswordResetEmail`, partner-notification path) — three near-identical 30-line blocks still cheaper than the abstraction. Extract when a fourth caller appears.
- Detached `context.Background()` for the email goroutine so fast client disconnects don't kill side effects mid-flight (same trick used elsewhere in the codebase)

## Testing locally

```sh
# Backend
cd api
RESEND_API_KEY=re_xxx \
BUSINESS_LEADS_TO_EMAIL=you@example.com \
DATABASE_URL=postgres://... \
REDIS_URL=redis://... \
go run .

# Frontend
cd myscrollr.com && npm run dev
```

Submit the form at `localhost:3000/business`. Expect a `business_leads` row, a notification email at `BUSINESS_LEADS_TO_EMAIL`, an auto-reply at the form-submitted email, and the success panel showing the submitted address.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `npx tsc --noEmit` | clean |
| `npx eslint` | clean |
| `npx prettier --check` | clean |
| `npm run build` | clean — `business-_OFBqf5l.js` chunk 44.15 KB / 11.70 KB gzipped |