### PR TITLE
Split desktop clock and timer widgets

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.15",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.0.15",
+      "version": "1.0.18",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4030,7 +4030,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "futures-util",
  "log",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.0.17"
+version = "1.0.18"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/components/ScrollrTicker.test.tsx
+++ b/desktop/src/components/ScrollrTicker.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ScrollrTicker from "./ScrollrTicker";
+import type React from "react";
+import type { WidgetTickerData } from "../types";
+
+vi.mock("motion-plus/react", () => ({
+  Ticker: ({ items }: { items: React.ReactNode[] }) => (
+    <div data-testid="ticker-items">{items}</div>
+  ),
+}));
+
+vi.mock("motion/react", () => ({
+  useMotionValue: () => ({
+    get: () => 0,
+    set: vi.fn(),
+  }),
+  animate: vi.fn(() => ({ stop: vi.fn() })),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+const widgetData: WidgetTickerData = {
+  clock: [],
+  timer: [
+    {
+      id: "timer",
+      kind: "timer",
+      label: "Timer",
+      value: "01:05",
+      detail: "Stopwatch",
+    },
+  ],
+  weather: [],
+  sysmon: [],
+  uptime: [],
+  github: [],
+};
+
+describe("ScrollrTicker", () => {
+  it("renders timer widget chips from widgetData.timer", () => {
+    render(
+      <ScrollrTicker
+        dashboard={null}
+        activeTabs={["timer"]}
+        widgetData={widgetData}
+      />,
+    );
+
+    expect(screen.getByText("Timer")).toBeInTheDocument();
+    expect(screen.getByText("01:05")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -35,7 +35,7 @@ import { buildYahooLeagueUrl, buildYahooPlayerUrl, chipUrlForFinance, chipUrlFor
 
 // ── Module-level constants ───────────────────────────────────────
 
-const WIDGET_TYPES = ["clock", "weather", "sysmon", "uptime", "github"] as const;
+const WIDGET_TYPES = ["clock", "timer", "weather", "sysmon", "uptime", "github"] as const;
 type WidgetType = (typeof WIDGET_TYPES)[number];
 
 // ── Types ────────────────────────────────────────────────────────

--- a/desktop/src/components/chips/ConsolidatedChip.tsx
+++ b/desktop/src/components/chips/ConsolidatedChip.tsx
@@ -1,5 +1,5 @@
 /**
- * ConsolidatedChip — generic ticker chip for clock, weather, sysmon, uptime, and github widgets.
+ * ConsolidatedChip — generic ticker chip for clock, timer, weather, sysmon, uptime, and github widgets.
  *
  * Replaces the three nearly-identical ClockConsolidatedChip,
  * WeatherConsolidatedChip, and SysmonConsolidatedChip components.
@@ -66,7 +66,7 @@ function HeartbeatBar({ heartbeats }: { heartbeats: number[] }) {
 // ── Props ───────────────────────────────────────────────────────
 
 interface ConsolidatedChipProps {
-  type: "clock" | "weather" | "sysmon" | "uptime" | "github";
+  type: "clock" | "timer" | "weather" | "sysmon" | "uptime" | "github";
   items: ChipItem[];
   comfort?: boolean;
   colorMode?: ChipColorMode;

--- a/desktop/src/hooks/useTickerLayout.test.ts
+++ b/desktop/src/hooks/useTickerLayout.test.ts
@@ -25,7 +25,11 @@ import { useTickerLayout } from "./useTickerLayout";
 import type { AppPreferences } from "../preferences";
 import type { SubscriptionTier } from "../auth";
 
-function makePrefs(rows: { sources: string[] }[]): AppPreferences {
+function makePrefs(
+  rows: { sources: string[] }[],
+  enabledWidgets: string[] = [],
+  widgetsOnTicker: string[] = [],
+): AppPreferences {
   // Include the bits of `widgets` that `removeTickerRow` reads
   // (pinnedWidgets) so the helper can re-map pins on row deletion
   // without crashing. Other fields stay undefined — the cast covers
@@ -36,6 +40,8 @@ function makePrefs(rows: { sources: string[] }[]): AppPreferences {
     },
     widgets: {
       pinnedWidgets: {},
+      enabledWidgets,
+      widgetsOnTicker,
     },
   } as unknown as AppPreferences;
 }
@@ -43,11 +49,13 @@ function makePrefs(rows: { sources: string[] }[]): AppPreferences {
 function setupHook(
   initialRows: { sources: string[] }[],
   tier: SubscriptionTier = "uplink_pro",
+  enabledWidgets: string[] = [],
+  widgetsOnTicker: string[] = [],
 ) {
   // We mimic React state: the test holds the latest prefs and the
   // hook's onPrefsChange writes back into it. Subsequent renders pick
   // up the new prefs the same way the real app would.
-  let prefs = makePrefs(initialRows);
+  let prefs = makePrefs(initialRows, enabledWidgets, widgetsOnTicker);
   const onPrefsChange = vi.fn((next: AppPreferences) => {
     prefs = next;
   });
@@ -164,6 +172,22 @@ describe("useTickerLayout — addRow", () => {
     });
     expect(returned).toBe(2);
   });
+
+  it("adds seeded enabled widgets to widgetsOnTicker", () => {
+    const harness = setupHook(
+      [{ sources: [] }],
+      "uplink",
+      ["timer"],
+      [],
+    );
+    act(() => {
+      harness.result.current.addRow("timer");
+    });
+    expect(harness.prefs.appearance.tickerLayout.rows[1].sources).toEqual([
+      "timer",
+    ]);
+    expect(harness.prefs.widgets.widgetsOnTicker).toEqual(["timer"]);
+  });
 });
 
 describe("useTickerLayout — setSourceRow / removeRow", () => {
@@ -195,6 +219,52 @@ describe("useTickerLayout — setSourceRow / removeRow", () => {
     expect(harness.prefs.appearance.tickerLayout.rows[1].sources).toEqual([
       "rss",
     ]);
+  });
+
+  it("setSourceRow adds enabled widgets to widgetsOnTicker", () => {
+    const harness = setupHook(
+      [{ sources: [] }, { sources: [] }],
+      "uplink",
+      ["timer"],
+      [],
+    );
+    act(() => {
+      harness.result.current.setSourceRow("timer", 1);
+    });
+    expect(harness.prefs.appearance.tickerLayout.rows[1].sources).toEqual([
+      "timer",
+    ]);
+    expect(harness.prefs.widgets.widgetsOnTicker).toEqual(["timer"]);
+  });
+
+  it("setSourceRow removes enabled widgets from widgetsOnTicker when row is null", () => {
+    const harness = setupHook(
+      [{ sources: ["timer"] }],
+      "uplink",
+      ["timer"],
+      ["clock", "timer"],
+    );
+    act(() => {
+      harness.result.current.setSourceRow("timer", null);
+    });
+    expect(harness.prefs.appearance.tickerLayout.rows[0].sources).toEqual([]);
+    expect(harness.prefs.widgets.widgetsOnTicker).toEqual(["clock"]);
+  });
+
+  it("setSourceRow preserves channel widgetsOnTicker behavior", () => {
+    const harness = setupHook(
+      [{ sources: [] }, { sources: [] }],
+      "uplink",
+      ["timer"],
+      ["timer"],
+    );
+    act(() => {
+      harness.result.current.setSourceRow("finance", 1);
+    });
+    expect(harness.prefs.appearance.tickerLayout.rows[1].sources).toEqual([
+      "finance",
+    ]);
+    expect(harness.prefs.widgets.widgetsOnTicker).toEqual(["timer"]);
   });
 
   it("removeRow drops a row and never collapses below 1", () => {

--- a/desktop/src/hooks/useTickerLayout.ts
+++ b/desktop/src/hooks/useTickerLayout.ts
@@ -28,6 +28,7 @@ import {
   setTickerLayout,
   removeTickerRow,
   setSourceTickerRow,
+  setWidgetTickerRow,
 } from "../preferences";
 import { getMaxTickerRows, canCustomizeTickerRows } from "../tierLimits";
 import type {
@@ -111,7 +112,10 @@ export function useTickerLayout(
           }))
         : rows;
       const newIndex = baseRows.length;
-      const next = setTickerLayout(prefs, { rows: [...baseRows, nextRow] });
+      const withRow = setTickerLayout(prefs, { rows: [...baseRows, nextRow] });
+      const next = initialSource && prefs.widgets.enabledWidgets.includes(initialSource)
+        ? setWidgetTickerRow(withRow, initialSource, newIndex)
+        : withRow;
       onPrefsChange(next);
       return newIndex;
     },
@@ -135,7 +139,10 @@ export function useTickerLayout(
 
   const setSourceRow = useCallback(
     (sourceId: string, row: number | null) => {
-      onPrefsChange(setSourceTickerRow(prefs, sourceId, row));
+      const next = prefs.widgets.enabledWidgets.includes(sourceId)
+        ? setWidgetTickerRow(prefs, sourceId, row)
+        : setSourceTickerRow(prefs, sourceId, row);
+      onPrefsChange(next);
     },
     [prefs, onPrefsChange],
   );

--- a/desktop/src/hooks/useWidgetConfig.ts
+++ b/desktop/src/hooks/useWidgetConfig.ts
@@ -9,7 +9,7 @@ import { savePrefs } from "../preferences";
 import type { AppPreferences, WidgetPrefs } from "../preferences";
 
 /** Subset of WidgetPrefs that are per-widget config objects (not arrays). */
-type WidgetConfigKey = "clock" | "weather" | "sysmon" | "uptime" | "github";
+type WidgetConfigKey = "clock" | "timer" | "weather" | "sysmon" | "uptime" | "github";
 
 /** The config object for a given widget key. */
 type WidgetConfig<K extends WidgetConfigKey> = WidgetPrefs[K];

--- a/desktop/src/hooks/useWidgetTickerData.test.ts
+++ b/desktop/src/hooks/useWidgetTickerData.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { LS_CLOCK_FORMAT, LS_TIMER_STATE } from "../constants";
+import { useWidgetTickerData } from "./useWidgetTickerData";
+import type { WidgetPrefs } from "../preferences";
+
+const storeValues = vi.hoisted(() => new Map<string, unknown>());
+
+vi.mock("../lib/store", () => ({
+  getStore: vi.fn((key: string, fallback: unknown) => (
+    storeValues.has(key) ? storeValues.get(key) : fallback
+  )),
+  onStoreChange: vi.fn(() => vi.fn()),
+  setStore: vi.fn(),
+}));
+
+function makeWidgetPrefs(widgetsOnTicker: string[]): WidgetPrefs {
+  return {
+    enabledWidgets: widgetsOnTicker,
+    widgetsOnTicker,
+    pinnedWidgets: {},
+    clock: {
+      ticker: {
+        localTime: false,
+        showTimezones: false,
+        excludedTimezones: [],
+      },
+    },
+    timer: {
+      ticker: { activeTimer: true },
+      pomodoro: {
+        workMins: 25,
+        shortBreakMins: 5,
+        longBreakMins: 15,
+        longBreakEvery: 4,
+      },
+    },
+    weather: { ticker: { excludedCities: [] } },
+    sysmon: {
+      refreshInterval: 2,
+      tempUnit: "celsius",
+      ticker: {
+        cpu: false,
+        memory: false,
+        gpu: false,
+        gpuPower: false,
+      },
+    },
+    uptime: {
+      url: "",
+      pollInterval: 60,
+      ticker: { excludedMonitors: [] },
+    },
+    github: {
+      repos: [],
+      pollInterval: 120,
+      ticker: { excludedRepos: [] },
+    },
+  };
+}
+
+function makeTimerPrefs(activeTimer: boolean): WidgetPrefs {
+  const prefs = makeWidgetPrefs(["timer"]);
+  return {
+    ...prefs,
+    timer: {
+      ...prefs.timer,
+      ticker: { activeTimer },
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  storeValues.clear();
+});
+
+describe("useWidgetTickerData", () => {
+  it("keeps clock and timer chips in separate buckets", async () => {
+    storeValues.set(LS_CLOCK_FORMAT, "12h");
+    storeValues.set(LS_TIMER_STATE, {
+      mode: "stopwatch",
+      startedAt: null,
+      bankedMs: 65_000,
+      targetSecs: 0,
+      completedSessions: 0,
+    });
+
+    const prefs = makeWidgetPrefs(["clock", "timer"]);
+    const { result } = renderHook(() => useWidgetTickerData(prefs));
+
+    await waitFor(() => {
+      expect(result.current.clock).toEqual([]);
+      expect(result.current.timer).toEqual([
+        {
+          id: "timer",
+          kind: "timer",
+          label: "Timer",
+          value: "01:05",
+          detail: "Stopwatch",
+        },
+      ]);
+    });
+  });
+
+  it("suppresses timer chips when the timer ticker setting is disabled", async () => {
+    storeValues.set(LS_TIMER_STATE, {
+      mode: "stopwatch",
+      startedAt: null,
+      bankedMs: 65_000,
+      targetSecs: 0,
+      completedSessions: 0,
+    });
+
+    const prefs = makeTimerPrefs(false);
+    const { result } = renderHook(() => useWidgetTickerData(prefs));
+
+    await waitFor(() => {
+      expect(result.current.timer).toEqual([]);
+    });
+  });
+
+  it("uses configured Pomodoro cadence in timer ticker detail", async () => {
+    storeValues.set(LS_TIMER_STATE, {
+      mode: "pomodoro",
+      startedAt: null,
+      bankedMs: 60_000,
+      targetSecs: 1500,
+      completedSessions: 2,
+    });
+
+    const prefs = makeWidgetPrefs(["timer"]);
+    const customPrefs = {
+      ...prefs,
+      timer: {
+        ...prefs.timer,
+        pomodoro: {
+          ...prefs.timer.pomodoro,
+          longBreakEvery: 3,
+        },
+      },
+    };
+    const { result } = renderHook(() => useWidgetTickerData(customPrefs));
+
+    await waitFor(() => {
+      expect(result.current.timer).toHaveLength(1);
+    });
+    expect(result.current.timer[0]?.detail).toBe("Pomodoro · 2/3 sessions");
+  });
+});

--- a/desktop/src/hooks/useWidgetTickerData.ts
+++ b/desktop/src/hooks/useWidgetTickerData.ts
@@ -10,12 +10,12 @@ import { weatherCodeToIcon, weatherCodeToLabel, formatTemp } from "../widgets/we
 import { findCpuTemp, findGpuTemp } from "../widgets/sysmon/utils";
 import { tzLabel } from "../widgets/clock/storage";
 import type { ClockChipData, WeatherChipData, SysmonChipData, UptimeChipData, GitHubChipData, WidgetTickerData } from "../types";
-import type { TimerState } from "../widgets/clock/types";
+import type { TimerState } from "../widgets/timer/types";
 import type { SavedCity } from "../widgets/weather/types";
 import { loadMonitors } from "../widgets/uptime/types";
 import { loadRepoData, repoKey } from "../widgets/github/types";
 
-const EMPTY: WidgetTickerData = { clock: [], weather: [], sysmon: [], uptime: [], github: [] };
+const EMPTY: WidgetTickerData = { clock: [], timer: [], weather: [], sysmon: [], uptime: [], github: [] };
 
 // ── Time formatting helpers ─────────────────────────────────────
 
@@ -57,7 +57,7 @@ function tzShortLabel(tz: string): string {
 
 // ── Timer helpers ───────────────────────────────────────────────
 
-function getTimerChipData(state: TimerState): ClockChipData | null {
+function getTimerChipData(state: TimerState, longBreakEvery: number): ClockChipData | null {
   const isRunning = state.startedAt != null;
   const elapsed = isRunning
     ? state.bankedMs + (Date.now() - state.startedAt!)
@@ -75,7 +75,7 @@ function getTimerChipData(state: TimerState): ClockChipData | null {
   const mode = state.mode.charAt(0).toUpperCase() + state.mode.slice(1);
   const sessions = state.completedSessions ?? 0;
   const detail = state.mode === "pomodoro"
-    ? `${mode} \u00B7 ${sessions}/4 sessions`
+    ? `${mode} \u00B7 ${sessions}/${longBreakEvery} sessions`
     : mode;
 
   return {
@@ -100,7 +100,7 @@ export function useWidgetTickerData(
     [widgetPrefs.widgetsOnTicker],
   );
 
-  // ── Build clock + timer chips ─────────────────────────────────
+  // ── Build clock chips ─────────────────────────────────────────
   const buildClockChips = useCallback((): ClockChipData[] => {
     if (!enabledWidgets.has("clock")) return [];
     const cfg = widgetPrefs.clock;
@@ -134,17 +134,20 @@ export function useWidgetTickerData(
       }
     }
 
-    // Active timer
-    if (cfg.ticker.activeTimer) {
-      const state = getStore<TimerState | null>(LS_TIMER_STATE, null);
-      if (state) {
-        const chip = getTimerChipData(state);
-        if (chip) chips.push(chip);
-      }
-    }
-
     return chips;
   }, [widgetPrefs.clock, enabledWidgets]);
+
+  // ── Build timer chips ─────────────────────────────────────────
+  const buildTimerChips = useCallback((): ClockChipData[] => {
+    if (!enabledWidgets.has("timer")) return [];
+    if (!widgetPrefs.timer.ticker.activeTimer) return [];
+
+    const state = getStore<TimerState | null>(LS_TIMER_STATE, null);
+    if (!state) return [];
+
+    const chip = getTimerChipData(state, widgetPrefs.timer.pomodoro.longBreakEvery);
+    return chip ? [chip] : [];
+  }, [widgetPrefs.timer, enabledWidgets]);
 
   // ── Build weather chips ───────────────────────────────────────
   const buildWeatherChips = useCallback((): WeatherChipData[] => {
@@ -315,12 +318,13 @@ export function useWidgetTickerData(
 
   useEffect(() => {
     const hasClock = enabledWidgets.has("clock");
+    const hasTimer = enabledWidgets.has("timer");
     const hasWeather = enabledWidgets.has("weather");
     const hasSysmon = enabledWidgets.has("sysmon");
     const hasUptime = enabledWidgets.has("uptime");
     const hasGithub = enabledWidgets.has("github");
 
-    if (!hasClock && !hasWeather && !hasSysmon && !hasUptime && !hasGithub) {
+    if (!hasClock && !hasTimer && !hasWeather && !hasSysmon && !hasUptime && !hasGithub) {
       setData(EMPTY);
       return;
     }
@@ -329,6 +333,7 @@ export function useWidgetTickerData(
     const refresh = () => {
       setData({
         clock: buildClockChips(),
+        timer: buildTimerChips(),
         weather: buildWeatherChips(),
         sysmon: buildSysmonChips(),
         uptime: buildUptimeChips(),
@@ -336,9 +341,14 @@ export function useWidgetTickerData(
       });
     };
 
-    // Clock + timer: update every second (timer needs 1s resolution)
+    // Clock: update every second
     const clockInterval = hasClock ? setInterval(() => {
       setData((prev) => ({ ...prev, clock: buildClockChips() }));
+    }, 1000) : null;
+
+    // Timer: update every second while enabled for live elapsed time
+    const timerInterval = hasTimer ? setInterval(() => {
+      setData((prev) => ({ ...prev, timer: buildTimerChips() }));
     }, 1000) : null;
 
     // Weather: listen for store changes instead of polling
@@ -354,12 +364,14 @@ export function useWidgetTickerData(
         })
       : null;
 
-    // Clock: listen for store changes (timer state, timezones, format)
-    const unsubTimerState = hasClock
+    // Timer: listen for store changes
+    const unsubTimerState = hasTimer
       ? onStoreChange<TimerState | null>(LS_TIMER_STATE, () => {
-          setData((prev) => ({ ...prev, clock: buildClockChips() }));
+          setData((prev) => ({ ...prev, timer: buildTimerChips() }));
         })
       : null;
+
+    // Clock: listen for store changes (timezones, format)
     const unsubClockTimezones = hasClock
       ? onStoreChange<string[]>(LS_CLOCK_TIMEZONES, () => {
           setData((prev) => ({ ...prev, clock: buildClockChips() }));
@@ -418,6 +430,7 @@ export function useWidgetTickerData(
 
     return () => {
       if (clockInterval) clearInterval(clockInterval);
+      if (timerInterval) clearInterval(timerInterval);
       unsubWeatherCities?.();
       unsubWeatherUnit?.();
       unsubTimerState?.();
@@ -438,6 +451,7 @@ export function useWidgetTickerData(
     widgetPrefs.uptime.pollInterval,
     widgetPrefs.github.pollInterval,
     buildClockChips,
+    buildTimerChips,
     buildWeatherChips,
     buildSysmonChips,
     buildUptimeChips,

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -12,7 +12,7 @@
  *  - unknown / corrupt values fall back to `"both"` so loadPrefs never
  *    throws or produces a bad shape
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   migrateVenue,
   shouldShowOnFeed,
@@ -33,8 +33,38 @@ import {
   isThemeFamily,
   isThemeMode,
   THEME_FAMILIES,
+  mergeWidgetPrefs,
+  loadPrefs,
 } from "./preferences";
-import type { Venue, AppPreferences } from "./preferences";
+import type { Venue, AppPreferences, WidgetPrefs } from "./preferences";
+
+const storeValues = vi.hoisted(() => new Map<string, unknown>());
+
+vi.mock("./lib/store", () => ({
+  getStore: vi.fn((key: string, fallback: unknown) => (
+    storeValues.has(key) ? storeValues.get(key) : fallback
+  )),
+  setStore: vi.fn((key: string, value: unknown) => {
+    storeValues.set(key, value);
+  }),
+}));
+
+afterEach(() => {
+  storeValues.clear();
+});
+
+interface LegacyClockTimerWidgetPrefs extends Omit<Partial<WidgetPrefs>, "clock"> {
+  clock?: {
+    ticker?: Partial<WidgetPrefs["clock"]["ticker"]> & {
+      activeTimer?: boolean;
+    };
+    pomodoro?: Partial<WidgetPrefs["timer"]["pomodoro"]>;
+  };
+}
+
+function legacyWidgetPrefs(input: LegacyClockTimerWidgetPrefs): Partial<WidgetPrefs> {
+  return input as Partial<WidgetPrefs>;
+}
 
 describe("migrateVenue", () => {
   it("keeps valid venue strings as-is", () => {
@@ -360,6 +390,9 @@ function makePrefs(rows: { sources: string[] }[]): AppPreferences {
     appearance: {
       tickerLayout: { rows },
     },
+    widgets: {
+      widgetsOnTicker: [],
+    },
   } as unknown as AppPreferences;
 }
 
@@ -459,6 +492,19 @@ describe("setSourceTickerRow / setChannelTickerRow / setWidgetTickerRow", () => 
       "finance",
       "clock",
     ]);
+  });
+
+  it("setWidgetTickerRow adds assigned widgets to widgetsOnTicker", () => {
+    const prefs = makePrefs([{ sources: [] }]);
+    const next = setWidgetTickerRow(prefs, "timer", 0);
+    expect(next.widgets.widgetsOnTicker).toEqual(["timer"]);
+  });
+
+  it("setWidgetTickerRow removes unassigned widgets from widgetsOnTicker", () => {
+    const prefs = makePrefs([{ sources: ["timer"] }]);
+    prefs.widgets.widgetsOnTicker = ["clock", "timer"];
+    const next = setWidgetTickerRow(prefs, "timer", null);
+    expect(next.widgets.widgetsOnTicker).toEqual(["clock"]);
   });
 
   it("does not mutate the original prefs object", () => {
@@ -608,5 +654,306 @@ describe("resolveThemeName", () => {
     expect(resolveThemeName("catppuccin", "dark")).toBe("catppuccin-dark");
     expect(resolveThemeName("tokyo-night", "light")).toBe("tokyo-night-light");
     expect(resolveThemeName("rose-pine", "dark")).toBe("rose-pine-dark");
+  });
+});
+
+describe("widget timer preference migration", () => {
+  it("moves legacy clock timer settings into widgets.timer", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      clock: {
+        ticker: {
+          localTime: false,
+          showTimezones: true,
+          excludedTimezones: ["America/New_York"],
+          activeTimer: false,
+        },
+        pomodoro: {
+          workMins: 50,
+          shortBreakMins: 10,
+          longBreakMins: 30,
+          longBreakEvery: 3,
+        },
+      },
+    }));
+
+    expect(prefs.clock).toMatchObject({
+      ticker: {
+        localTime: false,
+        showTimezones: true,
+        excludedTimezones: ["America/New_York"],
+      },
+    });
+    expect("activeTimer" in prefs.clock.ticker).toBe(false);
+    expect(prefs.timer).toEqual({
+      ticker: { activeTimer: false },
+      pomodoro: {
+        workMins: 50,
+        shortBreakMins: 10,
+        longBreakMins: 30,
+        longBreakEvery: 3,
+      },
+    });
+  });
+
+  it("prefers saved timer settings over conflicting legacy clock timer settings", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      clock: {
+        ticker: {
+          activeTimer: false,
+        },
+        pomodoro: {
+          workMins: 50,
+          shortBreakMins: 10,
+          longBreakMins: 30,
+          longBreakEvery: 3,
+        },
+      },
+      timer: {
+        ticker: { activeTimer: true },
+        pomodoro: {
+          workMins: 20,
+          shortBreakMins: 4,
+          longBreakMins: 12,
+          longBreakEvery: 5,
+        },
+      },
+    }));
+
+    expect(prefs.timer).toEqual({
+      ticker: { activeTimer: true },
+      pomodoro: {
+        workMins: 20,
+        shortBreakMins: 4,
+        longBreakMins: 12,
+        longBreakEvery: 5,
+      },
+    });
+  });
+
+  it("keeps legacy active timer chips on the ticker after timer becomes its own widget", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      enabledWidgets: ["clock", "timer"],
+      widgetsOnTicker: ["clock", "timer"],
+      clock: {
+        ticker: {
+          activeTimer: true,
+        },
+      },
+    }));
+
+    expect(prefs.enabledWidgets).toEqual(["clock", "timer"]);
+    expect(prefs.widgetsOnTicker).toEqual(["clock", "timer"]);
+  });
+
+  it("adds timer for legacy clock-on-ticker active timer users", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      enabledWidgets: ["clock"],
+      widgetsOnTicker: ["clock"],
+      clock: {
+        ticker: {
+          activeTimer: true,
+        },
+      },
+    }));
+
+    expect(prefs.enabledWidgets).toEqual(["clock", "timer"]);
+    expect(prefs.widgetsOnTicker).toEqual(["clock", "timer"]);
+  });
+
+  it("adds timer for legacy clock-on-ticker users when activeTimer was never saved", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      enabledWidgets: ["clock"],
+      widgetsOnTicker: ["clock"],
+      clock: {
+        ticker: {},
+      },
+    }));
+
+    expect(prefs.enabledWidgets).toEqual(["clock", "timer"]);
+    expect(prefs.widgetsOnTicker).toEqual(["clock", "timer"]);
+  });
+
+  it("enables timer for legacy clock users without adding ticker visibility", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      enabledWidgets: ["clock"],
+      widgetsOnTicker: [],
+      clock: {
+        ticker: {},
+      },
+    }));
+
+    expect(prefs.enabledWidgets).toEqual(["clock", "timer"]);
+    expect(prefs.widgetsOnTicker).toEqual([]);
+  });
+
+  it("enables timer for legacy clock users who had active timer hidden", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      enabledWidgets: ["clock"],
+      widgetsOnTicker: ["clock"],
+      clock: {
+        ticker: {
+          activeTimer: false,
+        },
+      },
+    }));
+
+    expect(prefs.enabledWidgets).toEqual(["clock", "timer"]);
+    expect(prefs.widgetsOnTicker).toEqual(["clock"]);
+    expect(prefs.timer.ticker.activeTimer).toBe(false);
+  });
+
+  it("does not auto-add timer visibility when current timer prefs exist", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      enabledWidgets: ["clock"],
+      widgetsOnTicker: ["clock"],
+      clock: {
+        ticker: {},
+      },
+      timer: {
+        ticker: { activeTimer: true },
+        pomodoro: {
+          workMins: 25,
+          shortBreakMins: 5,
+          longBreakMins: 15,
+          longBreakEvery: 4,
+        },
+      },
+    }));
+
+    expect(prefs.enabledWidgets).toEqual(["clock"]);
+    expect(prefs.widgetsOnTicker).toEqual(["clock"]);
+    expect(prefs.timer.ticker.activeTimer).toBe(true);
+  });
+
+  it("does not auto-enable timer for current timer prefs", () => {
+    const prefs = mergeWidgetPrefs(legacyWidgetPrefs({
+      enabledWidgets: ["clock"],
+      widgetsOnTicker: [],
+      clock: {
+        ticker: {},
+      },
+      timer: {
+        ticker: { activeTimer: true },
+        pomodoro: {
+          workMins: 25,
+          shortBreakMins: 5,
+          longBreakMins: 15,
+          longBreakEvery: 4,
+        },
+      },
+    }));
+
+    expect(prefs.enabledWidgets).toEqual(["clock"]);
+    expect(prefs.widgetsOnTicker).toEqual([]);
+  });
+
+  it("adds timer to explicit ticker layout rows when legacy clock timer was enabled by default", () => {
+    storeValues.set("scrollr:settings", {
+      appearance: {
+        tickerLayout: {
+          rows: [{ sources: ["clock"] }],
+        },
+      },
+      widgets: legacyWidgetPrefs({
+        enabledWidgets: ["clock"],
+        widgetsOnTicker: ["clock"],
+        clock: {
+          ticker: {},
+        },
+      }),
+    });
+
+    const prefs = loadPrefs();
+
+    expect(prefs.appearance.tickerLayout.rows[0].sources).toEqual(["clock", "timer"]);
+  });
+
+  it("adds timer to explicit ticker layout rows when legacy widgetsOnTicker is absent", () => {
+    storeValues.set("scrollr:settings", {
+      appearance: {
+        tickerLayout: {
+          rows: [{ sources: ["clock"] }],
+        },
+      },
+      widgets: legacyWidgetPrefs({
+        enabledWidgets: ["clock"],
+        clock: {
+          ticker: {},
+        },
+      }),
+    });
+
+    const prefs = loadPrefs();
+
+    expect(prefs.appearance.tickerLayout.rows[0].sources).toEqual(["clock", "timer"]);
+  });
+
+  it("preserves current explicit clock and timer rows when timer was already on ticker", () => {
+    storeValues.set("scrollr:auth", {
+      accessToken: "x.eyJyb2xlcyI6WyJ1cGxpbmsiXX0.x",
+      refreshToken: null,
+      expiresAt: Date.now() + 60_000,
+      userSub: "test-user",
+    });
+    storeValues.set("scrollr:settings", {
+      appearance: {
+        tickerLayout: {
+          rows: [{ sources: ["clock"] }, { sources: ["timer"] }],
+        },
+      },
+      widgets: legacyWidgetPrefs({
+        enabledWidgets: ["clock", "timer"],
+        widgetsOnTicker: ["clock", "timer"],
+        clock: {
+          ticker: {},
+        },
+        timer: {
+          ticker: { activeTimer: true },
+          pomodoro: {
+            workMins: 25,
+            shortBreakMins: 5,
+            longBreakMins: 15,
+            longBreakEvery: 4,
+          },
+        },
+      }),
+    });
+
+    const prefs = loadPrefs();
+
+    expect(prefs.appearance.tickerLayout.rows).toEqual([
+      { sources: ["clock"] },
+      { sources: ["timer"] },
+    ]);
+  });
+
+  it("preserves current explicit clock-only rows when timer prefs exist", () => {
+    storeValues.set("scrollr:settings", {
+      appearance: {
+        tickerLayout: {
+          rows: [{ sources: ["clock"] }],
+        },
+      },
+      widgets: legacyWidgetPrefs({
+        enabledWidgets: ["clock"],
+        widgetsOnTicker: ["clock"],
+        clock: {
+          ticker: {},
+        },
+        timer: {
+          ticker: { activeTimer: true },
+          pomodoro: {
+            workMins: 25,
+            shortBreakMins: 5,
+            longBreakMins: 15,
+            longBreakEvery: 4,
+          },
+        },
+      }),
+    });
+
+    const prefs = loadPrefs();
+
+    expect(prefs.appearance.tickerLayout.rows[0].sources).toEqual(["clock"]);
   });
 });

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -206,19 +206,26 @@ export interface ClockTickerConfig {
   showTimezones: boolean;
   /** Timezone IANA IDs excluded from the ticker (empty = all configured TZs shown). */
   excludedTimezones: string[];
+}
+
+export interface ClockWidgetConfig {
+  ticker: ClockTickerConfig;
+}
+
+export interface TimerTickerConfig {
   activeTimer: boolean;
 }
 
-export interface ClockPomodoroConfig {
+export interface TimerPomodoroConfig {
   workMins: number;
   shortBreakMins: number;
   longBreakMins: number;
   longBreakEvery: number;
 }
 
-export interface ClockWidgetConfig {
-  ticker: ClockTickerConfig;
-  pomodoro: ClockPomodoroConfig;
+export interface TimerWidgetConfig {
+  ticker: TimerTickerConfig;
+  pomodoro: TimerPomodoroConfig;
 }
 
 export interface WeatherTickerConfig {
@@ -286,6 +293,7 @@ export interface WidgetPrefs {
    *  places it as a static element on the chosen side. Keyed by widget ID. */
   pinnedWidgets: Record<string, WidgetPinConfig>;
   clock: ClockWidgetConfig;
+  timer: TimerWidgetConfig;
   weather: WeatherWidgetConfig;
   sysmon: SysmonWidgetConfig;
   uptime: UptimeWidgetConfig;
@@ -569,10 +577,13 @@ export const DEFAULT_CLOCK_TICKER: ClockTickerConfig = {
   localTime: true,
   showTimezones: false,
   excludedTimezones: [],
+};
+
+export const DEFAULT_TIMER_TICKER: TimerTickerConfig = {
   activeTimer: true,
 };
 
-export const DEFAULT_CLOCK_POMODORO: ClockPomodoroConfig = {
+export const DEFAULT_TIMER_POMODORO: TimerPomodoroConfig = {
   workMins: 25,
   shortBreakMins: 5,
   longBreakMins: 15,
@@ -650,7 +661,10 @@ const DEFAULT_WIDGETS: WidgetPrefs = {
   pinnedWidgets: {},
   clock: {
     ticker: { ...DEFAULT_CLOCK_TICKER },
-    pomodoro: { ...DEFAULT_CLOCK_POMODORO },
+  },
+  timer: {
+    ticker: { ...DEFAULT_TIMER_TICKER },
+    pomodoro: { ...DEFAULT_TIMER_POMODORO },
   },
   weather: {
     ticker: { ...DEFAULT_WEATHER_TICKER },
@@ -749,7 +763,7 @@ export function savePref<T>(key: string, value: T): void {
 
 /** Deep-merge saved widget prefs with defaults.
  *  Handles migration from the old flat shape gracefully. */
-function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
+export function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
   if (!saved) return { ...DEFAULT_WIDGETS };
 
   // Safe accessor for nested sub-objects that may not exist in old formats
@@ -757,23 +771,53 @@ function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
     v != null && typeof v === "object" ? (v as Record<string, unknown>) : undefined;
 
   const clk = obj(saved.clock);
+  const tmr = obj(saved.timer);
   const wth = obj(saved.weather);
   const sys = obj(saved.sysmon);
   const upt = obj(saved.uptime);
   const ghb = obj(saved.github);
+  const legacyClockTicker = obj(clk?.ticker);
+  const { activeTimer: _legacyActiveTimer, ...clockTicker } = legacyClockTicker ?? {};
+  void _legacyActiveTimer;
+  const timerTicker = obj(tmr?.ticker);
 
-  const enabledWidgets = Array.isArray(saved.enabledWidgets) ? saved.enabledWidgets : DEFAULT_WIDGETS.enabledWidgets;
+  const savedEnabledWidgets = Array.isArray(saved.enabledWidgets) ? saved.enabledWidgets : DEFAULT_WIDGETS.enabledWidgets;
+  const savedWidgetsOnTicker = Array.isArray(saved.widgetsOnTicker) ? saved.widgetsOnTicker : savedEnabledWidgets;
+  const hasLegacyTimerPrefs = !tmr;
+  const shouldEnableLegacyTimer = hasLegacyTimerPrefs && savedEnabledWidgets.includes("clock");
+  const shouldShowLegacyTimerOnTicker = hasLegacyTimerPrefs && legacyClockTicker?.activeTimer !== false && savedWidgetsOnTicker.includes("clock");
+  const enabledWidgets = shouldEnableLegacyTimer && !savedEnabledWidgets.includes("timer")
+    ? [...savedEnabledWidgets, "timer"]
+    : savedEnabledWidgets;
+  const widgetsOnTicker = shouldShowLegacyTimerOnTicker && !savedWidgetsOnTicker.includes("timer")
+    ? [...savedWidgetsOnTicker, "timer"]
+    : savedWidgetsOnTicker;
 
   return {
     enabledWidgets,
     // Migration: if widgetsOnTicker doesn't exist, default to enabledWidgets
-    widgetsOnTicker: Array.isArray(saved.widgetsOnTicker) ? saved.widgetsOnTicker : enabledWidgets,
+    widgetsOnTicker,
     pinnedWidgets: (saved.pinnedWidgets != null && typeof saved.pinnedWidgets === "object" && !Array.isArray(saved.pinnedWidgets))
       ? saved.pinnedWidgets as Record<string, WidgetPinConfig>
       : {},
     clock: {
-      ticker: { ...DEFAULT_CLOCK_TICKER, ...obj(clk?.ticker) },
-      pomodoro: { ...DEFAULT_CLOCK_POMODORO, ...obj(clk?.pomodoro) },
+      ticker: { ...DEFAULT_CLOCK_TICKER, ...clockTicker },
+    },
+    timer: {
+      ticker: {
+        ...DEFAULT_TIMER_TICKER,
+        activeTimer:
+          typeof timerTicker?.activeTimer === "boolean"
+            ? Boolean(timerTicker.activeTimer)
+            : typeof legacyClockTicker?.activeTimer === "boolean"
+              ? Boolean(legacyClockTicker.activeTimer)
+              : DEFAULT_TIMER_TICKER.activeTimer,
+      },
+      pomodoro: {
+        ...DEFAULT_TIMER_POMODORO,
+        ...obj(clk?.pomodoro),
+        ...obj(tmr?.pomodoro),
+      },
     },
     weather: {
       ticker: { ...DEFAULT_WEATHER_TICKER, ...obj(wth?.ticker) },
@@ -1184,6 +1228,40 @@ export function loadPrefs(): AppPreferences {
         : [],
     };
 
+    const savedWidgets = source.widgets as Record<string, unknown> | undefined;
+    const savedClock = savedWidgets?.clock != null && typeof savedWidgets.clock === "object"
+      ? (savedWidgets.clock as Record<string, unknown>)
+      : undefined;
+    const savedClockTicker = savedClock?.ticker != null && typeof savedClock.ticker === "object"
+      ? (savedClock.ticker as Record<string, unknown>)
+      : undefined;
+    const hasSavedTimerPrefs = savedWidgets?.timer != null && typeof savedWidgets.timer === "object";
+    const savedWidgetIdsOnTicker = Array.isArray(savedWidgets?.widgetsOnTicker)
+      ? (savedWidgets.widgetsOnTicker as unknown[]).filter((id): id is string => typeof id === "string")
+      : Array.isArray(savedWidgets?.enabledWidgets)
+        ? (savedWidgets.enabledWidgets as unknown[]).filter((id): id is string => typeof id === "string")
+        : [];
+    const shouldMigrateTimerRows =
+      !hasSavedTimerPrefs &&
+      savedClockTicker?.activeTimer !== false &&
+      savedWidgetIdsOnTicker.includes("clock") &&
+      !savedWidgetIdsOnTicker.includes("timer");
+    if (shouldMigrateTimerRows) {
+      let rowsChanged = false;
+      const rows = merged.appearance.tickerLayout.rows.map((row) => {
+        if (!row.sources.includes("clock") || row.sources.includes("timer")) return row;
+        rowsChanged = true;
+        return { ...row, sources: [...row.sources, "timer"] };
+      });
+
+      if (rowsChanged) {
+        merged.appearance = {
+          ...merged.appearance,
+          tickerLayout: { rows },
+        };
+      }
+    }
+
     // Clamp any widget pin rows that reference rows above the current
     // layout's row count (e.g. user downgraded from Pro to Uplink and
     // lost row 2). See spec §Edge Cases #2 — pins on dropped rows
@@ -1512,8 +1590,8 @@ export function updateWidgetPrefs(
 //     issue `channelsApi.update` separately; these helpers only mutate
 //     the client-side AppPreferences.
 //
-// Widgets only have the client-side layer (no server-side ticker_enabled),
-// so `setWidgetTickerRow` is just an alias to the source-id-based helper.
+// Widgets also keep `widgets.widgetsOnTicker` in sync because it is the
+// master render gate for widget ticker data.
 // See docs/superpowers/specs/2026-04-28-batch-d-…-design.md §Stream 3.
 
 /** Minimal shape of a Channel record used by `getChannelTickerRow`. */
@@ -1644,6 +1722,22 @@ export function setWidgetTickerRow(
   widgetId: string,
   row: number | null,
 ): AppPreferences {
-  return setSourceTickerRow(prefs, widgetId, row);
+  const withRow = setSourceTickerRow(prefs, widgetId, row);
+  if (withRow === prefs) return prefs;
+
+  const widgetsOnTicker = withRow.widgets.widgetsOnTicker;
+  const nextWidgetsOnTicker = row === null
+    ? widgetsOnTicker.filter((id) => id !== widgetId)
+    : widgetsOnTicker.includes(widgetId)
+      ? widgetsOnTicker
+      : [...widgetsOnTicker, widgetId];
+
+  return {
+    ...withRow,
+    widgets: {
+      ...withRow.widgets,
+      widgetsOnTicker: nextWidgetsOnTicker,
+    },
+  };
 }
 

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -34,6 +34,7 @@ import { loadMonitors } from "../widgets/uptime/types";
 import { loadRepoData } from "../widgets/github/types";
 import {
   LS_CLOCK_FORMAT,
+  LS_TIMER_STATE,
   LS_WEATHER_CITIES,
   LS_WEATHER_UNIT,
   LS_SYSMON_DATA,
@@ -54,9 +55,40 @@ import type {
 } from "../types";
 import type { TempUnit, HomePreview } from "../preferences";
 import type { SystemInfo } from "../hooks/useSysmonData";
+import type { TimerState } from "../widgets/timer/types";
 import type { SavedCity } from "../widgets/weather/types";
 
 const MAX_PREVIEW = 5;
+
+function formatTimerDuration(ms: number): string {
+  const totalSecs = Math.floor(Math.max(0, ms) / 1000);
+  const hours = Math.floor(totalSecs / 3600);
+  const mins = Math.floor((totalSecs % 3600) / 60);
+  const secs = totalSecs % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+  }
+
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+}
+
+function getTimerValue(): string {
+  const state = getStore<TimerState | null>(LS_TIMER_STATE, null);
+  if (!state) return "Idle";
+
+  const elapsed = state.startedAt == null
+    ? state.bankedMs
+    : state.bankedMs + (Date.now() - state.startedAt);
+
+  if (state.startedAt == null && elapsed <= 0) return "Idle";
+
+  const ms = state.mode === "stopwatch"
+    ? elapsed
+    : Math.max(0, state.targetSecs * 1000 - elapsed);
+
+  return formatTimerDuration(ms);
+}
 
 // ── Route ───────────────────────────────────────────────────────
 
@@ -1050,6 +1082,8 @@ function getWidgetValue(id: string): string {
         hour12: format === "12h",
       }).format(new Date());
     }
+    case "timer":
+      return getTimerValue();
     case "weather": {
       const cities = getStore<SavedCity[]>(LS_WEATHER_CITIES, []);
       const unit = getStore<string>(LS_WEATHER_UNIT, "fahrenheit") as TempUnit;

--- a/desktop/src/types/index.ts
+++ b/desktop/src/types/index.ts
@@ -205,6 +205,7 @@ export interface GitHubChipData {
 
 export interface WidgetTickerData {
   clock: ClockChipData[];
+  timer: ClockChipData[];
   weather: WeatherChipData[];
   sysmon: SysmonChipData[];
   uptime: UptimeChipData[];

--- a/desktop/src/widgets/WidgetConfigPanel.tsx
+++ b/desktop/src/widgets/WidgetConfigPanel.tsx
@@ -1,5 +1,6 @@
 import type { AppPreferences } from "../preferences";
 import ClockConfigPanel from "./clock/ConfigPanel";
+import TimerConfigPanel from "./timer/ConfigPanel";
 import WeatherConfigPanel from "./weather/ConfigPanel";
 import SysmonConfigPanel from "./sysmon/ConfigPanel";
 import UptimeConfigPanel from "./uptime/ConfigPanel";
@@ -21,6 +22,10 @@ export default function WidgetConfigPanel({
     case "clock":
       return (
         <ClockConfigPanel prefs={prefs} onPrefsChange={onPrefsChange} />
+      );
+    case "timer":
+      return (
+        <TimerConfigPanel prefs={prefs} onPrefsChange={onPrefsChange} />
       );
     case "weather":
       return (

--- a/desktop/src/widgets/clock/ConfigPanel.tsx
+++ b/desktop/src/widgets/clock/ConfigPanel.tsx
@@ -3,7 +3,6 @@ import {
   Section,
   ToggleRow,
   SegmentedRow,
-  SliderRow,
 } from "../../components/settings/SettingsControls";
 import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
 import TickerPinSection from "../../components/settings/TickerPinSection";
@@ -11,10 +10,9 @@ import { useWidgetConfig } from "../../hooks/useWidgetConfig";
 import { useTickerExclusion } from "../../hooks/useTickerExclusion";
 import { useStoreData } from "../../hooks/useStoreData";
 import { setStore } from "../../lib/store";
-import { DEFAULT_CLOCK_TICKER, DEFAULT_CLOCK_POMODORO } from "../../preferences";
+import { DEFAULT_CLOCK_TICKER } from "../../preferences";
 import { LS_CLOCK_FORMAT, LS_CLOCK_TIMEZONES } from "../../constants";
 import { loadTimezones, loadFormat, tzLabel } from "./storage";
-import type { ClockPomodoroConfig } from "../../preferences";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
 type ClockFormat = "12h" | "24h";
@@ -22,14 +20,6 @@ type ClockFormat = "12h" | "24h";
 const FORMAT_OPTIONS: { value: ClockFormat; label: string }[] = [
   { value: "12h", label: "12h" },
   { value: "24h", label: "24h" },
-];
-
-const LONG_BREAK_OPTIONS = [
-  { value: "2", label: "2" },
-  { value: "3", label: "3" },
-  { value: "4", label: "4" },
-  { value: "5", label: "5" },
-  { value: "6", label: "6" },
 ];
 
 export default function ClockConfigPanel({
@@ -42,13 +32,6 @@ export default function ClockConfigPanel({
   const { isExcluded: isTimezoneExcluded, toggle: toggleTimezone } =
     useTickerExclusion(config.ticker.excludedTimezones, "excludedTimezones", setTicker);
 
-  const setPomodoro = useCallback(
-    (patch: Partial<ClockPomodoroConfig>) => {
-      update({ pomodoro: { ...config.pomodoro, ...patch } });
-    },
-    [update, config.pomodoro],
-  );
-
   const handleFormatChange = useCallback(
     (v: ClockFormat) => {
       setFormatState(v);
@@ -60,7 +43,6 @@ export default function ClockConfigPanel({
   const resetAll = useCallback(() => {
     update({
       ticker: { ...DEFAULT_CLOCK_TICKER },
-      pomodoro: { ...DEFAULT_CLOCK_POMODORO },
     });
     setStore(LS_CLOCK_FORMAT, "12h");
     setFormatState("12h");
@@ -78,7 +60,7 @@ export default function ClockConfigPanel({
       icon={clockIcon}
       hex="var(--color-widget-clock)"
       title="Clock Settings"
-      subtitle="World clocks and Pomodoro timer"
+      subtitle="Local time and world clocks"
       onReset={resetAll}
     >
       {/* Ticker */}
@@ -115,51 +97,7 @@ export default function ClockConfigPanel({
             Add world clocks in the Clock tab to see them here.
           </div>
         )}
-        <ToggleRow
-          label="Active timer"
-          description="Show running timers on the ticker"
-          checked={config.ticker.activeTimer}
-          onChange={(v) => setTicker({ activeTimer: v })}
-        />
         <TickerPinSection widgetId="clock" prefs={prefs} onPrefsChange={onPrefsChange} />
-      </Section>
-
-      {/* Pomodoro */}
-      <Section title="Pomodoro">
-        <SliderRow
-          label="Work session"
-          value={config.pomodoro.workMins}
-          min={10}
-          max={60}
-          step={5}
-          displayValue={`${config.pomodoro.workMins} min`}
-          onChange={(v) => setPomodoro({ workMins: v })}
-        />
-        <SliderRow
-          label="Short break"
-          value={config.pomodoro.shortBreakMins}
-          min={1}
-          max={15}
-          step={1}
-          displayValue={`${config.pomodoro.shortBreakMins} min`}
-          onChange={(v) => setPomodoro({ shortBreakMins: v })}
-        />
-        <SliderRow
-          label="Long break"
-          value={config.pomodoro.longBreakMins}
-          min={5}
-          max={30}
-          step={5}
-          displayValue={`${config.pomodoro.longBreakMins} min`}
-          onChange={(v) => setPomodoro({ longBreakMins: v })}
-        />
-        <SegmentedRow
-          label="Long break every"
-          description="Sessions before a long break"
-          value={String(config.pomodoro.longBreakEvery)}
-          options={LONG_BREAK_OPTIONS}
-          onChange={(v) => setPomodoro({ longBreakEvery: Number(v) })}
-        />
       </Section>
     </ConfigPanelLayout>
   );

--- a/desktop/src/widgets/clock/FeedTab.tsx
+++ b/desktop/src/widgets/clock/FeedTab.tsx
@@ -1,93 +1,31 @@
-/**
- * Clock widget FeedTab — desktop-native.
- *
- * Combines World Clock and Timer under a single tabbed interface.
- * Internal tab selection ("clocks" | "timer") is persisted to
- * Tauri store for session continuity.
- */
-import { useState, useCallback } from "react";
 import { Clock } from "lucide-react";
 import { WorldClock } from "./WorldClock";
-import { Timer } from "./Timer";
-import { getStore, setStore } from "../../lib/store";
 import type { FeedTabProps, WidgetManifest } from "../../types";
-import type { ClockTab } from "./types";
-
-// ── Tab persistence ─────────────────────────────────────────────
-
-const TAB_KEY = "scrollr:widget:clock:tab";
-
-function loadTab(): ClockTab {
-  const raw = getStore<string>(TAB_KEY, "clocks");
-  return raw === "clocks" || raw === "timer" ? raw : "clocks";
-}
-
-function saveTab(tab: ClockTab): void {
-  setStore(TAB_KEY, tab);
-}
-
-// ── Widget manifest ─────────────────────────────────────────────
 
 export const clockWidget: WidgetManifest = {
   id: "clock",
   name: "Clock",
   tabLabel: "Clock",
-  description: "Local time, world clocks, and timers",
+  description: "Local time and world clocks",
   hex: "#6366f1",
   icon: Clock,
   info: {
     about:
-      "The Clock widget displays your local time on the ticker and provides " +
-      "world clocks for tracking multiple time zones. It also includes a " +
-      "countdown and stopwatch timer.",
+      "The Clock widget displays your local time and world clocks for tracking multiple time zones.",
     usage: [
-      "Your local time appears on the ticker by default.",
-      "Turn on world clocks in the Configure tab to add more time zones.",
-      "Use the timer tab in the feed view to set countdowns or run a stopwatch.",
-      "Hide specific time zones from the ticker in the Configure tab.",
+      "Your local time appears in the Clock feed and can appear on the ticker.",
+      "Add world clocks from the feed view to track more time zones.",
+      "Turn on world clocks in Configure to include selected time zones on the ticker.",
+      "Use the 12h/24h control to change clock formatting.",
     ],
   },
   FeedTab: ClockFeedTab,
 };
 
-// ── FeedTab ─────────────────────────────────────────────────────
-
 function ClockFeedTab({ mode }: FeedTabProps) {
-  const compact = mode === "compact";
-  const [activeTab, setActiveTab] = useState<ClockTab>(loadTab);
-
-  const switchTab = useCallback((tab: ClockTab) => {
-    setActiveTab(tab);
-    saveTab(tab);
-  }, []);
-
   return (
-    <div className="p-3 space-y-2">
-      {/* Top-level tabs: Clocks | Timer */}
-      <div className="flex items-center gap-1 px-1">
-        {(["clocks", "timer"] as ClockTab[]).map((tab) => (
-          <button
-            key={tab}
-            onClick={() => switchTab(tab)}
-            className={`text-xs font-mono font-semibold uppercase tracking-wider px-3 py-1 rounded-lg transition-colors ${
-              activeTab === tab
-                ? tab === "clocks"
-                  ? "text-widget-clock bg-widget-clock/10 border border-widget-clock/20"
-                  : "text-widget-timer bg-widget-timer/10 border border-widget-timer/20"
-                : "text-fg-2 hover:text-fg border border-transparent hover:border-edge"
-            }`}
-          >
-            {tab === "clocks" ? "Clocks" : "Timer"}
-          </button>
-        ))}
-      </div>
-
-      {/* Tab content */}
-      {activeTab === "clocks" ? (
-        <WorldClock compact={compact} />
-      ) : (
-        <Timer compact={compact} />
-      )}
+    <div className="p-3">
+      <WorldClock compact={mode === "compact"} />
     </div>
   );
 }

--- a/desktop/src/widgets/clock/WorldClock.tsx
+++ b/desktop/src/widgets/clock/WorldClock.tsx
@@ -149,7 +149,7 @@ function ClockCard({
   if (compact) {
     return (
       <div
-        className="group flex items-center justify-between px-3 py-2 rounded-lg bg-widget-clock/[0.04] border border-widget-clock/10 hover:border-widget-clock/20 transition-all"
+        className="group flex items-center justify-between px-3 py-2 rounded-lg bg-widget-clock/[0.04] border border-widget-clock/10 hover:border-widget-clock/25 transition-colors"
         style={
           animating
             ? { animation: "widget-card-enter 200ms ease-out" }
@@ -184,10 +184,10 @@ function ClockCard({
   return (
     <div
       className={
-        "group relative px-4 py-3 rounded-xl border transition-all " +
+        "group relative overflow-hidden px-4 py-3 rounded-xl border transition-colors " +
         (isLocal
-          ? "bg-widget-clock/[0.06] border-widget-clock/20 shadow-[inset_0_1px_0_0_rgba(99,102,241,0.08)]"
-          : "bg-widget-clock/[0.04] border-widget-clock/10 hover:border-widget-clock/20")
+          ? "bg-widget-clock/[0.07] border-widget-clock/25 shadow-[inset_0_1px_0_0_rgba(99,102,241,0.12)]"
+          : "bg-surface-2/70 border-widget-clock/10 hover:border-widget-clock/25")
       }
       style={
         animating
@@ -218,7 +218,7 @@ function ClockCard({
           {offset}
         </span>
       </div>
-      <div className="text-xl font-mono font-bold text-fg tabular-nums leading-none">
+      <div className={isLocal ? "text-2xl font-mono font-bold text-fg tabular-nums leading-none" : "text-xl font-mono font-bold text-fg tabular-nums leading-none"}>
         {time}
       </div>
       <div className="text-xs font-mono text-fg-2 mt-1">{date}</div>

--- a/desktop/src/widgets/clock/types.ts
+++ b/desktop/src/widgets/clock/types.ts
@@ -1,21 +1,7 @@
-/**
- * Clock widget types.
- */
-
-export type ClockTab = "clocks" | "timer";
 export type TimeFormat = "12h" | "24h";
-export type TimerMode = "pomodoro" | "countdown" | "stopwatch";
 
 export interface TimezoneEntry {
   tz: string;
   label: string;
   region: string;
-}
-
-export interface TimerState {
-  mode: TimerMode;
-  startedAt: number | null;
-  bankedMs: number;
-  targetSecs: number;
-  completedSessions: number;
 }

--- a/desktop/src/widgets/registry.ts
+++ b/desktop/src/widgets/registry.ts
@@ -15,7 +15,7 @@ const modules = import.meta.glob<Record<string, WidgetManifest>>("./*/FeedTab.ts
 const { get, getAll, ORDER } = createRegistry<WidgetManifest>(
   modules,
   "Widget",
-  ["clock", "weather", "sysmon", "uptime", "github"],
+  ["clock", "timer", "weather", "sysmon", "uptime", "github"],
 );
 
 /** Look up a widget by id. */

--- a/desktop/src/widgets/timer/ConfigPanel.tsx
+++ b/desktop/src/widgets/timer/ConfigPanel.tsx
@@ -1,0 +1,107 @@
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SegmentedRow,
+  SliderRow,
+} from "../../components/settings/SettingsControls";
+import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { DEFAULT_TIMER_TICKER, DEFAULT_TIMER_POMODORO } from "../../preferences";
+import type { TimerPomodoroConfig } from "../../preferences";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+
+const LONG_BREAK_OPTIONS = [
+  { value: "2", label: "2" },
+  { value: "3", label: "3" },
+  { value: "4", label: "4" },
+  { value: "5", label: "5" },
+  { value: "6", label: "6" },
+];
+
+export default function TimerConfigPanel({
+  prefs,
+  onPrefsChange,
+}: WidgetConfigPanelProps) {
+  const { config, update, setTicker } = useWidgetConfig("timer", prefs, onPrefsChange);
+
+  const setPomodoro = useCallback(
+    (patch: Partial<TimerPomodoroConfig>) => {
+      update({ pomodoro: { ...config.pomodoro, ...patch } });
+    },
+    [update, config.pomodoro],
+  );
+
+  const resetAll = useCallback(() => {
+    update({
+      ticker: { ...DEFAULT_TIMER_TICKER },
+      pomodoro: { ...DEFAULT_TIMER_POMODORO },
+    });
+  }, [update]);
+
+  const timerIcon = (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-timer)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 2h4" />
+      <path d="M12 14l3-3" />
+      <circle cx="12" cy="14" r="8" />
+    </svg>
+  );
+
+  return (
+    <ConfigPanelLayout
+      icon={timerIcon}
+      hex="var(--color-widget-timer)"
+      title="Timer Settings"
+      subtitle="Pomodoro, countdown, and stopwatch"
+      onReset={resetAll}
+    >
+      <Section title="Ticker">
+        <ToggleRow
+          label="Active timer"
+          description="Show running or paused timers on the scrolling ticker"
+          checked={config.ticker.activeTimer}
+          onChange={(v) => setTicker({ activeTimer: v })}
+        />
+        <TickerPinSection widgetId="timer" prefs={prefs} onPrefsChange={onPrefsChange} />
+      </Section>
+
+      <Section title="Pomodoro">
+        <SliderRow
+          label="Work session"
+          value={config.pomodoro.workMins}
+          min={10}
+          max={60}
+          step={5}
+          displayValue={`${config.pomodoro.workMins} min`}
+          onChange={(v) => setPomodoro({ workMins: v })}
+        />
+        <SliderRow
+          label="Short break"
+          value={config.pomodoro.shortBreakMins}
+          min={1}
+          max={15}
+          step={1}
+          displayValue={`${config.pomodoro.shortBreakMins} min`}
+          onChange={(v) => setPomodoro({ shortBreakMins: v })}
+        />
+        <SliderRow
+          label="Long break"
+          value={config.pomodoro.longBreakMins}
+          min={5}
+          max={30}
+          step={5}
+          displayValue={`${config.pomodoro.longBreakMins} min`}
+          onChange={(v) => setPomodoro({ longBreakMins: v })}
+        />
+        <SegmentedRow
+          label="Long break every"
+          description="Sessions before a long break"
+          value={String(config.pomodoro.longBreakEvery)}
+          options={LONG_BREAK_OPTIONS}
+          onChange={(v) => setPomodoro({ longBreakEvery: Number(v) })}
+        />
+      </Section>
+    </ConfigPanelLayout>
+  );
+}

--- a/desktop/src/widgets/timer/FeedTab.tsx
+++ b/desktop/src/widgets/timer/FeedTab.tsx
@@ -1,0 +1,31 @@
+import { TimerReset } from "lucide-react";
+import { Timer } from "./Timer";
+import type { FeedTabProps, WidgetManifest } from "../../types";
+
+export const timerWidget: WidgetManifest = {
+  id: "timer",
+  name: "Timer",
+  tabLabel: "Timer",
+  description: "Pomodoro, countdown, and stopwatch tools",
+  hex: "#f59e0b",
+  icon: TimerReset,
+  info: {
+    about:
+      "The Timer widget provides Pomodoro sessions, countdown timers, and a stopwatch as a focused desktop control surface.",
+    usage: [
+      "Choose Pomodoro, Countdown, or Stopwatch from the mode selector.",
+      "Use Space to start or pause and R to reset while the timer feed is focused.",
+      "Enable active timer ticker output in the Configure tab.",
+      "Adjust Pomodoro session lengths and long-break cadence in Configure.",
+    ],
+  },
+  FeedTab: TimerFeedTab,
+};
+
+function TimerFeedTab({ mode }: FeedTabProps) {
+  return (
+    <div className="p-3">
+      <Timer compact={mode === "compact"} />
+    </div>
+  );
+}

--- a/desktop/src/widgets/timer/Timer.tsx
+++ b/desktop/src/widgets/timer/Timer.tsx
@@ -5,14 +5,14 @@
  * window close/reopen within the same session.
  */
 import { useState, useEffect, useCallback, useRef } from "react";
+import { LS_TIMER_STATE } from "../../constants";
 import { getStore, setStore } from "../../lib/store";
+import { loadPrefs } from "../../preferences";
+import { getPomodoroTiming, reconcileIdlePomodoroTarget } from "./pomodoro";
 import type { TimerMode, TimerState } from "./types";
 
 // ── Constants ───────────────────────────────────────────────────
 
-const POMODORO_WORK = 25 * 60;
-const POMODORO_SHORT_BREAK = 5 * 60;
-const POMODORO_LONG_BREAK = 15 * 60;
 const COUNTDOWN_PRESETS = [
   { label: "1m", secs: 60 },
   { label: "5m", secs: 300 },
@@ -24,19 +24,27 @@ const COUNTDOWN_PRESETS = [
 
 // ── Storage ─────────────────────────────────────────────────────
 
-const TIMER_KEY = "scrollr:widget:timer:state";
+const TIMER_KEY = LS_TIMER_STATE;
 
-const DEFAULT_TIMER_STATE: TimerState = {
-  mode: "pomodoro",
-  startedAt: null,
-  bankedMs: 0,
-  targetSecs: POMODORO_WORK,
-  completedSessions: 0,
-};
+function loadPomodoroTiming() {
+  return getPomodoroTiming(loadPrefs().widgets.timer.pomodoro);
+}
+
+function defaultTimerState(): TimerState {
+  return {
+    mode: "pomodoro",
+    startedAt: null,
+    bankedMs: 0,
+    targetSecs: loadPomodoroTiming().workSecs,
+    completedSessions: 0,
+  };
+}
 
 function loadTimerState(): TimerState {
   const s = getStore<TimerState | null>(TIMER_KEY, null);
-  return s && typeof s.mode === "string" ? s : DEFAULT_TIMER_STATE;
+  return s && typeof s.mode === "string"
+    ? reconcileIdlePomodoroTarget(s, loadPomodoroTiming().workSecs)
+    : defaultTimerState();
 }
 
 function saveTimerState(s: TimerState): void {
@@ -253,6 +261,11 @@ export function Timer({ compact }: TimerProps) {
   const customInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    const { workSecs } = loadPomodoroTiming();
+    setState((p) => reconcileIdlePomodoroTarget(p, workSecs));
+  });
+
+  useEffect(() => {
     saveTimerState(state);
   }, [state]);
 
@@ -324,10 +337,16 @@ export function Timer({ compact }: TimerProps) {
     setState((p) => ({ ...p, startedAt: null, bankedMs: getElapsedMs(p) }));
   }, []);
   const reset = useCallback(() => {
-    setState((p) => ({ ...p, startedAt: null, bankedMs: 0 }));
+    setState((p) => ({
+      ...p,
+      startedAt: null,
+      bankedMs: 0,
+      targetSecs: p.mode === "pomodoro" ? loadPomodoroTiming().workSecs : p.targetSecs,
+    }));
   }, []);
 
   const doSwitchMode = useCallback((m: TimerMode) => {
+    const timing = loadPomodoroTiming();
     setState((p) => ({
       ...p,
       mode: m,
@@ -335,7 +354,7 @@ export function Timer({ compact }: TimerProps) {
       bankedMs: 0,
       targetSecs:
         m === "pomodoro"
-          ? POMODORO_WORK
+          ? timing.workSecs
           : m === "countdown"
             ? 300
             : 0,
@@ -367,11 +386,12 @@ export function Timer({ compact }: TimerProps) {
   }, [customMinutes, setTarget]);
 
   const startBreak = useCallback((long: boolean) => {
+    const timing = loadPomodoroTiming();
     setState((p) => ({
       ...p,
       startedAt: Date.now(),
       bankedMs: 0,
-      targetSecs: long ? POMODORO_LONG_BREAK : POMODORO_SHORT_BREAK,
+      targetSecs: long ? timing.longBreakSecs : timing.shortBreakSecs,
     }));
   }, []);
 
@@ -405,6 +425,7 @@ export function Timer({ compact }: TimerProps) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [isRunning, isComplete, start, pause, reset, confirmSwitch]);
 
+  const pomodoroTiming = loadPomodoroTiming();
   const notifPermission =
     "Notification" in globalThis ? Notification.permission : "denied";
 
@@ -435,11 +456,16 @@ export function Timer({ compact }: TimerProps) {
                 }}
               />
             )}
-            <span
-              className={`text-lg font-mono font-bold tabular-nums ${isComplete ? "text-widget-timer" : "text-fg"}`}
-            >
-              {displayTime}
-            </span>
+            <div className="flex items-baseline gap-2 min-w-0">
+              <span
+                className={`text-lg font-mono font-bold tabular-nums ${isComplete ? "text-widget-timer" : "text-fg"}`}
+              >
+                {displayTime}
+              </span>
+              <span className="text-[10px] font-mono uppercase tracking-wider text-widget-timer/70">
+                {state.mode === "pomodoro" ? "Pomodoro" : state.mode === "countdown" ? "Countdown" : "Stopwatch"}
+              </span>
+            </div>
           </div>
           <div className="flex gap-1">
             {isComplete ? (
@@ -499,42 +525,44 @@ export function Timer({ compact }: TimerProps) {
       />
 
       {/* Display */}
-      <div className="flex flex-col items-center">
-        {isCountdown ? (
-          <CircularProgress
-            progress={progress}
-            size={160}
-            strokeWidth={4}
-            running={isRunning}
-          >
-            <span
-              className={`text-2xl font-mono font-bold tabular-nums ${isComplete ? "text-widget-timer" : "text-fg"}`}
+      <div className="rounded-2xl border border-widget-timer/15 bg-widget-timer/[0.04] px-4 py-5 shadow-[inset_0_1px_0_0_rgba(245,158,11,0.08)]">
+        <div className="flex flex-col items-center">
+          {isCountdown ? (
+            <CircularProgress
+              progress={progress}
+              size={160}
+              strokeWidth={4}
+              running={isRunning}
             >
-              {displayTime}
-            </span>
-            {state.mode === "pomodoro" && (
-              <span className="text-[11px] font-mono text-fg-2 mt-1">
-                Session {state.completedSessions + 1}
-              </span>
-            )}
-          </CircularProgress>
-        ) : (
-          <div className="text-center py-4">
-            <div className="flex items-center justify-center gap-2">
-              {isRunning && (
-                <div
-                  className="w-2 h-2 rounded-full bg-widget-timer"
-                  style={{
-                    animation: "widget-pulse 1.5s ease-in-out infinite",
-                  }}
-                />
-              )}
-              <span className="text-3xl font-mono font-bold text-fg tabular-nums">
+              <span
+                className={`text-2xl font-mono font-bold tabular-nums ${isComplete ? "text-widget-timer" : "text-fg"}`}
+              >
                 {displayTime}
               </span>
+              {state.mode === "pomodoro" && (
+                <span className="text-[11px] font-mono text-fg-2 mt-1">
+                  Session {state.completedSessions + 1}
+                </span>
+              )}
+            </CircularProgress>
+          ) : (
+            <div className="text-center py-4">
+              <div className="flex items-center justify-center gap-2">
+                {isRunning && (
+                  <div
+                    className="w-2 h-2 rounded-full bg-widget-timer"
+                    style={{
+                      animation: "widget-pulse 1.5s ease-in-out infinite",
+                    }}
+                  />
+                )}
+                <span className="text-3xl font-mono font-bold text-fg tabular-nums">
+                  {displayTime}
+                </span>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       {/* Controls */}
@@ -556,7 +584,7 @@ export function Timer({ compact }: TimerProps) {
                   Short Break
                 </button>
                 {state.completedSessions > 0 &&
-                  state.completedSessions % 4 === 0 && (
+                  state.completedSessions % pomodoroTiming.longBreakEvery === 0 && (
                     <button
                       onClick={() => startBreak(true)}
                       className="text-xs font-mono text-fg px-4 py-2 rounded-full bg-surface-2 border border-edge hover:border-edge-2 transition-colors"

--- a/desktop/src/widgets/timer/pomodoro.test.ts
+++ b/desktop/src/widgets/timer/pomodoro.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_TIMER_POMODORO } from "../../preferences";
+import { getPomodoroTiming, reconcileIdlePomodoroTarget } from "./pomodoro";
+import type { TimerState } from "./types";
+
+describe("getPomodoroTiming", () => {
+  it("derives Pomodoro seconds and cadence from configured prefs", () => {
+    const timing = getPomodoroTiming({
+      workMins: 40,
+      shortBreakMins: 7,
+      longBreakMins: 20,
+      longBreakEvery: 3,
+    });
+
+    expect(timing).toEqual({
+      workSecs: 2400,
+      shortBreakSecs: 420,
+      longBreakSecs: 1200,
+      longBreakEvery: 3,
+    });
+  });
+
+  it("falls back to defaults for invalid values", () => {
+    const timing = getPomodoroTiming({
+      workMins: 0,
+      shortBreakMins: Number.NaN,
+      longBreakMins: -5,
+      longBreakEvery: 0,
+    });
+
+    expect(timing).toEqual({
+      workSecs: DEFAULT_TIMER_POMODORO.workMins * 60,
+      shortBreakSecs: DEFAULT_TIMER_POMODORO.shortBreakMins * 60,
+      longBreakSecs: DEFAULT_TIMER_POMODORO.longBreakMins * 60,
+      longBreakEvery: DEFAULT_TIMER_POMODORO.longBreakEvery,
+    });
+  });
+});
+
+describe("reconcileIdlePomodoroTarget", () => {
+  const idlePomodoro: TimerState = {
+    mode: "pomodoro",
+    startedAt: null,
+    bankedMs: 0,
+    targetSecs: 1500,
+    completedSessions: 2,
+  };
+
+  it("updates an idle Pomodoro target to the configured work duration", () => {
+    expect(reconcileIdlePomodoroTarget(idlePomodoro, 2400)).toEqual({
+      ...idlePomodoro,
+      targetSecs: 2400,
+    });
+  });
+
+  it("preserves running or partially elapsed Pomodoro timers", () => {
+    expect(
+      reconcileIdlePomodoroTarget(
+        { ...idlePomodoro, startedAt: 123, targetSecs: 1500 },
+        2400,
+      ),
+    ).toEqual({ ...idlePomodoro, startedAt: 123, targetSecs: 1500 });
+
+    expect(
+      reconcileIdlePomodoroTarget(
+        { ...idlePomodoro, bankedMs: 1000, targetSecs: 1500 },
+        2400,
+      ),
+    ).toEqual({ ...idlePomodoro, bankedMs: 1000, targetSecs: 1500 });
+  });
+
+  it("preserves Countdown and Stopwatch targets", () => {
+    expect(
+      reconcileIdlePomodoroTarget(
+        { ...idlePomodoro, mode: "countdown", targetSecs: 300 },
+        2400,
+      ),
+    ).toEqual({ ...idlePomodoro, mode: "countdown", targetSecs: 300 });
+
+    expect(
+      reconcileIdlePomodoroTarget(
+        { ...idlePomodoro, mode: "stopwatch", targetSecs: 0 },
+        2400,
+      ),
+    ).toEqual({ ...idlePomodoro, mode: "stopwatch", targetSecs: 0 });
+  });
+});

--- a/desktop/src/widgets/timer/pomodoro.ts
+++ b/desktop/src/widgets/timer/pomodoro.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_TIMER_POMODORO } from "../../preferences";
+import type { TimerPomodoroConfig } from "../../preferences";
+import type { TimerState } from "./types";
+
+export interface PomodoroTiming {
+  workSecs: number;
+  shortBreakSecs: number;
+  longBreakSecs: number;
+  longBreakEvery: number;
+}
+
+function positiveNumber(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function getPomodoroTiming(config: TimerPomodoroConfig): PomodoroTiming {
+  return {
+    workSecs: positiveNumber(config.workMins, DEFAULT_TIMER_POMODORO.workMins) * 60,
+    shortBreakSecs: positiveNumber(config.shortBreakMins, DEFAULT_TIMER_POMODORO.shortBreakMins) * 60,
+    longBreakSecs: positiveNumber(config.longBreakMins, DEFAULT_TIMER_POMODORO.longBreakMins) * 60,
+    longBreakEvery: positiveNumber(config.longBreakEvery, DEFAULT_TIMER_POMODORO.longBreakEvery),
+  };
+}
+
+export function reconcileIdlePomodoroTarget(
+  state: TimerState,
+  workSecs: number,
+): TimerState {
+  if (
+    state.mode !== "pomodoro" ||
+    state.startedAt !== null ||
+    state.bankedMs !== 0 ||
+    state.targetSecs === workSecs
+  ) {
+    return state;
+  }
+
+  return { ...state, targetSecs: workSecs };
+}

--- a/desktop/src/widgets/timer/types.ts
+++ b/desktop/src/widgets/timer/types.ts
@@ -1,0 +1,9 @@
+export type TimerMode = "pomodoro" | "countdown" | "stopwatch";
+
+export interface TimerState {
+  mode: TimerMode;
+  startedAt: number | null;
+  bankedMs: number;
+  targetSecs: number;
+  completedSessions: number;
+}

--- a/docs/superpowers/plans/2026-05-13-clock-timer-widget-split.md
+++ b/docs/superpowers/plans/2026-05-13-clock-timer-widget-split.md
@@ -1,0 +1,935 @@
+# Clock Timer Widget Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the combined desktop Clock widget into independent Clock and Timer widgets with separate config, ticker data, preferences, and refined UI.
+
+**Architecture:** Keep Clock in `desktop/src/widgets/clock/` and move Timer into `desktop/src/widgets/timer/`. Add timer-owned preferences and ticker data while migrating existing `clock.pomodoro`, `clock.ticker.activeTimer`, and runtime timer state without data loss.
+
+**Tech Stack:** React 19, TypeScript, Vite 7, TanStack Router, Tailwind v4, Tauri plugin-store.
+
+---
+
+## File Structure
+
+- Modify `desktop/src/preferences.ts`: add timer preference interfaces/defaults, remove timer ownership from Clock, migrate legacy clock timer settings into `widgets.timer`.
+- Modify `desktop/src/types/index.ts`: add `timer` to `WidgetTickerData` so clock and timer ticker chips are independently owned.
+- Modify `desktop/src/hooks/useWidgetTickerData.ts`: split clock chip building from timer chip building and return timer data under `timer`.
+- Modify `desktop/src/widgets/registry.ts`: add `timer` to canonical widget order.
+- Modify `desktop/src/widgets/WidgetConfigPanel.tsx`: route `timer` to a new Timer config panel.
+- Modify `desktop/src/widgets/clock/FeedTab.tsx`: remove internal clock/timer tabs and expose only Clock feed behavior.
+- Modify `desktop/src/widgets/clock/ConfigPanel.tsx`: remove Pomodoro and active-timer settings from Clock.
+- Modify `desktop/src/widgets/clock/types.ts`: remove `ClockTab`; keep shared time-related Clock types only.
+- Modify `desktop/src/widgets/clock/WorldClock.tsx`: polish Clock comfort/compact UI without Timer-specific behavior.
+- Create `desktop/src/widgets/timer/FeedTab.tsx`: Timer widget manifest and feed shell.
+- Create `desktop/src/widgets/timer/ConfigPanel.tsx`: Timer settings panel.
+- Move/create `desktop/src/widgets/timer/Timer.tsx`: Timer component implementation.
+- Create `desktop/src/widgets/timer/types.ts`: Timer mode/state types.
+
+---
+
+### Task 1: Add Timer-Owned Preferences
+
+**Files:**
+- Modify: `desktop/src/preferences.ts`
+
+- [ ] **Step 1: Add timer preference interfaces next to clock interfaces**
+
+Replace the current clock timer-owned interfaces around `ClockTickerConfig`, `ClockPomodoroConfig`, and `ClockWidgetConfig` with this shape:
+
+```ts
+export interface ClockTickerConfig {
+  localTime: boolean;
+  /** Whether to show world clocks on the ticker at all (default false). */
+  showTimezones: boolean;
+  /** Timezone IANA IDs excluded from the ticker (empty = all configured TZs shown). */
+  excludedTimezones: string[];
+}
+
+export interface ClockWidgetConfig {
+  ticker: ClockTickerConfig;
+}
+
+export interface TimerTickerConfig {
+  activeTimer: boolean;
+}
+
+export interface TimerPomodoroConfig {
+  workMins: number;
+  shortBreakMins: number;
+  longBreakMins: number;
+  longBreakEvery: number;
+}
+
+export interface TimerWidgetConfig {
+  ticker: TimerTickerConfig;
+  pomodoro: TimerPomodoroConfig;
+}
+```
+
+- [ ] **Step 2: Add `timer` to `WidgetPrefs`**
+
+Change the `WidgetPrefs` interface so the widget section includes timer as a peer:
+
+```ts
+export interface WidgetPrefs {
+  /** Widget IDs that are enabled (shown in sidebar and feed tabs). */
+  enabledWidgets: string[];
+  /** Widget IDs whose data appears on the ticker. Subset of enabledWidgets. */
+  widgetsOnTicker: string[];
+  /** Per-widget pin state: removes the chip from the scrolling ticker and
+   *  places it as a static element on the chosen side. Keyed by widget ID. */
+  pinnedWidgets: Record<string, WidgetPinConfig>;
+  clock: ClockWidgetConfig;
+  timer: TimerWidgetConfig;
+  weather: WeatherWidgetConfig;
+  sysmon: SysmonWidgetConfig;
+  uptime: UptimeWidgetConfig;
+  github: GitHubWidgetConfig;
+}
+```
+
+- [ ] **Step 3: Replace defaults with clock-only and timer-owned defaults**
+
+Use these defaults:
+
+```ts
+export const DEFAULT_CLOCK_TICKER: ClockTickerConfig = {
+  localTime: true,
+  showTimezones: false,
+  excludedTimezones: [],
+};
+
+export const DEFAULT_TIMER_TICKER: TimerTickerConfig = {
+  activeTimer: true,
+};
+
+export const DEFAULT_TIMER_POMODORO: TimerPomodoroConfig = {
+  workMins: 25,
+  shortBreakMins: 5,
+  longBreakMins: 15,
+  longBreakEvery: 4,
+};
+```
+
+- [ ] **Step 4: Add timer to `DEFAULT_WIDGETS`**
+
+Make the default widget config section look like this:
+
+```ts
+const DEFAULT_WIDGETS: WidgetPrefs = {
+  enabledWidgets: [],
+  widgetsOnTicker: [],
+  pinnedWidgets: {},
+  clock: {
+    ticker: { ...DEFAULT_CLOCK_TICKER },
+  },
+  timer: {
+    ticker: { ...DEFAULT_TIMER_TICKER },
+    pomodoro: { ...DEFAULT_TIMER_POMODORO },
+  },
+  weather: {
+    ticker: { ...DEFAULT_WEATHER_TICKER },
+  },
+  sysmon: {
+    refreshInterval: 2,
+    tempUnit: "celsius",
+    ticker: { ...DEFAULT_SYSMON_TICKER },
+  },
+  uptime: {
+    url: "",
+    pollInterval: 60,
+    ticker: { ...DEFAULT_UPTIME_TICKER },
+  },
+  github: {
+    repos: [],
+    pollInterval: 120,
+    ticker: { ...DEFAULT_GITHUB_TICKER },
+  },
+};
+```
+
+- [ ] **Step 5: Migrate saved timer prefs in `mergeWidgetPrefs`**
+
+Inside `mergeWidgetPrefs`, add `tmr` and build timer from either saved timer prefs or legacy clock prefs:
+
+```ts
+const clk = obj(saved.clock);
+const tmr = obj(saved.timer);
+const wth = obj(saved.weather);
+const sys = obj(saved.sysmon);
+const upt = obj(saved.uptime);
+const ghb = obj(saved.github);
+const legacyClockTicker = obj(clk?.ticker);
+```
+
+Then return clock and timer like this:
+
+```ts
+clock: {
+  ticker: { ...DEFAULT_CLOCK_TICKER, ...legacyClockTicker },
+},
+timer: {
+  ticker: {
+    ...DEFAULT_TIMER_TICKER,
+    activeTimer:
+      typeof obj(tmr?.ticker)?.activeTimer === "boolean"
+        ? Boolean(obj(tmr?.ticker)?.activeTimer)
+        : typeof legacyClockTicker?.activeTimer === "boolean"
+          ? Boolean(legacyClockTicker.activeTimer)
+          : DEFAULT_TIMER_TICKER.activeTimer,
+  },
+  pomodoro: {
+    ...DEFAULT_TIMER_POMODORO,
+    ...obj(clk?.pomodoro),
+    ...obj(tmr?.pomodoro),
+  },
+},
+```
+
+After this edit, remove any references to `ClockPomodoroConfig` and `DEFAULT_CLOCK_POMODORO` from `preferences.ts`.
+
+- [ ] **Step 6: Run TypeScript build to expose dependent errors**
+
+Run: `npm run build`
+
+Working directory: `desktop/`
+
+Expected: FAIL with TypeScript errors in clock config, widget ticker data, and timer imports because the rest of the split has not been implemented yet.
+
+- [ ] **Step 7: Commit preference migration**
+
+```bash
+git add desktop/src/preferences.ts
+git commit -m "refactor(desktop): add timer widget preferences"
+```
+
+---
+
+### Task 2: Split Clock And Timer Ticker Data
+
+**Files:**
+- Modify: `desktop/src/types/index.ts`
+- Modify: `desktop/src/hooks/useWidgetTickerData.ts`
+
+- [ ] **Step 1: Add `timer` to widget ticker data**
+
+In `desktop/src/types/index.ts`, update `WidgetTickerData`:
+
+```ts
+export interface WidgetTickerData {
+  clock: ClockChipData[];
+  timer: ClockChipData[];
+  weather: WeatherChipData[];
+  sysmon: SysmonChipData[];
+  uptime: UptimeChipData[];
+  github: GitHubChipData[];
+}
+```
+
+- [ ] **Step 2: Update empty ticker data**
+
+In `desktop/src/hooks/useWidgetTickerData.ts`, change `EMPTY`:
+
+```ts
+const EMPTY: WidgetTickerData = { clock: [], timer: [], weather: [], sysmon: [], uptime: [], github: [] };
+```
+
+- [ ] **Step 3: Split `buildClockChips` so it only builds clocks**
+
+Replace the existing `buildClockChips` with:
+
+```ts
+const buildClockChips = useCallback((): ClockChipData[] => {
+  if (!enabledWidgets.has("clock")) return [];
+  const cfg = widgetPrefs.clock;
+  const chips: ClockChipData[] = [];
+  const now = new Date();
+  const format = getStore<string>(LS_CLOCK_FORMAT, "12h");
+
+  if (cfg.ticker.localTime) {
+    chips.push({
+      id: "clock-local",
+      kind: "clock",
+      label: "Local",
+      value: formatTime(now, undefined, format),
+      detail: formatDetail(now, undefined),
+    });
+  }
+
+  if (cfg.ticker.showTimezones) {
+    const tzs = getStore<string[]>(LS_CLOCK_TIMEZONES, []);
+    for (const tz of Array.isArray(tzs) ? tzs : []) {
+      if (cfg.ticker.excludedTimezones.includes(tz)) continue;
+      chips.push({
+        id: `clock-${tz}`,
+        kind: "clock",
+        label: tzShortLabel(tz),
+        value: formatTime(now, tz, format),
+        detail: formatDetail(now, tz),
+      });
+    }
+  }
+
+  return chips;
+}, [widgetPrefs.clock, enabledWidgets]);
+```
+
+- [ ] **Step 4: Add `buildTimerChips`**
+
+Add this directly after `buildClockChips`:
+
+```ts
+const buildTimerChips = useCallback((): ClockChipData[] => {
+  if (!enabledWidgets.has("timer")) return [];
+  if (!widgetPrefs.timer.ticker.activeTimer) return [];
+
+  const state = getStore<TimerState | null>(LS_TIMER_STATE, null);
+  if (!state) return [];
+
+  const chip = getTimerChipData(state);
+  return chip ? [chip] : [];
+}, [widgetPrefs.timer, enabledWidgets]);
+```
+
+- [ ] **Step 5: Include timer in the returned ticker data**
+
+In the effect that calls all builders, set `timer: buildTimerChips()` next to `clock: buildClockChips()`:
+
+```ts
+setData({
+  clock: buildClockChips(),
+  timer: buildTimerChips(),
+  weather: buildWeatherChips(),
+  sysmon: buildSysmonChips(),
+  uptime: buildUptimeChips(),
+  github: buildGitHubChips(),
+});
+```
+
+Add `buildTimerChips` to that effect's dependency list.
+
+- [ ] **Step 6: Keep timer state store subscriptions**
+
+Keep `LS_TIMER_STATE` in the store-change listener list in `useWidgetTickerData.ts`. This keeps timer ticker chips updating when Timer writes runtime state.
+
+- [ ] **Step 7: Run TypeScript build**
+
+Run: `npm run build`
+
+Working directory: `desktop/`
+
+Expected: FAIL only on remaining widget split/config import errors. There should be no `WidgetTickerData` missing-property error.
+
+- [ ] **Step 8: Commit ticker split**
+
+```bash
+git add desktop/src/types/index.ts desktop/src/hooks/useWidgetTickerData.ts
+git commit -m "refactor(desktop): split timer ticker data from clock"
+```
+
+---
+
+### Task 3: Create Independent Timer Widget Module
+
+**Files:**
+- Create: `desktop/src/widgets/timer/types.ts`
+- Create: `desktop/src/widgets/timer/Timer.tsx`
+- Create: `desktop/src/widgets/timer/FeedTab.tsx`
+- Create: `desktop/src/widgets/timer/ConfigPanel.tsx`
+- Modify: `desktop/src/widgets/registry.ts`
+- Modify: `desktop/src/widgets/WidgetConfigPanel.tsx`
+- Modify: `desktop/src/widgets/clock/types.ts`
+- Modify: `desktop/src/widgets/clock/FeedTab.tsx`
+
+- [ ] **Step 1: Create timer types**
+
+Create `desktop/src/widgets/timer/types.ts`:
+
+```ts
+export type TimerMode = "pomodoro" | "countdown" | "stopwatch";
+
+export interface TimerState {
+  mode: TimerMode;
+  startedAt: number | null;
+  bankedMs: number;
+  targetSecs: number;
+  completedSessions: number;
+}
+```
+
+- [ ] **Step 2: Move Timer implementation**
+
+Move the current contents of `desktop/src/widgets/clock/Timer.tsx` into `desktop/src/widgets/timer/Timer.tsx` and update imports:
+
+```ts
+import { useState, useEffect, useCallback, useRef } from "react";
+import { LS_TIMER_STATE } from "../../constants";
+import { getStore, setStore } from "../../lib/store";
+import type { TimerMode, TimerState } from "./types";
+```
+
+Replace the hard-coded `TIMER_KEY` constant with:
+
+```ts
+const TIMER_KEY = LS_TIMER_STATE;
+```
+
+- [ ] **Step 3: Remove timer types from clock types**
+
+Change `desktop/src/widgets/clock/types.ts` to contain only:
+
+```ts
+export type TimeFormat = "12h" | "24h";
+
+export interface TimezoneEntry {
+  tz: string;
+  label: string;
+  region: string;
+}
+```
+
+- [ ] **Step 4: Update ticker data type import**
+
+In `desktop/src/hooks/useWidgetTickerData.ts`, change the timer type import:
+
+```ts
+import type { TimerState } from "../widgets/timer/types";
+```
+
+- [ ] **Step 5: Create Timer feed manifest**
+
+Create `desktop/src/widgets/timer/FeedTab.tsx`:
+
+```tsx
+import { TimerReset } from "lucide-react";
+import { Timer } from "./Timer";
+import type { FeedTabProps, WidgetManifest } from "../../types";
+
+export const timerWidget: WidgetManifest = {
+  id: "timer",
+  name: "Timer",
+  tabLabel: "Timer",
+  description: "Pomodoro, countdown, and stopwatch tools",
+  hex: "#f59e0b",
+  icon: TimerReset,
+  info: {
+    about:
+      "The Timer widget provides Pomodoro sessions, countdown timers, and a stopwatch as a focused desktop control surface.",
+    usage: [
+      "Choose Pomodoro, Countdown, or Stopwatch from the mode selector.",
+      "Use Space to start or pause and R to reset while the timer feed is focused.",
+      "Enable active timer ticker output in the Configure tab.",
+      "Adjust Pomodoro session lengths and long-break cadence in Configure.",
+    ],
+  },
+  FeedTab: TimerFeedTab,
+};
+
+function TimerFeedTab({ mode }: FeedTabProps) {
+  return (
+    <div className="p-3">
+      <Timer compact={mode === "compact"} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Create Timer config panel**
+
+Create `desktop/src/widgets/timer/ConfigPanel.tsx`:
+
+```tsx
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SegmentedRow,
+  SliderRow,
+} from "../../components/settings/SettingsControls";
+import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { DEFAULT_TIMER_TICKER, DEFAULT_TIMER_POMODORO } from "../../preferences";
+import type { TimerPomodoroConfig } from "../../preferences";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+
+const LONG_BREAK_OPTIONS = [
+  { value: "2", label: "2" },
+  { value: "3", label: "3" },
+  { value: "4", label: "4" },
+  { value: "5", label: "5" },
+  { value: "6", label: "6" },
+];
+
+export default function TimerConfigPanel({
+  prefs,
+  onPrefsChange,
+}: WidgetConfigPanelProps) {
+  const { config, update, setTicker } = useWidgetConfig("timer", prefs, onPrefsChange);
+
+  const setPomodoro = useCallback(
+    (patch: Partial<TimerPomodoroConfig>) => {
+      update({ pomodoro: { ...config.pomodoro, ...patch } });
+    },
+    [update, config.pomodoro],
+  );
+
+  const resetAll = useCallback(() => {
+    update({
+      ticker: { ...DEFAULT_TIMER_TICKER },
+      pomodoro: { ...DEFAULT_TIMER_POMODORO },
+    });
+  }, [update]);
+
+  const timerIcon = (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-timer)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 2h4" />
+      <path d="M12 14l3-3" />
+      <circle cx="12" cy="14" r="8" />
+    </svg>
+  );
+
+  return (
+    <ConfigPanelLayout
+      icon={timerIcon}
+      hex="var(--color-widget-timer)"
+      title="Timer Settings"
+      subtitle="Pomodoro, countdown, and stopwatch"
+      onReset={resetAll}
+    >
+      <Section title="Ticker">
+        <ToggleRow
+          label="Active timer"
+          description="Show running or paused timers on the scrolling ticker"
+          checked={config.ticker.activeTimer}
+          onChange={(v) => setTicker({ activeTimer: v })}
+        />
+        <TickerPinSection widgetId="timer" prefs={prefs} onPrefsChange={onPrefsChange} />
+      </Section>
+
+      <Section title="Pomodoro">
+        <SliderRow
+          label="Work session"
+          value={config.pomodoro.workMins}
+          min={10}
+          max={60}
+          step={5}
+          displayValue={`${config.pomodoro.workMins} min`}
+          onChange={(v) => setPomodoro({ workMins: v })}
+        />
+        <SliderRow
+          label="Short break"
+          value={config.pomodoro.shortBreakMins}
+          min={1}
+          max={15}
+          step={1}
+          displayValue={`${config.pomodoro.shortBreakMins} min`}
+          onChange={(v) => setPomodoro({ shortBreakMins: v })}
+        />
+        <SliderRow
+          label="Long break"
+          value={config.pomodoro.longBreakMins}
+          min={5}
+          max={30}
+          step={5}
+          displayValue={`${config.pomodoro.longBreakMins} min`}
+          onChange={(v) => setPomodoro({ longBreakMins: v })}
+        />
+        <SegmentedRow
+          label="Long break every"
+          description="Sessions before a long break"
+          value={String(config.pomodoro.longBreakEvery)}
+          options={LONG_BREAK_OPTIONS}
+          onChange={(v) => setPomodoro({ longBreakEvery: Number(v) })}
+        />
+      </Section>
+    </ConfigPanelLayout>
+  );
+}
+```
+
+- [ ] **Step 7: Route Timer config panel**
+
+In `desktop/src/widgets/WidgetConfigPanel.tsx`, add the import:
+
+```ts
+import TimerConfigPanel from "./timer/ConfigPanel";
+```
+
+Add the switch case after `clock`:
+
+```tsx
+case "timer":
+  return (
+    <TimerConfigPanel prefs={prefs} onPrefsChange={onPrefsChange} />
+  );
+```
+
+- [ ] **Step 8: Register Timer as a peer widget**
+
+In `desktop/src/widgets/registry.ts`, update order:
+
+```ts
+["clock", "timer", "weather", "sysmon", "uptime", "github"],
+```
+
+- [ ] **Step 9: Replace Clock feed with clock-only manifest**
+
+Replace `desktop/src/widgets/clock/FeedTab.tsx` with:
+
+```tsx
+import { Clock } from "lucide-react";
+import { WorldClock } from "./WorldClock";
+import type { FeedTabProps, WidgetManifest } from "../../types";
+
+export const clockWidget: WidgetManifest = {
+  id: "clock",
+  name: "Clock",
+  tabLabel: "Clock",
+  description: "Local time and world clocks",
+  hex: "#6366f1",
+  icon: Clock,
+  info: {
+    about:
+      "The Clock widget displays your local time and world clocks for tracking multiple time zones.",
+    usage: [
+      "Your local time appears in the Clock feed and can appear on the ticker.",
+      "Add world clocks from the feed view to track more time zones.",
+      "Turn on world clocks in Configure to include selected time zones on the ticker.",
+      "Use the 12h/24h control to change clock formatting.",
+    ],
+  },
+  FeedTab: ClockFeedTab,
+};
+
+function ClockFeedTab({ mode }: FeedTabProps) {
+  return (
+    <div className="p-3">
+      <WorldClock compact={mode === "compact"} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 10: Remove old clock timer file**
+
+Delete `desktop/src/widgets/clock/Timer.tsx` after `desktop/src/widgets/timer/Timer.tsx` exists and imports have been updated.
+
+- [ ] **Step 11: Run TypeScript build**
+
+Run: `npm run build`
+
+Working directory: `desktop/`
+
+Expected: FAIL only on Clock config references to removed timer settings, or PASS if Task 4 has already been done in the same branch.
+
+- [ ] **Step 12: Commit widget module split**
+
+```bash
+git add desktop/src/widgets desktop/src/hooks/useWidgetTickerData.ts desktop/src/types/index.ts
+git commit -m "refactor(desktop): split timer into its own widget"
+```
+
+---
+
+### Task 4: Make Clock Config Clock-Only
+
+**Files:**
+- Modify: `desktop/src/widgets/clock/ConfigPanel.tsx`
+
+- [ ] **Step 1: Remove timer-owned imports**
+
+Use these imports at the top:
+
+```tsx
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SegmentedRow,
+} from "../../components/settings/SettingsControls";
+import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { useTickerExclusion } from "../../hooks/useTickerExclusion";
+import { useStoreData } from "../../hooks/useStoreData";
+import { setStore } from "../../lib/store";
+import { DEFAULT_CLOCK_TICKER } from "../../preferences";
+import { LS_CLOCK_FORMAT, LS_CLOCK_TIMEZONES } from "../../constants";
+import { loadTimezones, loadFormat, tzLabel } from "./storage";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+```
+
+- [ ] **Step 2: Remove Pomodoro state/update logic**
+
+Delete `LONG_BREAK_OPTIONS`, the `ClockPomodoroConfig` type import, and the `setPomodoro` callback.
+
+- [ ] **Step 3: Reset only clock settings**
+
+Use this `resetAll` callback:
+
+```ts
+const resetAll = useCallback(() => {
+  update({
+    ticker: { ...DEFAULT_CLOCK_TICKER },
+  });
+  setStore(LS_CLOCK_FORMAT, "12h");
+  setFormatState("12h");
+}, [update]);
+```
+
+- [ ] **Step 4: Update panel copy**
+
+Use this layout header:
+
+```tsx
+<ConfigPanelLayout
+  icon={clockIcon}
+  hex="var(--color-widget-clock)"
+  title="Clock Settings"
+  subtitle="Local time and world clocks"
+  onReset={resetAll}
+>
+```
+
+- [ ] **Step 5: Remove Active Timer and Pomodoro sections**
+
+Keep only the Ticker section with time format, local time, show world clocks, timezone toggles, and clock pin section:
+
+```tsx
+<Section title="Ticker">
+  <SegmentedRow
+    label="Time format"
+    description="12-hour or 24-hour clock"
+    value={format}
+    options={FORMAT_OPTIONS}
+    onChange={handleFormatChange}
+  />
+  <ToggleRow
+    label="Local time"
+    description="Show your local clock on the scrolling ticker"
+    checked={config.ticker.localTime}
+    onChange={(v) => setTicker({ localTime: v })}
+  />
+  <ToggleRow
+    label="Show world clocks"
+    description="Include configured timezones on the ticker"
+    checked={config.ticker.showTimezones}
+    onChange={(v) => setTicker({ showTimezones: v })}
+  />
+  {config.ticker.showTimezones && timezones.map((tz) => (
+    <ToggleRow
+      key={tz}
+      label={tzLabel(tz)}
+      checked={!isTimezoneExcluded(tz)}
+      onChange={() => toggleTimezone(tz)}
+    />
+  ))}
+  {config.ticker.showTimezones && timezones.length === 0 && (
+    <div className="px-3 py-2.5 text-[11px] text-fg-4">
+      Add world clocks in the Clock tab to see them here.
+    </div>
+  )}
+  <TickerPinSection widgetId="clock" prefs={prefs} onPrefsChange={onPrefsChange} />
+</Section>
+```
+
+- [ ] **Step 6: Run TypeScript build**
+
+Run: `npm run build`
+
+Working directory: `desktop/`
+
+Expected: PASS if Tasks 1-3 are complete and no UI polish task has introduced errors.
+
+- [ ] **Step 7: Commit clock config cleanup**
+
+```bash
+git add desktop/src/widgets/clock/ConfigPanel.tsx
+git commit -m "refactor(desktop): make clock config clock-only"
+```
+
+---
+
+### Task 5: Polish Clock And Timer Feed UI
+
+**Files:**
+- Modify: `desktop/src/widgets/clock/WorldClock.tsx`
+- Modify: `desktop/src/widgets/timer/Timer.tsx`
+
+- [ ] **Step 1: Make Clock feed feel dashboard-like**
+
+In `WorldClock.tsx`, keep the existing state/storage logic. Adjust `ClockCard` comfort-mode classes so the local card is the hero card and world clock cards are quieter:
+
+```tsx
+className={
+  "group relative overflow-hidden px-4 py-3 rounded-xl border transition-colors " +
+  (isLocal
+    ? "bg-widget-clock/[0.07] border-widget-clock/25 shadow-[inset_0_1px_0_0_rgba(99,102,241,0.12)]"
+    : "bg-surface-2/70 border-widget-clock/10 hover:border-widget-clock/25")
+}
+```
+
+For the local card, render the local badge and offset exactly as it does now, but ensure the main time remains the largest visual element:
+
+```tsx
+<div className={isLocal ? "text-2xl font-mono font-bold text-fg tabular-nums leading-none" : "text-xl font-mono font-bold text-fg tabular-nums leading-none"}>
+  {time}
+</div>
+```
+
+- [ ] **Step 2: Make Clock compact rows match other widget rows**
+
+In compact `ClockCard`, use this row class:
+
+```tsx
+className="group flex items-center justify-between px-3 py-2 rounded-lg bg-widget-clock/[0.04] border border-widget-clock/10 hover:border-widget-clock/25 transition-colors"
+```
+
+Keep the existing remove button, offset, label, and time behavior.
+
+- [ ] **Step 3: Keep Clock picker empty states explicit**
+
+Verify `WorldClock.tsx` still renders these strings unchanged:
+
+```tsx
+{search ? "No matching cities" : "All timezones added"}
+```
+
+- [ ] **Step 4: Make Timer compact card include mode label**
+
+In `Timer.tsx` compact mode, add a small mode label next to the display time:
+
+```tsx
+<div className="flex flex-col min-w-0">
+  <span className="text-[10px] font-mono uppercase tracking-wider text-widget-timer/70">
+    {state.mode === "pomodoro" ? "Pomodoro" : state.mode === "countdown" ? "Countdown" : "Stopwatch"}
+  </span>
+  <span
+    className={`text-lg font-mono font-bold tabular-nums ${isComplete ? "text-widget-timer" : "text-fg"}`}
+  >
+    {displayTime}
+  </span>
+</div>
+```
+
+- [ ] **Step 5: Wrap Timer comfort display in an active card**
+
+In `Timer.tsx` comfort mode, wrap the display section in this shell:
+
+```tsx
+<div className="rounded-2xl border border-widget-timer/15 bg-widget-timer/[0.04] px-4 py-5 shadow-[inset_0_1px_0_0_rgba(245,158,11,0.08)]">
+  <div className="flex flex-col items-center">
+    {/* existing circular progress or stopwatch display */}
+  </div>
+</div>
+```
+
+Do not change timer behavior in this step.
+
+- [ ] **Step 6: Run TypeScript build**
+
+Run: `npm run build`
+
+Working directory: `desktop/`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit feed UI polish**
+
+```bash
+git add desktop/src/widgets/clock/WorldClock.tsx desktop/src/widgets/timer/Timer.tsx
+git commit -m "style(desktop): refine clock and timer widget UI"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- Verify: `desktop/src/widgets/registry.ts`
+- Verify: `desktop/src/widgets/WidgetConfigPanel.tsx`
+- Verify: `desktop/src/hooks/useWidgetTickerData.ts`
+- Verify: `desktop/src/preferences.ts`
+- Verify: `desktop/src/widgets/clock/FeedTab.tsx`
+- Verify: `desktop/src/widgets/timer/FeedTab.tsx`
+
+- [ ] **Step 1: Run desktop build**
+
+Run: `npm run build`
+
+Working directory: `desktop/`
+
+Expected: PASS with Vite build output and `tsc --noEmit` completing successfully.
+
+- [ ] **Step 2: Search for legacy combined-widget references**
+
+Run: `rg "ClockTab|clock/Timer|activeTimer|DEFAULT_CLOCK_POMODORO|ClockPomodoroConfig|timer tab|timers" desktop/src`
+
+Expected: Only legitimate timer-owned references remain. There should be no `ClockTab`, no `clock/Timer`, no `DEFAULT_CLOCK_POMODORO`, no `ClockPomodoroConfig`, and no Clock widget copy claiming it owns timers.
+
+- [ ] **Step 3: Confirm registry/config ownership by reading exact files**
+
+Check that `desktop/src/widgets/registry.ts` contains:
+
+```ts
+["clock", "timer", "weather", "sysmon", "uptime", "github"],
+```
+
+Check that `desktop/src/widgets/WidgetConfigPanel.tsx` has both cases:
+
+```tsx
+case "clock":
+  return (
+    <ClockConfigPanel prefs={prefs} onPrefsChange={onPrefsChange} />
+  );
+case "timer":
+  return (
+    <TimerConfigPanel prefs={prefs} onPrefsChange={onPrefsChange} />
+  );
+```
+
+- [ ] **Step 4: Confirm ticker ownership by reading exact code**
+
+Check that `desktop/src/hooks/useWidgetTickerData.ts` returns independent arrays:
+
+```ts
+setData({
+  clock: buildClockChips(),
+  timer: buildTimerChips(),
+  weather: buildWeatherChips(),
+  sysmon: buildSysmonChips(),
+  uptime: buildUptimeChips(),
+  github: buildGitHubChips(),
+});
+```
+
+- [ ] **Step 5: Commit final verification cleanup if needed**
+
+If verification required fixes, commit them:
+
+```bash
+git add desktop/src
+git commit -m "fix(desktop): complete clock timer widget split"
+```
+
+If verification required no fixes, do not create an empty commit.
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Independent widget architecture is covered by Tasks 1, 3, and 4.
+- Clock UI direction is covered by Tasks 3, 4, and 5.
+- Timer UI direction is covered by Tasks 3 and 5.
+- Ticker ownership is covered by Task 2 and verified in Task 6.
+- Preference migration is covered by Task 1.
+- Error handling and empty states are preserved in Tasks 3 and 5.
+- Build/manual verification is covered by Task 6.
+
+Placeholder scan: no placeholder markers or unspecified implementation steps remain.
+
+Type consistency: timer preferences use `TimerTickerConfig`, `TimerPomodoroConfig`, and `TimerWidgetConfig`; runtime timer state uses `TimerState` from `desktop/src/widgets/timer/types.ts`; ticker data uses `WidgetTickerData.timer`.

--- a/docs/superpowers/specs/2026-05-13-clock-timer-widget-split-design.md
+++ b/docs/superpowers/specs/2026-05-13-clock-timer-widget-split-design.md
@@ -1,0 +1,140 @@
+# Clock And Timer Widget Split Design
+
+## Goal
+
+Split the current combined Clock widget into two independent desktop widgets: Clock and Timer. The split should follow the same widget ownership model as the rest of the desktop app, while improving the visual design and UI/UX of both widgets.
+
+Clock should feel calm, glanceable, and precise. Timer should feel focused, active, and tactile. They should remain visually consistent with the desktop app through shared surfaces, borders, mono typography, compact/comfort modes, and ticker chip behavior.
+
+## Architecture
+
+Clock remains in `desktop/src/widgets/clock/` and owns only local/world-clock behavior:
+
+- Local time display.
+- World clock timezone list.
+- Time format.
+- Clock ticker settings.
+- Clock config panel.
+
+Timer moves into its own `desktop/src/widgets/timer/` module and becomes a first-class widget with:
+
+- Its own `FeedTab` widget manifest.
+- Its own `ConfigPanel`.
+- Its own widget preferences.
+- Its own ticker settings.
+- Its own persisted runtime state.
+
+The widget registry should list Timer as a normal peer widget, for example `clock`, `timer`, `weather`, `sysmon`, `uptime`, `github`.
+
+Existing users should not lose settings. Preference loading should migrate existing `clock.pomodoro` into `timer.pomodoro`, and existing `clock.ticker.activeTimer` into `timer.ticker.activeTimer`. Existing timer runtime state should remain readable. If the current runtime state key is already represented by `LS_TIMER_STATE`, keep it and treat it as timer-owned going forward.
+
+## Clock UI
+
+Clock becomes a focused world-time dashboard.
+
+Comfort mode should lead with a stronger local-time card containing the current time, date, local timezone label, UTC offset, and subtle indigo emphasis. World clocks should appear below as clean cards showing city, region or offset, time, and date.
+
+Compact mode should stay dense: one local row followed by timezone rows. The timezone picker remains available in compact mode, but should use the same small bordered search-panel language used by other desktop widgets.
+
+Clock controls:
+
+- `12h` / `24h` toggle stays in the feed header area.
+- `+ Add` opens the timezone picker.
+- Timezone removal stays per row/card.
+- Clock config keeps ticker visibility and timezone inclusion settings.
+- Pomodoro and timer settings are removed from Clock config.
+
+Clock visual language:
+
+- Use `widget-clock` indigo as the accent.
+- Prefer quiet card entry and hover-border motion.
+- Use strong tabular mono time displays.
+- Avoid active/tactile timer styling.
+
+## Timer UI
+
+Timer becomes a focused control surface and keeps all current modes: Pomodoro, Countdown, and Stopwatch.
+
+Comfort mode should include:
+
+- A top mode selector for `Pomodoro`, `Countdown`, and `Stopwatch`.
+- A dominant central time display.
+- Circular progress for Pomodoro and Countdown.
+- A simpler count-up display for Stopwatch.
+- Clear primary action states: `Start`, `Pause`, `Resume`, or `Reset`.
+- Contextual secondary controls: countdown presets/custom input, Pomodoro break buttons, notification permission prompt, and keyboard hints.
+
+Compact mode should fit the widget feed without feeling cramped:
+
+- Keep a tighter mode selector.
+- Show one compact status card with running dot, display time, mode label, and primary action.
+- Show secondary controls only when relevant and not running, especially countdown presets/custom input.
+
+Timer config:
+
+- Ticker section controls whether active timers appear on the ticker.
+- Pomodoro section controls work session, short break, long break, and long-break cadence.
+- Clock/timezone settings do not appear in Timer config.
+
+Timer visual language:
+
+- Use `widget-timer` amber as the accent.
+- Make active states more tactile than Clock while staying inside the desktop surface/border/text system.
+- Avoid noisy animation. Running state may pulse; progress ring should animate stroke only.
+
+## Data And Ticker Behavior
+
+Ticker data should follow normal widget ownership rules.
+
+Clock ticker data:
+
+- Built only when `clock` is enabled on the ticker.
+- Uses `clock.ticker.localTime`, `clock.ticker.showTimezones`, and `clock.ticker.excludedTimezones`.
+- Emits only clock chips.
+- Uses `widget-clock` chip coloring.
+
+Timer ticker data:
+
+- Built only when `timer` is enabled on the ticker.
+- Uses `timer.ticker.activeTimer`.
+- Emits only one timer chip when a timer is running or paused with elapsed time.
+- Uses `widget-timer` chip coloring.
+
+Preference ownership:
+
+- `WidgetPrefs.clock` owns clock config only.
+- `WidgetPrefs.timer` owns timer config only.
+- Legacy clock-owned timer settings are migrated during preference load.
+
+## Error Handling And Empty States
+
+Clock should show clear empty/search states in the timezone picker:
+
+- No matching cities.
+- All preset timezones added.
+- Config helper text when timezone ticker display is enabled but no world clocks are available.
+
+Timer should preserve resilient behavior:
+
+- Web Audio failures are ignored safely.
+- Notification support and permission prompts remain guarded by feature detection.
+- Switching modes with active or banked time still asks for confirmation before reset.
+- Invalid custom countdown values should not start or save a timer.
+
+## Verification
+
+Run the desktop build after implementation:
+
+```sh
+npm run build
+```
+
+Manual verification should confirm:
+
+- Clock and Timer appear as separate widgets in the desktop widget registry and UI.
+- Clock feed no longer contains Timer tabs.
+- Timer feed works independently with Pomodoro, Countdown, and Stopwatch.
+- Clock config contains only clock settings.
+- Timer config contains timer ticker and Pomodoro settings.
+- Clock ticker chips and Timer ticker chips are independently controlled.
+- Existing Pomodoro settings and active timer state are preserved after migration.


### PR DESCRIPTION
## Summary
- Split the combined desktop Clock widget into independent Clock and Timer widgets with separate config, preferences, ticker data, and registry entries.
- Migrated legacy clock-owned timer settings and ticker visibility, including multi-row ticker assignments and disabled-ticker edge cases.
- Bumped the desktop app version to 1.0.18 and added focused tests for migration, ticker rendering, and Pomodoro timing behavior.

## Test Plan
- npm run build
- npm run test -- src/preferences.test.ts src/hooks/useTickerLayout.test.ts src/hooks/useWidgetTickerData.test.ts src/widgets/timer/pomodoro.test.ts src/components/ScrollrTicker.test.tsx