### PR TITLE
fix(deploy): bump Go Dockerfiles to 1.25 (post-Sentry rollout fix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ MyScrollr aggregates financial market data, sports scores, RSS feeds, and Yahoo 
 
 Monorepo — each component is independently deployable with its own dependencies:
 
-- `api/` — Core gateway API (Go 1.22, Fiber v2, sub-package `core/`)
+- `api/` — Core gateway API (Go 1.25, Fiber v2, sub-package `core/`)
 - `myscrollr.com/` — Marketing website + auth/billing (React 19, Vite 7, TanStack Router, Tailwind v4)
 - `desktop/` — Tauri v2 desktop app (React 19, Vite 7, TanStack Router + Query, Tailwind v4, Rust backend) — **primary product**
 - `channels/{finance,sports,rss}/api/` — Channel Go APIs (flat `main` package, independent modules)
@@ -110,7 +110,7 @@ Components are rendered at build time in a Node environment. Any module-scope ac
 
 ## Code Style — Go
 
-- `gofmt` formatting. No custom linter. Go 1.22 across all modules.
+- `gofmt` formatting. No custom linter. Go 1.25 across all modules.
 - All use Fiber v2, pgx v5, go-redis v9.
 - **Module isolation is absolute.** Each Go API has its own `go.mod`. No shared packages. Code duplication between channels is intentional — do not extract shared libraries.
 - Core API: `core/` sub-package, package-level vars (`DBPool`, `Rdb`), `Server` struct.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 

--- a/channels/fantasy/api/Dockerfile
+++ b/channels/fantasy/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 

--- a/channels/finance/api/Dockerfile
+++ b/channels/finance/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/channels/rss/api/Dockerfile
+++ b/channels/rss/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/channels/sports/api/Dockerfile
+++ b/channels/sports/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

PR #183 (Sentry rollout) merged with go.mod files pinned to `go 1.25.0` (auto-bumped by `go mod tidy` when sentry-go@v0.46.2 was added — that version requires Go 1.24+). The Dockerfiles still pointed at `golang:1.21-alpine` / `golang:1.22-alpine`, so the post-merge deploy failed for every Go service with:

```
go: go.mod requires go >= 1.25.0 (running go 1.21.13; GOTOOLCHAIN=local)
```

## Fix

Bump the builder image in all 5 Go Dockerfiles to `golang:1.25-alpine`:
- `api/Dockerfile` (1.22 → 1.25)
- `channels/finance/api/Dockerfile` (1.21 → 1.25)
- `channels/sports/api/Dockerfile` (1.21 → 1.25)
- `channels/rss/api/Dockerfile` (1.21 → 1.25)
- `channels/fantasy/api/Dockerfile` (1.22 → 1.25)

Also updates AGENTS.md (was "Go 1.22 across all modules" → now "Go 1.25 across all modules").

## Verification

All 5 services build locally with Go 1.26 (which satisfies `go 1.25.0` minimum):
- `cd api && go build` — clean
- `cd channels/{finance,sports,rss,fantasy}/api && go build` — all clean

The Rust services + the marketing site succeeded in the first deploy already; this fix only touches the Go service Dockerfiles. Once merged, the deploy workflow should rebuild + roll out all 5 Go services and the previously-failed run is replaced by a clean one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)