### PR TITLE
fix(services): move init_async_logger inside Tokio runtime

### DIFF
--- a/channels/finance/service/src/main.rs
+++ b/channels/finance/service/src/main.rs
@@ -99,11 +99,15 @@ fn init_sentry() -> sentry::ClientInitGuard {
 
 fn main() -> Result<()> {
     dotenv().ok();
-    let _ = init_async_logger("./logs");
 
     // Sentry init — MUST happen before the Tokio runtime starts. The
     // guard's Drop flushes events on shutdown, so bind it locally for
     // the lifetime of main.
+    //
+    // init_async_logger is intentionally NOT called here — it uses
+    // tokio::spawn internally and panics with "there is no reactor running"
+    // if called outside a Tokio runtime. It runs as the first line of
+    // run_service() instead, inside the runtime built below.
     let _sentry_guard = init_sentry();
     sentry::configure_scope(|scope| {
         scope.set_tag("service", "scrollr-finance-svc");
@@ -121,6 +125,12 @@ fn main() -> Result<()> {
 }
 
 async fn run_service() -> Result<()> {
+    // Logger init MUST be inside the Tokio runtime — init_async_logger
+    // spawns background tasks. Calling it from sync main() panics with
+    // "there is no reactor running, must be called from the context of
+    // a Tokio 1.x runtime" (see commit log for the crash that caught this).
+    let _ = init_async_logger("./logs");
+
     let health = Arc::new(Mutex::new(FinanceHealth::new()));
     let readiness = Arc::new(ReadinessGate::new(Some(MAX_POLL_STALENESS)));
 

--- a/channels/rss/service/src/main.rs
+++ b/channels/rss/service/src/main.rs
@@ -91,10 +91,13 @@ fn init_sentry() -> sentry::ClientInitGuard {
 
 fn main() -> Result<()> {
     dotenv().ok();
-    let _ = init_async_logger("./logs");
 
     // Sentry init — MUST happen before the Tokio runtime starts. Guard's
     // Drop flushes events on shutdown.
+    //
+    // init_async_logger is intentionally NOT called here — it uses
+    // tokio::spawn internally and panics with "there is no reactor running"
+    // if called outside a Tokio runtime. It runs at the top of run_service().
     let _sentry_guard = init_sentry();
     sentry::configure_scope(|scope| {
         scope.set_tag("service", "scrollr-rss-svc");
@@ -112,6 +115,12 @@ fn main() -> Result<()> {
 }
 
 async fn run_service() -> Result<()> {
+    // Logger init MUST be inside the Tokio runtime — init_async_logger
+    // spawns background tasks. Calling it from sync main() panics with
+    // "there is no reactor running, must be called from the context of
+    // a Tokio 1.x runtime".
+    let _ = init_async_logger("./logs");
+
     let health = Arc::new(Mutex::new(RssHealth::new()));
     let readiness = Arc::new(ReadinessGate::new(Some(MAX_POLL_STALENESS)));
 

--- a/channels/sports/service/src/main.rs
+++ b/channels/sports/service/src/main.rs
@@ -109,10 +109,13 @@ fn init_sentry() -> sentry::ClientInitGuard {
 
 fn main() -> Result<()> {
     dotenv().ok();
-    let _ = init_async_logger("./logs");
 
     // Sentry init — MUST happen before the Tokio runtime starts. Guard's
     // Drop flushes events on shutdown.
+    //
+    // init_async_logger is intentionally NOT called here — it uses
+    // tokio::spawn internally and panics with "there is no reactor running"
+    // if called outside a Tokio runtime. It runs at the top of run_service().
     let _sentry_guard = init_sentry();
     sentry::configure_scope(|scope| {
         scope.set_tag("service", "scrollr-sports-svc");
@@ -130,6 +133,12 @@ fn main() -> Result<()> {
 }
 
 async fn run_service() -> Result<()> {
+    // Logger init MUST be inside the Tokio runtime — init_async_logger
+    // spawns background tasks. Calling it from sync main() panics with
+    // "there is no reactor running, must be called from the context of
+    // a Tokio 1.x runtime".
+    let _ = init_async_logger("./logs");
+
     let health = Arc::new(Mutex::new(SportsHealth::new()));
     let readiness = Arc::new(ReadinessGate::new(Some(Duration::from_secs(
         MAX_POLL_STALENESS_SECS,


### PR DESCRIPTION
## Summary

PR #183 (Sentry rollout) refactored the 3 Rust ingestion services from `#[tokio::main]` to a synchronous `main()` that builds the Tokio runtime manually (Sentry's docs forbid `#[tokio::main]`). Logger init was left at the top of the synchronous main, but `init_async_logger` uses `tokio::spawn` to drain its buffer.

Result: pods crash on startup with:

```
thread 'main' (1) panicked at src/log.rs:98:9:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

Caught in production after the Sentry deploy rolled out — `finance-service` went into CrashLoopBackOff (the other two Rust services hadn't been rolled out yet so they didn't crash visibly, but they'd hit the same bug).

## Fix

Move `init_async_logger` to the **first line of `run_service()`** (the async function called by `runtime.block_on()`). Sentry init stays in sync `main()` per its requirements. Both invariants are satisfied:

1. ✅ Sentry must initialize before the Tokio runtime starts
2. ✅ `init_async_logger` must be called inside a Tokio runtime

Added an explicit comment in each main() explaining the ordering so future refactors don't reintroduce the bug.

## Verification

- `cargo build --release` clean for all 3 services
- 22 tests pass per service
- The crash signature in finance-service's logs is now impossible by construction (the function with the panic is called from inside the runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)