### PR TITLE
fix(myscrollr.com): allow Sentry ingest in CSP connect-src

### DIFF
--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -112,7 +112,7 @@ RUN printf 'server {\n\
 printf 'add_header X-Content-Type-Options "nosniff" always;\n\
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;\n\
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;\n\
-add_header Content-Security-Policy "default-src '"'"'self'"'"'; frame-ancestors '"'"'self'"'"' https://relentnet.com; script-src '"'"'self'"'"' '"'"'unsafe-inline'"'"' https://js.stripe.com; style-src '"'"'self'"'"' '"'"'unsafe-inline'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"'; connect-src '"'"'self'"'"' https://api.myscrollr.com https://auth.myscrollr.com https://api.stripe.com https://api.github.com; frame-src https://js.stripe.com https://hooks.stripe.com; base-uri '"'"'self'"'"'; form-action '"'"'self'"'"';" always;\n\
+add_header Content-Security-Policy "default-src '"'"'self'"'"'; frame-ancestors '"'"'self'"'"' https://relentnet.com; script-src '"'"'self'"'"' '"'"'unsafe-inline'"'"' https://js.stripe.com; style-src '"'"'self'"'"' '"'"'unsafe-inline'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"'; connect-src '"'"'self'"'"' https://api.myscrollr.com https://auth.myscrollr.com https://api.stripe.com https://api.github.com https://*.ingest.us.sentry.io; frame-src https://js.stripe.com https://hooks.stripe.com; base-uri '"'"'self'"'"'; form-action '"'"'self'"'"';" always;\n\
 ' > /etc/nginx/security-headers.conf
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary

Smoke-test errors thrown in the marketing site's console don't appear in Sentry because the nginx CSP `connect-src` directive doesn't include the Sentry ingest host. The SDK silently fails to POST events.

## Verified

- DSN is in the shipped JS bundle (`d83316ce7a6da7597d3ee7818de6c11b@o4511384091033600.ingest.us.sentry.io/4511384375132160`)
- `Sentry.init` is called at runtime (not dead-code-eliminated)
- Release `myscrollr-web@2.1.0` is registered, source maps uploaded
- Current CSP `connect-src`: `'self' https://api.myscrollr.com https://auth.myscrollr.com https://api.stripe.com https://api.github.com` — does NOT include sentry.io

## Fix

Add `https://*.ingest.us.sentry.io` to `connect-src` in the nginx CSP header.

## Why this is tight

The wildcard only covers Sentry's ingest subdomains (e.g. `o4511384091033600.ingest.us.sentry.io`). Every project in our org POSTs to the same `o<orgid>.ingest.us.sentry.io` host. We do not allow `*.sentry.io` broadly — that would also permit `sentry.io` itself and other operational subdomains, which the client never needs to call.

## Out of scope

- Core API CSPs (api/core/server.go) — those govern resources loaded BY response pages (`/swagger`, `/yahoo/callback`), not Sentry ingest. Server-side Sentry doesn't hit them.
- Tauri webview CSP (desktop/src-tauri/tauri.conf.json) — already uses `connect-src 'self' https://*` (permits anything). Already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)