### PR TITLE
fix(myscrollr.com): enable real SSR + actually prerender the home page

### DIFF
--- a/myscrollr.com/public/robots.txt
+++ b/myscrollr.com/public/robots.txt
@@ -13,5 +13,8 @@ Disallow: /invite
 Disallow: /callback
 Disallow: /status
 Disallow: /u/
+# Synthetic SPA-shell route. Used internally by TanStack Start to
+# generate _shell.html for nginx's SPA fallback. Not a real page.
+Disallow: /tss-spa-shell
 
 Sitemap: https://myscrollr.com/sitemap.xml

--- a/myscrollr.com/scripts/check-prerender.mjs
+++ b/myscrollr.com/scripts/check-prerender.mjs
@@ -19,17 +19,64 @@ import { dirname, join } from 'node:path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const clientDir = join(__dirname, '..', 'dist', 'client')
 
-// Per-route expected contract. `minJsonLd` is the minimum number of
-// <script type="application/ld+json"> blocks expected.
+// Per-route expected contract.
+// - `minJsonLd`: minimum <script type="application/ld+json"> blocks
+// - `expectedBody`: substring that must appear in the prerendered body
+//   (NOT in <head>) to prove the page actually SSRs real content.
+//   Marketing routes need this so a future regression that re-wraps the
+//   layout in <ClientOnly> (and ships an empty body) fails the build.
+//   Auth/subscription pages (uplink, uplink/lifetime) intentionally
+//   render their bodies on the client only — they omit this field.
 const ROUTES = [
-  { path: '/', file: 'index.html', minJsonLd: 3 }, // Org, WebSite, SoftwareApp
-  { path: '/channels', file: 'channels/index.html', minJsonLd: 1 },
-  { path: '/download', file: 'download/index.html', minJsonLd: 2 }, // softwareApp + breadcrumbs
-  { path: '/business', file: 'business/index.html', minJsonLd: 1 },
-  { path: '/architecture', file: 'architecture/index.html', minJsonLd: 1 },
-  { path: '/support', file: 'support/index.html', minJsonLd: 2 }, // FAQ + breadcrumbs
-  { path: '/legal', file: 'legal/index.html', minJsonLd: 1 },
-  { path: '/uplink', file: 'uplink/index.html', minJsonLd: 3 }, // Product + FAQ + breadcrumbs
+  {
+    // The home page prerenders real hero content (the SPA shell is
+    // pointed at a synthetic `/tss-spa-shell` route via `spa.maskPath`
+    // so the home prerender wins the de-dup race). Asserts the hero
+    // body copy so a regression that breaks SSR is caught at build.
+    path: '/',
+    file: 'index.html',
+    minJsonLd: 3, // Org, WebSite, SoftwareApp
+    expectedBody: 'A quiet ticker at the edge of your screen',
+  },
+  {
+    path: '/channels',
+    file: 'channels/index.html',
+    minJsonLd: 1,
+    expectedBody: 'Real-time market data',
+  },
+  {
+    path: '/download',
+    file: 'download/index.html',
+    minJsonLd: 2, // softwareApp + breadcrumbs
+    expectedBody: 'Download for',
+  },
+  {
+    path: '/business',
+    file: 'business/index.html',
+    minJsonLd: 1,
+    expectedBody: 'Sports bars',
+  },
+  {
+    path: '/architecture',
+    file: 'architecture/index.html',
+    minJsonLd: 1,
+    expectedBody: 'Per-user Redis',
+  },
+  {
+    path: '/support',
+    file: 'support/index.html',
+    minJsonLd: 2, // FAQ + breadcrumbs
+    expectedBody: 'How can we',
+  },
+  {
+    path: '/legal',
+    file: 'legal/index.html',
+    minJsonLd: 1,
+    expectedBody: 'Terms of Service',
+  },
+  // Uplink pages render their auth-aware bodies client-side only;
+  // <head> still prerenders for SEO. No body assertion.
+  { path: '/uplink', file: 'uplink/index.html', minJsonLd: 3 },
   {
     path: '/uplink/lifetime',
     file: 'uplink/lifetime/index.html',
@@ -95,7 +142,26 @@ for (const route of ROUTES) {
     continue
   }
 
-  pass(route, `title="${titleMatch[1]}" jsonLd=${jsonLdCount}`)
+  if (route.expectedBody) {
+    // Strip <head>…</head> before searching so we never match metadata
+    // (title, description, og:*, JSON-LD) — only real rendered body.
+    const bodyOnly = html.replace(/<head[\s\S]*?<\/head>/i, '')
+    if (!bodyOnly.includes(route.expectedBody)) {
+      fail(
+        route,
+        `body missing expected content "${route.expectedBody}" ` +
+          `(this usually means the layout was re-wrapped in <ClientOnly> ` +
+          `or the route component crashed during SSR — body is empty)`,
+      )
+      continue
+    }
+  }
+
+  pass(
+    route,
+    `title="${titleMatch[1]}" jsonLd=${jsonLdCount}` +
+      (route.expectedBody ? ` body="${route.expectedBody}" ✓` : ''),
+  )
 }
 
 const shell = join(clientDir, '_shell.html')
@@ -103,7 +169,23 @@ if (!existsSync(shell)) {
   console.error('✗ _shell.html missing (SPA fallback target)')
   failures += 1
 } else {
-  console.log('✓ _shell.html present')
+  // Assert the shell body has real Header chrome so nginx never serves
+  // a blank page for unknown routes. The shell is rendered by fetching
+  // the synthetic `/tss-spa-shell` route; if that route or the layout
+  // ever ships an empty body again (e.g. a fresh <ClientOnly> wrap),
+  // this assertion fails.
+  const shellHtml = readFileSync(shell, 'utf8')
+  const shellBody = shellHtml.replace(/<head[\s\S]*?<\/head>/i, '')
+  const expectedShellChrome = 'Always Visible'
+  if (!shellBody.includes(expectedShellChrome)) {
+    console.error(
+      `✗ _shell.html missing expected chrome "${expectedShellChrome}" ` +
+        `— the SPA fallback would render a blank page for unknown routes`,
+    )
+    failures += 1
+  } else {
+    console.log('✓ _shell.html present with Header chrome')
+  }
 }
 
 // Guard: the client entry bundle must wrap StartClient in our auth providers.

--- a/myscrollr.com/src/components/Header.tsx
+++ b/myscrollr.com/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from '@tanstack/react-router'
+import { ClientOnly, Link, useLocation } from '@tanstack/react-router'
 import {
   Building2,
   ChevronRight,
@@ -18,30 +18,20 @@ import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import ScrollrSVG from '@/components/ScrollrSVG'
 import { ThemeToggle } from '@/components/ThemeToggle'
 
+/**
+ * Header is SSR-safe. Auth-dependent slices live inside the three
+ * <ClientOnly> children below (account nav link + auth menu, in both
+ * desktop and mobile layouts). The Header itself never calls
+ * `useScrollrAuth()`, so the entire layout chrome prerenders correctly.
+ *
+ * Each <ClientOnly>'s subtree consumes Logto via `useScrollrAuth()`.
+ * During SSR these render to null (the auth state is unknown server-
+ * side anyway), and hydrate on the client once Logto initialises.
+ */
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false)
   const drawerRef = useRef<HTMLElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
-  const { signIn, signOut, isAuthenticated, isLoading, getIdTokenClaims } =
-    useScrollrAuth()
-  const [userClaims, setUserClaims] = useState<IdTokenClaims>()
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      getIdTokenClaims().then(setUserClaims)
-    } else {
-      setUserClaims(undefined)
-    }
-  }, [isAuthenticated, getIdTokenClaims])
-
-  const handleSignIn = () => {
-    signIn()
-  }
-
-  const handleSignOut = () => {
-    // signOut() calls Logto signOut
-    signOut(`${window.location.origin}`)
-  }
 
   // Close drawer on Escape and trap focus
   const closeDrawer = useCallback(() => {
@@ -120,50 +110,18 @@ export default function Header() {
               Download
             </NavLink>
 
-            {isAuthenticated && (
-              <>
-                <NavLink to="/account" activeOn="/account">
-                  <UserCircle size={14} />
-                  {userClaims?.username || userClaims?.name || 'Account'}
-                </NavLink>
-              </>
-            )}
+            <ClientOnly>
+              <DesktopAccountLink />
+            </ClientOnly>
           </nav>
         </LayoutGroup>
 
         {/* Auth Section */}
         <div className="flex-1 hidden lg:flex items-center gap-3 justify-end">
           <ThemeToggle />
-
-          {isLoading ? (
-            <div className="flex items-center gap-2">
-              <div className="h-2 w-2 rounded-full bg-primary/40 animate-pulse" />
-              <span className="text-xs text-base-content/30">Initializing</span>
-            </div>
-          ) : isAuthenticated ? (
-            <motion.button
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
-              onClick={handleSignOut}
-              className="flex items-center gap-2 px-4 py-2 text-xs font-semibold border border-error/30 text-error/80 hover:bg-error/10 hover:border-error/50 transition-colors rounded-lg cursor-pointer"
-            >
-              <LogOut size={14} />
-              Sign Out
-            </motion.button>
-          ) : (
-            <motion.button
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
-              onClick={handleSignIn}
-              className="btn btn-primary btn-sm flex items-center gap-2"
-            >
-              <span className="relative flex h-1.5 w-1.5">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-content opacity-75" />
-                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary-content" />
-              </span>
-              Sign In
-            </motion.button>
-          )}
+          <ClientOnly>
+            <DesktopAuthMenu />
+          </ClientOnly>
         </div>
 
         {/* Mobile Menu Button */}
@@ -278,64 +236,176 @@ export default function Header() {
                   Download
                 </MobileNavLink>
 
-                {isAuthenticated && (
-                  <>
-                    <MobileNavLink
-                      to="/account"
-                      icon={<ChevronRight size={18} />}
-                      onClick={() => setIsOpen(false)}
-                    >
-                      {userClaims?.username || userClaims?.name || 'Account'}
-                    </MobileNavLink>
-                  </>
-                )}
+                <ClientOnly>
+                  <MobileAccountLink onNavigate={() => setIsOpen(false)} />
+                </ClientOnly>
               </nav>
 
               {/* Drawer Footer */}
               <div className="px-5 py-5 border-t border-base-300/50 space-y-3">
-                {isLoading ? (
-                  <div className="flex items-center justify-center gap-2 py-3">
-                    <div className="h-2 w-2 rounded-full bg-primary animate-pulse" />
-                    <span className="text-xs text-base-content/40">
-                      Loading...
-                    </span>
-                  </div>
-                ) : isAuthenticated ? (
-                  <motion.button
-                    whileHover={{ scale: 1.02 }}
-                    whileTap={{ scale: 0.98 }}
-                    onClick={() => {
-                      handleSignOut()
-                      setIsOpen(false)
-                    }}
-                    className="w-full flex items-center justify-center gap-2 px-5 py-3 text-sm font-semibold border border-error/30 text-error/80 hover:bg-error/10 hover:border-error/50 transition-colors rounded-lg cursor-pointer"
-                  >
-                    <LogOut size={16} />
-                    Sign Out
-                  </motion.button>
-                ) : (
-                  <motion.button
-                    whileHover={{ scale: 1.02 }}
-                    whileTap={{ scale: 0.98 }}
-                    onClick={() => {
-                      handleSignIn()
-                      setIsOpen(false)
-                    }}
-                    className="w-full btn btn-primary flex items-center justify-center gap-2"
-                  >
-                    <span className="relative flex h-2 w-2">
-                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-content opacity-75" />
-                      <span className="relative inline-flex rounded-full h-2 w-2 bg-primary-content" />
-                    </span>
-                    Sign In
-                  </motion.button>
-                )}
+                <ClientOnly>
+                  <MobileAuthMenu onAfterAction={() => setIsOpen(false)} />
+                </ClientOnly>
               </div>
             </motion.aside>
           </>
         )}
       </AnimatePresence>
     </>
+  )
+}
+
+// ── Auth-dependent slices ────────────────────────────────────────────
+// Each of these calls `useScrollrAuth()` and therefore must render
+// only on the client (wrapped in <ClientOnly> at the call site).
+
+function useUserClaims(): IdTokenClaims | undefined {
+  const { isAuthenticated, getIdTokenClaims } = useScrollrAuth()
+  const [userClaims, setUserClaims] = useState<IdTokenClaims>()
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      getIdTokenClaims().then(setUserClaims)
+    } else {
+      setUserClaims(undefined)
+    }
+  }, [isAuthenticated, getIdTokenClaims])
+
+  return userClaims
+}
+
+function DesktopAccountLink() {
+  const { isAuthenticated } = useScrollrAuth()
+  const userClaims = useUserClaims()
+
+  if (!isAuthenticated) return null
+
+  return (
+    <NavLink to="/account" activeOn="/account">
+      <UserCircle size={14} />
+      {userClaims?.username || userClaims?.name || 'Account'}
+    </NavLink>
+  )
+}
+
+function DesktopAuthMenu() {
+  const { signIn, signOut, isAuthenticated, isLoading } = useScrollrAuth()
+
+  const handleSignIn = () => {
+    signIn()
+  }
+  const handleSignOut = () => {
+    signOut(`${window.location.origin}`)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="h-2 w-2 rounded-full bg-primary/40 animate-pulse" />
+        <span className="text-xs text-base-content/30">Initializing</span>
+      </div>
+    )
+  }
+
+  if (isAuthenticated) {
+    return (
+      <motion.button
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        onClick={handleSignOut}
+        className="flex items-center gap-2 px-4 py-2 text-xs font-semibold border border-error/30 text-error/80 hover:bg-error/10 hover:border-error/50 transition-colors rounded-lg cursor-pointer"
+      >
+        <LogOut size={14} />
+        Sign Out
+      </motion.button>
+    )
+  }
+
+  return (
+    <motion.button
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      onClick={handleSignIn}
+      className="btn btn-primary btn-sm flex items-center gap-2"
+    >
+      <span className="relative flex h-1.5 w-1.5">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-content opacity-75" />
+        <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary-content" />
+      </span>
+      Sign In
+    </motion.button>
+  )
+}
+
+function MobileAccountLink({ onNavigate }: { onNavigate: () => void }) {
+  const { isAuthenticated } = useScrollrAuth()
+  const userClaims = useUserClaims()
+
+  if (!isAuthenticated) return null
+
+  return (
+    <MobileNavLink
+      to="/account"
+      icon={<ChevronRight size={18} />}
+      onClick={onNavigate}
+    >
+      {userClaims?.username || userClaims?.name || 'Account'}
+    </MobileNavLink>
+  )
+}
+
+function MobileAuthMenu({ onAfterAction }: { onAfterAction: () => void }) {
+  const { signIn, signOut, isAuthenticated, isLoading } = useScrollrAuth()
+
+  const handleSignIn = () => {
+    signIn()
+  }
+  const handleSignOut = () => {
+    signOut(`${window.location.origin}`)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-3">
+        <div className="h-2 w-2 rounded-full bg-primary animate-pulse" />
+        <span className="text-xs text-base-content/40">Loading...</span>
+      </div>
+    )
+  }
+
+  if (isAuthenticated) {
+    return (
+      <motion.button
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        onClick={() => {
+          handleSignOut()
+          onAfterAction()
+        }}
+        className="w-full flex items-center justify-center gap-2 px-5 py-3 text-sm font-semibold border border-error/30 text-error/80 hover:bg-error/10 hover:border-error/50 transition-colors rounded-lg cursor-pointer"
+      >
+        <LogOut size={16} />
+        Sign Out
+      </motion.button>
+    )
+  }
+
+  return (
+    <motion.button
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      onClick={() => {
+        handleSignIn()
+        onAfterAction()
+      }}
+      className="w-full btn btn-primary flex items-center justify-center gap-2"
+    >
+      <span className="relative flex h-2 w-2">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-content opacity-75" />
+        <span className="relative inline-flex rounded-full h-2 w-2 bg-primary-content" />
+      </span>
+      Sign In
+    </motion.button>
   )
 }
 

--- a/myscrollr.com/src/routeTree.gen.ts
+++ b/myscrollr.com/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as UplinkRouteImport } from './routes/uplink'
+import { Route as TssSpaShellRouteImport } from './routes/tss-spa-shell'
 import { Route as SupportRouteImport } from './routes/support'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as LegalRouteImport } from './routes/legal'
@@ -27,6 +28,11 @@ import { Route as UUsernameRouteImport } from './routes/u.$username'
 const UplinkRoute = UplinkRouteImport.update({
   id: '/uplink',
   path: '/uplink',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TssSpaShellRoute = TssSpaShellRouteImport.update({
+  id: '/tss-spa-shell',
+  path: '/tss-spa-shell',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SupportRoute = SupportRouteImport.update({
@@ -107,6 +113,7 @@ export interface FileRoutesByFullPath {
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
   '/support': typeof SupportRoute
+  '/tss-spa-shell': typeof TssSpaShellRoute
   '/uplink': typeof UplinkRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink/lifetime': typeof UplinkLifetimeRoute
@@ -123,6 +130,7 @@ export interface FileRoutesByTo {
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
   '/support': typeof SupportRoute
+  '/tss-spa-shell': typeof TssSpaShellRoute
   '/uplink': typeof UplinkRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink/lifetime': typeof UplinkLifetimeRoute
@@ -140,6 +148,7 @@ export interface FileRoutesById {
   '/legal': typeof LegalRoute
   '/status': typeof StatusRoute
   '/support': typeof SupportRoute
+  '/tss-spa-shell': typeof TssSpaShellRoute
   '/uplink': typeof UplinkRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink_/lifetime': typeof UplinkLifetimeRoute
@@ -158,6 +167,7 @@ export interface FileRouteTypes {
     | '/legal'
     | '/status'
     | '/support'
+    | '/tss-spa-shell'
     | '/uplink'
     | '/u/$username'
     | '/uplink/lifetime'
@@ -174,6 +184,7 @@ export interface FileRouteTypes {
     | '/legal'
     | '/status'
     | '/support'
+    | '/tss-spa-shell'
     | '/uplink'
     | '/u/$username'
     | '/uplink/lifetime'
@@ -190,6 +201,7 @@ export interface FileRouteTypes {
     | '/legal'
     | '/status'
     | '/support'
+    | '/tss-spa-shell'
     | '/uplink'
     | '/u/$username'
     | '/uplink_/lifetime'
@@ -207,6 +219,7 @@ export interface RootRouteChildren {
   LegalRoute: typeof LegalRoute
   StatusRoute: typeof StatusRoute
   SupportRoute: typeof SupportRoute
+  TssSpaShellRoute: typeof TssSpaShellRoute
   UplinkRoute: typeof UplinkRoute
   UUsernameRoute: typeof UUsernameRoute
   UplinkLifetimeRoute: typeof UplinkLifetimeRoute
@@ -219,6 +232,13 @@ declare module '@tanstack/react-router' {
       path: '/uplink'
       fullPath: '/uplink'
       preLoaderRoute: typeof UplinkRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tss-spa-shell': {
+      id: '/tss-spa-shell'
+      path: '/tss-spa-shell'
+      fullPath: '/tss-spa-shell'
+      preLoaderRoute: typeof TssSpaShellRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/support': {
@@ -327,6 +347,7 @@ const rootRouteChildren: RootRouteChildren = {
   LegalRoute: LegalRoute,
   StatusRoute: StatusRoute,
   SupportRoute: SupportRoute,
+  TssSpaShellRoute: TssSpaShellRoute,
   UplinkRoute: UplinkRoute,
   UUsernameRoute: UUsernameRoute,
   UplinkLifetimeRoute: UplinkLifetimeRoute,

--- a/myscrollr.com/src/routes/__root.tsx
+++ b/myscrollr.com/src/routes/__root.tsx
@@ -1,5 +1,4 @@
 import {
-  ClientOnly,
   HeadContent,
   Link,
   Outlet,
@@ -151,35 +150,33 @@ function RootLayout() {
 
   return (
     <RootDocument>
-      <ClientOnly>
-        <MotionConfig reducedMotion="user">
-          <div className="min-h-screen relative overflow-x-clip">
-            {/* Skip to main content — first focusable element */}
-            <a
-              href="#main-content"
-              className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-lg focus:bg-primary focus:text-primary-content focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:shadow-lg"
-            >
-              Skip to main content
-            </a>
+      <MotionConfig reducedMotion="user">
+        <div className="min-h-screen relative overflow-x-clip">
+          {/* Skip to main content — first focusable element */}
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-lg focus:bg-primary focus:text-primary-content focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:shadow-lg"
+          >
+            Skip to main content
+          </a>
 
-            {/* Navigation */}
-            <Header />
+          {/* Navigation */}
+          <Header />
 
-            {/* Main Content */}
-            <main
-              ref={mainRef}
-              id="main-content"
-              className="relative"
-              tabIndex={-1}
-            >
-              <Outlet />
-            </main>
+          {/* Main Content */}
+          <main
+            ref={mainRef}
+            id="main-content"
+            className="relative"
+            tabIndex={-1}
+          >
+            <Outlet />
+          </main>
 
-            {/* Footer */}
-            <Footer />
-          </div>
-        </MotionConfig>
-      </ClientOnly>
+          {/* Footer */}
+          <Footer />
+        </div>
+      </MotionConfig>
     </RootDocument>
   )
 }

--- a/myscrollr.com/src/routes/support.tsx
+++ b/myscrollr.com/src/routes/support.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { ClientOnly, createFileRoute } from '@tanstack/react-router'
 import { seo } from '@/lib/seo'
 import { breadcrumbs, faqPage } from '@/lib/structured-data'
 import { FAQ_ITEMS } from '@/components/support/support-content'
@@ -35,7 +35,11 @@ function SupportPage() {
       <SupportFAQ />
       <SupportTroubleshooting />
       <SupportBilling />
-      <SupportContactForm />
+      {/* Contact form is auth-aware (pre-fills name/email from claims).
+          Wrapped in ClientOnly so the rest of /support prerenders. */}
+      <ClientOnly>
+        <SupportContactForm />
+      </ClientOnly>
     </main>
   )
 }

--- a/myscrollr.com/src/routes/tss-spa-shell.tsx
+++ b/myscrollr.com/src/routes/tss-spa-shell.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+/**
+ * Synthetic SPA-shell route.
+ *
+ * TanStack Start's `spa.maskPath` is the route the prerender fetches
+ * to produce `_shell.html` — the static fallback nginx serves for any
+ * URL that doesn't have its own prerendered HTML (e.g. `/account`,
+ * `/u/:username`, `/callback`). With the default `maskPath: '/'`, the
+ * shell entry collides with the home page in the prerender's de-dup
+ * Map (keyed by path) and the home route never writes `index.html` —
+ * the shell ends up duplicated there instead, which shows users a bare
+ * Header + Footer with no content until hydration.
+ *
+ * Pointing `maskPath` here instead lets the home page prerender real
+ * body content while keeping a valid endpoint for the shell render.
+ * Visitors will never see this route's content — nginx only consumes
+ * `_shell.html` as a static file, and direct browser visits to
+ * `/tss-spa-shell` are not linked anywhere on the site (and are
+ * disallowed in `robots.txt` so crawlers ignore it).
+ *
+ * The body is intentionally a minimal hydration target: just enough
+ * DOM to keep the React tree consistent during the brief moment
+ * before the SPA router hydrates and routes the user to their real
+ * destination.
+ */
+export const Route = createFileRoute('/tss-spa-shell')({
+  component: ShellPlaceholder,
+})
+
+function ShellPlaceholder() {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ minHeight: '60vh' }}
+      className="bg-base-100"
+    />
+  )
+}

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -1,4 +1,4 @@
-import { Link, createFileRoute } from '@tanstack/react-router'
+import { ClientOnly, Link, createFileRoute } from '@tanstack/react-router'
 import {
   AnimatePresence,
   motion,
@@ -224,7 +224,16 @@ export const Route = createFileRoute('/uplink')({
         ]),
       ],
     }),
-  component: UplinkPage,
+  // Uplink is auth/subscription-aware throughout — wrap the entire page
+  // in ClientOnly so the route still prerenders correct <head> meta and
+  // JSON-LD, while the dynamic auth-conditional body hydrates on the
+  // client. The other landing pages prerender real body content; this
+  // one is interactive-only by design.
+  component: () => (
+    <ClientOnly>
+      <UplinkPage />
+    </ClientOnly>
+  ),
 })
 
 // ── Comparison Data ─────────────────────────────────────────────

--- a/myscrollr.com/src/routes/uplink_.lifetime.tsx
+++ b/myscrollr.com/src/routes/uplink_.lifetime.tsx
@@ -1,4 +1,4 @@
-import { Link, createFileRoute } from '@tanstack/react-router'
+import { ClientOnly, Link, createFileRoute } from '@tanstack/react-router'
 import { motion } from 'motion/react'
 import { Suspense, lazy, useEffect, useState } from 'react'
 import {
@@ -44,7 +44,14 @@ export const Route = createFileRoute('/uplink_/lifetime')({
         { name: 'Lifetime', path: '/uplink/lifetime' },
       ]),
     }),
-  component: LifetimePage,
+  // Lifetime is auth/subscription-aware throughout — wrap in ClientOnly
+  // so the route still prerenders correct <head> meta and JSON-LD,
+  // while the dynamic auth-conditional body hydrates on the client.
+  component: () => (
+    <ClientOnly>
+      <LifetimePage />
+    </ClientOnly>
+  ),
 })
 
 // ── Feature line ────────────────────────────────────────────────

--- a/myscrollr.com/vite.config.ts
+++ b/myscrollr.com/vite.config.ts
@@ -10,23 +10,21 @@ import viteReact from '@vitejs/plugin-react'
 import type { Plugin } from 'vite'
 
 /**
- * After the TanStack Start build + prerender phase, copy the prerendered
- * SPA shell (`dist/client/_shell.html`) to `dist/client/index.html` so that
- * static hosts (nginx, Coolify) serve the fully-prerendered home page
- * (with `<title>`, canonical, JSON-LD) at `/` — not the bare SPA shell.
+ * Safety net: if for any reason `dist/client/index.html` is missing
+ * after prerender, copy the SPA shell into its place so static hosts
+ * (nginx) still serve *something* at `/`.
  *
- * Background: with `spa.enabled: true`, start-plugin-core's `post-build.js`
- * pushes a shell entry at the SPA `maskPath` (defaults to `/`), then the
- * `autoStaticPathsDiscovery` step de-dupes via `new Map`. The shell entry
- * is pushed last, so it always wins for `/`. Setting `maskPath` to a
- * synthetic path doesn't help either, because Start renders the shell by
- * actually fetching that path — and a non-existent route returns 404.
+ * Background: this plugin was added when start-plugin-core's
+ * `post-build.js` pushed the SPA shell at the home path (`maskPath: '/'`)
+ * and the prerender de-dup Map (keyed by `path`) caused the shell entry
+ * to overwrite the home page entry — so `dist/client/index.html` never
+ * got written and nginx had to serve `_shell.html` (empty body) instead.
  *
- * Since the shell is rendered by fetching `/`, `_shell.html` already
- * contains the home route's full `head()` output (meta, canonical,
- * JSON-LD). Copying it to `index.html` gives correct content at `/`
- * without re-rendering, while preserving `_shell.html` as the SPA
- * fallback for dynamic routes (`/account`, `/u/$username`, etc.).
+ * That's now fixed by pointing `spa.maskPath` at a synthetic
+ * `/tss-spa-shell` route (see `src/routes/tss-spa-shell.tsx`), letting
+ * both the home prerender AND the shell render to distinct files
+ * (`index.html` and `_shell.html` respectively). This plugin therefore
+ * becomes a no-op under normal conditions — kept as defense in depth.
  */
 function copyShellToIndex(): Plugin {
   const run = (): Promise<void> => {
@@ -80,6 +78,21 @@ export default defineConfig({
       router: {},
       spa: {
         enabled: true,
+        // Render the SPA shell at a synthetic path so it doesn't
+        // collide with the home page in the prerender de-dup Map (which
+        // is keyed by `path`). With the default maskPath of "/", the
+        // shell entry overwrites the home entry and `dist/client/index.html`
+        // is never written — the home route then has to be filled in by
+        // `copyShellToIndex` with the shell's contents (Header+Footer +
+        // empty <main>), which is what caused the "everything flashes
+        // in" feel on the home page.
+        //
+        // The synthetic route at `src/routes/_tss-spa-shell.tsx`
+        // returns a minimal placeholder body so the prerender request
+        // succeeds. Both `_shell.html` (SPA fallback target nginx
+        // serves for unknown paths) AND `index.html` (real home
+        // prerender) get written separately.
+        maskPath: '/tss-spa-shell',
       },
       prerender: {
         enabled: true,
@@ -94,6 +107,11 @@ export default defineConfig({
           ]
           if (excluded.includes(path)) return false
           if (path.startsWith('/u/')) return false // dynamic profile pages
+          // NOTE: /tss-spa-shell intentionally passes through the filter
+          // — start-plugin-core uses spa.maskPath as a normal page entry
+          // with outputPath="/_shell", so it must be crawled in order
+          // for `_shell.html` to be written. The de-dup Map keyed by
+          // path naturally prevents a second `/tss-spa-shell/index.html`.
           return true
         },
       },


### PR DESCRIPTION
## Summary

Marketing site shipped with the entire layout wrapped in `<ClientOnly>`, plus a build-time hack that copied the SPA shell over the home page's prerender. Together this meant every visitor first painted an empty body, then watched chrome appear, then watched hero/sections fade in — the "everything flashes in" feel the user reported.

This PR makes the layout SSR-clean and lets every prerendered route (including `/`) ship with real body content.

## Root cause

Two stacked issues:

1. **`__root.tsx` wrapped Header + Outlet + Footer in `<ClientOnly>`** as a workaround for Logto's non-SSR-safe `useLogto()` hook. Way too coarse — hid the entire layout, not just the auth UI.

2. **start-plugin-core pushes the SPA shell at `spa.maskPath` (default `/`)**. The prerender's de-dup Map is keyed by `path`, so the shell entry silently overwrote the home page entry — `dist/client/index.html` was never written. Previous code papered over this by copying `_shell.html` to `index.html`, baking in the empty body.

## Changes

- Remove `<ClientOnly>` from `__root.tsx`. Layout chrome (Header, Footer) now SSRs.
- Narrow Logto access in `Header.tsx` to four small auth-aware children (`DesktopAccountLink`, `DesktopAuthMenu`, `MobileAccountLink`, `MobileAuthMenu`), each `<ClientOnly>`-wrapped at the call site. Header itself is SSR-clean.
- Wrap `SupportContactForm` in `<ClientOnly>` at the call site in `routes/support.tsx`.
- Wrap `UplinkPage` and `LifetimePage` in `<ClientOnly>` at the route level. Their `<head>` (title, JSON-LD, OG meta) still prerenders for SEO; the auth/subscription-heavy bodies hydrate client-side.
- Point `spa.maskPath` at a new synthetic `/tss-spa-shell` route (`src/routes/tss-spa-shell.tsx`). The shell renders to `_shell.html` for nginx's SPA fallback (`/account`, `/u/:username`, etc.); `/` writes its own real `index.html`.
- Add `/tss-spa-shell` to `robots.txt` Disallow.
- Extend `check-prerender.mjs` with per-route body assertions. Build fails if any prerendered route ships an empty body. `_shell.html` is also asserted to contain Header chrome.
- Keep `copyShellToIndex` as defense in depth (now a no-op).

## Verification

- `npm run build` green (clean rebuild)
- `npx tsc --noEmit` clean
- `npm run lint` clean
- All 9 prerender routes pass body assertions:
  - `/` — 192KB body, "A quiet ticker at the edge of your screen"
  - `/channels`, `/business`, `/architecture`, `/download`, `/support`, `/legal` — substantial bodies (37–98KB)
  - `/uplink`, `/uplink/lifetime` — intentional client-only bodies (head prerendered)
- `_shell.html` — 21KB with Header chrome (was effectively empty before)

## Before / After

| File | Before | After |
|---|---|---|
| `dist/client/index.html` | duplicate of `_shell.html` (~26KB, empty body) | 192KB (full hero + sections) |
| `dist/client/_shell.html` | 26KB, empty body | 21KB, Header chrome present |
| `/` user experience | blank → chrome pops in → hero fades in over ~1s | hero visible on first paint, animations layer on top |
| `<ClientOnly>` scope | entire layout | only auth-touching UI |

## Out of scope

- Hero motion animation timings — left as-is per the design call earlier.
- The 301-trailing-slash nginx redirect oddity I noticed (returns wrong port) — separate issue.
- Uplink page bodies — auth-conditional throughout, would need a big refactor to SSR.