### PR TITLE
feat(myscrollr.com): mobile refactor PR 1 — audit, universal fixes, viewport CI

### DIFF
--- a/docs/superpowers/specs/2026-05-14-mobile-refactor.md
+++ b/docs/superpowers/specs/2026-05-14-mobile-refactor.md
@@ -1,0 +1,249 @@
+# Mobile Refactor — myscrollr.com
+
+Date: 2026-05-14
+Status: Approved — implementation in progress
+
+## Summary
+
+The marketing website (`myscrollr.com/`) is well-designed on desktop but
+shows clear layout regressions on small screens. This document audits
+the current mobile state, defines design constraints, and lays out the
+sequence of incremental PRs that will bring mobile parity without
+disturbing the (locked) desktop appearance.
+
+## Design Constraints
+
+1. **Desktop appearance is locked.** Any change visible above the
+   `lg:` breakpoint (`1024px`) requires explicit approval. The current
+   desktop layout is the source of truth.
+2. **Mobile-first redesign permitted.** Where useful, mobile gets its
+   own structurally different layout. The pricing comparison table is
+   a clear case — a 5-column grid cannot be made readable below
+   `md:`. Stacked per-tier cards below `md:` is the correct mobile
+   pattern even though it looks completely different from the desktop
+   table.
+3. **Motion on desktop is preserved.** On mobile, motion may be
+   simplified (shorter delays, dropped opacity-fades) where it
+   contributes to perceived layout flash or jank.
+4. **No new JS dependencies for layout work.** CSS, structural
+   changes, and removing unused things only. Adding a Playwright
+   dev-dependency for mobile viewport regression testing is
+   acceptable since it runs only in CI/local, never in the shipped
+   bundle.
+
+## Audit Findings
+
+### Universal (cross-page) issues
+
+#### 1. `.container` has no mobile vertical-padding step
+
+In `src/styles.css:760`:
+
+```css
+.container {
+  @apply mx-auto px-5 sm:px-6 lg:px-8 py-16 lg:py-24;
+  max-width: 1400px;
+}
+```
+
+`py-16` (4rem = 64px) is the mobile padding. With every section
+inheriting this, two adjacent sections produce 128px of vertical
+gap. On a 667px-tall viewport (iPhone SE) that is ~20% of viewport
+height between sections — sections feel stretched and the page feels
+endless.
+
+**Fix:** add a mobile step. Target: `py-10 sm:py-12 lg:py-24` so
+mobile gets ~64px stacked padding between sections (half the current
+amount). Same change applied to `.container-sm` and `.container-lg`.
+
+#### 2. `body { overflow-x: hidden }` band-aid (styles.css:266)
+
+Hides horizontal overflow rather than preventing it. Keep the body
+rule (defense in depth), but treat any actual horizontal-scroll case
+as a bug to fix at the source. The new Playwright check will catch
+new offenders.
+
+Suspected offenders (from grep): elements with negative inset
+classes like `-inset-8`, animated `motion.div` containers with
+`whileHover.x`, and any element using a fixed pixel width that
+exceeds 360px without a `max-w-full`.
+
+#### 3. Touch targets below WCAG 2.5.5 AAA target (44×44 CSS px)
+
+WCAG 2.2 raised the bar; AAA target is 44×44 CSS px. Current
+violations:
+
+- Hero `WORD_ACCENTS` progress-bar buttons: `flex-1 py-2` on a `h-1`
+  track → ~16 CSS px tall. Should be at least 44 CSS px tall on
+  mobile. Suggestion: increase `py` to `py-3` on mobile to reach
+  44px (12+12+16 = 40, close enough; pad to `py-3.5` if needed).
+- `.btn-sm` is `py-2 text-xs` → ~32px tall. Many uses across the
+  site. Acceptable on desktop where pointing devices are precise;
+  borderline on touch. The pragmatic call: leave `.btn-sm` as-is
+  (used in tight contexts where 44px would be visually wrong), but
+  ensure no critical-flow CTAs use it on mobile.
+- Footer social icons: `w-10 h-10` = 40px. Slightly under 44px.
+  Acceptable given the optional importance.
+
+#### 4. H1 long-word overflow risk
+
+`h1 { font-size: clamp(2.5rem, 5vw, 4.5rem) }`. On a 320px viewport,
+2.5rem = 40px. A single word like "Headlines" at 40px in bold ≈
+~210px wide — fits within the 280px content area on iPhone SE
+(`px-5` = 20px each side). Adding `overflow-wrap: break-word`
+on `h1-h6` as defense-in-depth catches future long words and any
+narrower viewport.
+
+#### 5. iOS Safari address-bar gotcha
+
+`min-h-screen` (= `min-height: 100vh`) is unreliable on iOS Safari
+because `vh` includes the URL bar height even when it's collapsed.
+`min-h-dvh` (= `100dvh`, dynamic viewport height) is the correct
+modern unit. Several pages still use `min-h-screen`:
+
+```
+src/routes/uplink_.lifetime.tsx
+src/routes/uplink.tsx
+src/routes/business.tsx
+src/routes/channels.tsx
+src/routes/support.tsx
+src/routes/account.tsx
+src/routes/invite.tsx
+src/routes/download.tsx
+src/components/LoadingSpinner.tsx
+```
+
+Replace `min-h-screen` with `min-h-dvh` site-wide. No desktop
+visual change (`100vh == 100dvh` when address bar isn't auto-hiding).
+
+### Page-specific issues
+
+#### `/` (home)
+
+- **Hero takes a full `min-h-dvh`** with text below the screenshot on
+  mobile (`order-2 lg:order-1` swaps it). The screenshot is
+  `w-[360px]` on the smallest breakpoint — slight overflow risk on
+  320px viewports (iPhone SE 1st gen is 320px). Cap at
+  `w-full max-w-[360px]` so the image scales down with the viewport.
+- **Animation delays compound.** Hero text fades in at delays
+  300ms → 800ms → 1000ms → 1200ms. On desktop these layer nicely
+  over the prerendered HTML. On mobile, the same delays feel slower
+  because phones are touched-into faster (no hover preview, no
+  multi-window). Cut delays in half (or drop them entirely) for
+  `< md:` viewports. **Honor the design constraint: keep desktop
+  delays intact**.
+- **Hero order reversal** (`flex-col-reverse` to put text first on
+  mobile) was considered. Decision: keep text-first on mobile
+  (current behavior is `order-2 lg:order-1` on the image and
+  `order-1 lg:order-2` on the text → wait, actually image is
+  `order-2` (below) and text is `order-1` (above) on mobile —
+  current behavior already shows text first on mobile. **No
+  reordering needed.** This was a misread on first pass.
+
+#### `/uplink` (pricing)
+
+- **Comparison table** at `src/routes/uplink.tsx:3468`:
+  `className="grid grid-cols-[1.4fr_1fr_1fr_1fr_1fr]"`.
+  Unconditional 5-column layout. At 360px viewport with internal
+  padding, each column is ~64px wide. Cell content is `text-[11px]
+  font-mono` plus icons. Completely unusable on mobile.
+
+  **Fix:** below `md:`, swap the entire comparison block for a
+  stacked card layout: one card per tier (Free, Uplink, Pro,
+  Ultimate). Each card shows all comparison rows for that tier.
+  Cards have large touch-friendly text and full-width readable
+  rows. Above `md:`, the existing table renders unchanged.
+
+  Implementation note: the `comparisonRows` data structure stays
+  identical. The mobile component reads the same data and pivots
+  it (one card per tier, all rows under each card).
+
+- The rest of `/uplink` (tier showcases, billing toggle, FAQ) is
+  large but already responsive. Spot-check on mobile during PR 3.
+
+#### `/download`
+
+- Platform cards (`<DownloadButton>` + format picker) should reflow
+  fine because they're already single-column on mobile. Format
+  dropdown uses `document.addEventListener` for click-outside —
+  works on touch.
+- Spot-check in PR 4.
+
+#### `/channels`
+
+- Product screenshots are rendered via the shared
+  `<ProductScreenshot>` primitive which already handles responsive
+  sizing. Most likely OK; needs spot-check.
+- 961-line file; will inspect during PR 4.
+
+#### `/business`
+
+- 1817-line file. B2B copy-heavy. Likely candidates for issues:
+  contact-form rows, pricing/tier blocks. Inspect during PR 5.
+
+#### `/architecture`
+
+- Technical reader audience. Diagrams are inline SVG — should scale.
+  Inspect during PR 5.
+
+#### `/support`
+
+- FAQ + contact form. The form is in `<SupportContactForm>` which
+  we wrapped in `<ClientOnly>` in the previous PR. Spot-check input
+  sizes (touch-target compliance) during PR 5.
+
+#### `/legal`
+
+- Long text doc. Sidebar nav on desktop. Likely already mobile-OK
+  because it's a typography page. Inspect during PR 5.
+
+## PR Sequence
+
+| PR | Scope | Files |
+|----|-------|-------|
+| **1** | This audit doc + universal fixes + Playwright viewport check | `docs/`, `styles.css`, a handful of `<h1>-<h6>` guard rules, all `min-h-screen` → `min-h-dvh` replacements, new `tests/mobile-viewport.test.ts` + `playwright.config.ts` |
+| **2** | Home hero mobile polish | `src/components/landing/HeroSection.tsx`, `HeroProductShowcase.tsx` |
+| **3** | `/uplink` comparison table → stacked cards on mobile | `src/routes/uplink.tsx` (only the comparison section) |
+| **4** | `/download` + `/channels` polish | `src/routes/download.tsx`, `src/routes/channels.tsx`, `src/components/DownloadButton.tsx` |
+| **5** | `/business` + `/architecture` + `/support` + `/legal` polish | Per-file responsive tweaks |
+
+Each PR is squash-merged separately so risk is bounded.
+
+## Verification
+
+### Per-PR
+
+- `npm run build` green (includes typecheck via `tsc --noEmit`)
+- `npm run lint` clean
+- `check-prerender.mjs` postbuild check still passes (body content
+  for each prerendered route)
+- Playwright `mobile-viewport.test.ts` passes (after PR 1 introduces
+  it) — checks no horizontal scroll at 320/375/414/768 widths on
+  every marketing page
+
+### Subjective (per-PR)
+
+- Hard-reload the deployed PR preview on a real iPhone / Android
+  device
+- Walk every section, look for: horizontal scroll, awkward gaps,
+  cramped text, missed touch targets
+- Compare desktop side-by-side to confirm no regressions
+
+## Open Questions
+
+None at this point. All scope, constraints, and PR sequencing have
+been agreed upon in the brainstorming session.
+
+## Out of Scope
+
+- Performance optimization (image lazy-loading audits, JS bundle
+  splitting, etc.). Separate concern.
+- Auth-route mobile polish (`/account`, `/callback`, `/invite`,
+  `/u/$username`). These are interactive surfaces, not marketing
+  pages.
+- Dark/light theme toggle behavior on mobile (already works; not a
+  layout issue).
+- Animation timing changes on desktop (explicitly locked by the
+  user).
+- The 301-trailing-slash redirect that points at `:3000` —
+  separate nginx config concern, noted earlier.

--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -10,6 +10,7 @@ COPY myscrollr.com/package.json myscrollr.com/package-lock.json* ./myscrollr.com
 
 # Install dependencies
 WORKDIR /app/myscrollr.com
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN npm ci
 
 # Copy the rest of the frontend source
@@ -48,6 +49,7 @@ ENV VITE_STRIPE_PRICE_ULTIMATE_ANNUAL=${VITE_STRIPE_PRICE_ULTIMATE_ANNUAL}
 ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN}
 ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
 ENV SENTRY_ORG=${SENTRY_ORG}
+ENV SKIP_MOBILE_VIEWPORT_CHECK=1
 
 # Build (vite build + tsc)
 WORKDIR /app/myscrollr.com

--- a/myscrollr.com/package.json
+++ b/myscrollr.com/package.json
@@ -19,7 +19,7 @@
     "prebuild": "node scripts/fetch-latest-version.mjs && node scripts/generate-sitemap.mjs && node scripts/optimize-screenshots.mjs",
     "optimize:screenshots": "node scripts/optimize-screenshots.mjs",
     "build": "vite build && tsc",
-    "postbuild": "node scripts/check-sentry-tunnel.mjs && node scripts/check-prerender.mjs",
+    "postbuild": "node scripts/check-sentry-tunnel.mjs && node scripts/check-prerender.mjs && node scripts/check-mobile-viewport.mjs",
     "serve": "vite preview",
     "lint": "eslint",
     "format": "prettier",

--- a/myscrollr.com/scripts/check-mobile-viewport.mjs
+++ b/myscrollr.com/scripts/check-mobile-viewport.mjs
@@ -485,6 +485,143 @@ try {
           }
         }
 
+        await page.locator('#channels').scrollIntoViewIfNeeded()
+        await page.waitForTimeout(900)
+
+        const channelsMobileLayout = await page.evaluate(() => {
+          const channels = document.querySelector('#channels')
+          const buttons = Array.from(
+            channels?.querySelectorAll('button') ?? [],
+          ).filter((button) =>
+            ['Finance', 'Sports', 'News', 'Fantasy'].includes(
+              button.textContent?.trim() ?? '',
+            ),
+          )
+          const filterRow = buttons[0]?.parentElement
+          const tickerBand = channels?.querySelector('[data-channel-ticker-band]')
+          const caption = channels?.querySelector('[data-channel-ticker-caption]')
+
+          if (!channels || buttons.length !== 4 || !filterRow || !tickerBand || !caption) {
+            return null
+          }
+
+          const buttonTops = buttons.map((button) =>
+            Math.round(button.getBoundingClientRect().top),
+          )
+          const headerRect = channels.querySelector('h2')?.getBoundingClientRect()
+          const filterRect = filterRow.getBoundingClientRect()
+          const tickerRect = tickerBand.getBoundingClientRect()
+
+          return {
+            buttonRowCount: new Set(buttonTops).size,
+            filterCenter: Math.round(
+              (buttons[0].getBoundingClientRect().left +
+                buttons[buttons.length - 1].getBoundingClientRect().right) /
+                2,
+            ),
+            filterBottom: Math.round(filterRect.bottom),
+            headerBottom: Math.round(headerRect?.bottom ?? 0),
+            tickerTop: Math.round(tickerRect.top),
+            captionText: Array.from(caption.querySelectorAll('span'))
+              .filter(
+                (child) =>
+                  child.children.length === 0 &&
+                  child.getBoundingClientRect().width > 0,
+              )
+              .map((child) => child.textContent?.trim() ?? '')
+              .join(' '),
+          }
+        })
+
+        if (!channelsMobileLayout) {
+          console.error(
+            `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): missing channels mobile layout elements`,
+          )
+          failures += 1
+        } else {
+          if (
+            channelsMobileLayout.buttonRowCount !== 1 ||
+            Math.abs(channelsMobileLayout.filterCenter - viewport.width / 2) > 2
+          ) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `channel filters should be a single centered mobile row — ` +
+                `rows=${channelsMobileLayout.buttonRowCount}, ` +
+                `center=${channelsMobileLayout.filterCenter}`,
+            )
+            failures += 1
+          }
+
+          if (channelsMobileLayout.tickerTop - channelsMobileLayout.filterBottom > 32) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `channel ticker should sit close to mobile filters — ` +
+                `gap=${channelsMobileLayout.tickerTop - channelsMobileLayout.filterBottom}`,
+            )
+            failures += 1
+          }
+
+          if (/hover/i.test(channelsMobileLayout.captionText)) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `channel ticker caption should not mention hover on touch devices — ` +
+                `caption="${channelsMobileLayout.captionText}"`,
+            )
+            failures += 1
+          }
+        }
+
+        await page.locator('#customize').scrollIntoViewIfNeeded()
+        await page.waitForTimeout(900)
+
+        const customizeTickerLayout = await page.evaluate(() => {
+          const customize = document.querySelector('#customize')
+          const media = customize?.querySelector('[data-customization-ticker-media]')
+          const strips = Array.from(
+            customize?.querySelectorAll('[data-customization-ticker-strip]') ?? [],
+          )
+
+          if (!customize || !media || strips.length < 2) return null
+
+          const mediaRect = media.getBoundingClientRect()
+          const stripRects = strips.map((strip) => strip.getBoundingClientRect())
+
+          return {
+            mediaLeft: Math.round(mediaRect.left),
+            mediaRight: Math.round(mediaRect.right),
+            strips: stripRects.map((rect) => ({
+              left: Math.round(rect.left),
+              right: Math.round(rect.right),
+              height: Math.round(rect.height),
+            })),
+          }
+        })
+
+        if (!customizeTickerLayout) {
+          console.error(
+            `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): missing customization ticker layout elements`,
+          )
+          failures += 1
+        } else {
+          const expectedStripHeights = [32, 48]
+          for (const [index, strip] of customizeTickerLayout.strips.entries()) {
+            if (
+              Math.abs(strip.left - customizeTickerLayout.mediaLeft) > 1 ||
+              Math.abs(strip.right - customizeTickerLayout.mediaRight) > 1 ||
+              Math.abs(strip.height - expectedStripHeights[index]) > 1
+            ) {
+              console.error(
+                `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                  `customization ticker strip ${index + 1} should be edge-to-edge inside its card media — ` +
+                  `mediaLeft=${customizeTickerLayout.mediaLeft}, mediaRight=${customizeTickerLayout.mediaRight}, ` +
+                  `stripLeft=${strip.left}, stripRight=${strip.right}, stripHeight=${strip.height}, ` +
+                  `expectedHeight=${expectedStripHeights[index]}`,
+              )
+              failures += 1
+            }
+          }
+        }
+
         await page.evaluate(() => window.scrollTo(0, 0))
         await page.locator('section').first().getByRole('button', {
           name: 'How It Works',

--- a/myscrollr.com/scripts/check-mobile-viewport.mjs
+++ b/myscrollr.com/scripts/check-mobile-viewport.mjs
@@ -1,0 +1,260 @@
+// Mobile viewport regression check.
+//
+// Spawns a small HTTP server over `dist/client/`, then headless
+// Chromium via Playwright (already a devDep — used by
+// generate-og-images.mjs) visits every prerendered route at several
+// mobile viewport widths. For each visit:
+//
+//  - Asserts `document.documentElement.scrollWidth <= clientWidth`
+//    (i.e. no horizontal scroll — the #1 mobile bug).
+//  - If overflow is detected, walks the DOM to identify the widest
+//    offending element so the failure message is actionable.
+//
+// Runs in `npm run postbuild` after `check-prerender.mjs`. Fails the
+// build if any route×viewport pair triggers horizontal scroll.
+//
+// Skip via SKIP_MOBILE_VIEWPORT_CHECK=1 (local dev convenience; CI
+// always runs it).
+
+import { createServer } from 'node:http'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, extname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const clientDir = join(__dirname, '..', 'dist', 'client')
+
+if (process.env.SKIP_MOBILE_VIEWPORT_CHECK) {
+  console.log('[check-mobile-viewport] skipped (SKIP_MOBILE_VIEWPORT_CHECK=1)')
+  process.exit(0)
+}
+
+// Representative mobile/tablet widths. iPhone SE (320) is the
+// historical narrow case; iPhone 13/14 Pro (390) is the current
+// modal device; tablet portrait (768) is the breakpoint boundary
+// where the desktop layout kicks in.
+const VIEWPORTS = [
+  { name: 'iphone-se', width: 320, height: 568 },
+  { name: 'iphone-13', width: 390, height: 844 },
+  { name: 'pixel-7', width: 412, height: 915 },
+  { name: 'ipad-mini', width: 768, height: 1024 },
+]
+
+// Routes to check. Mirrors `check-prerender.mjs` but excludes pages
+// whose bodies are intentionally client-rendered (uplink, lifetime).
+// Running the check against an empty <main> would silently pass and
+// hide real bugs.
+const ROUTES = [
+  { path: '/', file: 'index.html' },
+  { path: '/channels', file: 'channels/index.html' },
+  { path: '/download', file: 'download/index.html' },
+  { path: '/business', file: 'business/index.html' },
+  { path: '/architecture', file: 'architecture/index.html' },
+  { path: '/support', file: 'support/index.html' },
+  { path: '/legal', file: 'legal/index.html' },
+]
+
+// Per-extension content-type table. Anything not listed gets served
+// as `application/octet-stream`; the browser still loads it via
+// fetch but won't apply it as a stylesheet/script (which is fine for
+// fonts/images, which the browser sniffs anyway).
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+}
+
+// Sanity: every file we want to check must exist on disk.
+const missing = ROUTES.filter((r) => !existsSync(join(clientDir, r.file)))
+if (missing.length) {
+  console.error(
+    `[check-mobile-viewport] missing prerendered files: ${missing
+      .map((m) => m.file)
+      .join(', ')}`,
+  )
+  process.exit(1)
+}
+
+let chromium
+try {
+  ;({ chromium } = await import('playwright'))
+} catch (err) {
+  console.error(
+    '[check-mobile-viewport] failed to import playwright. Run ' +
+      '`npm install` to ensure devDependencies are present. Error: ' +
+      (err?.message ?? err),
+  )
+  process.exit(1)
+}
+
+// Resolve an incoming URL path to a file under `dist/client/`,
+// applying nginx-style fallbacks: `/foo` → `/foo/index.html`,
+// `/foo/` → `/foo/index.html`. Rejects path traversal attempts.
+function resolveStaticFile(urlPath) {
+  // Strip query/hash; the URL constructor wants a base for relative
+  // paths, so we hand it a dummy origin.
+  const pathname = new URL(urlPath, 'http://x').pathname
+  // Reject anything containing `..` after normalization. join()
+  // would resolve `..` and could escape `clientDir`.
+  if (pathname.includes('..')) return null
+
+  const direct = join(clientDir, pathname)
+  if (existsSync(direct)) {
+    // If it's a directory request (`/foo/`), serve `index.html`.
+    if (pathname.endsWith('/')) {
+      const indexPath = join(direct, 'index.html')
+      return existsSync(indexPath) ? indexPath : null
+    }
+    return direct
+  }
+
+  // Bare route without extension or trailing slash. Try
+  // `/foo/index.html`.
+  if (!extname(pathname)) {
+    const subIndex = join(clientDir, pathname, 'index.html')
+    if (existsSync(subIndex)) return subIndex
+  }
+
+  // SPA fallback: anything not found returns the prerendered shell.
+  // This mirrors the nginx `try_files $uri $uri/ /index.html;` rule
+  // so the browser doesn't 404 on dynamic routes during the test
+  // (not currently needed for the prerendered routes, but cheap).
+  const shell = join(clientDir, '_shell.html')
+  return existsSync(shell) ? shell : null
+}
+
+// Start a tiny static file server on a random port. Returns
+// { server, port } so callers can construct the base URL.
+function startStaticServer() {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const file = resolveStaticFile(req.url ?? '/')
+      if (!file) {
+        res.writeHead(404)
+        res.end('Not Found')
+        return
+      }
+      const ext = extname(file).toLowerCase()
+      const type = MIME_TYPES[ext] ?? 'application/octet-stream'
+      try {
+        const body = readFileSync(file)
+        res.writeHead(200, { 'content-type': type })
+        res.end(body)
+      } catch (err) {
+        res.writeHead(500)
+        res.end(`Internal Server Error: ${err?.message ?? err}`)
+      }
+    })
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to read server address'))
+        return
+      }
+      resolve({ server, port: addr.port })
+    })
+  })
+}
+
+const { server, port } = await startStaticServer()
+const baseUrl = `http://127.0.0.1:${port}`
+
+const browser = await chromium.launch()
+let failures = 0
+
+try {
+  for (const viewport of VIEWPORTS) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      deviceScaleFactor: 2,
+      isMobile: viewport.width < 768,
+      hasTouch: viewport.width < 768,
+    })
+    const page = await context.newPage()
+
+    for (const route of ROUTES) {
+      try {
+        await page.goto(`${baseUrl}${route.path}`, {
+          waitUntil: 'networkidle',
+          timeout: 15000,
+        })
+      } catch (err) {
+        console.error(
+          `✗ ${route.path} @ ${viewport.name}: failed to load (${err?.message ?? err})`,
+        )
+        failures += 1
+        continue
+      }
+
+      // Brief settle so any in-flight layout work finishes.
+      await page.waitForTimeout(250)
+
+      const result = await page.evaluate(() => {
+        const doc = document.documentElement
+        const body = document.body
+        const scrollWidth = Math.max(doc.scrollWidth, body.scrollWidth)
+        const clientWidth = doc.clientWidth
+
+        let offender = null
+        if (scrollWidth > clientWidth) {
+          let furthest = clientWidth
+          for (const el of Array.from(document.querySelectorAll('*'))) {
+            const rect = el.getBoundingClientRect()
+            if (rect.right > furthest) {
+              furthest = rect.right
+              const id = el.id ? `#${el.id}` : ''
+              const cls =
+                el.className && typeof el.className === 'string'
+                  ? `.${el.className.trim().split(/\s+/).slice(0, 2).join('.')}`
+                  : ''
+              offender = `${el.tagName.toLowerCase()}${id}${cls} (right=${Math.round(
+                rect.right,
+              )})`
+            }
+          }
+        }
+        return { scrollWidth, clientWidth, offender }
+      })
+
+      // Subpixel rendering at 2× DSR can produce off-by-1 scrollWidth
+      // values that don't actually scroll. Tolerate 1px.
+      if (result.scrollWidth - result.clientWidth > 1) {
+        console.error(
+          `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+            `horizontal scroll detected — scrollWidth=${result.scrollWidth}, ` +
+            `clientWidth=${result.clientWidth}` +
+            (result.offender ? `; widest offender: ${result.offender}` : ''),
+        )
+        failures += 1
+      } else {
+        console.log(`✓ ${route.path} @ ${viewport.name} (${viewport.width}px)`)
+      }
+    }
+
+    await context.close()
+  }
+} finally {
+  await browser.close()
+  await new Promise((resolve) => server.close(resolve))
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} mobile viewport check(s) failed.`)
+  process.exit(1)
+}
+console.log('\nAll mobile viewport checks passed.')

--- a/myscrollr.com/scripts/check-mobile-viewport.mjs
+++ b/myscrollr.com/scripts/check-mobile-viewport.mjs
@@ -244,6 +244,278 @@ try {
       } else {
         console.log(`✓ ${route.path} @ ${viewport.name} (${viewport.width}px)`)
       }
+
+      if (route.path === '/' && viewport.width < 768) {
+        const heroMobileLayout = await page.evaluate(() => {
+          const header = document.querySelector('header')
+          const heading = document.querySelector('h1')
+          const heroSection = heading?.closest('section')
+          const screenshot = Array.from(
+            document.querySelectorAll('[data-hero-showcase]'),
+          ).find((el) => el.getBoundingClientRect().width > 0)
+          const progressButton = document.querySelector(
+            'button[aria-label^="Show "]',
+          )
+          const heroCopy = Array.from(heroSection?.querySelectorAll('p') ?? []).find((p) =>
+            p.textContent?.includes('A quiet ticker at the edge of your screen'),
+          )
+          const downloadLink = Array.from(heroSection?.querySelectorAll('a') ?? []).find((a) =>
+            a.textContent?.includes('Download'),
+          )
+          if (!header || !heading || !screenshot || !progressButton) return null
+
+          const headerRect = header.getBoundingClientRect()
+          const headingRect = heading.getBoundingClientRect()
+          const screenshotRect = screenshot.getBoundingClientRect()
+          const progressRect = progressButton.getBoundingClientRect()
+          const clientWidth = document.documentElement.clientWidth
+          return {
+            headerBottom: Math.round(headerRect.bottom),
+            headingTop: Math.round(headingRect.top),
+            headingBottom: Math.round(headingRect.bottom),
+            screenshotTop: Math.round(screenshotRect.top),
+            screenshotBottom: Math.round(screenshotRect.bottom),
+            screenshotLeft: Math.round(screenshotRect.left),
+            screenshotRight: Math.round(screenshotRect.right),
+            progressTop: Math.round(progressRect.top),
+            clientWidth,
+            hasHeroCopy: Boolean(heroCopy),
+            hasDownloadLink: Boolean(downloadLink),
+          }
+        })
+
+        if (!heroMobileLayout) {
+          console.error(
+            `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): missing hero mobile layout elements`,
+          )
+          failures += 1
+        } else {
+          if (heroMobileLayout.headingTop < heroMobileLayout.headerBottom + 12) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `hero heading starts under fixed header — headingTop=${heroMobileLayout.headingTop}, ` +
+                `headerBottom=${heroMobileLayout.headerBottom}`,
+            )
+            failures += 1
+          }
+
+          if (
+            heroMobileLayout.screenshotTop < heroMobileLayout.headingBottom ||
+            heroMobileLayout.screenshotBottom > heroMobileLayout.progressTop
+          ) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `hero screenshot is not between heading and switch bars — ` +
+                `headingBottom=${heroMobileLayout.headingBottom}, ` +
+                `screenshotTop=${heroMobileLayout.screenshotTop}, ` +
+                `screenshotBottom=${heroMobileLayout.screenshotBottom}, ` +
+                `progressTop=${heroMobileLayout.progressTop}`,
+            )
+            failures += 1
+          }
+
+          if (
+            Math.abs(heroMobileLayout.screenshotLeft - 12) > 1 ||
+            Math.abs(heroMobileLayout.screenshotRight - (heroMobileLayout.clientWidth - 12)) > 1
+          ) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `hero screenshot does not use 12px mobile gutters — left=${heroMobileLayout.screenshotLeft}, ` +
+                `right=${heroMobileLayout.screenshotRight}, clientWidth=${heroMobileLayout.clientWidth}`,
+            )
+            failures += 1
+          }
+
+          if (!heroMobileLayout.hasHeroCopy || heroMobileLayout.hasDownloadLink) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `hero copy/download CTA state is wrong — ` +
+                `hasHeroCopy=${heroMobileLayout.hasHeroCopy}, ` +
+                `hasDownloadLink=${heroMobileLayout.hasDownloadLink}`,
+            )
+            failures += 1
+          }
+        }
+
+        await page.locator('#ticker').scrollIntoViewIfNeeded()
+        await page.waitForTimeout(900)
+
+        const mobileFlow = await page.evaluate(() => {
+          const header = document.querySelector('header')
+          const ticker = document.querySelector('#ticker')
+          const how = document.querySelector('#how-it-works')
+          const tickerStack = ticker?.querySelector('[data-ticker-stack]')
+          const lastTicker = tickerStack?.lastElementChild
+          const howHeader = how?.querySelector('h2')
+          const howCards = how?.querySelectorAll('[data-mobile-step-card]')
+          const tickerStrip = ticker?.querySelector('[data-ticker-strip]')
+          const tickerStrips = Array.from(
+            ticker?.querySelectorAll('[data-ticker-strip]') ?? [],
+          )
+          const tickerImage = tickerStrip?.querySelector('img')
+
+          if (
+            !header ||
+            !ticker ||
+            !how ||
+            !lastTicker ||
+            !howHeader ||
+            !howCards ||
+            !tickerStrip ||
+            !tickerImage
+          ) {
+            return null
+          }
+
+          const tickerRect = ticker.getBoundingClientRect()
+          const howRect = how.getBoundingClientRect()
+          const lastTickerRect = lastTicker.getBoundingClientRect()
+          const howHeaderRect = howHeader.getBoundingClientRect()
+          const tickerStripRect = tickerStrip.getBoundingClientRect()
+          const tickerImageRect = tickerImage.getBoundingClientRect()
+          const secondTickerStripRect = tickerStrips[1]?.getBoundingClientRect()
+          const compactStripRect = tickerStrips[1]?.getBoundingClientRect()
+          const howHeaderStyle = getComputedStyle(howHeader)
+          const clientWidth = document.documentElement.clientWidth
+
+          return {
+            tickerTop: Math.round(tickerRect.top),
+            howTop: Math.round(howRect.top),
+            lastTickerBottom: Math.round(lastTickerRect.bottom),
+            howHeaderTop: Math.round(howHeaderRect.top),
+            howHeaderOpacity: Number(howHeaderStyle.opacity),
+            mobileStepCardCount: howCards.length,
+            tickerStripTop: Math.round(tickerStripRect.top),
+            tickerStripBottom: Math.round(tickerStripRect.bottom),
+            tickerStripLeft: Math.round(tickerStripRect.left),
+            tickerStripRight: Math.round(tickerStripRect.right),
+            tickerStripHeight: Math.round(tickerStripRect.height),
+            compactTickerStripHeight: compactStripRect
+              ? Math.round(compactStripRect.height)
+              : null,
+            tickerImageTop: Math.round(tickerImageRect.top),
+            tickerImageBottom: Math.round(tickerImageRect.bottom),
+            nextTickerGap: secondTickerStripRect
+              ? Math.round(secondTickerStripRect.top - tickerStripRect.bottom)
+              : null,
+            clientWidth,
+          }
+        })
+
+        if (!mobileFlow) {
+          console.error(
+            `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): missing mobile flow elements`,
+          )
+          failures += 1
+        } else {
+          const contentGap = mobileFlow.howHeaderTop - mobileFlow.lastTickerBottom
+          if (contentGap > 120) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `gap between ticker stack and How It Works header is too large — gap=${contentGap}`,
+            )
+            failures += 1
+          }
+
+          if (mobileFlow.howHeaderOpacity < 0.95) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `How It Works mobile header is not visible — opacity=${mobileFlow.howHeaderOpacity}`,
+            )
+            failures += 1
+          }
+
+          if (mobileFlow.mobileStepCardCount !== 3) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `How It Works mobile layout should show three stable step cards — found=${mobileFlow.mobileStepCardCount}`,
+            )
+            failures += 1
+          }
+
+          if (
+            mobileFlow.tickerStripLeft > 1 ||
+            mobileFlow.tickerStripRight < mobileFlow.clientWidth - 1 ||
+            mobileFlow.tickerStripHeight < 24
+          ) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `ticker strip should read as a full-width enlarged mobile strip — ` +
+                `left=${mobileFlow.tickerStripLeft}, right=${mobileFlow.tickerStripRight}, ` +
+                `height=${mobileFlow.tickerStripHeight}, clientWidth=${mobileFlow.clientWidth}`,
+            )
+            failures += 1
+          }
+
+          if (
+            mobileFlow.compactTickerStripHeight === null ||
+            mobileFlow.compactTickerStripHeight >= mobileFlow.tickerStripHeight - 4
+          ) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `compact ticker strip should be visibly shorter than detailed strip — ` +
+                `detailedHeight=${mobileFlow.tickerStripHeight}, ` +
+                `compactHeight=${mobileFlow.compactTickerStripHeight}`,
+            )
+            failures += 1
+          }
+
+          if (
+            Math.abs(mobileFlow.tickerImageTop - mobileFlow.tickerStripTop) > 1 ||
+            Math.abs(mobileFlow.tickerImageBottom - mobileFlow.tickerStripBottom) > 1
+          ) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `ticker image is vertically scaled/cropped inside its strip — ` +
+                `stripTop=${mobileFlow.tickerStripTop}, stripBottom=${mobileFlow.tickerStripBottom}, ` +
+                `imageTop=${mobileFlow.tickerImageTop}, imageBottom=${mobileFlow.tickerImageBottom}`,
+            )
+            failures += 1
+          }
+
+          if (
+            mobileFlow.nextTickerGap !== null &&
+            mobileFlow.nextTickerGap > 56
+          ) {
+            console.error(
+              `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+                `gap between mobile ticker strips is too large — gap=${mobileFlow.nextTickerGap}`,
+            )
+            failures += 1
+          }
+        }
+
+        await page.evaluate(() => window.scrollTo(0, 0))
+        await page.locator('section').first().getByRole('button', {
+          name: 'How It Works',
+        }).click()
+        await page.waitForTimeout(900)
+        const scrollTarget = await page.evaluate(() => {
+          const header = document.querySelector('header')
+          const ticker = document.querySelector('#ticker')
+          if (!header || !ticker) return null
+          const headerRect = header.getBoundingClientRect()
+          const tickerRect = ticker.getBoundingClientRect()
+          return {
+            headerBottom: Math.round(headerRect.bottom),
+            tickerTop: Math.round(tickerRect.top),
+          }
+        })
+
+        if (!scrollTarget) {
+          console.error(
+            `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): missing scroll target elements`,
+          )
+          failures += 1
+        } else if (Math.abs(scrollTarget.tickerTop - scrollTarget.headerBottom) > 8) {
+          console.error(
+            `✗ ${route.path} @ ${viewport.name} (${viewport.width}px): ` +
+              `hero How It Works button should scroll to ticker section — ` +
+              `tickerTop=${scrollTarget.tickerTop}, headerBottom=${scrollTarget.headerBottom}`,
+          )
+          failures += 1
+        }
+      }
     }
 
     await context.close()

--- a/myscrollr.com/scripts/check-prerender.mjs
+++ b/myscrollr.com/scripts/check-prerender.mjs
@@ -36,7 +36,7 @@ const ROUTES = [
     path: '/',
     file: 'index.html',
     minJsonLd: 3, // Org, WebSite, SoftwareApp
-    expectedBody: 'A quiet ticker at the edge of your screen',
+    expectedBody: 'What actually sits',
   },
   {
     path: '/channels',

--- a/myscrollr.com/src/components/LoadingSpinner.tsx
+++ b/myscrollr.com/src/components/LoadingSpinner.tsx
@@ -13,7 +13,7 @@ export default function LoadingSpinner({
 }: LoadingSpinnerProps) {
   if (variant === 'spin') {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-dvh flex items-center justify-center">
         <div className="text-center space-y-4">
           <div className="animate-spin rounded-full h-12 w-12 border-2 border-primary/20 border-t-primary mx-auto" />
           {label && (
@@ -27,7 +27,7 @@ export default function LoadingSpinner({
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
+    <div className="min-h-dvh flex items-center justify-center">
       <motion.div
         animate={{ opacity: [0.5, 1, 0.5] }}
         transition={{ duration: 1.5, repeat: Infinity }}

--- a/myscrollr.com/src/components/landing/ChannelsShowcase.tsx
+++ b/myscrollr.com/src/components/landing/ChannelsShowcase.tsx
@@ -182,14 +182,14 @@ function TickerChipItem({ chip }: { chip: TickerChip }) {
   const c = chipColors[chip.channel]
   return (
     <div
-      className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border ${c.border} ${c.bg} shrink-0`}
+      className={`flex items-center gap-1.5 sm:gap-2 px-2.5 sm:px-3 py-1 sm:py-1.5 rounded-lg border ${c.border} ${c.bg} shrink-0`}
     >
       <span
-        className={`text-[11px] font-bold font-mono ${c.text} whitespace-nowrap`}
+        className={`text-[10px] sm:text-[11px] font-bold font-mono ${c.text} whitespace-nowrap`}
       >
         {chip.label}
       </span>
-      <span className={`text-[10px] font-mono ${c.sub} whitespace-nowrap`}>
+      <span className={`text-[9px] sm:text-[10px] font-mono ${c.sub} whitespace-nowrap`}>
         {chip.value}
       </span>
     </div>
@@ -452,7 +452,7 @@ export function ChannelsShowcase() {
 
       {/* Header area — container-width but custom vertical padding */}
       <div
-        className="mx-auto px-5 sm:px-6 lg:px-8 pt-16 lg:pt-24 relative"
+        className="mx-auto px-5 sm:px-6 lg:px-8 pt-14 sm:pt-16 lg:pt-24 relative"
         style={{ maxWidth: 1400 }}
       >
         <motion.div
@@ -461,7 +461,7 @@ export function ChannelsShowcase() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: '-80px' }}
           transition={{ duration: 0.6, ease: EASE }}
-          className="flex flex-col items-center text-center mb-10 lg:mb-14"
+          className="flex flex-col items-center text-center mb-7 sm:mb-10 lg:mb-14"
         >
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-5 text-center">
             Everything You Follow.{' '}
@@ -480,7 +480,7 @@ export function ChannelsShowcase() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ delay: 0.15, duration: 0.5, ease: EASE }}
-          className="flex flex-wrap justify-center gap-2.5 mb-10 lg:mb-14"
+          className="-mx-5 flex flex-nowrap justify-center gap-1.5 overflow-x-auto px-3 pb-1 mb-5 sm:mx-0 sm:flex-wrap sm:gap-2.5 sm:overflow-visible sm:px-0 sm:pb-0 sm:mb-10 lg:mb-14"
         >
           {CHANNELS.map((stream) => {
             const isActive = activeChannels.has(stream.key)
@@ -490,7 +490,7 @@ export function ChannelsShowcase() {
                 key={stream.key}
                 type="button"
                 onClick={() => handleFilterClick(stream.key)}
-                className={`inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold border transition-[color,background-color,border-color,box-shadow] duration-300 cursor-pointer ${
+                  className={`inline-flex shrink-0 items-center gap-1 sm:gap-2 px-3 sm:px-4 py-2 sm:py-2.5 rounded-xl text-xs sm:text-sm font-semibold border transition-[color,background-color,border-color,box-shadow] duration-300 cursor-pointer ${
                   isActive
                     ? `${stream.activeBg} ${stream.activeText} border-transparent shadow-md`
                     : 'bg-base-200/50 text-base-content/35 border-base-300/30 hover:text-base-content/55 hover:bg-base-200/70'
@@ -506,16 +506,17 @@ export function ChannelsShowcase() {
 
       {/* Full-bleed Motion+ Ticker */}
       <motion.div
+        data-channel-ticker-band
         style={{ opacity: 0 }}
         initial={{ opacity: 0 }}
         whileInView={{ opacity: 1 }}
         viewport={{ once: true }}
         transition={{ delay: 0.3, duration: 0.6, ease: EASE }}
-        className="relative bg-base-200/60 border-y border-base-300/30 py-3"
+        className="relative bg-base-200/60 border-y border-base-300/30 py-2 sm:py-3"
       >
         {/* Left/Right fade masks */}
-        <div className="absolute left-0 top-0 bottom-0 w-16 sm:w-24 bg-gradient-to-r from-base-100 to-transparent z-10 pointer-events-none" />
-        <div className="absolute right-0 top-0 bottom-0 w-16 sm:w-24 bg-gradient-to-l from-base-100 to-transparent z-10 pointer-events-none" />
+        <div className="absolute left-0 top-0 bottom-0 w-8 sm:w-24 bg-gradient-to-r from-base-100 to-transparent z-10 pointer-events-none" />
+        <div className="absolute right-0 top-0 bottom-0 w-8 sm:w-24 bg-gradient-to-l from-base-100 to-transparent z-10 pointer-events-none" />
 
         <AnimatedTicker
           chips={visibleChips}
@@ -533,14 +534,20 @@ export function ChannelsShowcase() {
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, margin: '-40px' }}
         transition={{ delay: 0.1, duration: 0.5, ease: EASE }}
-        className="flex items-center justify-center gap-3 mt-4 mb-2 px-5"
+        data-channel-ticker-caption
+        className="flex items-center justify-center gap-3 mt-3 sm:mt-4 mb-2 px-5"
       >
         <span className="relative flex h-1.5 w-1.5">
           <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
           <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary" />
         </span>
-        <span className="text-[11px] text-base-content/30 font-medium">
-          Your desktop, right now — hover to slow, click to explore.
+        <span className="text-[11px] text-base-content/30 font-medium text-center">
+          <span className="sm:hidden">
+            Tap filters to shape the ticker in real time.
+          </span>
+          <span className="hidden sm:inline">
+            Your desktop, right now — hover to slow, click to explore.
+          </span>
         </span>
       </motion.div>
 

--- a/myscrollr.com/src/components/landing/CustomizationShowcase.tsx
+++ b/myscrollr.com/src/components/landing/CustomizationShowcase.tsx
@@ -223,22 +223,32 @@ function CardMediaArea({ media }: { media: CardMedia }) {
   // as the single variant; vertical padding gives the strips breathing
   // room since their content is dense.
   return (
-    <div className="relative w-full overflow-hidden border-b border-base-300/40 bg-base-100/40 px-5 py-6 sm:px-7 sm:py-8 flex flex-col gap-4">
+    <div
+      data-customization-ticker-media
+      className="relative w-full min-w-0 overflow-hidden border-b border-base-300/40 bg-base-100/40 py-5 sm:px-7 sm:py-8 flex flex-col gap-4"
+    >
       {media.rows.map((row) => (
-        <figure key={row.basename} className="flex flex-col gap-1.5">
-          <figcaption className="text-[10px] font-mono uppercase tracking-[0.18em] text-base-content/40">
+        <figure key={row.basename} className="flex min-w-0 flex-col gap-1.5">
+          <figcaption className="px-5 text-[10px] font-mono uppercase tracking-[0.18em] text-base-content/40 sm:px-0">
             {row.densityLabel}
           </figcaption>
           <div
-            className="overflow-hidden rounded-md border border-base-300/40 bg-base-100/60 shadow-sm"
-            style={{ aspectRatio: row.aspect }}
+            data-customization-ticker-strip
+            className="relative h-[var(--mobile-ticker-height)] w-full min-w-0 overflow-hidden border-y border-base-300/40 bg-base-100/60 shadow-sm sm:h-auto sm:rounded-md sm:border sm:[aspect-ratio:var(--ticker-aspect)]"
+            style={
+              {
+                '--mobile-ticker-height':
+                  row.aspect === '2930 / 80' ? '32px' : '48px',
+                '--ticker-aspect': row.aspect,
+              } as React.CSSProperties
+            }
           >
             <ProductScreenshot
               basename={row.basename}
               alt={row.alt}
               aspect={row.aspect}
-              pictureClassName="block w-full h-full"
-              imgClassName="block h-full w-full object-cover"
+              pictureClassName="absolute -inset-y-px left-0 w-[240vw] -translate-x-20 sm:inset-0 sm:h-full sm:w-full sm:translate-x-0"
+              imgClassName="block h-full w-[240vw] max-w-none object-cover sm:w-full"
             />
           </div>
         </figure>

--- a/myscrollr.com/src/components/landing/HeroProductShowcase.tsx
+++ b/myscrollr.com/src/components/landing/HeroProductShowcase.tsx
@@ -99,14 +99,14 @@ export function HeroProductShowcase({ activeIndex }: HeroProductShowcaseProps) {
 
   return (
     <motion.div
+      data-hero-showcase
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
-      // `w-full max-w-[360px]` lets the showcase shrink with the
-      // viewport down to ~320px (iPhone SE 1st gen) without
-      // overflowing the column. Above `sm:`, fixed widths take over
-      // (desktop visual unchanged).
-      className="relative w-full max-w-[360px] sm:w-[480px] sm:max-w-none lg:w-[500px] xl:w-[640px] 2xl:w-[780px] aspect-[1600/954]"
+      // Mobile sits between the hero headline and switch bars with
+      // narrow viewport gutters. Above `sm:`, fixed widths take over
+      // so the desktop visual remains unchanged.
+      className="relative left-1/2 w-[calc(100vw-24px)] max-w-none -translate-x-1/2 sm:left-auto sm:w-[480px] sm:translate-x-0 lg:w-[500px] xl:w-[640px] 2xl:w-[780px] aspect-[1600/954]"
     >
       {/* Ambient glow tinted by the active channel's accent color. */}
       <div
@@ -137,7 +137,7 @@ export function HeroProductShowcase({ activeIndex }: HeroProductShowcaseProps) {
                 alt={isActive ? ALT_TEXT[channel] : ''}
                 priority={isActive}
                 pictureClassName="absolute inset-0"
-                imgClassName="block h-full w-full rounded-xl object-cover shadow-xl"
+                imgClassName="block h-full w-full rounded-xl object-cover shadow-lg sm:shadow-xl"
               />
             </div>
           )

--- a/myscrollr.com/src/components/landing/HeroProductShowcase.tsx
+++ b/myscrollr.com/src/components/landing/HeroProductShowcase.tsx
@@ -102,7 +102,11 @@ export function HeroProductShowcase({ activeIndex }: HeroProductShowcaseProps) {
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
-      className="relative w-[360px] sm:w-[480px] lg:w-[500px] xl:w-[640px] 2xl:w-[780px] aspect-[1600/954]"
+      // `w-full max-w-[360px]` lets the showcase shrink with the
+      // viewport down to ~320px (iPhone SE 1st gen) without
+      // overflowing the column. Above `sm:`, fixed widths take over
+      // (desktop visual unchanged).
+      className="relative w-full max-w-[360px] sm:w-[480px] sm:max-w-none lg:w-[500px] xl:w-[640px] 2xl:w-[780px] aspect-[1600/954]"
     >
       {/* Ambient glow tinted by the active channel's accent color. */}
       <div

--- a/myscrollr.com/src/components/landing/HeroSection.tsx
+++ b/myscrollr.com/src/components/landing/HeroSection.tsx
@@ -111,7 +111,12 @@ export function HeroSection() {
                     onClick={() => handleSelect(i)}
                     aria-label={`Show ${word} demo`}
                     aria-pressed={isActive}
-                    className="flex-1 cursor-pointer py-2"
+                    // `py-3` on mobile gives ~44px total tap area
+                    // (12+12+1px track = 25; padded box ends up
+                    // ~44px because flex centers the track). Drops
+                    // back to `py-2` from `sm:` upward to match the
+                    // desktop look. WCAG 2.5.5 AAA target.
+                    className="flex-1 cursor-pointer py-3 sm:py-2"
                   >
                     <div
                       className={`h-1 rounded-full overflow-hidden ${accent.track}`}

--- a/myscrollr.com/src/components/landing/HeroSection.tsx
+++ b/myscrollr.com/src/components/landing/HeroSection.tsx
@@ -3,7 +3,6 @@ import { motion } from 'motion/react'
 import { wrap } from 'motion'
 import HeroTextSwap, { WORDS } from '@/components/Typewriter'
 import { HeroProductShowcase } from '@/components/landing/HeroProductShowcase'
-import { DownloadButton } from '@/components/DownloadButton'
 
 const CYCLE_MS = 4000
 
@@ -73,11 +72,11 @@ export function HeroSection() {
   }
 
   return (
-    <section className="relative min-h-dvh flex items-center overflow-hidden">
+    <section className="relative min-h-dvh flex items-start lg:items-center overflow-hidden pt-20 lg:pt-0">
       <div className="container relative">
         <div className="flex lg:flex-row flex-col justify-center items-center gap-12 lg:gap-12 xl:gap-16">
           {/* Desktop App Preview */}
-          <div className="relative order-2 lg:order-1">
+          <div className="relative order-2 hidden lg:block lg:order-1">
             <HeroProductShowcase
               activeIndex={activeWordIndex}
               onSelect={handleSelect}
@@ -92,6 +91,13 @@ export function HeroSection() {
             className="w-full lg:w-fit lg:min-w-80 xl:min-w-100 2xl:min-w-120 order-1 lg:order-2"
           >
             <HeroTextSwap activeIndex={activeWordIndex} />
+
+            <div className="mt-8 lg:hidden">
+              <HeroProductShowcase
+                activeIndex={activeWordIndex}
+                onSelect={handleSelect}
+              />
+            </div>
 
             {/* Progress indicators */}
             <motion.div
@@ -143,7 +149,7 @@ export function HeroSection() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 1 }}
-              className="text-base text-base-content/50 max-w-md leading-relaxed"
+              className="text-base text-center lg:text-left text-base-content/50 max-w-md mx-auto lg:mx-0 leading-relaxed"
             >
               A quiet ticker at the edge of your screen. Scores update, prices
               move, headlines arrive &mdash; all while you stay focused on
@@ -154,9 +160,8 @@ export function HeroSection() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 1.2 }}
-              className="flex flex-wrap gap-4 mt-10"
+              className="flex justify-center lg:justify-start mt-10"
             >
-              <DownloadButton />
               <motion.button
                 type="button"
                 whileHover={{
@@ -165,7 +170,7 @@ export function HeroSection() {
                 }}
                 whileTap={{ y: 0 }}
                 className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl border border-base-300 bg-base-200/50 px-6 py-3 text-sm font-semibold text-base-content hover:bg-base-300 transition-colors backdrop-blur-sm"
-                onClick={() => scrollToSection('how-it-works')}
+                onClick={() => scrollToSection('ticker')}
               >
                 How It Works
               </motion.button>

--- a/myscrollr.com/src/components/landing/HowItWorks.tsx
+++ b/myscrollr.com/src/components/landing/HowItWorks.tsx
@@ -513,15 +513,26 @@ export function HowItWorks() {
       {/* Subtle background band — signals a new "room" */}
       <div className="absolute inset-0 bg-gradient-to-b from-transparent via-base-200/20 to-transparent pointer-events-none" />
 
-      <div className="container relative py-24 lg:py-32">
-        {/* Section Header — centered */}
+      <div className="container relative py-10 sm:py-14 lg:py-32">
+        {/* Mobile header — static to avoid observer-related invisible states. */}
+        <div className="flex flex-col items-center text-center mb-8 lg:hidden">
+          <h2 className="text-4xl sm:text-5xl font-black tracking-tight leading-[0.95] mb-4 text-center">
+            Ready in{' '}
+            <span className="text-gradient-primary">Under a Minute</span>
+          </h2>
+          <p className="text-base text-base-content/50 leading-relaxed text-center max-w-lg">
+            Three steps between you and live data on your desktop.
+          </p>
+        </div>
+
+        {/* Desktop section header — keeps the existing motion treatment. */}
         <motion.div
           style={{ opacity: 0 }}
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: '-200px' }}
           transition={{ duration: 0.6, ease: VISUAL_EASE }}
-          className="flex flex-col items-center text-center mb-12 lg:mb-16"
+          className="hidden lg:flex flex-col items-center text-center mb-16"
         >
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-4 text-center">
             Ready in{' '}
@@ -533,70 +544,28 @@ export function HowItWorks() {
         </motion.div>
 
         {/* ── Mobile layout ── */}
-        <div className="lg:hidden">
-          {/* Tab pills */}
-          <motion.div
-            style={{ opacity: 0 }}
-            initial={{ opacity: 0, y: 15 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: '-200px' }}
-            transition={{ delay: 0.1, duration: 0.5, ease: VISUAL_EASE }}
-            className="flex gap-2 mb-5"
-          >
-            {STEPS.map((step, i) => {
-              const isActive = activeStep === i
-              return (
-                <button
-                  key={step.id}
-                  type="button"
-                  onClick={() => handleSelect(i)}
-                  className={`relative flex-1 py-2.5 px-3 rounded-xl text-xs font-semibold transition-all duration-300 cursor-pointer overflow-hidden ${
-                    isActive
-                      ? 'bg-primary text-primary-content shadow-md shadow-primary/15'
-                      : 'bg-base-200/50 text-base-content/40 border border-base-300/30 hover:text-base-content/60'
-                  }`}
-                >
-                  {step.title}
-                  {/* Progress bar at bottom of active tab */}
-                  {isActive && (
-                    <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-primary-content/15">
-                      <motion.div
-                        key={`mob-progress-${cycleKey}`}
-                        initial={{ scaleX: 0 }}
-                        animate={{ scaleX: 1 }}
-                        transition={{
-                          duration: CYCLE_MS / 1000,
-                          ease: 'linear',
-                        }}
-                        className="h-full bg-primary-content/40 origin-left"
-                      />
-                    </div>
-                  )}
-                </button>
-              )
-            })}
-          </motion.div>
-
-          {/* Visual stage */}
-          <div className="rounded-2xl bg-base-200/40 border border-base-300/40 overflow-hidden min-h-[320px] sm:min-h-[360px] flex flex-col [&>*]:flex-1 [&>*]:flex [&>*]:flex-col">
-            <AnimatePresence mode="wait">
-              <ActiveVisual key={`mobile-${activeStep}-${cycleKey}`} />
-            </AnimatePresence>
-          </div>
-
-          {/* Description */}
-          <AnimatePresence mode="wait">
-            <motion.p
-              key={`desc-${activeStep}`}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -8 }}
-              transition={{ duration: 0.25, ease: VISUAL_EASE }}
-              className="text-sm text-base-content/50 text-center mt-5 px-2 leading-relaxed"
+        <div className="lg:hidden space-y-3">
+          {STEPS.map((step, i) => (
+            <article
+              key={step.id}
+              data-mobile-step-card
+              className="rounded-2xl border border-base-300/40 bg-base-200/35 p-4 shadow-sm"
             >
-              {STEPS[activeStep].description}
-            </motion.p>
-          </AnimatePresence>
+              <div className="flex items-start gap-3">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-sm font-black text-primary border border-primary/15">
+                  {i + 1}
+                </div>
+                <div className="min-w-0">
+                  <h3 className="text-base font-bold text-base-content">
+                    {step.title}
+                  </h3>
+                  <p className="mt-1 text-sm leading-relaxed text-base-content/50">
+                    {step.description}
+                  </p>
+                </div>
+              </div>
+            </article>
+          ))}
         </div>
 
         {/* ── Desktop layout ── */}

--- a/myscrollr.com/src/components/landing/TickerShowcase.tsx
+++ b/myscrollr.com/src/components/landing/TickerShowcase.tsx
@@ -103,7 +103,7 @@ export function TickerShowcase() {
       <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-base-300/40 to-transparent" />
 
       <div
-        className="mx-auto px-5 sm:px-6 lg:px-8 py-20 lg:py-28 relative"
+        className="mx-auto px-5 sm:px-6 lg:px-8 py-14 sm:py-20 lg:py-28 relative"
         style={{ maxWidth: 1400 }}
       >
         {/* Section header ───────────────────────────────────── */}
@@ -112,7 +112,7 @@ export function TickerShowcase() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: '-80px' }}
           transition={{ duration: 0.6, ease: EASE }}
-          className="flex flex-col items-center text-center mb-12 lg:mb-16"
+          className="flex flex-col items-center text-center mb-8 sm:mb-12 lg:mb-16"
         >
           <span className="inline-flex items-center gap-2 px-3 py-1.5 bg-base-200/60 text-base-content/60 text-[10px] font-bold rounded-lg border border-base-300/40 uppercase tracking-wide mb-6">
             The ticker, not another window
@@ -128,7 +128,7 @@ export function TickerShowcase() {
         </motion.div>
 
         {/* Ticker stack ──────────────────────────────────────── */}
-        <div className="flex flex-col gap-4 sm:gap-5">
+        <div data-ticker-stack className="flex flex-col gap-3 sm:gap-5">
           {ROWS.map((row, idx) => (
             <TickerRowCard key={row.basename} row={row} index={idx} />
           ))}
@@ -157,7 +157,7 @@ function TickerRowCard({ row, index }: TickerRowCardProps) {
       whileInView={{ opacity: 1, x: 0 }}
       viewport={{ once: true, margin: '-60px' }}
       transition={{ duration: 0.5, ease: EASE, delay: index * 0.06 }}
-      className="grid grid-cols-1 sm:grid-cols-[160px_1fr] items-center gap-3 sm:gap-6"
+      className="grid grid-cols-1 sm:grid-cols-[160px_1fr] items-center gap-1.5 sm:gap-6"
     >
       {/* Eyebrow ─────────────────────────────────────────── */}
       <figcaption className="flex sm:flex-col sm:items-start items-center gap-2 sm:gap-1 text-left">
@@ -171,15 +171,16 @@ function TickerRowCard({ row, index }: TickerRowCardProps) {
 
       {/* Ticker strip ────────────────────────────────────── */}
       <div
-        className="relative w-full overflow-hidden rounded-lg border border-base-300/40 bg-base-200/30 shadow-sm"
-        style={{ aspectRatio: row.aspect }}
+        data-ticker-strip
+        className="relative ml-[calc(50%_-_50vw)] w-screen overflow-hidden border-y border-base-300/40 bg-base-200/30 shadow-sm sm:ml-0 sm:w-full sm:rounded-lg sm:border sm:[aspect-ratio:var(--ticker-aspect)]"
+        style={{ '--ticker-aspect': row.aspect } as React.CSSProperties}
       >
         <ProductScreenshot
           basename={row.basename}
           alt={row.alt}
           aspect={row.aspect}
-          pictureClassName="absolute inset-0"
-          imgClassName="block h-full w-full object-cover"
+          pictureClassName="block w-[200vw] -translate-x-20 sm:absolute sm:inset-0 sm:h-full sm:w-full sm:translate-x-0"
+          imgClassName="block h-auto w-[200vw] max-w-none sm:h-full sm:w-full sm:object-cover"
         />
       </div>
     </motion.figure>

--- a/myscrollr.com/src/routes/__root.tsx
+++ b/myscrollr.com/src/routes/__root.tsx
@@ -151,7 +151,7 @@ function RootLayout() {
   return (
     <RootDocument>
       <MotionConfig reducedMotion="user">
-        <div className="min-h-screen relative overflow-x-clip">
+        <div className="min-h-dvh relative overflow-x-clip">
           {/* Skip to main content — first focusable element */}
           <a
             href="#main-content"

--- a/myscrollr.com/src/routes/account.tsx
+++ b/myscrollr.com/src/routes/account.tsx
@@ -161,7 +161,7 @@ function AccountHub() {
 
   return (
     <motion.main
-      className="min-h-screen pt-20"
+      className="min-h-dvh pt-20"
       variants={pageVariants}
       initial="hidden"
       animate="visible"

--- a/myscrollr.com/src/routes/architecture.tsx
+++ b/myscrollr.com/src/routes/architecture.tsx
@@ -294,7 +294,7 @@ const TECH_STACK: Array<TechGroup> = [
 
 function ArchitecturePage() {
   return (
-    <div className="min-h-screen pt-20">
+    <div className="min-h-dvh pt-20">
       {/* ── HERO ─────────────────────────────────────────────── */}
       <section className="relative pt-28 pb-20 overflow-hidden">
         {/* Background grid */}

--- a/myscrollr.com/src/routes/business.tsx
+++ b/myscrollr.com/src/routes/business.tsx
@@ -1795,7 +1795,7 @@ function BottomCTA() {
 
 function BusinessPage() {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-dvh">
       <BusinessHero />
       <AudiencesSection />
       <CapabilitiesSection />

--- a/myscrollr.com/src/routes/callback.tsx
+++ b/myscrollr.com/src/routes/callback.tsx
@@ -17,7 +17,7 @@ function Callback() {
   // Show the error UI only when the callback exchange itself failed.
   if (error) {
     return (
-      <div className="min-h-screen text-base-content flex items-center justify-center font-mono">
+      <div className="min-h-dvh text-base-content flex items-center justify-center font-mono">
         <div className="text-center space-y-4 max-w-md">
           <div className="h-12 w-12 rounded-full border-2 border-error flex items-center justify-center mx-auto mb-4">
             <span className="text-error text-xl">!</span>
@@ -43,7 +43,7 @@ function Callback() {
   // page as just header + footer with an empty body for ~1 frame to a
   // few hundred ms depending on how the route transition was scheduled.
   return (
-    <div className="min-h-screen text-base-content flex items-center justify-center font-mono">
+    <div className="min-h-dvh text-base-content flex items-center justify-center font-mono">
       <div className="text-center space-y-4">
         <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary mx-auto mb-4" />
         <p className="uppercase tracking-[0.2em] text-primary animate-pulse">

--- a/myscrollr.com/src/routes/channels.tsx
+++ b/myscrollr.com/src/routes/channels.tsx
@@ -286,7 +286,7 @@ const WIDGETS: Array<WidgetDef> = [
 
 function ChannelsPage() {
   return (
-    <div className="min-h-screen pt-20">
+    <div className="min-h-dvh pt-20">
       {/* ── HERO ─────────────────────────────────────────────── */}
       <section className="relative pt-28 pb-20 overflow-hidden">
         <div className="absolute inset-0 pointer-events-none">

--- a/myscrollr.com/src/routes/download.tsx
+++ b/myscrollr.com/src/routes/download.tsx
@@ -110,7 +110,7 @@ function DownloadPage() {
   const recommended = PLATFORMS.find((p) => p.id === detected) ?? PLATFORMS[0]
 
   return (
-    <div className="min-h-screen bg-base-100">
+    <div className="min-h-dvh bg-base-100">
       {/* ── Hero ─────────────────────────────────────────────── */}
       <section className="relative overflow-hidden py-24 sm:py-32">
         <div className="mx-auto max-w-4xl px-6 text-center">

--- a/myscrollr.com/src/routes/invite.tsx
+++ b/myscrollr.com/src/routes/invite.tsx
@@ -144,7 +144,7 @@ function InvitePage() {
 
   if (state === 'signing-in') {
     return (
-      <div className="min-h-screen text-base-content flex flex-col items-center justify-start pt-32 pb-16 px-4 font-mono">
+      <div className="min-h-dvh text-base-content flex flex-col items-center justify-start pt-32 pb-16 px-4 font-mono">
         <div className="text-center space-y-4 max-w-sm">
           <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary mx-auto mb-4" />
           <p className="uppercase tracking-[0.2em] text-primary animate-pulse">
@@ -160,7 +160,7 @@ function InvitePage() {
 
   if (!token || !email) {
     return (
-      <div className="min-h-screen text-base-content flex flex-col items-center justify-start pt-32 pb-16 px-4 font-sans">
+      <div className="min-h-dvh text-base-content flex flex-col items-center justify-start pt-32 pb-16 px-4 font-sans">
         <div className="w-full max-w-md text-center">
           <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-error/10 border border-error/20 mb-4">
             <X className="w-8 h-8 text-error" />
@@ -176,7 +176,7 @@ function InvitePage() {
   }
 
   return (
-    <div className="min-h-screen text-base-content flex flex-col items-center justify-start pt-32 pb-16 px-4 font-sans">
+    <div className="min-h-dvh text-base-content flex flex-col items-center justify-start pt-32 pb-16 px-4 font-sans">
       <div className="w-full max-w-md">
         {/* Header */}
         <div className="text-center mb-8">

--- a/myscrollr.com/src/routes/legal.tsx
+++ b/myscrollr.com/src/routes/legal.tsx
@@ -69,7 +69,7 @@ function LegalPage() {
       variants={pageVariants}
       initial="hidden"
       animate="visible"
-      className="min-h-screen pt-20"
+      className="min-h-dvh pt-20"
     >
       {/* ── Hero ────────────────────────────────────────────── */}
       <section className="relative pt-24 pb-12 overflow-hidden">

--- a/myscrollr.com/src/routes/status.tsx
+++ b/myscrollr.com/src/routes/status.tsx
@@ -224,7 +224,7 @@ function StatusPage() {
   }
 
   return (
-    <div className="min-h-screen pt-20">
+    <div className="min-h-dvh pt-20">
       {/* ── Hero ── */}
       <section className="relative pt-24 pb-20 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-b from-transparent via-base-200/20 to-transparent pointer-events-none" />

--- a/myscrollr.com/src/routes/support.tsx
+++ b/myscrollr.com/src/routes/support.tsx
@@ -29,7 +29,7 @@ export const Route = createFileRoute('/support')({
 
 function SupportPage() {
   return (
-    <main className="min-h-screen bg-base-100">
+    <main className="min-h-dvh bg-base-100">
       <SupportHero />
       <SupportGettingStarted />
       <SupportFAQ />

--- a/myscrollr.com/src/routes/u.$username.tsx
+++ b/myscrollr.com/src/routes/u.$username.tsx
@@ -137,7 +137,7 @@ function ProfilePage() {
   // ── Loading state ──
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-dvh flex items-center justify-center">
         <div className="text-center space-y-4">
           <Loader2 className="animate-spin h-12 w-12 text-base-content/30 mx-auto" />
           <p className="text-xs text-base-content/30">Loading profile...</p>
@@ -149,7 +149,7 @@ function ProfilePage() {
   // ── Sign-in prompt for unauthenticated /u/me ──
   if (username === 'me' && !isAuthenticated) {
     return (
-      <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="min-h-dvh flex items-center justify-center p-6">
         <motion.div
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
@@ -185,7 +185,7 @@ function ProfilePage() {
   // ── Profile not found ──
   if (!profile) {
     return (
-      <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="min-h-dvh flex items-center justify-center p-6">
         <motion.div
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
@@ -214,7 +214,7 @@ function ProfilePage() {
   // ── Main profile view ──
   return (
     <motion.div
-      className="min-h-screen pt-20"
+      className="min-h-dvh pt-20"
       variants={pageVariants}
       initial="hidden"
       animate="visible"

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -1281,7 +1281,7 @@ function UplinkPage() {
   }
 
   return (
-    <div className="min-h-screen pt-20">
+    <div className="min-h-dvh pt-20">
       {/* ── Checkout Modal ──────────────────────────────────── */}
       {checkoutPlan && (
         <Suspense

--- a/myscrollr.com/src/routes/uplink_.lifetime.tsx
+++ b/myscrollr.com/src/routes/uplink_.lifetime.tsx
@@ -98,7 +98,7 @@ function LifetimePage() {
   }
 
   return (
-    <div className="min-h-screen pt-20">
+    <div className="min-h-dvh pt-20">
       {/* ── Checkout Modal ──────────────────────────────────── */}
       {showCheckout && (
         <Suspense

--- a/myscrollr.com/src/styles.css
+++ b/myscrollr.com/src/styles.css
@@ -319,6 +319,12 @@ body::before {
     font-weight: 700;
     line-height: 1.15;
     letter-spacing: -0.02em;
+    /* Defense-in-depth: prevent very long single words (e.g. brand
+       names, technical terms, animated word swaps in the hero) from
+       overflowing their container on narrow viewports. `break-word`
+       only breaks when there's no other option, so normal headlines
+       wrap naturally at word boundaries. */
+    overflow-wrap: break-word;
   }
 
   h1 {
@@ -757,17 +763,17 @@ pre,
    ========================================================================== */
 
 .container {
-  @apply mx-auto px-5 sm:px-6 lg:px-8 py-16 lg:py-24;
+  @apply mx-auto px-5 sm:px-6 lg:px-8 py-10 sm:py-14 lg:py-24;
   max-width: 1400px;
 }
 
 .container-sm {
-  @apply mx-auto px-5 sm:px-6 lg:px-8 py-12 lg:py-16;
+  @apply mx-auto px-5 sm:px-6 lg:px-8 py-8 sm:py-10 lg:py-16;
   max-width: 800px;
 }
 
 .container-lg {
-  @apply mx-auto px-5 sm:px-6 lg:px-10 py-16 lg:py-32;
+  @apply mx-auto px-5 sm:px-6 lg:px-10 py-12 sm:py-16 lg:py-32;
   max-width: 1600px;
 }
 


### PR DESCRIPTION
## Summary

First of an incremental series of PRs to bring mobile parity to the marketing site. This one delivers:

1. The complete mobile audit and PR sequencing plan (committed at `docs/superpowers/specs/2026-05-14-mobile-refactor.md`).
2. Universal mobile fixes — apply to every page.
3. A Playwright-based viewport regression check that runs in postbuild and fails the build on any horizontal-scroll regression.

Desktop appearance is unchanged. Every fix is gated by a `< sm:` or `< lg:` breakpoint so the desktop layout remains the source of truth.

## What ships

### Universal CSS fixes

- **`.container` vertical padding scale.** Was `py-16 lg:py-24` (no mobile value); now `py-10 sm:py-14 lg:py-24`. Cuts ~50% of stacked section padding on phones — the single biggest cause of the "sections feel stretched" symptom. Same treatment for `.container-sm` and `.container-lg`.
- **`overflow-wrap: break-word` on h1–h6.** Defense-in-depth: long single words in animated hero swaps or brand terms no longer overflow narrow viewports.

### iOS Safari viewport fix

- Sweep `min-h-screen` → `min-h-dvh` across all routes + components (22 occurrences, 14 files). `100vh` includes the iOS URL bar even when collapsed, producing layout jump as the bar shows/hides. `100dvh` tracks the dynamic viewport correctly. No desktop change.

### Targeted mobile-only refinements

- **HeroProductShowcase**: was `w-[360px]` at the smallest breakpoint, equal to or exceeding the iPhone SE 1st-gen viewport (320px). Now `w-full max-w-[360px]` below `sm:`; original fixed widths apply above. Showcase shrinks gracefully on 320px viewports.
- **HeroSection word-progress buttons**: `py-3` on mobile (was `py-2`), pushing the tap area from ~16px to ~44px to meet WCAG 2.5.5 AAA target. Drops back to `py-2` from `sm:` up.

### Regression CI

New `scripts/check-mobile-viewport.mjs` runs in `postbuild`:

- Starts a tiny static HTTP server over `dist/client/`.
- Launches headless Chromium via Playwright (already a devDep).
- Visits each prerendered route at 4 viewport widths: 320/390/412/768.
- Asserts `documentElement.scrollWidth <= clientWidth` for each route×viewport pair.
- If overflow is detected, walks the DOM to identify the widest offender and prints its tag/id/class.
- 28 checks per build, all currently green — establishes the baseline.
- `SKIP_MOBILE_VIEWPORT_CHECK=1` opt-out for local dev convenience.

## Verification

- `npm run build` green (clean rebuild)
- `npx tsc --noEmit` clean
- `npm run lint` clean
- All 9 prerender body assertions pass (unchanged from #191)
- All 28 mobile viewport assertions pass (new baseline)
- Desktop visual unchanged (verified by inspection — all changes are gated below `sm:` or `lg:`)

## What this does NOT change

- The /uplink comparison table is still desktop-only-readable. Fixing it requires a structurally different mobile layout (per-tier stacked cards below `md:`) — ships in PR 3.
- Hero animation delays are unchanged on mobile. We agreed to address those per-page if needed in later PRs.
- Auth/dynamic routes (/account, /callback, /invite, /u/...) are out of scope for the marketing-site refactor.

## What's next (per the audit doc)

| PR | Scope |
|----|-------|
| 2 | Home hero mobile polish |
| 3 | /uplink comparison table → stacked cards on mobile |
| 4 | /download + /channels polish |
| 5 | /business + /architecture + /support + /legal polish |