### PR TITLE
fix(desktop): make home ticker status read-only

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4450,7 +4450,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "dirs 5.0.1",
  "futures-util",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.0.18"
+version = "1.0.19"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/components/ScrollrTicker.test.tsx
+++ b/desktop/src/components/ScrollrTicker.test.tsx
@@ -54,4 +54,34 @@ describe("ScrollrTicker", () => {
     expect(screen.getByText("Timer")).toBeInTheDocument();
     expect(screen.getByText("01:05")).toBeInTheDocument();
   });
+
+  it("does not render pinned widgets filtered out of the current row", () => {
+    render(
+      <ScrollrTicker
+        dashboard={null}
+        activeTabs={["finance"]}
+        widgetData={widgetData}
+        pinnedWidgets={{ timer: { side: "right", row: 0 } }}
+        rowIndex={0}
+      />,
+    );
+
+    expect(screen.queryByText("Timer")).not.toBeInTheDocument();
+    expect(screen.queryByText("01:05")).not.toBeInTheDocument();
+  });
+
+  it("renders pinned widgets included in the current row", () => {
+    render(
+      <ScrollrTicker
+        dashboard={null}
+        activeTabs={["timer"]}
+        widgetData={widgetData}
+        pinnedWidgets={{ timer: { side: "right", row: 0 } }}
+        rowIndex={0}
+      />,
+    );
+
+    expect(screen.getByText("Timer")).toBeInTheDocument();
+    expect(screen.getByText("01:05")).toBeInTheDocument();
+  });
 });

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -605,6 +605,7 @@ export default function ScrollrTicker({
 
   for (const [widgetId, pin] of Object.entries(pinnedWidgets)) {
     if ((pin.row ?? 0) !== rowIndex) continue;
+    if (!activeTabs.includes(widgetId)) continue;
     const target = pin.side === "left" ? pinnedLeft : pinnedRight;
 
     if (WIDGET_TYPES.includes(widgetId as WidgetType)) {

--- a/desktop/src/components/TickerLayoutSummary.test.tsx
+++ b/desktop/src/components/TickerLayoutSummary.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import TickerLayoutSummary from "./TickerLayoutSummary";
+import type { ChannelManifest, WidgetManifest } from "../types";
+
+const channelManifests = [
+  { id: "finance", tabLabel: "Finance", hex: "#22c55e" },
+] as ChannelManifest[];
+
+const widgetManifests = [
+  { id: "timer", tabLabel: "Timer", hex: "#38bdf8" },
+] as WidgetManifest[];
+
+describe("TickerLayoutSummary", () => {
+  it("shows the current layout without exposing Home-side row mutations", () => {
+    render(
+      <TickerLayoutSummary
+        rows={[{ sources: ["finance"] }]}
+        tierMaxRows={3}
+        canAddRow={true}
+        onOpenSettings={vi.fn()}
+        channelManifests={channelManifests}
+        widgetManifests={widgetManifests}
+      />,
+    );
+
+    expect(screen.getByText("Ticker layout")).toBeInTheDocument();
+    expect(screen.getByText("Finance")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /open the full ticker layout editor/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add a new ticker row/i })).not.toBeInTheDocument();
+  });
+
+  it("describes empty rows as all ticker-enabled sources", () => {
+    render(
+      <TickerLayoutSummary
+        rows={[{ sources: [] }]}
+        tierMaxRows={1}
+        canAddRow={false}
+        onOpenSettings={vi.fn()}
+        channelManifests={channelManifests}
+        widgetManifests={widgetManifests}
+      />,
+    );
+
+    expect(screen.getByText("All ticker-enabled sources")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/components/TickerLayoutSummary.tsx
+++ b/desktop/src/components/TickerLayoutSummary.tsx
@@ -9,16 +9,14 @@
  *   each, and how to grow/shrink the structure. Users had to leave Home
  *   for Settings → Ticker just to see "do I currently have 1 row or 2?"
  *
- *   This strip surfaces the layout summary inline, with affordances to
- *   add a row (when under the tier cap) or jump straight into the full
- *   editor for power-user changes (per-row scroll overrides, mix mode).
+ *   This strip surfaces the layout summary inline and links to the full
+ *   editor for power-user changes (source assignment, per-row scroll
+ *   overrides, mix mode).
  *
- *   Contract: read-only diagnostics + two CTA buttons. All actual
- *   mutations route through the same `useTickerLayout` hook the
- *   row-pickers use, so this component cannot get out of sync with the
- *   per-source pickers below it.
+ *   Contract: read-only diagnostics + a Manage CTA. Home intentionally
+ *   does not mutate ticker layout; Settings → Ticker is the sole editor.
  */
-import { Plus, Settings as SettingsIcon } from "lucide-react";
+import { Settings as SettingsIcon } from "lucide-react";
 import clsx from "clsx";
 import Tooltip from "./Tooltip";
 import type { TickerRowConfig } from "../preferences";
@@ -31,8 +29,6 @@ interface TickerLayoutSummaryProps {
   tierMaxRows: number;
   /** Whether the layout has room for another row. */
   canAddRow: boolean;
-  /** Append an empty row. No-op when `canAddRow` is false. */
-  onAddRow: () => void;
   /** Open the full Settings → Ticker editor. */
   onOpenSettings: () => void;
   /** Channel manifests, used to color the per-row source bars. */
@@ -45,7 +41,6 @@ export default function TickerLayoutSummary({
   rows,
   tierMaxRows,
   canAddRow,
-  onAddRow,
   onOpenSettings,
   channelManifests,
   widgetManifests,
@@ -64,6 +59,14 @@ export default function TickerLayoutSummary({
     return "#6b7280"; // neutral gray-500 fallback
   };
 
+  const sourceLabel = (id: string): string => {
+    const ch = channelManifests.find((c) => c.id === id);
+    if (ch) return ch.tabLabel || ch.name || id;
+    const w = widgetManifests.find((mf) => mf.id === id);
+    if (w) return w.tabLabel || w.name || id;
+    return id;
+  };
+
   return (
     <section
       aria-label="Ticker layout summary"
@@ -80,20 +83,6 @@ export default function TickerLayoutSummary({
         </span>
 
         <div className="flex-1" />
-
-        {canAddRow && (
-          <Tooltip content="Add an empty row to your ticker" side="top">
-            <button
-              type="button"
-              onClick={onAddRow}
-              className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-dashed border-edge/60 text-ui-meta font-medium text-fg-3 hover:text-accent hover:border-accent/60 transition-colors"
-              aria-label="Add a new ticker row"
-            >
-              <Plus size={11} />
-              Add row
-            </button>
-          </Tooltip>
-        )}
 
         <Tooltip content="Open the full ticker editor in Settings" side="top">
           <button
@@ -122,7 +111,7 @@ export default function TickerLayoutSummary({
             </span>
             {row.sources.length === 0 ? (
               <span className="italic text-fg-3">
-                shows all enabled sources
+                All ticker-enabled sources
               </span>
             ) : (
               <div className="flex items-center gap-1 flex-wrap">
@@ -139,7 +128,7 @@ export default function TickerLayoutSummary({
                       className="w-1.5 h-1.5 rounded-full"
                       style={{ backgroundColor: sourceColor(id) }}
                     />
-                    {id}
+                    {sourceLabel(id)}
                   </span>
                 ))}
               </div>

--- a/desktop/src/components/settings/TickerSettings.tsx
+++ b/desktop/src/components/settings/TickerSettings.tsx
@@ -9,7 +9,7 @@ import { useCallback, useMemo } from "react";
 import { motion } from "motion/react";
 import { clsx } from "clsx";
 import { Plus, Trash2, Lock } from "lucide-react";
-import { resetCategory, removeTickerRow } from "../../preferences";
+import { resetCategory, removeTickerRow, setTickerRowSourceMembership } from "../../preferences";
 import {
   Section,
   SegmentedRow,
@@ -93,7 +93,6 @@ export default function TickerSettings({ prefs, onPrefsChange }: TickerSettingsP
     canAddRow,
     canCustomize,
     addRow: addRowFromHook,
-    setSourceRow,
   } = tickerLayout;
 
   // Undoable destructive-action wrapper. Every "the user might regret
@@ -118,12 +117,9 @@ export default function TickerSettings({ prefs, onPrefsChange }: TickerSettingsP
 
   // ── Row mutations ─────────────────────────────────────────────
   // Thin wrappers around the hook so the JSX below stays readable.
-  // Note: the toggle is now `setSourceRow(id, row | null)` — moving a
-  // source into a row implicitly removes it from any other row, which
-  // matches the Home-page RowSelector semantics. Pre-refactor the
-  // Settings checkbox grid had its own custom multi-row toggle logic
-  // that duplicated `setSourceTickerRow`; collapsing them removes a
-  // class of "Settings says X, Home says Y" bugs.
+  // Ticker settings edits row membership only. Removing a widget from a
+  // row must not remove it from `widgetsOnTicker`; otherwise returning a
+  // row to the empty "all sources" state would still hide that widget.
   const addRow = useCallback(() => {
     addRowFromHook();
   }, [addRowFromHook]);
@@ -132,12 +128,14 @@ export default function TickerSettings({ prefs, onPrefsChange }: TickerSettingsP
     (rowIndex: number, sourceId: string) => {
       const row = rows[rowIndex];
       const isInTarget = row.sources.includes(sourceId);
-      // Toggling ON in row N moves the source there (and out of any
-      // other row). Toggling OFF removes it entirely (Off everywhere).
-      // This mirrors Home's [Off][Row 1]…[Row N] semantics exactly.
-      setSourceRow(sourceId, isInTarget ? null : rowIndex);
+      onPrefsChange(setTickerRowSourceMembership(
+        prefs,
+        sourceId,
+        rowIndex,
+        !isInTarget,
+      ));
     },
-    [rows, setSourceRow],
+    [prefs, rows, onPrefsChange],
   );
 
   const deleteRow = useCallback(

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -28,6 +28,7 @@ import {
   setSourceTickerRow,
   setChannelTickerRow,
   setWidgetTickerRow,
+  setTickerRowSourceMembership,
   migrateAppearanceTheme,
   resolveThemeName,
   isThemeFamily,
@@ -522,6 +523,45 @@ describe("setSourceTickerRow / setChannelTickerRow / setWidgetTickerRow", () => 
     const prefs = makePrefs([{ sources: ["finance"] }]);
     const next = setSourceTickerRow(prefs, "finance", null);
     expect(next.appearance.tickerLayout.rows.length).toBe(1);
+  });
+});
+
+describe("setTickerRowSourceMembership", () => {
+  it("keeps widgets globally ticker-enabled when removing row membership", () => {
+    const prefs = {
+      appearance: {
+        tickerLayout: { rows: [{ sources: ["timer"] }] },
+      },
+      widgets: {
+        enabledWidgets: ["timer"],
+        widgetsOnTicker: ["timer"],
+      },
+    } as unknown as AppPreferences;
+
+    const next = setTickerRowSourceMembership(prefs, "timer", 0, false);
+
+    expect(next.appearance.tickerLayout.rows[0].sources).toEqual([]);
+    expect(next.widgets.widgetsOnTicker).toEqual(["timer"]);
+  });
+
+  it("adds widgets to widgetsOnTicker when assigning them to a row", () => {
+    const prefs = {
+      appearance: {
+        tickerLayout: { rows: [{ sources: ["finance"] }] },
+      },
+      widgets: {
+        enabledWidgets: ["timer"],
+        widgetsOnTicker: [],
+      },
+    } as unknown as AppPreferences;
+
+    const next = setTickerRowSourceMembership(prefs, "timer", 0, true);
+
+    expect(next.appearance.tickerLayout.rows[0].sources).toEqual([
+      "finance",
+      "timer",
+    ]);
+    expect(next.widgets.widgetsOnTicker).toEqual(["timer"]);
   });
 });
 

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -1741,3 +1741,49 @@ export function setWidgetTickerRow(
   };
 }
 
+/**
+ * Toggle a source's membership in one ticker row without treating removal
+ * from that row as a global ticker-off action.
+ *
+ * Settings → Ticker uses this for its per-row source grid. If a user removes
+ * the last explicit source from a row, the row becomes "all sources" again;
+ * widgets must stay in `widgetsOnTicker` so they can reappear in that all-row
+ * state. Explicitly assigning a widget to a row still adds it to
+ * `widgetsOnTicker`, matching the real ticker's activeTabs gate.
+ */
+export function setTickerRowSourceMembership(
+  prefs: AppPreferences,
+  sourceId: string,
+  rowIndex: number,
+  selected: boolean,
+): AppPreferences {
+  const rows = prefs.appearance.tickerLayout?.rows ?? [];
+  if (rowIndex < 0 || rowIndex >= rows.length) return prefs;
+
+  const cleanedRows: TickerRowConfig[] = rows.map((row) => ({
+    ...row,
+    sources: (row.sources ?? []).filter((id) => id !== sourceId),
+  }));
+
+  if (selected) {
+    cleanedRows[rowIndex] = {
+      ...cleanedRows[rowIndex],
+      sources: [...cleanedRows[rowIndex].sources, sourceId],
+    };
+  }
+
+  const withLayout = setTickerLayout(prefs, { rows: cleanedRows });
+  const isWidget = withLayout.widgets.enabledWidgets.includes(sourceId);
+  if (!selected || !isWidget || withLayout.widgets.widgetsOnTicker.includes(sourceId)) {
+    return withLayout;
+  }
+
+  return {
+    ...withLayout,
+    widgets: {
+      ...withLayout.widgets,
+      widgetsOnTicker: [...withLayout.widgets.widgetsOnTicker, sourceId],
+    },
+  };
+}
+

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -20,7 +20,6 @@ import { motion, AnimatePresence } from "motion/react";
 import SportsEmptyState from "../channels/sports/EmptyState";
 import RouteError from "../components/RouteError";
 import Tooltip from "../components/Tooltip";
-import RowSelector from "../components/RowSelector";
 import TickerLayoutSummary from "../components/TickerLayoutSummary";
 import PageLayout from "../components/layout/PageLayout";
 import EmptySection from "../components/layout/EmptySection";
@@ -39,12 +38,14 @@ import {
   LS_WEATHER_UNIT,
   LS_SYSMON_DATA,
 } from "../constants";
-import {
-  getChannelTickerRow,
-  getWidgetTickerRow,
-} from "../preferences";
 import { useTickerLayout } from "../hooks/useTickerLayout";
-import type { ChannelType, Channel } from "../api/client";
+import {
+  formatEffectiveWidgetTickerStatus,
+  formatTickerStatus,
+  getEffectiveChannelTickerRow,
+  getEffectiveWidgetTickerStatus,
+} from "../utils/tickerStatus";
+import type { Channel } from "../api/client";
 import type { LeagueMeta } from "../api/queries";
 import type {
   ChannelManifest,
@@ -105,7 +106,6 @@ function HomePage() {
     allChannelManifests,
     allWidgets,
     authenticated,
-    onToggleChannelTicker,
     onLogin,
   } = shell;
 
@@ -125,12 +125,6 @@ function HomePage() {
   );
   const { rows: layoutRows, tierMaxRows, canAddRow } = tickerLayout;
 
-  // RowSelector buttons collapse to [Off][On] when only one row exists,
-  // and expand to [Off][Row 1]…[Row N] otherwise. The picker reflects
-  // the *actual* layout (not the tier cap) so users don't see ghost
-  // rows; the +Add affordance below grows the layout in-place.
-  const pickerRows = Math.max(1, layoutRows.length);
-
   const setHomePreview = useCallback(
     (channelType: string, keys: string[]) => {
       const next: HomePreview = { ...homePreview, [channelType]: keys };
@@ -138,60 +132,6 @@ function HomePage() {
     },
     [homePreview, shell],
   );
-
-  // ── Unified ticker row selector handlers ────────────────────────
-  // Channel row change updates BOTH layers atomically:
-  //   1. tickerLayout.rows[i].sources[]   (client-side prefs)
-  //   2. Channel.ticker_enabled            (server-side master gate)
-  // See preferences.ts §"Unified ticker row selector helpers".
-  const handleChannelRowChange = useCallback(
-    (channelType: ChannelType, row: number | null) => {
-      tickerLayout.setSourceRow(channelType, row);
-      // Server-side flag: enable when assigned to any row, disable for "off".
-      // onToggleChannelTicker is async but fire-and-forget here — the existing
-      // handler shows a toast on failure and re-syncs from the dashboard refetch.
-      onToggleChannelTicker(channelType, row !== null);
-    },
-    [tickerLayout, onToggleChannelTicker],
-  );
-
-  const handleWidgetRowChange = useCallback(
-    (widgetId: string, row: number | null) => {
-      tickerLayout.setSourceRow(widgetId, row);
-    },
-    [tickerLayout],
-  );
-
-  // ── +Add row handlers ────────────────────────────────────────
-  // Single-click flow: create a new row AND assign the source to it,
-  // so Home users never have to leave the page to grow the ticker.
-  // A no-op (returns null) when the layout is at the tier cap.
-  const handleChannelAddRow = useCallback(
-    (channelType: ChannelType) => {
-      const newRow = tickerLayout.addRow(channelType);
-      if (newRow !== null) {
-        // The source might have been off-ticker before (server flag
-        // false). Flip it on alongside the layout change so both layers
-        // stay consistent.
-        onToggleChannelTicker(channelType, true);
-      }
-    },
-    [tickerLayout, onToggleChannelTicker],
-  );
-
-  const handleWidgetAddRow = useCallback(
-    (widgetId: string) => {
-      tickerLayout.addRow(widgetId);
-    },
-    [tickerLayout],
-  );
-
-  // Plain "add an empty row" handler used by the layout summary strip.
-  // No source seeding — useful when the user just wants a second row
-  // and will populate it later.
-  const handleAddEmptyRow = useCallback(() => {
-    tickerLayout.addRow();
-  }, [tickerLayout]);
 
   const openTickerSettings = useCallback(() => {
     navigate({ to: "/ticker" });
@@ -270,7 +210,6 @@ function HomePage() {
           rows={layoutRows}
           tierMaxRows={tierMaxRows}
           canAddRow={canAddRow}
-          onAddRow={handleAddEmptyRow}
           onOpenSettings={openTickerSettings}
           channelManifests={allChannelManifests}
           widgetManifests={allWidgets}
@@ -293,7 +232,6 @@ function HomePage() {
         );
         const hasData = channelData.length > 0;
         const targetTab = hasData ? "feed" : "configuration";
-        const currentRow = getChannelTickerRow(shell.prefs, ch);
         return (
           <motion.div
             key={ch.channel_type}
@@ -309,15 +247,10 @@ function HomePage() {
               channel={ch}
               manifest={manifest}
               data={dashboard?.data}
-              currentRow={currentRow}
-              maxRows={pickerRows}
-              canAddRow={canAddRow}
-              onAddRow={() =>
-                handleChannelAddRow(ch.channel_type as ChannelType)
-              }
-              onRowChange={(next) =>
-                handleChannelRowChange(ch.channel_type as ChannelType, next)
-              }
+              tickerStatus={formatTickerStatus(
+                getEffectiveChannelTickerRow(shell.prefs, ch),
+                layoutRows.length,
+              )}
               selectedKeys={homePreview[ch.channel_type] ?? []}
               onSelectionChange={(keys) =>
                 setHomePreview(ch.channel_type, keys)
@@ -358,11 +291,12 @@ function HomePage() {
         >
           <WidgetStrip
             widgets={orderedWidgets}
-            maxRows={pickerRows}
-            canAddRow={canAddRow}
-            onWidgetAddRow={handleWidgetAddRow}
-            getWidgetRow={(id) => getWidgetTickerRow(shell.prefs, id)}
-            onWidgetRowChange={handleWidgetRowChange}
+            getTickerStatus={(id) =>
+              formatEffectiveWidgetTickerStatus(
+                getEffectiveWidgetTickerStatus(shell.prefs, id),
+                layoutRows.length,
+              )
+            }
             onNavigate={(id) =>
               navigate({
                 to: "/widget/$id/$tab",
@@ -444,23 +378,7 @@ interface ChannelSectionProps {
   channel: Channel;
   manifest: ChannelManifest;
   data: Record<string, unknown> | undefined;
-  /** Currently assigned ticker row, or null for off. */
-  currentRow: number | null;
-  /**
-   * Number of rows currently in the layout (reflects what the user has
-   * built, not the tier cap). Drives the RowSelector's button count.
-   */
-  maxRows: number;
-  /** Whether the layout has room for another row at the user's tier. */
-  canAddRow: boolean;
-  /**
-   * Single-click handler: create a new row in the layout AND assign
-   * this channel to it. Called from the RowSelector's trailing
-   * `[+ Add]` button.
-   */
-  onAddRow: () => void;
-  /** Called when the user picks a different row or "Off". */
-  onRowChange: (row: number | null) => void;
+  tickerStatus: string;
   selectedKeys: string[];
   onSelectionChange: (keys: string[]) => void;
   onViewAll: () => void;
@@ -472,11 +390,7 @@ function ChannelSection({
   channel,
   manifest,
   data,
-  currentRow,
-  maxRows,
-  canAddRow,
-  onAddRow,
-  onRowChange,
+  tickerStatus,
   selectedKeys,
   onSelectionChange,
   onViewAll,
@@ -516,6 +430,7 @@ function ChannelSection({
         <span className="text-sm font-semibold text-fg flex-1">
           {manifest.name}
         </span>
+        <TickerStatusBadge label={tickerStatus} />
 
         {/* Edit toggle */}
         {groups.length > 0 && (
@@ -543,25 +458,6 @@ function ChannelSection({
             </button>
           </Tooltip>
         )}
-
-        {/* Row selector — replaces the legacy Eye/EyeOff toggle so users
-            can pick exactly which ticker row a channel appears on (Off /
-            Row 1 / 2 / 3) instead of a binary visibility flip that
-            silently fought with the Settings source picker.
-            The trailing `[+ Add]` button (when canAddRow) creates a
-            new row and assigns this channel to it in a single click. */}
-        <RowSelector
-          value={currentRow}
-          maxRows={maxRows}
-          disabled={!channel.enabled}
-          disabledHint={
-            !channel.enabled ? "Enable from the Catalog first" : undefined
-          }
-          onChange={onRowChange}
-          ariaLabel={`${manifest.name} ticker row`}
-          canAddRow={canAddRow}
-          onAddRow={onAddRow}
-        />
 
         {/* View all */}
         {!editing && (
@@ -951,26 +847,13 @@ function EmptyDataRow({
 
 interface WidgetStripProps {
   widgets: WidgetManifest[];
-  /** Number of rows currently in the layout. */
-  maxRows: number;
-  /** Whether the layout has room for another row at the user's tier. */
-  canAddRow: boolean;
-  /** Read the row a widget is currently assigned to (null = off). */
-  getWidgetRow: (id: string) => number | null;
-  /** Move a widget to the given row (null = off). */
-  onWidgetRowChange: (id: string, row: number | null) => void;
-  /** Create a new row and assign this widget to it. */
-  onWidgetAddRow: (id: string) => void;
+  getTickerStatus: (id: string) => string;
   onNavigate: (id: string) => void;
 }
 
 function WidgetStrip({
   widgets,
-  maxRows,
-  canAddRow,
-  getWidgetRow,
-  onWidgetRowChange,
-  onWidgetAddRow,
+  getTickerStatus,
   onNavigate,
 }: WidgetStripProps) {
   return (
@@ -986,11 +869,7 @@ function WidgetStrip({
           <WidgetChip
             key={widget.id}
             widget={widget}
-            currentRow={getWidgetRow(widget.id)}
-            maxRows={maxRows}
-            canAddRow={canAddRow}
-            onAddRow={() => onWidgetAddRow(widget.id)}
-            onRowChange={(row) => onWidgetRowChange(widget.id, row)}
+            tickerStatus={getTickerStatus(widget.id)}
             onClick={() => onNavigate(widget.id)}
           />
         ))}
@@ -1001,31 +880,18 @@ function WidgetStrip({
 
 interface WidgetChipProps {
   widget: WidgetManifest;
-  currentRow: number | null;
-  maxRows: number;
-  canAddRow: boolean;
-  onAddRow: () => void;
-  onRowChange: (row: number | null) => void;
+  tickerStatus: string;
   onClick: () => void;
 }
 
 function WidgetChip({
   widget,
-  currentRow,
-  maxRows,
-  canAddRow,
-  onAddRow,
-  onRowChange,
+  tickerStatus,
   onClick,
 }: WidgetChipProps) {
   const Icon = widget.icon;
   const value = getWidgetValue(widget.id);
 
-  // Note: this used to be a single <button> wrapping the whole chip, but
-  // the RowSelector is a radiogroup of <button>s — nesting buttons is
-  // invalid HTML. The outer container is now a div with role="button"
-  // + tabIndex so the chip body still acts as a click target while the
-  // RowSelector renders cleanly inside it.
   return (
     <div
       role="button"
@@ -1046,27 +912,29 @@ function WidgetChip({
         <span className="text-xs font-medium text-fg truncate flex-1">
           {widget.tabLabel}
         </span>
+        <TickerStatusBadge label={tickerStatus} />
       </div>
 
-      <p className="text-sm font-medium text-fg-2 tabular-nums truncate mb-2">
+      <p className="text-sm font-medium text-fg-2 tabular-nums truncate">
         {value}
       </p>
-
-      {/* Row selector — replaces the legacy Eye/EyeOff toggle. Click events
-          inside the radiogroup are stopPropagation'd by RowSelector itself
-          so they don't trigger the chip's navigate-on-click. The
-          trailing `[+ Add]` button creates a new row and assigns the
-          widget to it in a single tap (when the layout isn't already
-          at the tier cap). */}
-      <RowSelector
-        value={currentRow}
-        maxRows={maxRows}
-        onChange={onRowChange}
-        ariaLabel={`${widget.tabLabel} ticker row`}
-        canAddRow={canAddRow}
-        onAddRow={onAddRow}
-      />
     </div>
+  );
+}
+
+function TickerStatusBadge({ label }: { label: string }) {
+  const isOff = label === "Not on ticker";
+  return (
+    <span
+      className={clsx(
+        "shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+        isOff
+          ? "border-edge/30 text-fg-4 bg-base-200/40"
+          : "border-accent/25 text-accent bg-accent/10",
+      )}
+    >
+      {label}
+    </span>
   );
 }
 

--- a/desktop/src/utils/tickerStatus.test.ts
+++ b/desktop/src/utils/tickerStatus.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTickerStatus,
+  getEffectiveChannelTickerRow,
+  getEffectiveWidgetTickerStatus,
+} from "./tickerStatus";
+import type { AppPreferences } from "../preferences";
+
+function makePrefs(
+  rows: { sources: string[] }[],
+  widgetsOnTicker: string[] = [],
+  pinnedWidgets: AppPreferences["widgets"]["pinnedWidgets"] = {},
+): AppPreferences {
+  return {
+    appearance: { tickerLayout: { rows } },
+    widgets: {
+      widgetsOnTicker,
+      pinnedWidgets,
+    },
+  } as unknown as AppPreferences;
+}
+
+describe("formatTickerStatus", () => {
+  it("labels an assigned single-row source as on ticker", () => {
+    expect(formatTickerStatus(0, 1)).toBe("On ticker");
+  });
+
+  it("labels an assigned multi-row source by row number", () => {
+    expect(formatTickerStatus(1, 3)).toBe("Row 2");
+  });
+
+  it("labels unassigned sources as not on ticker", () => {
+    expect(formatTickerStatus(null, 2)).toBe("Not on ticker");
+  });
+});
+
+describe("getEffectiveChannelTickerRow", () => {
+  it("returns null for disabled channels even when the legacy fallback would be row 0", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }]);
+
+    expect(
+      getEffectiveChannelTickerRow(prefs, {
+        channel_type: "sports",
+        enabled: false,
+        ticker_enabled: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for enabled channels excluded from explicit rows", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }]);
+
+    expect(
+      getEffectiveChannelTickerRow(prefs, {
+        channel_type: "sports",
+        enabled: true,
+        ticker_enabled: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("uses the first empty row for ticker-enabled channels when a row shows all sources", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }, { sources: [] }]);
+
+    expect(
+      getEffectiveChannelTickerRow(prefs, {
+        channel_type: "sports",
+        enabled: true,
+        ticker_enabled: true,
+      }),
+    ).toBe(1);
+  });
+});
+
+describe("getEffectiveWidgetTickerStatus", () => {
+  it("labels pinned widgets by their pin row", () => {
+    const prefs = makePrefs(
+      [{ sources: ["finance"] }, { sources: [] }],
+      ["timer"],
+      { timer: { side: "right", row: 1 } },
+    );
+
+    expect(getEffectiveWidgetTickerStatus(prefs, "timer")).toEqual({
+      kind: "pinned",
+      row: 1,
+    });
+  });
+
+  it("returns off for pinned widgets filtered out of their pinned row", () => {
+    const prefs = makePrefs(
+      [{ sources: ["finance"] }],
+      ["timer"],
+      { timer: { side: "right", row: 0 } },
+    );
+
+    expect(getEffectiveWidgetTickerStatus(prefs, "timer")).toEqual({
+      kind: "off",
+      row: null,
+    });
+  });
+
+  it("returns null for widgets excluded from explicit rows", () => {
+    const prefs = makePrefs([{ sources: ["finance"] }], ["timer"]);
+
+    expect(getEffectiveWidgetTickerStatus(prefs, "timer")).toEqual({
+      kind: "off",
+      row: null,
+    });
+  });
+});

--- a/desktop/src/utils/tickerStatus.ts
+++ b/desktop/src/utils/tickerStatus.ts
@@ -1,0 +1,82 @@
+import { isChannelTickerEnabled } from "../api/client";
+import type { AppPreferences } from "../preferences";
+
+interface ChannelTickerInfo {
+  channel_type: string;
+  enabled?: boolean;
+  ticker_enabled?: boolean;
+  visible?: boolean;
+}
+
+export interface EffectiveWidgetTickerStatus {
+  kind: "off" | "scrolling" | "pinned";
+  row: number | null;
+}
+
+export function formatTickerStatus(row: number | null, rowCount: number): string {
+  if (row === null) return "Not on ticker";
+  if (rowCount <= 1) return "On ticker";
+  return `Row ${row + 1}`;
+}
+
+export function formatEffectiveWidgetTickerStatus(
+  status: EffectiveWidgetTickerStatus,
+  rowCount: number,
+): string {
+  if (status.kind === "pinned") {
+    return rowCount <= 1 ? "Pinned" : `Pinned row ${(status.row ?? 0) + 1}`;
+  }
+  return formatTickerStatus(status.row, rowCount);
+}
+
+export function getEffectiveChannelTickerRow(
+  prefs: AppPreferences,
+  channel: ChannelTickerInfo,
+): number | null {
+  if (channel.enabled === false || !isChannelTickerEnabled(channel)) return null;
+  return getEffectiveSourceRow(prefs, channel.channel_type);
+}
+
+export function getEffectiveWidgetTickerStatus(
+  prefs: AppPreferences,
+  widgetId: string,
+): EffectiveWidgetTickerStatus {
+  const onTicker = prefs.widgets.widgetsOnTicker.includes(widgetId);
+  const pin = prefs.widgets.pinnedWidgets[widgetId];
+
+  if (pin && onTicker) {
+    const pinRow = pin.row ?? 0;
+    return rowAllowsSource(prefs, pinRow, widgetId)
+      ? { kind: "pinned", row: pinRow }
+      : { kind: "off", row: null };
+  }
+
+  if (!onTicker) return { kind: "off", row: null };
+
+  const row = getEffectiveSourceRow(prefs, widgetId);
+  return row === null
+    ? { kind: "off", row: null }
+    : { kind: "scrolling", row };
+}
+
+function getEffectiveSourceRow(
+  prefs: AppPreferences,
+  sourceId: string,
+): number | null {
+  const rows = prefs.appearance.tickerLayout.rows;
+  const explicitRow = rows.findIndex((row) => row.sources.includes(sourceId));
+  if (explicitRow >= 0) return explicitRow;
+
+  const allSourcesRow = rows.findIndex((row) => row.sources.length === 0);
+  return allSourcesRow >= 0 ? allSourcesRow : null;
+}
+
+function rowAllowsSource(
+  prefs: AppPreferences,
+  rowIndex: number,
+  sourceId: string,
+): boolean {
+  const row = prefs.appearance.tickerLayout.rows[rowIndex];
+  if (!row) return false;
+  return row.sources.length === 0 || row.sources.includes(sourceId);
+}


### PR DESCRIPTION
## Summary
- Removes Home dashboard ticker mutation controls while keeping a read-only ticker layout summary.
- Aligns Home ticker status badges with the real ticker render path, including explicit rows and pinned widgets.
- Bumps desktop release metadata to 1.0.19.

## Test Plan
- npm run test -- src/preferences.test.ts src/components/ScrollrTicker.test.tsx src/utils/tickerStatus.test.ts src/components/TickerLayoutSummary.test.tsx
- npm run build