### PR TITLE
fix(ci): avoid poisoned macOS cargo cache

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -124,8 +124,12 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
+          # Do not restore ~/.cargo/bin on macOS: a poisoned cache can replace
+          # cargo with rustup-init and break cargo metadata inside tauri-action.
+          prefix-key: "v1-rust-no-bin"
           workspaces: "desktop/src-tauri -> target"
           cache-on-failure: "true"
+          cache-bin: "false"
 
       - name: Install frontend dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Disable caching/restoring ~/.cargo/bin in the desktop release Rust cache.
- Rotate the Rust cache prefix so macOS jobs stop reusing the poisoned cargo archive.

## Root Cause
The macOS release job restored ~/.cargo/bin after the PATH workaround. The restored cargo binary was actually a rustup-init stub, so cargo metadata failed inside tauri-action with \`unexpected argument 'metadata' found\`.

## Verification
- \`ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/desktop-release.yml\"); puts \"desktop-release.yml parsed\"'\`