### PR TITLE
fix(myscrollr.com): stop pod nginx from leaking :3000 and downgrading https in redirects

### DIFF
--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -65,8 +65,24 @@ COPY --from=builder /app/myscrollr.com/dist/client /usr/share/nginx/html
 # Includes security headers, gzip compression, and proper caching
 RUN printf 'server {\n\
     listen 3000;\n\
+    server_name _;\n\
     root /usr/share/nginx/html;\n\
     index index.html;\n\
+\n\
+    # ── Redirect-leak guards ────────────────────────────────────\n\
+    # Without these, nginx builds Location headers using its own\n\
+    # listen port (3000) and the inbound scheme (http, since TLS\n\
+    # is terminated at the k8s ingress). That produced redirects\n\
+    # like "http://myscrollr.com:3000/uplink/" — port-leaked,\n\
+    # scheme-downgraded, and unreachable from the public edge.\n\
+    # absolute_redirect off  -> emit relative Location ("/uplink/")\n\
+    #                          which clients resolve against the\n\
+    #                          original request URL (preserving\n\
+    #                          https + correct host).\n\
+    # port_in_redirect off   -> belt + suspenders: never include\n\
+    #                          ":3000" in any Location header.\n\
+    absolute_redirect off;\n\
+    port_in_redirect off;\n\
 \n\
     # ── Security headers (server-level) ─────────────────────────\n\
     # NOTE: nginx add_header in a child location block overrides\n\
@@ -100,10 +116,23 @@ RUN printf 'server {\n\
     }\n\
 \n\
     # ── HTML: no-cache so users always get latest deploy ────────\n\
+    # try_files order matters:\n\
+    #   1. $uri              — exact file (e.g. /robots.txt, /sitemap.xml)\n\
+    #   2. $uri/index.html   — prerendered route (e.g. /uplink ->\n\
+    #                          /uplink/index.html). Serves the file\n\
+    #                          DIRECTLY at 200. This avoids the built-in\n\
+    #                          "$uri/" directory match, which would have\n\
+    #                          issued a 301 to add a trailing slash —\n\
+    #                          the source of the original redirect leak\n\
+    #                          and a mismatch with our canonical URLs\n\
+    #                          (sitemap + <link rel=canonical> declare\n\
+    #                          /uplink, not /uplink/).\n\
+    #   3. /index.html       — SPA fallback for dynamic routes\n\
+    #                          (/account, /callback, /u/$username, etc.)\n\
     location / {\n\
         include /etc/nginx/security-headers.conf;\n\
         add_header Cache-Control "no-cache";\n\
-        try_files $uri $uri/ /index.html;\n\
+        try_files $uri $uri/index.html /index.html;\n\
     }\n\
 \n\
     # ── Hashed static assets: cache forever ─────────────────────\n\


### PR DESCRIPTION
## The bug

Every sub-route on production was issuing a broken 301:

```
$ curl -sI https://myscrollr.com/uplink
HTTP/2 301
location: http://myscrollr.com:3000/uplink/
```

Three problems in that Location header:

1. HTTPS → HTTP downgrade (TLS stripped)
2. Internal port `:3000` leaked to the public
3. Unreachable from the public edge (`:3000` isn't open)

`/` worked fine — only sub-routes that the prerender turns into directories were affected (`/uplink`, `/channels`, `/download`, `/architecture`, `/business`, `/legal`, `/support`, `/uplink/lifetime`). Launch-blocking: every internal nav link from a cold visit was landing users on a dead URL.

Before (prod):

```
=== / ===                HTTP/2 200
=== /uplink ===          HTTP/2 301  →  http://myscrollr.com:3000/uplink/
=== /channels ===        HTTP/2 301  →  http://myscrollr.com:3000/channels/
=== /download ===        HTTP/2 301  →  http://myscrollr.com:3000/download/
=== /architecture ===    HTTP/2 301  →  http://myscrollr.com:3000/architecture/
=== /business ===        HTTP/2 301  →  http://myscrollr.com:3000/business/
=== /legal ===           HTTP/2 301  →  http://myscrollr.com:3000/legal/
=== /support ===         HTTP/2 301  →  http://myscrollr.com:3000/support/
```

## Root cause

The proxy chain is `browser → k8s nginx-ingress (TLS termination) → website pod nginx (listen 3000)`. **Not** Coolify. The k8s ingress is fine; the bug is in the pod nginx config built inline in `myscrollr.com/Dockerfile`.

The TanStack Start prerender places each marketing route into its own directory:

```
dist/client/uplink/index.html
dist/client/uplink/lifetime/index.html
dist/client/channels/index.html
...
```

The pod nginx had `try_files $uri $uri/ /index.html;`. When a request hits `/uplink`:

1. `$uri` (`/uplink`) — no such file
2. `$uri/` (`/uplink/`) — directory exists → **nginx triggers its built-in trailing-slash redirect**
3. nginx synthesizes the Location header using its own `listen` port (`3000`), `Host` from the client, and `http` scheme (since the inbound connection from the ingress is plain HTTP — TLS is terminated upstream)
4. Result: `Location: http://myscrollr.com:3000/uplink/`

The pod doesn't trust `X-Forwarded-Proto` or have `port_in_redirect off`, so it leaks both the scheme and the port. The trailing-slash variant also fights the site's canonical URLs (sitemap + `<link rel="canonical">` both declare the non-slash version, e.g. `https://myscrollr.com/uplink`).

## The fix

`myscrollr.com/Dockerfile` (single file changed):

1. **`try_files $uri $uri/index.html /index.html;`** — checks for `$uri/index.html` as a file *before* matching `$uri/` as a directory. nginx now serves `/uplink/index.html` **directly at 200**, eliminating the redirect entirely. Bonus: now matches the site's declared canonical URLs (sitemap.xml + `<link rel=canonical>` say `/uplink`, not `/uplink/`) and saves a roundtrip.

2. **`absolute_redirect off;`** — defense-in-depth. Any future stray redirect from this server emits a relative Location (`/foo/`), which the client resolves against the original request URL, preserving https + correct host automatically.

3. **`port_in_redirect off;`** — belt + suspenders: `:3000` will never appear in any Location header from this server, even if `absolute_redirect` is ever toggled back on.

4. **`server_name _;`** — explicit catch-all so nginx never falls back to the pod's `gethostname()` value when synthesizing redirects.

Config-driven (no hardcoded hostname), no manual steps outside the repo, no changes to k8s ingress, secrets, or env vars.

## Verification (local Docker build)

Built `myscrollr.com/Dockerfile` from the repo root with `docker build -f myscrollr.com/Dockerfile -t test:fix .` and ran on `:8888 → 3000`:

```
=== Marketing routes (sitemap'd, canonical) ===
/                    HTTP/1.1 200 OK   (no Location)
/uplink              HTTP/1.1 200 OK   (no Location)
/channels            HTTP/1.1 200 OK   (no Location)
/download            HTTP/1.1 200 OK   (no Location)
/architecture        HTTP/1.1 200 OK   (no Location)
/business            HTTP/1.1 200 OK   (no Location)
/legal               HTTP/1.1 200 OK   (no Location)
/support             HTTP/1.1 200 OK   (no Location)
/uplink/lifetime     HTTP/1.1 200 OK   (no Location)

=== Trailing-slash variants (should still 200, not loop) ===
/uplink/             HTTP/1.1 200 OK
/channels/           HTTP/1.1 200 OK

=== SPA fallback routes (dynamic, not prerendered) ===
/account             HTTP/1.1 200 OK   (serves SPA shell)
/callback            HTTP/1.1 200 OK   (serves SPA shell)
/u/someuser          HTTP/1.1 200 OK   (serves SPA shell)
/nonexistent         HTTP/1.1 200 OK   (serves SPA shell)

=== robots.txt ===
User-agent: *
Disallow: /account
Disallow: /invite
Disallow: /callback
Disallow: /status
Disallow: /u/
Disallow: /tss-spa-shell
Sitemap: https://myscrollr.com/sitemap.xml      (unchanged)

=== sitemap.xml ===                HTTP/1.1 200 OK  (unchanged)
```

**Content correctness check** — each prerendered route serves its own HTML:

```
GET /uplink   → <title>Uplink — Pricing for Scrollr</title>
                <link rel="canonical" href="https://myscrollr.com/uplink"/>
GET /channels → <title>Channels — Scrollr</title>
                <link rel="canonical" href="https://myscrollr.com/channels"/>
```

**Security headers preserved byte-for-byte** (X-Content-Type-Options, Referrer-Policy, Permissions-Policy, full CSP, Cache-Control). HSTS is added by the k8s ingress upstream and is unaffected.

**Redirect chain ≤ 1 hop** — actually 0 hops for prerendered routes (200 direct), still 1 hop for the `http://` → `https://` upgrade at the ingress (which was always correct).

## Why not just fix the redirect to be correct (301 to https://myscrollr.com/uplink/)?

Option A (`absolute_redirect off;` alone) would have produced a correct `Location: /uplink/` (relative). That works, but it would still:
- Add an extra roundtrip on every cold visit
- Send users to `/uplink/` while the page declares `/uplink` as canonical (SEO inconsistency)

Option B (serve the file directly at 200) eliminates both problems. I kept `absolute_redirect off; port_in_redirect off;` as defense-in-depth so if anyone ever adds another redirect to this config they can't accidentally leak the port/scheme again.

## Manual steps outside the repo

None. Push-to-main on `myscrollr.com/**` triggers `.github/workflows/deploy.yml`, which builds the website image, pushes it to DOCR, and rolls out via `kubectl apply -f k8s/website.yaml`. No k8s ingress, secrets, or ConfigMap changes required.

## Post-deploy plan

Once the deploy workflow finishes, re-run the curl loop against `https://myscrollr.com/` and post the output as a comment. Expected: every route returns `HTTP/2 200` with no Location header (matching the local Docker output above).