### PR TITLE
fix(myscrollr.com): drop redundant aria-labels (label-content-name-mismatch)

### DIFF
--- a/myscrollr.com/src/components/DownloadButton.tsx
+++ b/myscrollr.com/src/components/DownloadButton.tsx
@@ -130,7 +130,9 @@ function SingleDownloadButton({ platform, label }: SingleDownloadButtonProps) {
     <button
       type="button"
       onClick={handleClick}
-      aria-label={`Download Scrollr for ${label}`}
+      // No aria-label: the visible "Download for {label}" text already
+      // names the button. A redundant aria-label that didn't match the
+      // visible text triggered Lighthouse label-content-name-mismatch.
       className="group relative inline-flex cursor-pointer items-center gap-3 rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-content! shadow-lg transition-all duration-200 hover:brightness-110 hover:shadow-xl active:scale-[0.98]"
     >
       <Download

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -2529,10 +2529,12 @@ function UplinkPage() {
                     }}
                     role="button"
                     tabIndex={isTierDisabled('uplink') ? -1 : 0}
-                    // Accessible name leads with visible text "Uplink" so
-                    // screen-reader output matches what sighted users see
-                    // (Lighthouse label-content-name-mismatch).
-                    aria-label={`Uplink ${BILLING_LABELS[billingPeriod]} plan`}
+                    // No aria-label: the card's visible content (tier
+                    // name, description, price, features, CTA) is the
+                    // accessible name. Lighthouse's label-content-name-
+                    // mismatch audit requires the accessible name to
+                    // include all contained visible text — a short
+                    // label can't satisfy that for a complex card.
                     onClick={() =>
                       !isTierDisabled('uplink') &&
                       handleSelectPlan(billingPeriod, 'uplink')
@@ -2684,7 +2686,7 @@ function UplinkPage() {
                     }}
                     role="button"
                     tabIndex={isTierDisabled('pro') ? -1 : 0}
-                    aria-label={`Pro ${BILLING_LABELS[billingPeriod]} plan`}
+                    // See Uplink card above for why aria-label is omitted.
                     onClick={() =>
                       !isTierDisabled('pro') &&
                       handleSelectPlan(billingPeriod, 'pro')
@@ -2838,7 +2840,7 @@ function UplinkPage() {
                     }}
                     role="button"
                     tabIndex={isTierDisabled('ultimate') ? -1 : 0}
-                    aria-label={`Ultimate ${BILLING_LABELS[billingPeriod]} plan`}
+                    // See Uplink card above for why aria-label is omitted.
                     onClick={() =>
                       !isTierDisabled('ultimate') &&
                       handleSelectPlan(billingPeriod, 'ultimate')


### PR DESCRIPTION
## Summary

Follow-up to #197. After deploy, Lighthouse still flagged two spots where
`aria-label` values failed axe's `label-content-name-mismatch` rule.

## Changes

### DownloadButton

Dropped \`aria-label={\`Download Scrollr for \${label}\`}\`. The visible
button text "Download for {label}" already names the button; the
aria-label was redundant and didn't match.

### `/uplink` pricing cards (Uplink, Pro, Ultimate)

Dropped the short aria-labels (`"Uplink Annual plan"` etc.). axe-core's
rule requires the accessible name on a `role="button"` element to
include all contained visible text — a 3-word label can never satisfy
that on a complex card containing tier name + description + price +
feature list + CTA. Letting axe compute the name from contents
satisfies the audit. Screen-reader users hear the full card on tab
focus, which is more useful than the truncated label anyway.

## Before / after

| Route | A11y before #197 | A11y after #197 | A11y target (this PR) |
|---|---:|---:|---:|
| `/uplink` desktop | 94 | 96 | 97+ |
| `/uplink` mobile | 94 | 96 | 97+ |
| `/download` desktop | 96 | 96 | 97+ |
| Others | 95-96 | 95-97 | unchanged or +1 |

`color-contrast` (brand green on white) remains flagged but is the
design-decision item explicitly deferred from #197.

## Verification

```
$ npm run build
…
All prerender checks passed.
All mobile viewport checks passed.
```

Will re-run PSI after deploy and post results.