### PR TITLE
fix(api): consistent billing eligibility guards + testable webhook decision logic

### DIFF
--- a/api/core/billing.go
+++ b/api/core/billing.go
@@ -112,6 +112,44 @@ func planRank(plan string) int {
 	}
 }
 
+// hasSubscriptionConflict reports whether an existing billing record blocks
+// starting a new subscription checkout for newPlan. An active or trialing
+// paid plan conflicts, with one exception: lifetime members may stack an
+// Ultimate or Pro subscription on top of their lifetime plan.
+//
+// Shared by HandleCreateCheckoutSession, HandleCreateSetupIntent, and
+// HandleConfirmSubscription so the eligibility rule can't drift between the
+// checkout entry points.
+func hasSubscriptionConflict(existingPlan, existingStatus string, isLifetime bool, newPlan string) bool {
+	if existingPlan == "free" {
+		return false
+	}
+	if existingStatus != "active" && existingStatus != "trialing" {
+		return false
+	}
+	if isLifetime && (isUltimatePlan(newPlan) || isProPlan(newPlan)) {
+		return false
+	}
+	return true
+}
+
+// hasLifetimeCheckoutConflict reports whether an existing billing record blocks
+// purchasing the lifetime plan. Existing lifetime members are blocked, as is
+// anyone with an active or trialing paid subscription — a trial converts to a
+// paid subscription, which would then stack on top of lifetime.
+//
+// Shared by HandleCreateLifetimeCheckout and HandleCreatePaymentIntent so the
+// eligibility rule can't drift between the two lifetime purchase entry points.
+func hasLifetimeCheckoutConflict(existingPlan, existingStatus string, isLifetime bool) bool {
+	if isLifetime {
+		return true
+	}
+	if existingPlan == "free" {
+		return false
+	}
+	return existingStatus == "active" || existingStatus == "trialing"
+}
+
 // getOrCreateStripeCustomer looks up or creates a Stripe customer for the user.
 // If a cached customer ID is stale (e.g. Stripe mode switch, deleted customer),
 // it deletes the stale record and creates a fresh customer.
@@ -212,16 +250,12 @@ func HandleCreateCheckoutSession(c *fiber.Ctx) error {
 		`SELECT plan, status, lifetime FROM stripe_customers WHERE logto_sub = $1`, userID,
 	).Scan(&existingPlan, &existingStatus, &isLifetime)
 
-	if err == nil && existingPlan != "free" && (existingStatus == "active" || existingStatus == "trialing") {
-		// Lifetime members can add an Ultimate or Pro subscription on top
-		// (Ultimate gets 50% off coupon applied below)
-		if isLifetime && (isUltimatePlan(plan) || isProPlan(plan)) {
-			// Allow through
-		} else {
-			return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
-				Status: "error", Error: "You already have an active subscription",
-			})
-		}
+	// Lifetime members can add an Ultimate or Pro subscription on top
+	// (Ultimate gets 50% off coupon applied below)
+	if err == nil && hasSubscriptionConflict(existingPlan, existingStatus, isLifetime, plan) {
+		return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
+			Status: "error", Error: "You already have an active subscription",
+		})
 	}
 
 	// Get email from JWT claims (may be empty)
@@ -320,7 +354,7 @@ func HandleCreateLifetimeCheckout(c *fiber.Ctx) error {
 				Status: "error", Error: "You already have a lifetime membership",
 			})
 		}
-		if existingPlan != "free" && existingStatus == "active" {
+		if hasLifetimeCheckoutConflict(existingPlan, existingStatus, isLifetime) {
 			return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
 				Status: "error", Error: "Please cancel your current subscription before purchasing lifetime",
 			})
@@ -401,15 +435,11 @@ func HandleCreateSetupIntent(c *fiber.Ctx) error {
 		`SELECT plan, status, lifetime FROM stripe_customers WHERE logto_sub = $1`, userID,
 	).Scan(&existingPlan, &existingStatus, &isLifetime)
 
-	if err == nil && existingPlan != "free" && (existingStatus == "active" || existingStatus == "trialing") {
-		// Lifetime members can add Ultimate or Pro on top
-		if isLifetime && (isUltimatePlan(plan) || isProPlan(plan)) {
-			// Allow through
-		} else {
-			return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
-				Status: "error", Error: "You already have an active subscription",
-			})
-		}
+	// Lifetime members can add Ultimate or Pro on top
+	if err == nil && hasSubscriptionConflict(existingPlan, existingStatus, isLifetime, plan) {
+		return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
+			Status: "error", Error: "You already have an active subscription",
+		})
 	}
 
 	email, _ := c.Locals("user_email").(string)
@@ -511,14 +541,11 @@ func HandleConfirmSubscription(c *fiber.Ctx) error {
 		`SELECT plan, status, lifetime FROM stripe_customers WHERE logto_sub = $1`, userID,
 	).Scan(&existingPlan, &existingStatus, &existingLifetime)
 
-	if err == nil && existingPlan != "free" && (existingStatus == "active" || existingStatus == "trialing") {
-		if existingLifetime && (isUltimatePlan(plan) || isProPlan(plan)) {
-			// Allow lifetime members to add Ultimate or Pro
-		} else {
-			return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
-				Status: "error", Error: "You already have an active subscription",
-			})
-		}
+	// Lifetime members can add Ultimate or Pro on top
+	if err == nil && hasSubscriptionConflict(existingPlan, existingStatus, existingLifetime, plan) {
+		return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
+			Status: "error", Error: "You already have an active subscription",
+		})
 	}
 
 	// Retrieve the SetupIntent and verify ownership
@@ -704,7 +731,7 @@ func HandleCreatePaymentIntent(c *fiber.Ctx) error {
 				Status: "error", Error: "You already have lifetime access",
 			})
 		}
-		if existingPlan != "free" && (existingStatus == "active" || existingStatus == "trialing") {
+		if hasLifetimeCheckoutConflict(existingPlan, existingStatus, existingLifetime) {
 			return c.Status(fiber.StatusConflict).JSON(ErrorResponse{
 				Status: "error", Error: "Please cancel your current subscription before purchasing lifetime",
 			})

--- a/api/core/billing_test.go
+++ b/api/core/billing_test.go
@@ -156,3 +156,93 @@ func TestPlanRankUpgradeDowngrade(t *testing.T) {
 		}
 	}
 }
+
+func TestHasSubscriptionConflict(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingPlan   string
+		existingStatus string
+		isLifetime     bool
+		newPlan        string
+		want           bool
+	}{
+		// Free users never conflict.
+		{"free plan", "free", "active", false, "monthly", false},
+		{"free plan trialing status", "free", "trialing", false, "ultimate_monthly", false},
+
+		// Active or trialing paid plans block a new subscription.
+		{"active monthly blocks", "monthly", "active", false, "pro_monthly", true},
+		{"active pro blocks", "pro_monthly", "active", false, "ultimate_monthly", true},
+		{"trialing blocks", "monthly", "trialing", false, "monthly", true},
+
+		// Ended subscriptions don't block re-subscribing.
+		{"canceled does not block", "monthly", "canceled", false, "monthly", false},
+		{"canceling does not block", "pro_monthly", "canceling", false, "pro_monthly", false},
+		{"past_due does not block", "monthly", "past_due", false, "monthly", false},
+		{"none status does not block", "monthly", "none", false, "monthly", false},
+
+		// Lifetime members may stack Ultimate or Pro on top...
+		{"lifetime can add ultimate monthly", "lifetime", "active", true, "ultimate_monthly", false},
+		{"lifetime can add ultimate annual", "lifetime", "active", true, "ultimate_annual", false},
+		{"lifetime can add pro monthly", "lifetime", "active", true, "pro_monthly", false},
+		{"lifetime can add pro annual", "lifetime", "active", true, "pro_annual", false},
+		// ...but not a base Uplink subscription.
+		{"lifetime cannot add base monthly", "lifetime", "active", true, "monthly", true},
+		{"lifetime cannot add base annual", "lifetime", "active", true, "annual", true},
+
+		// Non-lifetime users get no stacking exception.
+		{"active without lifetime cannot add ultimate", "monthly", "active", false, "ultimate_monthly", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasSubscriptionConflict(tc.existingPlan, tc.existingStatus, tc.isLifetime, tc.newPlan)
+			if got != tc.want {
+				t.Errorf("hasSubscriptionConflict(%q, %q, %v, %q) = %v, want %v",
+					tc.existingPlan, tc.existingStatus, tc.isLifetime, tc.newPlan, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasLifetimeCheckoutConflict(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingPlan   string
+		existingStatus string
+		isLifetime     bool
+		want           bool
+	}{
+		// Existing lifetime members can't buy lifetime again.
+		{"lifetime member blocks", "lifetime", "none", true, true},
+		{"lifetime member with stacked sub blocks", "ultimate_monthly", "active", true, true},
+
+		// Free users can always buy lifetime.
+		{"free plan", "free", "none", false, false},
+		{"free plan active status", "free", "active", false, false},
+		{"free plan trialing status", "free", "trialing", false, false},
+
+		// Active or trialing paid subscriptions block lifetime purchase —
+		// a trial converts to a paid subscription that would stack on lifetime.
+		{"active monthly blocks", "monthly", "active", false, true},
+		{"active annual blocks", "annual", "active", false, true},
+		{"trialing monthly blocks", "monthly", "trialing", false, true},
+		{"trialing pro blocks", "pro_monthly", "trialing", false, true},
+
+		// Ended subscriptions don't block buying lifetime.
+		{"canceled does not block", "monthly", "canceled", false, false},
+		{"canceling does not block", "annual", "canceling", false, false},
+		{"past_due does not block", "monthly", "past_due", false, false},
+		{"none status does not block", "monthly", "none", false, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasLifetimeCheckoutConflict(tc.existingPlan, tc.existingStatus, tc.isLifetime)
+			if got != tc.want {
+				t.Errorf("hasLifetimeCheckoutConflict(%q, %q, %v) = %v, want %v",
+					tc.existingPlan, tc.existingStatus, tc.isLifetime, got, tc.want)
+			}
+		})
+	}
+}

--- a/api/core/stripe_webhook.go
+++ b/api/core/stripe_webhook.go
@@ -46,22 +46,24 @@ func HandleStripeWebhook(c *fiber.Ctx) error {
 	// it — skip to avoid double-processing. This collapses the previous
 	// check-then-insert flow (which had a race window between the EXISTS probe
 	// and the INSERT) into a single atomic statement.
-	var claimedID string
-	claimErr := DBPool.QueryRow(context.Background(),
-		`INSERT INTO stripe_webhook_events (event_id) VALUES ($1)
-		 ON CONFLICT (event_id) DO NOTHING
-		 RETURNING event_id`,
-		event.ID,
-	).Scan(&claimedID)
-	if claimErr == pgx.ErrNoRows {
-		// Another worker already claimed this event. Skip.
-		log.Printf("[Stripe Webhook] Skipping duplicate event %s (type: %s)", event.ID, event.Type)
-		return c.SendStatus(fiber.StatusOK)
-	}
-	if claimErr != nil {
-		// Some other DB error. Log and proceed — better to double-process than to
-		// drop events. The handlers below are all idempotent.
-		log.Printf("[Stripe Webhook] Failed to claim event idempotency slot: %v", claimErr)
+	if DBPool != nil {
+		var claimedID string
+		claimErr := DBPool.QueryRow(context.Background(),
+			`INSERT INTO stripe_webhook_events (event_id) VALUES ($1)
+			 ON CONFLICT (event_id) DO NOTHING
+			 RETURNING event_id`,
+			event.ID,
+		).Scan(&claimedID)
+		if claimErr == pgx.ErrNoRows {
+			// Another worker already claimed this event. Skip.
+			log.Printf("[Stripe Webhook] Skipping duplicate event %s (type: %s)", event.ID, event.Type)
+			return c.SendStatus(fiber.StatusOK)
+		}
+		if claimErr != nil {
+			// Some other DB error. Log and proceed — better to double-process than to
+			// drop events. The handlers below are all idempotent.
+			log.Printf("[Stripe Webhook] Failed to claim event idempotency slot: %v", claimErr)
+		}
 	}
 
 	switch event.Type {
@@ -161,18 +163,9 @@ func handleCheckoutCompleted(event stripe.Event) {
 	// Assign the appropriate Logto role.
 	// During trial, always grant Ultimate access regardless of selected plan.
 	// When the trial ends, subscription.updated fires and assigns the correct role.
-	if subStatus == "trialing" || plan == "lifetime" || isUltimatePlan(plan) {
-		if err := AssignUltimateRole(logtoSub); err != nil {
-			log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)
-		}
-	} else if isProPlan(plan) {
-		if err := AssignProRole(logtoSub); err != nil {
-			log.Printf("[Stripe Webhook] Failed to assign uplink_pro role to %s: %v", logtoSub, err)
-		}
-	} else {
-		if err := AssignUplinkRole(logtoSub); err != nil {
-			log.Printf("[Stripe Webhook] Failed to assign uplink role to %s: %v", logtoSub, err)
-		}
+	tier := decideCheckoutTier(subStatus, plan)
+	if err := assignTierRole(logtoSub, tier); err != nil {
+		log.Printf("[Stripe Webhook] Failed to assign %s role to %s: %v", tier, logtoSub, err)
 	}
 
 	// Subscription state changed — overview's tier + subscription
@@ -212,63 +205,38 @@ func handleSubscriptionUpdated(event stripe.Event) {
 	log.Printf("[Stripe Webhook] Subscription updated: user=%s status=%s plan=%s cancel_at_period_end=%v",
 		logtoSub, status, plan, sub.CancelAtPeriodEnd)
 
-	dbStatus := status
-	if sub.CancelAtPeriodEnd {
-		dbStatus = "canceling"
-	}
+	action := decideSubscriptionUpdate(status, sub.CancelAtPeriodEnd, plan)
 
 	_, err := DBPool.Exec(context.Background(),
 		`UPDATE stripe_customers SET
 		   plan = $2, status = $3, current_period_end = $4,
 		   stripe_subscription_id = $5, updated_at = now()
 		 WHERE logto_sub = $1`,
-		logtoSub, plan, dbStatus, periodEnd, sub.ID,
+		logtoSub, plan, action.DBStatus, periodEnd, sub.ID,
 	)
 	if err != nil {
 		log.Printf("[Stripe Webhook] Failed to update subscription for %s: %v", logtoSub, err)
 	}
 
-	// If subscription is active (not canceling), ensure correct role is assigned.
-	newTier := ""
-	if (status == "active" || status == "trialing") && !sub.CancelAtPeriodEnd {
-		if status == "trialing" {
-			// During trial, always grant Ultimate access regardless of selected plan.
-			// This matches checkout.session.completed behavior — trial users get
-			// full access. When the trial ends, this handler fires again with
-			// status="active" and assigns the plan-appropriate role.
-			if err := AssignUltimateRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to assign trial ultimate role to %s: %v", logtoSub, err)
-			}
-			newTier = "uplink_ultimate"
-		} else {
-			// Active subscription: remove stale roles first to handle plan
-			// up/downgrades cleanly, then assign only the current one.
-			if err := RemoveUplinkRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to remove uplink role from %s: %v", logtoSub, err)
-			}
-			if err := RemoveProRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to remove uplink_pro role from %s: %v", logtoSub, err)
-			}
-			if err := RemoveUltimateRole(logtoSub); err != nil {
-				log.Printf("[Stripe Webhook] Failed to remove uplink_ultimate role from %s: %v", logtoSub, err)
-			}
-
-			if isUltimatePlan(plan) {
-				if err := AssignUltimateRole(logtoSub); err != nil {
-					log.Printf("[Stripe Webhook] Failed to assign uplink_ultimate role to %s: %v", logtoSub, err)
-				}
-				newTier = "uplink_ultimate"
-			} else if isProPlan(plan) {
-				if err := AssignProRole(logtoSub); err != nil {
-					log.Printf("[Stripe Webhook] Failed to assign uplink_pro role to %s: %v", logtoSub, err)
-				}
-				newTier = "uplink_pro"
-			} else {
-				if err := AssignUplinkRole(logtoSub); err != nil {
-					log.Printf("[Stripe Webhook] Failed to assign uplink role to %s: %v", logtoSub, err)
-				}
-				newTier = "uplink"
-			}
+	// Active subscriptions remove stale roles first to handle plan
+	// up/downgrades cleanly, then assign only the current one. Trials
+	// always get Ultimate access (matching checkout.session.completed);
+	// when the trial ends, this handler fires again with status="active"
+	// and assigns the plan-appropriate role.
+	if action.ClearPaidRoles {
+		if err := RemoveUplinkRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to remove uplink role from %s: %v", logtoSub, err)
+		}
+		if err := RemoveProRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to remove uplink_pro role from %s: %v", logtoSub, err)
+		}
+		if err := RemoveUltimateRole(logtoSub); err != nil {
+			log.Printf("[Stripe Webhook] Failed to remove uplink_ultimate role from %s: %v", logtoSub, err)
+		}
+	}
+	if action.AssignTier != "" {
+		if err := assignTierRole(logtoSub, action.AssignTier); err != nil {
+			log.Printf("[Stripe Webhook] Failed to assign %s role to %s: %v", action.AssignTier, logtoSub, err)
 		}
 	}
 
@@ -276,8 +244,8 @@ func handleSubscriptionUpdated(event stripe.Event) {
 	// This is a no-op for upgrades (higher caps = nothing to trim) and
 	// the safety net for downgrades. Called after role assignment so a
 	// failed Logto call doesn't block the prune.
-	if newTier != "" {
-		PruneUserChannelsForTier(context.Background(), logtoSub, newTier)
+	if action.AssignTier != "" {
+		PruneUserChannelsForTier(context.Background(), logtoSub, action.AssignTier)
 	}
 
 	// Tier and subscription fields in the overview response just changed.
@@ -370,18 +338,9 @@ func handleInvoicePaid(event stripe.Event) {
 		logtoSub,
 	)
 
-	if isUltimatePlan(currentPlan) {
-		if err := AssignUltimateRole(logtoSub); err != nil {
-			log.Printf("[Stripe Webhook] Failed to re-assign uplink_ultimate role to %s: %v", logtoSub, err)
-		}
-	} else if isProPlan(currentPlan) {
-		if err := AssignProRole(logtoSub); err != nil {
-			log.Printf("[Stripe Webhook] Failed to re-assign uplink_pro role to %s: %v", logtoSub, err)
-		}
-	} else {
-		if err := AssignUplinkRole(logtoSub); err != nil {
-			log.Printf("[Stripe Webhook] Failed to re-assign uplink role to %s: %v", logtoSub, err)
-		}
+	tier := tierForPlan(currentPlan)
+	if err := assignTierRole(logtoSub, tier); err != nil {
+		log.Printf("[Stripe Webhook] Failed to re-assign %s role to %s: %v", tier, logtoSub, err)
 	}
 }
 

--- a/api/core/stripe_webhook_decisions.go
+++ b/api/core/stripe_webhook_decisions.go
@@ -1,0 +1,92 @@
+package core
+
+// =============================================================================
+// Stripe Webhook Decision Logic
+// =============================================================================
+//
+// Pure decision functions for the webhook handlers in stripe_webhook.go.
+// They encode the tier/role rules in one place so the rules are unit-testable
+// without a database or Logto connection:
+//
+//   - Trialing users always get Ultimate access regardless of selected plan.
+//   - Lifetime purchases grant Ultimate access.
+//   - cancel_at_period_end is stored as "canceling" and never changes roles.
+//   - Only active/trialing subscriptions touch roles; past_due, canceled,
+//     incomplete, etc. leave roles as-is.
+
+// Tier identifiers returned by the decision helpers. These match the Logto
+// role names and the tier strings PruneUserChannelsForTier expects.
+const (
+	tierUplink   = "uplink"
+	tierPro      = "uplink_pro"
+	tierUltimate = "uplink_ultimate"
+)
+
+// tierForPlan maps a plan name to the tier role it grants. Unknown plans
+// fall back to the base paid tier, mirroring planRank.
+func tierForPlan(plan string) string {
+	switch {
+	case isUltimatePlan(plan):
+		return tierUltimate
+	case isProPlan(plan):
+		return tierPro
+	default:
+		return tierUplink
+	}
+}
+
+// decideCheckoutTier returns the tier role to assign after a completed
+// checkout. During trial, always grant Ultimate access regardless of selected
+// plan — when the trial ends, subscription.updated fires and assigns the
+// plan-appropriate role. Lifetime purchases also grant Ultimate access.
+func decideCheckoutTier(subStatus, plan string) string {
+	if subStatus == "trialing" || plan == "lifetime" {
+		return tierUltimate
+	}
+	return tierForPlan(plan)
+}
+
+// subscriptionUpdateAction describes the state changes a
+// customer.subscription.updated event should produce.
+type subscriptionUpdateAction struct {
+	// DBStatus is the status persisted to stripe_customers.
+	DBStatus string
+	// ClearPaidRoles removes all existing paid roles before assigning,
+	// so plan up/downgrades don't leave stale roles behind.
+	ClearPaidRoles bool
+	// AssignTier is the tier role to assign; "" leaves roles untouched.
+	// Non-empty also triggers PruneUserChannelsForTier for that tier.
+	AssignTier string
+}
+
+// decideSubscriptionUpdate computes the DB status and role changes for a
+// customer.subscription.updated event.
+func decideSubscriptionUpdate(status string, cancelAtPeriodEnd bool, plan string) subscriptionUpdateAction {
+	action := subscriptionUpdateAction{DBStatus: status}
+	if cancelAtPeriodEnd {
+		action.DBStatus = "canceling"
+		return action
+	}
+	switch status {
+	case "trialing":
+		// Trial users get full access; the plan-appropriate role is
+		// assigned when this handler fires again with status="active".
+		action.AssignTier = tierUltimate
+	case "active":
+		action.ClearPaidRoles = true
+		action.AssignTier = tierForPlan(plan)
+	}
+	return action
+}
+
+// assignTierRole assigns the Logto role for the given tier.
+func assignTierRole(logtoSub, tier string) error {
+	switch tier {
+	case tierUltimate:
+		return AssignUltimateRole(logtoSub)
+	case tierPro:
+		return AssignProRole(logtoSub)
+	default:
+		return AssignUplinkRole(logtoSub)
+	}
+}

--- a/api/core/stripe_webhook_test.go
+++ b/api/core/stripe_webhook_test.go
@@ -1,0 +1,275 @@
+package core
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stripe/stripe-go/v82/webhook"
+)
+
+// =============================================================================
+// Decision logic — decideCheckoutTier
+// =============================================================================
+
+func TestDecideCheckoutTier(t *testing.T) {
+	tests := []struct {
+		name      string
+		subStatus string
+		plan      string
+		want      string
+	}{
+		// Trials always get Ultimate access regardless of the selected plan.
+		{"trialing monthly", "trialing", "monthly", tierUltimate},
+		{"trialing pro", "trialing", "pro_monthly", tierUltimate},
+		{"trialing ultimate", "trialing", "ultimate_annual", tierUltimate},
+		// Lifetime purchases grant Ultimate access.
+		{"lifetime", "active", "lifetime", tierUltimate},
+		// Active subscriptions get the plan-appropriate role.
+		{"active ultimate monthly", "active", "ultimate_monthly", tierUltimate},
+		{"active ultimate annual", "active", "ultimate_annual", tierUltimate},
+		{"active pro monthly", "active", "pro_monthly", tierPro},
+		{"active pro annual", "active", "pro_annual", tierPro},
+		{"active monthly", "active", "monthly", tierUplink},
+		{"active annual", "active", "annual", tierUplink},
+		// Unknown plans fall back to the base paid tier (mirrors planRank).
+		{"active unknown plan", "active", "unknown", tierUplink},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideCheckoutTier(tc.subStatus, tc.plan)
+			if got != tc.want {
+				t.Errorf("decideCheckoutTier(%q, %q) = %q, want %q", tc.subStatus, tc.plan, got, tc.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Decision logic — decideSubscriptionUpdate
+// =============================================================================
+
+func TestDecideSubscriptionUpdate(t *testing.T) {
+	tests := []struct {
+		name              string
+		status            string
+		cancelAtPeriodEnd bool
+		plan              string
+		want              subscriptionUpdateAction
+	}{
+		{
+			name: "active ultimate assigns ultimate after clearing stale roles",
+			status: "active", plan: "ultimate_monthly",
+			want: subscriptionUpdateAction{DBStatus: "active", ClearPaidRoles: true, AssignTier: tierUltimate},
+		},
+		{
+			name: "active pro assigns pro after clearing stale roles",
+			status: "active", plan: "pro_annual",
+			want: subscriptionUpdateAction{DBStatus: "active", ClearPaidRoles: true, AssignTier: tierPro},
+		},
+		{
+			name: "active base plan assigns uplink after clearing stale roles",
+			status: "active", plan: "monthly",
+			want: subscriptionUpdateAction{DBStatus: "active", ClearPaidRoles: true, AssignTier: tierUplink},
+		},
+		{
+			// Documents current behavior: an unmapped price ID (e.g. a missing
+			// STRIPE_PRICE_* env var) stores plan="unknown" and grants the
+			// base paid tier rather than revoking access.
+			name: "active unknown plan falls back to uplink",
+			status: "active", plan: "unknown",
+			want: subscriptionUpdateAction{DBStatus: "active", ClearPaidRoles: true, AssignTier: tierUplink},
+		},
+		{
+			// Trials get Ultimate access without clearing roles; the
+			// plan-appropriate role is assigned when the trial converts.
+			name: "trialing grants ultimate regardless of plan",
+			status: "trialing", plan: "monthly",
+			want: subscriptionUpdateAction{DBStatus: "trialing", AssignTier: tierUltimate},
+		},
+		{
+			name: "cancel at period end stores canceling and never touches roles",
+			status: "active", cancelAtPeriodEnd: true, plan: "ultimate_monthly",
+			want: subscriptionUpdateAction{DBStatus: "canceling"},
+		},
+		{
+			name: "canceling trial stores canceling and never touches roles",
+			status: "trialing", cancelAtPeriodEnd: true, plan: "pro_monthly",
+			want: subscriptionUpdateAction{DBStatus: "canceling"},
+		},
+		{
+			name: "past_due keeps roles untouched",
+			status: "past_due", plan: "ultimate_monthly",
+			want: subscriptionUpdateAction{DBStatus: "past_due"},
+		},
+		{
+			name: "canceled keeps roles untouched",
+			status: "canceled", plan: "monthly",
+			want: subscriptionUpdateAction{DBStatus: "canceled"},
+		},
+		{
+			name: "incomplete keeps roles untouched",
+			status: "incomplete", plan: "pro_monthly",
+			want: subscriptionUpdateAction{DBStatus: "incomplete"},
+		},
+		{
+			name: "unpaid keeps roles untouched",
+			status: "unpaid", plan: "ultimate_annual",
+			want: subscriptionUpdateAction{DBStatus: "unpaid"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideSubscriptionUpdate(tc.status, tc.cancelAtPeriodEnd, tc.plan)
+			if got != tc.want {
+				t.Errorf("decideSubscriptionUpdate(%q, %v, %q) = %+v, want %+v",
+					tc.status, tc.cancelAtPeriodEnd, tc.plan, got, tc.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Decision logic — tierForPlan
+// =============================================================================
+
+func TestTierForPlan(t *testing.T) {
+	tests := []struct {
+		plan string
+		want string
+	}{
+		{"ultimate_monthly", tierUltimate},
+		{"ultimate_annual", tierUltimate},
+		{"pro_monthly", tierPro},
+		{"pro_annual", tierPro},
+		{"monthly", tierUplink},
+		{"annual", tierUplink},
+		{"lifetime", tierUplink}, // lifetime is handled upstream by decideCheckoutTier
+		{"unknown", tierUplink},
+		{"", tierUplink},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.plan, func(t *testing.T) {
+			got := tierForPlan(tc.plan)
+			if got != tc.want {
+				t.Errorf("tierForPlan(%q) = %q, want %q", tc.plan, got, tc.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// HandleStripeWebhook — signature verification
+// =============================================================================
+
+// newWebhookTestApp returns a Fiber app with only the Stripe webhook route,
+// mirroring how server.go registers it.
+func newWebhookTestApp() *fiber.App {
+	app := fiber.New()
+	app.Post("/webhooks/stripe", HandleStripeWebhook)
+	return app
+}
+
+// signStripePayload produces a valid Stripe-Signature header for the payload,
+// using the same scheme Stripe uses (t=<unix>,v1=<hex HMAC-SHA256>).
+func signStripePayload(t *testing.T, payload []byte, secret string, at time.Time) string {
+	t.Helper()
+	sig := webhook.ComputeSignature(at, payload, secret)
+	return fmt.Sprintf("t=%d,v1=%s", at.Unix(), hex.EncodeToString(sig))
+}
+
+func postWebhook(t *testing.T, app *fiber.App, payload []byte, sigHeader string) int {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	if sigHeader != "" {
+		req.Header.Set("Stripe-Signature", sigHeader)
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test failed: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// unhandledEvent is a minimal valid Stripe event of a type the handler
+// ignores, so the dispatch path runs without touching the database or Logto.
+const unhandledEvent = `{"id":"evt_test_1","object":"event","type":"product.created","data":{"object":{}}}`
+
+func TestHandleStripeWebhookMissingSecret(t *testing.T) {
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "")
+
+	app := newWebhookTestApp()
+	status := postWebhook(t, app, []byte(unhandledEvent), "")
+	if status != fiber.StatusInternalServerError {
+		t.Errorf("missing webhook secret: status = %d, want %d", status, fiber.StatusInternalServerError)
+	}
+}
+
+func TestHandleStripeWebhookRejectsMissingSignature(t *testing.T) {
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_test_secret")
+
+	app := newWebhookTestApp()
+	status := postWebhook(t, app, []byte(unhandledEvent), "")
+	if status != fiber.StatusBadRequest {
+		t.Errorf("missing signature: status = %d, want %d", status, fiber.StatusBadRequest)
+	}
+}
+
+func TestHandleStripeWebhookRejectsWrongSecret(t *testing.T) {
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_test_secret")
+
+	app := newWebhookTestApp()
+	payload := []byte(unhandledEvent)
+	sig := signStripePayload(t, payload, "whsec_wrong_secret", time.Now())
+	status := postWebhook(t, app, payload, sig)
+	if status != fiber.StatusBadRequest {
+		t.Errorf("wrong secret: status = %d, want %d", status, fiber.StatusBadRequest)
+	}
+}
+
+func TestHandleStripeWebhookRejectsTamperedPayload(t *testing.T) {
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_test_secret")
+
+	app := newWebhookTestApp()
+	sig := signStripePayload(t, []byte(unhandledEvent), "whsec_test_secret", time.Now())
+	tampered := []byte(`{"id":"evt_evil","object":"event","type":"product.created","data":{"object":{}}}`)
+	status := postWebhook(t, app, tampered, sig)
+	if status != fiber.StatusBadRequest {
+		t.Errorf("tampered payload: status = %d, want %d", status, fiber.StatusBadRequest)
+	}
+}
+
+func TestHandleStripeWebhookRejectsExpiredTimestamp(t *testing.T) {
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_test_secret")
+
+	app := newWebhookTestApp()
+	payload := []byte(unhandledEvent)
+	// Signed well outside StripeWebhookTolerance (300s).
+	stale := time.Now().Add(-2 * StripeWebhookTolerance * time.Second)
+	sig := signStripePayload(t, payload, "whsec_test_secret", stale)
+	status := postWebhook(t, app, payload, sig)
+	if status != fiber.StatusBadRequest {
+		t.Errorf("expired timestamp: status = %d, want %d", status, fiber.StatusBadRequest)
+	}
+}
+
+func TestHandleStripeWebhookAcceptsValidSignature(t *testing.T) {
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_test_secret")
+
+	app := newWebhookTestApp()
+	payload := []byte(unhandledEvent)
+	sig := signStripePayload(t, payload, "whsec_test_secret", time.Now())
+	status := postWebhook(t, app, payload, sig)
+	if status != fiber.StatusOK {
+		t.Errorf("valid signature: status = %d, want %d", status, fiber.StatusOK)
+	}
+}


### PR DESCRIPTION
## What changed

**Lifetime purchase eligibility (bug fix).** The two lifetime purchase entry points disagreed about trialing users: `HandleCreateLifetimeCheckout` (Checkout Session path) only blocked `active` subscriptions, so a trialing user could buy lifetime while their trial subscription still existed — and the trial would later convert to a paid subscription stacked on top of lifetime. `HandleCreatePaymentIntent` (embedded checkout path) already blocked trialing users. Both paths now block `active` and `trialing` via a new shared `hasLifetimeCheckoutConflict` helper.

**Subscription checkout eligibility (consolidation).** The three subscription checkout paths (`HandleCreateCheckoutSession`, `HandleCreateSetupIntent`, `HandleConfirmSubscription`) had the same inline conflict check copy-pasted; it now lives in a shared `hasSubscriptionConflict` helper. Behavior is unchanged, including the exception that lets lifetime members stack an Ultimate or Pro subscription.

**Webhook decision logic (refactor).** The tier/role rules in the Stripe webhook handlers are extracted into pure functions in `stripe_webhook_decisions.go` (`decideCheckoutTier`, `decideSubscriptionUpdate`, `tierForPlan`, `assignTierRole`) so they are unit-testable without a database or Logto connection. The idempotency claim is guarded behind `DBPool != nil` so the handler can be exercised in tests.

## Why

The eligibility rules govern real billing and had already drifted between duplicated copies once (the trialing-user hole). Centralizing each rule in one helper with table-driven tests prevents the entry points from drifting again.

## Tests

- `TestHasSubscriptionConflict` and `TestHasLifetimeCheckoutConflict` — table-driven coverage of both eligibility helpers (free users, active/trialing blocks, ended-subscription pass-through, lifetime stacking exception).
- `TestDecideCheckoutTier` and friends in `stripe_webhook_test.go` — decision-logic coverage plus webhook signature-verification tests.
- `go test ./...` in `api/` passes.

## Reviewer notes

- The only behavior change is the Checkout Session lifetime path now returning 409 for trialing users (previously allowed through). The guard runs before any Stripe API call, so no Stripe-side behavior changes; an end-to-end check in Stripe test mode would be: start a trial with a test card, then attempt lifetime checkout and confirm the "Please cancel your current subscription" error.
- Each lifetime handler keeps its own explicit lifetime-membership check before the helper because the two return distinct error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)