### PR TITLE
ci: bump actions to node24-ready majors ahead of forced migration

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -57,9 +57,9 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.21"
           cache: true
@@ -85,7 +85,7 @@ jobs:
         working-directory: ${{ matrix.dir }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       fantasy-api: ${{ steps.manual.outputs.fantasy-api || steps.changes.outputs.fantasy-api }}
       k8s: ${{ steps.manual.outputs.k8s || steps.changes.outputs.k8s }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve manual service selection
         id: manual
@@ -102,7 +102,7 @@ jobs:
             esac
           done
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: changes
         if: github.event_name == 'push'
         with:
@@ -177,7 +177,7 @@ jobs:
         if: matrix.changed != 'true'
         run: echo "Skipping ${{ matrix.service }} — no changes detected"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: matrix.changed == 'true'
 
       - name: Install doctl
@@ -310,7 +310,7 @@ jobs:
     needs: [detect-changes, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -31,9 +31,9 @@ jobs:
         working-directory: ${{ matrix.dir }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6, `actions/setup-node` v4 → v6, `actions/setup-go` v5 → v6, and `dorny/paths-filter` v3 → v4 across `backend-tests.yml`, `frontend-tests.yml`, and `deploy.yml`
- GitHub retires the node20 action runtime on **June 16, 2026**; these majors run on node24
- `desktop-release.yml` was already on checkout@v6/setup-node@v6; `auto-close-osticket.yml` uses no marketplace actions
- `paths-filter` v4.0.0 is a pure node24 runtime bump (dorny/paths-filter#294) — no API/output changes, so the deploy change-detection job is unaffected
- `digitalocean/action-doctl@v2`, `Swatinem/rust-cache@v2`, `tauri-apps/tauri-action@v0` are major-pinned at their current latest majors and need no change

## Test plan
- [ ] backend-tests and frontend-tests workflows pass on this PR
- [ ] After merge, confirm the next deploy run's `changes` job (paths-filter v4) produces the same service-selection outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)