### PR TITLE
test: add cross-language tier-limit drift guard

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -57,9 +57,9 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.21"
           cache: true
@@ -85,7 +85,7 @@ jobs:
         working-directory: ${{ matrix.dir }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       fantasy-api: ${{ steps.manual.outputs.fantasy-api || steps.changes.outputs.fantasy-api }}
       k8s: ${{ steps.manual.outputs.k8s || steps.changes.outputs.k8s }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve manual service selection
         id: manual
@@ -102,7 +102,7 @@ jobs:
             esac
           done
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: changes
         if: github.event_name == 'push'
         with:
@@ -177,7 +177,7 @@ jobs:
         if: matrix.changed != 'true'
         run: echo "Skipping ${{ matrix.service }} — no changes detected"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: matrix.changed == 'true'
 
       - name: Install doctl
@@ -310,7 +310,7 @@ jobs:
     needs: [detect-changes, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -31,9 +31,9 @@ jobs:
         working-directory: ${{ matrix.dir }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -8,6 +8,9 @@ on:
       - "desktop/src/**"
       - "desktop/package*.json"
       - "desktop/vitest*.ts"
+      # Tier-limit drift guard: both frontends pin their hardcoded tier
+      # tables to this snapshot, so an edit to it must re-run their tests.
+      - "api/core/tier_limits.json"
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +18,9 @@ on:
       - "desktop/src/**"
       - "desktop/package*.json"
       - "desktop/vitest*.ts"
+      # Tier-limit drift guard: both frontends pin their hardcoded tier
+      # tables to this snapshot, so an edit to it must re-run their tests.
+      - "api/core/tier_limits.json"
 
 jobs:
   vitest:

--- a/api/core/tier_limits.go
+++ b/api/core/tier_limits.go
@@ -28,9 +28,12 @@ type TierLimitsResponse struct {
 // DefaultTierLimits is the authoritative source of truth for per-tier caps.
 //
 // SOURCE OF TRUTH — any change here MUST also propagate to:
+//   - api/core/tier_limits.json     (shared sync snapshot — a Go test and
+//     both frontends' Vitest suites pin their copies to it, so CI fails
+//     on whichever side was left stale)
 //   - desktop/src/tierLimits.ts     (kept in sync manually; synchronous
 //     reads required by config panels during render)
-//   - myscrollr.com/src/routes/uplink.tsx (`FALLBACK_LIMITS` constant,
+//   - myscrollr.com/src/lib/fallbackTierLimits.ts (`FALLBACK_LIMITS`,
 //     used only for first-paint while the API response is in flight)
 //   - api/core/tier_limits_test.go  (assertion protecting this table
 //     from silent edits — run `go test ./core/...` after any change)

--- a/api/core/tier_limits.json
+++ b/api/core/tier_limits.json
@@ -1,0 +1,50 @@
+{
+  "tiers": {
+    "free": {
+      "symbols": 5,
+      "feeds": 1,
+      "custom_feeds": 0,
+      "leagues": 1,
+      "fantasy": 0,
+      "max_ticker_rows": 1,
+      "max_ticker_customization": false
+    },
+    "uplink": {
+      "symbols": 25,
+      "feeds": 25,
+      "custom_feeds": 1,
+      "leagues": 8,
+      "fantasy": 1,
+      "max_ticker_rows": 2,
+      "max_ticker_customization": false
+    },
+    "uplink_pro": {
+      "symbols": 75,
+      "feeds": 100,
+      "custom_feeds": 3,
+      "leagues": 20,
+      "fantasy": 3,
+      "max_ticker_rows": 3,
+      "max_ticker_customization": false
+    },
+    "uplink_ultimate": {
+      "symbols": null,
+      "feeds": null,
+      "custom_feeds": 10,
+      "leagues": null,
+      "fantasy": 10,
+      "max_ticker_rows": 3,
+      "max_ticker_customization": true
+    },
+    "super_user": {
+      "symbols": null,
+      "feeds": null,
+      "custom_feeds": null,
+      "leagues": null,
+      "fantasy": null,
+      "max_ticker_rows": 3,
+      "max_ticker_customization": true
+    }
+  }
+}
+

--- a/api/core/tier_limits_sync_test.go
+++ b/api/core/tier_limits_sync_test.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	_ "embed"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// tier_limits.json is the cross-language sync snapshot for DefaultTierLimits.
+// Three test suites assert against the same file:
+//
+//   - this test (backend-tests CI)
+//   - desktop/src/tierLimits.test.ts            (frontend-tests CI)
+//   - myscrollr.com/src/lib/fallbackTierLimits.test.ts (frontend-tests CI)
+//
+// Changing any one of the four copies without the others fails CI on the
+// stale side. To change a limit: edit DefaultTierLimits, tier_limits.json,
+// desktop/src/tierLimits.ts, and myscrollr.com/src/lib/fallbackTierLimits.ts
+// in the same PR.
+//
+//go:embed tier_limits.json
+var tierLimitsSnapshot []byte
+
+// TestDefaultTierLimits_MatchesSnapshot asserts that DefaultTierLimits
+// serializes to exactly the contents of tier_limits.json — the same wire
+// shape GET /tier-limits serves. Comparison is on parsed values, so JSON
+// formatting/key order in the snapshot file doesn't matter.
+func TestDefaultTierLimits_MatchesSnapshot(t *testing.T) {
+	served, err := json.Marshal(TierLimitsResponse{Tiers: DefaultTierLimits})
+	if err != nil {
+		t.Fatalf("marshal DefaultTierLimits: %v", err)
+	}
+
+	var got, want any
+	if err := json.Unmarshal(served, &got); err != nil {
+		t.Fatalf("unmarshal serialized DefaultTierLimits: %v", err)
+	}
+	if err := json.Unmarshal(tierLimitsSnapshot, &want); err != nil {
+		t.Fatalf("unmarshal tier_limits.json: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("DefaultTierLimits drifted from tier_limits.json\n  got:  %s\n  want: %s\n"+
+			"Update both (plus desktop/src/tierLimits.ts and myscrollr.com/src/lib/fallbackTierLimits.ts) in the same PR.",
+			served, tierLimitsSnapshot)
+	}
+}

--- a/desktop/src/tierLimits.test.ts
+++ b/desktop/src/tierLimits.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import snapshot from "../../api/core/tier_limits.json";
 import {
   TIER_LIMITS,
   getLimit,
@@ -151,6 +152,30 @@ describe("TIER_LIMITS table", () => {
     for (const tier of tiers) {
       expect(TIER_LIMITS[tier]).toBeDefined();
     }
+  });
+
+  // Cross-language drift guard. api/core/tier_limits.json is the shared
+  // snapshot of the backend's DefaultTierLimits (api/core/tier_limits.go);
+  // a Go test pins the Go map to it and a myscrollr.com test pins the
+  // pricing page's FALLBACK_LIMITS to it. This test closes the loop for
+  // the desktop mirror. Infinity here corresponds to null on the wire.
+  it("matches the shared snapshot api/core/tier_limits.json exactly", () => {
+    const toWire = (n: number) => (n === Infinity ? null : n);
+    const wire = Object.fromEntries(
+      Object.entries(TIER_LIMITS).map(([tier, l]) => [
+        tier,
+        {
+          symbols: toWire(l.symbols),
+          feeds: toWire(l.feeds),
+          custom_feeds: toWire(l.customFeeds),
+          leagues: toWire(l.leagues),
+          fantasy: toWire(l.fantasy),
+          max_ticker_rows: l.maxTickerRows,
+          max_ticker_customization: l.maxTickerCustomization,
+        },
+      ])
+    );
+    expect(wire).toEqual(snapshot.tiers);
   });
 
   it("super_user matches or exceeds every other tier on every numeric key", () => {

--- a/desktop/src/tierLimits.ts
+++ b/desktop/src/tierLimits.ts
@@ -12,9 +12,11 @@ import type { SubscriptionTier } from "./auth";
 //
 // If you change a number here, you MUST also update:
 //   - api/core/tier_limits.go        (the Go map)
+//   - api/core/tier_limits.json      (shared sync snapshot — the test in
+//     tierLimits.test.ts pins this file to it, so CI catches drift)
 //   - api/core/tier_limits_test.go   (the assertion)
-//   - myscrollr.com/src/routes/uplink.tsx (the FALLBACK_LIMITS constant,
-//     for first-paint before the runtime fetch resolves)
+//   - myscrollr.com/src/lib/fallbackTierLimits.ts (the FALLBACK_LIMITS
+//     constant, for first-paint before the runtime fetch resolves)
 //
 // Infinity here corresponds to `null` on the wire (null round-trips
 // through JSON; Infinity does not).

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "jsx": "react-jsx",
     "strict": true,
     "noUnusedLocals": false,

--- a/myscrollr.com/src/lib/fallbackTierLimits.test.ts
+++ b/myscrollr.com/src/lib/fallbackTierLimits.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import snapshot from '../../../api/core/tier_limits.json'
+import { FALLBACK_LIMITS } from './fallbackTierLimits'
+
+// Cross-language drift guard. api/core/tier_limits.json is the shared
+// snapshot of DefaultTierLimits (api/core/tier_limits.go); a Go test
+// pins the Go map to it and a desktop test pins desktop/src/tierLimits.ts
+// to it. This test closes the loop for the marketing site's first-paint
+// fallback. If it fails, a limit changed somewhere without updating all
+// four copies in the same PR.
+describe('FALLBACK_LIMITS sync with api/core/tier_limits.json', () => {
+  it('matches the shared backend snapshot exactly', () => {
+    expect(FALLBACK_LIMITS).toEqual(snapshot)
+  })
+})

--- a/myscrollr.com/src/lib/fallbackTierLimits.ts
+++ b/myscrollr.com/src/lib/fallbackTierLimits.ts
@@ -1,0 +1,60 @@
+import type { TierLimitsResponse } from '@/api/client'
+
+// FALLBACK_LIMITS mirrors api/core/tier_limits.go DefaultTierLimits. It
+// only renders during the ~20-50ms between component mount and the
+// /tier-limits fetch response — after that the real API values take over.
+//
+// SYNC GUARD: fallbackTierLimits.test.ts asserts this constant equals
+// api/core/tier_limits.json (the cross-language snapshot also pinned by
+// Go and desktop tests). If you edit a limit, update all four copies in
+// the same PR: api/core/tier_limits.go, api/core/tier_limits.json,
+// desktop/src/tierLimits.ts, and this file. Drift is billing-trust damage.
+export const FALLBACK_LIMITS: TierLimitsResponse = {
+  tiers: {
+    free: {
+      symbols: 5,
+      feeds: 1,
+      custom_feeds: 0,
+      leagues: 1,
+      fantasy: 0,
+      max_ticker_rows: 1,
+      max_ticker_customization: false,
+    },
+    uplink: {
+      symbols: 25,
+      feeds: 25,
+      custom_feeds: 1,
+      leagues: 8,
+      fantasy: 1,
+      max_ticker_rows: 2,
+      max_ticker_customization: false,
+    },
+    uplink_pro: {
+      symbols: 75,
+      feeds: 100,
+      custom_feeds: 3,
+      leagues: 20,
+      fantasy: 3,
+      max_ticker_rows: 3,
+      max_ticker_customization: false,
+    },
+    uplink_ultimate: {
+      symbols: null,
+      feeds: null,
+      custom_feeds: 10,
+      leagues: null,
+      fantasy: 10,
+      max_ticker_rows: 3,
+      max_ticker_customization: true,
+    },
+    super_user: {
+      symbols: null,
+      feeds: null,
+      custom_feeds: null,
+      leagues: null,
+      fantasy: null,
+      max_ticker_rows: 3,
+      max_ticker_customization: true,
+    },
+  },
+}

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -56,6 +56,7 @@ import {
   productOffers,
 } from '@/lib/structured-data'
 import { seededRandom } from '@/lib/seededRandom'
+import { FALLBACK_LIMITS } from '@/lib/fallbackTierLimits'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import { useGetToken } from '@/hooks/useGetToken'
 import { billingApi, tierLimitsApi } from '@/api/client'
@@ -587,61 +588,9 @@ function tierFromPlan(plan: string): TierKey | null {
 
 // ── Tier Limits (fetched from /tier-limits, fallback for first paint) ──
 //
-// FALLBACK_LIMITS mirrors api/core/tier_limits.go DefaultTierLimits. It
-// only renders during the ~20-50ms between component mount and the fetch
-// response — after that the real API values take over. If you edit
-// this constant, also update api/core/tier_limits.go and
-// desktop/src/tierLimits.ts. Drift is billing-trust damage.
-
-const FALLBACK_LIMITS: TierLimitsResponse = {
-  tiers: {
-    free: {
-      symbols: 5,
-      feeds: 1,
-      custom_feeds: 0,
-      leagues: 1,
-      fantasy: 0,
-      max_ticker_rows: 1,
-      max_ticker_customization: false,
-    },
-    uplink: {
-      symbols: 25,
-      feeds: 25,
-      custom_feeds: 1,
-      leagues: 8,
-      fantasy: 1,
-      max_ticker_rows: 2,
-      max_ticker_customization: false,
-    },
-    uplink_pro: {
-      symbols: 75,
-      feeds: 100,
-      custom_feeds: 3,
-      leagues: 20,
-      fantasy: 3,
-      max_ticker_rows: 3,
-      max_ticker_customization: false,
-    },
-    uplink_ultimate: {
-      symbols: null,
-      feeds: null,
-      custom_feeds: 10,
-      leagues: null,
-      fantasy: 10,
-      max_ticker_rows: 3,
-      max_ticker_customization: true,
-    },
-    super_user: {
-      symbols: null,
-      feeds: null,
-      custom_feeds: null,
-      leagues: null,
-      fantasy: null,
-      max_ticker_rows: 3,
-      max_ticker_customization: true,
-    },
-  },
-}
+// FALLBACK_LIMITS lives in @/lib/fallbackTierLimits, where a Vitest sync
+// test pins it to api/core/tier_limits.json (the shared snapshot of the
+// backend's DefaultTierLimits).
 
 /** Render a numeric cap in the form "25 feeds" / "Unlimited". */
 function fmtLimit(value: number | null, unit: string): string {

--- a/myscrollr.com/tsconfig.json
+++ b/myscrollr.com/tsconfig.json
@@ -19,6 +19,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowJs": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
## Summary
Backlog item 3 from the June hardening campaign: tier limits live in three hand-synced copies — `api/core/tier_limits.go` (`DefaultTierLimits`, source of truth), `desktop/src/tierLimits.ts`, and the pricing page `FALLBACK_LIMITS`. Sync was enforced only by comments plus a Go-side pin test, so a one-sided frontend edit would ship silently.

- Add **`api/core/tier_limits.json`** — a wire-format snapshot of `DefaultTierLimits` (exactly what `GET /tier-limits` serves)
- Pin all three copies to it, each in CI legs that already run:
  - `tier_limits_sync_test.go` (go:embed + deep-compare) → backend-tests
  - `desktop/src/tierLimits.test.ts` (camelCase→snake_case, `Infinity`→`null` conversion, then compare) → frontend-tests
  - `myscrollr.com/src/lib/fallbackTierLimits.test.ts` (direct compare) → frontend-tests
- Move `FALLBACK_LIMITS` out of `uplink.tsx` into `src/lib/fallbackTierLimits.ts` so the test can import it without pulling in the whole route (values unchanged; type-only import keeps it runtime-free)
- Trigger frontend-tests on the snapshot path so a JSON-only edit re-runs both frontend suites (backend-tests already watches `api/**`)
- Add `resolveJsonModule` to both tsconfigs for the JSON imports

Now any edit that leaves one copy stale fails CI on the stale side.

Stacked on #200 (both touch `frontend-tests.yml`); base is `ci/node24-actions-bump`, retarget to `main` after #200 merges.

## Test plan
- [x] `go test ./core/ -run TierLimits` — 3 tests pass, including the new snapshot test
- [x] Desktop: 310/310 Vitest tests pass; `tsc --noEmit` clean
- [x] myscrollr.com: 40/40 Vitest tests pass (tsc has pre-existing unrelated errors on the generated `latestVersion.generated` module)
- [x] Negative check: mutating `tier_limits.json` (`symbols: 5→6`) fails the desktop sync test, restored after

🤖 Generated with [Claude Code](https://claude.com/claude-code)
