### PR TITLE
docs(cdc): record WAL cap as applied, fix broken doctl instructions

### DIFF
--- a/docs/cdc-runbook.md
+++ b/docs/cdc-runbook.md
@@ -306,16 +306,30 @@ the damage a future Sequin outage can do:
    **Settings** → **Advanced Configuration** → **Edit** → set
    `max_slot_wal_keep_size` to `10240` (the panel takes MB → 10 GB).
 
-   Or via the CLI (the panel's parameter list is authoritative —
-   if the API rejects the key, use the panel):
+   `doctl databases configuration update` is known-broken for this
+   (tested June 2026 against doctl's bundled godo: the API returns
+   `422 the mask must be set with which fields are being updated`).
+   If you want a CLI path, PATCH the API directly — it accepts the
+   single-key body fine:
 
    ```sh
    doctl databases list   # get the cluster UUID
-   doctl databases configuration update <db-uuid> --engine pg \
-     --config-json '{"max_slot_wal_keep_size": 10240}'
+   curl -X PATCH "https://api.digitalocean.com/v2/databases/<db-uuid>/config" \
+     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"config": {"max_slot_wal_keep_size": 10240}}'
+   # expect HTTP 200 with empty body
    ```
 
-2. **Verify it took effect** (psql against the cluster):
+2. **Verify it took effect** — read the config back:
+
+   ```sh
+   curl -s "https://api.digitalocean.com/v2/databases/<db-uuid>/config" \
+     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" | \
+     jq .config.max_slot_wal_keep_size   # want: 10240, not absent/-1
+   ```
+
+   or via psql against the cluster:
 
    ```sql
    SHOW max_slot_wal_keep_size;   -- want: 10GB, not -1
@@ -331,8 +345,12 @@ Sizing: trades (~40 writes/sec) dominate WAL volume; 10 GB is many
 hours of slot-stall headroom, and both 2026-04 incidents blew well
 past it before detection — so the cap binds long before auto-scale
 billing does. This is managed-cluster config — it cannot be set via
-the regular DATABASE_URL path or from this repo, so it remains a
-manual ops step until someone runs the above.
+the regular DATABASE_URL path or from this repo.
+
+**Status: applied 2026-06-10** to `scrollr-db`
+(8ab18589-09fb-4a7a-aaca-03f2dc5d56a2) via the direct API PATCH
+above; readback confirmed `10240`. If the cluster is ever rebuilt or
+migrated, re-apply and re-verify.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- `max_slot_wal_keep_size = 10240` (10 GB) was applied to the `scrollr-db` cluster on 2026-06-10 and verified via API readback — closes the WAL-cap prevention item from the June hardening campaign (the runbook's "manual ops step" footnote no longer applies)
- The runbook's `doctl databases configuration update` command turned out broken: DO's config PATCH endpoint rejects doctl's request with `422 the mask must be set with which fields are being updated`. Replaced with a direct API `curl` PATCH that works (single-key body, returns 200)
- Added a curl readback as a verification alternative for when psql access isn't handy

## Test plan
- [x] Docs-only change; the documented commands are exactly what was run successfully against the live cluster today

🤖 Generated with [Claude Code](https://claude.com/claude-code)
