### PR TITLE
feat(sse): broadcast topic-resubscribe via Redis for multi-replica (ADR-0001)

### DIFF
--- a/api/core/channels.go
+++ b/api/core/channels.go
@@ -112,8 +112,9 @@ func addChannelSubscriptions(ctx context.Context, logtoSub, channelType string, 
 		}
 	}
 
-	// Rebuild topic subscriptions so active SSE connections get the new channel
-	UpdateUserTopicSubscriptions(logtoSub)
+	// Rebuild topic subscriptions on every replica holding an SSE
+	// connection for this user (Redis control message, ADR-0001)
+	NotifyTopicSubscriptionChange(logtoSub)
 
 	enabled := true
 	callChannelLifecycle(ctx, channelType, "sync", logtoSub, config, nil, &enabled)
@@ -139,8 +140,10 @@ func removeChannelSubscriptions(ctx context.Context, logtoSub, channelType strin
 		}
 	}
 
-	// Rebuild topic subscriptions so active SSE connections stop receiving this channel
-	UpdateUserTopicSubscriptions(logtoSub)
+	// Rebuild topic subscriptions on every replica so active SSE
+	// connections stop receiving this channel (Redis control message,
+	// ADR-0001)
+	NotifyTopicSubscriptionChange(logtoSub)
 
 	enabled := false
 	callChannelLifecycle(ctx, channelType, "sync", logtoSub, config, nil, &enabled)

--- a/api/core/constants.go
+++ b/api/core/constants.go
@@ -57,6 +57,14 @@ const (
 	TopicPrefixRSS     = "cdc:rss:"       // cdc:rss:{feed_url_fnv_hash}
 	TopicPrefixFantasy = "cdc:fantasy:"   // cdc:fantasy:{league_key}
 	TopicPrefixCore    = "cdc:core:user:" // cdc:core:user:{logto_sub}
+
+	// TopicSSEControlResubscribe carries cross-replica SSE control
+	// messages (ADR-0001): payload is the logto sub whose channel config
+	// changed. Every replica receives it and rebuilds that user's topic
+	// subscriptions if it holds an SSE connection for them — without
+	// this, only the replica that served the config-change HTTP request
+	// would refresh, leaving the connection-holding replica stale.
+	TopicSSEControlResubscribe = "sse:ctl:resubscribe"
 )
 
 // =============================================================================

--- a/api/core/events.go
+++ b/api/core/events.go
@@ -127,8 +127,9 @@ func (h *Hub) dispatchWorker(ctx context.Context) {
 	}
 }
 
-// listenToTopics subscribes to all CDC topic patterns and dispatches to
-// registered clients based on the topic subscription registry.
+// listenToTopics subscribes to all CDC topic patterns plus the SSE
+// control channel and dispatches to registered clients based on the
+// topic subscription registry.
 func (h *Hub) listenToTopics(ctx context.Context) {
 	pubsub := PSubscribe(ctx,
 		TopicPrefixFinance+"*",
@@ -136,14 +137,15 @@ func (h *Hub) listenToTopics(ctx context.Context) {
 		TopicPrefixRSS+"*",
 		TopicPrefixFantasy+"*",
 		TopicPrefixCore+"*",
+		TopicSSEControlResubscribe,
 	)
 	defer pubsub.Close()
 
 	ch := pubsub.Channel()
 
-	log.Printf("[EventHub] Listening to topic patterns: %s* %s* %s* %s* %s*",
+	log.Printf("[EventHub] Listening to topic patterns: %s* %s* %s* %s* %s* + %s",
 		TopicPrefixFinance, TopicPrefixSports, TopicPrefixRSS,
-		TopicPrefixFantasy, TopicPrefixCore)
+		TopicPrefixFantasy, TopicPrefixCore, TopicSSEControlResubscribe)
 
 	for {
 		select {
@@ -153,41 +155,53 @@ func (h *Hub) listenToTopics(ctx context.Context) {
 			if !ok {
 				return
 			}
+			h.handleTopicMessage(msg.Channel, []byte(msg.Payload))
+		}
+	}
+}
 
-			topic := msg.Channel
-			payload := []byte(msg.Payload)
+// handleTopicMessage routes a single pub/sub message. Split from
+// listenToTopics so tests can exercise routing without a live Redis
+// subscription loop.
+func (h *Hub) handleTopicMessage(topic string, payload []byte) {
+	// Control message: a user's channel config changed somewhere in the
+	// fleet (ADR-0001). Rebuild local topic subscriptions; replicas
+	// holding no connection for the user no-op inside
+	// UpdateUserTopicSubscriptions.
+	if topic == TopicSSEControlResubscribe {
+		UpdateUserTopicSubscriptions(string(payload))
+		return
+	}
 
-			// Special case: core user-specific topics (user_preferences, user_channels).
-			// These target a single user directly -- no registry lookup needed.
-			if strings.HasPrefix(topic, TopicPrefixCore) {
-				userID := topic[len(TopicPrefixCore):]
-				select {
-				case h.dispatchCh <- dispatchJob{userID: userID, payload: payload}:
-				default:
-					// Queue full — drop to avoid blocking the listener.
-					// Rate-limited log so the drop is observable without
-					// flooding logs when the queue saturates.
-					logDispatchDrop()
-				}
-				continue
-			}
+	// Special case: core user-specific topics (user_preferences, user_channels).
+	// These target a single user directly -- no registry lookup needed.
+	if strings.HasPrefix(topic, TopicPrefixCore) {
+		userID := topic[len(TopicPrefixCore):]
+		select {
+		case h.dispatchCh <- dispatchJob{userID: userID, payload: payload}:
+		default:
+			// Queue full — drop to avoid blocking the listener.
+			// Rate-limited log so the drop is observable without
+			// flooding logs when the queue saturates.
+			logDispatchDrop()
+		}
+		return
+	}
 
-			// Look up all users subscribed to this topic
-			users := h.registry.getUsersForTopic(topic)
-			if users == nil {
-				continue
-			}
+	// Look up all users subscribed to this topic
+	users := h.registry.getUsersForTopic(topic)
+	if users == nil {
+		return
+	}
 
-			// Fan-out via worker pool (non-blocking enqueue)
-			for userID := range users {
-				select {
-				case h.dispatchCh <- dispatchJob{userID: userID, payload: payload}:
-				default:
-					// Queue full — drop oldest-style backpressure.
-					// Rate-limited log so the drop is observable.
-					logDispatchDrop()
-				}
-			}
+	// Fan-out via worker pool (non-blocking enqueue)
+	for userID := range users {
+		select {
+		case h.dispatchCh <- dispatchJob{userID: userID, payload: payload}:
+		default:
+			// Queue full — drop oldest-style backpressure.
+			// Rate-limited log so the drop is observable.
+			logDispatchDrop()
 		}
 	}
 }
@@ -337,15 +351,33 @@ func UnsubscribeFromTopic(userID, topic string) {
 	globalHub.registry.unsubscribe(userID, topic)
 }
 
-// UpdateUserTopicSubscriptions rebuilds a user's topic subscriptions.
-// Called from channel CRUD handlers when a user modifies their channels.
-// Only operates if the user has an active SSE connection.
+// UpdateUserTopicSubscriptions rebuilds a user's topic subscriptions on
+// THIS replica. Only operates if the user has an active SSE connection
+// here — which is why channel CRUD handlers must not call it directly:
+// with multiple replicas, the HTTP request and the SSE connection can
+// live on different pods. Reached via NotifyTopicSubscriptionChange →
+// Redis control message → handleTopicMessage, so every replica runs it
+// (ADR-0001).
 func UpdateUserTopicSubscriptions(userID string) {
 	if _, ok := globalHub.clients.Load(userID); !ok {
-		return // No active connection, nothing to update
+		return // No active connection on this replica, nothing to update
 	}
 	globalHub.registry.unsubscribeAll(userID)
 	go subscribeUserToTopics(userID)
+}
+
+// NotifyTopicSubscriptionChange tells every replica to rebuild the
+// user's SSE topic subscriptions after a channel config change. Goes
+// through Redis pub/sub so the replica holding the user's SSE
+// connection refreshes even when this HTTP request was served by a
+// different replica (ADR-0001). Falls back to a local refresh if the
+// publish fails, so a Redis hiccup never makes a single replica worse
+// than the old direct call.
+func NotifyTopicSubscriptionChange(userID string) {
+	if err := PublishRaw(TopicSSEControlResubscribe, []byte(userID)); err != nil {
+		log.Printf("[EventHub] resubscribe publish failed for %s (falling back to local refresh): %v", userID, err)
+		UpdateUserTopicSubscriptions(userID)
+	}
 }
 
 // RouteToRecordOwner sends a CDC event directly to the user identified in the record.

--- a/api/core/events_control_test.go
+++ b/api/core/events_control_test.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Tests for the cross-replica SSE resubscribe control message (ADR-0001):
+// channel CRUD publishes the affected user's sub on
+// TopicSSEControlResubscribe, every replica's hub receives it via
+// handleTopicMessage, and only replicas holding an SSE connection for
+// that user rebuild their local registry.
+
+// swapHub installs a fresh minimal hub (no dispatch workers, no Redis
+// listener) for the duration of a test and restores the previous one.
+func swapHub(t *testing.T) *Hub {
+	t.Helper()
+	prev := globalHub
+	globalHub = &Hub{
+		registry:   &topicRegistry{},
+		dispatchCh: make(chan dispatchJob, 8),
+	}
+	t.Cleanup(func() { globalHub = prev })
+	return globalHub
+}
+
+// TestNotifyTopicSubscriptionChange_PublishesControlMessage asserts the
+// CRUD-side half: the notification goes out on the control channel with
+// the user's sub as payload, where every replica's listener can see it.
+func TestNotifyTopicSubscriptionChange_PublishesControlMessage(t *testing.T) {
+	_, cleanup := setupMiniRedis(t)
+	defer cleanup()
+	swapHub(t)
+
+	ctx := context.Background()
+	sub := Rdb.Subscribe(ctx, TopicSSEControlResubscribe)
+	defer sub.Close()
+	// Wait for the subscription to be confirmed before publishing, or
+	// the message can be lost (pub/sub has no replay).
+	if _, err := sub.Receive(ctx); err != nil {
+		t.Fatalf("establish subscription: %v", err)
+	}
+
+	NotifyTopicSubscriptionChange("user-control-pub")
+
+	select {
+	case msg := <-sub.Channel():
+		if msg.Channel != TopicSSEControlResubscribe {
+			t.Errorf("channel = %q, want %q", msg.Channel, TopicSSEControlResubscribe)
+		}
+		if msg.Payload != "user-control-pub" {
+			t.Errorf("payload = %q, want %q", msg.Payload, "user-control-pub")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no control message received within 2s")
+	}
+}
+
+// TestHandleTopicMessage_ControlRefreshesConnectedUser asserts the
+// listener-side half on a replica that DOES hold the user's connection:
+// stale registry entries are dropped synchronously when the control
+// message arrives. Integration-gated because the async re-subscribe
+// half reads the user's channels from the DB (the test user has none,
+// so nothing comes back).
+func TestHandleTopicMessage_ControlRefreshesConnectedUser(t *testing.T) {
+	if !testDBAvailable(t) {
+		return
+	}
+	h := swapHub(t)
+
+	const userID = "user-control-connected"
+	client := &Client{UserID: userID, Ch: make(chan []byte, 1)}
+	h.register(client)
+	defer h.unregister(client)
+
+	staleTopic := TopicPrefixFinance + "STALE"
+	h.registry.subscribe(userID, staleTopic)
+
+	h.handleTopicMessage(TopicSSEControlResubscribe, []byte(userID))
+
+	if users := h.registry.getUsersForTopic(staleTopic); users != nil {
+		if _, ok := users[userID]; ok {
+			t.Errorf("user still subscribed to %s after resubscribe control message", staleTopic)
+		}
+	}
+}
+
+// TestHandleTopicMessage_ControlNoConnection_NoOp asserts the
+// listener-side half on a replica that does NOT hold the user's
+// connection: the control message must be a strict no-op (this is what
+// makes broadcasting to every replica safe).
+func TestHandleTopicMessage_ControlNoConnection_NoOp(t *testing.T) {
+	h := swapHub(t)
+
+	// A registry entry without a client doesn't occur naturally
+	// (unregister cleans up), but it's the sharpest probe that the
+	// no-connection path touches nothing.
+	const userID = "user-control-absent"
+	topic := TopicPrefixSports + "NFL"
+	h.registry.subscribe(userID, topic)
+
+	h.handleTopicMessage(TopicSSEControlResubscribe, []byte(userID))
+
+	users := h.registry.getUsersForTopic(topic)
+	if users == nil {
+		t.Fatal("registry entry vanished for a user with no local connection")
+	}
+	if _, ok := users[userID]; !ok {
+		t.Errorf("user removed from %s despite having no local connection", topic)
+	}
+}
+
+// TestHandleTopicMessage_CoreUserTopicStillDispatches guards the
+// pre-existing routing against regressions from the control-message
+// split: a cdc:core:user:* message must still enqueue a dispatch job
+// for exactly that user.
+func TestHandleTopicMessage_CoreUserTopicStillDispatches(t *testing.T) {
+	h := swapHub(t)
+
+	const userID = "user-core-dispatch"
+	h.handleTopicMessage(TopicPrefixCore+userID, []byte(`{"kind":"prefs"}`))
+
+	select {
+	case job := <-h.dispatchCh:
+		if job.userID != userID {
+			t.Errorf("dispatch job userID = %q, want %q", job.userID, userID)
+		}
+	default:
+		t.Fatal("no dispatch job enqueued for core user topic")
+	}
+}


### PR DESCRIPTION
## Summary
Action item 1 of [ADR-0001](docs/adr/0001-sse-multi-replica.md) — fixes the one real multi-replica correctness bug before scaling core-api past one pod.

- Channel CRUD used to call `UpdateUserTopicSubscriptions` directly, which no-ops unless the request-serving process holds the user's SSE connection (`events.go`). Correct at `replicas: 1`; at `replicas: 2` a config change served by pod A leaves pod B's registry stale until the client reconnects
- Channel CRUD now publishes the user's sub on a new `sse:ctl:resubscribe` Redis channel; every replica's hub listener handles it and refreshes locally. Replicas without that user's connection no-op exactly as before, so the broadcast is safe
- Falls back to the direct local call if the publish fails — a Redis hiccup never makes single-replica behavior worse than before
- Listener loop body extracted into `handleTopicMessage` so routing is testable without a live Redis subscription

## Test plan
- [x] New tests: publish side (miniredis pub/sub round-trip), refresh-when-connected (integration-gated, runs in CI's postgres container), strict no-op-when-absent, and a regression guard on the pre-existing `cdc:core:user:*` dispatch path
- [x] `go vet` + full unit suite pass locally
- [ ] backend-tests green on this PR (integration leg included)
- [ ] After merge + deploy: single-replica smoke — change channel config while an SSE stream is open, confirm the stream picks up the new topic (same behavior as today, now routed through Redis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
