### PR TITLE
feat(k8s): scale core-api to 2 replicas with PDB and surge-only rollouts

### DIFF
--- a/docs/cdc-runbook.md
+++ b/docs/cdc-runbook.md
@@ -17,9 +17,15 @@ Sequin (self-hosted on scrollr-infra Coolify, sequin.myscrollr.com)
         │
         │  HTTP POST /webhooks/sequin with SEQUIN_WEBHOOK_SECRET
         ▼
-core-api (k8s, scrollr/core-api)
+core-api (k8s, scrollr/core-api — ANY replica receives the webhook)
   └── `handlers_webhook.go::HandleSequinWebhook`
-  └── routes to Redis topic PubSub: cdc:finance:*, cdc:sports:*, etc.
+  └── publishes to Redis topic PubSub: cdc:finance:*, cdc:sports:*, etc.
+        │
+        ▼
+Redis pub/sub ──▶ EVERY core-api replica PSUBSCRIBEs the cdc:* patterns
+  └── each replica fans out in-process to its own SSE connections
+  └── channel-config changes broadcast `sse:ctl:resubscribe` so the
+      replica holding the user's stream refreshes (ADR-0001)
         │
         ▼
 Desktop client via SSE (`/events/dashboard`)

--- a/k8s/core-api.yaml
+++ b/k8s/core-api.yaml
@@ -6,7 +6,18 @@ metadata:
   labels:
     app: core-api
 spec:
-  replicas: 1
+  # Two replicas for HA and zero-drop deploys (ADR-0001). Safe because
+  # SSE fan-out rides Redis pub/sub per replica, channel-config changes
+  # broadcast resubscribes via sse:ctl:resubscribe, and rate-limit
+  # counters live in Redis — no remaining state assumes a single pod.
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Never drop below the replica count during rollouts: surge a new
+      # pod first, kill an old one only after the new one is Ready.
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: core-api
@@ -85,3 +96,16 @@ spec:
     - port: 8080
       targetPort: 8080
   type: ClusterIP
+---
+# Keep at least one core-api pod through voluntary disruptions (node
+# drains, cluster upgrades) — the whole API surface routes through it.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: core-api
+  namespace: scrollr
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: core-api


### PR DESCRIPTION
## Summary
Action items 3 + 5 of [ADR-0001](docs/adr/0001-sse-multi-replica.md) — the final step. Prereqs already merged: `sse:ctl:resubscribe` control channel (#206) and Redis-backed rate-limit counters (#207). With those deployed, no remaining core-api state assumes a single pod.

- `replicas: 2` with `maxUnavailable: 0` / `maxSurge: 1` — rollouts surge a new pod before killing an old one, so deploys stop being micro-outages; SSE clients ride through on their 3s retry
- PodDisruptionBudget (`minAvailable: 1`) so node drains and cluster upgrades can't take the whole API down
- cdc-runbook architecture diagram updated to show per-replica Redis pub/sub fan-out and the resubscribe control channel

**Merge order matters:** merge only after #206 and #207 have deployed to the cluster (both are in main; confirm the core-api rollout finished).

## Test plan
- [ ] After merge: `kubectl -n scrollr get pods -l app=core-api` shows 2 Ready pods
- [ ] In-cluster verification from the ADR (action item 4): SSE stream against pod A, channel-config change served by pod B, confirm the stream picks up the new topic without reconnect
- [ ] During the next deploy, confirm `/health` never 503s from the gateway (zero-drop rollout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
