### PR TITLE
ci(desktop): exclude test/tooling files from release build trigger

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -15,8 +15,23 @@ on:
           - linux
   push:
     branches: [main]
+    # Pattern order matters: a negated pattern after a positive match excludes
+    # the path. The workflow still runs if at least one changed file survives
+    # the net filter, so a push touching both a test file and a source file
+    # still builds. Excluded files are covered by frontend-tests.yml, and
+    # tsconfig.json deliberately stays included — it is an input to the
+    # release build (vite build && tsc --noEmit).
     paths:
       - "desktop/**"
+      # Test-only changes don't need release artifacts.
+      - "!desktop/src/**/*.test.ts"
+      - "!desktop/src/**/*.test.tsx"
+      - "!desktop/vitest*.ts"
+      # Docs and dev tooling that never reach the release artifacts.
+      - "!desktop/**/*.md"
+      - "!desktop/.env.example"
+      - "!desktop/screenshots/**"
+      - "!desktop/scripts/capture-screenshots.mjs"
       - ".github/workflows/desktop-release.yml"
 
 permissions:


### PR DESCRIPTION
## Summary
- A test-only merge on 2026-06-10 (touching only `desktop/src/tierLimits.test.ts` and `desktop/tsconfig.json`) kicked off full 3-platform Tauri release builds (~10 min each) for artifacts nobody needed.
- Adds negated globs to the `push.paths` filter in `desktop-release.yml` so test-only and tooling-only changes no longer trigger release builds: `desktop/src/**/*.test.ts(x)`, `desktop/vitest*.ts`, markdown docs, `.env.example`, `desktop/screenshots/**`, and the screenshot capture script.
- All excluded files are already covered by `frontend-tests.yml`, so no CI coverage is lost.

## Notes
- Verified against GitHub Actions docs: pattern order matters (later negative patterns exclude), and the workflow still runs if at least one changed file survives the net filter — so a push touching both a test file and a source file still builds.
- `desktop/tsconfig.json` deliberately stays included: it is a real input to the release build (`vite build && tsc --noEmit`), so excluding it could skip a rebuild that changes the shipped artifact. A comment in the workflow documents this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)