### PR TITLE
feat(sports): add FIFA World Cup 2026 league; bump desktop to 1.0.20

### DIFF
--- a/channels/sports/service/configs/leagues.json
+++ b/channels/sports/service/configs/leagues.json
@@ -100,6 +100,17 @@
     "offseason_months": [6, 7]
   },
   {
+    "name": "FIFA World Cup",
+    "sport_api": "football",
+    "api_host": "v3.football.api-sports.io",
+    "league_id": 1,
+    "category": "Soccer",
+    "country": "World",
+    "season_format": "calendar",
+    "season": "2026",
+    "offseason_months": [1, 2, 3, 4, 5, 8, 9, 10, 11, 12]
+  },
+  {
     "name": "Formula 1",
     "sport_api": "formula-1",
     "api_host": "v1.formula-1.api-sports.io",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4450,7 +4450,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "dirs 5.0.1",
  "futures-util",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.0.19"
+version = "1.0.20"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Add **FIFA World Cup** to the sports ingestion config (`channels/sports/service/configs/leagues.json`): api-sports.io football endpoint, `league_id: 1`, explicit `season: "2026"`, in-season June–July only. Verified against [API-Football World Cup 2026 guide](https://www.api-football.com/news/post/fifa-world-cup-2026-guide-to-using-data-with-api-sports) — 104 fixtures, group standings return per-group tables which map onto the existing `group_name` parsing.
- Bump desktop version **1.0.19 → 1.0.20** (package.json, package-lock.json, tauri.conf.json, Cargo.toml, Cargo.lock) to cut a release.

## Why no code changes
The league pipeline is fully table-driven: `leagues.json` upserts into `tracked_leagues` on service startup, fixtures parse via the existing football parser, CDC/Redis routing keys off the league name, and the desktop LeagueManager renders the catalog from `/sports/leagues`. The World Cup shows up as a one-click add, and the default catalog sort floats it to the top while matches are live.

## Quota note
Premier League, La Liga, and Champions League are off-season in June–July, so the shared `v3.football.api-sports.io` daily quota only carries MLS + World Cup during the tournament.

## Deploy note
The sports service must restart to seed the new league (idempotent `ON CONFLICT (name) DO UPDATE` upsert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)