### PR TITLE
fix(sports): stop off-season leagues from burning football-host quota

### DIFF
--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -191,6 +191,17 @@ pub struct TrackedLeague {
     pub offseason_months: Option<Vec<i32>>,
 }
 
+impl TrackedLeague {
+    /// True when `month` (1-12) falls inside this league's configured
+    /// off-season window. Leagues without `offseason_months` are treated
+    /// as always in season.
+    pub fn is_offseason(&self, month: i32) -> bool {
+        self.offseason_months
+            .as_ref()
+            .is_some_and(|months| months.contains(&month))
+    }
+}
+
 // =============================================================================
 // Game data — normalized from all api-sports.io sport APIs
 // =============================================================================

--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -21,9 +21,11 @@ pub mod types;
 /// Number of days ahead to poll in the schedule task. 7 days covers a full
 /// week of fixtures — Premier League Saturday matches show up Monday morning.
 ///
-/// Rate-budget impact (worst case, 4 in-season football leagues): 4 leagues
-/// × 8 dates × 48 polls/day = 1,536 calls/day on the football host, well
-/// under the 7,500/day quota.
+/// Rate-budget impact: only in-season leagues are polled (off-season leagues
+/// are skipped in both poll_live and poll_schedule). Worst case on the
+/// football host is 4 simultaneous in-season leagues (Aug–Nov, Mar–May):
+/// 4 leagues × 8 dates × 48 polls/day = 1,536 schedule calls/day, leaving
+/// ~6,000 of the 7,500/day quota for live polling.
 const SCHEDULE_DAYS_AHEAD: i64 = 7;
 
 /// Delay between league requests on startup burst to avoid rate limits.
@@ -158,7 +160,16 @@ pub async fn poll_live(
     let mut total_failed = 0u32;
     let mut leagues_with_live = 0u32;
 
+    let current_month = now.month() as i32;
+
     for league in leagues {
+        // Off-season leagues have no fixtures — polling them burns the shared
+        // budget pool on requests that return empty. Skip silently (this loop
+        // runs every 30-60s; logging would flood).
+        if league.is_offseason(current_month) {
+            continue;
+        }
+
         if !rate_limiter.try_consume(&league.name) {
             warn!("[{}] Skipping live poll — per-league budget exhausted (reserved={}, shared={})",
                 league.name,
@@ -256,9 +267,20 @@ pub async fn poll_schedule(
     let mut total_upserted = 0u32;
     let mut total_failed = 0u32;
 
+    let current_month = now.month() as i32;
+
     for league in leagues {
         // Formula 1 fetches the whole season (no date param), skip per-date polling
         if league.sport_api == "formula-1" {
+            continue;
+        }
+
+        // Off-season leagues have no upcoming fixtures inside the 8-date
+        // window. Skipping saves 8 requests × 48 cycles/day per dormant
+        // league — with three off-season soccer leagues that's ~1,150
+        // football-host requests/day spent on empty schedules.
+        if league.is_offseason(current_month) {
+            info!("[{}] Skipping schedule poll — off-season in month {}", league.name, current_month);
             continue;
         }
 

--- a/channels/sports/service/src/types.rs
+++ b/channels/sports/service/src/types.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Datelike, Utc};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::RwLock;
 
 #[derive(Serialize, Clone)]
 pub struct SportsHealth {
@@ -78,6 +79,12 @@ pub struct RateLimiter {
     league_to_host: HashMap<String, String>,
     /// Per-host shared pool — fed by off-season leagues' donated shares.
     host_shared: HashMap<String, AtomicU32>,
+    /// League names currently inside their off-season window. These leagues
+    /// have no reserved budget AND may not borrow from the shared pool — the
+    /// pool exists so in-season leagues can use the budget dormant leagues
+    /// donated. Refreshed at construction and at each daily reset (the month
+    /// can change at UTC midnight).
+    offseason_leagues: RwLock<HashSet<String>>,
 }
 
 impl RateLimiter {
@@ -93,6 +100,7 @@ impl RateLimiter {
             league_reserved: HashMap::new(),
             league_to_host: HashMap::new(),
             host_shared: HashMap::new(),
+            offseason_leagues: RwLock::new(HashSet::new()),
         }
     }
 
@@ -120,18 +128,18 @@ impl RateLimiter {
         let mut league_to_host = HashMap::new();
         let mut host_shared = HashMap::new();
         let mut host_remaining = HashMap::new();
+        let mut offseason = HashSet::new();
 
         for (host, host_leagues) in &by_host {
             let n = host_leagues.len().max(1) as u32;
             let share = daily_total / n;
             let mut donated = 0u32;
             for l in host_leagues {
-                let is_offseason = l.offseason_months.as_ref()
-                    .map(|months| months.contains(&current_month))
-                    .unwrap_or(false);
+                let is_offseason = l.is_offseason(current_month);
                 let reserved = if is_offseason { 0 } else { share };
                 if is_offseason {
                     donated += share;
+                    offseason.insert(l.name.clone());
                 }
                 league_reserved.insert(l.name.clone(), AtomicU32::new(reserved));
                 league_to_host.insert(l.name.clone(), host.clone());
@@ -145,6 +153,7 @@ impl RateLimiter {
             league_reserved,
             league_to_host,
             host_shared,
+            offseason_leagues: RwLock::new(offseason),
         }
     }
 
@@ -164,6 +173,17 @@ impl RateLimiter {
                     Err(actual) => cur = actual,
                 }
             }
+        }
+        // Off-season leagues have no reserved share and may not raid the
+        // shared pool — it exists so in-season leagues can borrow the budget
+        // dormant leagues donated. Without this check, a dormant league that
+        // is still polled drains the very pool it donated (June 2026: three
+        // off-season soccer leagues burned the whole football-host quota).
+        if self.offseason_leagues.read()
+            .map(|s| s.contains(league_name))
+            .unwrap_or(false)
+        {
+            return false;
         }
         // Fall back to shared pool
         let Some(host) = self.league_to_host.get(league_name) else {
@@ -207,17 +227,17 @@ impl RateLimiter {
             by_host.entry(l.sport_api.clone()).or_default().push(l);
         }
 
+        let mut offseason = HashSet::new();
         for (host, host_leagues) in &by_host {
             let n = host_leagues.len().max(1) as u32;
             let share = daily_total / n;
             let mut donated = 0u32;
             for l in host_leagues {
-                let is_offseason = l.offseason_months.as_ref()
-                    .map(|months| months.contains(&current_month))
-                    .unwrap_or(false);
+                let is_offseason = l.is_offseason(current_month);
                 let reserved = if is_offseason { 0 } else { share };
                 if is_offseason {
                     donated += share;
+                    offseason.insert(l.name.clone());
                 }
                 if let Some(slot) = self.league_reserved.get(&l.name) {
                     slot.store(reserved, Ordering::Relaxed);
@@ -229,6 +249,11 @@ impl RateLimiter {
             if let Some(slot) = self.host_remaining.get(host) {
                 slot.store(daily_total, Ordering::Relaxed);
             }
+        }
+        // Re-derive the off-season set — the month may have rolled over,
+        // moving leagues into or out of their off-season window.
+        if let Ok(mut s) = self.offseason_leagues.write() {
+            *s = offseason;
         }
     }
 
@@ -416,6 +441,31 @@ mod tests {
         }
         assert_eq!(rl.shared_remaining("football"), 0);
         // Now exhausted
+        assert!(!rl.try_consume("Premier League"));
+    }
+
+    #[test]
+    fn test_offseason_league_cannot_drain_shared_pool() {
+        use chrono::Datelike;
+        // Regression test for the June 2026 quota exhaustion: an off-season
+        // league has reserved=0, and try_consume must NOT let it fall through
+        // to the shared pool — that pool exists for in-season leagues.
+        let current_month = chrono::Utc::now().month() as i32;
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("Off", "football", Some(vec![current_month])),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 1000);
+
+        // Off-season league is denied outright; shared pool untouched.
+        assert!(!rl.try_consume("Off"));
+        assert_eq!(rl.shared_remaining("football"), 500);
+
+        // In-season league can still spend its reserved share AND borrow
+        // the donated share from the pool.
+        for _ in 0..1000 {
+            assert!(rl.try_consume("Premier League"));
+        }
         assert!(!rl.try_consume("Premier League"));
     }
 


### PR DESCRIPTION
## Problem

On June 11 the football host (v3.football.api-sports.io) reported "request limit for the day" for every soccer league all day. Audit showed the service legitimately burns the full 7,500/day quota:

- `poll_live` (30-60s cadence) and `poll_schedule` (8 dates x 48 cycles/day) iterate **all** 5 football leagues, including off-season ones (Premier League, La Liga, Champions League in June).
- Off-season leagues get `reserved=0` and donate their share to the per-host shared pool - but `try_consume` let those same dormant leagues fall through to the shared pool, draining the budget they donated on requests that return zero fixtures.
- Unconstrained demand with 5 leagues: ~9,100-16,300 req/day vs the 7,500 quota - exhausted by late morning UTC.

## Fix

- `poll_live` / `poll_schedule` skip leagues whose `offseason_months` include the current UTC month.
- `RateLimiter::try_consume` denies shared-pool fallback to off-season leagues (defense in depth); the off-season set is refreshed at construction and at the UTC-midnight daily reset.
- New `TrackedLeague::is_offseason` helper; updated the stale rate-budget comment on `SCHEDULE_DAYS_AHEAD`.

## Post-fix volume (June, MLS + FIFA World Cup in-season)

2 leagues x 2,880 live polls + 768 schedule + ~5 standings = ~6,800/day worst case, under the 7,500 quota. Quota frees up at the upstream daily reset.

## Testing

- 35/35 unit tests pass, including new regression test `test_offseason_league_cannot_drain_shared_pool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)