### PR TITLE
feat(sports): persist daily rate-budget consumption across pod restarts

### DIFF
--- a/channels/sports/service/migrations/120000000008_rate_budget.down.sql
+++ b/channels/sports/service/migrations/120000000008_rate_budget.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sports_rate_budget;

--- a/channels/sports/service/migrations/120000000008_rate_budget.up.sql
+++ b/channels/sports/service/migrations/120000000008_rate_budget.up.sql
@@ -1,0 +1,19 @@
+-- Per-host daily request consumption for the api-sports.io rate budget.
+--
+-- The in-memory RateLimiter (src/types.rs) budgets 7,500 requests/day per
+-- sport host, but a pod restart (deploy, OOM, node drain) used to reset
+-- every bucket back to the full quota while the upstream counter only
+-- resets at UTC midnight — letting a restarted pod overshoot the daily
+-- quota. The service flushes its consumed counts here periodically and
+-- seeds the limiter from today's row on startup.
+--
+-- One row per (host, UTC day). `consumed` is monotonically increasing
+-- within a day; rows older than a week are pruned by the daily reset task.
+
+CREATE TABLE IF NOT EXISTS sports_rate_budget (
+    host TEXT NOT NULL,
+    day DATE NOT NULL,
+    consumed INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (host, day)
+);

--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -1,9 +1,9 @@
-use std::{env, time::Duration, sync::Arc};
+use std::{collections::HashMap, env, time::Duration, sync::Arc};
 use anyhow::{Context, Result};
 use sqlx::postgres::PgPoolOptions;
 pub use sqlx::PgPool;
 use sqlx::{FromRow, query, query_as};
-use chrono::Utc;
+use chrono::{NaiveDate, Utc};
 use serde::Deserialize;
 
 /// Build the sqlx migrator for this service.
@@ -418,6 +418,79 @@ pub async fn cleanup_old_games(pool: &Arc<PgPool>) -> Result<u64> {
     )
     .execute(&mut *connection)
     .await?;
+    Ok(result.rows_affected())
+}
+
+// =============================================================================
+// Rate budget persistence — sports_rate_budget (host, UTC day) → consumed
+// =============================================================================
+
+/// Load today's (UTC) consumed request count per host. Used once on startup
+/// to seed the RateLimiter so a mid-day restart resumes from the quota
+/// actually spent instead of a fresh full budget.
+///
+/// Errors are logged and yield an empty map (fail open: the service starts
+/// with full budgets, which is exactly the pre-persistence behavior). The
+/// header clamp in RateLimiter::update still catches the overshoot.
+pub async fn get_consumed_today(pool: &Arc<PgPool>) -> HashMap<String, u32> {
+    let today = Utc::now().date_naive();
+    let result: Result<Vec<(String, i32)>, sqlx::Error> = async {
+        let mut conn = pool.acquire().await?;
+        let rows = query_as("SELECT host, consumed FROM sports_rate_budget WHERE day = $1")
+            .bind(today)
+            .fetch_all(&mut *conn)
+            .await?;
+        Ok(rows)
+    }.await;
+
+    match result {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|(host, consumed)| (host, consumed.max(0) as u32))
+            .collect(),
+        Err(e) => {
+            log::error!("Failed to load persisted rate-budget consumption, starting from full quota: {}", e);
+            HashMap::new()
+        }
+    }
+}
+
+/// Add per-host consumption deltas to the given UTC day's rows. Additive
+/// upsert (`consumed + delta`, not overwrite) so flushes are safe even if
+/// another writer touched the row between flushes.
+pub async fn add_consumed(
+    pool: &Arc<PgPool>,
+    day: NaiveDate,
+    deltas: &HashMap<String, u32>,
+) -> Result<()> {
+    let mut conn = pool.acquire().await?;
+    for (host, delta) in deltas {
+        query(
+            "INSERT INTO sports_rate_budget (host, day, consumed)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (host, day) DO UPDATE SET
+                 consumed = sports_rate_budget.consumed + EXCLUDED.consumed,
+                 updated_at = NOW()"
+        )
+        .bind(host)
+        .bind(day)
+        .bind(*delta as i32)
+        .execute(&mut *conn)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Delete rate-budget rows older than a week. Only today's row is ever read
+/// back; a week of history is kept for operator debugging (e.g. comparing
+/// against the api-sports dashboard after a quota incident).
+pub async fn prune_rate_budget(pool: &Arc<PgPool>) -> Result<u64> {
+    let cutoff = Utc::now().date_naive() - chrono::Days::new(7);
+    let mut conn = pool.acquire().await?;
+    let result = query("DELETE FROM sports_rate_budget WHERE day < $1")
+        .bind(cutoff)
+        .execute(&mut *conn)
+        .await?;
     Ok(result.rows_affected())
 }
 

--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -367,6 +367,9 @@ pub async fn poll_standings(
             url = format!("{}&sport={}", url, league.sport_api);
         }
 
+        // Standings requests don't go through try_consume (has_budget gate
+        // above), so record them against the persisted consumption count.
+        rate_limiter.note_consumed(&league.sport_api, 1);
         match client.get(&url).send().await {
             Ok(resp) => {
                 if let Some(remaining) = resp.headers()
@@ -920,6 +923,9 @@ pub async fn poll_teams(
             url = format!("{}&sport={}", url, league.sport_api);
         }
 
+        // Teams requests don't go through try_consume (has_budget gate
+        // above), so record them against the persisted consumption count.
+        rate_limiter.note_consumed(&league.sport_api, 1);
         match client.get(&url).send().await {
             Ok(resp) => {
                 if let Some(remaining) = resp.headers()

--- a/channels/sports/service/src/main.rs
+++ b/channels/sports/service/src/main.rs
@@ -6,7 +6,7 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use sports_service::{
-    database::initialize_pool,
+    database::{add_consumed, get_consumed_today, initialize_pool, prune_rate_budget, PgPool},
     init::{fatal, spawn_supervised, ReadinessGate, ReadinessSnapshot},
     init_sports_service,
     log::init_async_logger,
@@ -51,6 +51,31 @@ const READINESS_BRIDGE_INTERVAL: Duration = Duration::from_secs(10);
 /// reset. Keep these in lockstep — drift between them would silently corrupt
 /// the per-league budget allocation.
 const SPORTS_DAILY_QUOTA: u32 = 7500;
+
+/// How often accumulated per-host request consumption is flushed to the
+/// `sports_rate_budget` table. Batched rather than per-request to keep DB
+/// write load negligible (at most one upsert per host per interval). An
+/// unclean shutdown can lose up to one interval's worth of counts — small,
+/// bounded slack compared to the full-quota reset this persistence prevents.
+const BUDGET_FLUSH_INTERVAL_SECS: u64 = 60;
+
+/// Persist accumulated per-host consumption to Postgres, attributed to the
+/// current UTC day. On write failure the deltas are handed back to the
+/// in-memory buffer so the next flush retries them — dropping them would
+/// under-count after a restart and let the service overshoot the quota.
+async fn flush_consumed(pool: &Arc<PgPool>, rate_limiter: &Arc<RateLimiter>) {
+    let deltas = rate_limiter.take_consumed();
+    if deltas.is_empty() {
+        return;
+    }
+    let day = chrono::Utc::now().date_naive();
+    if let Err(e) = add_consumed(pool, day, &deltas).await {
+        eprintln!("[Rate Budget] Failed to persist consumed counts, will retry: {e:#}");
+        for (host, n) in deltas {
+            rate_limiter.note_consumed(&host, n);
+        }
+    }
+}
 
 /// Initialize Sentry. The returned guard MUST live for the lifetime of
 /// the process — Drop flushes pending events on shutdown. Sentry MUST
@@ -219,7 +244,24 @@ async fn run_service() -> Result<()> {
         // in-season league can borrow from when its reserved budget is
         // exhausted. Prevents Champions League knockout nights from starving
         // Premier League polls.
-        let rate_limiter = Arc::new(RateLimiter::new_per_league(&leagues, SPORTS_DAILY_QUOTA));
+        //
+        // Budgets are seeded from today's persisted consumption so a pod
+        // restart mid-day (deploy, OOM, node drain) resumes from the quota
+        // actually remaining — the upstream counter only resets at UTC
+        // midnight, while a fresh in-memory limiter would grant itself the
+        // full 7,500 again.
+        let consumed_today = get_consumed_today(&pool).await;
+        if !consumed_today.is_empty() {
+            println!(
+                "[Rate Budget] Seeding budgets from persisted consumption: {:?}",
+                consumed_today
+            );
+        }
+        let rate_limiter = Arc::new(RateLimiter::new_per_league_seeded(
+            &leagues,
+            SPORTS_DAILY_QUOTA,
+            &consumed_today,
+        ));
 
         let client = Arc::new(client);
         let leagues = Arc::new(leagues);
@@ -355,7 +397,35 @@ async fn run_service() -> Result<()> {
             }
         });
 
+        // ── Periodic flush: persist consumed counts to Postgres ──────────
+        // Drains the RateLimiter's per-host consumption buffer into the
+        // sports_rate_budget table so the counts survive a pod restart
+        // (see the seeding above). Final flush on shutdown so a graceful
+        // termination loses nothing.
+        let pool_flush = pool.clone();
+        let rl_flush = rate_limiter.clone();
+        let cancel_flush = cancel_bg.clone();
+        spawn_supervised("sports-budget-flush", async move {
+            println!(
+                "Starting rate-budget flush loop (every {}s)...",
+                BUDGET_FLUSH_INTERVAL_SECS
+            );
+            loop {
+                tokio::select! {
+                    _ = cancel_flush.cancelled() => {
+                        flush_consumed(&pool_flush, &rl_flush).await;
+                        println!("Budget flush loop shutting down (final flush done)...");
+                        break;
+                    }
+                    _ = tokio::time::sleep(Duration::from_secs(BUDGET_FLUSH_INTERVAL_SECS)) => {
+                        flush_consumed(&pool_flush, &rl_flush).await;
+                    }
+                }
+            }
+        });
+
         // ── Daily reset: rate budgets at UTC midnight ─────────────────────
+        let pool_reset = pool.clone();
         let leagues_reset = leagues.clone();
         let rl_reset = rate_limiter.clone();
         let cancel_reset = cancel_bg.clone();
@@ -377,7 +447,18 @@ async fn run_service() -> Result<()> {
                         break;
                     }
                     _ = tokio::time::sleep(std::time::Duration::from_secs(wait_secs)) => {
+                        // Drain the consumption buffer before resetting. We're
+                        // just past midnight here, so up to one flush-interval
+                        // of pre-midnight requests lands in the new day's row —
+                        // a small, conservative error (shrinks the new day's
+                        // seed slightly on a later restart).
+                        flush_consumed(&pool_reset, &rl_reset).await;
                         rl_reset.reset_daily(&leagues_reset, SPORTS_DAILY_QUOTA);
+                        match prune_rate_budget(&pool_reset).await {
+                            Ok(n) if n > 0 => println!("[Rate Budget] Pruned {n} old budget rows"),
+                            Ok(_) => {}
+                            Err(e) => eprintln!("[Rate Budget] Failed to prune old budget rows: {e:#}"),
+                        }
                         println!("[Rate Budget] Daily reset completed at UTC midnight");
                     }
                 }

--- a/channels/sports/service/src/types.rs
+++ b/channels/sports/service/src/types.rs
@@ -85,6 +85,10 @@ pub struct RateLimiter {
     /// donated. Refreshed at construction and at each daily reset (the month
     /// can change at UTC midnight).
     offseason_leagues: RwLock<HashSet<String>>,
+    /// Per-host consumption since the last flush to Postgres. This is a
+    /// flush buffer, not a budget: `take_consumed` drains it periodically
+    /// so the counts survive pod restarts (sports_rate_budget table).
+    host_consumed: HashMap<String, AtomicU32>,
 }
 
 impl RateLimiter {
@@ -92,8 +96,10 @@ impl RateLimiter {
     /// Kept for tests that don't exercise the per-league logic.
     pub fn new(sports: &[String], initial: u32) -> Self {
         let mut host_remaining = HashMap::new();
+        let mut host_consumed = HashMap::new();
         for s in sports {
             host_remaining.insert(s.clone(), AtomicU32::new(initial));
+            host_consumed.insert(s.clone(), AtomicU32::new(0));
         }
         Self {
             host_remaining,
@@ -101,6 +107,7 @@ impl RateLimiter {
             league_to_host: HashMap::new(),
             host_shared: HashMap::new(),
             offseason_leagues: RwLock::new(HashSet::new()),
+            host_consumed,
         }
     }
 
@@ -114,6 +121,20 @@ impl RateLimiter {
     ///   - Off-season leagues (current UTC month is in offseason_months) get
     ///     `reserved = 0` and donate their share to the host's shared pool.
     pub fn new_per_league(leagues: &[crate::database::TrackedLeague], daily_total: u32) -> Self {
+        Self::new_per_league_seeded(leagues, daily_total, &HashMap::new())
+    }
+
+    /// Like [`new_per_league`](Self::new_per_league), but each host's budget
+    /// is reduced by `consumed_today[host]` — the request count already spent
+    /// today (UTC), persisted in the `sports_rate_budget` table. This is what
+    /// `main.rs` uses on startup so a pod restart mid-day resumes from the
+    /// quota actually remaining instead of a fresh full quota (the upstream
+    /// api-sports.io counter only resets at UTC midnight).
+    pub fn new_per_league_seeded(
+        leagues: &[crate::database::TrackedLeague],
+        daily_total: u32,
+        consumed_today: &HashMap<String, u32>,
+    ) -> Self {
         use std::collections::HashMap as Map;
 
         let current_month: i32 = Utc::now().month() as i32;
@@ -129,10 +150,14 @@ impl RateLimiter {
         let mut host_shared = HashMap::new();
         let mut host_remaining = HashMap::new();
         let mut offseason = HashSet::new();
+        let mut host_consumed = HashMap::new();
 
         for (host, host_leagues) in &by_host {
+            // Budget left for the rest of today, not the nominal daily quota.
+            let effective_total = daily_total
+                .saturating_sub(consumed_today.get(host.as_str()).copied().unwrap_or(0));
             let n = host_leagues.len().max(1) as u32;
-            let share = daily_total / n;
+            let share = effective_total / n;
             let mut donated = 0u32;
             for l in host_leagues {
                 let is_offseason = l.is_offseason(current_month);
@@ -145,7 +170,8 @@ impl RateLimiter {
                 league_to_host.insert(l.name.clone(), host.clone());
             }
             host_shared.insert(host.clone(), AtomicU32::new(donated));
-            host_remaining.insert(host.clone(), AtomicU32::new(daily_total));
+            host_remaining.insert(host.clone(), AtomicU32::new(effective_total));
+            host_consumed.insert(host.clone(), AtomicU32::new(0));
         }
 
         Self {
@@ -154,6 +180,7 @@ impl RateLimiter {
             league_to_host,
             host_shared,
             offseason_leagues: RwLock::new(offseason),
+            host_consumed,
         }
     }
 
@@ -169,7 +196,12 @@ impl RateLimiter {
             let mut cur = reserved.load(Ordering::Relaxed);
             while cur > 0 {
                 match reserved.compare_exchange_weak(cur, cur - 1, Ordering::Relaxed, Ordering::Relaxed) {
-                    Ok(_) => return true,
+                    Ok(_) => {
+                        if let Some(host) = self.league_to_host.get(league_name) {
+                            self.note_consumed(host, 1);
+                        }
+                        return true;
+                    }
                     Err(actual) => cur = actual,
                 }
             }
@@ -195,11 +227,38 @@ impl RateLimiter {
         let mut cur = shared.load(Ordering::Relaxed);
         while cur > 0 {
             match shared.compare_exchange_weak(cur, cur - 1, Ordering::Relaxed, Ordering::Relaxed) {
-                Ok(_) => return true,
+                Ok(_) => {
+                    self.note_consumed(host, 1);
+                    return true;
+                }
                 Err(actual) => cur = actual,
             }
         }
         false
+    }
+
+    /// Record `n` requests consumed against a host's flush buffer without
+    /// touching the budget buckets. Used by `try_consume` internally, by the
+    /// standings/teams polls (which gate on `has_budget` instead of
+    /// `try_consume`), and to return deltas after a failed Postgres flush.
+    /// Unknown hosts are ignored.
+    pub fn note_consumed(&self, host: &str, n: u32) {
+        if let Some(counter) = self.host_consumed.get(host) {
+            counter.fetch_add(n, Ordering::Relaxed);
+        }
+    }
+
+    /// Drain the per-host consumption buffer, returning only non-zero
+    /// entries. The caller persists these to `sports_rate_budget`; if the
+    /// write fails it must hand them back via `note_consumed` so the next
+    /// flush retries them.
+    pub fn take_consumed(&self) -> HashMap<String, u32> {
+        self.host_consumed.iter()
+            .filter_map(|(host, counter)| {
+                let n = counter.swap(0, Ordering::Relaxed);
+                (n > 0).then(|| (host.clone(), n))
+            })
+            .collect()
     }
 
     /// Snapshot of the per-league reserved budget. Used only by tests + logs.
@@ -259,9 +318,57 @@ impl RateLimiter {
 
     // ── Legacy methods (preserved for the health endpoint + standings/teams polls) ──
 
+    /// Record the upstream `x-ratelimit-requests-remaining` header value for
+    /// a host. Besides refreshing the legacy snapshot bucket, this clamps the
+    /// per-league budgets: the header is the authoritative count of what's
+    /// actually left today, so if it reports less than our local buckets sum
+    /// to (restart with lost state, requests not routed through
+    /// `try_consume`, another consumer on the same key), the local budgets
+    /// are an over-estimate and would let us overshoot the daily quota.
     pub fn update(&self, sport: &str, remaining: u32) {
         if let Some(counter) = self.host_remaining.get(sport) {
             counter.store(remaining, Ordering::Relaxed);
+        }
+        self.clamp_to_host_remaining(sport, remaining);
+    }
+
+    /// Shrink a host's reserved + shared buckets proportionally so their sum
+    /// does not exceed `header_remaining`. Never grows budgets — a header
+    /// reporting more than the local sum is ignored so the fair-share
+    /// allocation (and off-season donations) stays intact.
+    ///
+    /// The load-sum-then-store sequence is not atomic with respect to
+    /// concurrent `try_consume` calls; a racing decrement may be overwritten
+    /// by the scaled store. That's acceptable: the error is at most a few
+    /// requests and the next response header re-clamps.
+    fn clamp_to_host_remaining(&self, host: &str, header_remaining: u32) {
+        let shared = self.host_shared.get(host);
+        let league_slots: Vec<&AtomicU32> = self.league_to_host.iter()
+            .filter(|(_, h)| h.as_str() == host)
+            .filter_map(|(name, _)| self.league_reserved.get(name))
+            .collect();
+        if league_slots.is_empty() && shared.is_none() {
+            return;
+        }
+
+        let local: u64 = league_slots.iter()
+            .map(|s| s.load(Ordering::Relaxed) as u64)
+            .sum::<u64>()
+            + shared.map(|s| s.load(Ordering::Relaxed) as u64).unwrap_or(0);
+        if local == 0 || header_remaining as u64 >= local {
+            return;
+        }
+
+        // Integer scaling floors each bucket, so the post-clamp sum is
+        // guaranteed <= header_remaining.
+        let scale = |v: u32| ((v as u64) * (header_remaining as u64) / local) as u32;
+        for slot in &league_slots {
+            let cur = slot.load(Ordering::Relaxed);
+            slot.store(scale(cur), Ordering::Relaxed);
+        }
+        if let Some(s) = shared {
+            let cur = s.load(Ordering::Relaxed);
+            s.store(scale(cur), Ordering::Relaxed);
         }
     }
 
@@ -481,5 +588,239 @@ mod tests {
         // Reset
         rl.reset_daily(&leagues, 100);
         assert_eq!(rl.reserved("Premier League"), 100);
+    }
+
+    // ── Persisted-consumption seeding ────────────────────────────────────
+
+    #[test]
+    fn test_seeded_constructor_subtracts_consumed() {
+        // 7000 of 7500 already spent today → only 500 left to split across
+        // 2 leagues = 250 reserved each. The legacy host bucket is also
+        // seeded with the effective remainder, not the nominal quota.
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("La Liga", "football", None),
+        ];
+        let mut consumed = HashMap::new();
+        consumed.insert("football".to_string(), 7000u32);
+        let rl = RateLimiter::new_per_league_seeded(&leagues, 7500, &consumed);
+
+        assert_eq!(rl.reserved("Premier League"), 250);
+        assert_eq!(rl.reserved("La Liga"), 250);
+        assert_eq!(rl.remaining("football"), 500);
+    }
+
+    #[test]
+    fn test_seeded_constructor_empty_map_matches_unseeded() {
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("La Liga", "football", None),
+        ];
+        let rl = RateLimiter::new_per_league_seeded(&leagues, 7500, &HashMap::new());
+        assert_eq!(rl.reserved("Premier League"), 3750);
+        assert_eq!(rl.remaining("football"), 7500);
+    }
+
+    #[test]
+    fn test_seeded_constructor_consumed_exceeds_quota() {
+        // More consumed than the quota (e.g. another consumer on the same
+        // key) must saturate to zero, not underflow.
+        let leagues = vec![make_league("Premier League", "football", None)];
+        let mut consumed = HashMap::new();
+        consumed.insert("football".to_string(), 9000u32);
+        let rl = RateLimiter::new_per_league_seeded(&leagues, 7500, &consumed);
+
+        assert_eq!(rl.reserved("Premier League"), 0);
+        assert_eq!(rl.remaining("football"), 0);
+        assert!(!rl.try_consume("Premier League"));
+    }
+
+    #[test]
+    fn test_seeded_constructor_offseason_donates_effective_share() {
+        // Off-season donation is computed from the effective (post-consumed)
+        // total: 1000 - 500 consumed = 500, split 2 ways → in-season league
+        // reserves 250, off-season league donates 250 to the shared pool.
+        use chrono::Datelike;
+        let current_month = chrono::Utc::now().month() as i32;
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("Off", "football", Some(vec![current_month])),
+        ];
+        let mut consumed = HashMap::new();
+        consumed.insert("football".to_string(), 500u32);
+        let rl = RateLimiter::new_per_league_seeded(&leagues, 1000, &consumed);
+
+        assert_eq!(rl.reserved("Premier League"), 250);
+        assert_eq!(rl.reserved("Off"), 0);
+        assert_eq!(rl.shared_remaining("football"), 250);
+    }
+
+    #[test]
+    fn test_seeded_constructor_only_affects_named_host() {
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("NBA", "basketball", None),
+        ];
+        let mut consumed = HashMap::new();
+        consumed.insert("football".to_string(), 1000u32);
+        let rl = RateLimiter::new_per_league_seeded(&leagues, 2000, &consumed);
+
+        assert_eq!(rl.reserved("Premier League"), 1000); // 2000 - 1000
+        assert_eq!(rl.reserved("NBA"), 2000); // untouched
+    }
+
+    // ── Consumption tracking + flush buffer ──────────────────────────────
+
+    #[test]
+    fn test_take_consumed_counts_and_drains() {
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("NBA", "basketball", None),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 1000);
+
+        for _ in 0..5 {
+            assert!(rl.try_consume("Premier League"));
+        }
+        assert!(rl.try_consume("NBA"));
+
+        let deltas = rl.take_consumed();
+        assert_eq!(deltas.get("football"), Some(&5));
+        assert_eq!(deltas.get("basketball"), Some(&1));
+
+        // Draining resets the buffer; a second take with no new consumption
+        // returns nothing (so the flush task writes no empty rows).
+        assert!(rl.take_consumed().is_empty());
+    }
+
+    #[test]
+    fn test_take_consumed_counts_shared_pool_consumption() {
+        // Reserved exhausted → consumption from the shared pool must still
+        // count toward the host's persisted total.
+        use chrono::Datelike;
+        let current_month = chrono::Utc::now().month() as i32;
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("Off", "football", Some(vec![current_month])),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 100);
+        // 50 reserved + 50 shared; consume 60 → 10 from the shared pool
+        for _ in 0..60 {
+            assert!(rl.try_consume("Premier League"));
+        }
+        assert_eq!(rl.take_consumed().get("football"), Some(&60));
+    }
+
+    #[test]
+    fn test_note_consumed_adds_back_after_failed_flush() {
+        let leagues = vec![make_league("Premier League", "football", None)];
+        let rl = RateLimiter::new_per_league(&leagues, 1000);
+
+        for _ in 0..3 {
+            assert!(rl.try_consume("Premier League"));
+        }
+        let deltas = rl.take_consumed();
+        assert_eq!(deltas.get("football"), Some(&3));
+
+        // Simulate a failed Postgres flush: hand the deltas back, consume
+        // once more, and the next take must report the combined count.
+        rl.note_consumed("football", 3);
+        assert!(rl.try_consume("Premier League"));
+        assert_eq!(rl.take_consumed().get("football"), Some(&4));
+
+        // Unknown hosts are ignored, not panicked on.
+        rl.note_consumed("cricket", 7);
+        assert!(rl.take_consumed().is_empty());
+    }
+
+    #[test]
+    fn test_failed_try_consume_does_not_count() {
+        let leagues = vec![make_league("Premier League", "football", None)];
+        let rl = RateLimiter::new_per_league(&leagues, 2);
+        assert!(rl.try_consume("Premier League"));
+        assert!(rl.try_consume("Premier League"));
+        assert!(!rl.try_consume("Premier League")); // exhausted, no request made
+        assert_eq!(rl.take_consumed().get("football"), Some(&2));
+    }
+
+    // ── Header clamping ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_header_clamp_shrinks_proportionally() {
+        // Local budgets believe 1000 remain (500 + 500) but the upstream
+        // header says only 500 actually do → halve every bucket.
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("La Liga", "football", None),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 1000);
+        rl.update("football", 500);
+
+        assert_eq!(rl.reserved("Premier League"), 250);
+        assert_eq!(rl.reserved("La Liga"), 250);
+        assert_eq!(rl.remaining("football"), 500); // legacy bucket still stored
+    }
+
+    #[test]
+    fn test_header_clamp_scales_shared_pool() {
+        use chrono::Datelike;
+        let current_month = chrono::Utc::now().month() as i32;
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("Off", "football", Some(vec![current_month])),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 1000);
+        // 500 reserved + 500 shared, header says 250 → quarter both
+        rl.update("football", 250);
+        assert_eq!(rl.reserved("Premier League"), 125);
+        assert_eq!(rl.shared_remaining("football"), 125);
+    }
+
+    #[test]
+    fn test_header_clamp_never_grows_budgets() {
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("La Liga", "football", None),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 1000);
+        for _ in 0..100 {
+            assert!(rl.try_consume("Premier League"));
+        }
+        // Header reports more than the local sum (e.g. another pod hasn't
+        // consumed yet) — fair-share allocation must stay intact.
+        rl.update("football", 7500);
+        assert_eq!(rl.reserved("Premier League"), 400);
+        assert_eq!(rl.reserved("La Liga"), 500);
+    }
+
+    #[test]
+    fn test_header_clamp_to_zero_blocks_consumption() {
+        let leagues = vec![make_league("Premier League", "football", None)];
+        let rl = RateLimiter::new_per_league(&leagues, 1000);
+        rl.update("football", 0);
+        assert_eq!(rl.reserved("Premier League"), 0);
+        assert!(!rl.try_consume("Premier League"));
+    }
+
+    #[test]
+    fn test_header_clamp_only_affects_named_host() {
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("NBA", "basketball", None),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 1000);
+        rl.update("football", 100);
+        assert_eq!(rl.reserved("Premier League"), 100);
+        assert_eq!(rl.reserved("NBA"), 1000);
+    }
+
+    #[test]
+    fn test_header_clamp_noop_for_legacy_constructor() {
+        // The legacy constructor has no per-league buckets; update must
+        // keep storing the header value without panicking.
+        let sports = vec!["basketball".to_string()];
+        let rl = RateLimiter::new(&sports, 1000);
+        rl.update("basketball", 50);
+        assert_eq!(rl.remaining("basketball"), 50);
     }
 }


### PR DESCRIPTION
## Problem

The `RateLimiter` in the sports service is purely in-memory. Every pod restart (deploy, OOM, node drain) rebuilt it via `RateLimiter::new_per_league` with a fresh full 7,500/day quota per host — but the upstream api-sports.io counter only resets at UTC midnight, so a mid-day restart let the service overshoot the daily quota (root cause family of the June 11 soccer-ingestion outage, alongside #211).

## Fix

**Persistence (primary):**
- New `sports_rate_budget` table (migration `120000000008`): one row per (host, UTC day) with a monotonically increasing `consumed` count.
- `try_consume` feeds a per-host flush buffer; the standings/teams polls (which gate on `has_budget` instead) call `note_consumed` directly so nothing is missed.
- A new supervised `sports-budget-flush` task drains the buffer to Postgres every 60s (additive upsert, so flushes are restart-safe), does a final flush on graceful shutdown, and hands deltas back to the buffer if the write fails.
- On startup, budgets are seeded from today''s row via `new_per_league_seeded` — per-league shares are computed from `daily_total - consumed_today[host]`. DB errors fail open to the old full-quota behavior.
- The UTC-midnight `sports-budget-reset` task flushes before resetting and prunes rows older than a week.

**Header clamp (backstop):**
- `RateLimiter::update` now treats `x-ratelimit-requests-remaining` (already parsed on every response) as authoritative: if the header reports fewer requests than the host''s reserved+shared buckets sum to, every bucket is scaled down proportionally (integer floor, post-clamp sum ≤ header). Never grows budgets; no-op for the legacy constructor. This catches overshoot even when the last unflushed minute is lost to an unclean restart.

## Notes

- Built on top of #211; the off-season set and the consumption buffer coexist in the struct, and denied off-season consumes record nothing.
- Consumed counts track request *attempts* (consume happens before the HTTP call), so errors lean toward under-spending.
- Up to one flush interval of pre-midnight requests can land in the new day''s row — small and conservative.

## Testing

- 13 new unit tests in `types.rs`: seeded budgets (subtraction, saturation, off-season donation from effective total, per-host isolation), flush buffer (drain/reset, shared-pool counting, add-back after failed flush, failed consume not counting), header clamp (proportional shrink, shared-pool scaling, never-grow, clamp-to-zero, per-host isolation, legacy no-op).
- Full suite: 60 passed, 0 failed; clean build with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)