### PR TITLE
fix(website): tier-snapshot test breaks the website Docker build

### DIFF
--- a/myscrollr.com/src/lib/fallbackTierLimits.test.ts
+++ b/myscrollr.com/src/lib/fallbackTierLimits.test.ts
@@ -1,5 +1,5 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import snapshot from '../../../api/core/tier_limits.json'
 import { FALLBACK_LIMITS } from './fallbackTierLimits'
 
 // Cross-language drift guard. api/core/tier_limits.json is the shared
@@ -8,6 +8,19 @@ import { FALLBACK_LIMITS } from './fallbackTierLimits'
 // to it. This test closes the loop for the marketing site's first-paint
 // fallback. If it fails, a limit changed somewhere without updating all
 // four copies in the same PR.
+//
+// Read at RUNTIME, not via a static import: the website's Docker image
+// build copies only myscrollr.com/, so `tsc --noEmit` inside the image
+// cannot resolve a module path into api/ — a static import fails the
+// production build (2026-07-02 deploy failure). Vitest always runs from
+// a full repo checkout (frontend-tests.yml), where the file exists.
+const snapshot = JSON.parse(
+  readFileSync(
+    new URL('../../../api/core/tier_limits.json', import.meta.url),
+    'utf-8',
+  ),
+) as unknown
+
 describe('FALLBACK_LIMITS sync with api/core/tier_limits.json', () => {
   it('matches the shared backend snapshot exactly', () => {
     expect(FALLBACK_LIMITS).toEqual(snapshot)


### PR DESCRIPTION
The PR #214 drift-guard test statically imports api/core/tier_limits.json, which doesn't exist inside the website image build context (only myscrollr.com/ is copied) — tsc failed with TS2307, the website image build failed, and the deploy job for the v1.1.0 merge skipped entirely (nothing reached prod).

This converts the import to a runtime readFileSync so the guard still runs everywhere vitest runs (full checkouts) but the image build's tsc never sees it. Verified: tsc exit 0 with the json hidden (simulating Docker), 59/59 vitest with it present, and no other cross-boundary imports exist in myscrollr.com/src.

After merge: dispatching deploy.yml with services=all to run the full v1.1.0 rollout the skipped job owed us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)