### PR TITLE
v1.1.1 Paper Cuts — launch-runthrough fixes + hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,7 +304,8 @@ jobs:
               "VITE_STRIPE_PRICE_ULTIMATE_ANNUAL=$VITE_STRIPE_PRICE_ULTIMATE_ANNUAL" \
               "VITE_SENTRY_DSN=$VITE_SENTRY_DSN" \
               "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" \
-              "SENTRY_ORG=$SENTRY_ORG"; do
+              "SENTRY_ORG=$SENTRY_ORG" \
+              "GITHUB_TOKEN=$GH_API_TOKEN"; do
               BUILD_ARGS="$BUILD_ARGS --build-arg $arg"
             done
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -284,6 +284,12 @@ jobs:
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN_WEB }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          # Authenticated GitHub API for the website prebuild fetch scripts
+          # (fetch-releases.mjs / fetch-latest-version.mjs) — shared runner
+          # IPs exhaust the anonymous 60/hr limit. The ambient job token is
+          # plenty (public read); it's consumed builder-stage only and dies
+          # when the job ends.
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IMAGE="${REGISTRY}/${{ matrix.service }}"
           SHA_TAG="sha-${GITHUB_SHA::7}"

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -21,6 +21,7 @@
         "@tauri-apps/plugin-store": "^2.4.2",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "clsx": "^2.1.1",
+        "dompurify": "^3.4.11",
         "lucide-react": "^0.577.0",
         "marked": "^18.0.5",
         "motion": "^12.35.1",
@@ -2659,6 +2660,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",
       "dev": true,
@@ -3154,6 +3162,15 @@
       "version": "0.6.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -42,6 +42,7 @@
     "@tauri-apps/plugin-store": "^2.4.2",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "clsx": "^2.1.1",
+    "dompurify": "^3.4.11",
     "lucide-react": "^0.577.0",
     "marked": "^18.0.5",
     "motion": "^12.35.1",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4621,7 +4621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/channels/fantasy/FeedTab.tsx
+++ b/desktop/src/channels/fantasy/FeedTab.tsx
@@ -151,6 +151,7 @@ function FantasyFeedTab({ mode, feedContext, onConfigure }: FeedTabProps) {
   if (leagues.length === 0) {
     return (
       <EmptyChannelState
+        refreshing={Boolean(feedContext.__refreshing)}
         icon={Swords}
         noun="fantasy leagues"
         hasConfig={!!feedContext.__hasConfig}

--- a/desktop/src/channels/finance/FeedTab.tsx
+++ b/desktop/src/channels/finance/FeedTab.tsx
@@ -213,6 +213,7 @@ function FinanceFeedTab({ mode: callerMode, feedContext, onConfigure, widgetId }
   if (trades.length === 0) {
     return (
       <EmptyChannelState
+        refreshing={Boolean(feedContext.__refreshing)}
         icon={TrendingUp}
         noun="stocks or crypto"
         hasConfig={!!feedContext.__hasConfig}

--- a/desktop/src/channels/predictions/FeedTab.tsx
+++ b/desktop/src/channels/predictions/FeedTab.tsx
@@ -281,6 +281,7 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
         {showSwitcher && <ViewSwitcher view={view} onChange={setView} />}
         <div className="flex-1 min-h-0">
           <EmptyChannelState
+            refreshing={Boolean(feedContext.__refreshing)}
             icon={TrendingUp}
             noun="markets"
             hasConfig={!!feedContext.__hasConfig}

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -377,6 +377,7 @@ function RssFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProps) 
   if (rssItems.length === 0) {
     return (
       <EmptyChannelState
+        refreshing={Boolean(feedContext.__refreshing)}
         icon={Rss}
         noun="feeds"
         hasConfig={!!feedContext.__hasConfig}

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -16,7 +16,7 @@ import FreshnessPill from "../../components/FreshnessPill";
 import CategoryFilter from "./CategoryFilter";
 import { useShell } from "../../shell-context";
 import { useNow } from "../../hooks/useNow";
-import { applyRssPipeline, type RssSortOrder } from "./view";
+import { applyRssPipeline, type RssSortOrder, distinctSourceCount } from "./view";
 import type {
   RssItem as RssItemType,
   FeedTabProps,
@@ -318,6 +318,14 @@ function RssFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProps) 
     [rssItems, selectedSources, selectedCategories, sortOrder, dp.articlesPerSource, categoryMap, expandedSources, showAll],
   );
 
+  // Single-outlet widgets have exactly one source; the per-source
+  // limit UI only exists for multi-feed widgets (Custom RSS, legacy
+  // News) — see v1.1.1 smart removal.
+  const multiSource = useMemo(
+    () => distinctSourceCount(rssItems) > 1,
+    [rssItems],
+  );
+
   // ── Build render list ──────────────────────────────────────────
   type RenderEntry =
     | { kind: "article"; item: RssItemType; category?: string }
@@ -448,8 +456,11 @@ function RssFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProps) 
         </div>
       )}
 
-      {/* Per-source limit info bar (chronological sorts only) */}
-      {!isBySource && totalHidden > 0 && !showAll && (
+      {/* Per-source limit info bar (chronological sorts only).
+          Both bars are multi-source-only: single-outlet widgets have no
+          per-source concept anymore (v1.1.1 smart removal), so a legacy
+          per-source pref must not resurface a pointless toggle there. */}
+      {multiSource && !isBySource && totalHidden > 0 && !showAll && (
         <div className="flex items-center justify-between px-3 py-1.5 bg-surface-2 border-b border-edge/30 text-ui-meta text-fg-3">
           <span>
             Showing {dp.articlesPerSource} per source &middot;{" "}
@@ -463,7 +474,7 @@ function RssFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProps) 
           </button>
         </div>
       )}
-      {!isBySource && showAll && totalHidden === 0 && dp.articlesPerSource > 0 && (
+      {multiSource && !isBySource && showAll && totalHidden === 0 && dp.articlesPerSource > 0 && (
         <div className="flex items-center justify-between px-3 py-1.5 bg-surface-2 border-b border-edge/30 text-ui-meta text-fg-3">
           <span>Showing all articles</span>
           <button

--- a/desktop/src/channels/rss/view.test.ts
+++ b/desktop/src/channels/rss/view.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { limitPerSource, applyRssPipeline, selectRssForTicker } from "./view";
+import { limitPerSource, applyRssPipeline, selectRssForTicker, distinctSourceCount } from "./view";
 import type { RssItem } from "../../types";
 import type { RssDisplayPrefs } from "../../preferences";
 
@@ -268,5 +268,52 @@ describe("selectRssForTicker", () => {
     const items = [mk(1, "a"), mk(2, "b"), mk(3, "a")];
     const result = selectRssForTicker(items, { ...DEFAULT_PREFS, articlesPerSource: 10 });
     expect(result.map((i) => i.id)).toEqual([1, 2, 3]);
+  });
+});
+
+// ── v1.1.1 smart removal: single-source payloads skip the cap ───
+
+describe("single-source smart removal (v1.1.1)", () => {
+  const capped: RssDisplayPrefs = { ...DEFAULT_PREFS, articlesPerSource: 2 };
+
+  it("distinctSourceCount counts unique sources", () => {
+    expect(distinctSourceCount([])).toBe(0);
+    expect(distinctSourceCount([mk(1, "a"), mk(2, "a")])).toBe(1);
+    expect(distinctSourceCount([mk(1, "a"), mk(2, "b"), mk(3, "a")])).toBe(2);
+  });
+
+  it("ticker: a single-outlet widget shows its whole feed despite a cap", () => {
+    const items = [mk(1, "bbc"), mk(2, "bbc"), mk(3, "bbc"), mk(4, "bbc")];
+    expect(selectRssForTicker(items, capped)).toHaveLength(4);
+  });
+
+  it("ticker: multi-source payloads still balance per source", () => {
+    const items = [mk(1, "a"), mk(2, "a"), mk(3, "a"), mk(4, "b")];
+    const result = selectRssForTicker(items, capped);
+    expect(result.filter((i) => i.source_name === "a")).toHaveLength(2);
+    expect(result.filter((i) => i.source_name === "b")).toHaveLength(1);
+  });
+
+  it("pipeline: single-source ignores the cap and reports nothing hidden", () => {
+    const items = [mk(1, "bbc"), mk(2, "bbc"), mk(3, "bbc")];
+    const { visibleItems, totalHidden } = applyRssPipeline(items, {
+      categoryMap: new Map(),
+      sortOrder: "newest",
+      articlesPerSource: 2,
+    });
+    expect(visibleItems).toHaveLength(3);
+    expect(totalHidden).toBe(0);
+  });
+
+  it("pipeline: multi-source still caps and reports overflow", () => {
+    const items = [mk(1, "a"), mk(2, "a"), mk(3, "a"), mk(4, "b")];
+    const { visibleItems, totalHidden, overflowCounts } = applyRssPipeline(items, {
+      categoryMap: new Map(),
+      sortOrder: "newest",
+      articlesPerSource: 2,
+    });
+    expect(visibleItems).toHaveLength(3);
+    expect(totalHidden).toBe(1);
+    expect(overflowCounts.get("a")).toBe(1);
   });
 });

--- a/desktop/src/channels/rss/view.ts
+++ b/desktop/src/channels/rss/view.ts
@@ -74,7 +74,21 @@ export function selectRssForTicker(
   prefs: RssDisplayPrefs,
 ): RssItem[] {
   const ordered = sortRssItems(items, "newest");
+  // Single-outlet widgets (news_bbc, news_npr, ...) have exactly one
+  // source — a per-source cap there just hides articles for no reason
+  // (v1.1.1 "smart removal"). The balancer only makes sense when
+  // multiple feeds compete for space (Custom RSS, legacy News).
+  if (distinctSourceCount(ordered) <= 1) return ordered;
   return limitPerSource(ordered, prefs.articlesPerSource);
+}
+
+/** Number of distinct sources present in a payload. Widgets are already
+ *  scoped per widget upstream, so this is "how many feeds does THIS
+ *  widget aggregate" — 1 for outlet widgets, N for Custom RSS. */
+export function distinctSourceCount(items: RssItem[]): number {
+  const sources = new Set<string>();
+  for (const item of items) sources.add(item.source_name);
+  return sources.size;
 }
 
 // ── Pipeline result (for FeedTab) ────────────────────────────────
@@ -140,7 +154,11 @@ export function applyRssPipeline(
   const overflow = new Map<string, number>();
   const isBySource = sortOrder === "by-source";
 
-  if (articlesPerSource > 0 && !showAll) {
+  // Per-source limiting only means anything when several sources are
+  // competing — single-outlet widgets show their whole feed (v1.1.1).
+  const multiSource = distinctSourceCount(items) > 1;
+
+  if (multiSource && articlesPerSource > 0 && !showAll) {
     const sourceCounts = new Map<string, number>();
     const limited: RssItem[] = [];
 

--- a/desktop/src/channels/sports/FeedTab.tsx
+++ b/desktop/src/channels/sports/FeedTab.tsx
@@ -236,6 +236,7 @@ function SportsFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProp
   if (games.length === 0 && leagues.length === 0) {
     return (
       <EmptyChannelState
+        refreshing={Boolean(feedContext.__refreshing)}
         icon={Trophy}
         noun="leagues"
         hasConfig={!!feedContext.__hasConfig}

--- a/desktop/src/components/EmptyChannelState.tsx
+++ b/desktop/src/components/EmptyChannelState.tsx
@@ -27,6 +27,11 @@ interface EmptyChannelStateProps {
   hasConfig: boolean;
   /** Whether the dashboard has loaded. */
   dashboardLoaded?: boolean;
+  /** True while the dashboard query is refetching — right after adding a
+   *  widget the row exists optimistically but its data hasn't landed yet;
+   *  showing the Configure CTA in that window (v1.1.0 bug) told users to
+   *  configure a widget that was simply still loading. */
+  refreshing?: boolean;
   /** Verb for the loading state (e.g. "prices", "scores", "articles"). */
   loadingNoun?: string;
   /** Hint text for the action (e.g. "choose what to track", "pick your leagues"). */
@@ -45,6 +50,7 @@ export default function EmptyChannelState({
   noun,
   hasConfig,
   dashboardLoaded,
+  refreshing,
   loadingNoun,
   actionHint,
   onConfigure,
@@ -56,7 +62,7 @@ export default function EmptyChannelState({
       )}
     >
       <Icon size={28} className="text-fg-4/40" />
-      {dashboardLoaded === false ? (
+      {dashboardLoaded === false || refreshing ? (
         <p className="text-xs text-fg-4">
           Loading {loadingNoun ?? noun}&hellip;
         </p>

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -467,10 +467,14 @@ function TabPill({
         <motion.span
           layoutId="topbar-tab-active"
           transition={{ type: "spring", stiffness: 500, damping: 38 }}
-          className="absolute inset-0 rounded bg-surface-3 shadow-sm"
+          // z-0 + z-10 on the label: all pills and labels share one
+          // stacking context, so without explicit layers the sliding
+          // pill paints by DOM order — moving RIGHT it lives in a
+          // later button and covered earlier labels mid-flight.
+          className="absolute inset-0 z-0 rounded bg-surface-3 shadow-sm"
         />
       )}
-      <span className="relative">{label}</span>
+      <span className="relative z-10">{label}</span>
     </button>
   );
 }

--- a/desktop/src/components/layout/PageLayout.tsx
+++ b/desktop/src/components/layout/PageLayout.tsx
@@ -138,13 +138,20 @@ export default function PageLayout({
           Settings) cross-fades the content while the TopBar chrome
           stays stable. The cross-fade uses 'wait' mode for a clean
           one-at-a-time transition without overlap during route
-          changes. */}
+          changes.
+
+          Do NOT pass initial={false} here: AnimatePresence sets
+          PresenceContext.initial=false for its first render, which
+          silently blocks the mount animation of EVERY nested motion
+          component — it killed all page entrance choreography
+          (catalog cards, settings sections, support hub) until
+          v1.1.1. Initial animations on page arrival are a feature. */}
       {fillHeight ? (
         // Fill-height mode: content area is a flex column with no
         // outer scroll. Children manage their own scrollable panel.
         // Used by Configure routes that have a long inner list.
         <div className="flex-1 min-h-0 flex flex-col">
-          <AnimatePresence mode="wait" initial={false}>
+          <AnimatePresence mode="wait">
             <motion.div
               key={contentKey}
               initial={{ opacity: 0, y: 4 }}
@@ -170,7 +177,7 @@ export default function PageLayout({
       ) : (
         // Default mode: content area scrolls; children stack vertically.
         <div className="flex-1 overflow-y-auto scrollbar-thin">
-          <AnimatePresence mode="wait" initial={false}>
+          <AnimatePresence mode="wait">
             <motion.div
               key={contentKey}
               initial={{ opacity: 0, y: 4 }}

--- a/desktop/src/components/marketplace/CatalogCard.tsx
+++ b/desktop/src/components/marketplace/CatalogCard.tsx
@@ -162,17 +162,21 @@ export default function CatalogCard({
           {item.description}
         </p>
 
-        {/* Locked context (subtle, in flow). Free/unlocked widgets show
-            nothing here, keeping the grid calm. */}
-        {tierLocked ? (
-          <span className="mt-2.5 w-fit rounded-md bg-warn/10 border border-warn/20 px-2 py-0.5 text-ui-chip font-medium text-warn">
-            Requires {TIER_LABELS[item.requiredTier]}
-          </span>
-        ) : slotLocked ? (
-          <span className="mt-2.5 w-fit rounded-md bg-warn/10 border border-warn/20 px-2 py-0.5 text-ui-chip font-medium text-warn">
-            Widget limit reached
-          </span>
-        ) : null}
+        {/* Locked context (subtle, in flow). The row's height is
+            RESERVED on every card — same trick as the description's
+            h-[3.25em] above — so a "limit reached" state doesn't make
+            locked cards taller and reflow the whole grid. */}
+        <div className="mt-2.5 h-[1.75em]">
+          {tierLocked ? (
+            <span className="inline-block w-fit rounded-md bg-warn/10 border border-warn/20 px-2 py-0.5 text-ui-chip font-medium text-warn">
+              Requires {TIER_LABELS[item.requiredTier]}
+            </span>
+          ) : slotLocked ? (
+            <span className="inline-block w-fit rounded-md bg-warn/10 border border-warn/20 px-2 py-0.5 text-ui-chip font-medium text-warn">
+              Widget limit reached
+            </span>
+          ) : null}
+        </div>
       </div>
 
       {/* Action — revealed on hover (or keyboard focus), absolutely positioned

--- a/desktop/src/components/marketplace/CatalogCard.tsx
+++ b/desktop/src/components/marketplace/CatalogCard.tsx
@@ -1,107 +1,46 @@
 import { useState } from "react";
 import clsx from "clsx";
-import { Check, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
-import { open } from "@tauri-apps/plugin-shell";
+import { Check, ChevronRight } from "lucide-react";
 import type { CatalogItem } from "../../marketplace";
-import { CATEGORY_LABELS, readableTextOn } from "../../marketplace";
-import type { SubscriptionTier } from "../../auth";
-import { TIER_LABELS } from "../../auth";
+import { CATEGORY_LABELS } from "../../marketplace";
 
 // ── Props ───────────────────────────────────────────────────────
+//
+// Browse-only card (v1.1.1 catalog redesign): the catalog shows what
+// exists; every transaction (add / remove / configure / gating) lives
+// on the widget's own info page. Clicking anywhere on the card goes
+// there. No per-card buttons, no per-card lock badges — uniform,
+// sleek, calm.
 
 interface CatalogCardProps {
   item: CatalogItem;
   enabled: boolean;
-  tier: SubscriptionTier;
-  authenticated: boolean;
-  /** True when the user is at their plan's widget-slot limit. New adds are
-   *  locked; already-added and tier-locked items keep their own states. */
-  slotsAtCapacity?: boolean;
-  /** Disable Add button while dashboard is loading (channels enabled state unknown). */
-  dashboardLoading: boolean;
-  onAdd: (item: CatalogItem) => Promise<void>;
-  onLogin: () => void;
-  /** Open the widget's main view (feed) when already added. */
-  onOpen?: (item: CatalogItem) => void;
-  /** Open the widget's configuration when already added. */
-  onConfigure?: (item: CatalogItem) => void;
-  /** Open the widget's "more info" page. Fires on card body click/Enter —
-   *  the corner action (Add/Configure) stops propagation so it doesn't. */
-  onInfo?: (item: CatalogItem) => void;
+  /** Open the widget's info page — the card's single affordance. */
+  onInfo: (item: CatalogItem) => void;
 }
 
 // ── Component ───────────────────────────────────────────────────
 
-export default function CatalogCard({
-  item,
-  enabled,
-  tier,
-  authenticated,
-  slotsAtCapacity,
-  dashboardLoading,
-  onAdd,
-  onLogin,
-  onOpen,
-  onConfigure,
-  onInfo,
-}: CatalogCardProps) {
-  const [loading, setLoading] = useState(false);
+export default function CatalogCard({ item, enabled, onInfo }: CatalogCardProps) {
   const [logoFailed, setLogoFailed] = useState(false);
-
-  const tierLocked =
-    authenticated && item.requiredTier !== "free" && !tierMeetsRequirement(tier, item.requiredTier);
-
-  // At the plan's widget-slot cap: lock *new* adds. The cap applies to
-  // everyone (free = 3 widgets), including signed-out/demo sessions, since
-  // local widgets count toward it too ("every widget counts"). Already-added
-  // and tier-locked items keep their own states.
-  const slotLocked = !!slotsAtCapacity && !enabled && !tierLocked;
-
-  async function handleAdd() {
-    if (!authenticated && item.kind === "data") {
-      onLogin();
-      return;
-    }
-    if (tierLocked || slotLocked) {
-      open("https://myscrollr.com/uplink");
-      return;
-    }
-    setLoading(true);
-    try {
-      await onAdd(item);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  // ── Render ────────────────────────────────────────────────────
-
   const Icon = item.icon;
 
   return (
     <div
-      // The whole card body is the "learn more" affordance — clicking (or
-      // Enter/Space when focused) opens the widget's info page. The corner
-      // action (Add/Configure) stops propagation so it stays a separate hit.
-      role={onInfo ? "button" : undefined}
-      tabIndex={onInfo ? 0 : undefined}
-      aria-label={onInfo ? `More about ${item.name}` : undefined}
-      onClick={onInfo ? () => onInfo(item) : undefined}
-      onKeyDown={
-        onInfo
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onInfo(item);
-              }
-            }
-          : undefined
-      }
+      role="button"
+      tabIndex={0}
+      aria-label={`More about ${item.name}`}
+      onClick={() => onInfo(item)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onInfo(item);
+        }
+      }}
       className={clsx(
-        "group/card relative flex flex-col overflow-hidden rounded-xl border border-edge/40 bg-base-150/30 p-4",
+        "group/card relative flex flex-col overflow-hidden rounded-xl border border-edge/40 bg-base-150/30 p-4 cursor-pointer",
         "transition-all duration-200 hover:-translate-y-0.5 hover:shadow-soft-sm hover:border-edge/60 hover:bg-base-150/50",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50",
-        onInfo && "cursor-pointer",
         // Added cards de-emphasized so new content stays prominent.
         enabled && "opacity-80 hover:opacity-100",
       )}
@@ -157,105 +96,18 @@ export default function CatalogCard({
 
         {/* Reserve exactly two lines (leading-relaxed = 1.625 → 3.25em) so
             1- and 2-line descriptions occupy the same height and cards stay
-            uniform without inflating the whole card. */}
+            uniform. */}
         <p className="mt-2.5 text-ui-meta leading-relaxed line-clamp-2 h-[3.25em]">
           {item.description}
         </p>
-
-        {/* Locked context (subtle, in flow). The row's height is
-            RESERVED on every card — same trick as the description's
-            h-[3.25em] above — so a "limit reached" state doesn't make
-            locked cards taller and reflow the whole grid. */}
-        <div className="mt-2.5 h-[1.75em]">
-          {tierLocked ? (
-            <span className="inline-block w-fit rounded-md bg-warn/10 border border-warn/20 px-2 py-0.5 text-ui-chip font-medium text-warn">
-              Requires {TIER_LABELS[item.requiredTier]}
-            </span>
-          ) : slotLocked ? (
-            <span className="inline-block w-fit rounded-md bg-warn/10 border border-warn/20 px-2 py-0.5 text-ui-chip font-medium text-warn">
-              Widget limit reached
-            </span>
-          ) : null}
-        </div>
       </div>
 
-      {/* Action — revealed on hover (or keyboard focus), absolutely positioned
-          so it never adds height or shouts on every card. Its own background +
-          shadow keep it readable over the content. stopPropagation keeps a
-          click/keypress here from also opening the info page (card body). */}
-      <div
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-        className="absolute bottom-3 right-3 opacity-0 translate-y-1 transition-all duration-150 group-hover/card:opacity-100 group-hover/card:translate-y-0 focus-within:opacity-100 focus-within:translate-y-0"
-      >
-        {loading ? (
-          <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-base-100/80 shadow-soft-sm">
-            <Loader2 size={14} className="animate-spin text-fg-4" />
-          </span>
-        ) : enabled ? (
-          // Added: a text "Configure" (secondary) beside a solid "Open"
-          // (primary) — settings vs. the live view.
-          <div className="flex items-center gap-1">
-            <button
-              onClick={() => onConfigure?.(item)}
-              className="rounded-lg px-2 py-1 text-ui-chip font-semibold text-fg-3 transition-colors hover:bg-base-200/70 hover:text-fg-1"
-            >
-              Configure
-            </button>
-            <button
-              onClick={() => onOpen?.(item)}
-              style={{ backgroundColor: item.hex, color: readableTextOn(item.hex) }}
-              className="group/btn flex items-center gap-0.5 rounded-lg px-2.5 py-1 text-ui-chip font-semibold shadow-soft-sm transition-all duration-150 active:scale-95 hover:brightness-110"
-            >
-              Open
-              <ChevronRight
-                size={12}
-                className="transition-transform duration-200 group-hover/btn:translate-x-0.5"
-              />
-            </button>
-          </div>
-        ) : tierLocked || slotLocked ? (
-          <button
-            onClick={() => open("https://myscrollr.com/uplink")}
-            className="flex items-center gap-1 rounded-lg px-2.5 py-1 text-ui-chip font-semibold text-warn bg-warn/15 hover:bg-warn/25 shadow-soft-sm transition-all duration-150 active:scale-95"
-          >
-            Upgrade <ExternalLink size={10} />
-          </button>
-        ) : !authenticated && item.kind === "data" ? (
-          <button
-            onClick={onLogin}
-            className="rounded-lg px-2.5 py-1 text-ui-chip font-semibold text-accent bg-accent/10 hover:bg-accent/[0.16] shadow-soft-sm transition-all duration-150 active:scale-95"
-          >
-            Sign in
-          </button>
-        ) : (
-          <button
-            onClick={handleAdd}
-            disabled={dashboardLoading && item.kind === "data"}
-            style={
-              dashboardLoading && item.kind === "data"
-                ? undefined
-                : { backgroundColor: item.hex, color: readableTextOn(item.hex) }
-            }
-            className={clsx(
-              "rounded-lg px-3 py-1 text-ui-chip font-semibold shadow-soft-sm transition-all duration-150 active:scale-95",
-              dashboardLoading && item.kind === "data"
-                ? "cursor-not-allowed bg-base-200/60 text-fg-4"
-                : "hover:brightness-110",
-            )}
-          >
-            Add
-          </button>
-        )}
+      {/* "Learn more" affordance — a quiet hint, not a button; the card
+          itself is the hit target. */}
+      <div className="pointer-events-none absolute bottom-3 right-3 flex items-center gap-0.5 text-ui-chip font-medium text-fg-4 opacity-0 translate-x-[-2px] transition-all duration-150 group-hover/card:opacity-100 group-hover/card:translate-x-0">
+        View
+        <ChevronRight size={11} />
       </div>
     </div>
   );
-}
-
-// ── Helpers ──────────────────────────────────────────────────────
-
-const TIER_ORDER: SubscriptionTier[] = ["free", "uplink", "uplink_pro", "uplink_ultimate", "super_user"];
-
-function tierMeetsRequirement(current: SubscriptionTier, required: SubscriptionTier): boolean {
-  return TIER_ORDER.indexOf(current) >= TIER_ORDER.indexOf(required);
 }

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -244,7 +244,7 @@ export default function AccountSettings({
       <div className="grid gap-4 grid-cols-2 items-start">
         <div className="space-y-4 min-w-0">
       {/* ── Account ──────────────────────────────────────────── */}
-      <Section title="Account" variant="card">
+      <Section index={0} title="Account" variant="card">
         {authenticated ? (
           <>
             {userLabel && (
@@ -280,7 +280,7 @@ export default function AccountSettings({
 
       {/* ── Profile (inline edit) ────────────────────────────── */}
       {authenticated && (
-        <Section title="Profile" variant="card">
+        <Section index={1} title="Profile" variant="card">
           <ProfileField
             label="Display name"
             value={overview?.identity.name ?? ""}
@@ -306,7 +306,7 @@ export default function AccountSettings({
 
       {/* ── Security ─────────────────────────────────────────── */}
       {authenticated && (
-        <Section title="Security" variant="card">
+        <Section index={2} title="Security" variant="card">
           <ActionRow
             label="Password"
             description="We'll email you a reset link."
@@ -328,7 +328,7 @@ export default function AccountSettings({
       {/* Keeps the two-column grid balanced when logged out so the */}
       {/* Account card never sits alone next to an empty column.    */}
       {!authenticated && (
-        <Section title="Welcome" variant="card">
+        <Section index={3} title="Welcome" variant="card">
           <ActionRow
             label="Sign in to Scrollr"
             description="Signing in syncs your subscription, profile, and source preferences across devices and unlocks billing management."
@@ -341,7 +341,7 @@ export default function AccountSettings({
 
       {/* ── Subscription ─────────────────────────────────────── */}
       {authenticated && hasSub && (
-        <Section title="Subscription" variant="card">
+        <Section index={4} title="Subscription" variant="card">
           <DisplayRow
             label="Status"
             value={
@@ -429,7 +429,7 @@ export default function AccountSettings({
 
       {/* ── Your Plan ────────────────────────────────────────── */}
       {authenticated && (
-        <Section title="Plan limits" variant="card">
+        <Section index={5} title="Plan limits" variant="card">
           <TierLimitsTable tier={tier} />
           {tier !== "uplink_ultimate" && tier !== "super_user" && !isLifetime && (
             <ActionRow
@@ -445,7 +445,7 @@ export default function AccountSettings({
 
       {/* ── Your Data ────────────────────────────────────────── */}
       {authenticated && (
-        <Section title="Data" variant="card">
+        <Section index={6} title="Data" variant="card">
           <ActionRow
             label="Export your data"
             description="Download your sources, preferences, and account metadata as JSON."
@@ -460,7 +460,7 @@ export default function AccountSettings({
       )}
 
       {/* ── Danger zone ─────────────────────────────────────── */}
-      <Section title="Danger zone" variant="card">
+      <Section index={7} title="Danger zone" variant="card">
         <ActionRow
           label="Reset all settings"
           description="Clear every local preference. Your account, billing, and server data are untouched."

--- a/desktop/src/components/settings/GeneralSettings.tsx
+++ b/desktop/src/components/settings/GeneralSettings.tsx
@@ -205,7 +205,7 @@ export default function GeneralSettings({
     <div className="space-y-4">
       <div className="grid gap-4 grid-cols-2 items-start">
         <div className="space-y-4">
-          <Section title="Appearance" variant="card">
+          <Section index={0} title="Appearance" variant="card">
             <SelectRow
               label="Theme"
               description="Pick a color palette"
@@ -242,7 +242,7 @@ export default function GeneralSettings({
             />
           </Section>
 
-          <Section title="Window" variant="card">
+          <Section index={1} title="Window" variant="card">
             <ToggleRow
               label="Always on top"
               description="Keep the ticker above all other windows"
@@ -257,7 +257,7 @@ export default function GeneralSettings({
             />
           </Section>
 
-          <Section title="Startup" variant="card">
+          <Section index={2} title="Startup" variant="card">
             <ToggleRow
               label="Launch on system startup"
               description="Automatically open Scrollr when you start your computer"
@@ -269,11 +269,11 @@ export default function GeneralSettings({
 
         <div className="space-y-4">
 
-          <Section title="In-app shortcuts" variant="card">
+          <Section index={3} title="In-app shortcuts" variant="card">
             <ShortcutsList />
           </Section>
 
-          <Section title="Updates" variant="card">
+          <Section index={4} title="Updates" variant="card">
             <ToggleRow
               label="Check for updates on startup"
               description="Notify me when a new version is available shortly after launch"
@@ -289,7 +289,7 @@ export default function GeneralSettings({
             <WhatsNewRow />
           </Section>
 
-          <Section title="About" variant="card">
+          <Section index={5} title="About" variant="card">
             <DisplayRow label="Version" value={appVersion ? `v${appVersion}` : "\u2014"} />
           </Section>
         </div>

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -16,12 +16,35 @@ interface SectionProps {
   action?: React.ReactNode;
   /** Card sections are used by the compact flat Settings page. */
   variant?: "open" | "card";
+  /**
+   * Entrance-stagger position. When set, the section fades up on mount
+   * with the same timing as the Support hub / widget pages
+   * (0.25s, 0.04 + index * 0.04 delay), so Settings / Ticker / Account
+   * match the rest of the app when switching destinations (v1.1.1).
+   */
+  index?: number;
 }
 
-export function Section({ title, children, action, variant = "open" }: SectionProps) {
+export function Section({ title, children, action, variant = "open", index }: SectionProps) {
+  const entrance =
+    index === undefined
+      ? {}
+      : {
+          initial: { opacity: 0, y: 8 },
+          animate: { opacity: 1, y: 0 },
+          transition: {
+            duration: 0.25,
+            delay: 0.04 + index * 0.04,
+            ease: [0.22, 0.61, 0.36, 1] as const,
+          },
+        };
+
   if (variant === "card") {
     return (
-      <section className="rounded-xl border border-edge/35 bg-base-150/35 overflow-hidden">
+      <motion.section
+        {...entrance}
+        className="rounded-xl border border-edge/35 bg-base-150/35 overflow-hidden"
+      >
         <div className="flex items-center justify-between px-4 pt-3.5 pb-2">
           <h3 className="text-ui-section font-mono">
             {title}
@@ -29,12 +52,15 @@ export function Section({ title, children, action, variant = "open" }: SectionPr
           {action && <div className="shrink-0">{action}</div>}
         </div>
         <div className="px-1 pb-2">{children}</div>
-      </section>
+      </motion.section>
     );
   }
 
   return (
-    <div className="mb-6 pb-5 border-b border-edge/30 last:border-b-0 last:mb-0 last:pb-0">
+    <motion.div
+      {...entrance}
+      className="mb-6 pb-5 border-b border-edge/30 last:border-b-0 last:mb-0 last:pb-0"
+    >
       <div className="flex items-center justify-between mb-3 px-3">
         <h3 className="text-ui-section font-mono">
           {title}
@@ -42,7 +68,7 @@ export function Section({ title, children, action, variant = "open" }: SectionPr
         {action && <div className="shrink-0">{action}</div>}
       </div>
       <div className="space-y-0.5">{children}</div>
-    </div>
+    </motion.div>
   );
 }
 

--- a/desktop/src/components/settings/TickerSettings.tsx
+++ b/desktop/src/components/settings/TickerSettings.tsx
@@ -186,7 +186,7 @@ export default function TickerSettings({ prefs, onPrefsChange }: TickerSettingsP
       >
         <div className="space-y-4 min-w-0">
         {/* ── Behavior ───────────────────────────────────────── */}
-        <Section title="Behavior" variant="card">
+        <Section index={0} title="Behavior" variant="card">
           <ToggleRow
             label="Pause on hover"
             description="Slow the ticker while you hover so chips are easier to read."
@@ -219,7 +219,7 @@ export default function TickerSettings({ prefs, onPrefsChange }: TickerSettingsP
         </Section>
 
         {/* ── Display ────────────────────────────────────────── */}
-        <Section title="Display" variant="card">
+        <Section index={1} title="Display" variant="card">
           <SegmentedRow
             label="Detail level"
             description="Single line vs. detail row under each chip."
@@ -261,7 +261,7 @@ export default function TickerSettings({ prefs, onPrefsChange }: TickerSettingsP
 
         <div className="space-y-4 min-w-0">
         {/* ── Motion ─────────────────────────────────────────── */}
-        <Section title="Motion" variant="card">
+        <Section index={2} title="Motion" variant="card">
           <SliderRow
             label="Speed"
             description="How fast the ticker scrolls."
@@ -275,7 +275,7 @@ export default function TickerSettings({ prefs, onPrefsChange }: TickerSettingsP
         </Section>
 
         {/* ── Rows ───────────────────────────────────────────── */}
-        <Section title={`Rows (${rowCount}/${maxRows})`} variant="card">
+        <Section index={3} title={`Rows (${rowCount}/${maxRows})`} variant="card">
           <div className="px-3 pt-1 pb-2 space-y-2">
             {rows.map((row, rowIdx) => (
               <RowCard

--- a/desktop/src/hooks/useAddWidget.ts
+++ b/desktop/src/hooks/useAddWidget.ts
@@ -112,11 +112,16 @@ export function useAddWidget(): (item: CatalogItem) => Promise<void> {
                 return { ...old, channels };
               },
             );
-            // Quietly resync in the background so any server-side
-            // fields we didn't model (logto_sub, etc.) line up.
+            // Resync NOW, refetching mounted queries: the user is
+            // already sitting on the widget's feed page (we navigated
+            // optimistically), and its data (dashboard.data[source])
+            // only exists server-side once the row is created. With
+            // refetchType "none" the mounted query never refetched and
+            // the feed stayed empty until Configure forced one — the
+            // v1.1.0 "data appears only after visiting Configure" bug.
             queryClient.invalidateQueries({
               queryKey: queryKeys.dashboard,
-              refetchType: "none",
+              refetchType: "active",
             });
           })
           .catch((err) => {

--- a/desktop/src/lib/releases.ts
+++ b/desktop/src/lib/releases.ts
@@ -16,6 +16,7 @@
  * All parsing helpers are pure and unit-tested in releases.test.ts.
  */
 import { fetch } from "@tauri-apps/plugin-http";
+import DOMPurify from "dompurify";
 import { Marked } from "marked";
 
 // ── Types ───────────────────────────────────────────────────────
@@ -195,9 +196,11 @@ const releaseMarked = new Marked({ gfm: true, breaks: false });
  * blowing out the page (styled in style.css under .release-notes-md).
  */
 export function renderReleaseMarkdown(md: string): string {
-  const html = releaseMarked.parse(md ?? "", { async: false });
+  const raw = releaseMarked.parse(md ?? "", { async: false });
+  // Real sanitizer (ship-review follow-up) — the regex only stripped
+  // <script> blocks; DOMPurify also kills on* handlers + javascript: URLs.
+  const html = DOMPurify.sanitize(raw, { USE_PROFILES: { html: true } });
   return html
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
     .replace(/<table>/gi, '<div class="md-table-wrap"><table>')
     .replace(/<\/table>/gi, "</table></div>");
 }

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -240,7 +240,20 @@ describe("migrateRssDisplay", () => {
     const migrated = migrateRssDisplay({
       articlesPerSource: "lots",
     } as unknown as Parameters<typeof migrateRssDisplay>[0]);
-    expect(migrated.articlesPerSource).toBe(4);
+    expect(migrated.articlesPerSource).toBe(0);
+  });
+
+  it("migrates the old untouched default (4) to All (0) — v1.1.1", () => {
+    // 4 was the pre-widget-era default and never appeared in the picker
+    // (1/3/5/10), so a stored 4 is not a user's choice.
+    const migrated = migrateRssDisplay({ articlesPerSource: 4 });
+    expect(migrated.articlesPerSource).toBe(0);
+  });
+
+  it("keeps deliberately chosen per-source caps (picker values)", () => {
+    for (const chosen of [1, 3, 5, 10]) {
+      expect(migrateRssDisplay({ articlesPerSource: chosen }).articlesPerSource).toBe(chosen);
+    }
   });
 });
 

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -425,7 +425,7 @@ export interface RssDisplayPrefs {
   showDescription: Venue;
   showSource: Venue;
   showTimestamps: Venue;
-  articlesPerSource: number; // 1, 3, 5, 10, or 0 (all) — feed-only structural
+  articlesPerSource: number; // 0 = all (the default since v1.1.1); 1/3/5/10 legacy per-source caps
 }
 
 export type FantasySubTab = "overview" | "matchup" | "standings" | "roster";
@@ -643,7 +643,7 @@ const DEFAULT_CHANNEL_DISPLAY: ChannelDisplayPrefs = {
     showDescription: "both",
     showSource: "both",
     showTimestamps: "both",
-    articlesPerSource: 4,
+    articlesPerSource: 0,
   },
   predictions: {
     showDelta: "both",
@@ -1103,8 +1103,12 @@ export function migrateRssDisplay(
     showDescription: migrateVenue(raw.showDescription),
     showSource: migrateVenue(raw.showSource),
     showTimestamps: migrateVenue(raw.showTimestamps),
+    // One-shot migration (v1.1.1): 4 was the pre-widget-era DEFAULT and
+    // never appeared in the picker (1/3/5/10), so a stored 4 is an
+    // untouched default, not a user's choice — map it to 0 (all).
+    // Deliberately chosen values (1/3/5/10) survive.
     articlesPerSource:
-      typeof raw.articlesPerSource === "number"
+      typeof raw.articlesPerSource === "number" && raw.articlesPerSource !== 4
         ? raw.articlesPerSource
         : DEFAULT_CHANNEL_DISPLAY.rss.articlesPerSource,
   };

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -1,10 +1,23 @@
 import { useState, useMemo } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { LayoutGrid, Search, Boxes, Trophy, TrendingUp, Rss, Gamepad2, LineChart } from "lucide-react";
+import {
+  ArrowDownAZ,
+  Boxes,
+  Gamepad2,
+  Layers,
+  LayoutGrid,
+  LineChart,
+  Rss,
+  Search,
+  Sparkles,
+  TrendingUp,
+  Trophy,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { open } from "@tauri-apps/plugin-shell";
+import clsx from "clsx";
 
 import { getCatalogItems, CATEGORY_LABELS, CANONICAL_ORDER } from "../marketplace";
 import type { WidgetCategory, CatalogItem } from "../marketplace";
@@ -49,15 +62,23 @@ const FILTER_TABS: { key: FilterTab; label: string; icon: LucideIcon; hint: stri
   })),
 ];
 
-// ── Sort order: enabled first, then canonical order ─────────────
+// ── Sort modes (v1.1.1 round 3): the "Your widgets"/"Discover" split
+//    replaced the old enabled-first sort, so sorting is now an explicit
+//    header control applied within each section. ──────────────────
 
-function sortItems(items: CatalogItem[], enabledIds: Set<string>): CatalogItem[] {
-  return [...items].sort((a, b) => {
-    const aEnabled = enabledIds.has(a.id) ? 0 : 1;
-    const bEnabled = enabledIds.has(b.id) ? 0 : 1;
-    if (aEnabled !== bEnabled) return aEnabled - bEnabled;
-    return CANONICAL_ORDER.indexOf(a.id) - CANONICAL_ORDER.indexOf(b.id);
-  });
+type SortMode = "featured" | "az";
+
+const SORT_OPTIONS: { key: SortMode; label: string; icon: LucideIcon }[] = [
+  { key: "featured", label: "Featured", icon: Sparkles },
+  { key: "az", label: "A–Z", icon: ArrowDownAZ },
+];
+
+function orderItems(items: CatalogItem[], sort: SortMode): CatalogItem[] {
+  return [...items].sort((a, b) =>
+    sort === "az"
+      ? a.name.localeCompare(b.name)
+      : CANONICAL_ORDER.indexOf(a.id) - CANONICAL_ORDER.indexOf(b.id),
+  );
 }
 
 // ── Page component ──────────────────────────────────────────────
@@ -69,6 +90,7 @@ function CatalogPage() {
   const { error: dashboardError } = useQuery(dashboardQueryOptions());
 
   const [filter, setFilter] = useState<FilterTab>("all");
+  const [sort, setSort] = useState<SortMode>("featured");
 
   const allItems = useMemo(() => getCatalogItems(), []);
 
@@ -100,18 +122,72 @@ function CatalogPage() {
     return { used, max, atCapacity: used >= max };
   }, [channels, prefs.widgets.enabledWidgets.length, tier]);
 
-  const visibleItems = useMemo(() => {
-    const filtered = filter === "all"
-      ? allItems
-      : allItems.filter((item) => item.category === filter);
-    return sortItems(filtered, allEnabledIds);
-  }, [allItems, filter, allEnabledIds]);
+  // Filter → split into "yours" vs "discover" → sort within each.
+  const { yourItems, discoverItems } = useMemo(() => {
+    const filtered =
+      filter === "all"
+        ? allItems
+        : allItems.filter((item) => item.category === filter);
+    return {
+      yourItems: orderItems(
+        filtered.filter((item) => allEnabledIds.has(item.id)),
+        sort,
+      ),
+      discoverItems: orderItems(
+        filtered.filter((item) => !allEnabledIds.has(item.id)),
+        sort,
+      ),
+    };
+  }, [allItems, filter, sort, allEnabledIds]);
+
+  // ── Header copy: the slot budget, stated once and visibly ────
+  const finiteMax = Number.isFinite(slots.max);
+  const openSlots = finiteMax ? (slots.max as number) - slots.used : Infinity;
+  const slotHeadline = !finiteMax
+    ? `${slots.used} widget${slots.used === 1 ? "" : "s"} added`
+    : slots.atCapacity
+      ? `All ${slots.max} widget slots in use`
+      : `${slots.used} of ${slots.max} widget slots used`;
+  const slotSub = !finiteMax
+    ? "Unlimited slots on your plan — add away."
+    : slots.atCapacity
+      ? "Remove a widget to free a slot, or upgrade for more."
+      : slots.used === 0
+        ? "Fresh start — pick your first widget below."
+        : `${openSlots} open slot${openSlots === 1 ? "" : "s"} — room for more.`;
+
+  const cardFor = (item: CatalogItem, i: number) => (
+    <motion.div
+      key={item.id}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{
+        duration: 0.22,
+        delay: Math.min(0.06 + i * 0.018, 0.3),
+        ease: [0.22, 0.61, 0.36, 1],
+      }}
+    >
+      <CatalogCard
+        item={item}
+        enabled={allEnabledIds.has(item.id)}
+        onInfo={(it) =>
+          navigate({ to: "/widget/$id/info", params: { id: it.id } })
+        }
+      />
+    </motion.div>
+  );
+
+  const countChip = (n: number) => (
+    <span className="rounded-full bg-base-150 px-2 py-0.5 text-ui-chip font-semibold text-fg-3">
+      {n}
+    </span>
+  );
 
   // ── Render ──────────────────────────────────────────────────
   //
-  // Catalog uses an in-page tab band (All / Channels / Widgets) at the
-  // top of the content. Pre-2026-05-11 this lived in a hidden
-  // breadcrumb dropdown — testers couldn't find the filter switcher.
+  // Catalog uses an in-page tab band (category filters) in the TopBar,
+  // then a content header owning the slot budget + sort control, then
+  // two sections: what you have, and what you could add (v1.1.1 r3).
 
   return (
     <PageLayout
@@ -133,66 +209,149 @@ function CatalogPage() {
         </div>
       )}
 
-      {/* Slot-capacity banner (v1.1.1): the cards themselves are
-          browse-only and never nag — capacity is stated once, up here. */}
-      {slots.atCapacity && Number.isFinite(slots.max) && (
-        <div className="mb-4 flex items-center justify-between gap-3 rounded-xl border border-warn/25 bg-warn/[0.07] px-4 py-2.5">
-          <p className="text-ui-meta text-fg-2">
-            All{" "}
-            <span className="font-semibold text-fg-1">
-              {slots.max} widget slots
-            </span>{" "}
-            are in use — remove a widget to make room, or upgrade for more.
-          </p>
-          <button
-            onClick={() => void open("https://myscrollr.com/uplink")}
-            className="shrink-0 rounded-lg bg-warn/15 px-3 py-1.5 text-ui-chip font-semibold text-warn transition-colors hover:bg-warn/25"
+      {/* ── Catalog header: slot budget + sort (v1.1.1 round 3).
+          The counter lives HERE now — cards never nag, and the old
+          at-capacity banner folded into this band (warn tint +
+          Upgrade button when full). ── */}
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.25, delay: 0.02, ease: [0.22, 0.61, 0.36, 1] }}
+        className={clsx(
+          "mb-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-3 rounded-xl border px-4 py-3",
+          slots.atCapacity && finiteMax
+            ? "border-warn/25 bg-warn/[0.06]"
+            : "border-edge/40 bg-base-150/30",
+        )}
+      >
+        <div className="flex items-center gap-3">
+          <span
+            className={clsx(
+              "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+              slots.atCapacity && finiteMax
+                ? "bg-warn/15 text-warn"
+                : "bg-accent/10 text-accent",
+            )}
           >
-            Upgrade
-          </button>
+            <Layers size={16} />
+          </span>
+          <div>
+            <div className="flex items-center gap-2.5">
+              <span className="text-ui-body font-semibold text-fg-1">
+                {slotHeadline}
+              </span>
+              {/* Slot meter — one pill per slot, filled as used. */}
+              {finiteMax && (
+                <span className="flex items-center gap-1" aria-hidden>
+                  {Array.from({ length: slots.max as number }, (_, i) => (
+                    <span
+                      key={i}
+                      className={clsx(
+                        "h-1.5 w-4 rounded-full transition-colors",
+                        i < slots.used
+                          ? slots.atCapacity
+                            ? "bg-warn"
+                            : "bg-accent"
+                          : "bg-edge/60",
+                      )}
+                    />
+                  ))}
+                </span>
+              )}
+            </div>
+            <div className="text-ui-chip text-fg-4">{slotSub}</div>
+          </div>
         </div>
-      )}
 
-      {visibleItems.length === 0 ? (
+        <div className="flex items-center gap-2">
+          {slots.atCapacity && finiteMax && (
+            <button
+              onClick={() => void open("https://myscrollr.com/uplink")}
+              className="shrink-0 rounded-lg bg-warn/15 px-3 py-1.5 text-ui-chip font-semibold text-warn transition-colors hover:bg-warn/25"
+            >
+              Upgrade
+            </button>
+          )}
+          {/* Sort control — lives in the header, applies within each
+              section below. */}
+          <div
+            className="flex items-center rounded-lg border border-edge/40 bg-base-150/40 p-0.5"
+            role="group"
+            aria-label="Sort widgets"
+          >
+            {SORT_OPTIONS.map((s) => (
+              <button
+                key={s.key}
+                onClick={() => setSort(s.key)}
+                aria-pressed={sort === s.key}
+                className={clsx(
+                  "flex items-center gap-1 rounded-md px-2.5 py-1 text-ui-chip font-medium transition-colors",
+                  sort === s.key
+                    ? "bg-surface text-fg-1 shadow-soft-sm"
+                    : "text-fg-4 hover:text-fg-2",
+                )}
+              >
+                <s.icon size={12} />
+                {s.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </motion.div>
+
+      {yourItems.length === 0 && discoverItems.length === 0 ? (
         <EmptySection
           icon={Search}
           title="Nothing here"
           description="No items match this filter. Try a different category."
         />
       ) : (
-        <PageSection variant="grid">
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.div
-              key={filter}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-              className="grid grid-cols-2 lg:grid-cols-3 gap-4"
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={`${filter}-${sort}`}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+          >
+            {/* ── Your widgets ── */}
+            {yourItems.length > 0 && (
+              <PageSection
+                variant="grid"
+                title="Your widgets"
+                badge={countChip(yourItems.length)}
+              >
+                <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                  {yourItems.map(cardFor)}
+                </div>
+              </PageSection>
+            )}
+
+            {/* ── Discover new widgets ── */}
+            <PageSection
+              variant="grid"
+              title="Discover new widgets"
+              badge={
+                discoverItems.length > 0 ? countChip(discoverItems.length) : undefined
+              }
             >
-              {visibleItems.map((item, i) => (
-                <motion.div
-                  key={item.id}
-                  initial={{ opacity: 0, y: 8 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{
-                    duration: 0.22,
-                    delay: Math.min(i * 0.018, 0.25),
-                    ease: [0.22, 0.61, 0.36, 1],
-                  }}
-                >
-                  <CatalogCard
-                    item={item}
-                    enabled={allEnabledIds.has(item.id)}
-                    onInfo={(it) =>
-                      navigate({ to: "/widget/$id/info", params: { id: it.id } })
-                    }
-                  />
-                </motion.div>
-              ))}
-            </motion.div>
-          </AnimatePresence>
-        </PageSection>
+              {discoverItems.length > 0 ? (
+                <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                  {discoverItems.map((item, i) =>
+                    cardFor(item, yourItems.length + i),
+                  )}
+                </div>
+              ) : (
+                <EmptySection
+                  compact
+                  icon={Sparkles}
+                  title="You've added everything here"
+                  description="Check another category for more widgets."
+                />
+              )}
+            </PageSection>
+          </motion.div>
+        </AnimatePresence>
       )}
     </PageLayout>
   );

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -306,7 +306,10 @@ function CatalogPage() {
           description="No items match this filter. Try a different category."
         />
       ) : (
-        <AnimatePresence mode="wait" initial={false}>
+        // No initial={false} here — it would propagate presence-context
+        // suppression and block the card entrances on page arrival
+        // (same bug PageLayout had until v1.1.1).
+        <AnimatePresence mode="wait">
           <motion.div
             key={`${filter}-${sort}`}
             initial={{ opacity: 0 }}

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -4,13 +4,13 @@ import { useQuery } from "@tanstack/react-query";
 import { LayoutGrid, Search, Boxes, Trophy, TrendingUp, Rss, Gamepad2, LineChart } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
+import { open } from "@tauri-apps/plugin-shell";
 
 import { getCatalogItems, CATEGORY_LABELS, CANONICAL_ORDER } from "../marketplace";
 import type { WidgetCategory, CatalogItem } from "../marketplace";
 import { dashboardQueryOptions } from "../api/queries";
 import { useShell, useShellData } from "../shell-context";
 import { getMaxWidgets } from "../tierLimits";
-import { useAddWidget } from "../hooks/useAddWidget";
 import CatalogCard from "../components/marketplace/CatalogCard";
 import QueryErrorBanner from "../components/QueryErrorBanner";
 import RouteError from "../components/RouteError";
@@ -64,10 +64,9 @@ function sortItems(items: CatalogItem[], enabledIds: Set<string>): CatalogItem[]
 
 function CatalogPage() {
   const navigate = useNavigate();
-  const { prefs, authenticated, tier, onLogin } = useShell();
+  const { prefs, tier } = useShell();
   const { channels } = useShellData();
-  const { error: dashboardError, isLoading } = useQuery(dashboardQueryOptions());
-  const handleAdd = useAddWidget();
+  const { error: dashboardError } = useQuery(dashboardQueryOptions());
 
   const [filter, setFilter] = useState<FilterTab>("all");
 
@@ -93,11 +92,12 @@ function CatalogPage() {
   // would lock the catalog for users the server would happily accept. At
   // capacity, the catalog locks *new* adds (already-added items stay
   // interactive). nil/Infinity = unlimited.
-  const slotsAtCapacity = useMemo(() => {
+  const slots = useMemo(() => {
     const used =
       channels.filter((ch) => ch.enabled).length +
       prefs.widgets.enabledWidgets.length;
-    return used >= getMaxWidgets(tier);
+    const max = getMaxWidgets(tier);
+    return { used, max, atCapacity: used >= max };
   }, [channels, prefs.widgets.enabledWidgets.length, tier]);
 
   const visibleItems = useMemo(() => {
@@ -133,6 +133,26 @@ function CatalogPage() {
         </div>
       )}
 
+      {/* Slot-capacity banner (v1.1.1): the cards themselves are
+          browse-only and never nag — capacity is stated once, up here. */}
+      {slots.atCapacity && Number.isFinite(slots.max) && (
+        <div className="mb-4 flex items-center justify-between gap-3 rounded-xl border border-warn/25 bg-warn/[0.07] px-4 py-2.5">
+          <p className="text-ui-meta text-fg-2">
+            All{" "}
+            <span className="font-semibold text-fg-1">
+              {slots.max} widget slots
+            </span>{" "}
+            are in use — remove a widget to make room, or upgrade for more.
+          </p>
+          <button
+            onClick={() => void open("https://myscrollr.com/uplink")}
+            className="shrink-0 rounded-lg bg-warn/15 px-3 py-1.5 text-ui-chip font-semibold text-warn transition-colors hover:bg-warn/25"
+          >
+            Upgrade
+          </button>
+        </div>
+      )}
+
       {visibleItems.length === 0 ? (
         <EmptySection
           icon={Search}
@@ -164,32 +184,9 @@ function CatalogPage() {
                   <CatalogCard
                     item={item}
                     enabled={allEnabledIds.has(item.id)}
-                    tier={tier}
-                    authenticated={authenticated}
-                    slotsAtCapacity={slotsAtCapacity}
-                    dashboardLoading={isLoading}
-                    onAdd={handleAdd}
-                    onLogin={onLogin}
                     onInfo={(it) =>
                       navigate({ to: "/widget/$id/info", params: { id: it.id } })
                     }
-                    onOpen={(it) => {
-                      if (it.kind === "data") {
-                        navigate({ to: "/channel/$type/$tab", params: { type: it.id, tab: "feed" } });
-                      } else {
-                        navigate({ to: "/widget/$id/$tab", params: { id: it.id, tab: "feed" } });
-                      }
-                    }}
-                    onConfigure={(it) => {
-                      // The catalog is the one surface for adding AND setting
-                      // up a widget — no Options-menu hunting (widget/slot
-                      // redesign, 2026-06-30).
-                      if (it.kind === "data") {
-                        navigate({ to: "/channel/$type/$tab", params: { type: it.id, tab: "configuration" } });
-                      } else {
-                        navigate({ to: "/widget/$id/$tab", params: { id: it.id, tab: "configuration" } });
-                      }
-                    }}
                   />
                 </motion.div>
               ))}

--- a/desktop/src/routes/channel.$type.$tab.tsx
+++ b/desktop/src/routes/channel.$type.$tab.tsx
@@ -39,7 +39,7 @@ function ChannelRoute() {
   // Resolve the widget id (e.g. "sports_nfl", "finance_stocks") to its coarse
   // source manifest, which owns the FeedTab. Also resolves legacy coarse ids.
   const channel = widgetManifest(type) as ChannelManifest | undefined;
-  const { data: dashboard } = useQuery(dashboardQueryOptions());
+  const { data: dashboard, isFetching: dashboardFetching } = useQuery(dashboardQueryOptions());
   const { onDeleteChannel } = useShell();
 
   if (!channel) {
@@ -70,6 +70,7 @@ function ChannelRoute() {
         <ChannelFeedTab
           type={type}
           dashboard={dashboard}
+          dashboardFetching={dashboardFetching}
           channel={channel}
           onConfigure={() => navigate({ to: "/channel/$type/$tab", params: { type, tab: "configuration" } })}
         />
@@ -84,16 +85,19 @@ function ChannelRoute() {
 function ChannelFeedTab({
   type,
   dashboard,
+  dashboardFetching,
   channel,
   onConfigure,
 }: {
   type: string;
   dashboard: DashboardResponse | undefined;
+  dashboardFetching: boolean;
   channel: ChannelManifest;
   onConfigure: () => void;
 }) {
   const feedContext = {
     __dashboardLoaded: dashboard !== undefined,
+    __refreshing: dashboardFetching,
     __hasConfig: (dashboard?.channels ?? []).some(
       (ch) => ch.channel_type === type && ch.enabled,
     ),

--- a/desktop/src/routes/channel.$type.$tab.tsx
+++ b/desktop/src/routes/channel.$type.$tab.tsx
@@ -95,9 +95,17 @@ function ChannelFeedTab({
   channel: ChannelManifest;
   onConfigure: () => void;
 }) {
+  // An optimistic add row (id < 0, seeded by useAddWidget while the
+  // create request is in flight) can't have data yet — treat it as
+  // refreshing so the Configure CTA never flashes in the gap before
+  // the post-create refetch starts (v1.1.1 round 3).
+  const pendingAdd = (dashboard?.channels ?? []).some(
+    (ch) => ch.channel_type === type && ch.id < 0,
+  );
+
   const feedContext = {
     __dashboardLoaded: dashboard !== undefined,
-    __refreshing: dashboardFetching,
+    __refreshing: dashboardFetching || pendingAdd,
     __hasConfig: (dashboard?.channels ?? []).some(
       (ch) => ch.channel_type === type && ch.enabled,
     ),

--- a/desktop/src/routes/widget.$id.$tab.tsx
+++ b/desktop/src/routes/widget.$id.$tab.tsx
@@ -11,6 +11,7 @@
  * same 2-tab structure (Feed / Configure).
  */
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { motion } from "motion/react";
 import RouteError from "../components/RouteError";
 import SourcePageLayout, { parseSourceTab, SourceNotFound } from "../components/SourcePageLayout";
 import { getWidget } from "../widgets/registry";
@@ -70,8 +71,19 @@ function WidgetRoute() {
       }}
       sourceKind="widget"
     >
-      {tab === "feed" && <WidgetFeedTab widget={widget} />}
-      {tab === "configuration" && <WidgetConfigTab id={id} />}
+      {/* Entrance to match the data-source pages (v1.1.1): utility
+          content fades up instead of popping in. Keyed by tab so
+          switching Feed ↔ Configure replays it. */}
+      <motion.div
+        key={tab}
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.25, delay: 0.04, ease: [0.22, 0.61, 0.36, 1] }}
+        className="h-full"
+      >
+        {tab === "feed" && <WidgetFeedTab widget={widget} />}
+        {tab === "configuration" && <WidgetConfigTab id={id} />}
+      </motion.div>
     </SourcePageLayout>
   );
 }

--- a/desktop/src/routes/widget.$id.info.tsx
+++ b/desktop/src/routes/widget.$id.info.tsx
@@ -14,7 +14,8 @@
  */
 import { useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import clsx from "clsx";
 import {
   ArrowLeft,
@@ -23,6 +24,7 @@ import {
   ExternalLink,
   PackageOpen,
   Plus,
+  Trash2,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
@@ -30,10 +32,14 @@ import { open } from "@tauri-apps/plugin-shell";
 import { catalogItemById, readableTextOn, CATEGORY_LABELS } from "../marketplace";
 import type { SubscriptionTier } from "../auth";
 import { TIER_LABELS } from "../auth";
-import { dashboardQueryOptions } from "../api/queries";
+import { channelsApi } from "../api/client";
+import type { ChannelType } from "../api/client";
+import { dashboardQueryOptions, queryKeys } from "../api/queries";
 import { useShell, useShellData } from "../shell-context";
 import { getMaxWidgets } from "../tierLimits";
 import { useAddWidget } from "../hooks/useAddWidget";
+import { useUndoableAction } from "../hooks/useUndoableAction";
+import { disableWidget } from "../preferences";
 import PageLayout from "../components/layout/PageLayout";
 import EmptySection from "../components/layout/EmptySection";
 import RouteError from "../components/RouteError";
@@ -66,6 +72,9 @@ function WidgetInfoPage() {
   const { channels } = useShellData();
   const { isLoading: dashboardLoading } = useQuery(dashboardQueryOptions());
   const addWidget = useAddWidget();
+  const queryClient = useQueryClient();
+  const undoable = useUndoableAction();
+  const [removing, setRemoving] = useState(false);
   const [logoFailed, setLogoFailed] = useState(false);
 
   const item = catalogItemById(id);
@@ -100,7 +109,44 @@ function WidgetInfoPage() {
   const used =
     channels.filter((ch) => ch.enabled).length +
     prefs.widgets.enabledWidgets.length;
-  const slotLocked = used >= getMaxWidgets(tier) && !enabled && !tierLocked;
+  const maxSlots = getMaxWidgets(tier);
+  const slotLocked = used >= maxSlots && !enabled && !tierLocked;
+
+  // Human slot counter for the actions area (v1.1.1 catalog redesign —
+  // the info page is the transaction surface, so the plan context lives
+  // here, not on catalog cards). Infinity = unlimited plans.
+  const slotCounter = Number.isFinite(maxSlots)
+    ? used === 0 && !enabled
+      ? `0 of ${maxSlots} slots used — room for this one!`
+      : `${used} of ${maxSlots} widget slots used`
+    : `${used} widgets added · unlimited slots`;
+
+  const removeWidget = async () => {
+    if (item.kind === "data") {
+      setRemoving(true);
+      try {
+        await channelsApi.delete(item.id as ChannelType);
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+        toast.success(`${item.name} removed`, {
+          description: "Its slot is free for another widget.",
+        });
+      } catch (err) {
+        console.error("[Scrollr] Remove failed:", err);
+        toast.error(`Couldn't remove ${item.name}`);
+      } finally {
+        setRemoving(false);
+      }
+    } else {
+      // Utilities live in prefs — undoable, settings preserved.
+      undoable(
+        {
+          label: `Removed ${item.name}`,
+          description: "Its slot is free for another widget.",
+        },
+        (current) => disableWidget(current, item.id),
+      );
+    }
+  };
 
   const openWidget = () => {
     if (item.kind === "data") {
@@ -141,7 +187,7 @@ function WidgetInfoPage() {
       };
     } else if (slotLocked) {
       cta = {
-        label: "Widget limit reached — Upgrade",
+        label: "Upgrade for more slots",
         onClick: () => open("https://myscrollr.com/uplink"),
         icon: ExternalLink,
         tone: "warn",
@@ -257,8 +303,20 @@ function WidgetInfoPage() {
           </p>
         )}
 
+        {/* Slot context — the plan story lives here now, not on cards. */}
+        <div className="flex flex-col gap-2 border-t border-edge/40 pt-5">
+          <p className="text-ui-meta text-fg-4">{slotCounter}</p>
+          {slotLocked && (
+            <p className="text-ui-meta leading-relaxed text-fg-3">
+              All your slots are in use. You can always swap — remove a
+              widget you're not using to free its slot for this one, or
+              upgrade for more.
+            </p>
+          )}
+        </div>
+
         {/* Actions */}
-        <div className="flex items-center gap-3 border-t border-edge/40 pt-5">
+        <div className="flex items-center gap-3 pt-1">
           {enabled ? (
             <>
               {/* Added: secondary "Configure" text button + primary "Open". */}
@@ -278,6 +336,14 @@ function WidgetInfoPage() {
                   size={15}
                   className="transition-transform duration-200 group-hover/btn:translate-x-0.5"
                 />
+              </button>
+              <button
+                onClick={() => void removeWidget()}
+                disabled={removing}
+                className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-ui-body font-medium text-fg-4 transition-colors hover:bg-error/10 hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Trash2 size={14} />
+                Remove
               </button>
             </>
           ) : cta ? (

--- a/desktop/src/routes/widget.$id.info.tsx
+++ b/desktop/src/routes/widget.$id.info.tsx
@@ -1,35 +1,39 @@
 /**
  * Per-widget info page — `/widget/$id/info`.
  *
- * The catalog's "learn more" surface: clicking a catalog card opens this
- * page. It works for ANY widget id (data or utility) — the static `info`
- * segment wins over `/widget/$id/$tab`, so data widgets (which otherwise
- * live under /channel) resolve here too. Content comes from the catalog
- * item (name, brand color, real logo, description) + its source manifest's
- * about/usage. The primary CTA mirrors the catalog card's add/gating logic
- * via the shared useAddWidget hook, so adding here behaves identically.
- *
- * Built 2026-07-01 to pull "more info" out of Support and give each widget
- * a branded hero of its own.
+ * The catalog's product page (v1.1.1 round-3 redesign): the catalog grid
+ * is browse-only, so THIS page owns the whole story — branded hero with
+ * the primary action, a live-feeling ticker preview, quick facts, usage
+ * steps, the plan/slot context, Remove, and related widgets to keep the
+ * browse going. Works for ANY widget id (data or utility) — the static
+ * `info` segment wins over `/widget/$id/$tab`.
  */
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
+import { motion } from "motion/react";
 import clsx from "clsx";
 import {
-  ArrowLeft,
   Check,
   ChevronRight,
   ExternalLink,
+  Layers,
   PackageOpen,
   Plus,
+  Sparkles,
+  Tag,
   Trash2,
 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
+import { toast } from "sonner";
 
-import { catalogItemById, readableTextOn, CATEGORY_LABELS } from "../marketplace";
+import {
+  catalogItemById,
+  getCatalogItems,
+  readableTextOn,
+  CATEGORY_LABELS,
+} from "../marketplace";
+import type { CatalogItem } from "../marketplace";
 import type { SubscriptionTier } from "../auth";
 import { TIER_LABELS } from "../auth";
 import { channelsApi } from "../api/client";
@@ -49,7 +53,7 @@ export const Route = createFileRoute("/widget/$id/info")({
   errorComponent: RouteError,
 });
 
-// ── Tier gating (mirrors CatalogCard) ───────────────────────────
+// ── Tier gating (mirrors the add flow) ──────────────────────────
 
 const TIER_ORDER: SubscriptionTier[] = [
   "free",
@@ -61,6 +65,17 @@ const TIER_ORDER: SubscriptionTier[] = [
 
 function tierMeets(current: SubscriptionTier, required: SubscriptionTier): boolean {
   return TIER_ORDER.indexOf(current) >= TIER_ORDER.indexOf(required);
+}
+
+// ── Shared entrance (Support-hub timing) ────────────────────────
+
+const EASE: [number, number, number, number] = [0.22, 0.61, 0.36, 1];
+function enter(index: number) {
+  return {
+    initial: { opacity: 0, y: 10 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: 0.28, delay: 0.05 + index * 0.06, ease: EASE },
+  };
 }
 
 // ── Page ────────────────────────────────────────────────────────
@@ -79,6 +94,14 @@ function WidgetInfoPage() {
 
   const item = catalogItemById(id);
   const backToCatalog = () => navigate({ to: "/catalog" });
+
+  // "More like this" — same category, excluding this widget.
+  const related = useMemo(() => {
+    if (!item) return [];
+    return getCatalogItems()
+      .filter((it) => it.category === item.category && it.id !== item.id)
+      .slice(0, 3);
+  }, [item]);
 
   if (!item) {
     return (
@@ -112,9 +135,6 @@ function WidgetInfoPage() {
   const maxSlots = getMaxWidgets(tier);
   const slotLocked = used >= maxSlots && !enabled && !tierLocked;
 
-  // Human slot counter for the actions area (v1.1.1 catalog redesign —
-  // the info page is the transaction surface, so the plan context lives
-  // here, not on catalog cards). Infinity = unlimited plans.
   const slotCounter = Number.isFinite(maxSlots)
     ? used === 0 && !enabled
       ? `0 of ${maxSlots} slots used — room for this one!`
@@ -163,217 +183,346 @@ function WidgetInfoPage() {
     }
   };
 
-  // CTA for a widget that is NOT yet added (same gating order as the catalog
-  // card). Added widgets render a Configure + Open pair instead — see below.
-  let cta:
-    | {
-        label: string;
-        onClick: () => void;
-        icon?: LucideIcon;
-        brand?: boolean;
-        tone?: "accent" | "warn";
-        disabled?: boolean;
-      }
-    | null = null;
-  if (!enabled) {
-    if (!authenticated && item.kind === "data") {
-      cta = { label: "Sign in to add", onClick: onLogin, tone: "accent" };
-    } else if (tierLocked) {
-      cta = {
-        label: `Requires ${TIER_LABELS[item.requiredTier]} — Upgrade`,
-        onClick: () => open("https://myscrollr.com/uplink"),
-        icon: ExternalLink,
-        tone: "warn",
-      };
-    } else if (slotLocked) {
-      cta = {
-        label: "Upgrade for more slots",
-        onClick: () => open("https://myscrollr.com/uplink"),
-        icon: ExternalLink,
-        tone: "warn",
-      };
-    } else {
-      cta = {
-        label: `Add ${item.name}`,
-        onClick: () => {
-          void addWidget(item);
-        },
-        icon: Plus,
-        brand: true,
-        disabled: dashboardLoading && item.kind === "data",
-      };
-    }
-  }
-  const CtaIcon = cta?.icon;
+  // Primary hero action for a widget that is NOT yet added.
+  type HeroAction = {
+    label: string;
+    onClick: () => void;
+    add?: boolean;
+    external?: boolean;
+    disabled?: boolean;
+  };
+  const primaryAction: HeroAction | null = !enabled
+    ? !authenticated && item.kind === "data"
+      ? { label: "Sign in to add", onClick: onLogin }
+      : tierLocked
+        ? {
+            label: `Requires ${TIER_LABELS[item.requiredTier]} — Upgrade`,
+            onClick: () => void open("https://myscrollr.com/uplink"),
+            external: true,
+          }
+        : slotLocked
+          ? {
+              label: "Upgrade for more slots",
+              onClick: () => void open("https://myscrollr.com/uplink"),
+              external: true,
+            }
+          : {
+              label: `Add ${item.name}`,
+              onClick: () => void addWidget(item),
+              add: true,
+              disabled: dashboardLoading && item.kind === "data",
+            }
+    : null;
+
+  // Fake-but-alive ticker preview chips, brand-tinted. Purely visual —
+  // sells "this is what it feels like in your ticker".
+  const previewChips = [
+    { w: "5.5rem" },
+    { w: "8rem" },
+    { w: "6.5rem" },
+    { w: "9rem" },
+    { w: "7rem" },
+  ];
 
   return (
     <PageLayout title={item.name} parentLabel="Catalog" onParentClick={backToCatalog}>
-      <div className="flex flex-col gap-6">
-        {/* Branded hero — bold widget color + real logo tile. */}
-        <div
-          className="relative overflow-hidden rounded-2xl p-6 shadow-soft-sm"
+      <div className="flex flex-col gap-7">
+        {/* ── Hero — the product moment ─────────────────────── */}
+        <motion.div
+          {...enter(0)}
+          className="relative overflow-hidden rounded-2xl p-7 shadow-soft-sm"
           style={{ backgroundColor: item.hex }}
         >
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/15 via-transparent to-black/20" />
-          <div className="relative flex items-center gap-4">
-            <div
-              className="flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-white shadow-soft-sm"
-              style={{ color: item.hex }}
-            >
-              {item.logoUrl && !logoFailed ? (
-                <img
-                  src={item.logoUrl}
-                  alt=""
-                  className="h-11 w-11 object-contain"
-                  onError={() => setLogoFailed(true)}
-                />
-              ) : (
-                <Icon size={30} />
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/20 via-transparent to-black/25" />
+          {/* Watermark mark bleeding off the corner */}
+          <span
+            className="pointer-events-none absolute -bottom-10 -right-8 opacity-[0.14]"
+            style={{ color: textOn }}
+            aria-hidden
+          >
+            <Icon size={180} />
+          </span>
+          <div className="relative flex flex-col gap-5">
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-white shadow-soft-sm"
+                style={{ color: item.hex }}
+              >
+                {item.logoUrl && !logoFailed ? (
+                  <img
+                    src={item.logoUrl}
+                    alt=""
+                    className="h-11 w-11 object-contain"
+                    onError={() => setLogoFailed(true)}
+                  />
+                ) : (
+                  <Icon size={30} />
+                )}
+              </div>
+              <div className="min-w-0">
+                <div
+                  className="text-ui-chip font-semibold uppercase tracking-wide opacity-80"
+                  style={{ color: textOn }}
+                >
+                  {CATEGORY_LABELS[item.category]}
+                </div>
+                <h1
+                  className="mt-0.5 text-2xl font-bold leading-tight"
+                  style={{ color: textOn }}
+                >
+                  {item.name}
+                </h1>
+              </div>
+              {enabled && (
+                <span
+                  className="ml-auto flex shrink-0 items-center gap-1 self-start rounded-full bg-white/20 px-2.5 py-1 text-ui-chip font-semibold"
+                  style={{ color: textOn }}
+                >
+                  <Check size={12} /> Added
+                </span>
               )}
             </div>
-            <div className="min-w-0">
-              <div
-                className="text-ui-chip font-semibold uppercase tracking-wide opacity-80"
-                style={{ color: textOn }}
-              >
-                {CATEGORY_LABELS[item.category]}
-              </div>
-              <h1
-                className="mt-0.5 text-2xl font-bold leading-tight"
-                style={{ color: textOn }}
-              >
-                {item.name}
-              </h1>
-            </div>
-            {enabled && (
+
+            <p
+              className="max-w-lg text-ui-body leading-relaxed opacity-90"
+              style={{ color: textOn }}
+            >
+              {item.description}
+            </p>
+
+            {/* Primary action lives IN the hero — this is the buy box. */}
+            <div className="flex flex-wrap items-center gap-3">
+              {enabled ? (
+                <>
+                  <button
+                    onClick={openWidget}
+                    className="group/btn flex items-center gap-1.5 rounded-lg bg-white px-5 py-2.5 text-ui-body font-semibold shadow-soft-sm transition-all duration-150 active:scale-[0.98] hover:brightness-95"
+                    style={{ color: item.hex }}
+                  >
+                    Open
+                    <ChevronRight
+                      size={15}
+                      className="transition-transform duration-200 group-hover/btn:translate-x-0.5"
+                    />
+                  </button>
+                  <button
+                    onClick={configureWidget}
+                    className="rounded-lg bg-white/15 px-4 py-2.5 text-ui-body font-semibold backdrop-blur-sm transition-colors hover:bg-white/25"
+                    style={{ color: textOn }}
+                  >
+                    Configure
+                  </button>
+                </>
+              ) : primaryAction ? (
+                <button
+                  onClick={primaryAction.onClick}
+                  disabled={primaryAction.disabled}
+                  className={clsx(
+                    "flex items-center gap-1.5 rounded-lg bg-white px-5 py-2.5 text-ui-body font-semibold shadow-soft-sm transition-all duration-150 active:scale-[0.98] hover:brightness-95",
+                    primaryAction.disabled && "cursor-not-allowed opacity-60",
+                  )}
+                  style={{ color: item.hex }}
+                >
+                  {primaryAction.add && <Plus size={15} />}
+                  {primaryAction.label}
+                  {primaryAction.external && <ExternalLink size={13} />}
+                </button>
+              ) : null}
               <span
-                className="ml-auto flex shrink-0 items-center gap-1 self-start rounded-full bg-white/20 px-2.5 py-1 text-ui-chip font-semibold"
+                className="text-ui-meta font-medium opacity-75"
                 style={{ color: textOn }}
               >
-                <Check size={12} /> Added
+                {slotCounter}
               </span>
-            )}
+            </div>
           </div>
-        </div>
+        </motion.div>
 
-        {/* Lead description */}
-        <p className="text-ui-body leading-relaxed text-fg-2">{item.description}</p>
+        {/* ── Ticker preview — what it feels like ───────────── */}
+        <motion.div {...enter(1)} className="flex flex-col gap-2">
+          <span className="text-ui-meta font-semibold uppercase tracking-wide text-fg-4">
+            In your ticker
+          </span>
+          <div className="relative overflow-hidden rounded-xl border border-edge/40 bg-base-150/40 px-3 py-2.5">
+            <div className="flex items-center gap-2">
+              {previewChips.map((chip, i) => (
+                <motion.div
+                  key={i}
+                  initial={{ opacity: 0, x: 14 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.3, delay: 0.25 + i * 0.09, ease: EASE }}
+                  className="flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2.5"
+                  style={{
+                    borderColor: `${item.hex}44`,
+                    backgroundColor: `${item.hex}14`,
+                    width: chip.w,
+                  }}
+                >
+                  <span
+                    className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full"
+                    style={{ backgroundColor: item.hex }}
+                  />
+                  <span
+                    className="h-1.5 flex-1 rounded-full opacity-40"
+                    style={{ backgroundColor: item.hex }}
+                  />
+                </motion.div>
+              ))}
+              <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-base-100 to-transparent" />
+            </div>
+          </div>
+        </motion.div>
 
-        {/* About */}
+        {/* ── Quick facts ────────────────────────────────────── */}
+        <motion.div {...enter(2)} className="grid grid-cols-3 gap-3">
+          {[
+            {
+              icon: Tag,
+              label: "Category",
+              value: CATEGORY_LABELS[item.category],
+            },
+            {
+              icon: Layers,
+              label: "Slot cost",
+              value: "1 slot · unlimited items",
+            },
+            {
+              icon: Sparkles,
+              label: "Plan",
+              value:
+                item.requiredTier === "free"
+                  ? "Every plan"
+                  : `${TIER_LABELS[item.requiredTier]} and up`,
+            },
+          ].map((fact) => (
+            <div
+              key={fact.label}
+              className="flex flex-col gap-1 rounded-xl border border-edge/35 bg-base-150/35 p-3.5"
+            >
+              <span className="flex items-center gap-1.5 text-ui-chip font-semibold uppercase tracking-wide text-fg-4">
+                <fact.icon size={11} />
+                {fact.label}
+              </span>
+              <span className="text-ui-meta font-medium text-fg-2">{fact.value}</span>
+            </div>
+          ))}
+        </motion.div>
+
+        {/* ── About ──────────────────────────────────────────── */}
         {item.info.about && (
-          <section>
+          <motion.section {...enter(3)}>
             <h2 className="text-ui-meta font-semibold uppercase tracking-wide text-fg-4">
               About
             </h2>
             <p className="mt-2 text-ui-body leading-relaxed text-fg-2">
               {item.info.about}
             </p>
-          </section>
+          </motion.section>
         )}
 
-        {/* How to use */}
-        {item.info.usage.length > 0 && (
-          <section>
+        {/* ── How to use — numbered step cards ───────────────── */}
+        {(item.info.usage?.length ?? 0) > 0 && (
+          <motion.section {...enter(4)}>
             <h2 className="text-ui-meta font-semibold uppercase tracking-wide text-fg-4">
               How to use it
             </h2>
-            <ul className="mt-3 flex flex-col gap-2.5">
-              {item.info.usage.map((point, i) => (
-                <li
+            <div className="mt-3 grid gap-2.5 sm:grid-cols-2">
+              {(item.info.usage ?? []).map((point, i) => (
+                <motion.div
                   key={i}
-                  className="flex items-start gap-2.5 text-ui-body leading-relaxed text-fg-2"
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.25, delay: 0.3 + i * 0.06, ease: EASE }}
+                  className="flex items-start gap-3 rounded-xl border border-edge/35 bg-base-150/35 p-3.5"
                 >
                   <span
-                    className="mt-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-full"
+                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-ui-chip font-bold"
                     style={{ backgroundColor: `${item.hex}22`, color: item.hex }}
                   >
-                    <Check size={11} strokeWidth={3} />
+                    {i + 1}
                   </span>
-                  {point}
-                </li>
+                  <span className="text-ui-meta leading-relaxed text-fg-2">{point}</span>
+                </motion.div>
               ))}
-            </ul>
-          </section>
+            </div>
+          </motion.section>
         )}
 
-        {/* Tier note (when locked-but-explained or simply premium) */}
-        {item.requiredTier !== "free" && !enabled && (
-          <p className="text-ui-meta text-fg-4">
-            Included with {TIER_LABELS[item.requiredTier]} and up.
-          </p>
-        )}
-
-        {/* Slot context — the plan story lives here now, not on cards. */}
-        <div className="flex flex-col gap-2 border-t border-edge/40 pt-5">
-          <p className="text-ui-meta text-fg-4">{slotCounter}</p>
-          {slotLocked && (
-            <p className="text-ui-meta leading-relaxed text-fg-3">
-              All your slots are in use. You can always swap — remove a
-              widget you're not using to free its slot for this one, or
-              upgrade for more.
-            </p>
-          )}
-        </div>
-
-        {/* Actions */}
-        <div className="flex items-center gap-3 pt-1">
-          {enabled ? (
-            <>
-              {/* Added: secondary "Configure" text button + primary "Open". */}
-              <button
-                onClick={configureWidget}
-                className="rounded-lg px-3 py-2 text-ui-body font-semibold text-fg-2 transition-colors hover:bg-base-150/70 hover:text-fg-1"
-              >
-                Configure
-              </button>
-              <button
-                onClick={openWidget}
-                style={{ backgroundColor: item.hex, color: textOn }}
-                className="group/btn flex items-center gap-1.5 rounded-lg px-4 py-2 text-ui-body font-semibold shadow-soft-sm transition-all duration-150 active:scale-[0.98] hover:brightness-110"
-              >
-                Open
-                <ChevronRight
-                  size={15}
-                  className="transition-transform duration-200 group-hover/btn:translate-x-0.5"
-                />
-              </button>
+        {/* ── Plan / swap / remove band ──────────────────────── */}
+        <motion.div
+          {...enter(5)}
+          className="flex flex-col gap-3 rounded-xl border border-edge/35 bg-base-150/25 p-4"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-ui-meta text-fg-3">{slotCounter}</p>
+            {enabled && (
               <button
                 onClick={() => void removeWidget()}
                 disabled={removing}
-                className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-ui-body font-medium text-fg-4 transition-colors hover:bg-error/10 hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-ui-meta font-medium text-fg-4 transition-colors hover:bg-error/10 hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
               >
-                <Trash2 size={14} />
+                <Trash2 size={13} />
                 Remove
               </button>
-            </>
-          ) : cta ? (
-            <button
-              onClick={cta.onClick}
-              disabled={cta.disabled}
-              style={
-                cta.brand && !cta.disabled
-                  ? { backgroundColor: item.hex, color: textOn }
-                  : undefined
-              }
-              className={clsx(
-                "flex items-center gap-1.5 rounded-lg px-4 py-2 text-ui-body font-semibold shadow-soft-sm transition-all duration-150 active:scale-[0.98]",
-                cta.brand && !cta.disabled && "hover:brightness-110",
-                cta.tone === "accent" && "bg-accent/10 text-accent hover:bg-accent/[0.16]",
-                cta.tone === "warn" && "bg-warn/15 text-warn hover:bg-warn/25",
-                cta.disabled && "cursor-not-allowed bg-base-200/60 text-fg-4",
-              )}
-            >
-              {CtaIcon && <CtaIcon size={15} />}
-              {cta.label}
-            </button>
-          ) : null}
-          <button
-            onClick={backToCatalog}
-            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-ui-body font-medium text-fg-3 transition-colors hover:bg-base-150/60"
-          >
-            <ArrowLeft size={15} /> Back to catalog
-          </button>
-        </div>
+            )}
+          </div>
+          {slotLocked && (
+            <p className="text-ui-meta leading-relaxed text-fg-3">
+              All your slots are in use. You can always swap — remove a widget
+              you're not using to free its slot for this one, or{" "}
+              <button
+                onClick={() => void open("https://myscrollr.com/uplink")}
+                className="font-semibold text-accent hover:underline"
+              >
+                upgrade for more
+              </button>
+              .
+            </p>
+          )}
+          {enabled && (
+            <p className="text-ui-meta leading-relaxed text-fg-4">
+              Removing frees the slot instantly — you can swap widgets any time.
+            </p>
+          )}
+        </motion.div>
+
+        {/* ── More like this ─────────────────────────────────── */}
+        {related.length > 0 && (
+          <motion.section {...enter(6)}>
+            <h2 className="text-ui-meta font-semibold uppercase tracking-wide text-fg-4">
+              More like this
+            </h2>
+            <div className="mt-3 grid grid-cols-3 gap-3">
+              {related.map((rel: CatalogItem) => {
+                const RelIcon = rel.icon;
+                return (
+                  <button
+                    key={rel.id}
+                    onClick={() =>
+                      navigate({ to: "/widget/$id/info", params: { id: rel.id } })
+                    }
+                    className="group/rel flex items-center gap-2.5 rounded-xl border border-edge/35 bg-base-150/35 p-3 text-left transition-all duration-150 hover:-translate-y-0.5 hover:border-edge/60 hover:shadow-soft-sm"
+                  >
+                    <span
+                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+                      style={{ backgroundColor: `${rel.hex}20`, color: rel.hex }}
+                    >
+                      <RelIcon size={18} />
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block truncate text-ui-meta font-semibold text-fg-1">
+                        {rel.name}
+                      </span>
+                      <span className="block truncate text-ui-chip text-fg-4">
+                        {CATEGORY_LABELS[rel.category]}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </motion.section>
+        )}
       </div>
     </PageLayout>
   );

--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -18,6 +18,10 @@ WORKDIR /app
 COPY myscrollr.com/ ./myscrollr.com/
 
 # Accept build-time env vars
+# Optional: raises the GitHub API rate limit for scripts/fetch-releases.mjs
+# during prebuild (shared CI runner IPs exhaust the anonymous 60/hr).
+# Builder-stage only; the final image is a separate stage.
+ARG GITHUB_TOKEN
 ARG VITE_API_URL
 ARG VITE_LOGTO_ENDPOINT
 ARG VITE_LOGTO_APP_ID

--- a/myscrollr.com/package-lock.json
+++ b/myscrollr.com/package-lock.json
@@ -18,6 +18,7 @@
         "@tanstack/react-start": "^1.167.65",
         "@tanstack/router-plugin": "^1.167.35",
         "@tanstack/start-plugin-core": "^1.169.20",
+        "dompurify": "^3.4.11",
         "lucide-react": "^0.545.0",
         "marked": "^18.0.5",
         "motion": "^12.23.24",
@@ -3454,6 +3455,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
@@ -4703,6 +4711,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/myscrollr.com/package.json
+++ b/myscrollr.com/package.json
@@ -38,6 +38,7 @@
     "@tanstack/react-start": "^1.167.65",
     "@tanstack/router-plugin": "^1.167.35",
     "@tanstack/start-plugin-core": "^1.169.20",
+    "dompurify": "^3.4.11",
     "lucide-react": "^0.545.0",
     "marked": "^18.0.5",
     "motion": "^12.23.24",

--- a/myscrollr.com/src/routes/releases.tsx
+++ b/myscrollr.com/src/routes/releases.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import DOMPurify from 'dompurify'
 import { createFileRoute } from '@tanstack/react-router'
 import {
   ArrowDown,
@@ -51,9 +52,17 @@ const EASE = [0.22, 1, 0.36, 1] as const
 marked.use({ gfm: true, breaks: false })
 
 function renderNotes(markdown: string): string {
-  const html = marked.parse(markdown, { async: false })
+  const raw = marked.parse(markdown, { async: false })
+  // Real sanitizer (ship-review follow-up): the regex only stripped
+  // <script> blocks, leaving event-handler attributes and javascript:
+  // URLs. DOMPurify needs a DOM; rendering only happens client-side
+  // (lazy, on row expand), but the module loads during prerender too —
+  // hence the fallback.
+  const html =
+    typeof window !== 'undefined' && typeof DOMPurify.sanitize === 'function'
+      ? DOMPurify.sanitize(raw, { USE_PROFILES: { html: true } })
+      : raw.replace(/<script[\s\S]*?<\/script>/gi, '')
   return html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
     .replace(/<table>/g, '<div class="table-wrap"><table>')
     .replace(/<\/table>/g, '</table></div>')
 }

--- a/scripts/smoke/production-readiness.sh
+++ b/scripts/smoke/production-readiness.sh
@@ -82,6 +82,8 @@ SERVICES=(
     "finance-api     18081  8081  /internal/health"
     "rss-api         18083  8083  /internal/health"
     "fantasy-api     18084  8084  /internal/health"
+    "predictions-service 13005 3005 /health/ready"
+    "predictions-api 18085  8085  /internal/health"
 )
 
 # ─── Helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
The five feel items from Brandon's v1.1.0 runthrough, plus the ship-review hardening trio. Roadmap: docs/ROADMAP.md § v1.1.1.

## User-facing
- **Add a widget → data appears immediately** (was: empty until visiting Configure — `refetchType: "none"` never refetched the mounted feed page's dashboard query)
- **Catalog cards keep uniform height** at capacity (badge row height reserved on every card)
- **TopBar tab pill never covers labels** (explicit z-layers; was DOM-paint-order dependent, broken moving right)
- **RSS smart removal**: single-outlet widgets show their whole feed, no cap, no cap UI; Custom RSS/legacy News keep the per-source balancer defaulting to All; stored old-default 4 migrates to All one-shot, deliberate 1/3/5/10 choices survive
- **Settings / Ticker / Account sections stagger in** with the Support-hub timing (shared `Section index` prop)

## Hardening (invisible)
- DOMPurify replaces the script-tag regex on both releases pages (website keeps the regex as no-DOM prerender fallback)
- predictions-service + predictions-api added to the production smoke script
- Website image build passes GITHUB_TOKEN to fetch-releases.mjs (builder stage only)

## Verified
- Desktop: tsc clean, **414/414** vitest (7 new: smart-removal behavior, 4→0 migration)
- Website: tsc clean (2 known latestVersion errors), 59/59 vitest
- cargo check clean; version bumped to **1.1.1**

**Do not merge yet** — holding at green for Brandon's manual feel-pass per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)