### PR TITLE
v1.1.2 The Library — slots-only monetization everywhere

### DIFF
--- a/channels/fantasy/api/tier_limits.go
+++ b/channels/fantasy/api/tier_limits.go
@@ -3,48 +3,31 @@ package main
 import "github.com/gofiber/fiber/v2"
 
 // =============================================================================
-// Tier Limits — Fantasy League Imports
+// Tier Limits — Fantasy League Imports (RETIRED)
 // =============================================================================
 //
-// Mirrors the `Fantasy` column of api/core/tier_limits.go DefaultTierLimits.
-// Kept package-local on purpose: each Go module is independently deployable
-// and cross-module imports are banned by AGENTS.md. When the authoritative
-// table in api/core/tier_limits.go changes, update this file too.
+// v1.1.2 (2026-07-02): the per-tier league cap is GONE. The widget/slot model
+// made the widget slot — enforced by the core API's CreateChannel — the only
+// monetization lever, and Yahoo Fantasy is a normal widget on every plan with
+// unlimited depth inside it ("as many leagues as you play"). The old ladder
+// (free 0 / uplink 1 / pro 3 / ultimate 10) predated that model and survived
+// here by accident: this file is a package-local mirror (cross-module imports
+// are banned by AGENTS.md), so the 2026-07-02 core-side cap retirement never
+// reached it.
 //
-// Semantics:
-//   - Positive integer: hard cap on league count.
-//   - -1: unlimited (used for super_user and matches the JSON `null` cap
-//     contract exposed by /tier-limits).
-//
-// Unknown tiers fall through to "free" as a defensive default — an attacker
-// sending a bogus X-User-Tier header should get the strictest cap, not a
-// higher one.
+// FantasyLeagueCap and its call site in user_handlers.go are kept as a seam:
+// if a per-tier depth cap ever returns, the enforcement plumbing (header →
+// tier → cap → 403) is already wired and tested end-to-end.
 
-const (
-	TierFree           = "free"
-	TierUplink         = "uplink"
-	TierUplinkPro      = "uplink_pro"
-	TierUplinkUltimate = "uplink_ultimate"
-	TierSuperUser      = "super_user"
-)
+// TierFree is the least-privileged tier — GetUserTier's fallback when the
+// gateway header is missing.
+const TierFree = "free"
 
-// FantasyLeagueCap returns the league cap for a tier. -1 means unlimited.
+// FantasyLeagueCap returns the league-import cap for a tier. -1 means
+// unlimited — which is now every tier (see file header).
 func FantasyLeagueCap(tier string) int {
-	switch tier {
-	case TierSuperUser:
-		return -1
-	case TierUplinkUltimate:
-		return 10
-	case TierUplinkPro:
-		return 3
-	case TierUplink:
-		return 1
-	case TierFree:
-		return 0
-	default:
-		// Unknown / missing header — apply the strictest cap.
-		return 0
-	}
+	_ = tier
+	return -1
 }
 
 // GetUserTier reads the X-User-Tier header set by the core gateway for

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4621,7 +4621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/components/ContextMenu.tsx
+++ b/desktop/src/components/ContextMenu.tsx
@@ -1,0 +1,127 @@
+/**
+ * ContextMenu — minimal right-click menu primitive.
+ *
+ * Fixed-position floating menu at the pointer, clamped to the viewport,
+ * dismissed on outside pointerdown / Escape / window blur / resize.
+ * First consumer: the sidebar's per-widget menu (v1.1.2); built as a
+ * standalone primitive so the ticker's row menus (v1.2.0 Double-Decker)
+ * can reuse it.
+ */
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { motion, AnimatePresence } from "motion/react";
+import clsx from "clsx";
+import type { LucideIcon } from "lucide-react";
+
+export interface ContextMenuItem {
+  key: string;
+  label: string;
+  icon?: LucideIcon;
+  /** Error-tinted styling for irreversible actions (Remove). */
+  destructive?: boolean;
+  disabled?: boolean;
+  /** Render a hairline divider above this item. */
+  dividerBefore?: boolean;
+  onSelect: () => void;
+}
+
+interface ContextMenuProps {
+  open: boolean;
+  /** Viewport coordinates — pass the triggering pointer event's clientX/Y. */
+  x: number;
+  y: number;
+  items: ContextMenuItem[];
+  onClose: () => void;
+}
+
+export default function ContextMenu({
+  open,
+  x,
+  y,
+  items,
+  onClose,
+}: ContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ left: x, top: y });
+
+  // Clamp to the viewport once the menu has real dimensions. Layout
+  // effect so the clamp lands before paint — no jump on open.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const el = ref.current;
+    if (!el) {
+      setPos({ left: x, top: y });
+      return;
+    }
+    const { width, height } = el.getBoundingClientRect();
+    const pad = 8;
+    setPos({
+      left: Math.max(pad, Math.min(x, window.innerWidth - width - pad)),
+      top: Math.max(pad, Math.min(y, window.innerHeight - height - pad)),
+    });
+  }, [open, x, y]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: PointerEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    // Capture phase so a click that opens something else still closes us.
+    window.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("blur", onClose);
+    window.addEventListener("resize", onClose);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("blur", onClose);
+      window.removeEventListener("resize", onClose);
+    };
+  }, [open, onClose]);
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          ref={ref}
+          initial={{ opacity: 0, scale: 0.96 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.98 }}
+          transition={{ duration: 0.12, ease: [0.22, 0.61, 0.36, 1] }}
+          role="menu"
+          style={{ left: pos.left, top: pos.top, transformOrigin: "top left" }}
+          className="fixed z-[100] min-w-[180px] rounded-lg border border-edge/60 bg-surface-2 py-1 shadow-lg"
+        >
+          {items.map((item) => (
+            <div key={item.key}>
+              {item.dividerBefore && <div className="my-1 h-px bg-edge/40" />}
+              <button
+                role="menuitem"
+                disabled={item.disabled}
+                onClick={() => {
+                  onClose();
+                  item.onSelect();
+                }}
+                className={clsx(
+                  "flex w-full items-center gap-2 px-3 py-1.5 text-left text-ui-meta transition-colors cursor-pointer",
+                  item.disabled && "cursor-not-allowed opacity-50",
+                  !item.disabled &&
+                    (item.destructive
+                      ? "text-error/90 hover:bg-error/10 hover:text-error"
+                      : "text-fg-2 hover:bg-surface-hover hover:text-fg"),
+                )}
+              >
+                {item.icon && <item.icon size={13} className="shrink-0" />}
+                {item.label}
+              </button>
+            </div>
+          ))}
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -32,21 +32,37 @@
  * the divider lines stay so the grouping survives visually.
  */
 import { useState } from "react";
-import { Settings, LifeBuoy, PanelLeftClose, PanelLeftOpen, Plus, RadioTower, UserCircle } from "lucide-react";
+import {
+  ArrowUpRight,
+  Info,
+  LifeBuoy,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Plus,
+  RadioTower,
+  Settings,
+  Settings2,
+  Trash2,
+  UserCircle,
+} from "lucide-react";
 import clsx from "clsx";
 import { motion } from "motion/react";
 import Tooltip from "./Tooltip";
+import ContextMenu from "./ContextMenu";
 import type { ChannelManifest, WidgetManifest } from "../types";
 import { loadPref, savePref } from "../preferences";
 
 // ── Props ───────────────────────────────────────────────────────
 
-interface SidebarSource {
+export interface SidebarSource {
   id: string;
   name: string;
   hex: string;
   icon: React.ComponentType<{ size?: number; className?: string }>;
   kind: "channel" | "widget";
+  /** Whether this source currently has chips on the ticker — drives
+   *  the context menu's Show/Hide label (v1.1.2). */
+  onTicker: boolean;
 }
 
 interface SidebarProps {
@@ -79,6 +95,16 @@ interface SidebarProps {
   onNavigateToSupport: () => void;
   /** Navigate to a specific source (channel or widget) feed. */
   onSelectItem: (id: string, kind: "channel" | "widget") => void;
+
+  // ── Context-menu actions (v1.1.2: right-click a source row) ──
+  /** Open the source's Configure tab. */
+  onConfigureItem: (id: string, kind: "channel" | "widget") => void;
+  /** Open the widget's catalog info page. */
+  onInfoItem: (id: string) => void;
+  /** Toggle the source's presence on the ticker. */
+  onToggleItemTicker: (source: SidebarSource) => void;
+  /** Remove the widget (frees its slot). */
+  onRemoveItem: (source: SidebarSource) => void;
 }
 
 // ── Component ───────────────────────────────────────────────────
@@ -97,10 +123,21 @@ export default function Sidebar({
   onNavigateToAccount,
   onNavigateToSupport,
   onSelectItem,
+  onConfigureItem,
+  onInfoItem,
+  onToggleItemTicker,
+  onRemoveItem,
 }: SidebarProps) {
   const [collapsed, setCollapsed] = useState(() =>
     loadPref("sidebarCollapsed", false),
   );
+  // Right-click menu on a source row (v1.1.2). One menu at a time,
+  // anchored at the pointer.
+  const [menu, setMenu] = useState<{
+    source: SidebarSource;
+    x: number;
+    y: number;
+  } | null>(null);
 
   function toggleCollapsed() {
     const next = !collapsed;
@@ -137,6 +174,10 @@ export default function Sidebar({
               active={activeItem === source.id}
               collapsed={collapsed}
               onClick={() => onSelectItem(source.id, source.kind)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                setMenu({ source, x: e.clientX, y: e.clientY });
+              }}
             />
           ))
         ) : (
@@ -235,6 +276,58 @@ export default function Sidebar({
           </button>
         </Tooltip>
       </div>
+
+      {/* ── Source context menu (v1.1.2) ───────────────────────
+          Everything you can do to a widget without leaving the rail:
+          open, configure, ticker visibility, its catalog page, and
+          remove. Actions resolve in the shell layer — the same paths
+          the info page and ticker settings use. */}
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        onClose={() => setMenu(null)}
+        items={
+          menu
+            ? [
+                {
+                  key: "open",
+                  label: "Open",
+                  icon: ArrowUpRight,
+                  onSelect: () => onSelectItem(menu.source.id, menu.source.kind),
+                },
+                {
+                  key: "configure",
+                  label: "Configure",
+                  icon: Settings2,
+                  onSelect: () => onConfigureItem(menu.source.id, menu.source.kind),
+                },
+                {
+                  key: "ticker",
+                  label: menu.source.onTicker
+                    ? "Hide from ticker"
+                    : "Show on ticker",
+                  icon: RadioTower,
+                  onSelect: () => onToggleItemTicker(menu.source),
+                },
+                {
+                  key: "info",
+                  label: "Widget page",
+                  icon: Info,
+                  onSelect: () => onInfoItem(menu.source.id),
+                },
+                {
+                  key: "remove",
+                  label: "Remove",
+                  icon: Trash2,
+                  destructive: true,
+                  dividerBefore: true,
+                  onSelect: () => onRemoveItem(menu.source),
+                },
+              ]
+            : []
+        }
+      />
     </aside>
   );
 }
@@ -288,6 +381,7 @@ function NavItem({
   collapsed,
   accent = false,
   onClick,
+  onContextMenu,
 }: {
   icon: React.ReactNode;
   label: string;
@@ -296,11 +390,14 @@ function NavItem({
   /** Accent variant for CTA-like items (currently "Add source"). */
   accent?: boolean;
   onClick: () => void;
+  /** Right-click handler — source rows open their context menu. */
+  onContextMenu?: (e: React.MouseEvent) => void;
 }) {
   return (
     <Tooltip content={collapsed ? label : undefined} side="right">
       <button
         onClick={onClick}
+        onContextMenu={onContextMenu}
         aria-current={active ? "page" : undefined}
         aria-label={collapsed ? label : undefined}
         className={clsx(

--- a/desktop/src/components/SlotMeter.test.ts
+++ b/desktop/src/components/SlotMeter.test.ts
@@ -1,0 +1,86 @@
+/**
+ * SlotMeter pure-logic tests — the slot math + copy shared by the
+ * Catalog header and the Account page (v1.1.2).
+ */
+import { describe, expect, it } from "vitest";
+import { computeSlotUsage, slotHeadline, slotSubline } from "./SlotMeter";
+
+describe("computeSlotUsage", () => {
+  it("sums enabled channels and enabled local widgets", () => {
+    const u = computeSlotUsage(2, 1, 6);
+    expect(u).toEqual({ used: 3, max: 6, finite: true, atCapacity: false });
+  });
+
+  it("flags capacity at exactly the cap", () => {
+    expect(computeSlotUsage(4, 2, 6).atCapacity).toBe(true);
+  });
+
+  it("stays at-capacity for grandfathered over-cap users", () => {
+    // Downgrade prune disables newest over-cap rows, but a race or a
+    // legacy state can leave used > max — still "at capacity", never
+    // negative-open or crashing.
+    const u = computeSlotUsage(5, 3, 6);
+    expect(u.used).toBe(8);
+    expect(u.atCapacity).toBe(true);
+  });
+
+  it("treats Infinity as unlimited (never at capacity)", () => {
+    const u = computeSlotUsage(20, 5, Infinity);
+    expect(u.finite).toBe(false);
+    expect(u.atCapacity).toBe(false);
+  });
+
+  it("zero slots used on a fresh install", () => {
+    const u = computeSlotUsage(0, 0, 3);
+    expect(u.used).toBe(0);
+    expect(u.atCapacity).toBe(false);
+  });
+});
+
+describe("slotHeadline", () => {
+  it("counts against the cap on finite plans", () => {
+    expect(slotHeadline(computeSlotUsage(2, 1, 6))).toBe(
+      "3 of 6 widget slots used",
+    );
+  });
+
+  it("announces a full plan", () => {
+    expect(slotHeadline(computeSlotUsage(3, 0, 3))).toBe(
+      "All 3 widget slots in use",
+    );
+  });
+
+  it("counts widgets (with pluralization) on unlimited plans", () => {
+    expect(slotHeadline(computeSlotUsage(1, 0, Infinity))).toBe(
+      "1 widget added",
+    );
+    expect(slotHeadline(computeSlotUsage(4, 3, Infinity))).toBe(
+      "7 widgets added",
+    );
+  });
+});
+
+describe("slotSubline", () => {
+  it("invites a first add on a fresh install", () => {
+    expect(slotSubline(computeSlotUsage(0, 0, 3))).toMatch(/Fresh start/);
+  });
+
+  it("counts open slots with singular/plural forms", () => {
+    expect(slotSubline(computeSlotUsage(2, 0, 3))).toBe(
+      "1 open slot — room for more.",
+    );
+    expect(slotSubline(computeSlotUsage(2, 0, 6))).toBe(
+      "4 open slots — room for more.",
+    );
+  });
+
+  it("teaches the swap at capacity", () => {
+    expect(slotSubline(computeSlotUsage(3, 0, 3))).toMatch(
+      /Remove a widget to free a slot/,
+    );
+  });
+
+  it("celebrates unlimited plans", () => {
+    expect(slotSubline(computeSlotUsage(9, 0, Infinity))).toMatch(/Unlimited/);
+  });
+});

--- a/desktop/src/components/SlotMeter.tsx
+++ b/desktop/src/components/SlotMeter.tsx
@@ -1,0 +1,94 @@
+/**
+ * SlotMeter — the widget-slot budget, shared by the Catalog header and
+ * the Account page so the two surfaces can't drift (v1.1.2).
+ *
+ * Slots in use = ENABLED channels + enabled local widgets — the server
+ * gate counts `WHERE enabled = true`, and the downgrade prune disables
+ * (never deletes) over-cap rows, so counting disabled rows here would
+ * claim slots the server would happily accept.
+ */
+import { useMemo } from "react";
+import clsx from "clsx";
+import { useShell, useShellData } from "../shell-context";
+import { getMaxWidgets } from "../tierLimits";
+
+export interface SlotUsage {
+  used: number;
+  max: number;
+  finite: boolean;
+  atCapacity: boolean;
+}
+
+/** Pure slot math — exported for tests. */
+export function computeSlotUsage(
+  enabledChannelCount: number,
+  enabledWidgetCount: number,
+  max: number,
+): SlotUsage {
+  const used = enabledChannelCount + enabledWidgetCount;
+  return {
+    used,
+    max,
+    finite: Number.isFinite(max),
+    atCapacity: used >= max,
+  };
+}
+
+export function useSlotUsage(): SlotUsage {
+  const { prefs, tier } = useShell();
+  const { channels } = useShellData();
+  return useMemo(
+    () =>
+      computeSlotUsage(
+        channels.filter((ch) => ch.enabled).length,
+        prefs.widgets.enabledWidgets.length,
+        getMaxWidgets(tier),
+      ),
+    [channels, prefs.widgets.enabledWidgets.length, tier],
+  );
+}
+
+/** Human one-liner under the headline. Same voice on every surface. */
+export function slotSubline(usage: SlotUsage): string {
+  if (!usage.finite) return "Unlimited slots on your plan — add away.";
+  if (usage.atCapacity)
+    return "Remove a widget to free a slot, or upgrade for more.";
+  if (usage.used === 0) return "Fresh start — pick your first widget.";
+  const open = usage.max - usage.used;
+  return `${open} open slot${open === 1 ? "" : "s"} — room for more.`;
+}
+
+export function slotHeadline(usage: SlotUsage): string {
+  if (!usage.finite)
+    return `${usage.used} widget${usage.used === 1 ? "" : "s"} added`;
+  if (usage.atCapacity) return `All ${usage.max} widget slots in use`;
+  return `${usage.used} of ${usage.max} widget slots used`;
+}
+
+/** One pill per slot, filled as used. Renders nothing on unlimited plans. */
+export function SlotPills({
+  usage,
+  className,
+}: {
+  usage: SlotUsage;
+  className?: string;
+}) {
+  if (!usage.finite) return null;
+  return (
+    <span className={clsx("flex items-center gap-1", className)} aria-hidden>
+      {Array.from({ length: usage.max }, (_, i) => (
+        <span
+          key={i}
+          className={clsx(
+            "h-1.5 w-4 rounded-full transition-colors",
+            i < usage.used
+              ? usage.atCapacity
+                ? "bg-warn"
+                : "bg-accent"
+              : "bg-edge/60",
+          )}
+        />
+      ))}
+    </span>
+  );
+}

--- a/desktop/src/components/settings/AccountSettings.tsx
+++ b/desktop/src/components/settings/AccountSettings.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { open } from "@tauri-apps/plugin-shell";
 import { toast } from "sonner";
 import clsx from "clsx";
@@ -11,7 +12,12 @@ import {
   updateProfile,
 } from "../../api/client";
 import { queryKeys, userOverviewQueryOptions } from "../../api/queries";
-import { TIER_LIMITS, isUnlimited, type NumericLimitKey } from "../../tierLimits";
+import {
+  SlotPills,
+  slotHeadline,
+  slotSubline,
+  useSlotUsage,
+} from "../SlotMeter";
 import type { SubscriptionTier } from "../../auth";
 import type { SubscriptionInfo } from "../../api/client";
 import { Section, DisplayRow, ActionRow } from "./SettingsControls";
@@ -100,6 +106,8 @@ export default function AccountSettings({
   const identity = authenticated ? getUserIdentity() : null;
   const userLabel = identity?.email ?? identity?.name ?? null;
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const slots = useSlotUsage();
 
   // Aggregated overview: channels count, fantasy summary, GDPR state.
   // Only fires when authenticated; query is cheap (cached server-side, 30s stale).
@@ -429,12 +437,31 @@ export default function AccountSettings({
 
       {/* ── Your Plan ────────────────────────────────────────── */}
       {authenticated && (
-        <Section index={5} title="Plan limits" variant="card">
-          <TierLimitsTable tier={tier} />
+        <Section index={5} title="Widget slots" variant="card">
+          {/* The plan story is ONE number now (v1.1.2): how many widgets
+              you run at once. The old per-feature limits table — five
+              rows of "Unlimited" since the caps were retired — is gone.
+              Meter + copy come from SlotMeter.tsx, shared with the
+              Catalog header. */}
+          <div className="px-3 py-2">
+            <div className="flex flex-wrap items-center gap-2.5">
+              <span className="text-ui-body font-semibold text-fg">
+                {slotHeadline(slots)}
+              </span>
+              <SlotPills usage={slots} />
+            </div>
+            <p className="mt-1 text-ui-meta text-fg-4">{slotSubline(slots)}</p>
+          </div>
+          <ActionRow
+            label="Manage widgets"
+            description="Add, remove, and swap widgets in the Catalog."
+            action="Open Catalog"
+            onClick={() => navigate({ to: "/catalog" })}
+          />
           {tier !== "uplink_ultimate" && tier !== "super_user" && !isLifetime && (
             <ActionRow
               label={tier === "free" ? "Upgrade to Uplink" : "Upgrade plan"}
-              description="See plan details and pricing on the web."
+              description="More slots — run more widgets at once."
               action="Upgrade"
               actionClass="bg-accent/10 text-accent hover:bg-accent/20"
               onClick={() => open("https://myscrollr.com/uplink")}
@@ -505,28 +532,3 @@ export default function AccountSettings({
   );
 }
 
-// ── Tier limits table ───────────────────────────────────────────
-
-const LIMIT_ROWS: { label: string; key: NumericLimitKey }[] = [
-  { label: "Finance symbols", key: "symbols" },
-  { label: "News feeds", key: "feeds" },
-  { label: "Custom feeds", key: "customFeeds" },
-  { label: "Sports leagues", key: "leagues" },
-  { label: "Fantasy leagues", key: "fantasy" },
-];
-
-function TierLimitsTable({ tier }: { tier: SubscriptionTier }) {
-  const limits = TIER_LIMITS[tier];
-  return (
-    <>
-      {LIMIT_ROWS.map(({ label, key }) => (
-        <DisplayRow
-          key={key}
-          label={label}
-          value={isUnlimited(tier, key) ? "Unlimited" : String(limits[key])}
-          valueClass="text-ui-muted text-fg-2 tabular-nums"
-        />
-      ))}
-    </>
-  );
-}

--- a/desktop/src/hooks/useRemoveWidget.ts
+++ b/desktop/src/hooks/useRemoveWidget.ts
@@ -1,0 +1,53 @@
+/**
+ * useRemoveWidget — the single "remove a widget" flow, shared by the
+ * per-widget info page and the sidebar context menu (v1.1.2) so the two
+ * surfaces can't drift:
+ *   - DATA widget → DELETE /users/me/channels/{type}, dashboard refetch,
+ *     success toast. The slot frees immediately.
+ *   - UTILITY widget → disabled via the undoable prefs path (settings
+ *     preserved, Undo in the toast).
+ *
+ * Errors are surfaced as toasts here — callers never need a catch.
+ */
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { channelsApi } from "../api/client";
+import type { ChannelType } from "../api/client";
+import { queryKeys } from "../api/queries";
+import type { CatalogItem } from "../marketplace";
+import { disableWidget } from "../preferences";
+import { useUndoableAction } from "./useUndoableAction";
+
+export function useRemoveWidget(): (item: CatalogItem) => Promise<void> {
+  const queryClient = useQueryClient();
+  const undoable = useUndoableAction();
+
+  return useCallback(
+    async (item: CatalogItem) => {
+      if (item.kind === "data") {
+        try {
+          await channelsApi.delete(item.id as ChannelType);
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
+          toast.success(`${item.name} removed`, {
+            description: "Its slot is free for another widget.",
+          });
+        } catch (err) {
+          console.error("[Scrollr] Remove failed:", err);
+          toast.error(`Couldn't remove ${item.name}`);
+        }
+      } else {
+        // Utilities live in prefs — undoable, settings preserved.
+        undoable(
+          {
+            label: `Removed ${item.name}`,
+            description: "Its slot is free for another widget.",
+          },
+          (current) => disableWidget(current, item.id),
+        );
+      }
+    },
+    [queryClient, undoable],
+  );
+}

--- a/desktop/src/hooks/useRemoveWidget.ts
+++ b/desktop/src/hooks/useRemoveWidget.ts
@@ -19,10 +19,17 @@ import { queryKeys } from "../api/queries";
 import type { CatalogItem } from "../marketplace";
 import { disableWidget } from "../preferences";
 import { useUndoableAction } from "./useUndoableAction";
+import type { UndoShellPlumbing } from "./useUndoableAction";
 
-export function useRemoveWidget(): (item: CatalogItem) => Promise<void> {
+/**
+ * `shell` is only for callers OUTSIDE the shell provider (RootLayout's
+ * sidebar menu passes its own prefs + persistPrefs). Inside, omit.
+ */
+export function useRemoveWidget(
+  shell?: UndoShellPlumbing,
+): (item: CatalogItem) => Promise<void> {
   const queryClient = useQueryClient();
-  const undoable = useUndoableAction();
+  const undoable = useUndoableAction(shell);
 
   return useCallback(
     async (item: CatalogItem) => {

--- a/desktop/src/hooks/useUndoableAction.ts
+++ b/desktop/src/hooks/useUndoableAction.ts
@@ -34,9 +34,9 @@
  *     wasn't worth the complexity for the first cut.
  */
 
-import { useCallback } from "react";
+import { useCallback, useContext } from "react";
 import { toast } from "sonner";
-import { useShell } from "../shell-context";
+import { ShellContext } from "../shell-context";
 import { pushSnapshot, restoreSnapshot } from "../lib/undoStack";
 import type { AppPreferences } from "../preferences";
 
@@ -62,16 +62,35 @@ interface UndoableActionOptions {
 type Mutator = (current: AppPreferences) => AppPreferences;
 
 /**
+ * Explicit prefs plumbing for callers that sit OUTSIDE the shell
+ * provider. RootLayout itself is the component that *renders*
+ * ShellContext.Provider, so hooks called in its body can't read the
+ * context — the v1.1.2 sidebar remove flow passes RootLayout's own
+ * `prefs` + `persistPrefs` here instead. Inside the provider, omit.
+ */
+export interface UndoShellPlumbing {
+  prefs: AppPreferences;
+  onPrefsChange: (prefs: AppPreferences) => void;
+}
+
+/**
  * Returns a function `(opts, mutator) => void` that executes the
  * mutation and shows an undo toast. The function identity is stable
  * across renders (useCallback) so it's safe to put in dependency
  * arrays.
  */
-export function useUndoableAction(): (
+export function useUndoableAction(external?: UndoShellPlumbing): (
   opts: UndoableActionOptions,
   mutator: Mutator,
 ) => void {
-  const { prefs, onPrefsChange } = useShell();
+  const ctx = useContext(ShellContext);
+  const resolved = external ?? ctx;
+  if (!resolved) {
+    throw new Error(
+      "useUndoableAction must be used within RootLayout or given explicit prefs plumbing",
+    );
+  }
+  const { prefs, onPrefsChange } = resolved;
 
   return useCallback(
     (opts: UndoableActionOptions, mutator: Mutator) => {

--- a/desktop/src/marketplace.ts
+++ b/desktop/src/marketplace.ts
@@ -309,7 +309,9 @@ const DATA_WIDGETS: DataWidgetDef[] = [
   },
   // Fantasy, Predictions.
   {
-    id: "fantasy_yahoo", name: "Yahoo Fantasy", category: "fantasy", source: "fantasy", color: "#6001d2", requiredTier: "uplink",
+    // Tier gate RETIRED v1.1.2 — Yahoo Fantasy is a normal widget on every
+    // plan (the slot is the only lever). No requiredTier = "free".
+    id: "fantasy_yahoo", name: "Yahoo Fantasy", category: "fantasy", source: "fantasy", color: "#6001d2",
     description: "Your Yahoo Fantasy leagues, matchups, and standings.",
     about: "Your Yahoo Fantasy leagues in the ticker — live scoring, matchups, and standings without ever opening the app.",
     usage: [

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -55,6 +55,8 @@ import {
   savePrefs,
   consumeTickerLayoutChanged,
   resolveThemeMode,
+  getChannelTickerRow,
+  getWidgetTickerRow,
 } from "../preferences";
 import type { AppPreferences } from "../preferences";
 import {
@@ -66,13 +68,14 @@ import { showTipOnce, TIP_IDS } from "../lib/tips";
 
 // Types
 import type { DeliveryMode } from "../types";
-import type { Channel, SubscriptionInfo } from "../api/client";
+import type { Channel, ChannelType, SubscriptionInfo } from "../api/client";
 
 // Hooks
 import { useTheme } from "../hooks/useTheme";
 import { useAuthState } from "../hooks/useAuthState";
 import { useChannelActions } from "../hooks/useChannelActions";
 import { useWidgetActions } from "../hooks/useWidgetActions";
+import { useRemoveWidget } from "../hooks/useRemoveWidget";
 import { useDashboardCDC } from "../hooks/useDashboardCDC";
 import { useTauriListener } from "../hooks/useTauriListener";
 import { useDeliveryHealth } from "../hooks/useDeliveryHealth";
@@ -587,6 +590,53 @@ function RootLayout() {
     [navigate],
   );
 
+  // ── Sidebar context-menu actions (v1.1.2) ───────────────────
+  // Right-click on a source row. Ticker + remove resolve through the
+  // same handlers the ticker settings and the widget info page use —
+  // no new mutation paths.
+  const removeWidgetShared = useRemoveWidget();
+
+  const handleConfigureItem = useCallback(
+    (id: string, kind: "channel" | "widget") => {
+      if (kind === "channel") {
+        navigate({ to: "/channel/$type/$tab", params: { type: id, tab: "configuration" } });
+      } else {
+        navigate({ to: "/widget/$id/$tab", params: { id, tab: "configuration" } });
+      }
+    },
+    [navigate],
+  );
+
+  const handleInfoItem = useCallback(
+    (id: string) => navigate({ to: "/widget/$id/info", params: { id } }),
+    [navigate],
+  );
+
+  const handleToggleItemTicker = useCallback(
+    (source: { id: string; kind: "channel" | "widget"; onTicker: boolean }) => {
+      if (source.kind === "channel") {
+        channelActions.handleToggleChannel(
+          source.id as ChannelType,
+          !source.onTicker,
+        );
+      } else {
+        widgetActions.handleToggleWidgetTicker(source.id);
+      }
+    },
+    [channelActions.handleToggleChannel, widgetActions.handleToggleWidgetTicker],
+  );
+
+  const handleRemoveItem = useCallback(
+    (source: { id: string }) => {
+      const item = catalogItemById(source.id);
+      if (!item) return;
+      // Removing the page you're standing on → land back on Home.
+      if (route.activeItem === source.id) navigate({ to: "/feed" });
+      void removeWidgetShared(item);
+    },
+    [navigate, removeWidgetShared, route.activeItem],
+  );
+
   // Build the sidebar source list from the user's enabled channels and
   // widgets. Channels come from the live `dashboard.channels` payload
   // (filtered to `enabled === true`); widgets come from
@@ -596,10 +646,10 @@ function RootLayout() {
   // flag controls whether chips appear on the ticker, not whether the
   // channel appears in navigation.
   const sidebarSources = useMemo(() => {
-    const enabledChannelIds = new Set<string>(
+    const enabledChannels = new Map<string, Channel>(
       (dashboard?.channels ?? [])
         .filter((c) => c.enabled === true)
-        .map((c) => c.channel_type),
+        .map((c) => [c.channel_type, c]),
     );
     const enabledWidgetIds = new Set(prefs.widgets.enabledWidgets);
 
@@ -609,23 +659,44 @@ function RootLayout() {
       hex: string;
       icon: React.ComponentType<{ size?: number; className?: string }>;
       kind: "channel" | "widget";
+      onTicker: boolean;
     }> = [];
 
     for (const id of CANONICAL_ORDER) {
-      if (enabledChannelIds.has(id)) {
+      const channel = enabledChannels.get(id);
+      if (channel) {
         const m = catalogItemById(id);
         if (m) {
-          sources.push({ id, name: m.name, hex: m.hex, icon: m.icon, kind: "channel" });
+          sources.push({
+            id,
+            name: m.name,
+            hex: m.hex,
+            icon: m.icon,
+            kind: "channel",
+            // On-ticker = assigned to a ticker row (v1.1.2 context menu).
+            onTicker: getChannelTickerRow(prefs, channel) !== null,
+          });
         }
       } else if (enabledWidgetIds.has(id)) {
         const m = allWidgets.find((w) => w.id === id);
         if (m) {
-          sources.push({ id, name: m.name, hex: m.hex, icon: m.icon, kind: "widget" });
+          sources.push({
+            id,
+            name: m.name,
+            hex: m.hex,
+            icon: m.icon,
+            kind: "widget",
+            onTicker: getWidgetTickerRow(prefs, id) !== null,
+          });
         }
       }
     }
     return sources;
-  }, [dashboard?.channels, prefs.widgets.enabledWidgets, allChannelManifests, allWidgets]);
+    // `prefs` wholesale: the ticker-row layout lives under
+    // prefs.appearance and enabled widgets under prefs.widgets — the
+    // list build is cheap, so one broad dep beats two narrow ones
+    // that could silently miss a third source of truth later.
+  }, [dashboard?.channels, prefs, allChannelManifests, allWidgets]);
 
   // ── Keyboard shortcuts ──────────────────────────────────────
   useEffect(() => {
@@ -835,6 +906,10 @@ function RootLayout() {
               onNavigateToAccount={handleNavigateToAccount}
               onNavigateToSupport={handleNavigateToSupport}
               onSelectItem={handleSelectPinned}
+              onConfigureItem={handleConfigureItem}
+              onInfoItem={handleInfoItem}
+              onToggleItemTicker={handleToggleItemTicker}
+              onRemoveItem={handleRemoveItem}
             />
 
             <main className="flex-1 flex flex-col min-w-0 overflow-hidden relative">

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -55,9 +55,11 @@ import {
   savePrefs,
   consumeTickerLayoutChanged,
   resolveThemeMode,
-  getChannelTickerRow,
-  getWidgetTickerRow,
 } from "../preferences";
+import {
+  getEffectiveChannelTickerRow,
+  getEffectiveWidgetTickerStatus,
+} from "../utils/tickerStatus";
 import type { AppPreferences } from "../preferences";
 import {
   gcExpired as undoStackGc,
@@ -678,8 +680,12 @@ function RootLayout() {
             hex: m.hex,
             icon: m.icon,
             kind: "channel",
-            // On-ticker = assigned to a ticker row (v1.1.2 context menu).
-            onTicker: getChannelTickerRow(prefs, channel) !== null,
+            // EFFECTIVE ticker state (v1.1.2 context menu) — the raw row
+            // getter ignores the server ticker_enabled flag, which made
+            // row-assigned channels read permanently "on" and the menu
+            // toggle one-way. The effective helper is what the feed page
+            // uses for exactly this question.
+            onTicker: getEffectiveChannelTickerRow(prefs, channel) !== null,
           });
         }
       } else if (enabledWidgetIds.has(id)) {
@@ -691,7 +697,12 @@ function RootLayout() {
             hex: m.hex,
             icon: m.icon,
             kind: "widget",
-            onTicker: getWidgetTickerRow(prefs, id) !== null,
+            // Effective status, NOT the raw row getter: pinned-zone
+            // widgets live in widgetsOnTicker/pinnedWidgets and never
+            // appear in rows[].sources — the raw getter read them as
+            // "off" and inverted the menu toggle.
+            onTicker:
+              getEffectiveWidgetTickerStatus(prefs, id).kind !== "off",
           });
         }
       }

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -593,8 +593,13 @@ function RootLayout() {
   // ── Sidebar context-menu actions (v1.1.2) ───────────────────
   // Right-click on a source row. Ticker + remove resolve through the
   // same handlers the ticker settings and the widget info page use —
-  // no new mutation paths.
-  const removeWidgetShared = useRemoveWidget();
+  // no new mutation paths. RootLayout PROVIDES ShellContext, so its
+  // own hooks can't read it — pass the local prefs plumbing instead
+  // (the "useShell must be used within RootLayout" crash).
+  const removeWidgetShared = useRemoveWidget({
+    prefs,
+    onPrefsChange: persistPrefs,
+  });
 
   const handleConfigureItem = useCallback(
     (id: string, kind: "channel" | "widget") => {

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -23,7 +23,12 @@ import { getCatalogItems, CATEGORY_LABELS, CANONICAL_ORDER } from "../marketplac
 import type { WidgetCategory, CatalogItem } from "../marketplace";
 import { dashboardQueryOptions } from "../api/queries";
 import { useShell, useShellData } from "../shell-context";
-import { getMaxWidgets } from "../tierLimits";
+import {
+  SlotPills,
+  slotHeadline,
+  slotSubline,
+  useSlotUsage,
+} from "../components/SlotMeter";
 import CatalogCard from "../components/marketplace/CatalogCard";
 import QueryErrorBanner from "../components/QueryErrorBanner";
 import RouteError from "../components/RouteError";
@@ -85,7 +90,7 @@ function orderItems(items: CatalogItem[], sort: SortMode): CatalogItem[] {
 
 function CatalogPage() {
   const navigate = useNavigate();
-  const { prefs, tier } = useShell();
+  const { prefs } = useShell();
   const { channels } = useShellData();
   const { error: dashboardError } = useQuery(dashboardQueryOptions());
 
@@ -107,20 +112,11 @@ function CatalogPage() {
     [enabledChannelIds, enabledWidgetIds],
   );
 
-  // Widget/slot model (2026-06-30): a plan caps how many widgets run at
-  // once. Slots in use = ENABLED channels + enabled local widgets — the
-  // server gate counts `WHERE enabled = true`, and the downgrade prune
-  // disables (never deletes) over-cap rows, so counting disabled rows here
-  // would lock the catalog for users the server would happily accept. At
+  // Widget/slot model: slot math + meter live in SlotMeter.tsx, shared
+  // with the Account page so the two surfaces can't drift (v1.1.2). At
   // capacity, the catalog locks *new* adds (already-added items stay
-  // interactive). nil/Infinity = unlimited.
-  const slots = useMemo(() => {
-    const used =
-      channels.filter((ch) => ch.enabled).length +
-      prefs.widgets.enabledWidgets.length;
-    const max = getMaxWidgets(tier);
-    return { used, max, atCapacity: used >= max };
-  }, [channels, prefs.widgets.enabledWidgets.length, tier]);
+  // interactive).
+  const slots = useSlotUsage();
 
   // Filter → split into "yours" vs "discover" → sort within each.
   const { yourItems, discoverItems } = useMemo(() => {
@@ -139,22 +135,6 @@ function CatalogPage() {
       ),
     };
   }, [allItems, filter, sort, allEnabledIds]);
-
-  // ── Header copy: the slot budget, stated once and visibly ────
-  const finiteMax = Number.isFinite(slots.max);
-  const openSlots = finiteMax ? (slots.max as number) - slots.used : Infinity;
-  const slotHeadline = !finiteMax
-    ? `${slots.used} widget${slots.used === 1 ? "" : "s"} added`
-    : slots.atCapacity
-      ? `All ${slots.max} widget slots in use`
-      : `${slots.used} of ${slots.max} widget slots used`;
-  const slotSub = !finiteMax
-    ? "Unlimited slots on your plan — add away."
-    : slots.atCapacity
-      ? "Remove a widget to free a slot, or upgrade for more."
-      : slots.used === 0
-        ? "Fresh start — pick your first widget below."
-        : `${openSlots} open slot${openSlots === 1 ? "" : "s"} — room for more.`;
 
   const cardFor = (item: CatalogItem, i: number) => (
     <motion.div
@@ -219,7 +199,7 @@ function CatalogPage() {
         transition={{ duration: 0.25, delay: 0.02, ease: [0.22, 0.61, 0.36, 1] }}
         className={clsx(
           "mb-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-3 rounded-xl border px-4 py-3",
-          slots.atCapacity && finiteMax
+          slots.atCapacity && slots.finite
             ? "border-warn/25 bg-warn/[0.06]"
             : "border-edge/40 bg-base-150/30",
         )}
@@ -228,7 +208,7 @@ function CatalogPage() {
           <span
             className={clsx(
               "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-              slots.atCapacity && finiteMax
+              slots.atCapacity && slots.finite
                 ? "bg-warn/15 text-warn"
                 : "bg-accent/10 text-accent",
             )}
@@ -238,33 +218,17 @@ function CatalogPage() {
           <div>
             <div className="flex items-center gap-2.5">
               <span className="text-ui-body font-semibold text-fg-1">
-                {slotHeadline}
+                {slotHeadline(slots)}
               </span>
               {/* Slot meter — one pill per slot, filled as used. */}
-              {finiteMax && (
-                <span className="flex items-center gap-1" aria-hidden>
-                  {Array.from({ length: slots.max as number }, (_, i) => (
-                    <span
-                      key={i}
-                      className={clsx(
-                        "h-1.5 w-4 rounded-full transition-colors",
-                        i < slots.used
-                          ? slots.atCapacity
-                            ? "bg-warn"
-                            : "bg-accent"
-                          : "bg-edge/60",
-                      )}
-                    />
-                  ))}
-                </span>
-              )}
+              <SlotPills usage={slots} />
             </div>
-            <div className="text-ui-chip text-fg-4">{slotSub}</div>
+            <div className="text-ui-chip text-fg-4">{slotSubline(slots)}</div>
           </div>
         </div>
 
         <div className="flex items-center gap-2">
-          {slots.atCapacity && finiteMax && (
+          {slots.atCapacity && slots.finite && (
             <button
               onClick={() => void open("https://myscrollr.com/uplink")}
               className="shrink-0 rounded-lg bg-warn/15 px-3 py-1.5 text-ui-chip font-semibold text-warn transition-colors hover:bg-warn/25"

--- a/desktop/src/routes/widget.$id.info.tsx
+++ b/desktop/src/routes/widget.$id.info.tsx
@@ -10,7 +10,7 @@
  */
 import { useMemo, useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { motion } from "motion/react";
 import clsx from "clsx";
 import {
@@ -25,7 +25,6 @@ import {
   Trash2,
 } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
-import { toast } from "sonner";
 
 import {
   catalogItemById,
@@ -36,14 +35,11 @@ import {
 import type { CatalogItem } from "../marketplace";
 import type { SubscriptionTier } from "../auth";
 import { TIER_LABELS } from "../auth";
-import { channelsApi } from "../api/client";
-import type { ChannelType } from "../api/client";
-import { dashboardQueryOptions, queryKeys } from "../api/queries";
+import { dashboardQueryOptions } from "../api/queries";
 import { useShell, useShellData } from "../shell-context";
 import { getMaxWidgets } from "../tierLimits";
 import { useAddWidget } from "../hooks/useAddWidget";
-import { useUndoableAction } from "../hooks/useUndoableAction";
-import { disableWidget } from "../preferences";
+import { useRemoveWidget } from "../hooks/useRemoveWidget";
 import PageLayout from "../components/layout/PageLayout";
 import EmptySection from "../components/layout/EmptySection";
 import RouteError from "../components/RouteError";
@@ -87,8 +83,7 @@ function WidgetInfoPage() {
   const { channels } = useShellData();
   const { isLoading: dashboardLoading } = useQuery(dashboardQueryOptions());
   const addWidget = useAddWidget();
-  const queryClient = useQueryClient();
-  const undoable = useUndoableAction();
+  const removeWidgetShared = useRemoveWidget();
   const [removing, setRemoving] = useState(false);
   const [logoFailed, setLogoFailed] = useState(false);
 
@@ -141,30 +136,13 @@ function WidgetInfoPage() {
       : `${used} of ${maxSlots} widget slots used`
     : `${used} widgets added · unlimited slots`;
 
+  // Shared flow (useRemoveWidget) — same behavior as the sidebar menu.
   const removeWidget = async () => {
-    if (item.kind === "data") {
-      setRemoving(true);
-      try {
-        await channelsApi.delete(item.id as ChannelType);
-        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
-        toast.success(`${item.name} removed`, {
-          description: "Its slot is free for another widget.",
-        });
-      } catch (err) {
-        console.error("[Scrollr] Remove failed:", err);
-        toast.error(`Couldn't remove ${item.name}`);
-      } finally {
-        setRemoving(false);
-      }
-    } else {
-      // Utilities live in prefs — undoable, settings preserved.
-      undoable(
-        {
-          label: `Removed ${item.name}`,
-          description: "Its slot is free for another widget.",
-        },
-        (current) => disableWidget(current, item.id),
-      );
+    setRemoving(true);
+    try {
+      await removeWidgetShared(item);
+    } finally {
+      setRemoving(false);
     }
   };
 

--- a/myscrollr.com/src/components/landing/FAQSection.tsx
+++ b/myscrollr.com/src/components/landing/FAQSection.tsx
@@ -29,7 +29,7 @@ const FAQ_ITEMS: Array<FAQItem> = [
     question: 'Is Scrollr free?',
     highlight: 'A generous free tier with no ads or tracking. Upgrade anytime.',
     answer:
-      'The free tier streams real-time data with no ads or tracking. Uplink plans unlock more widgets at once, Yahoo Fantasy sync, and power-user tools like custom alerts and integrations. The entire codebase is open source under the AGPL-3.0 license.',
+      'The free tier streams real-time data with no ads or tracking. Uplink plans unlock more widgets at once, priority support, and power-user tools like custom alerts and integrations. The entire codebase is open source under the AGPL-3.0 license.',
     accent: 'emerald',
   },
   {

--- a/myscrollr.com/src/components/support/support-content.ts
+++ b/myscrollr.com/src/components/support/support-content.ts
@@ -16,7 +16,7 @@ export const FAQ_ITEMS: Array<FAQItem> = [
   {
     question: 'Is Scrollr free?',
     answer:
-      'Yes. The free tier streams real-time data to 3 widgets at once with no ads. Upgrade to Uplink or higher for more widget slots, Yahoo Fantasy sync, and power-user tools like alerts and integrations.',
+      'Yes. The free tier streams real-time data to 3 widgets at once with no ads. Upgrade to Uplink or higher for more widget slots, priority support, and power-user tools like alerts and integrations.',
   },
   {
     question: "Does it affect my computer's performance?",

--- a/myscrollr.com/src/lib/structured-data.ts
+++ b/myscrollr.com/src/lib/structured-data.ts
@@ -102,7 +102,7 @@ export function productOffers(tiers: Array<Tier>) {
     '@type': 'Product',
     name: 'Scrollr Uplink',
     description:
-      'Premium subscription tiers for the Scrollr desktop app: more widgets at once, Yahoo Fantasy sync, and early access to new widgets.',
+      'Premium subscription tiers for the Scrollr desktop app: more widgets at once, priority support, and early access to new widgets.',
     brand: { '@type': 'Brand', name: 'Scrollr' },
     offers: tiers.flatMap((t) => [
       {
@@ -174,7 +174,7 @@ export const HOMEPAGE_FAQ_ITEMS: ReadonlyArray<{
   {
     question: 'Is Scrollr free?',
     answer:
-      'The free tier streams real-time data with no ads or tracking. Uplink plans unlock more widgets at once, Yahoo Fantasy sync, and power-user tools like custom alerts and integrations. The entire codebase is open source under the AGPL-3.0 license.',
+      'The free tier streams real-time data with no ads or tracking. Uplink plans unlock more widgets at once, priority support, and power-user tools like custom alerts and integrations. The entire codebase is open source under the AGPL-3.0 license.',
   },
   {
     question: 'Does it affect performance?',

--- a/myscrollr.com/src/routes/channels.tsx
+++ b/myscrollr.com/src/routes/channels.tsx
@@ -164,7 +164,7 @@ const CHANNELS: Array<ChannelDef> = [
     name: 'Yahoo Fantasy',
     description: 'Fantasy sports leagues',
     detail:
-      'Connect your Yahoo account to view league standings, team rosters, weekly matchups, and live scoring across unlimited fantasy leagues. Available on every paid plan — Uplink and up.',
+      'Connect your Yahoo account to view league standings, team rosters, weekly matchups, and live scoring across unlimited fantasy leagues. Included on every plan.',
     Icon: Ghost,
     hex: HEX.accent,
     Watermark: Ghost,

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -130,7 +130,7 @@ const STATIC_TIERS = [
   {
     name: 'Uplink',
     description:
-      'Six widgets at once, Yahoo Fantasy sync, and early access to new widgets.',
+      'Six widgets at once, priority support, and early access to new widgets.',
     priceMonthly: 9.99,
     priceAnnual: 79.99,
   },
@@ -144,7 +144,7 @@ const STATIC_TIERS = [
   {
     name: 'Ultimate',
     description:
-      'Unlimited widgets at once, webhooks, data export, API access, and priority support.',
+      'Unlimited widgets at once, plus webhooks, data export, and API access as they land.',
     priceMonthly: 49.99,
     priceAnnual: 399.99,
   },
@@ -179,7 +179,7 @@ const STATIC_FAQ = [
   {
     question: 'How many fantasy leagues can I connect?',
     answer:
-      'As many as you play. Scrollr syncs with Yahoo Fantasy Sports to show your standings, matchups, and roster updates. The Yahoo Fantasy widget is available on every paid plan — Uplink and up — and syncs unlimited leagues across every sport.',
+      'As many as you play. Scrollr syncs with Yahoo Fantasy Sports to show your standings, matchups, and roster updates. The Yahoo Fantasy widget is included on every plan — even Free — and syncs unlimited leagues across every sport.',
   },
   {
     question: 'What are custom alerts?',
@@ -219,7 +219,7 @@ export const Route = createFileRoute('/uplink')({
     seo({
       title: 'Scrollr Uplink: Pricing & Plans',
       description:
-        'Scrollr Uplink unlocks more widgets at once, Yahoo Fantasy sync, and power-user tools — on top of real-time streaming for everyone. Plans from $9.99/month with annual savings.',
+        'Scrollr Uplink unlocks more widgets at once, priority support, and power-user tools — on top of real-time streaming for everyone. Plans from $9.99/month with annual savings.',
       path: '/uplink',
       image: 'https://myscrollr.com/og/uplink.png',
       type: 'product',
@@ -302,14 +302,13 @@ function buildComparison(limits: TierLimitsResponse): Array<ComparisonRow> {
       ultimate: 'Unlimited',
     },
     {
+      // Tier gate retired v1.1.2 — a normal widget on every plan. The row
+      // stays because four checkmarks SELL the giveaway better than silence.
       label: 'Yahoo Fantasy',
-      free: 'No',
+      free: 'Yes',
       uplink: 'Yes',
       pro: 'Yes',
       ultimate: 'Yes',
-      uplinkUp: true,
-      proUp: true,
-      ultimateUp: true,
     },
     {
       label: 'Site Filtering',
@@ -396,11 +395,14 @@ function buildComparison(limits: TierLimitsResponse): Array<ComparisonRow> {
       ultimateUp: true,
     },
     {
+      // v1.1.2: moved from Ultimate-only to every paid tier.
       label: 'Priority Support',
       free: 'No',
-      uplink: 'No',
-      pro: 'No',
+      uplink: 'Yes',
+      pro: 'Yes',
       ultimate: 'Yes',
+      uplinkUp: true,
+      proUp: true,
       ultimateUp: true,
     },
     {
@@ -446,10 +448,10 @@ function buildTierShowcases(limits: TierLimitsResponse): Array<TierShowcase> {
       delivery: `${uplink.max_widgets} widgets`,
       deliverySub: 'Double the free plan',
       useCase:
-        "You open Scrollr with your coffee, scan your watchlist, skim the morning headlines, and check last night's scores — with your fantasy roster and an extra league running alongside. Everything streams in live, so you catch the pre-market move before you leave for work.",
+        "You open Scrollr with your coffee, scan your watchlist, skim the morning headlines, and check last night's scores — with your fantasy leagues running alongside. Everything streams in live, so you catch the pre-market move before you leave for work.",
       features: [
         `${uplink.max_widgets} widgets at once`,
-        'Yahoo Fantasy sync',
+        'Priority support',
         'Unlimited items per widget',
         'Every sports & news widget',
         'Blacklist site filtering',
@@ -490,7 +492,6 @@ function buildTierShowcases(limits: TierLimitsResponse): Array<TierShowcase> {
         'Webhooks & integrations',
         'Data export (CSV / JSON)',
         'API access',
-        'Priority support',
         'Everything in Pro, plus more',
       ],
     },
@@ -679,10 +680,9 @@ function buildUplinkFAQ(limits: TierLimitsResponse): Array<FAQItem> {
     {
       icon: Crown,
       question: 'How many fantasy leagues can I connect?',
-      highlight:
-        'Unlimited Yahoo leagues on any paid plan — Uplink and up.',
+      highlight: 'Unlimited Yahoo leagues on every plan — even Free.',
       answer:
-        'As many as you play. Scrollr syncs with Yahoo Fantasy Sports to show your standings, matchups, and roster updates. The Yahoo Fantasy widget is available on every paid plan — Uplink and up — and syncs unlimited leagues across every sport.',
+        'As many as you play. Scrollr syncs with Yahoo Fantasy Sports to show your standings, matchups, and roster updates. The Yahoo Fantasy widget is included on every plan — even Free — and syncs unlimited leagues across every sport.',
       accent: 'rose',
     },
     {
@@ -2552,7 +2552,7 @@ function UplinkPage() {
                         <PricingFeature>
                           {tierLimits.tiers.uplink.max_widgets} widgets at once
                         </PricingFeature>
-                        <PricingFeature>Yahoo Fantasy sync</PricingFeature>
+                        <PricingFeature>Priority support</PricingFeature>
                         <PricingFeature>Real-time SSE delivery</PricingFeature>
                         <PricingFeature>
                           Unlimited items per widget

--- a/myscrollr.com/src/routes/uplink_.lifetime.tsx
+++ b/myscrollr.com/src/routes/uplink_.lifetime.tsx
@@ -271,7 +271,7 @@ function LifetimePage() {
                 </Feature>
                 <Feature>Unlimited widgets at once</Feature>
                 <Feature>Webhooks, data export & API access</Feature>
-                <Feature>Yahoo Fantasy sync + unlimited items per widget</Feature>
+                <Feature>Unlimited items inside every widget</Feature>
                 <Feature>Founding member badge & priority support</Feature>
                 <Feature>Early access to new features & widgets</Feature>
               </motion.div>


### PR DESCRIPTION
The whole product now tells one monetization story: **your plan = how many widgets you run at once.** The catalog half of The Library shipped early in v1.1.1; this is the monetization half plus the sidebar interaction item.

## Desktop
- **Account page slot meter** — the "Plan limits" table (five rows of retired caps, all reading "Unlimited") is replaced by "X of Y widget slots used" + the per-slot pill meter + Manage widgets / Upgrade actions. Meter, math, and copy live in a shared `SlotMeter.tsx` consumed by both the Account page and the catalog header, so the two can never drift. 12 new pure-logic tests.
- **Sidebar right-click menu** — Open / Configure / Show-Hide on ticker / Widget page / Remove on every source row. New reusable `ContextMenu` primitive; all actions route through the existing shell handlers. Remove shares the info page's flow via the new `useRemoveWidget` hook (undo toast for utilities), and removing the page you're on returns you to Home.
- **Fantasy gate retired (client)** — `requiredTier: "uplink"` removed from the Yahoo Fantasy catalog entry; it's a normal widget on every plan including Free.

## API
- **Fantasy league-import cap retired** — `channels/fantasy/api/tier_limits.go` still enforced the pre-widget-era ladder (free 0 / uplink 1 / pro 3 / ultimate 10). That mirror was missed by the 2026-07-02 cap retirement because it's a package-local copy in an independent module — meaning prod currently caps Uplink users at ONE league while the marketing FAQ promises "unlimited leagues." Now unlimited on every tier, enforcement seam kept for the future.

## Website
- **Pricing story** — Yahoo Fantasy compare row shows four checkmarks (the giveaway sells itself); **Priority Support moves from Ultimate-only to every paid tier** across the compare table, tier cards, showcases, FAQ, and meta description; Ultimate's blurb leads with its coming-soon suite (webhooks, export, API) instead. JSON-LD structured-data mirrors updated in lockstep with the visible FAQ.
- Fantasy tier-gate language swept from /channels, the homepage FAQ, support content, and the lifetime page.

## Verification
Desktop `tsc` clean + 426/426 vitest · site `tsc` clean + 59/59 (tier-table drift guard untouched — the 4-file synced table did not change) · fantasy API `go build` + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)