### PR TITLE
v1.1.3 Time Controls — day-range windows for sports & news

### DIFF
--- a/channels/sports/api/sports.go
+++ b/channels/sports/api/sports.go
@@ -446,7 +446,12 @@ func (a *App) handleInternalDashboard(c *fiber.Ctx) error {
 
 	favoriteTeams := a.getUserFavoriteTeams(userSub)
 	// Home dashboard uses fair-share so every selected league is visible
-	// within the 20-row glanceable preview, regardless of relative volume.
+	// within the 60-row payload, regardless of relative volume. KNOWN GAP
+	// (v1.1.3): the priority ORDER ranks finals after ALL pre rows, so a
+	// high-volume league (MLB: ~15 fixtures/day x 8 days ingested) fills
+	// its share with live+pre and the ticker's "days back" window sees
+	// few or no finals. Fix = interleave recency (e.g. split each share
+	// between soonest-pre and newest-final) — queued for v1.1.4.
 	games, err := a.queryGamesByLeagues(ctx, leagues, DashboardSportsLimit, favoriteTeams, true)
 	if err != nil {
 		log.Printf("[Sports] Dashboard query failed: %v", err)
@@ -664,7 +669,7 @@ const MinPerLeagueShare = 2
 
 // queryGamesByLeagues fetches games for specific leagues.
 //
-// When `fairShare` is true (used by /dashboard with limit=20): each league
+// When `fairShare` is true (used by /dashboard with limit=60): each league
 // gets max(MinPerLeagueShare, ceil(limit/N)) candidate rows via a window
 // function, ranked by the standard priority (live > pre > final, favorites
 // first, soonest upcoming first). The global LIMIT then trims. This keeps

--- a/channels/sports/api/sports.go
+++ b/channels/sports/api/sports.go
@@ -53,10 +53,14 @@ const (
 	// see every game for every selected league.
 	DefaultSportsLimit = 200
 
-	// DashboardSportsLimit caps the number of games returned for the
-	// home-feed glanceable row. The fair-share allocator (MinPerLeagueShare)
-	// ensures every selected league gets visibility within this cap.
-	DashboardSportsLimit = 20
+	// DashboardSportsLimit caps the number of games returned in the
+	// /dashboard payload — the desktop's only sports data source. Raised
+	// 20 → 60 for v1.1.3 Time Controls: finals now survive 7 days
+	// server-side and the per-widget day window (up to 7 back + 7 ahead)
+	// must find its games in this payload; at 20, a week of finals would
+	// have starved the upcoming slate. The fair-share allocator
+	// (MinPerLeagueShare) still guarantees every league visibility.
+	DashboardSportsLimit = 60
 
 	// PollingStaleThreshold is the maximum acceptable age of the last
 	// successful poll before a league is marked polling_healthy: false.

--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -401,7 +401,12 @@ pub async fn get_live_yesterday_leagues(pool: &Arc<PgPool>) -> Vec<String> {
 
 /// Delete stale games using per-state thresholds.
 ///
-/// - `final` / `postponed`: 12 hours past `start_time` — they're done.
+/// - `final` / `postponed`: 7 days past `start_time`. Was 12 hours until
+///           v1.1.3 Time Controls: the desktop's per-widget "N days back"
+///           window (0..7) needs finals to still EXIST server-side — with
+///           the 12h purge, "show me the last 3 days of scores" had no
+///           data to show. 7 days matches the pre-game horizon so the
+///           window is symmetric.
 /// - `pre`:  7 days past `start_time` — survives short polling outages.
 ///           A `pre` row this old means the API stopped returning the fixture
 ///           entirely; safe to prune.
@@ -412,7 +417,7 @@ pub async fn cleanup_old_games(pool: &Arc<PgPool>) -> Result<u64> {
     let mut connection = pool.acquire().await?;
     let result = query(
         "DELETE FROM games WHERE
-            (state IN ('final', 'postponed') AND start_time < NOW() - INTERVAL '12 hours')
+            (state IN ('final', 'postponed') AND start_time < NOW() - INTERVAL '7 days')
             OR (state = 'pre' AND start_time < NOW() - INTERVAL '7 days')
             OR (state = 'in' AND updated_at < NOW() - INTERVAL '24 hours')"
     )

--- a/channels/sports/service/tests/cleanup.rs
+++ b/channels/sports/service/tests/cleanup.rs
@@ -48,9 +48,12 @@ async fn test_cleanup_per_state_thresholds() {
         ("alive_pre_recent",   "pre",   h(-1),  h(-1),  true),   // started 1h ago, well within 7d
         ("alive_pre_3d",       "pre",   d(-3),  d(-3),  true),   // 3 days old, still within 7d
         ("dead_pre_8d",        "pre",   d(-8),  d(-8),  false),  // 8 days past kickoff
-        ("alive_final_6h",     "final", h(-6),  h(-6),  true),   // <12h post final
-        ("dead_final_13h",     "final", h(-13), h(-13), false),  // 13h post final
-        ("dead_postponed_13h", "postponed", h(-13), h(-13), false),
+        // v1.1.3 Time Controls: finals/postponed retained 7 DAYS (was 12h)
+        // so the desktop day-window has data to look back at.
+        ("alive_final_6h",     "final", h(-6),  h(-6),  true),   // fresh final
+        ("alive_final_3d",     "final", d(-3),  d(-3),  true),   // within 7d window
+        ("dead_final_8d",      "final", d(-8),  d(-8),  false),  // past 7d retention
+        ("dead_postponed_8d",  "postponed", d(-8), d(-8), false),
         ("alive_in_recent",    "in",    h(-1),  h(-1),  true),   // live, recently seen
         ("alive_in_20h",       "in",    h(-22), h(-20), true),   // live, seen 20h ago
         ("dead_in_25h",        "in",    h(-30), h(-25), false),  // live, stale 25h

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4621,7 +4621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/channels/rss/ConfigPanel.tsx
+++ b/desktop/src/channels/rss/ConfigPanel.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import FeedManager from "./FeedManager";
 import { ToggleRow } from "../../components/settings/SettingsControls";
+import { ArticleAgeControl } from "../../components/TimeWindowControl";
 import { rssCatalogOptions } from "../../api/queries";
 import { useChannelConfig } from "../../hooks/useChannelConfig";
 import { useShell } from "../../shell-context";
@@ -61,6 +62,18 @@ function NewsWidgetConfig({ channel }: { channel: Channel }) {
         </div>
       </section>
 
+      {/* Time window (v1.1.3) — per-widget article age. Applies to the
+          feed AND the ticker (getRssDisplayPrefs merges this override). */}
+      <section className="flex flex-col gap-0.5">
+        <h3 className="px-3 text-sm font-semibold text-fg">Time window</h3>
+        <ArticleAgeControl
+          maxAgeDays={override.maxArticleAgeDays ?? globalRss.maxArticleAgeDays}
+          onChange={(days) =>
+            updateItems({ ...override, maxArticleAgeDays: days })
+          }
+        />
+      </section>
+
       <section className="flex flex-col gap-0.5">
         <h3 className="px-3 text-sm font-semibold text-fg">Display</h3>
         <ToggleRow
@@ -96,6 +109,16 @@ function RssFeedConfig({
   const { error, setError, saving, updateItems } = useChannelConfig<
     Array<{ name: string; url: string; is_custom?: boolean }>
   >(channel.channel_type, "feeds");
+
+  // Time window (v1.1.3) — same per-widget config.display slot the
+  // curated widgets use; separate keyed hook so feed writes and
+  // display writes can't clobber each other.
+  const { prefs: shellPrefs } = useShell();
+  const displayOverride =
+    (channel.config as { display?: Partial<RssDisplayPrefs> })?.display ?? {};
+  const { updateItems: updateDisplay } = useChannelConfig<
+    Partial<RssDisplayPrefs>
+  >(channel.channel_type, "display");
 
   const rssConfig = channel.config as RssChannelConfig;
   const feeds = Array.isArray(rssConfig?.feeds) ? rssConfig.feeds : [];
@@ -166,6 +189,20 @@ function RssFeedConfig({
           </button>
         </div>
       )}
+
+      {/* Time window (v1.1.3) — compact strip above the feed manager;
+          applies to feed + ticker via the config.display override. */}
+      <div className="shrink-0">
+        <ArticleAgeControl
+          maxAgeDays={
+            displayOverride.maxArticleAgeDays ??
+            shellPrefs.channelDisplay.rss.maxArticleAgeDays
+          }
+          onChange={(days) =>
+            updateDisplay({ ...displayOverride, maxArticleAgeDays: days })
+          }
+        />
+      </div>
 
       <div className="flex-1 min-h-0">
         <FeedManager

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -312,10 +312,11 @@ function RssFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProps) 
         categoryMap,
         sortOrder,
         articlesPerSource: dp.articlesPerSource,
+        maxArticleAgeDays: dp.maxArticleAgeDays,
         showAll,
         expandedSources,
       }),
-    [rssItems, selectedSources, selectedCategories, sortOrder, dp.articlesPerSource, categoryMap, expandedSources, showAll],
+    [rssItems, selectedSources, selectedCategories, sortOrder, dp.articlesPerSource, dp.maxArticleAgeDays, categoryMap, expandedSources, showAll],
   );
 
   // Single-outlet widgets have exactly one source; the per-source

--- a/desktop/src/channels/rss/view.test.ts
+++ b/desktop/src/channels/rss/view.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { limitPerSource, applyRssPipeline, selectRssForTicker, distinctSourceCount } from "./view";
+import {
+  limitPerSource,
+  applyRssPipeline,
+  selectRssForTicker,
+  distinctSourceCount,
+  filterByArticleAge,
+} from "./view";
 import type { RssItem } from "../../types";
 import type { RssDisplayPrefs } from "../../preferences";
 
@@ -30,7 +36,82 @@ const DEFAULT_PREFS: RssDisplayPrefs = {
   showSource: "both",
   showTimestamps: "both",
   articlesPerSource: 4,
+  maxArticleAgeDays: 0,
 };
+
+// ── filterByArticleAge (v1.1.3 Time Controls) ───────────────────
+
+describe("filterByArticleAge", () => {
+  // Noon local time, so calendar-day math has slack on both sides.
+  const NOW = new Date("2026-06-10T12:00:00").getTime();
+  const hoursAgo = (h: number) =>
+    new Date(NOW - h * 3_600_000).toISOString();
+
+  it("passes everything through when maxAgeDays is 0", () => {
+    const items = [mk(1, "a", hoursAgo(24 * 30))];
+    expect(filterByArticleAge(items, 0, NOW)).toBe(items);
+  });
+
+  it("'today' (1 day) keeps this morning's article, drops yesterday's", () => {
+    const items = [
+      mk(1, "a", hoursAgo(3)), // 9am today
+      mk(2, "a", hoursAgo(20)), // 4pm yesterday
+    ];
+    const result = filterByArticleAge(items, 1, NOW);
+    expect(result.map((i) => i.id)).toEqual([1]);
+  });
+
+  it("counts calendar days including today", () => {
+    const items = [
+      mk(1, "a", hoursAgo(30)), // yesterday morning — inside 2 days
+      mk(2, "a", hoursAgo(3 * 24)), // three days back — outside 2 days
+    ];
+    const result = filterByArticleAge(items, 2, NOW);
+    expect(result.map((i) => i.id)).toEqual([1]);
+  });
+
+  it("falls back to created_at when published_at is null", () => {
+    const fresh = { ...mk(1, "a", null), created_at: hoursAgo(2) };
+    const stale = { ...mk(2, "a", null), created_at: hoursAgo(24 * 10) };
+    const result = filterByArticleAge([fresh, stale], 3, NOW);
+    expect(result.map((i) => i.id)).toEqual([1]);
+  });
+
+  it("keeps items with unparseable timestamps visible", () => {
+    const weird = { ...mk(1, "a", "not-a-date"), created_at: "also-bad" };
+    expect(filterByArticleAge([weird], 1, NOW)).toHaveLength(1);
+  });
+
+  it("applies inside the ticker selector via prefs", () => {
+    const items = [
+      mk(1, "a", hoursAgo(2)),
+      mk(2, "b", hoursAgo(24 * 5)),
+    ];
+    const result = selectRssForTicker(
+      items,
+      { ...DEFAULT_PREFS, maxArticleAgeDays: 2 },
+      NOW,
+    );
+    expect(result.map((i) => i.id)).toEqual([1]);
+  });
+
+  it("applies inside applyRssPipeline before per-source limiting", () => {
+    const items = [
+      mk(1, "a", hoursAgo(1)),
+      mk(2, "a", hoursAgo(24 * 9)), // stale — must not consume a slot
+      mk(3, "b", hoursAgo(2)),
+    ];
+    const result = applyRssPipeline(items, {
+      categoryMap: new Map(),
+      sortOrder: "newest",
+      articlesPerSource: 1,
+      maxArticleAgeDays: 2,
+      now: NOW,
+    });
+    expect(result.visibleItems.map((i) => i.id)).toEqual([1, 3]);
+    expect(result.totalHidden).toBe(0);
+  });
+});
 
 // ── limitPerSource ──────────────────────────────────────────────
 

--- a/desktop/src/channels/rss/view.ts
+++ b/desktop/src/channels/rss/view.ts
@@ -39,6 +39,35 @@ function sortRssItems(items: RssItem[], order: RssSortOrder): RssItem[] {
   });
 }
 
+// ── Pure: article-age window (v1.1.3 Time Controls) ─────────────
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Drop articles older than `maxAgeDays` (published_at, falling back to
+ * created_at). 0 = no filter. Unparseable timestamps stay visible rather
+ * than silently vanishing. `now` is injectable for tests.
+ *
+ * The cutoff is anchored to LOCAL CALENDAR DAYS, matching the sports
+ * window: maxAgeDays 1 = "published today", 3 = today + the two prior
+ * days — not a rolling 24h/72h period that would hide this morning's
+ * article at 11pm.
+ */
+export function filterByArticleAge(
+  items: RssItem[],
+  maxAgeDays: number,
+  now: number = Date.now(),
+): RssItem[] {
+  if (maxAgeDays <= 0) return items;
+  const dayStart = new Date(now);
+  dayStart.setHours(0, 0, 0, 0);
+  const cutoff = dayStart.getTime() - (maxAgeDays - 1) * DAY_MS;
+  return items.filter((i) => {
+    const t = new Date(i.published_at ?? i.created_at).getTime();
+    return !Number.isFinite(t) || t >= cutoff;
+  });
+}
+
 // ── Pure: per-source limit ───────────────────────────────────────
 
 /**
@@ -72,8 +101,12 @@ export function limitPerSource(items: RssItem[], limit: number): RssItem[] {
 export function selectRssForTicker(
   items: RssItem[],
   prefs: RssDisplayPrefs,
+  now: number = Date.now(),
 ): RssItem[] {
-  const ordered = sortRssItems(items, "newest");
+  // Age window first (v1.1.3) so the per-source balancer only allocates
+  // slots among articles that are actually eligible to show.
+  const fresh = filterByArticleAge(items, prefs.maxArticleAgeDays ?? 0, now);
+  const ordered = sortRssItems(fresh, "newest");
   // Single-outlet widgets (news_bbc, news_npr, ...) have exactly one
   // source — a per-source cap there just hides articles for no reason
   // (v1.1.1 "smart removal"). The balancer only makes sense when
@@ -91,6 +124,41 @@ export function distinctSourceCount(items: RssItem[]): number {
   return sources.size;
 }
 
+// ── Helper: per-widget display prefs (global + config.display) ──
+
+import type { DashboardResponse } from "../../types";
+
+/**
+ * Resolve a widget's effective RSS display prefs: the global
+ * `prefs.channelDisplay.rss` with the widget row's `config.display`
+ * override merged on top — the same merge FeedTab does. Added in
+ * v1.1.3 so the TICKER honors per-widget overrides (time window,
+ * per-source limit) instead of only the global prefs; mirror of
+ * `getSportsDisplayConfig`.
+ */
+export function getRssDisplayPrefs(
+  globalPrefs: RssDisplayPrefs,
+  dashboard: DashboardResponse | null | undefined,
+  widgetType?: string,
+): RssDisplayPrefs {
+  const channels = dashboard?.channels ?? [];
+  // channel_type is a widget id at runtime (news_bbc, rss_custom, …);
+  // compare as string so the legacy coarse rows ("rss" pre-000014,
+  // "news" post-rename) both resolve as the fallback.
+  const channel =
+    (widgetType
+      ? channels.find((c) => (c.channel_type as string) === widgetType)
+      : undefined) ??
+    channels.find((c) => {
+      const t = c.channel_type as string;
+      return t === "rss" || t === "news";
+    });
+  const override = (
+    channel?.config as { display?: Partial<RssDisplayPrefs> } | undefined
+  )?.display;
+  return override ? { ...globalPrefs, ...override } : globalPrefs;
+}
+
 // ── Pipeline result (for FeedTab) ────────────────────────────────
 
 export interface RssPipelineOptions {
@@ -104,6 +172,10 @@ export interface RssPipelineOptions {
   sortOrder: RssSortOrder;
   /** Per-source limit (from Display prefs). 0 = no limit. */
   articlesPerSource: number;
+  /** Article-age window in days (v1.1.3). 0 = no filter. */
+  maxArticleAgeDays?: number;
+  /** Injectable clock for tests; defaults to Date.now(). */
+  now?: number;
   /** Feed-page interactive toggle that disables the per-source limit. */
   showAll?: boolean;
   /** Feed-page: sources the user has expanded in by-source view. */
@@ -132,11 +204,15 @@ export function applyRssPipeline(
     categoryMap,
     sortOrder,
     articlesPerSource,
+    maxArticleAgeDays = 0,
+    now = Date.now(),
     showAll,
     expandedSources,
   } = opts;
 
-  let filtered = items;
+  // Age window first (v1.1.3) — everything downstream (filters, limit,
+  // overflow counts) should only ever see eligible articles.
+  let filtered = filterByArticleAge(items, maxArticleAgeDays, now);
 
   if (selectedSources && selectedSources.size > 0) {
     filtered = filtered.filter((i) => selectedSources.has(i.source_name));

--- a/desktop/src/channels/sports/ConfigPanel.tsx
+++ b/desktop/src/channels/sports/ConfigPanel.tsx
@@ -3,6 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { Star, X } from "lucide-react";
 import LeagueManager from "./LeagueManager";
 import { ToggleRow } from "../../components/settings/SettingsControls";
+import { DayRangeControl } from "../../components/TimeWindowControl";
+import { SPORTS_WINDOW_MAX_DAYS } from "./view";
 import { useSportsConfig } from "../../hooks/useSportsConfig";
 import { sportsCatalogOptions, sportsTeamsOptions } from "../../api/queries";
 import type { TeamInfo } from "../../api/queries";
@@ -129,22 +131,23 @@ function SportsWidgetConfig({
         </div>
       </section>
 
+      {/* Time window (v1.1.3) — replaces the old upcoming/final toggles
+          with "how many days back / ahead". Live games always show. */}
+      <section className="flex flex-col gap-0.5">
+        <h3 className="px-3 text-sm font-semibold text-fg">Time window</h3>
+        <DayRangeControl
+          daysBack={display.daysBack}
+          daysAhead={display.daysAhead}
+          max={SPORTS_WINDOW_MAX_DAYS}
+          disabled={saving}
+          onChange={(next) => setDisplay(next)}
+        />
+      </section>
+
       {/* Display — venue collapsed to an on/off switch (on = "both",
           off = "off"); feed-vs-ticker granularity isn't exposed per-widget. */}
       <section className="flex flex-col gap-0.5">
         <h3 className="px-3 text-sm font-semibold text-fg">Display</h3>
-        <ToggleRow
-          label="Upcoming games"
-          description="Show games that haven't started yet"
-          checked={display.showUpcoming !== "off"}
-          onChange={(c) => setDisplay({ showUpcoming: c ? "both" : "off" })}
-        />
-        <ToggleRow
-          label="Final scores"
-          description="Keep completed games in the feed"
-          checked={display.showFinal !== "off"}
-          onChange={(c) => setDisplay({ showFinal: c ? "both" : "off" })}
-        />
         <ToggleRow
           label="Team logos"
           checked={display.showLogos !== "off"}

--- a/desktop/src/channels/sports/ScoresTab.tsx
+++ b/desktop/src/channels/sports/ScoresTab.tsx
@@ -3,6 +3,7 @@ import { clsx } from "clsx";
 import { GameItem } from "./GameItem";
 import { isLive, isPre, isFinal } from "../../utils/gameHelpers";
 import { shouldShowOnFeed } from "../../preferences";
+import { selectSportsForFeed } from "./view";
 import type { Game, FeedMode } from "../../types";
 import type { SportsDisplayPrefs } from "../../hooks/useSportsConfig";
 import type { StatusFilter } from "./FeedTab";
@@ -29,21 +30,20 @@ export function ScoresTab({
   statusFilter,
 }: ScoresTabProps) {
   const filtered = useMemo(() => {
-    return games.filter((g) => {
+    // Day window first (v1.1.3 Time Controls — live games always pass),
+    // then the transient in-page filters on top.
+    const windowed = selectSportsForFeed(games, display);
+    return windowed.filter((g) => {
       // League filter
       if (leagueFilter.size > 0 && !leagueFilter.has(g.league)) return false;
 
-      // Status filter overrides display prefs when not "all"
+      // Status quick-filter narrows within the window when not "all"
       if (statusFilter === "live") return isLive(g);
       if (statusFilter === "upcoming") return isPre(g);
       if (statusFilter === "final") return isFinal(g);
-
-      // "all" — use display prefs
-      if (!shouldShowOnFeed(display.showUpcoming) && isPre(g)) return false;
-      if (!shouldShowOnFeed(display.showFinal) && isFinal(g)) return false;
       return true;
     });
-  }, [games, display.showUpcoming, display.showFinal, leagueFilter, statusFilter]);
+  }, [games, display, leagueFilter, statusFilter]);
 
   const grouped = useMemo(() => {
     const map = new Map<string, Game[]>();

--- a/desktop/src/channels/sports/view.test.ts
+++ b/desktop/src/channels/sports/view.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { selectSportsForTicker, gameEngagement } from "./view";
+import {
+  selectSportsForTicker,
+  gameEngagement,
+  normalizeSportsDisplayConfig,
+  SPORTS_WINDOW_DEFAULTS,
+  SPORTS_WINDOW_MAX_DAYS,
+} from "./view";
 import type { SportsDisplayConfig } from "./view";
 import type { Game } from "../../types";
 
@@ -158,39 +164,70 @@ describe("selectSportsForTicker", () => {
     expect(result).toHaveLength(2);
   });
 
-  it("hides upcoming games when showUpcoming is feed-only", () => {
+  // ── Day window (v1.1.3 Time Controls) ──────────────────────────
+
+  it("hides finals older than daysBack (calendar-day anchored)", () => {
     const games = [
-      preGame(1, 10 * 60_000),
-      liveGame(2),
-      finalGame(3, 60 * 60_000),
+      finalGame(1, 30 * 60_000),          // finished 30m ago — today
+      finalGame(2, 3 * 24 * 3_600_000),   // 3 days ago
+      liveGame(3),
     ];
-    const config: SportsDisplayConfig = { showUpcoming: "feed" };
+    const config: SportsDisplayConfig = { daysBack: 1, daysAhead: 7 };
     const result = selectSportsForTicker(games, config);
-    expect(result.map((g) => g.id)).toEqual([2, 3]);
+    expect(result.map((g) => g.id)).toEqual([3, 1]);
   });
 
-  it("hides final games when showFinal is feed-only", () => {
+  it("hides pre-games beyond daysAhead", () => {
     const games = [
-      preGame(1, 10 * 60_000),
-      liveGame(2),
-      finalGame(3, 60 * 60_000),
+      preGame(1, 30 * 60_000),            // in 30 minutes
+      preGame(2, 5 * 24 * 3_600_000),     // in 5 days
     ];
-    const config: SportsDisplayConfig = { showFinal: "feed" };
+    const config: SportsDisplayConfig = { daysBack: 1, daysAhead: 1 };
     const result = selectSportsForTicker(games, config);
-    expect(result.map((g) => g.id)).toEqual([2, 1]);
+    expect(result.map((g) => g.id)).toEqual([1]);
   });
 
-  it("can hide both upcoming and final from the ticker at once (live only)", () => {
+  it("'Today' (0/0) keeps tonight's game AND today's earlier final", () => {
+    // Calendar-day anchoring: at any time of day, the whole of today
+    // is inside a 0/0 window — a rolling ±0h window would be empty.
     const games = [
-      preGame(1, 10 * 60_000),
-      liveGame(2),
-      finalGame(3, 60 * 60_000),
+      preGame(1, 2 * 3_600_000),   // tips off in 2h (still today at NOW)
+      finalGame(2, 2 * 3_600_000), // ended 2h ago (still today at NOW)
+      preGame(3, 2 * 24 * 3_600_000), // day after tomorrow
     ];
-    const result = selectSportsForTicker(games, {
-      showUpcoming: "off",
-      showFinal: "off",
+    const result = selectSportsForTicker(games, { daysBack: 0, daysAhead: 0 });
+    expect(result.map((g) => g.id)).toEqual([1, 2]);
+  });
+
+  it("live games always show, even outside the window", () => {
+    const games = [
+      liveGame(1),
+      finalGame(2, 4 * 24 * 3_600_000), // way outside
+    ];
+    const result = selectSportsForTicker(games, { daysBack: 0, daysAhead: 0 });
+    expect(result.map((g) => g.id)).toEqual([1]);
+  });
+
+  it("legacy showFinal:'off' maps to daysBack 0 via normalize", () => {
+    const cfg = normalizeSportsDisplayConfig({ showFinal: "off" });
+    expect(cfg.daysBack).toBe(0);
+    expect(cfg.daysAhead).toBe(SPORTS_WINDOW_DEFAULTS.daysAhead);
+  });
+
+  it("legacy showUpcoming:'off' maps to daysAhead 0 via normalize", () => {
+    const cfg = normalizeSportsDisplayConfig({ showUpcoming: "off" });
+    expect(cfg.daysAhead).toBe(0);
+    expect(cfg.daysBack).toBe(SPORTS_WINDOW_DEFAULTS.daysBack);
+  });
+
+  it("explicit stored day values beat the legacy inference and clamp", () => {
+    const cfg = normalizeSportsDisplayConfig({
+      showFinal: "off", // would infer 0…
+      daysBack: 3,      // …but explicit wins
+      daysAhead: 99,    // clamped to the retention horizon
     });
-    expect(result.map((g) => g.id)).toEqual([2]);
+    expect(cfg.daysBack).toBe(3);
+    expect(cfg.daysAhead).toBe(SPORTS_WINDOW_MAX_DAYS);
   });
 
   it("returns [] for empty input", () => {

--- a/desktop/src/channels/sports/view.ts
+++ b/desktop/src/channels/sports/view.ts
@@ -4,13 +4,13 @@
  * Sports display prefs live server-side on the dashboard channel config
  * (not in `prefs.channelDisplay`), so this selector accepts the config
  * blob shape. Both `FeedTab` and `ScrollrTicker` call `selectSportsForTicker`
- * to apply showUpcoming/showFinal filters + engagement sort.
+ * to apply the day window (v1.1.3 Time Controls) + engagement sort.
  *
  * SINGLE SOURCE OF TRUTH for Sports display prefs.
  */
 import type { Game } from "../../types";
-import { isLive, isCloseGame, isFinal, isPre } from "../../utils/gameHelpers";
-import { migrateVenue, shouldShowOnFeed, shouldShowOnTicker } from "../../preferences";
+import { isLive, isCloseGame } from "../../utils/gameHelpers";
+import { migrateVenue } from "../../preferences";
 import type { Venue } from "../../preferences";
 
 // ── Display prefs shape (mirrors server-side channel config.display) ─
@@ -21,10 +21,62 @@ import type { Venue } from "../../preferences";
 // read through `migrateVenue`.
 
 export interface SportsDisplayConfig {
-  showUpcoming?: Venue;
-  showFinal?: Venue;
+  /**
+   * Day window (v1.1.3 Time Controls): show games whose start_time falls
+   * between `daysBack` days ago and `daysAhead` days ahead. LIVE games
+   * always show regardless of the window — a live game is definitionally
+   * "now". Replaces the retired showUpcoming/showFinal venue toggles
+   * (normalizeSportsDisplayConfig still maps legacy stored values).
+   */
+  daysBack?: number;
+  daysAhead?: number;
   showLogos?: Venue;
   showTimer?: Venue;
+}
+
+/** Defaults: yesterday's finals through next week's slate. */
+export const SPORTS_WINDOW_DEFAULTS = { daysBack: 1, daysAhead: 7 } as const;
+
+/**
+ * Hard ceiling for both steppers — the server only retains games ±7 days
+ * (cleanup_old_games in the sports service), so offering more would show
+ * windows with no data in them.
+ */
+export const SPORTS_WINDOW_MAX_DAYS = 7;
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Window predicate shared by the ticker + feed selectors.
+ *
+ * Bounds are anchored to LOCAL CALENDAR DAYS, not rolling 24h periods:
+ * "Today" (0 back / 0 ahead) means all of today — a 7pm tip-off must
+ * not vanish from the window at 3pm. daysBack counts whole days before
+ * today; daysAhead counts whole days after today (inclusive of their
+ * full span).
+ */
+function inDayWindow(
+  g: Game,
+  daysBack: number,
+  daysAhead: number,
+  now: number,
+): boolean {
+  if (isLive(g)) return true;
+  const t = new Date(g.start_time).getTime();
+  // Defensive: an unparseable start_time stays visible rather than
+  // silently vanishing from every surface.
+  if (!Number.isFinite(t)) return true;
+  const dayStart = new Date(now);
+  dayStart.setHours(0, 0, 0, 0);
+  const lower = dayStart.getTime() - daysBack * DAY_MS;
+  const upper = dayStart.getTime() + (daysAhead + 1) * DAY_MS;
+  return t >= lower && t < upper;
+}
+
+function clampWindowDays(v: unknown, fallback: number): number {
+  return typeof v === "number" && Number.isFinite(v)
+    ? Math.min(SPORTS_WINDOW_MAX_DAYS, Math.max(0, Math.round(v)))
+    : fallback;
 }
 
 // ── Pure: engagement score ──────────────────────────────────────
@@ -57,15 +109,11 @@ export function gameEngagement(g: Game): number {
 // ── Pure: selector for the ticker ────────────────────────────────
 
 /**
- * Baseline pipeline used by the ticker: applies `showUpcoming`/`showFinal`
- * filters from the channel config.display blob, then sorts by engagement
- * (live games first, then upcoming, then finals) with a deterministic
- * tie-break on `start_time` so the ticker rail stays stable across
- * dashboard refetches.
- *
- * Filters only apply when the venue is `off` or ticker-only-excluded
- * ("feed"). `both` and `ticker` both permit the category to show on the
- * ticker.
+ * Baseline pipeline used by the ticker: applies the day window from the
+ * channel config.display blob (v1.1.3 Time Controls — live games always
+ * pass), then sorts by engagement (live games first, then upcoming, then
+ * finals) with a deterministic tie-break on `start_time` so the ticker
+ * rail stays stable across dashboard refetches.
  *
  * Tie-break direction is per-state:
  *   - pre/live   → start_time ASC (sooner / more in-progress first)
@@ -75,20 +123,19 @@ export function gameEngagement(g: Game): number {
  * old time-bucketed engagement encoded discretely, without producing a
  * different sort order on every refetch as games drift across clock
  * thresholds.
+ *
+ * `now` is injectable for tests; production callers omit it.
  */
 export function selectSportsForTicker(
   games: Game[],
   config: SportsDisplayConfig | null | undefined,
+  now: number = Date.now(),
 ): Game[] {
   const cfg = config ?? {};
-  const showUpcoming = shouldShowOnTicker(cfg.showUpcoming ?? "both");
-  const showFinal = shouldShowOnTicker(cfg.showFinal ?? "both");
+  const daysBack = cfg.daysBack ?? SPORTS_WINDOW_DEFAULTS.daysBack;
+  const daysAhead = cfg.daysAhead ?? SPORTS_WINDOW_DEFAULTS.daysAhead;
 
-  const filtered = games.filter((g) => {
-    if (!showUpcoming && isPre(g)) return false;
-    if (!showFinal && isFinal(g)) return false;
-    return true;
-  });
+  const filtered = games.filter((g) => inDayWindow(g, daysBack, daysAhead, now));
 
   return filtered.sort((a, b) => {
     const eDiff = gameEngagement(b) - gameEngagement(a);
@@ -103,22 +150,18 @@ export function selectSportsForTicker(
 }
 
 /**
- * Feed-side filter mirroring `selectSportsForTicker`. Filters apply
- * when a category's venue is `off` or ticker-only.
+ * Feed-side filter mirroring `selectSportsForTicker` — same day window,
+ * same live-game bypass, no re-sort (the feed has its own grouping).
  */
 export function selectSportsForFeed(
   games: Game[],
   config: SportsDisplayConfig | null | undefined,
+  now: number = Date.now(),
 ): Game[] {
   const cfg = config ?? {};
-  const showUpcoming = shouldShowOnFeed(cfg.showUpcoming ?? "both");
-  const showFinal = shouldShowOnFeed(cfg.showFinal ?? "both");
-
-  return games.filter((g) => {
-    if (!showUpcoming && isPre(g)) return false;
-    if (!showFinal && isFinal(g)) return false;
-    return true;
-  });
+  const daysBack = cfg.daysBack ?? SPORTS_WINDOW_DEFAULTS.daysBack;
+  const daysAhead = cfg.daysAhead ?? SPORTS_WINDOW_DEFAULTS.daysAhead;
+  return games.filter((g) => inDayWindow(g, daysBack, daysAhead, now));
 }
 
 // ── Helper: extract sports display config from dashboard ────────
@@ -152,9 +195,25 @@ export function normalizeSportsDisplayConfig(
   raw: unknown,
 ): SportsDisplayConfig {
   const obj = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+
+  // Legacy mapping (v1.1.3): the retired showUpcoming/showFinal venue
+  // toggles collapse into the day window. Only "off" ever hid a category
+  // on every surface, so it's the only value whose intent survives:
+  //   showFinal: "off"    → daysBack 0  (user didn't want past games)
+  //   showUpcoming: "off" → daysAhead 0 (user didn't want future games)
+  // Explicit stored day values always win over the legacy inference.
+  const legacyUpcoming = migrateVenue(obj.showUpcoming);
+  const legacyFinal = migrateVenue(obj.showFinal);
+
   return {
-    showUpcoming: migrateVenue(obj.showUpcoming),
-    showFinal: migrateVenue(obj.showFinal),
+    daysBack: clampWindowDays(
+      obj.daysBack,
+      legacyFinal === "off" ? 0 : SPORTS_WINDOW_DEFAULTS.daysBack,
+    ),
+    daysAhead: clampWindowDays(
+      obj.daysAhead,
+      legacyUpcoming === "off" ? 0 : SPORTS_WINDOW_DEFAULTS.daysAhead,
+    ),
     showLogos: migrateVenue(obj.showLogos),
     showTimer: migrateVenue(obj.showTimer),
   };

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -22,7 +22,7 @@ import PredictionChip from "./chips/PredictionChip";
 import FantasyStatChip from "./chips/FantasyStatChip";
 import FollowedPlayerChip from "./chips/FollowedPlayerChip";
 import ConsolidatedChip from "./chips/ConsolidatedChip";
-import { selectRssForTicker } from "../channels/rss/view";
+import { selectRssForTicker, getRssDisplayPrefs } from "../channels/rss/view";
 import { selectFinanceForTicker } from "../channels/finance/view";
 import { selectFantasyForTicker } from "../channels/fantasy/view";
 import { selectSportsForTicker, getSportsDisplayConfig } from "../channels/sports/view";
@@ -475,13 +475,13 @@ export default function ScrollrTicker({
         }
 
         case "rss": {
-          // Apply Display prefs: `articlesPerSource` is feed-structural
-          // but still applies universally (both surfaces cap at the same
-          // per-source count). Per-field visibility (showSource, etc.)
-          // consults the Venue enum.
+          // Global Display prefs merged with THIS widget's config.display
+          // override (v1.1.3: the per-widget time window must gate ticker
+          // chips exactly like the feed — mirror of getSportsDisplayConfig).
           const rssPrefs = channelDisplay?.rss;
           if (!rssPrefs) continue;
-          const curated = selectRssForTicker(data as RssItem[], rssPrefs);
+          const merged = getRssDisplayPrefs(rssPrefs, dashboard, tab);
+          const curated = selectRssForTicker(data as RssItem[], merged);
           for (const item of curated) {
             bucket.push(
               wrap(`rss-${item.id}`,

--- a/desktop/src/components/TimeWindowControl.tsx
+++ b/desktop/src/components/TimeWindowControl.tsx
@@ -37,8 +37,10 @@ function PresetChips({
           aria-pressed={activeKey === o.key}
           className={clsx(
             "rounded-md px-2.5 py-1 text-ui-chip font-medium transition-colors disabled:opacity-50",
+            // Accent-tinted active state — bg-surface on bg-base-150 is
+            // near-invisible in the dark themes (#141420 vs #171726).
             activeKey === o.key
-              ? "bg-surface text-fg-1 shadow-soft-sm"
+              ? "bg-accent/15 font-semibold text-accent"
               : "text-fg-4 hover:text-fg-2",
           )}
         >

--- a/desktop/src/components/TimeWindowControl.tsx
+++ b/desktop/src/components/TimeWindowControl.tsx
@@ -1,0 +1,232 @@
+/**
+ * Time Controls (v1.1.3) — preset chips + steppers for per-widget day
+ * windows. Two flavors sharing internals:
+ *   - DayRangeControl (sports): games from N days back to N days ahead
+ *   - ArticleAgeControl (news): articles from the last N days (0 = all)
+ *
+ * Presets cover the 90% case; "Custom" reveals steppers. A value that
+ * matches no preset renders as Custom with the steppers open.
+ */
+import { useState } from "react";
+import clsx from "clsx";
+import { Minus, Plus } from "lucide-react";
+
+// ── Shared primitives ───────────────────────────────────────────
+
+function PresetChips({
+  options,
+  activeKey,
+  disabled,
+  onPick,
+}: {
+  options: { key: string; label: string }[];
+  activeKey: string;
+  disabled?: boolean;
+  onPick: (key: string) => void;
+}) {
+  return (
+    <div
+      className="flex items-center gap-0.5 self-start rounded-lg border border-edge/40 bg-base-150/40 p-0.5"
+      role="group"
+    >
+      {options.map((o) => (
+        <button
+          key={o.key}
+          disabled={disabled}
+          onClick={() => onPick(o.key)}
+          aria-pressed={activeKey === o.key}
+          className={clsx(
+            "rounded-md px-2.5 py-1 text-ui-chip font-medium transition-colors disabled:opacity-50",
+            activeKey === o.key
+              ? "bg-surface text-fg-1 shadow-soft-sm"
+              : "text-fg-4 hover:text-fg-2",
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Stepper({
+  label,
+  value,
+  min,
+  max,
+  disabled,
+  format,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  disabled?: boolean;
+  /** Value display, e.g. (n) => `${n}d`. Defaults to String. */
+  format?: (n: number) => string;
+  onChange: (n: number) => void;
+}) {
+  const clamp = (n: number) => Math.min(max, Math.max(min, n));
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-ui-meta text-fg-3">{label}</span>
+      <div className="flex items-center gap-1">
+        <button
+          disabled={disabled || value <= min}
+          onClick={() => onChange(clamp(value - 1))}
+          aria-label={`Decrease ${label}`}
+          className="flex h-6 w-6 items-center justify-center rounded-md border border-edge/40 text-fg-3 transition-colors hover:bg-base-200 hover:text-fg-1 disabled:opacity-40"
+        >
+          <Minus size={12} />
+        </button>
+        <span className="min-w-[3.5rem] text-center text-ui-meta font-semibold tabular-nums text-fg-1">
+          {(format ?? String)(value)}
+        </span>
+        <button
+          disabled={disabled || value >= max}
+          onClick={() => onChange(clamp(value + 1))}
+          aria-label={`Increase ${label}`}
+          className="flex h-6 w-6 items-center justify-center rounded-md border border-edge/40 text-fg-3 transition-colors hover:bg-base-200 hover:text-fg-1 disabled:opacity-40"
+        >
+          <Plus size={12} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Sports: two-sided day range ─────────────────────────────────
+
+const RANGE_PRESETS = [
+  { key: "today", label: "Today", back: 0, ahead: 0 },
+  { key: "week", label: "This week", back: 1, ahead: 7 },
+  { key: "max", label: "Everything", back: 7, ahead: 7 },
+] as const;
+
+export function DayRangeControl({
+  daysBack,
+  daysAhead,
+  max,
+  disabled,
+  onChange,
+}: {
+  daysBack: number;
+  daysAhead: number;
+  /** Server retention horizon — steppers clamp here. */
+  max: number;
+  disabled?: boolean;
+  onChange: (next: { daysBack: number; daysAhead: number }) => void;
+}) {
+  const matched = RANGE_PRESETS.find(
+    (p) => p.back === daysBack && p.ahead === daysAhead,
+  );
+  const [customOpen, setCustomOpen] = useState(!matched);
+  const activeKey = customOpen ? "custom" : (matched?.key ?? "custom");
+
+  return (
+    <div className="flex flex-col gap-2 px-3 py-2">
+      <PresetChips
+        options={[...RANGE_PRESETS, { key: "custom", label: "Custom" }]}
+        activeKey={activeKey}
+        disabled={disabled}
+        onPick={(key) => {
+          if (key === "custom") {
+            setCustomOpen(true);
+            return;
+          }
+          setCustomOpen(false);
+          const p = RANGE_PRESETS.find((x) => x.key === key);
+          if (p) onChange({ daysBack: p.back, daysAhead: p.ahead });
+        }}
+      />
+      {activeKey === "custom" && (
+        <div className="flex flex-col gap-1.5 rounded-lg border border-edge/30 bg-base-150/30 px-3 py-2">
+          <Stepper
+            label="Days back"
+            value={daysBack}
+            min={0}
+            max={max}
+            disabled={disabled}
+            format={(n) => (n === 0 ? "Off" : `${n}d`)}
+            onChange={(n) => onChange({ daysBack: n, daysAhead })}
+          />
+          <Stepper
+            label="Days ahead"
+            value={daysAhead}
+            min={0}
+            max={max}
+            disabled={disabled}
+            format={(n) => (n === 0 ? "Off" : `${n}d`)}
+            onChange={(n) => onChange({ daysBack, daysAhead: n })}
+          />
+        </div>
+      )}
+      <p className="text-ui-chip leading-relaxed text-fg-4">
+        Live games always show. Scores stay for up to {max} days.
+      </p>
+    </div>
+  );
+}
+
+// ── News: one-sided article age ─────────────────────────────────
+
+const AGE_PRESETS = [
+  { key: "today", label: "Today", days: 1 },
+  { key: "3d", label: "3 days", days: 3 },
+  { key: "week", label: "Week", days: 7 },
+  { key: "all", label: "All", days: 0 },
+] as const;
+
+export const ARTICLE_AGE_MAX_DAYS = 30;
+
+export function ArticleAgeControl({
+  maxAgeDays,
+  disabled,
+  onChange,
+}: {
+  /** 0 = no age filter (every article the server sends). */
+  maxAgeDays: number;
+  disabled?: boolean;
+  onChange: (days: number) => void;
+}) {
+  const matched = AGE_PRESETS.find((p) => p.days === maxAgeDays);
+  const [customOpen, setCustomOpen] = useState(!matched);
+  const activeKey = customOpen ? "custom" : (matched?.key ?? "custom");
+
+  return (
+    <div className="flex flex-col gap-2 px-3 py-2">
+      <PresetChips
+        options={[...AGE_PRESETS, { key: "custom", label: "Custom" }]}
+        activeKey={activeKey}
+        disabled={disabled}
+        onPick={(key) => {
+          if (key === "custom") {
+            setCustomOpen(true);
+            return;
+          }
+          setCustomOpen(false);
+          const p = AGE_PRESETS.find((x) => x.key === key);
+          if (p) onChange(p.days);
+        }}
+      />
+      {activeKey === "custom" && (
+        <div className="rounded-lg border border-edge/30 bg-base-150/30 px-3 py-2">
+          <Stepper
+            label="Last N days"
+            value={maxAgeDays === 0 ? 1 : maxAgeDays}
+            min={1}
+            max={ARTICLE_AGE_MAX_DAYS}
+            disabled={disabled}
+            format={(n) => `${n}d`}
+            onChange={onChange}
+          />
+        </div>
+      )}
+      <p className="text-ui-chip leading-relaxed text-fg-4">
+        Articles older than the window are hidden everywhere. "All" shows
+        everything your feeds provide.
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/hooks/useSportsConfig.ts
+++ b/desktop/src/hooks/useSportsConfig.ts
@@ -12,7 +12,10 @@ import type { ChannelType } from "../api/client";
 import type { DashboardResponse } from "../types";
 import { queryKeys } from "../api/queries";
 import { useShellData } from "../shell-context";
-import { normalizeSportsDisplayConfig } from "../channels/sports/view";
+import {
+  normalizeSportsDisplayConfig,
+  SPORTS_WINDOW_DEFAULTS,
+} from "../channels/sports/view";
 import type { Venue } from "../preferences";
 
 export interface FavoriteTeam {
@@ -21,8 +24,9 @@ export interface FavoriteTeam {
 }
 
 export interface SportsDisplayPrefs {
-  showUpcoming: Venue;
-  showFinal: Venue;
+  /** Day window (v1.1.3 Time Controls) — see SportsDisplayConfig. */
+  daysBack: number;
+  daysAhead: number;
   showLogos: Venue;
   showTimer: Venue;
 }
@@ -34,8 +38,8 @@ export interface SportsConfig {
 }
 
 const DEFAULT_DISPLAY: SportsDisplayPrefs = {
-  showUpcoming: "both",
-  showFinal: "both",
+  daysBack: SPORTS_WINDOW_DEFAULTS.daysBack,
+  daysAhead: SPORTS_WINDOW_DEFAULTS.daysAhead,
   showLogos: "both",
   showTimer: "both",
 };
@@ -51,16 +55,16 @@ export function useSportsConfig(channelType: string = "sports") {
   const raw = (sportsChannel?.config ?? {}) as Record<string, unknown>;
 
   const config: SportsConfig = useMemo(() => {
-    // v1.0.2: normalize raw.display through `migrateVenue` so
-    // pre-venue-enum boolean configs (stored server-side by clients on
-    // <v1.0.2) deserialize to valid Venue values. `normalizeSportsDisplayConfig`
-    // returns a SportsDisplayConfig with all four fields populated.
+    // `normalizeSportsDisplayConfig` handles both legacy migrations:
+    // v1.0.2 boolean→Venue for the cosmetic toggles, and v1.1.3
+    // showUpcoming/showFinal→day-window mapping (an "off" toggle
+    // becomes 0 days on that side).
     const normalizedDisplay = normalizeSportsDisplayConfig(raw.display);
     return {
       leagues: Array.isArray(raw.leagues) ? (raw.leagues as string[]) : [],
       display: {
-        showUpcoming: normalizedDisplay.showUpcoming ?? DEFAULT_DISPLAY.showUpcoming,
-        showFinal: normalizedDisplay.showFinal ?? DEFAULT_DISPLAY.showFinal,
+        daysBack: normalizedDisplay.daysBack ?? DEFAULT_DISPLAY.daysBack,
+        daysAhead: normalizedDisplay.daysAhead ?? DEFAULT_DISPLAY.daysAhead,
         showLogos: normalizedDisplay.showLogos ?? DEFAULT_DISPLAY.showLogos,
         showTimer: normalizedDisplay.showTimer ?? DEFAULT_DISPLAY.showTimer,
       },

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -426,6 +426,10 @@ export interface RssDisplayPrefs {
   showSource: Venue;
   showTimestamps: Venue;
   articlesPerSource: number; // 0 = all (the default since v1.1.1); 1/3/5/10 legacy per-source caps
+  /** v1.1.3 Time Controls: hide articles older than N days (published_at,
+   *  falling back to created_at). 0 = no age filter — every article the
+   *  server sends, which is the pre-v1.1.3 behavior. */
+  maxArticleAgeDays: number;
 }
 
 export type FantasySubTab = "overview" | "matchup" | "standings" | "roster";
@@ -644,6 +648,7 @@ const DEFAULT_CHANNEL_DISPLAY: ChannelDisplayPrefs = {
     showSource: "both",
     showTimestamps: "both",
     articlesPerSource: 0,
+    maxArticleAgeDays: 0,
   },
   predictions: {
     showDelta: "both",
@@ -1111,6 +1116,13 @@ export function migrateRssDisplay(
       typeof raw.articlesPerSource === "number" && raw.articlesPerSource !== 4
         ? raw.articlesPerSource
         : DEFAULT_CHANNEL_DISPLAY.rss.articlesPerSource,
+    // v1.1.3: clamp to a sane range; missing/invalid → 0 (no filter),
+    // which is exactly the pre-v1.1.3 behavior.
+    maxArticleAgeDays:
+      typeof raw.maxArticleAgeDays === "number" &&
+      Number.isFinite(raw.maxArticleAgeDays)
+        ? Math.min(30, Math.max(0, Math.round(raw.maxArticleAgeDays)))
+        : DEFAULT_CHANNEL_DISPLAY.rss.maxArticleAgeDays,
   };
 }
 

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -250,8 +250,11 @@ function CatalogPage() {
                 aria-pressed={sort === s.key}
                 className={clsx(
                   "flex items-center gap-1 rounded-md px-2.5 py-1 text-ui-chip font-medium transition-colors",
+                  // Accent-tinted active state — bg-surface on bg-base-150
+                  // is near-invisible in the dark themes (v1.1.3 fix,
+                  // matches TimeWindowControl).
                   sort === s.key
-                    ? "bg-surface text-fg-1 shadow-soft-sm"
+                    ? "bg-accent/15 font-semibold text-accent"
                     : "text-fg-4 hover:text-fg-2",
                 )}
               >

--- a/myscrollr.com/src/components/TiltCard.tsx
+++ b/myscrollr.com/src/components/TiltCard.tsx
@@ -1,0 +1,67 @@
+/**
+ * useTilt — pointer-tracking 3D card tilt with spring return.
+ *
+ * Ported from the motion-v (Vue) TiltCard example for the pricing
+ * cards: the card rotates toward the pointer (up to `maxTilt` degrees)
+ * and sinks slightly on entry, springing flat again on leave. Spread
+ * the returned pieces onto a `motion.div`:
+ *
+ *   const tilt = useTilt()
+ *   <motion.div ref={tilt.ref} style={tilt.style} {...tilt.handlers} />
+ *
+ * The springs are standalone MotionValues, so they compose with any
+ * `initial`/`animate` entrance the element already has (transform
+ * channels merge; the entrance `y` and the tilt `rotateX/rotateY/z`
+ * don't fight).
+ */
+import { useRef } from 'react'
+import { useSpring } from 'motion/react'
+import type { MotionStyle } from 'motion/react'
+import type * as React from 'react'
+
+const TILT_SPRING = { stiffness: 200, damping: 20 }
+
+export function useTilt(maxTilt = 7): {
+  ref: React.RefObject<HTMLDivElement | null>
+  style: MotionStyle
+  handlers: {
+    onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void
+    onPointerEnter: () => void
+    onPointerLeave: () => void
+  }
+} {
+  const ref = useRef<HTMLDivElement>(null)
+  const rotateX = useSpring(0, TILT_SPRING)
+  const rotateY = useSpring(0, TILT_SPRING)
+  const z = useSpring(0, TILT_SPRING)
+
+  return {
+    ref,
+    style: {
+      // Perspective on the element itself so the z push-back reads;
+      // 800px keeps wide cards subtle (500 gets fishbowl-y).
+      transformPerspective: 800,
+      z,
+      rotateX,
+      rotateY,
+      willChange: 'transform',
+    },
+    handlers: {
+      onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => {
+        const el = ref.current
+        if (!el) return
+        const rect = el.getBoundingClientRect()
+        const xPercent = (e.clientX - rect.left) / rect.width
+        const yPercent = (e.clientY - rect.top) / rect.height
+        rotateX.set(maxTilt * (0.5 - yPercent))
+        rotateY.set(maxTilt * (xPercent - 0.5))
+      },
+      onPointerEnter: () => z.set(-6),
+      onPointerLeave: () => {
+        rotateX.set(0)
+        rotateY.set(0)
+        z.set(0)
+      },
+    },
+  }
+}

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -58,6 +58,7 @@ import { seededRandom } from '@/lib/seededRandom'
 import { FALLBACK_LIMITS } from '@/lib/fallbackTierLimits'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import { useGetToken } from '@/hooks/useGetToken'
+import { useTilt } from '@/components/TiltCard'
 import { billingApi, tierLimitsApi } from '@/api/client'
 import { FAQSection } from '@/components/landing/FAQSection'
 
@@ -962,6 +963,13 @@ function UplinkPage() {
   // Rebuilds the comparison table, tier showcases, and FAQ whenever the
   // fetch resolves or the cached response changes.
   const tierLimits = useTierLimits()
+
+  // Pointer-tracking 3D tilt for the four plan cards (v1.1.3 polish).
+  // One spring set per card; replaces the old whileHover y-lift.
+  const freeTilt = useTilt()
+  const uplinkTilt = useTilt()
+  const proTilt = useTilt()
+  const ultimateTilt = useTilt()
   const comparisonRows = useMemo(
     () => buildComparison(tierLimits),
     [tierLimits],
@@ -2283,6 +2291,9 @@ function UplinkPage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.03, duration: 0.5, ease: EASE }}
+                    ref={freeTilt.ref}
+                    style={freeTilt.style}
+                    {...freeTilt.handlers}
                     className="group relative bg-base-200/20 border border-base-300/20 rounded-xl p-6 overflow-hidden flex flex-col"
                   >
                     <div className="relative z-10 flex flex-col flex-1">
@@ -2327,7 +2338,7 @@ function UplinkPage() {
 
                       {/* v1.1.3: the card IS the widget cap — everything
                           else lives in the compare table below. */}
-                      <div className="mb-6 flex flex-col items-center gap-1.5 py-5">
+                      <div className="mb-6 flex flex-col items-start gap-1.5 py-5">
                         <span className="font-mono text-6xl font-black leading-none text-base-content/80">
                           {tierLimits.tiers.free.max_widgets}
                         </span>
@@ -2372,10 +2383,9 @@ function UplinkPage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.06, duration: 0.5, ease: EASE }}
-                    whileHover={{
-                      y: -3,
-                      transition: { type: 'tween', duration: 0.2 },
-                    }}
+                    ref={uplinkTilt.ref}
+                    style={uplinkTilt.style}
+                    {...uplinkTilt.handlers}
                     role="button"
                     tabIndex={isTierDisabled('uplink') ? -1 : 0}
                     // No aria-label: the card's visible content (tier
@@ -2482,7 +2492,7 @@ function UplinkPage() {
                         </div>
                       </div>
 
-                      <div className="mb-6 flex flex-col items-center gap-1.5 py-5">
+                      <div className="mb-6 flex flex-col items-start gap-1.5 py-5">
                         <span
                           className="font-mono text-6xl font-black leading-none"
                           style={{
@@ -2524,10 +2534,9 @@ function UplinkPage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.09, duration: 0.5, ease: EASE }}
-                    whileHover={{
-                      y: -3,
-                      transition: { type: 'tween', duration: 0.2 },
-                    }}
+                    ref={proTilt.ref}
+                    style={proTilt.style}
+                    {...proTilt.handlers}
                     role="button"
                     tabIndex={isTierDisabled('pro') ? -1 : 0}
                     // See Uplink card above for why aria-label is omitted.
@@ -2629,7 +2638,7 @@ function UplinkPage() {
                         </div>
                       </div>
 
-                      <div className="mb-6 flex flex-col items-center gap-1.5 py-5">
+                      <div className="mb-6 flex flex-col items-start gap-1.5 py-5">
                         <span
                           className="font-mono text-6xl font-black leading-none"
                           style={{
@@ -2671,10 +2680,9 @@ function UplinkPage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.12, duration: 0.5, ease: EASE }}
-                    whileHover={{
-                      y: -4,
-                      transition: { type: 'tween', duration: 0.2 },
-                    }}
+                    ref={ultimateTilt.ref}
+                    style={ultimateTilt.style}
+                    {...ultimateTilt.handlers}
                     role="button"
                     tabIndex={isTierDisabled('ultimate') ? -1 : 0}
                     // See Uplink card above for why aria-label is omitted.
@@ -2919,7 +2927,7 @@ function UplinkPage() {
                           </div>
                         </div>
 
-                        <div className="mb-6 flex flex-col items-center gap-1.5 py-5">
+                        <div className="mb-6 flex flex-col items-start gap-1.5 py-5">
                           <span
                             className="font-mono text-6xl font-black leading-none"
                             style={{

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -466,11 +466,13 @@ interface PricingPlan {
 const PRICING: Record<TierKey, Record<PlanKey, PricingPlan>> = {
   uplink: {
     monthly: { price: 9.99, period: '/mo', perMonth: 9.99 },
+    // Annual = exactly 8x monthly on every tier — sell it as time, not
+    // a dollar delta ("4 months free" beats "Save ~$40/yr").
     annual: {
       price: 79.99,
       period: '/yr',
       perMonth: 6.67,
-      savings: 'Save ~$40/yr',
+      savings: '4 months free',
     },
   },
   pro: {
@@ -479,7 +481,7 @@ const PRICING: Record<TierKey, Record<PlanKey, PricingPlan>> = {
       price: 199.99,
       period: '/yr',
       perMonth: 16.67,
-      savings: 'Save ~$100/yr',
+      savings: '4 months free',
     },
   },
   ultimate: {
@@ -488,7 +490,7 @@ const PRICING: Record<TierKey, Record<PlanKey, PricingPlan>> = {
       price: 399.99,
       period: '/yr',
       perMonth: 33.33,
-      savings: 'Save ~$200/yr',
+      savings: '4 months free',
     },
   },
 }
@@ -2325,8 +2327,8 @@ function UplinkPage() {
 
                       {/* v1.1.3: the card IS the widget cap — everything
                           else lives in the compare table below. */}
-                      <div className="mb-6 flex flex-col items-center gap-1 py-4">
-                        <span className="font-mono text-5xl font-bold text-base-content/90">
+                      <div className="mb-6 flex flex-col items-center gap-1.5 py-5">
+                        <span className="font-mono text-6xl font-black leading-none text-base-content/80">
                           {tierLimits.tiers.free.max_widgets}
                         </span>
                         <span className="text-[10px] font-mono uppercase tracking-widest text-base-content/40">
@@ -2480,8 +2482,14 @@ function UplinkPage() {
                         </div>
                       </div>
 
-                      <div className="mb-6 flex flex-col items-center gap-1 py-4">
-                        <span className="font-mono text-5xl font-bold text-base-content/90">
+                      <div className="mb-6 flex flex-col items-center gap-1.5 py-5">
+                        <span
+                          className="font-mono text-6xl font-black leading-none"
+                          style={{
+                            color: '#00b8db',
+                            textShadow: '0 0 28px #00b8db40',
+                          }}
+                        >
                           {tierLimits.tiers.uplink.max_widgets}
                         </span>
                         <span className="text-[10px] font-mono uppercase tracking-widest text-base-content/40">
@@ -2621,8 +2629,14 @@ function UplinkPage() {
                         </div>
                       </div>
 
-                      <div className="mb-6 flex flex-col items-center gap-1 py-4">
-                        <span className="font-mono text-5xl font-bold text-base-content/90">
+                      <div className="mb-6 flex flex-col items-center gap-1.5 py-5">
+                        <span
+                          className="font-mono text-6xl font-black leading-none"
+                          style={{
+                            color: '#a78bfa',
+                            textShadow: '0 0 28px #a78bfa40',
+                          }}
+                        >
                           {tierLimits.tiers.uplink_pro.max_widgets}
                         </span>
                         <span className="text-[10px] font-mono uppercase tracking-widest text-base-content/40">
@@ -2905,8 +2919,14 @@ function UplinkPage() {
                           </div>
                         </div>
 
-                        <div className="mb-6 flex flex-col items-center gap-1 py-4">
-                          <span className="font-mono text-5xl font-bold text-base-content/90">
+                        <div className="mb-6 flex flex-col items-center gap-1.5 py-5">
+                          <span
+                            className="font-mono text-6xl font-black leading-none"
+                            style={{
+                              color: '#34d399',
+                              textShadow: '0 0 28px #34d39940',
+                            }}
+                          >
                             ∞
                           </span>
                           <span className="text-[10px] font-mono uppercase tracking-widest text-base-content/40">

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -294,31 +294,10 @@ function buildComparison(limits: TierLimitsResponse): Array<ComparisonRow> {
       pro: 'Real-time SSE',
       ultimate: 'Real-time SSE',
     },
-    {
-      label: 'Items per Widget',
-      free: 'Unlimited',
-      uplink: 'Unlimited',
-      pro: 'Unlimited',
-      ultimate: 'Unlimited',
-    },
-    {
-      // Tier gate retired v1.1.2 — a normal widget on every plan. The row
-      // stays because four checkmarks SELL the giveaway better than silence.
-      label: 'Yahoo Fantasy',
-      free: 'Yes',
-      uplink: 'Yes',
-      pro: 'Yes',
-      ultimate: 'Yes',
-    },
-    {
-      label: 'Site Filtering',
-      free: 'Blacklist',
-      uplink: 'Blacklist',
-      pro: 'Blacklist + Whitelist',
-      ultimate: 'Blacklist + Whitelist',
-      proUp: true,
-      ultimateUp: true,
-    },
+    // v1.1.3 trim: Items-per-Widget, Yahoo Fantasy, and Site Filtering
+    // rows removed — rows where every column reads the same (or that
+    // describe table-stakes) dilute the one comparison that sells:
+    // widgets at once.
     {
       label: 'Custom Alerts',
       free: 'No',
@@ -348,24 +327,7 @@ function buildComparison(limits: TierLimitsResponse): Array<ComparisonRow> {
       proUp: true,
       ultimateUp: true,
     },
-    {
-      label: 'Priority RSS Refresh',
-      free: 'No',
-      uplink: 'No',
-      pro: 'Yes',
-      ultimate: 'Yes',
-      proUp: true,
-      ultimateUp: true,
-    },
-    {
-      label: 'Webhooks & Integrations',
-      free: 'No',
-      uplink: 'No',
-      pro: 'No',
-      ultimate: 'Yes',
-      ultimateUp: true,
-      comingSoon: true,
-    },
+    // v1.1.3 trim: Priority-RSS and Webhooks rows removed (see above).
     {
       label: 'Data Export',
       free: 'No',
@@ -405,13 +367,7 @@ function buildComparison(limits: TierLimitsResponse): Array<ComparisonRow> {
       proUp: true,
       ultimateUp: true,
     },
-    {
-      label: 'Dashboard Access',
-      free: 'Full',
-      uplink: 'Full',
-      pro: 'Full',
-      ultimate: 'Full',
-    },
+    // v1.1.3 trim: Dashboard-Access row removed (all-"Full" row said nothing).
   ]
 }
 
@@ -991,33 +947,10 @@ function BottomCTA({
   )
 }
 
-// ── Pricing Feature Line ──────────────────────────────────────────
-
-function PricingFeature({
-  children,
-  highlight,
-}: {
-  children: React.ReactNode
-  highlight?: boolean
-}) {
-  return (
-    <div className="flex items-center gap-2.5">
-      <Check
-        size={12}
-        className={
-          highlight ? 'text-primary shrink-0' : 'text-base-content/20 shrink-0'
-        }
-      />
-      <span
-        className={`text-xs ${highlight ? 'text-base-content/60' : 'text-base-content/35'}`}
-      >
-        {children}
-      </span>
-    </div>
-  )
-}
-
 // ── Page Component ──────────────────────────────────────────────
+// (PricingFeature bullet-line component retired v1.1.3 — the plan
+// cards show only the widget cap; differentiators live in the
+// compare table.)
 
 function UplinkPage() {
   const { isAuthenticated, signIn } = useScrollrAuth()
@@ -2390,16 +2323,15 @@ function UplinkPage() {
                         </div>
                       </div>
 
-                      <div className="space-y-2.5 mb-6">
-                        <PricingFeature>
-                          {tierLimits.tiers.free.max_widgets} widgets at once
-                        </PricingFeature>
-                        <PricingFeature>Real-time SSE delivery</PricingFeature>
-                        <PricingFeature>
-                          Unlimited items per widget
-                        </PricingFeature>
-                        <PricingFeature>Every sports league</PricingFeature>
-                        <PricingFeature>Full desktop app access</PricingFeature>
+                      {/* v1.1.3: the card IS the widget cap — everything
+                          else lives in the compare table below. */}
+                      <div className="mb-6 flex flex-col items-center gap-1 py-4">
+                        <span className="font-mono text-5xl font-bold text-base-content/90">
+                          {tierLimits.tiers.free.max_widgets}
+                        </span>
+                        <span className="text-[10px] font-mono uppercase tracking-widest text-base-content/40">
+                          widgets at once
+                        </span>
                       </div>
 
                       <div className="mt-auto pt-2 flex flex-col items-center gap-1.5">
@@ -2548,17 +2480,13 @@ function UplinkPage() {
                         </div>
                       </div>
 
-                      <div className="space-y-2.5 mb-6">
-                        <PricingFeature>
-                          {tierLimits.tiers.uplink.max_widgets} widgets at once
-                        </PricingFeature>
-                        <PricingFeature>Priority support</PricingFeature>
-                        <PricingFeature>Real-time SSE delivery</PricingFeature>
-                        <PricingFeature>
-                          Unlimited items per widget
-                        </PricingFeature>
-                        <PricingFeature>Every sports league</PricingFeature>
-                        <PricingFeature>Early access</PricingFeature>
+                      <div className="mb-6 flex flex-col items-center gap-1 py-4">
+                        <span className="font-mono text-5xl font-bold text-base-content/90">
+                          {tierLimits.tiers.uplink.max_widgets}
+                        </span>
+                        <span className="text-[10px] font-mono uppercase tracking-widest text-base-content/40">
+                          widgets at once
+                        </span>
                       </div>
 
                       <div className="mt-auto pt-2 flex flex-col items-center gap-1.5">
@@ -2693,26 +2621,13 @@ function UplinkPage() {
                         </div>
                       </div>
 
-                      <div className="space-y-2.5 mb-6">
-                        <PricingFeature highlight>
-                          {tierLimits.tiers.uplink_pro.max_widgets} widgets at
-                          once
-                        </PricingFeature>
-                        <PricingFeature highlight>
-                          Custom alerts & notifications
-                        </PricingFeature>
-                        <PricingFeature highlight>
-                          Feed profiles & controls
-                        </PricingFeature>
-                        <PricingFeature highlight>
-                          Priority RSS refresh
-                        </PricingFeature>
-                        <PricingFeature highlight>
-                          Whitelist site filtering
-                        </PricingFeature>
-                        <PricingFeature highlight>
-                          Everything in Uplink
-                        </PricingFeature>
+                      <div className="mb-6 flex flex-col items-center gap-1 py-4">
+                        <span className="font-mono text-5xl font-bold text-base-content/90">
+                          {tierLimits.tiers.uplink_pro.max_widgets}
+                        </span>
+                        <span className="text-[10px] font-mono uppercase tracking-widest text-base-content/40">
+                          widgets at once
+                        </span>
                       </div>
 
                       <div className="mt-auto pt-2 flex flex-col items-center gap-1.5">
@@ -2990,25 +2905,13 @@ function UplinkPage() {
                           </div>
                         </div>
 
-                        <div className="space-y-2.5 mb-6">
-                          <PricingFeature highlight>
-                            Unlimited widgets at once
-                          </PricingFeature>
-                          <PricingFeature highlight>
-                            Unlimited everything
-                          </PricingFeature>
-                          <PricingFeature highlight>
-                            Webhooks & integrations
-                          </PricingFeature>
-                          <PricingFeature highlight>
-                            Data export & API access
-                          </PricingFeature>
-                          <PricingFeature highlight>
-                            Priority support
-                          </PricingFeature>
-                          <PricingFeature highlight>
-                            Everything in Pro, plus more
-                          </PricingFeature>
+                        <div className="mb-6 flex flex-col items-center gap-1 py-4">
+                          <span className="font-mono text-5xl font-bold text-base-content/90">
+                            ∞
+                          </span>
+                          <span className="text-[10px] font-mono uppercase tracking-widest text-base-content/40">
+                            widgets at once
+                          </span>
                         </div>
 
                         <div className="mt-auto pt-2 flex flex-col items-center gap-1.5">


### PR DESCRIPTION
Replaces the venue-era show-upcoming/show-final toggles with the control people actually think in: **how many days back, how many days ahead** — per widget, honored identically by the feed and the ticker.

## Server (makes the window real)
- **Finals now survive 7 days** (was 12 hours) in the sports service cleanup — "show me the last 3 days of scores" finally has data to show. Pre-game and live thresholds unchanged.
- **DashboardSportsLimit 20 → 60** so a week of finals and the upcoming slate fit the payload without starving each other; per-league fair share unchanged.

## Desktop
- **Sports**: `daysBack`/`daysAhead` (defaults 1/7, clamped to the 7-day retention horizon) on the per-widget `config.display`. Windows are **local-calendar-day anchored** — "Today" means all of today, so tonight''s game doesn''t vanish at 3pm — and **live games always show**. The old toggles are retired; a stored `showFinal: "off"` maps to 0 days back (and `showUpcoming: "off"` to 0 ahead) so nobody''s intent is lost. ScoresTab drops its duplicated filter and shares the selector; its status quick-filter narrows within the window.
- **News**: `maxArticleAgeDays` (0 = all — the default, i.e. today''s exact behavior) filters both `applyRssPipeline` and `selectRssForTicker` *before* the per-source balancer, so stale articles can''t consume slots. New `getRssDisplayPrefs` merges per-widget overrides into the **ticker** path (mirror of `getSportsDisplayConfig`) — previously the ticker read only global rss prefs.
- **UI**: shared `TimeWindowControl` — preset chips (Today / This week / Everything · Today / 3 days / Week / All) with steppers behind Custom; wired into the sports Configure and both news Configure branches.

## Verification
Desktop `tsc` clean + **437/437** vitest (11 new: calendar-day window boundaries, the live-game bypass, legacy-toggle migration mapping, article-age filtering on both surfaces). Sports API `go build` + tests green; Rust service `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)