### PR TITLE
fix(core): auth fail-open on the dynamic proxy — Auth:true channel routes were public

### DIFF
--- a/api/core/auth.go
+++ b/api/core/auth.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -97,10 +98,24 @@ func ValidateToken(tokenString string) (sub string, claims jwt.MapClaims, err er
 	return sub, mapClaims, nil
 }
 
+// ErrUnauthenticated signals that ValidateAuth rejected the request and has
+// ALREADY written the 401 response. Callers must stop processing and return
+// nil so the written response stands — returning this error instead sends
+// Fiber's default error shape (still fails closed, but with the wrong body).
+var ErrUnauthenticated = errors.New("unauthenticated")
+
 // ValidateAuth extracts and validates the JWT from the request, setting
 // user_id and user_roles in c.Locals. It does NOT call c.Next(), making it
 // safe to use inline (e.g. from the dynamic proxy) without advancing
 // Fiber's handler chain.
+//
+// Returns nil ONLY when authentication succeeded. On failure it writes the
+// 401 response and returns ErrUnauthenticated. (It previously returned the
+// result of c.JSON — nil on a successful write — so `err != nil` callers
+// treated a rendered 401 as auth success and kept going: the dynamic proxy
+// forwarded unauthenticated requests to channels, whose upstream response
+// then overwrote the 401. That fail-open made every Auth:true channel route
+// effectively public.)
 func ValidateAuth(c *fiber.Ctx) error {
 	tokenString := ""
 	authHeader := c.Get("Authorization")
@@ -117,19 +132,21 @@ func ValidateAuth(c *fiber.Ctx) error {
 	}
 
 	if tokenString == "" {
-		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+		_ = c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
 			Status: "unauthorized",
 			Error:  "Missing authentication",
 		})
+		return ErrUnauthenticated
 	}
 
 	sub, claims, err := ValidateToken(tokenString)
 	if err != nil {
 		log.Printf("[Auth Error] %v", err)
-		return c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
+		_ = c.Status(fiber.StatusUnauthorized).JSON(ErrorResponse{
 			Status: "unauthorized",
 			Error:  "Invalid or expired token",
 		})
+		return ErrUnauthenticated
 	}
 
 	c.Locals("user_id", sub)
@@ -179,11 +196,14 @@ func ValidateAuth(c *fiber.Ctx) error {
 }
 
 // LogtoAuth is the Fiber middleware that validates the Logto JWT and advances
-// to the next handler. For inline auth checks (e.g. in the dynamic proxy),
+// to the next handler. For inline auth checks (e.g. from the dynamic proxy),
 // use ValidateAuth instead.
 func LogtoAuth(c *fiber.Ctx) error {
 	if err := ValidateAuth(c); err != nil {
-		return err
+		// ValidateAuth already wrote the 401 — do NOT advance the chain
+		// (protected handlers must never execute unauthenticated), and
+		// return nil so the written response stands.
+		return nil
 	}
 	return c.Next()
 }

--- a/api/core/proxy.go
+++ b/api/core/proxy.go
@@ -56,7 +56,10 @@ func dynamicProxyHandler(c *fiber.Ctx) error {
 		if route.Auth {
 			if err := ValidateAuth(c); err != nil {
 				log.Printf("[Proxy] Auth failed for %s %s: %v", requestMethod, requestPath, err)
-				return err
+				// ValidateAuth already wrote the 401 — returning nil keeps
+				// it. Proxying anyway would let the upstream response
+				// overwrite the 401 (the fail-open this fixes).
+				return nil
 			}
 		}
 

--- a/api/core/proxy_auth_test.go
+++ b/api/core/proxy_auth_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// Regression tests for the dynamic-proxy fail-open (2026-07-03): ValidateAuth
+// used to return c.JSON's nil after writing a 401, so `err != nil` callers
+// treated a rendered 401 as success — the proxy forwarded unauthenticated
+// requests and the upstream response overwrote the 401, making every
+// Auth:true channel route effectively public.
+
+// seedTestChannel installs a fake channel in the discovery registry and
+// returns a restore func. Tests using it must not run in parallel.
+func seedTestChannel(t *testing.T, info *ChannelInfo) func() {
+	t.Helper()
+	globalDiscovery.mu.Lock()
+	prev := globalDiscovery.channels
+	globalDiscovery.channels = map[string]*ChannelInfo{info.Name: info}
+	globalDiscovery.mu.Unlock()
+	return func() {
+		globalDiscovery.mu.Lock()
+		globalDiscovery.channels = prev
+		globalDiscovery.mu.Unlock()
+	}
+}
+
+func TestDynamicProxyRejectsUnauthenticated(t *testing.T) {
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"leaked":true}`))
+	}))
+	defer upstream.Close()
+
+	restore := seedTestChannel(t, &ChannelInfo{
+		Name:        "testchan",
+		InternalURL: upstream.URL,
+		Routes: []ChannelRoute{
+			{Method: "GET", Path: "/testchan/private", Auth: true},
+			{Method: "GET", Path: "/testchan/public", Auth: false},
+		},
+	})
+	defer restore()
+
+	app := fiber.New()
+	SetupDynamicProxy(app)
+
+	// Auth:true without a token must 401 and never reach the channel.
+	req := httptest.NewRequest("GET", "/testchan/private", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("unauthenticated Auth:true route: got %d, want 401", resp.StatusCode)
+	}
+	if n := upstreamHits.Load(); n != 0 {
+		t.Errorf("unauthenticated request reached the channel upstream (%d hits)", n)
+	}
+
+	// Auth:false still proxies straight through.
+	req = httptest.NewRequest("GET", "/testchan/public", nil)
+	resp, err = app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Errorf("public route: got %d, want 200", resp.StatusCode)
+	}
+	if n := upstreamHits.Load(); n != 1 {
+		t.Errorf("public route upstream hits: got %d, want 1", n)
+	}
+}
+
+func TestLogtoAuthBlocksHandlerWhenUnauthenticated(t *testing.T) {
+	var handlerRan atomic.Bool
+
+	app := fiber.New()
+	app.Get("/protected", LogtoAuth, func(c *fiber.Ctx) error {
+		handlerRan.Store(true)
+		return c.SendString("secret")
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/protected", nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("unauthenticated protected route: got %d, want 401", resp.StatusCode)
+	}
+	if handlerRan.Load() {
+		t.Error("protected handler executed for an unauthenticated request")
+	}
+}


### PR DESCRIPTION
## What

`ValidateAuth` signalled failure by returning `c.Status(401).JSON(...)` — which returns **nil** when the response write succeeds. Both callers (`dynamicProxyHandler`, `LogtoAuth`) treated nil as "auth passed" and kept going:

- **Dynamic proxy**: unauthenticated requests to `Auth: true` channel routes were forwarded anyway (no `X-User-Sub`), and the upstream response overwrote the rendered 401. Every gated channel route was effectively public — verified live: unauthenticated `GET /predictions` returned 200 with the full premier-tier payload (156 KB), and the new v1.1.4 candlesticks route served without a token.
- **LogtoAuth**: the middleware advanced into protected core handlers after writing the 401. Handlers bail on missing locals today, but they should never execute unauthenticated.

## Fix

`ValidateAuth` now writes the 401 and returns a sentinel `ErrUnauthenticated`; both call sites stop processing and return nil so the written 401 stands. Any future caller doing the intuitive `return err` fails **closed** (default error shape) instead of open. Response bodies/status are byte-identical to the intended behavior — no client-visible contract change.

## Tests

- `TestDynamicProxyRejectsUnauthenticated` — Auth:true route 401s and the channel upstream is never hit; Auth:false still proxies.
- `TestLogtoAuthBlocksHandlerWhenUnauthenticated` — protected handler must not run.
- Full `api/core` suite green.

## Deploy note

Touches `api/core` only → core-api image rebuilds and rolls on merge. Post-deploy smoke: unauth `GET /predictions` → 401, unauth `GET /predictions/public` + `/predictions/catalog` → 200, authed desktop flows unchanged (identity forwarding via `X-User-Sub` untouched).

Found during the v1.1.4 ship smoke; pre-existing since at least 7c101dc (Feb 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)