### PR TITLE
fix(core): split News into per-feed widgets + retire empty legacy rows

### DIFF
--- a/api/migrations/000015_split_news_into_feeds.down.sql
+++ b/api/migrations/000015_split_news_into_feeds.down.sql
@@ -1,0 +1,26 @@
+-- Best-effort reversal of the News per-feed split (mirrors 000014.down).
+-- Forward-only is preferred (see README "Rollbacks via rolling forward"); this
+-- exists for completeness and local dev. It merges the per-feed news_* and
+-- rss_custom rows back into one coarse 'news' row per user.
+--
+-- Lossy by design: per-widget config nuance is dropped, feeds are deduped into
+-- a single array, and bool_or re-enables the coarse row if ANY feed widget was
+-- enabled. The typeof guard mirrors the up migration.
+INSERT INTO user_channels (logto_sub, channel_type, enabled, visible, config, created_at, updated_at)
+SELECT
+    uc.logto_sub,
+    'news',
+    bool_or(uc.enabled),
+    bool_or(uc.visible),
+    jsonb_build_object('feeds', jsonb_agg(DISTINCT f.feed)),
+    min(uc.created_at),
+    max(uc.updated_at)
+FROM user_channels uc
+CROSS JOIN LATERAL jsonb_array_elements(uc.config -> 'feeds') AS f(feed)
+WHERE (left(uc.channel_type, 5) = 'news_' OR uc.channel_type = 'rss_custom')
+  AND jsonb_typeof(uc.config -> 'feeds') = 'array'
+GROUP BY uc.logto_sub
+ON CONFLICT (logto_sub, channel_type) DO NOTHING;
+
+DELETE FROM user_channels
+WHERE left(channel_type, 5) = 'news_' OR channel_type = 'rss_custom';

--- a/api/migrations/000015_split_news_into_feeds.up.sql
+++ b/api/migrations/000015_split_news_into_feeds.up.sql
@@ -1,0 +1,101 @@
+-- Finish the channel→widget split for News (follow-up to 000014).
+--
+-- 000014 split sports per-league but only RENAMED rss → 'news' (a single
+-- coarse row). The catalog, though, is per-feed — news_bbc, news_guardian, …
+-- (desktop/src/marketplace.ts) — and the "already added?" check is an exact
+-- widget-id match (catalog.tsx). So a pre-split user's coarse 'news' row never
+-- matches any per-feed card: a feed they already read (e.g. The Guardian)
+-- shows as addable and, if added, spawns a second slot-consuming row for the
+-- same content. This splits each coarse 'news' row into per-feed widgets so
+-- the id space matches the catalog and dedup/slot-counting work.
+--
+-- Mapping mirrors the marketplace catalog: match each feed to a curated widget
+-- id by URL (name is a fallback for slight URL drift); everything unmatched is
+-- a user's own feed and collapses into the one rss_custom widget (which is
+-- built to hold many feeds).
+--
+-- Grandfather contract (same as 000014): additive — never drops a user below
+-- their slot cap. A news-heavy user ends up over-cap but keeps every feed;
+-- only NEW adds are gated. We delete only the coarse rows the split consumed.
+
+WITH feed_map(match_url, match_name, widget_id) AS (VALUES
+    ('https://feeds.bbci.co.uk/news/rss.xml',                                                  'BBC News',          'news_bbc'),
+    ('https://feeds.npr.org/1001/rss.xml',                                                      'NPR News',          'news_npr'),
+    ('https://www.theguardian.com/world/rss',                                                   'The Guardian',      'news_guardian'),
+    ('https://www.aljazeera.com/xml/rss/all.xml',                                               'Al Jazeera',        'news_aljazeera'),
+    ('https://feeds.propublica.org/propublica/main',                                            'ProPublica',        'news_propublica'),
+    ('https://feeds.bloomberg.com/markets/news.rss',                                            'Bloomberg Markets', 'news_bloomberg'),
+    ('https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=100003114',    'CNBC Top News',     'news_cnbc'),
+    ('https://www.nasa.gov/news-release/feed/',                                                 'NASA Breaking News','news_nasa'),
+    ('https://hnrss.org/frontpage',                                                             'Hacker News',       'news_hackernews'),
+    ('https://www.theverge.com/rss/index.xml',                                                  'The Verge',         'news_theverge')
+),
+-- Explode every coarse 'news' row into its individual feeds. The typeof guard
+-- mirrors 000014: a scalar/absent feeds value would make jsonb_array_elements
+-- abort the whole migration.
+exploded AS (
+    SELECT
+        uc.logto_sub,
+        uc.enabled,
+        uc.visible,
+        uc.created_at,
+        uc.updated_at,
+        f.feed,
+        f.feed->>'url'  AS feed_url,
+        f.feed->>'name' AS feed_name
+    FROM user_channels uc
+    CROSS JOIN LATERAL jsonb_array_elements(uc.config -> 'feeds') AS f(feed)
+    WHERE uc.channel_type = 'news'
+      AND jsonb_typeof(uc.config -> 'feeds') = 'array'
+),
+-- Resolve each feed to a widget id: curated match → news_*, else rss_custom.
+resolved AS (
+    SELECT
+        e.logto_sub, e.enabled, e.visible, e.created_at, e.updated_at, e.feed,
+        COALESCE(m.widget_id, 'rss_custom') AS widget_id
+    FROM exploded e
+    LEFT JOIN feed_map m
+        ON m.match_url = e.feed_url OR m.match_name = e.feed_name
+)
+-- One row per (user, widget_id). A curated widget carries its single feed;
+-- rss_custom aggregates all of a user's custom feeds. On conflict (the target
+-- widget already exists — e.g. the user re-added it from the new catalog, or a
+-- rolling deploy raced this migration) MERGE the feed lists (deduped) instead
+-- of dropping the coarse row's feeds.
+INSERT INTO user_channels (logto_sub, channel_type, enabled, visible, config, created_at, updated_at)
+SELECT
+    r.logto_sub,
+    r.widget_id,
+    bool_or(r.enabled),
+    bool_or(r.visible),
+    jsonb_build_object('feeds', jsonb_agg(DISTINCT r.feed)),
+    min(r.created_at),
+    max(r.updated_at)
+FROM resolved r
+GROUP BY r.logto_sub, r.widget_id
+ON CONFLICT (logto_sub, channel_type) DO UPDATE
+    -- Parenthesise (EXCLUDED.config -> 'feeds'): Postgres ranks -> and || at
+    -- the SAME precedence (left-associative), so without parens this parses as
+    -- (existing_array || EXCLUDED.config) -> 'feeds' → NULL → a scalar-null
+    -- feeds. Concatenate the two feed ARRAYS, then dedup.
+    SET config = jsonb_build_object('feeds', (
+            SELECT jsonb_agg(DISTINCT f)
+            FROM jsonb_array_elements(
+                COALESCE(user_channels.config -> 'feeds', '[]'::jsonb)
+                || (EXCLUDED.config -> 'feeds')
+            ) AS f
+        )),
+        enabled    = user_channels.enabled OR EXCLUDED.enabled,
+        visible    = user_channels.visible OR EXCLUDED.visible,
+        updated_at = GREATEST(user_channels.updated_at, EXCLUDED.updated_at);
+
+-- Remove only the coarse 'news' rows the split actually consumed (had a
+-- non-empty feeds array). Empty/malformed 'news' rows stay as legacy — as in
+-- 000014's sports handling, deleting them would silently drop a user's widget.
+-- (CASE, not chained AND: Postgres may reorder WHERE predicates, so the
+-- array-length call must be provably guarded by the typeof check.)
+DELETE FROM user_channels
+WHERE channel_type = 'news'
+  AND CASE WHEN jsonb_typeof(config -> 'feeds') = 'array'
+           THEN jsonb_array_length(config -> 'feeds') > 0
+           ELSE false END;

--- a/api/migrations/000016_retire_empty_legacy_channels.down.sql
+++ b/api/migrations/000016_retire_empty_legacy_channels.down.sql
@@ -1,0 +1,5 @@
+-- Irreversible by nature: this migration only DELETED contentless legacy rows
+-- (empty 'sports' / 'news' widgets that held no leagues or feeds). They carried
+-- no user data, so there is nothing to restore. Forward-only is the norm here
+-- anyway (see README "Rollbacks via rolling forward"). No-op.
+SELECT 1;

--- a/api/migrations/000016_retire_empty_legacy_channels.up.sql
+++ b/api/migrations/000016_retire_empty_legacy_channels.up.sql
@@ -1,0 +1,29 @@
+-- Retire the contentless legacy coarse widget rows left by the channel→widget
+-- split, so no coarse ids linger to break catalog dedup / slot counting.
+--
+--   * 000014 KEPT coarse 'sports' rows whose leagues array was empty/malformed
+--     (splitting per-league produced nothing to keep).
+--   * 000015 leaves coarse 'news' rows with no feeds (nothing to split).
+--
+-- Both are husks: they render nothing, yet occupy a slot AND — being coarse
+-- ids — never match a per-item catalog card, so the user sees every league/
+-- feed as addable. Delete ONLY rows with no content. A coarse row that still
+-- carries leagues/feeds is left untouched — there is real config to lose, so it
+-- stays grandfathered (this is a near-impossible state post-000014/000015, but
+-- the guard makes the cleanup safe regardless).
+--
+-- (CASE, not chained AND: Postgres may reorder WHERE predicates, so the
+-- array-length call must be provably guarded by the typeof check. The ELSE
+-- branch deletes rows whose content key is absent or a non-array scalar.)
+
+DELETE FROM user_channels
+WHERE channel_type = 'sports'
+  AND CASE WHEN jsonb_typeof(config -> 'leagues') = 'array'
+           THEN jsonb_array_length(config -> 'leagues') = 0
+           ELSE true END;
+
+DELETE FROM user_channels
+WHERE channel_type = 'news'
+  AND CASE WHEN jsonb_typeof(config -> 'feeds') = 'array'
+           THEN jsonb_array_length(config -> 'feeds') = 0
+           ELSE true END;


### PR DESCRIPTION
## What

Finishes the channel→widget split for **News**, the one source 000014 left inconsistent.

000014 split sports per-league (`sports_nfl`, …) and renamed finance/fantasy, but only **renamed** `rss` → `news` — a single coarse row. The catalog, though, is **per-feed** (`news_guardian`, `news_bbc`, …) with an **exact widget-id** installed-check (`catalog.tsx`: `allEnabledIds.has(item.id)`). So a pre-split user's coarse `news` row never matches any per-feed card: a feed they already read shows as *addable* and, if added, creates a **second slot-consuming row** for the same content. (Reported in the wild: "1/3 widgets, one is The Guardian, but it still lets me add The Guardian.")

## Changes

- **000015** splits each coarse `news` row into per-feed `news_*` rows, mapping each feed to its widget id **by URL** (name fallback); unmatched/custom feeds collapse into the one `rss_custom` widget. Mirrors the sports per-league split and the 000014 grandfather contract (additive; never drops a user below their cap). Collisions with an already-owned target widget **merge** feed lists (deduped) rather than dropping feeds.
- **000016** retires the contentless coarse **husks** that remain — empty `news` rows 000015 leaves and the empty/malformed `sports` rows 000014 kept. Deletes **only** rows with no leagues/feeds; a coarse row carrying real content is left untouched.

## Blast radius / behavior

Every pre-v1.1.0 news subscriber is currently on a coarse `news` row; this brings them into the per-item model the rest of the widgets already use. **Server-side only** — no desktop release; existing clients get correct dedup + slot counts on their next `/dashboard`. A news-heavy user's slot count rises (each feed = a widget, same as each league today) — grandfathered, only new adds are gated.

## Testing (local Postgres, in rolled-back transactions)

- 7-scenario split: curated, mixed, custom-only, empty, malformed, and both collision cases — all correct, invariants 0. **Caught a real `->`/`||` precedence bug** in the merge (produced `{"feeds": null}`) before it could ship; fixed with parens.
- Down round-trip recombines cleanly.
- 000016 chain: empty husks retired, contentful rows + per-item widgets untouched.
- Clean `golang-migrate` boot: `schema_migrations_core` = 16, not dirty, core healthy.

Deploys via the K8s pipeline on merge (core-api applies both on boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)