### PR TITLE
fix(predictions): sweep reconciliation — dead markets leave the feed

### DIFF
--- a/channels/predictions/CONTRACT.md
+++ b/channels/predictions/CONTRACT.md
@@ -28,6 +28,8 @@ JSON keys == DB column names (snake_case), matching the finance channel conventi
 | `status` | TEXT | lifecycle: active/closed/determined/settled |
 | `result` | TEXT | yes/no/'' when settled |
 | `is_primary` | BOOLEAN NOT NULL DEFAULT TRUE | representative market per event (filter noise) |
+| `in_sweep` | BOOLEAN NOT NULL DEFAULT TRUE | v1.1.5: in the current sweep selection; FALSE = dropped out (kept for history/"Resolved today") |
+| `settled_at` | TIMESTAMPTZ | v1.1.5: stamped ONCE on the transition into a resolved state (status settled/determined/finalized or result yes/no); NULL for pre-migration resolutions. Drives "Resolved today" — never use `updated_at` for that |
 | `open_time` | TIMESTAMPTZ | |
 | `close_time` | TIMESTAMPTZ | |
 | `link` | TEXT | `https://kalshi.com/markets/{series}/{event}` |
@@ -37,6 +39,19 @@ JSON keys == DB column names (snake_case), matching the finance channel conventi
 `REPLICA IDENTITY FULL`. Upsert on `id`. **Coalesce/change-detect**: only UPDATE
 when a displayed field actually changed (skip no-op ticks) — finance has no such
 guard; predictions needs it (Kalshi ticks are high-frequency).
+
+**Sweep reconciliation invariant (v1.1.5):** every catalog sweep demotes
+(`in_sweep = FALSE`) rows that are no longer in the current selection and
+REST-rechecks recently-dropped tickers so settlements land even when the
+`market_lifecycle_v2` WS event was missed. The WS ticker path never writes to
+demoted rows (`upsert_market` early-return); lifecycle/status writes still do.
+The Go API serves two branches: the live curated set (`in_sweep AND rank
+filter AND close_time not past AND status not settled`) plus anything with
+`settled_at` in the trailing 24h (feeds "Resolved today"), ordered by
+`volume_24h DESC` (all-time volume never shrinks, so it can't rank
+liveliness). Resolved-state detection (settled/determined/finalized or
+result yes/no) exists in three places — Rust `database::is_resolved`, the Go
+filter, desktop `view.ts::isResolved` — keep them in sync.
 
 ### `tracked_markets` — catalog (mirrors finance `tracked_symbols`)
 `id SERIAL PK, ticker TEXT UNIQUE, title TEXT, category TEXT, series_ticker TEXT,
@@ -58,9 +73,12 @@ export interface Prediction {
   yes_ask?: number;
   prev_yes_price?: number; // for ▲/▼ delta
   volume?: number;
+  volume_24h?: number;     // v1.1.5 — "Trending" sort; absent on old payloads
   open_interest?: number;
+  in_sweep?: boolean;      // v1.1.5 — false = left the curated set; treat undefined as true
   status?: string;
   result?: string;
+  settled_at?: string;     // v1.1.5 — RFC3339; when the market resolved (once-stamped)
   close_time?: string;     // RFC3339
   link?: string;
   updated_at?: string;     // RFC3339
@@ -84,9 +102,11 @@ export interface Prediction {
   favorites cap. Tier placement is open product decision Q10.
 
 ## User channel config shape (`user_channels.config` for channel_type=predictions)
-`{ "categories": string[], "favorites": string[] }` — categories drive the
-ticker contents; favorites pin specific markets. (v1 routing ignores these and
-broadcasts; they're stored for the UI + future per-category routing.)
+`{ "categories": string[], "favorites": string[] }` — **retired as of v1.1.5**:
+new desktop clients write neither key (personalization is the local star
+watchlist; all filtering is client-side) and actively clear their own config
+once. The Go API keeps honoring non-empty configs (category narrowing +
+favorites union in `queryMarketsForUser`) for pre-v1.1.5 builds indefinitely.
 
 ## Ports / env (Rust service + Go API)
 - Rust service: PORT default `3005` (finance 3001, sports 3002, rss 3004).

--- a/channels/predictions/api/models.go
+++ b/channels/predictions/api/models.go
@@ -21,17 +21,31 @@ type Prediction struct {
 	Category     string     `json:"category,omitempty"`
 	Title        string     `json:"title"`
 	Subtitle     string     `json:"subtitle,omitempty"`
-	YesPrice     int        `json:"yes_price"`
-	YesBid       int        `json:"yes_bid,omitempty"`
-	YesAsk       int        `json:"yes_ask,omitempty"`
-	PrevYesPrice int        `json:"prev_yes_price,omitempty"`
-	Volume       int64      `json:"volume,omitempty"`
-	OpenInterest int64      `json:"open_interest,omitempty"`
-	Status       string     `json:"status,omitempty"`
-	Result       string     `json:"result,omitempty"`
-	CloseTime    *time.Time `json:"close_time,omitempty"`
-	Link         string     `json:"link,omitempty"`
-	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
+	YesPrice     int   `json:"yes_price"`
+	YesBid       int   `json:"yes_bid,omitempty"`
+	YesAsk       int   `json:"yes_ask,omitempty"`
+	PrevYesPrice int   `json:"prev_yes_price,omitempty"`
+	Volume       int64 `json:"volume,omitempty"`
+	// Volume24h is the trailing-24h contract volume (refreshed by the
+	// catalog sweep). Drives the desktop's "Trending" sort — all-time
+	// Volume never shrinks, so it can't rank liveliness. v1.1.5.
+	Volume24h    int64 `json:"volume_24h,omitempty"`
+	OpenInterest int64 `json:"open_interest,omitempty"`
+	// InSweep is false once the market drops out of the curated sweep
+	// selection (settled / delisted / out-ranked). Such rows only appear
+	// in the payload while recently resolved ("Resolved today"); clients
+	// must not render them as live markets. No omitempty — false is the
+	// meaningful value. v1.1.5.
+	InSweep bool   `json:"in_sweep"`
+	Status  string `json:"status,omitempty"`
+	Result  string `json:"result,omitempty"`
+	// SettledAt is when the market transitioned into a resolved state
+	// (stamped once by the ingestion service). Drives "Resolved today";
+	// updated_at is unusable for that — any write refreshes it. v1.1.5.
+	SettledAt *time.Time `json:"settled_at,omitempty"`
+	CloseTime *time.Time `json:"close_time,omitempty"`
+	Link      string     `json:"link,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // CDCRecord represents a Change Data Capture record from Sequin.

--- a/channels/predictions/api/predictions.go
+++ b/channels/predictions/api/predictions.go
@@ -58,11 +58,11 @@ const (
 	// audience.
 	RedisChannelSubscribersPrefix = "channel:subscribers:"
 
-	// MarketsQuery is the SQL used to fetch all tracked markets for display.
-	// COALESCE guards against NULL columns for rows that have been inserted
-	// but not yet updated by the Rust ingestion service.
-	MarketsQuery = `
-		SELECT
+	// marketsSelectList is the shared column list for market display
+	// queries. COALESCE guards against NULL columns for rows that have been
+	// inserted but not yet updated by the Rust ingestion service. Scan order
+	// must match scanMarkets / queryMarkets.
+	marketsSelectList = `
 			id,
 			COALESCE(source, 'kalshi'),
 			ticker,
@@ -77,15 +77,46 @@ const (
 			COALESCE(yes_ask, 0),
 			COALESCE(prev_yes_price, 0),
 			COALESCE(volume, 0),
+			COALESCE(volume_24h, 0),
 			COALESCE(open_interest, 0),
+			COALESCE(in_sweep, TRUE),
 			COALESCE(status, ''),
 			COALESCE(result, ''),
+			settled_at,
 			close_time,
 			COALESCE(link, ''),
-			COALESCE(updated_at, created_at)
+			COALESCE(updated_at, created_at)`
+
+	// marketsLiveWhere is the "live curated set" predicate (v1.1.5): rows in
+	// the current sweep selection that haven't passed close or settled. The
+	// close_time guard is a zombie backstop only — Kalshi sets close_time
+	// weeks past real settlement, so it can't DETECT settlement (that's what
+	// in_sweep + the lifecycle/recheck status writes are for), but a row
+	// past its close is definitively not live.
+	marketsLiveWhere = `in_sweep = TRUE
+			AND (is_primary = TRUE OR event_rank = 2)
+			AND (close_time IS NULL OR close_time > now())
+			AND lower(COALESCE(status, '')) NOT IN ('settled', 'determined', 'finalized')`
+
+	// marketsResolvedRecentlyWhere keeps just-settled markets in the payload
+	// for the desktop's "Resolved today" strip, regardless of sweep
+	// membership (settled markets leave the sweep by definition). Keyed on
+	// settled_at — the once-stamped resolution transition — NOT updated_at,
+	// which any write refreshes (a sweep volume touch or bulk demotion would
+	// make markets settled weeks ago look freshly resolved).
+	marketsResolvedRecentlyWhere = `settled_at IS NOT NULL
+			AND settled_at > now() - interval '24 hours'`
+
+	// MarketsQuery fetches every market the widget may display: the live
+	// curated set plus the trailing-24h resolved rows. Ordered by 24h volume
+	// (liveliness) — all-time volume never shrinks, so settled giants would
+	// permanently outrank live markets (the v1.1.4 stale-feed bug).
+	MarketsQuery = `
+		SELECT` + marketsSelectList + `
 		FROM markets
-		WHERE is_primary = true OR event_rank = 2
-		ORDER BY volume DESC, ticker ASC`
+		WHERE (` + marketsLiveWhere + `)
+		   OR (` + marketsResolvedRecentlyWhere + `)
+		ORDER BY volume_24h DESC NULLS LAST, volume DESC, ticker ASC`
 )
 
 // =============================================================================
@@ -291,16 +322,33 @@ func (a *App) handleInternalDashboard(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"predictions": []Prediction{}})
 	}
 
-	// Check per-user cache first
+	// Resolve the user's view: favorites/categories from channel config.
+	// v1.1.5 clients write no server config, so the common case is "no
+	// narrowing" — everyone gets the same payload, served from ONE shared
+	// cache entry (the same key getPredictions uses) instead of a
+	// duplicate per-user copy in Redis.
+	favorites, categories := a.getUserPredictionsConfig(userSub)
+	if len(favorites) == 0 && len(categories) == 0 {
+		var predictions []Prediction
+		if GetCache(a.rdb, CacheKeyPredictions, &predictions) {
+			return c.JSON(fiber.Map{"predictions": predictions})
+		}
+		predictions, err := a.queryMarkets(context.Background())
+		if err != nil {
+			log.Printf("[Predictions] Dashboard query failed: %v", err)
+			return c.JSON(fiber.Map{"predictions": []Prediction{}})
+		}
+		SetCache(a.rdb, CacheKeyPredictions, predictions, PredictionsCacheTTL)
+		return c.JSON(fiber.Map{"predictions": predictions})
+	}
+
+	// Narrowed view (pre-v1.1.5 client config): cached per user.
 	cacheKey := CacheKeyPredictionsPrefix + userSub
 	var predictions []Prediction
 	if GetCache(a.rdb, cacheKey, &predictions) {
 		return c.JSON(fiber.Map{"predictions": predictions})
 	}
 
-	// Resolve the user's view: their favorites/categories from channel config,
-	// falling back to all enabled markets.
-	favorites, categories := a.getUserPredictionsConfig(userSub)
 	predictions = a.queryMarketsForUser(favorites, categories)
 	if predictions == nil {
 		predictions = make([]Prediction, 0)
@@ -447,7 +495,8 @@ func (a *App) queryMarkets(ctx context.Context) ([]Prediction, error) {
 			&p.ID, &p.Source, &p.Ticker, &p.EventTicker, &p.EventTitle,
 			&p.EventRank, &p.Category, &p.Title,
 			&p.Subtitle, &p.YesPrice, &p.YesBid, &p.YesAsk, &p.PrevYesPrice,
-			&p.Volume, &p.OpenInterest, &p.Status, &p.Result, &p.CloseTime,
+			&p.Volume, &p.Volume24h, &p.OpenInterest, &p.InSweep,
+			&p.Status, &p.Result, &p.SettledAt, &p.CloseTime,
 			&p.Link, &p.UpdatedAt,
 		); err != nil {
 			log.Printf("[Predictions] Row scan failed: %v", err)
@@ -481,20 +530,17 @@ func (a *App) queryMarketsForUser(favorites, categories []string) []Prediction {
 		return predictions
 	}
 
+	// Old-client path (pre-v1.1.5 configs): category narrowing + favorites
+	// union, but on top of the same liveness gates as MarketsQuery — a
+	// starred or category-matched market that left the sweep must not keep
+	// serving frozen prices to old builds either.
 	rows, err := a.db.Query(ctx, `
-		SELECT
-			id, COALESCE(source, 'kalshi'), ticker, COALESCE(event_ticker, ''),
-			COALESCE(event_title, ''), COALESCE(event_rank, 1),
-			COALESCE(category, 'Other'), COALESCE(title, ''), COALESCE(subtitle, ''),
-			COALESCE(yes_price, 0), COALESCE(yes_bid, 0), COALESCE(yes_ask, 0),
-			COALESCE(prev_yes_price, 0), COALESCE(volume, 0), COALESCE(open_interest, 0),
-			COALESCE(status, ''), COALESCE(result, ''), close_time,
-			COALESCE(link, ''), COALESCE(updated_at, created_at)
+		SELECT`+marketsSelectList+`
 		FROM markets
-		WHERE ((is_primary = true OR event_rank = 2)
-		       AND (cardinality($1::text[]) = 0 OR category = ANY($1)))
-		   OR ticker = ANY($2)
-		ORDER BY volume DESC, ticker ASC
+		WHERE ((`+marketsLiveWhere+`)
+		       AND (cardinality($1::text[]) = 0 OR category = ANY($1) OR ticker = ANY($2)))
+		   OR (`+marketsResolvedRecentlyWhere+`)
+		ORDER BY volume_24h DESC NULLS LAST, volume DESC, ticker ASC
 	`, categories, favorites)
 	return scanMarkets(rows, err)
 }
@@ -515,7 +561,8 @@ func scanMarkets(rows pgx.Rows, err error) []Prediction {
 			&p.ID, &p.Source, &p.Ticker, &p.EventTicker, &p.EventTitle,
 			&p.EventRank, &p.Category, &p.Title,
 			&p.Subtitle, &p.YesPrice, &p.YesBid, &p.YesAsk, &p.PrevYesPrice,
-			&p.Volume, &p.OpenInterest, &p.Status, &p.Result, &p.CloseTime,
+			&p.Volume, &p.Volume24h, &p.OpenInterest, &p.InSweep,
+			&p.Status, &p.Result, &p.SettledAt, &p.CloseTime,
 			&p.Link, &p.UpdatedAt,
 		); err != nil {
 			log.Printf("[Predictions] Row scan failed: %v", err)

--- a/channels/predictions/service/migrations/140000000003_sweep_reconciliation.down.sql
+++ b/channels/predictions/service/migrations/140000000003_sweep_reconciliation.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE markets
+    DROP COLUMN IF EXISTS in_sweep;

--- a/channels/predictions/service/migrations/140000000003_sweep_reconciliation.up.sql
+++ b/channels/predictions/service/migrations/140000000003_sweep_reconciliation.up.sql
@@ -1,0 +1,18 @@
+-- v1.1.5 Kalshi Cleans Up: track sweep membership so dead markets leave
+-- the feed.
+--
+-- The catalog sweep upserts the current top-240 open markets but never
+-- demoted rows that dropped out of the selection, so `markets` accumulated
+-- every market that was EVER curated — 3,905 rows served against 240
+-- maintained in prod, with settled World Cup/UFC giants permanently
+-- outranking live markets on all-time volume.
+--
+--   in_sweep: TRUE  = part of the current sweep selection (live, curated).
+--             FALSE = dropped out; kept for history/"Resolved today" but
+--                     excluded from the live feed and skipped by the WS
+--                     ticker path so it stops generating CDC churn.
+--
+-- Default TRUE so existing rows stay visible until the first post-deploy
+-- sweep reconciles them (~15 minutes worst case).
+ALTER TABLE markets
+    ADD COLUMN in_sweep BOOLEAN NOT NULL DEFAULT TRUE;

--- a/channels/predictions/service/migrations/140000000004_settled_at.down.sql
+++ b/channels/predictions/service/migrations/140000000004_settled_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE markets
+    DROP COLUMN IF EXISTS settled_at;

--- a/channels/predictions/service/migrations/140000000004_settled_at.up.sql
+++ b/channels/predictions/service/migrations/140000000004_settled_at.up.sql
@@ -1,0 +1,15 @@
+-- v1.1.5: record WHEN a market resolved, not just that it did.
+--
+-- "Resolved today" was previously approximated by `updated_at`, which any
+-- write refreshes — a sweep volume touch (or the reconcile demotion) made
+-- markets that settled weeks ago look freshly resolved. `settled_at` is
+-- stamped exactly once, by the write that transitions the row INTO a
+-- resolved state (status settled/determined/finalized, or result yes/no),
+-- whether that write came from the lifecycle WS, the sweep, or the
+-- dropped-market recheck.
+--
+-- Left NULL for rows that resolved before this migration — they are
+-- history, not "today", so the API's resolved-recently branch correctly
+-- never serves them.
+ALTER TABLE markets
+    ADD COLUMN settled_at TIMESTAMPTZ;

--- a/channels/predictions/service/src/bin/serve_bridge.rs
+++ b/channels/predictions/service/src/bin/serve_bridge.rs
@@ -49,8 +49,13 @@ use predictions_service::kalshi::{
     ws,
 };
 
-/// How many of the highest-volume primary markets to seed the feed with.
-const FEED_CAP: usize = 80;
+/// How many of the highest-volume markets to seed the feed with. Two legs
+/// per event (mirroring the real service's MARKETS_PER_EVENT), so this is
+/// ~80 events — enough to exercise the category sections in the desktop UI.
+const FEED_CAP: usize = 160;
+
+/// How many outcomes each event keeps (contract parity with `lib.rs`).
+const MARKETS_PER_EVENT: u32 = 2;
 /// Per-page limit for the initial `GET /markets` sweep.
 const PAGE_LIMIT: u32 = 200;
 /// Safety stop so a misbehaving cursor can't paginate forever.
@@ -68,6 +73,10 @@ struct Prediction {
     source: String,
     ticker: String,
     event_ticker: String,
+    /// The event's human question (v1.1.4 contract).
+    event_title: String,
+    /// Leg rank within its event: 1 = most liquid, 2 = second outcome.
+    event_rank: i64,
     category: String,
     title: String,
     subtitle: String,
@@ -76,7 +85,11 @@ struct Prediction {
     yes_ask: i64,
     prev_yes_price: i64,
     volume: i64,
+    /// Trailing-24h volume (v1.1.5 contract) — drives the Trending sort.
+    volume_24h: i64,
     open_interest: i64,
+    /// Always true on the bridge: the in-memory feed IS the current sweep.
+    in_sweep: bool,
     status: String,
     result: String,
     close_time: String,
@@ -274,16 +287,20 @@ async fn initial_sweep(rest: &RestClient) -> Result<Vec<Prediction>> {
         fp_volume(b.volume_fp.as_deref()).cmp(&fp_volume(a.volume_fp.as_deref()))
     });
 
-    // First (highest-volume) market per event is the representative.
-    let mut seen_events: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Keep the top MARKETS_PER_EVENT legs per event (volume order means an
+    // event's rank-1 leg is always its most-liquid one) — contract parity
+    // with the real service's sweep.
+    let mut event_counts: std::collections::HashMap<String, u32> =
+        std::collections::HashMap::new();
     let mut out: Vec<Prediction> = Vec::with_capacity(FEED_CAP);
     for m in &markets {
-        let is_primary = seen_events.insert(m.event_ticker.clone());
-        if !is_primary {
+        let count = event_counts.entry(m.event_ticker.clone()).or_insert(0);
+        if *count >= MARKETS_PER_EVENT {
             continue;
         }
+        *count += 1;
         let meta = event_meta.get(&m.ticker);
-        out.push(market_to_prediction(m, meta));
+        out.push(market_to_prediction(m, meta, *count as i64));
         if out.len() >= FEED_CAP {
             break;
         }
@@ -487,9 +504,11 @@ async fn events(
 
 /// `meta` is the optional `(event_category, event_title)` captured from the
 /// `/events` sweep, used to enrich the display bucket/title when present.
+/// `rank` is the leg's position within its event (1 = most liquid).
 fn market_to_prediction(
     m: &Market,
     meta: Option<&(Option<String>, String)>,
+    rank: i64,
 ) -> Prediction {
     // Prefer the event's own category from Kalshi; fall back to our derived
     // bucket. Map Kalshi's category strings onto the CONTRACT buckets.
@@ -513,6 +532,11 @@ fn market_to_prediction(
         source: "kalshi".to_string(),
         ticker: m.ticker.clone(),
         event_ticker: m.event_ticker.clone(),
+        event_title: meta
+            .map(|(_, t)| t.clone())
+            .filter(|t| !t.is_empty())
+            .unwrap_or_default(),
+        event_rank: rank,
         category,
         title,
         subtitle: m.yes_sub_title.clone().unwrap_or_default(),
@@ -521,7 +545,9 @@ fn market_to_prediction(
         yes_ask: cents(m.yes_ask_dollars.as_deref()).unwrap_or(0),
         prev_yes_price: cents(m.previous_price_dollars.as_deref()).unwrap_or(yes_price),
         volume: fp_volume(m.volume_fp.as_deref()),
+        volume_24h: fp_opt(m.volume_24h_fp.as_deref()).unwrap_or(0),
         open_interest: fp_opt(m.open_interest_fp.as_deref()).unwrap_or(0),
+        in_sweep: true,
         status: m.status.clone().unwrap_or_default(),
         result: m.result.clone().unwrap_or_default(),
         close_time: m.close_time.clone().unwrap_or_default(),

--- a/channels/predictions/service/src/database.rs
+++ b/channels/predictions/service/src/database.rs
@@ -479,11 +479,13 @@ pub async fn upsert_market(
 /// selection (v1.1.5 reconciliation). Returns the demoted tickers so the
 /// caller can REST-check their real settlement status.
 ///
-/// One statement, sweep-cadence (every 15 min): the demotion write bumps
-/// `updated_at` and fires a CDC event per row, which is intended — clients
-/// learn the market left the curated set. Re-promotion happens naturally via
-/// the sweep's own upsert (`in_sweep: Some(true)`) *before* this runs, so a
-/// market that re-enters the selection is never demoted in the same cycle.
+/// One statement, sweep-cadence (every 15 min); each demotion fires a CDC
+/// event (WAL-based), which is intended — clients learn the market left the
+/// curated set. Re-promotion happens naturally via the sweep's own upsert
+/// (`in_sweep: Some(true)`) *before* this runs, so a market that re-enters
+/// the selection is never demoted in the same cycle. CALLERS must gate this
+/// on a complete, plausibly-sized selection (`lib.rs::should_reconcile`) —
+/// an empty list demotes every live row.
 pub async fn reconcile_sweep_selection(
     pool: &Arc<PgPool>,
     selected_ids: &[String],

--- a/channels/predictions/service/src/database.rs
+++ b/channels/predictions/service/src/database.rs
@@ -179,6 +179,7 @@ pub struct MarketRow {
     pub category: Option<String>,
     pub event_title: Option<String>,
     pub event_rank: Option<i16>,
+    pub in_sweep: Option<bool>,
 }
 
 /// The full set of displayed fields for a market upsert. All optional so a
@@ -210,6 +211,10 @@ pub struct MarketUpsert {
     /// the stored value).
     pub event_title: Option<String>,
     pub event_rank: Option<i16>,
+    /// Sweep membership (v1.1.5): Some(true) from the catalog sweep, None
+    /// from WS ticks (COALESCE keeps the stored value). Demotion to false
+    /// happens only via `reconcile_sweep_selection`.
+    pub in_sweep: Option<bool>,
 }
 
 impl MarketUpsert {
@@ -230,13 +235,54 @@ async fn get_market_row(pool: &Arc<PgPool>, id: &str) -> Result<Option<MarketRow
     let mut conn = pool.acquire().await?;
     let row: Option<MarketRow> = query_as(
         "SELECT id, yes_price, yes_bid, yes_ask, volume, volume_24h, open_interest,
-                status, result, title, subtitle, category, event_title, event_rank
+                status, result, title, subtitle, category, event_title, event_rank,
+                in_sweep
          FROM markets WHERE id = $1",
     )
     .bind(id)
     .fetch_optional(&mut *conn)
     .await?;
     Ok(row)
+}
+
+/// True when a status/result pair represents a resolved market. Mirrors the
+/// desktop's `isResolved` (view.ts) and the Go API's resolved-recently
+/// predicate — keep the three in sync (CONTRACT.md).
+fn is_resolved(status: Option<&str>, result: Option<&str>) -> bool {
+    let status_resolved = status
+        .map(|s| {
+            let s = s.to_ascii_lowercase();
+            s == "settled" || s == "determined" || s == "finalized"
+        })
+        .unwrap_or(false);
+    let result_resolved = result
+        .map(|r| {
+            let r = r.to_ascii_lowercase();
+            r == "yes" || r == "no"
+        })
+        .unwrap_or(false);
+    status_resolved || result_resolved
+}
+
+/// The `settled_at` stamp for a write that may transition a row into a
+/// resolved state: Some(now) only when the effective next state is resolved
+/// and the previous state was not. Stamped once; COALESCE in SQL keeps the
+/// first value if a later write would stamp again.
+fn settled_at_stamp(
+    prev_status: Option<&str>,
+    prev_result: Option<&str>,
+    next_status: Option<&str>,
+    next_result: Option<&str>,
+) -> Option<chrono::DateTime<Utc>> {
+    let effective_status = next_status.or(prev_status);
+    let effective_result = next_result.or(prev_result);
+    if is_resolved(effective_status, effective_result)
+        && !is_resolved(prev_status, prev_result)
+    {
+        Some(Utc::now())
+    } else {
+        None
+    }
 }
 
 /// Returns true when any displayed field in `next` differs from `prev`.
@@ -260,6 +306,7 @@ fn displayed_field_changed(prev: &MarketRow, next: &MarketUpsert) -> bool {
         || changed!(category)
         || changed!(event_title)
         || changed!(event_rank)
+        || changed!(in_sweep)
 }
 
 /// Upsert a market into the `markets` display table with CHANGE-DETECTION.
@@ -286,6 +333,16 @@ pub async fn upsert_market(
 
     match existing {
         Some(prev) => {
+            // Dormant row + WS tick (v1.1.5): the ticker firehose covers
+            // every open Kalshi market, including thousands that dropped
+            // out of the curated sweep. Once demoted, those rows must stop
+            // generating writes/CDC events — only the sweep (create_missing
+            // = true) may touch them again, which is also how a market that
+            // re-enters the selection gets promoted back.
+            if !create_missing && prev.in_sweep == Some(false) {
+                return Ok(false);
+            }
+
             if !displayed_field_changed(&prev, upsert) {
                 // No-op tick — skip the write entirely to avoid CDC churn.
                 return Ok(false);
@@ -294,6 +351,14 @@ pub async fn upsert_market(
             // A displayed field changed. COALESCE each column so a sparse
             // ticker event only overwrites the fields it carries; carry the
             // OLD yes_price into prev_yes_price for the movers delta.
+            // settled_at is stamped once, on the transition into a resolved
+            // state (COALESCE on the COLUMN keeps the first stamp).
+            let settled_at = settled_at_stamp(
+                prev.status.as_deref(),
+                prev.result.as_deref(),
+                upsert.status.as_deref(),
+                upsert.result.as_deref(),
+            );
             let mut conn = pool.acquire().await?;
             query(
                 "UPDATE markets SET
@@ -317,6 +382,8 @@ pub async fn upsert_market(
                     link          = COALESCE($19, link),
                     event_title   = COALESCE($20, event_title),
                     event_rank    = COALESCE($21, event_rank),
+                    in_sweep      = COALESCE($22, in_sweep),
+                    settled_at    = COALESCE(settled_at, $23),
                     updated_at    = now()
                  WHERE id = $1",
             )
@@ -341,6 +408,8 @@ pub async fn upsert_market(
             .bind(&upsert.link)
             .bind(&upsert.event_title)
             .bind(upsert.event_rank)
+            .bind(upsert.in_sweep)
+            .bind(settled_at)
             .execute(&mut *conn)
             .await
             .context("update market")?;
@@ -352,17 +421,26 @@ pub async fn upsert_market(
                 // (WS ticker path) -- drop the tick.
                 return Ok(false);
             }
+            // A row that is resolved at insert (rare: a settled leg of a
+            // still-open event entering the selection) is stamped now — it
+            // just became visible to us, which is the best signal we have.
+            let settled_at = settled_at_stamp(
+                None,
+                None,
+                upsert.status.as_deref(),
+                upsert.result.as_deref(),
+            );
             let mut conn = pool.acquire().await?;
             query(
                 "INSERT INTO markets (
                     id, source, ticker, event_ticker, series_ticker, category, title,
                     subtitle, yes_price, yes_bid, yes_ask, prev_yes_price, volume,
                     volume_24h, open_interest, status, result, is_primary, open_time,
-                    close_time, link, event_title, event_rank
+                    close_time, link, event_title, event_rank, in_sweep, settled_at
                  ) VALUES (
                     $1, 'kalshi', $2, $3, $4, $5, $6, $7, $8, $9, $10, $8, $11, $12, $13,
                     $14, $15, COALESCE($16, TRUE), $17, $18, $19,
-                    COALESCE($20, ''), COALESCE($21, 1)
+                    COALESCE($20, ''), COALESCE($21, 1), COALESCE($22, TRUE), $23
                  )
                  ON CONFLICT (id) DO NOTHING",
             )
@@ -387,12 +465,45 @@ pub async fn upsert_market(
             .bind(&upsert.link)
             .bind(&upsert.event_title)
             .bind(upsert.event_rank)
+            .bind(upsert.in_sweep)
+            .bind(settled_at)
             .execute(&mut *conn)
             .await
             .context("insert market")?;
             Ok(true)
         }
     }
+}
+
+/// Demote every `in_sweep = TRUE` row that is NOT part of the current sweep
+/// selection (v1.1.5 reconciliation). Returns the demoted tickers so the
+/// caller can REST-check their real settlement status.
+///
+/// One statement, sweep-cadence (every 15 min): the demotion write bumps
+/// `updated_at` and fires a CDC event per row, which is intended — clients
+/// learn the market left the curated set. Re-promotion happens naturally via
+/// the sweep's own upsert (`in_sweep: Some(true)`) *before* this runs, so a
+/// market that re-enters the selection is never demoted in the same cycle.
+pub async fn reconcile_sweep_selection(
+    pool: &Arc<PgPool>,
+    selected_ids: &[String],
+) -> Result<Vec<String>> {
+    let mut conn = pool.acquire().await?;
+    // Deliberately does NOT touch updated_at: demotion is a membership
+    // change, not a data refresh. updated_at feeds "how fresh is this
+    // market" displays and the resolved-today window used to key off it —
+    // bumping it here made every long-settled row in a bulk demotion look
+    // freshly resolved (found during v1.1.5 verification).
+    let rows: Vec<(String,)> = query_as(
+        "UPDATE markets SET in_sweep = FALSE
+         WHERE in_sweep = TRUE AND NOT (id = ANY($1))
+         RETURNING ticker",
+    )
+    .bind(selected_ids)
+    .fetch_all(&mut *conn)
+    .await
+    .context("reconcile sweep selection")?;
+    Ok(rows.into_iter().map(|(t,)| t).collect())
 }
 
 /// Update only the lifecycle status/result of a market (from
@@ -416,17 +527,28 @@ pub async fn update_market_lifecycle(
         return Ok(false);
     }
 
+    // Stamp settled_at when THIS write is the transition into a resolved
+    // state (lifecycle WS event or the sweep's dropped-market recheck).
+    let settled_at = settled_at_stamp(
+        prev.status.as_deref(),
+        prev.result.as_deref(),
+        status,
+        result,
+    );
+
     let mut conn = pool.acquire().await?;
     query(
         "UPDATE markets SET
             status = COALESCE($2, status),
             result = COALESCE($3, result),
+            settled_at = COALESCE(settled_at, $4),
             updated_at = now()
          WHERE id = $1",
     )
     .bind(&id)
     .bind(status)
     .bind(result)
+    .bind(settled_at)
     .execute(&mut *conn)
     .await
     .context("update market lifecycle")?;
@@ -593,6 +715,7 @@ mod tests {
             category: None,
             event_title: None,
             event_rank: None,
+            in_sweep: Some(true),
         }
     }
 
@@ -627,6 +750,52 @@ mod tests {
         let mut next = MarketUpsert::new("TEST");
         next.status = Some("closed".into());
         assert!(displayed_field_changed(&prev, &next));
+    }
+
+    #[test]
+    fn resolved_state_detection() {
+        assert!(is_resolved(Some("settled"), None));
+        assert!(is_resolved(Some("Determined"), None));
+        assert!(is_resolved(Some("FINALIZED"), None));
+        assert!(is_resolved(Some("active"), Some("yes")));
+        assert!(is_resolved(None, Some("no")));
+        assert!(!is_resolved(Some("active"), Some("")));
+        assert!(!is_resolved(Some("closed"), None)); // closed trades no more but isn't resolved
+        assert!(!is_resolved(None, None));
+    }
+
+    #[test]
+    fn settled_at_stamps_only_on_transition() {
+        // active -> finalized: stamp.
+        assert!(settled_at_stamp(Some("active"), None, Some("finalized"), None).is_some());
+        // result arrives while status stays active: stamp.
+        assert!(settled_at_stamp(Some("active"), Some(""), None, Some("yes")).is_some());
+        // already resolved -> another resolved write: no re-stamp.
+        assert!(settled_at_stamp(Some("finalized"), None, Some("settled"), None).is_none());
+        assert!(settled_at_stamp(Some("active"), Some("yes"), Some("finalized"), None).is_none());
+        // sparse write carrying nothing lifecycle-ish on an active row: no stamp.
+        assert!(settled_at_stamp(Some("active"), None, None, None).is_none());
+        // insert-time resolution (no prev state): stamp.
+        assert!(settled_at_stamp(None, None, Some("finalized"), None).is_some());
+    }
+
+    #[test]
+    fn in_sweep_transition_detected() {
+        // v1.1.5: demotion/promotion must count as a displayed change so a
+        // CDC event tells clients the market left/re-entered the curated
+        // set; a sweep re-asserting the current value is a no-op.
+        let prev = row(Some(62), Some("active")); // in_sweep: Some(true)
+        let mut demote = MarketUpsert::new("TEST");
+        demote.in_sweep = Some(false);
+        assert!(displayed_field_changed(&prev, &demote));
+
+        let mut reassert = MarketUpsert::new("TEST");
+        reassert.in_sweep = Some(true);
+        assert!(!displayed_field_changed(&prev, &reassert));
+
+        // WS ticks (in_sweep: None) never count as a membership change.
+        let ws_tick = MarketUpsert::new("TEST");
+        assert!(!displayed_field_changed(&prev, &ws_tick));
     }
 
     #[test]

--- a/channels/predictions/service/src/lib.rs
+++ b/channels/predictions/service/src/lib.rs
@@ -14,8 +14,8 @@ use std::{fs, sync::Arc, time::Duration};
 use tokio::{sync::Mutex, time::sleep};
 
 use crate::database::{
-    record_poll_error, record_poll_success, seed_tracked_markets, upsert_market,
-    upsert_tracked_market, MarketUpsert, PgPool,
+    record_poll_error, record_poll_success, reconcile_sweep_selection, seed_tracked_markets,
+    update_market_lifecycle, upsert_market, upsert_tracked_market, MarketUpsert, PgPool,
 };
 use crate::kalshi::model::Market;
 use crate::log::{error, info, warn};
@@ -48,6 +48,18 @@ const CATALOG_MAX_MARKETS: usize = 240;
 /// Kalshi-style event cards with the top two legs. Rank 1 is `is_primary`
 /// for back-compat with pre-1.1.4 consumers.
 const MARKETS_PER_EVENT: u32 = 2;
+
+/// Per-request ticker batch for the dropped-market settlement recheck
+/// (v1.1.5). Kalshi's `GET /markets?tickers=` accepts a CSV; keep batches
+/// small to stay well inside URL-length and rate limits.
+const RECHECK_CHUNK: usize = 50;
+
+/// If a single reconcile demotes more rows than this, skip the settlement
+/// recheck for that cycle. A normal sweep drops a few dozen markets; a
+/// four-digit demotion is the one-time post-deploy backlog (or a Kalshi-side
+/// catalog upheaval), where per-ticker rechecks would be thousands of
+/// pointless signed calls about ancient markets.
+const RECHECK_SKIP_THRESHOLD: usize = 500;
 
 pub async fn start_predictions_services(
     pool: Arc<PgPool>,
@@ -273,6 +285,7 @@ async fn catalog_sweep(state: &PredictionsState) {
             link: Some(market_link(series.as_deref(), &m.event_ticker)),
             event_title: non_empty(ev_title),
             event_rank: Some(*rank as i16),
+            in_sweep: Some(true),
         };
 
         match upsert_market(&state.pool, &upsert, true).await {
@@ -301,6 +314,74 @@ async fn catalog_sweep(state: &PredictionsState) {
     }
 
     info!("[ Kalshi ] Catalog sweep complete: {persisted} markets persisted");
+
+    // Reconciliation (v1.1.5): demote every row that is no longer part of
+    // the selection so the feed stops serving dead markets. Runs AFTER the
+    // upsert loop, so a market that re-entered the selection was already
+    // re-promoted (in_sweep: Some(true)) and is never demoted here.
+    let selected_ids: Vec<String> = selected
+        .iter()
+        .map(|(m, _, _, _)| format!("kalshi:{}", m.ticker))
+        .collect();
+    match reconcile_sweep_selection(&state.pool, &selected_ids).await {
+        Ok(dropped) if dropped.is_empty() => {}
+        Ok(dropped) => {
+            info!("[ Kalshi ] Sweep reconcile: {} rows demoted", dropped.len());
+            recheck_dropped_markets(state, dropped).await;
+        }
+        Err(e) => warn!("[ Kalshi ] Sweep reconcile failed: {e:#}"),
+    }
+}
+
+/// REST-check the real status of markets that just dropped out of the sweep
+/// selection, so settlements land even though (a) settled markets vanish
+/// from the open-events sweep and (b) the `market_lifecycle_v2` WS message
+/// may have been missed (pod restart, reconnect gap). This is what keeps
+/// "Resolved today" honest — without it a settled market's row stays
+/// frozen at status='active' forever.
+async fn recheck_dropped_markets(state: &PredictionsState, dropped: Vec<String>) {
+    if dropped.len() > RECHECK_SKIP_THRESHOLD {
+        info!(
+            "[ Kalshi ] Skipping settlement recheck for {} demoted markets (> {RECHECK_SKIP_THRESHOLD}; bulk backlog, not fresh settlements)",
+            dropped.len()
+        );
+        return;
+    }
+
+    let mut updated = 0u64;
+    for chunk in dropped.chunks(RECHECK_CHUNK) {
+        let query = format!("tickers={}&limit={RECHECK_CHUNK}", chunk.join(","));
+        match state.rest.get_markets(&query).await {
+            Ok(resp) => {
+                for m in resp.markets {
+                    if m.ticker.is_empty() {
+                        continue;
+                    }
+                    match update_market_lifecycle(
+                        &state.pool,
+                        &m.ticker,
+                        m.status.as_deref(),
+                        m.result.as_deref(),
+                    )
+                    .await
+                    {
+                        Ok(true) => updated += 1,
+                        Ok(false) => {}
+                        Err(e) => warn!(
+                            "[ Kalshi ] Recheck lifecycle write failed for {}: {e:#}",
+                            m.ticker
+                        ),
+                    }
+                }
+            }
+            Err(e) => warn!("[ Kalshi ] Recheck fetch failed for a chunk of {}: {e:#}", chunk.len()),
+        }
+        // Same politeness delay as the sweep pagination.
+        sleep(Duration::from_millis(250)).await;
+    }
+    if updated > 0 {
+        info!("[ Kalshi ] Settlement recheck: {updated} demoted markets updated");
+    }
 }
 
 // ─── parsing / derivation helpers ────────────────────────────────────────

--- a/channels/predictions/service/src/lib.rs
+++ b/channels/predictions/service/src/lib.rs
@@ -61,6 +61,22 @@ const RECHECK_CHUNK: usize = 50;
 /// pointless signed calls about ancient markets.
 const RECHECK_SKIP_THRESHOLD: usize = 500;
 
+/// Reconciliation only runs on a sweep that is plausibly COMPLETE. A sweep
+/// whose pagination errored (or hit the safety page cap) has an incomplete
+/// selection — demoting against it would mark live markets dead; with an
+/// empty selection it would demote EVERY live market and blank the feed
+/// until the next successful sweep. Kalshi lists thousands of open events,
+/// so a clean sweep selecting fewer than this is itself an upstream anomaly
+/// we refuse to act on. (Ship-blocker caught in the v1.1.5 pre-merge
+/// review: a single timeout on the first /events page would have wiped the
+/// live set ~96x/day worst case.)
+const RECONCILE_MIN_SELECTED: usize = 50;
+
+/// Pure guard for `catalog_sweep`'s reconciliation step.
+fn should_reconcile(sweep_complete: bool, selected_len: usize) -> bool {
+    sweep_complete && selected_len >= RECONCILE_MIN_SELECTED
+}
+
 pub async fn start_predictions_services(
     pool: Arc<PgPool>,
     health_state: Arc<Mutex<PredictionsHealth>>,
@@ -169,6 +185,10 @@ async fn catalog_sweep(state: &PredictionsState) {
     let mut all: Vec<(Market, Option<String>, String)> = Vec::new();
     let mut cursor = String::new();
     let mut pages = 0u32;
+    // True only when pagination drained Kalshi's full open-events list. A
+    // partial sweep (page error / safety cap) may still upsert what it got,
+    // but MUST NOT reconcile — see `should_reconcile`.
+    let mut sweep_complete = true;
 
     loop {
         let query = if cursor.is_empty() {
@@ -200,11 +220,13 @@ async fn catalog_sweep(state: &PredictionsState) {
                 // Safety stop so a misbehaving cursor can't loop forever.
                 if pages >= 50 {
                     warn!("[ Kalshi ] Catalog sweep hit 50-page cap; stopping pagination");
+                    sweep_complete = false;
                     break;
                 }
             }
             Err(e) => {
                 warn!("[ Kalshi ] Catalog sweep page fetch failed: {e:#}");
+                sweep_complete = false;
                 break;
             }
         }
@@ -319,6 +341,17 @@ async fn catalog_sweep(state: &PredictionsState) {
     // the selection so the feed stops serving dead markets. Runs AFTER the
     // upsert loop, so a market that re-entered the selection was already
     // re-promoted (in_sweep: Some(true)) and is never demoted here.
+    //
+    // GUARDED: only a complete, plausibly-sized sweep may demote. "Absent
+    // from an incomplete selection" says nothing about a market being dead —
+    // and an errored first page would otherwise demote everything.
+    if !should_reconcile(sweep_complete, selected.len()) {
+        warn!(
+            "[ Kalshi ] Skipping sweep reconcile (complete={sweep_complete}, selected={}) — partial or implausibly small sweep",
+            selected.len()
+        );
+        return;
+    }
     let selected_ids: Vec<String> = selected
         .iter()
         .map(|(m, _, _, _)| format!("kalshi:{}", m.ticker))
@@ -472,6 +505,17 @@ fn derive_category(ticker: &str, event_ticker: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reconcile_guard_requires_complete_plausible_sweep() {
+        // The v1.1.5 ship-blocker: an errored/empty sweep must never demote.
+        assert!(!should_reconcile(true, 0)); // empty selection
+        assert!(!should_reconcile(false, 240)); // partial pagination
+        assert!(!should_reconcile(false, 0)); // errored first page
+        assert!(!should_reconcile(true, RECONCILE_MIN_SELECTED - 1)); // implausibly small
+        assert!(should_reconcile(true, RECONCILE_MIN_SELECTED)); // floor is inclusive
+        assert!(should_reconcile(true, 240)); // normal sweep
+    }
 
     #[test]
     fn cents_rounds_dollars() {

--- a/channels/predictions/service/src/websocket.rs
+++ b/channels/predictions/service/src/websocket.rs
@@ -473,6 +473,12 @@ pub(crate) async fn connect(
                         last_error = Some(format!("Kalshi WS error: {text}"));
                         error_count += 1;
                     }
+                    // Kalshi's newer EVENT-level lifecycle channel piggybacks
+                    // on our subscription. We track lifecycle per-market via
+                    // market_lifecycle_v2 (+ the sweep's settlement recheck);
+                    // parsing event-level payloads is deliberately deferred.
+                    // Ignore quietly — this was ~90% of our log volume.
+                    "event_lifecycle" => {}
                     other => {
                         warn!("Unhandled Kalshi WS message type '{other}': {text}");
                     }


### PR DESCRIPTION
## Problem

The Kalshi widget showed outdated data. Root cause (measured in prod): the catalog sweep upserts the current top-240 open markets but **never demotes rows that drop out**, and the API serves everything `is_primary OR event_rank=2` ordered by **all-time volume** — so settled World Cup/UFC giants permanently outranked live markets. 3,905 rows served vs 240 maintained; 51 of the top 60 stale >1 day. Status was also untrustworthy: 1,672 rows past close, only 156 ever marked settled (lifecycle WS events missed during pod downtime; settled markets leave the open-events sweep so nothing reconciles them).

## Fix

**Service (Rust)**
- `markets.in_sweep` (migration `140000000003`): every sweep demotes rows no longer in the selection via `reconcile_sweep_selection` (no `updated_at` bump — membership isn't a data change).
- WS ticker path skips demoted rows (`upsert_market` early-return) — ends perpetual CDC churn from ~3.6k dormant rows in prod. Lifecycle writes still land.
- **Settlement recheck**: demoted tickers are REST-checked (`GET /markets?tickers=`, ≤50/batch, 250ms politeness) and settlements recorded — covers missed lifecycle events. Skipped when >500 drop at once (one-time post-deploy backlog guard).
- `markets.settled_at` (migration `140000000004`): stamped **once**, on the transition into a resolved state. Found during verification: keying "Resolved today" off `updated_at` made bulk-demoted/re-swept settled rows look freshly resolved (617 false riders locally).
- `event_lifecycle` WS messages explicitly ignored (~90% of log volume was the unhandled-type warning).

**API (Go)**
- Two-branch filter: live curated set (`in_sweep` + rank + not past close + not settled) **plus** `settled_at` within 24h ("Resolved today" keeps working after demotion).
- Payload gains `volume_24h` (Trending sort), `in_sweep`, `settled_at`; ordered by `volume_24h DESC`.
- Shared dashboard cache when a user has no favorites/categories config (the post-redesign common case); per-user path kept verbatim for old clients.
- `serve_bridge` brought up to contract (event context, 2 legs/event, new fields) so the desktop UI PR can develop against it.

## Verification (local stack, dirty DB with 974 accumulated rows)

- `cargo test` 34 pass; `go build/vet/test` pass.
- First sweep: `Sweep reconcile: 738 rows demoted`, recheck correctly skipped (backlog guard). Steady state: 2 demoted, **recheck recorded 1 real settlement end-to-end**.
- Payload: 974 → **211 rows**, zero past-close zombies, zero false "resolved today" riders, `volume_24h` present.
- Top of feed flipped from a settled July 5 World Cup market to **today's England vs Argentina** (matches kalshi.com trending).
- No more `event_lifecycle` log spam.

## Deploy notes

- First prod sweep after deploy emits a one-time CDC burst (~3.6k demotions → `cdc:predictions:all`). Harmless (clients refetch via the 500ms safety net) but deploy off-peak if convenient.
- Old desktop clients: unchanged API shape, fewer-but-correct rows; favorites/categories configs still honored.

Part 1 of 2 for the v1.1.5 "Kalshi Cleans Up" release — the desktop UI overhaul PR follows on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)