### PR TITLE
Kalshi v1.1.6: broken graphs + empty positions fixed, search, category filters, card UX

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4621,7 +4621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.5"
+version = "1.1.6"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/src/kalshi/model.rs
+++ b/desktop/src-tauri/src/kalshi/model.rs
@@ -27,6 +27,23 @@ fn cents(int_cents: Option<i64>, dollars: &Option<String>) -> i64 {
     0
 }
 
+/// Resolve a contract count, preferring the legacy integer field and falling
+/// back to the `*_fp` fixed-point decimal string ("5.00" → 5). Kalshi's 2026
+/// API migration removed the integer count fields (`position`, `count`,
+/// `remaining_count`) in favor of `*_fp` — parsing only the legacy field made
+/// every position deserialize as flat (see ui-review/NOTES.md, A2).
+fn count(int_count: Option<i64>, fp: &Option<String>) -> i64 {
+    if let Some(c) = int_count {
+        return c;
+    }
+    if let Some(s) = fp {
+        if let Ok(f) = s.trim().parse::<f64>() {
+            return f.round() as i64;
+        }
+    }
+    0
+}
+
 // ── /portfolio/balance ───────────────────────────────────────────
 
 #[derive(Debug, Deserialize, Default)]
@@ -50,8 +67,12 @@ pub struct RawMarketPosition {
     #[serde(default)]
     pub ticker: String,
     /// Net signed contract count: positive = long YES, negative = long NO.
+    /// Legacy integer form — absent since Kalshi's fixed-point migration.
     #[serde(default)]
     pub position: Option<i64>,
+    /// Fixed-point replacement ("5.00"); the only form current responses carry.
+    #[serde(default)]
+    pub position_fp: Option<String>,
     #[serde(default)]
     pub market_exposure: Option<i64>,
     #[serde(default)]
@@ -84,14 +105,20 @@ pub struct RawPositionsResponse {
 pub struct RawFill {
     #[serde(default)]
     pub ticker: String,
-    /// "yes" | "no" — which side the user traded.
+    /// "yes" | "no" — which side the user traded. Deprecated upstream in
+    /// favor of `outcome_side` (removal slated May 2026); we read both.
     #[serde(default)]
     pub side: String,
+    /// Current name for the traded side ("yes" | "no").
+    #[serde(default)]
+    pub outcome_side: Option<String>,
     /// "buy" | "sell".
     #[serde(default)]
     pub action: String,
     #[serde(default)]
     pub count: Option<i64>,
+    #[serde(default)]
+    pub count_fp: Option<String>,
     #[serde(default)]
     pub yes_price: Option<i64>,
     #[serde(default)]
@@ -133,6 +160,8 @@ pub struct RawOrder {
     #[serde(default)]
     pub remaining_count: Option<i64>,
     #[serde(default)]
+    pub remaining_count_fp: Option<String>,
+    #[serde(default)]
     pub created_time: Option<String>,
 }
 
@@ -163,7 +192,7 @@ pub struct Position {
 
 impl From<RawMarketPosition> for Position {
     fn from(r: RawMarketPosition) -> Self {
-        let position = r.position.unwrap_or(0);
+        let position = count(r.position, &r.position_fp);
         let side = if position > 0 {
             "yes"
         } else if position < 0 {
@@ -199,18 +228,24 @@ pub struct Fill {
 
 impl From<RawFill> for Fill {
     fn from(r: RawFill) -> Self {
+        // `side` is deprecated upstream for `outcome_side`; accept either.
+        let side = if r.side.is_empty() {
+            r.outcome_side.clone().unwrap_or_default()
+        } else {
+            r.side.clone()
+        };
         // Report the price of the side actually traded so the UI can show the
         // user's execution price directly.
-        let price_cents = if r.side.eq_ignore_ascii_case("no") {
+        let price_cents = if side.eq_ignore_ascii_case("no") {
             cents(r.no_price, &r.no_price_dollars)
         } else {
             cents(r.yes_price, &r.yes_price_dollars)
         };
         Fill {
             ticker: r.ticker,
-            side: r.side,
+            side,
             action: r.action,
-            count: r.count.unwrap_or(0),
+            count: count(r.count, &r.count_fp),
             price_cents,
             is_taker: r.is_taker.unwrap_or(false),
             created_time: r.created_time.unwrap_or_default(),
@@ -240,7 +275,7 @@ impl From<RawOrder> for RestingOrder {
             side: r.side,
             action: r.action,
             price_cents,
-            remaining_count: r.remaining_count.unwrap_or(0),
+            remaining_count: count(r.remaining_count, &r.remaining_count_fp),
             created_time: r.created_time.unwrap_or_default(),
         }
     }
@@ -305,6 +340,108 @@ mod tests {
         }
         .into();
         assert_eq!(flat.side, "flat");
+    }
+
+    /// A2 regression: a CURRENT-shape (2026 fixed-point) GetPositions
+    /// response — `position_fp` string, `*_dollars` money, no legacy integer
+    /// fields, no `resting_orders_count` — must normalize to a real open
+    /// position, not a flat row that the zero-filter drops.
+    #[test]
+    fn position_parses_current_fixed_point_shape() {
+        let raw: RawPositionsResponse = serde_json::from_str(
+            r#"{
+              "market_positions": [
+                {
+                  "ticker": "KXWCADVANCE-26JUL15ENGARG-ARG",
+                  "position_fp": "15.00",
+                  "market_exposure_dollars": "7.0500",
+                  "realized_pnl_dollars": "0.000000",
+                  "total_traded_dollars": "7.0500",
+                  "fees_paid_dollars": "0.070000",
+                  "last_updated_ts": "2026-07-14T22:10:03Z"
+                },
+                {
+                  "ticker": "KXFEDHIKE-26DEC31",
+                  "position_fp": "-4.00",
+                  "market_exposure_dollars": "1.6800",
+                  "realized_pnl_dollars": "0.000000",
+                  "total_traded_dollars": "1.6800",
+                  "fees_paid_dollars": "0.020000"
+                }
+              ],
+              "cursor": ""
+            }"#,
+        )
+        .unwrap();
+
+        let positions: Vec<Position> = raw
+            .market_positions
+            .into_iter()
+            .map(Position::from)
+            .filter(|p| p.position != 0 || p.resting_orders_count != 0)
+            .collect();
+
+        assert_eq!(positions.len(), 2, "open positions must survive the flat filter");
+        assert_eq!(positions[0].side, "yes");
+        assert_eq!(positions[0].count, 15);
+        assert_eq!(positions[0].exposure_cents, 705);
+        assert_eq!(positions[1].side, "no");
+        assert_eq!(positions[1].count, 4);
+    }
+
+    /// Same migration, fills leg: `count_fp` + `outcome_side` + `*_dollars`
+    /// only. The row must keep its count and side.
+    #[test]
+    fn fill_parses_current_fixed_point_shape() {
+        let raw: RawFillsResponse = serde_json::from_str(
+            r#"{
+              "fills": [
+                {
+                  "ticker": "KXWCADVANCE-26JUL15ENGARG-ARG",
+                  "outcome_side": "yes",
+                  "action": "buy",
+                  "count_fp": "15.00",
+                  "yes_price_dollars": "0.4700",
+                  "no_price_dollars": "0.5300",
+                  "is_taker": true,
+                  "created_time": "2026-07-14T22:10:03Z"
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+        let fill = Fill::from(raw.fills.into_iter().next().unwrap());
+        assert_eq!(fill.side, "yes");
+        assert_eq!(fill.count, 15);
+        assert_eq!(fill.price_cents, 47);
+    }
+
+    /// Orders leg: `remaining_count_fp` fallback.
+    #[test]
+    fn order_parses_current_fixed_point_shape() {
+        let raw: RawOrder = serde_json::from_str(
+            r#"{
+              "ticker": "T",
+              "side": "no",
+              "action": "buy",
+              "remaining_count_fp": "9.00",
+              "no_price_dollars": "0.3800"
+            }"#,
+        )
+        .unwrap();
+        let order = RestingOrder::from(raw);
+        assert_eq!(order.remaining_count, 9);
+        assert_eq!(order.price_cents, 38);
+    }
+
+    /// Legacy integer fields, when present, still win (mid-migration safety).
+    #[test]
+    fn legacy_integer_counts_still_preferred() {
+        assert_eq!(count(Some(7), &Some("5.00".into())), 7);
+        assert_eq!(count(None, &Some("5.00".into())), 5);
+        assert_eq!(count(None, &Some("-4.00".into())), -4);
+        assert_eq!(count(None, &Some("garbage".into())), 0);
+        assert_eq!(count(None, &None), 0);
     }
 
     #[test]

--- a/desktop/src-tauri/src/kalshi/rest.rs
+++ b/desktop/src-tauri/src/kalshi/rest.rs
@@ -79,11 +79,15 @@ impl RestClient {
     /// `GET /portfolio/positions` → the user's market positions (normalized),
     /// dropping flat (zero-contract, zero-resting) rows that Kalshi sometimes
     /// returns for previously-held markets.
+    ///
+    /// `count_filter` accepts only `position`/`total_traded` today —
+    /// `resting_order_count` was retired with the fixed-point migration.
+    /// `limit=1000` (the max) keeps every realistic account on one page.
     pub async fn positions(&self) -> Result<Vec<Position>> {
         let raw: RawPositionsResponse = self
             .get_json(
                 &format!("{API_PREFIX}/portfolio/positions"),
-                "count_filter=position,resting_order_count",
+                "count_filter=position&limit=1000",
             )
             .await?;
         Ok(raw

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/channels/predictions/FeedTab.tsx
+++ b/desktop/src/channels/predictions/FeedTab.tsx
@@ -17,15 +17,21 @@
  */
 import { memo, useMemo, useRef, useEffect, useState, useCallback } from "react";
 import { clsx } from "clsx";
+import { motion, AnimatePresence } from "motion/react";
 import {
   TrendingUp,
   LineChart,
   Wallet,
   Star,
+  Check,
   CheckCircle2,
+  ChevronDown,
   ChevronRight,
   Flame,
   Clock,
+  Search,
+  SlidersHorizontal,
+  X,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { dashboardQueryOptions, predictionsCatalogOptions } from "../../api/queries";
@@ -59,10 +65,21 @@ import {
   groupByEvent,
   groupEventsByCategory,
   priceDelta,
+  cardOutcomes,
+  outcomesByPrice,
+  timeIndicator,
+  isResolved,
   type PredictionEvent,
   type PredictionsLens,
   type CategorySection,
+  type TimeIndicator,
 } from "./view";
+import {
+  searchEvents,
+  outcomeLabel,
+  type EventSearchHit,
+  type MatchRange,
+} from "./search";
 import type { Prediction, FeedTabProps, ChannelManifest } from "../../types";
 import { shouldShowOnFeed } from "../../preferences";
 import type { PredictionsDisplayPrefs } from "../../preferences";
@@ -177,16 +194,26 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
     setAlerts(persistRemoveAlert(id));
   }, []);
 
-  // ── Lens + category focus + market-detail modal ───────────────
+  // ── Lens + category filter + market-detail modal ──────────────
   const [lens, setLens] = useState<PredictionsLens>("trending");
-  const [categoryFocus, setCategoryFocus] = useState<string | null>(null);
+  // Multi-select category filter (empty = all). "View all" on a section
+  // focuses exactly that category; the menu toggles combine freely.
+  const [selectedCats, setSelectedCats] = useState<string[]>([]);
   const [detailMarket, setDetailMarket] = useState<Prediction | null>(null);
   const openDetail = useCallback((m: Prediction) => setDetailMarket(m), []);
   const closeDetail = useCallback(() => setDetailMarket(null), []);
 
+  const toggleCat = useCallback((c: string) => {
+    setSelectedCats((prev) =>
+      prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c],
+    );
+  }, []);
+  const clearCats = useCallback(() => setSelectedCats([]), []);
+  const focusCategory = useCallback((c: string) => setSelectedCats([c]), []);
+
   const pickLens = useCallback((next: PredictionsLens) => {
     setLens(next);
-    setCategoryFocus(null);
+    setSelectedCats([]);
   }, []);
 
   // Resolved-today recap (trailing 24h), refreshed as `now` ticks.
@@ -227,22 +254,53 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
 
   const focusedItems = useMemo(
     () =>
-      categoryFocus
-        ? lensItems.filter((m) => categoryOf(m) === categoryFocus)
+      selectedCats.length > 0
+        ? lensItems.filter((m) => selectedCats.includes(categoryOf(m)))
         : lensItems,
-    [lensItems, categoryFocus, categoryOf],
+    [lensItems, selectedCats, categoryOf],
   );
 
   const events = useMemo(() => groupByEvent(focusedItems), [focusedItems]);
   const isComfort = mode === "comfort";
 
-  // Browse mode: Trending with no category focus = Kalshi-style sections.
+  // ── Market search (client-side only — see search.ts) ─────────
+  // The dashboard payload IS the full universe, so matching is pure and
+  // synchronous per keystroke: no debounce, no network, no loading state.
+  const [query, setQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  // Roving selection for ↑/↓ + Enter, indexing into render order.
+  const [selIdx, setSelIdx] = useState(-1);
+
+  const eventCategoryOf = useCallback(
+    (ev: PredictionEvent): string | undefined =>
+      ev.outcomes[0] ? categoryOf(ev.outcomes[0]) : ev.category,
+    [categoryOf],
+  );
+
+  // null = search inactive (empty query, or compact density has no bar).
+  const hits = useMemo(
+    () => (isComfort ? searchEvents(query, events, eventCategoryOf) : null),
+    [isComfort, query, events, eventCategoryOf],
+  );
+  const searching = hits !== null;
+
+  const shownEvents = useMemo(
+    () => (hits ? events.filter((ev) => hits.has(ev.eventTicker)) : events),
+    [events, hits],
+  );
+
+  const changeQuery = useCallback((next: string) => {
+    setQuery(next);
+    setSelIdx(-1);
+  }, []);
+
+  // Browse mode: Trending with no category filter = Kalshi-style sections.
   const sections: CategorySection[] | null = useMemo(
     () =>
-      isComfort && lens === "trending" && !categoryFocus
-        ? groupEventsByCategory(events)
+      isComfort && lens === "trending" && selectedCats.length === 0
+        ? groupEventsByCategory(shownEvents)
         : null,
-    [isComfort, lens, categoryFocus, events],
+    [isComfort, lens, selectedCats, shownEvents],
   );
 
   // ── Pagination (flat modes only — sections self-cap) ─────────
@@ -251,12 +309,12 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
 
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-  }, [lens, categoryFocus, watchlist]);
+  }, [lens, selectedCats, watchlist, query]);
 
-  const renderTotal = isComfort ? events.length : focusedItems.length;
+  const renderTotal = isComfort ? shownEvents.length : focusedItems.length;
   const visible = Math.min(visibleCount, renderTotal);
   const pageItems = focusedItems.slice(0, visible);
-  const pageEvents = events.slice(0, visible);
+  const pageEvents = shownEvents.slice(0, visible);
   const remaining = Math.max(0, renderTotal - visible);
 
   // Most-recent update across visible markets — drives the FreshnessPill.
@@ -279,19 +337,139 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
     [detailMarket, markets],
   );
 
+  // Every leg of the open market's event, price-sorted — the detail view's
+  // "All outcomes" list (B2). Dropped-but-unresolved siblings are excluded
+  // (their frozen prices are the stale-data bug v1.1.5 killed).
+  const detailSiblings = useMemo(() => {
+    if (!liveDetail?.event_ticker) return [];
+    return outcomesByPrice(
+      markets.filter(
+        (m) =>
+          m.event_ticker === liveDetail.event_ticker &&
+          (m.in_sweep !== false || isResolved(m)),
+      ),
+    );
+  }, [liveDetail, markets]);
+
+  // ── Filter bar state (B4/B5) ──────────────────────────────────
+  // ALL categories in the payload (live + resolved), NOT the current
+  // lens's subset — the selector's options must not reshuffle when the
+  // user flips between Trending/Closing/Resolved. A category empty under
+  // the current lens just shows the empty state. Alphabetical.
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    for (const m of markets) {
+      if (m.in_sweep !== false || isResolved(m)) set.add(categoryOf(m));
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [markets, categoryOf]);
+
+  // Sticky-bar elevation: a 1px sentinel above the bar leaves view exactly
+  // when the bar pins. Default (viewport) root — intersection is clipped
+  // through whichever ancestor actually scrolls (the Source page's
+  // PageLayout scroller in-app, the harness shell in dev), so this works
+  // without knowing the scroller. The sentinel is tracked as STATE, not a
+  // ref: the markets tree unmounts on the Positions view, and an observer
+  // left watching the detached node would freeze `stuck` at its last
+  // value — the bar came back pre-shadowed after a scrolled view switch.
+  const [stuck, setStuck] = useState(false);
+  const [sentinelEl, setSentinelEl] = useState<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!sentinelEl) {
+      setStuck(false);
+      return;
+    }
+    const io = new IntersectionObserver(
+      ([entry]) => setStuck(!entry.isIntersecting),
+      { threshold: 0 },
+    );
+    io.observe(sentinelEl);
+    return () => io.disconnect();
+  }, [sentinelEl]);
+
   // ── View switcher (Markets / My Positions) ───────────────────
   // Only on the full-size Source page (comfort). The compact Home preview
   // stays a pure markets list. "My Positions" is desktop-only (keychain).
   const [view, setView] = useState<FeedView>("markets");
   const showSwitcher = mode === "comfort" && isKalshiAvailable();
 
+  // ── Search keyboard support ───────────────────────────────────
+  // Render-order list of matched events for ↑/↓ + Enter. Sections show
+  // every match while searching, so section order IS the nav order.
+  const navEvents = useMemo(() => {
+    if (!searching) return [];
+    return sections ? sections.flatMap((s) => s.events) : pageEvents;
+  }, [searching, sections, pageEvents]);
+
+  const navIndex = useMemo(
+    () => new Map(navEvents.map((ev, i) => [ev.eventTicker, i])),
+    [navEvents],
+  );
+
+  // "/" focuses search from anywhere in the channel (unless typing).
+  useEffect(() => {
+    if (!isComfort || view !== "markets") return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "/" || e.ctrlKey || e.metaKey || e.altKey) return;
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)
+      ) {
+        return;
+      }
+      // Don't steal focus out of an open modal (market detail).
+      if (document.querySelector('[role="dialog"]')) return;
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isComfort, view]);
+
+  // Keep the keyboard-selected card in view.
+  useEffect(() => {
+    if (selIdx < 0) return;
+    containerRef.current
+      ?.querySelector(`[data-nav-idx="${selIdx}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selIdx]);
+
+  const onSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        // First Escape clears, second blurs.
+        e.preventDefault();
+        if (query) changeQuery("");
+        else e.currentTarget.blur();
+        return;
+      }
+      if (!searching || navEvents.length === 0) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelIdx((i) => Math.min(i + 1, navEvents.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelIdx((i) => Math.max(i - 1, -1));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const ev = navEvents[selIdx >= 0 && selIdx < navEvents.length ? selIdx : 0];
+        // Same landing as a card click: the top-priced leg.
+        const target = ev ? outcomesByPrice(ev.outcomes)[0] : undefined;
+        if (target) openDetail(target);
+      }
+    },
+    [query, changeQuery, searching, navEvents, selIdx, openDetail],
+  );
+
   if (showSwitcher && view === "positions") {
     return (
-      <div className="flex h-full flex-col min-h-0">
-        <div className="flex shrink-0 items-center gap-2 border-b border-edge/30 bg-surface px-3 py-1.5">
+      <div className="flex min-h-full flex-col">
+        {/* Sticky so the way back to Markets survives scrolling. */}
+        <div className="sticky top-0 z-20 flex shrink-0 items-center gap-2 border-b border-edge/30 bg-surface px-3 py-1.5">
           <ViewSwitcher view={view} onChange={setView} />
         </div>
-        <div className="flex-1 min-h-0">
+        <div className="flex flex-1 flex-col">
           <MyPositionsPanel markets={markets} hex={PREDICTIONS_HEX} />
         </div>
       </div>
@@ -301,13 +479,13 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
   // ── Empty state (no data at all) ─────────────────────────────
   if (markets.length === 0) {
     return (
-      <div className="flex h-full flex-col min-h-0">
+      <div className="flex min-h-full flex-col">
         {showSwitcher && (
           <div className="flex shrink-0 items-center gap-2 border-b border-edge/30 bg-surface px-3 py-1.5">
             <ViewSwitcher view={view} onChange={setView} />
           </div>
         )}
-        <div className="flex-1 min-h-0">
+        <div className="flex flex-1 flex-col justify-center">
           <EmptyChannelState
             refreshing={Boolean(feedContext.__refreshing)}
             icon={TrendingUp}
@@ -324,58 +502,123 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
   }
 
   return (
-    <div ref={containerRef} className="flex flex-col h-full overflow-y-auto">
+    // NO inner scroll container: the Source page (PageLayout) owns the
+    // scroll. `overflow-y-auto` here created a never-scrolling scrollport
+    // that swallowed the bar's `sticky` in the real app — the bar only
+    // pins against the ancestor that actually scrolls. (RSS uses the same
+    // page-scroll structure.)
+    <div ref={containerRef} className="flex min-h-full flex-col">
       {/* ONE control bar: view switcher (segmented, Tauri-only) · lens
-          pills · freshness. Two chrome rows collapsed into one; the two
-          control levels stay legible because the switcher is a contained
-          segmented control while lenses are open pills. */}
+          pills + category select · freshness. Sticky with an elevation
+          change once pinned (sentinel + IntersectionObserver). The bar is
+          a @container: at narrow channel widths the lens pills + category
+          select collapse into a single Filter button so nothing clips
+          (B4/B5). */}
       {isComfort && (
-        <div className="sticky top-0 z-20 flex items-center gap-2 border-b border-edge/30 bg-surface px-3 py-1.5">
-          {showSwitcher && (
-            <>
-              <ViewSwitcher view={view} onChange={setView} />
-              <div aria-hidden className="h-4 w-px shrink-0 bg-edge/60" />
-            </>
-          )}
-          <div className="scrollbar-none flex min-w-0 items-center gap-1 overflow-x-auto">
-            {LENSES.map((l) => {
-              const Icon = l.icon;
-              const active = lens === l.value && !categoryFocus;
-              return (
-                <LensPill key={l.value} active={active} onClick={() => pickLens(l.value)}>
-                  {Icon && (
-                    <Icon
-                      size={12}
-                      className={l.value === "watchlist" && active ? "fill-current" : ""}
-                    />
-                  )}
-                  {l.label}
-                  {l.value === "watchlist" && watchlist.length > 0
-                    ? ` ${watchlist.length}`
-                    : l.value === "resolved" && resolvedToday.length > 0
-                      ? ` ${resolvedToday.length}`
-                      : ""}
-                </LensPill>
-              );
-            })}
-            {categoryFocus && (
-              <LensPill active onClick={() => setCategoryFocus(null)}>
-                {categoryFocus}
-                <span aria-hidden className="text-accent/70">×</span>
-              </LensPill>
+        <>
+          <div ref={setSentinelEl} aria-hidden className="h-px shrink-0" />
+          <div
+            className={clsx(
+              "@container sticky top-0 z-20 -mt-px flex items-center gap-2 border-b bg-surface px-3 py-1.5 transition-shadow duration-200",
+              stuck
+                ? "border-edge/50 bg-surface/95 shadow-[0_6px_16px_-8px_rgba(0,0,0,0.35)] backdrop-blur-sm"
+                : "border-edge/30",
             )}
-          </div>
-          {latestUpdated && (
-            <div className="ml-auto shrink-0">
-              <FreshnessPill lastUpdated={latestUpdated} label="odds" />
+          >
+            {showSwitcher && (
+              <>
+                <ViewSwitcher view={view} onChange={setView} />
+                <div aria-hidden className="h-4 w-px shrink-0 bg-edge/60" />
+              </>
+            )}
+
+            {/* Wide: open lens pills. Counts live in the filter menu and
+                section headers — pills stay quiet (de-crowd pass). The
+                @5xl threshold collapses BEFORE the row runs out of room —
+                pills must never render cut off. */}
+            <div className="scrollbar-none hidden min-w-0 items-center gap-1 overflow-x-auto @5xl:flex">
+              {LENSES.map((l) => {
+                const Icon = l.icon;
+                const active = lens === l.value && selectedCats.length === 0;
+                return (
+                  <LensPill key={l.value} active={active} onClick={() => pickLens(l.value)}>
+                    {Icon && (
+                      <Icon
+                        size={12}
+                        className={l.value === "watchlist" && active ? "fill-current" : ""}
+                      />
+                    )}
+                    {l.label}
+                  </LensPill>
+                );
+              })}
             </div>
-          )}
-        </div>
+
+            {/* Narrow: everything above collapses into one Filter button. */}
+            <div className="@5xl:hidden">
+              <FilterMenu
+                lens={lens}
+                onPickLens={pickLens}
+                watchlistCount={watchlist.length}
+                resolvedCount={resolvedToday.length}
+                categories={categories}
+                selectedCats={selectedCats}
+                onToggleCategory={toggleCat}
+                onClearCategories={clearCats}
+              />
+            </div>
+
+            <div className="ml-auto flex min-w-0 shrink items-center gap-2">
+              {/* Category rides with the other narrowing controls (search)
+                  so the lens row keeps its breathing room. */}
+              <span className="hidden @5xl:block">
+                <CategoryMenu
+                  categories={categories}
+                  selected={selectedCats}
+                  onToggle={toggleCat}
+                  onClear={clearCats}
+                />
+              </span>
+              <SearchBox
+                inputRef={searchInputRef}
+                query={query}
+                onQueryChange={changeQuery}
+                onKeyDown={onSearchKeyDown}
+                resultCount={searching ? shownEvents.length : null}
+              />
+              {latestUpdated && (
+                <span className="hidden @xl:block">
+                  <FreshnessPill lastUpdated={latestUpdated} label="odds" />
+                </span>
+              )}
+            </div>
+          </div>
+        </>
       )}
 
       {/* Market browse / grids */}
       {renderTotal === 0 ? (
-        lens === "watchlist" ? (
+        searching ? (
+          <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
+            <Search size={22} className="text-fg-4" />
+            <p className="text-[12px] text-fg-3">
+              No markets match{" "}
+              <span className="font-medium text-fg-2">“{query.trim()}”</span>
+            </p>
+            <p className="text-[11px] text-fg-4">
+              Check the spelling, or try a shorter word.
+            </p>
+            <button
+              onClick={() => {
+                changeQuery("");
+                searchInputRef.current?.focus();
+              }}
+              className="mt-1 px-3 py-1.5 rounded-md text-ui-meta font-medium text-accent bg-accent/10 hover:bg-accent/20 transition-colors cursor-pointer"
+            >
+              Clear search
+            </button>
+          </div>
+        ) : lens === "watchlist" ? (
           <div className="flex flex-col items-center justify-center py-12 gap-2 px-6 text-center">
             <Star size={22} className="text-fg-4" />
             <p className="text-[12px] text-fg-3">No watched markets yet</p>
@@ -408,38 +651,62 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
         // ── Browse mode: category sections, hottest first ─────────
         <div className="flex flex-col">
           {sections.map((section) => (
-            <div key={section.category} className="flex flex-col">
-              <div className="flex items-center gap-1.5 px-3 pt-3 pb-1.5">
-                <h3 className="text-ui-section font-semibold uppercase tracking-wide text-fg-3">
+            // rounded-md is invisible here — it only feeds the header
+            // button's inherited focus-ring radius (global focus rule).
+            <div key={section.category} className="flex flex-col rounded-md">
+              {/* Whole header row is the "View all" target (B1) — same
+                  hover treatment as the cards. mx/px split keeps the label
+                  x-aligned with card content (12px) while the hover surface
+                  stays inset. */}
+              <button
+                type="button"
+                onClick={() => focusCategory(section.category)}
+                aria-label={`View all ${section.category} markets`}
+                className="group mx-1.5 mb-1 mt-1.5 flex cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1.5 text-left transition-colors hover:bg-surface-hover active:bg-surface-hover/70"
+              >
+                <span
+                  data-section-title
+                  role="heading"
+                  aria-level={3}
+                  className="text-ui-section font-semibold uppercase tracking-wide text-fg-3 transition-colors group-hover:text-fg-2"
+                >
                   {section.category}
-                </h3>
+                </span>
                 <span className="font-mono text-ui-chip tabular-nums text-fg-4">
                   {section.events.length}
                 </span>
-                {section.events.length > SECTION_PREVIEW_COUNT && (
-                  <button
-                    type="button"
-                    onClick={() => setCategoryFocus(section.category)}
-                    className="ml-auto inline-flex items-center gap-0.5 text-ui-meta font-medium text-accent hover:text-accent/80 transition-colors cursor-pointer"
-                  >
+                {!searching && (
+                  <span className="ml-auto inline-flex items-center gap-0.5 text-ui-meta font-medium text-accent opacity-80 transition-opacity group-hover:opacity-100">
                     View all
                     <ChevronRight size={13} />
-                  </button>
+                  </span>
                 )}
-              </div>
+              </button>
               <div className="grid grid-cols-1 gap-2 px-3 pb-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                {section.events.slice(0, SECTION_PREVIEW_COUNT).map((ev) => (
-                  <EventCard
-                    key={ev.eventTicker}
-                    event={ev}
-                    display={dp}
-                    category={categoryOf(ev.outcomes[0])}
-                    now={now}
-                    watchedSet={watchedSet}
-                    onToggleWatch={toggleWatch}
-                    onOpenDetail={openDetail}
-                  />
-                ))}
+                {/* While searching every match shows (no preview cap) and
+                    leavers animate out. */}
+                <AnimatePresence initial={false} mode="popLayout">
+                  {section.events
+                    .slice(0, searching ? undefined : SECTION_PREVIEW_COUNT)
+                    .map((ev) => (
+                      <CardCell
+                        key={ev.eventTicker}
+                        navIdx={navIndex.get(ev.eventTicker)}
+                        selected={selIdx >= 0 && navIndex.get(ev.eventTicker) === selIdx}
+                      >
+                        <EventCard
+                          event={ev}
+                          display={dp}
+                          category={categoryOf(ev.outcomes[0])}
+                          now={now}
+                          watchedSet={watchedSet}
+                          onToggleWatch={toggleWatch}
+                          onOpenDetail={openDetail}
+                          hit={hits?.get(ev.eventTicker)}
+                        />
+                      </CardCell>
+                    ))}
+                </AnimatePresence>
               </div>
             </div>
           ))}
@@ -455,40 +722,50 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
                 : "grid grid-cols-1 gap-px bg-edge",
             )}
           >
-            {!isComfort
-              ? pageItems.map((market) => (
-                  <MarketItem
-                    key={market.id}
-                    market={market}
-                    display={dp}
-                    now={now}
-                  />
-                ))
-              : lens === "resolved"
-                ? pageEvents.map((ev) => (
-                    <ResolvedCard
-                      key={ev.eventTicker}
-                      event={ev}
-                      display={dp}
-                      category={categoryOf(ev.outcomes[0])}
-                      now={now}
-                      watchedSet={watchedSet}
-                      onToggleWatch={toggleWatch}
-                      onOpenDetail={openDetail}
-                    />
-                  ))
-                : pageEvents.map((ev) => (
-                    <EventCard
-                      key={ev.eventTicker}
-                      event={ev}
-                      display={dp}
-                      category={categoryOf(ev.outcomes[0])}
-                      now={now}
-                      watchedSet={watchedSet}
-                      onToggleWatch={toggleWatch}
-                      onOpenDetail={openDetail}
-                    />
-                  ))}
+            {!isComfort ? (
+              pageItems.map((market) => (
+                <MarketItem
+                  key={market.id}
+                  market={market}
+                  display={dp}
+                  now={now}
+                />
+              ))
+            ) : (
+              <AnimatePresence initial={false} mode="popLayout">
+                {pageEvents.map((ev) => (
+                  <CardCell
+                    key={ev.eventTicker}
+                    navIdx={navIndex.get(ev.eventTicker)}
+                    selected={selIdx >= 0 && navIndex.get(ev.eventTicker) === selIdx}
+                  >
+                    {lens === "resolved" ? (
+                      <ResolvedCard
+                        event={ev}
+                        display={dp}
+                        category={categoryOf(ev.outcomes[0])}
+                        now={now}
+                        watchedSet={watchedSet}
+                        onToggleWatch={toggleWatch}
+                        onOpenDetail={openDetail}
+                        hit={hits?.get(ev.eventTicker)}
+                      />
+                    ) : (
+                      <EventCard
+                        event={ev}
+                        display={dp}
+                        category={categoryOf(ev.outcomes[0])}
+                        now={now}
+                        watchedSet={watchedSet}
+                        onToggleWatch={toggleWatch}
+                        onOpenDetail={openDetail}
+                        hit={hits?.get(ev.eventTicker)}
+                      />
+                    )}
+                  </CardCell>
+                ))}
+              </AnimatePresence>
+            )}
           </div>
           {remaining > 0 && (
             <div className="flex items-center justify-center gap-3 px-3 pb-3">
@@ -514,6 +791,8 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
       {liveDetail && (
         <MarketDetail
           market={liveDetail}
+          siblings={detailSiblings}
+          onSelectMarket={openDetail}
           now={now}
           watched={watchedSet.has(liveDetail.ticker)}
           onToggleWatch={() => toggleWatch(liveDetail.ticker)}
@@ -554,6 +833,415 @@ function LensPill({
   );
 }
 
+// ── Filter bar controls (B4/B5) ──────────────────────────────────
+
+/** Close an open popover on outside-mousedown or Escape. */
+function useDismiss<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  open: boolean,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [ref, open, onClose]);
+}
+
+/** Shared dropdown panel: one look + one entrance for every bar menu. */
+function MenuPanel({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.div
+      role="menu"
+      initial={{ opacity: 0, y: -4, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: -4, scale: 0.98 }}
+      transition={{ duration: 0.14, ease: "easeOut" }}
+      className={clsx(
+        "absolute top-full z-30 mt-1 max-h-80 origin-top overflow-y-auto rounded-xl border border-edge/50 bg-surface p-1 shadow-xl scrollbar-thin",
+        className,
+      )}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+/** Category filter — multi-select popover (empty selection = all).
+ *  Toggling keeps the menu open so several categories combine in one
+ *  visit; outside-click or Esc dismisses. */
+function CategoryMenu({
+  categories,
+  selected,
+  onToggle,
+  onClear,
+}: {
+  categories: string[];
+  selected: string[];
+  onToggle: (c: string) => void;
+  onClear: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useDismiss(rootRef, open, close);
+
+  const label =
+    selected.length === 0
+      ? "All"
+      : selected.length === 1
+        ? selected[0]
+        : `${selected.length} categories`;
+
+  return (
+    // rounded-full on the WRAPPER matters: the app's global focus rule
+    // draws its ring with `border-radius: inherit` (from the parent).
+    <div ref={rootRef} className="relative shrink-0 rounded-full">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Filter by category"
+        className={clsx(
+          "flex max-w-40 cursor-pointer items-center gap-1 rounded-full border py-1 pl-2.5 pr-2 text-ui-meta font-medium transition-colors",
+          selected.length > 0 || open
+            ? "border-accent/40 bg-accent/15 text-accent"
+            : "border-edge/30 bg-base-150/60 text-fg-3 hover:text-fg-2",
+        )}
+      >
+        <span className="truncate">{label}</span>
+        <ChevronDown
+          size={12}
+          aria-hidden
+          className={clsx(
+            "shrink-0 transition-transform duration-150",
+            open && "rotate-180",
+            selected.length > 0 || open ? "text-accent/70" : "text-fg-4",
+          )}
+        />
+      </button>
+      <AnimatePresence>
+        {open && (
+          <MenuPanel className="right-0 w-56">
+            <MenuRow
+              selected={selected.length === 0}
+              onClick={onClear}
+              role="menuitemradio"
+            >
+              All categories
+            </MenuRow>
+            {categories.map((c) => (
+              <MenuRow
+                key={c}
+                selected={selected.includes(c)}
+                onClick={() => onToggle(c)}
+                role="menuitemcheckbox"
+              >
+                {c}
+              </MenuRow>
+            ))}
+          </MenuPanel>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+/** Narrow-width collapse of the lens pills + category menu: one Filter
+ *  button (with an active-filter count badge) opening a compact menu. The
+ *  wide bar hides this via container queries and vice versa. */
+function FilterMenu({
+  lens,
+  onPickLens,
+  watchlistCount,
+  resolvedCount,
+  categories,
+  selectedCats,
+  onToggleCategory,
+  onClearCategories,
+}: {
+  lens: PredictionsLens;
+  onPickLens: (l: PredictionsLens) => void;
+  watchlistCount: number;
+  resolvedCount: number;
+  categories: string[];
+  selectedCats: string[];
+  onToggleCategory: (c: string) => void;
+  onClearCategories: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useDismiss(rootRef, open, close);
+
+  const activeCount = (lens !== "trending" ? 1 : 0) + selectedCats.length;
+
+  return (
+    // NOT position:relative — the dropdown anchors to the sticky bar (the
+    // nearest positioned ancestor) so it spans the channel width instead of
+    // clipping off-screen at narrow widths. rounded-lg feeds the global
+    // focus rule's `border-radius: inherit` for the button's ring.
+    <div ref={rootRef} className="shrink-0 rounded-lg">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Filters"
+        className={clsx(
+          "relative flex h-7 w-8 cursor-pointer items-center justify-center rounded-lg border transition-colors",
+          open || activeCount > 0
+            ? "border-accent/40 bg-accent/15 text-accent"
+            : "border-edge/30 bg-base-150/60 text-fg-3 hover:text-fg-2",
+        )}
+      >
+        <SlidersHorizontal size={13} />
+        {activeCount > 0 && (
+          <span className="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-accent px-0.5 font-mono text-[9px] font-bold leading-none text-white">
+            {activeCount}
+          </span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <MenuPanel className="inset-x-2">
+            <MenuHeading>View</MenuHeading>
+            {LENSES.map((l) => (
+              <MenuRow
+                key={l.value}
+                selected={lens === l.value}
+                onClick={() => onPickLens(l.value)}
+                role="menuitemradio"
+              >
+                {l.label}
+                {l.value === "watchlist" && watchlistCount > 0
+                  ? ` ${watchlistCount}`
+                  : l.value === "resolved" && resolvedCount > 0
+                    ? ` ${resolvedCount}`
+                    : ""}
+              </MenuRow>
+            ))}
+            <MenuHeading>Category</MenuHeading>
+            <MenuRow
+              selected={selectedCats.length === 0}
+              onClick={onClearCategories}
+              role="menuitemradio"
+            >
+              All categories
+            </MenuRow>
+            {categories.map((c) => (
+              <MenuRow
+                key={c}
+                selected={selectedCats.includes(c)}
+                onClick={() => onToggleCategory(c)}
+                role="menuitemcheckbox"
+              >
+                {c}
+              </MenuRow>
+            ))}
+          </MenuPanel>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function MenuHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-2 pb-0.5 pt-2 text-[10px] font-semibold uppercase tracking-wide text-fg-4 first:pt-1">
+      {children}
+    </div>
+  );
+}
+
+function MenuRow({
+  selected,
+  onClick,
+  children,
+  role = "menuitemradio",
+}: {
+  selected: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  /** menuitemcheckbox rows toggle (multi-select) and stay hoverable. */
+  role?: "menuitemradio" | "menuitemcheckbox";
+}) {
+  return (
+    <button
+      type="button"
+      role={role}
+      aria-checked={selected}
+      onClick={onClick}
+      className={clsx(
+        "flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-ui-meta transition-colors hover:bg-surface-hover",
+        selected ? "text-accent" : "text-fg-2",
+      )}
+    >
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+      {selected && <Check size={13} className="shrink-0" />}
+    </button>
+  );
+}
+
+// ── Search UI ────────────────────────────────────────────────────
+
+/** Compact-by-default search field; expands on focus (or while a query is
+ *  set). Same contained shape as the ViewSwitcher so the control bar stays
+ *  one family. Results filter the grid in place as the user types. */
+function SearchBox({
+  inputRef,
+  query,
+  onQueryChange,
+  onKeyDown,
+  resultCount,
+}: {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  query: string;
+  onQueryChange: (next: string) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  /** Matched-event count while searching, null when search is inactive. */
+  resultCount: number | null;
+}) {
+  const [focused, setFocused] = useState(false);
+  const expanded = focused || query.length > 0;
+  return (
+    <div
+      className={clsx(
+        "relative flex items-center rounded-lg border transition-all duration-200",
+        expanded
+          ? "w-40 border-accent/50 bg-surface ring-1 ring-accent/25 sm:w-64"
+          : "w-24 border-edge/30 bg-base-150/60 sm:w-32",
+      )}
+    >
+      <Search
+        size={13}
+        className={clsx(
+          "pointer-events-none absolute left-2",
+          expanded ? "text-accent" : "text-fg-4",
+        )}
+      />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder="Search"
+        aria-label="Search markets"
+        spellCheck={false}
+        autoCorrect="off"
+        autoComplete="off"
+        className="w-full bg-transparent py-1 pl-7 pr-6 text-ui-meta text-fg outline-none placeholder:text-fg-4"
+      />
+      {query ? (
+        <button
+          type="button"
+          aria-label="Clear search"
+          // Keep focus in the input across the click (mousedown blurs).
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => {
+            onQueryChange("");
+            inputRef.current?.focus();
+          }}
+          className="absolute right-1.5 flex h-4 w-4 cursor-pointer items-center justify-center rounded text-fg-4 transition-colors hover:text-fg-2"
+        >
+          <X size={12} />
+        </button>
+      ) : (
+        !focused && (
+          <kbd
+            aria-hidden
+            className="pointer-events-none absolute right-1.5 rounded border border-edge/40 bg-base-150 px-1 font-mono text-[9px] leading-4 text-fg-4"
+          >
+            /
+          </kbd>
+        )
+      )}
+      {resultCount !== null && (
+        <span role="status" className="sr-only">
+          {resultCount === 0
+            ? "No markets match"
+            : `${resultCount} markets match`}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Grid cell for a card: exit animation (search filter), keyboard-selection
+ *  ring, and the data-nav-idx hook scrollIntoView targets. */
+function CardCell({
+  navIdx,
+  selected,
+  children,
+}: {
+  navIdx?: number;
+  selected?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.div
+      exit={{ opacity: 0, scale: 0.95 }}
+      transition={{ duration: 0.12 }}
+      data-nav-idx={navIdx}
+      className={clsx(
+        "h-full min-w-0 rounded-lg",
+        selected && "ring-2 ring-accent",
+      )}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+/** Text with matched substrings wrapped in a subtle accent mark. */
+function Highlight({
+  text,
+  ranges,
+}: {
+  text: string;
+  ranges?: MatchRange[];
+}) {
+  if (!ranges || ranges.length === 0) return <>{text}</>;
+  const parts: React.ReactNode[] = [];
+  let pos = 0;
+  for (const [start, end] of ranges) {
+    if (start >= text.length) break;
+    if (start > pos) parts.push(text.slice(pos, start));
+    parts.push(
+      <mark
+        key={start}
+        className="rounded-[2px] bg-accent/25 text-inherit"
+      >
+        {text.slice(start, Math.min(end, text.length))}
+      </mark>,
+    );
+    pos = end;
+  }
+  if (pos < text.length) parts.push(text.slice(pos));
+  return <>{parts}</>;
+}
+
 // ── ResolvedCard (the Resolved lens) ─────────────────────────────
 //
 // Same card anatomy as EventCard — header (category · settled-time + ★),
@@ -570,6 +1258,8 @@ interface ResolvedCardProps {
   watchedSet: Set<string>;
   onToggleWatch: (ticker: string) => void;
   onOpenDetail: (market: Prediction) => void;
+  /** Search-match highlight ranges, present only while searching. */
+  hit?: EventSearchHit;
 }
 
 function resolvedStamp(p: Prediction | undefined): string | undefined {
@@ -584,6 +1274,7 @@ const ResolvedCard = memo(function ResolvedCard({
   watchedSet,
   onToggleWatch,
   onOpenDetail,
+  hit,
 }: ResolvedCardProps) {
   const lead = event.outcomes[0];
   const watched = lead ? watchedSet.has(lead.ticker) : false;
@@ -617,12 +1308,29 @@ const ResolvedCard = memo(function ResolvedCard({
     </span>
   );
 
+  const openCard = () => {
+    if (lead) onOpenDetail(lead);
+  };
+
   return (
-    <div className="flex flex-col gap-1.5 rounded-lg border border-edge/40 bg-surface p-3 transition-colors hover:border-edge/70">
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${event.title}`}
+      onClick={openCard}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          openCard();
+        }
+      }}
+      className="flex h-full cursor-pointer flex-col gap-1.5 rounded-lg border border-edge/40 bg-surface p-3 transition-[border-color,box-shadow,transform,background-color] duration-150 hover:border-edge/80 hover:bg-surface-hover/40 hover:shadow-soft-sm active:scale-[0.99]"
+    >
       {showHeaderCategory && (
         <div className="flex h-5 items-center justify-between gap-2">
           <span className="truncate text-ui-chip font-medium uppercase tracking-wide text-fg-4">
-            {category}
+            <Highlight text={category!} ranges={hit?.categoryRanges} />
           </span>
           {metaGroup}
         </div>
@@ -630,7 +1338,7 @@ const ResolvedCard = memo(function ResolvedCard({
 
       <div className="flex items-start justify-between gap-2">
         <span className="text-ui-title line-clamp-2 sm:min-h-10">
-          {event.title}
+          <Highlight text={event.title} ranges={hit?.titleRanges} />
         </span>
         {!showHeaderCategory && metaGroup}
       </div>
@@ -642,17 +1350,19 @@ const ResolvedCard = memo(function ResolvedCard({
           const result = (m.result ?? "").toLowerCase();
           const won = result === "yes";
           const lost = result === "no";
-          const legLabel =
-            m.title && m.title.toLowerCase() !== "yes" ? m.title : "Yes";
+          const legLabel = outcomeLabel(m);
           return (
             <button
               key={m.id}
               type="button"
-              onClick={() => onOpenDetail(m)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenDetail(m);
+              }}
               className="flex w-full cursor-pointer items-center gap-1.5 rounded-md border border-edge/30 bg-base-100/40 px-2 py-1.5 text-left transition-colors hover:border-edge/60 hover:bg-surface-hover"
             >
               <span className="min-w-0 flex-1 truncate text-ui-meta text-fg-2">
-                {legLabel}
+                <Highlight text={legLabel} ranges={hit?.outcomeRanges[m.id]} />
               </span>
               <span
                 className={clsx(
@@ -770,6 +1480,7 @@ const MarketItem = memo(function MarketItem({
 
   const dirColor = isUp ? "text-up" : isDown ? "text-down" : "text-fg-3";
   const countdown = formatCloseCountdown(market.close_time, now);
+  const ind = timeIndicator(market, now);
 
   return (
     <a
@@ -797,9 +1508,18 @@ const MarketItem = memo(function MarketItem({
           {formatCompactNumber(market.volume_24h ?? market.volume)}
         </span>
       )}
-      {shouldShowOnFeed(display.showCloseTime) && countdown && (
-        <span className="text-fg-3 tabular-nums shrink-0">{countdown}</span>
-      )}
+      {/* Compact rows share the indicator logic: LIVE badge when live,
+          else the terse countdown in a reserved slot (no tick reflow). */}
+      {shouldShowOnFeed(display.showCloseTime) &&
+        (ind.kind === "live" ? (
+          <TimeBadge ind={ind} />
+        ) : (
+          countdown && (
+            <span className="inline-block min-w-[4ch] shrink-0 text-right tabular-nums text-fg-3">
+              {countdown}
+            </span>
+          )
+        ))}
     </a>
   );
 }, (prev, next) =>
@@ -842,6 +1562,8 @@ interface EventCardProps {
   watchedSet: Set<string>;
   onToggleWatch: (ticker: string) => void;
   onOpenDetail: (market: Prediction) => void;
+  /** Search-match highlight ranges, present only while searching. */
+  hit?: EventSearchHit;
 }
 
 const EventCard = memo(function EventCard({
@@ -852,30 +1574,34 @@ const EventCard = memo(function EventCard({
   watchedSet,
   onToggleWatch,
   onOpenDetail,
+  hit,
 }: EventCardProps) {
   const lead = event.outcomes[0];
   const watched = lead ? watchedSet.has(lead.ticker) : false;
-  const countdown = formatCloseCountdown(
-    event.closeTime ?? lead?.close_time,
-    now,
-  );
+  // Time indicator (B3) — evaluated against the event's close time; the
+  // lead leg carries any (future) start_time field.
+  const ind: TimeIndicator = lead
+    ? timeIndicator(
+        { ...lead, close_time: event.closeTime ?? lead.close_time },
+        now,
+      )
+    : { kind: "none" };
   const showHeaderCategory =
     shouldShowOnFeed(display.showCategory) && Boolean(category);
-  const showCountdown =
-    shouldShowOnFeed(display.showCloseTime) && Boolean(countdown);
+  const showTime = shouldShowOnFeed(display.showCloseTime) && ind.kind !== "none";
+
+  // Top outcomes by price + the hidden count (B2). Detail shows them all.
+  const { visible, extra } = cardOutcomes(event.outcomes);
+  // Card click lands on the top-priced leg — the first row the user reads
+  // (the ★ still anchors to the rank-1 lead; rank ≠ price on some events).
+  const openCard = () => {
+    const target = visible[0] ?? lead;
+    if (target) onOpenDetail(target);
+  };
 
   const metaGroup = (
     <span className="flex shrink-0 items-center gap-1">
-      {showCountdown && (
-        <span
-          className={clsx(
-            "font-mono text-ui-chip tabular-nums",
-            countdown === "Closed" ? "text-fg-4" : "text-fg-3",
-          )}
-        >
-          {countdown === "Closed" ? countdown : `Closes ${countdown}`}
-        </span>
-      )}
+      {showTime && <TimeBadge ind={ind} />}
       {lead && (
         <button
           type="button"
@@ -897,13 +1623,29 @@ const EventCard = memo(function EventCard({
   );
 
   return (
-    <div className="flex flex-col gap-1.5 rounded-lg border border-edge/40 bg-surface p-3 transition-colors hover:border-edge/70">
+    // Whole card opens the market detail (B1); the outcome rows, star and
+    // "+N more" are their own targets via stopPropagation. role=button (not
+    // <button>) because interactive children live inside.
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${event.title}`}
+      onClick={openCard}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return; // inner controls handle their own keys
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          openCard();
+        }
+      }}
+      className="flex h-full cursor-pointer flex-col gap-1.5 rounded-lg border border-edge/40 bg-surface p-3 transition-[border-color,box-shadow,transform,background-color] duration-150 hover:border-edge/80 hover:bg-surface-hover/40 hover:shadow-soft-sm active:scale-[0.99]"
+    >
       {/* Header row — category anchors the left so the countdown/star
           never sit alone. */}
       {showHeaderCategory && (
         <div className="flex h-5 items-center justify-between gap-2">
           <span className="truncate text-ui-chip font-medium uppercase tracking-wide text-fg-4">
-            {category}
+            <Highlight text={category!} ranges={hit?.categoryRanges} />
           </span>
           {metaGroup}
         </div>
@@ -914,23 +1656,23 @@ const EventCard = memo(function EventCard({
           neighbors row-aligned; single-column cards hug their title. */}
       <div className="flex items-start justify-between gap-2">
         <span className="text-ui-title line-clamp-2 sm:min-h-10">
-          {event.title}
+          <Highlight text={event.title} ranges={hit?.titleRanges} />
         </span>
         {!showHeaderCategory && metaGroup}
       </div>
 
-      {/* Outcome legs. ANY single-leg event gets a synthetic No row —
-          a lone market's No side is always its complement (100 - yes),
-          whether the leg is "Yes", "Reza Pahlavi", or "Before Jan 1,
-          2027" — mirroring Kalshi's own Yes/No pair instead of leaving
-          one row stranded. */}
+      {/* Outcome legs, highest price first, capped at two (B2). ANY
+          single-leg event gets a synthetic No row — a lone market's No
+          side is always its complement (100 - yes) — mirroring Kalshi's
+          own Yes/No pair instead of leaving one row stranded. */}
       <div className="flex flex-col gap-1">
-        {event.outcomes.map((m) => (
+        {visible.map((m) => (
           <OutcomeRow
             key={m.id}
             market={m}
             display={display}
             onOpenDetail={onOpenDetail}
+            ranges={hit?.outcomeRanges[m.id]}
           />
         ))}
         {event.outcomes.length === 1 && (
@@ -940,6 +1682,18 @@ const EventCard = memo(function EventCard({
             onOpenDetail={onOpenDetail}
             syntheticNo
           />
+        )}
+        {extra > 0 && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              openCard();
+            }}
+            className="self-start rounded-md px-2 py-0.5 text-ui-chip font-medium text-accent transition-colors hover:bg-accent/10 cursor-pointer"
+          >
+            +{extra} more
+          </button>
         )}
       </div>
 
@@ -954,6 +1708,40 @@ const EventCard = memo(function EventCard({
     </div>
   );
 });
+
+/** The card's time indicator (B3): a LIVE badge, a reserved-width
+ *  countdown ("Starts in 3h" / "Closes 5d"), or a muted "Closed". Reserved
+ *  widths (ch, mono) mean the 1s tick can shorten the text without ever
+ *  reflowing the card. */
+function TimeBadge({ ind }: { ind: TimeIndicator }) {
+  if (ind.kind === "none") return null;
+  if (ind.kind === "live") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-error/10 px-1.5 py-px font-mono text-ui-chip font-bold uppercase tracking-wide text-error">
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-full bg-error motion-safe:animate-pulse"
+        />
+        Live
+      </span>
+    );
+  }
+  if (ind.kind === "closed") {
+    return (
+      <span className="font-mono text-ui-chip tabular-nums text-fg-4">Closed</span>
+    );
+  }
+  return (
+    <span
+      className={clsx(
+        "inline-block whitespace-nowrap text-right font-mono text-ui-chip tabular-nums text-fg-3",
+        ind.kind === "starts" ? "min-w-[13ch]" : "min-w-[11ch]",
+      )}
+    >
+      {ind.label}
+    </span>
+  );
+}
 
 /** One outcome leg inside an EventCard — label, delta, probability pill.
  *
@@ -971,11 +1759,14 @@ function OutcomeRow({
   display,
   onOpenDetail,
   syntheticNo = false,
+  ranges,
 }: {
   market: Prediction;
   display: PredictionsDisplayPrefs;
   onOpenDetail: (market: Prediction) => void;
   syntheticNo?: boolean;
+  /** Search-match ranges within the (non-synthetic) leg label. */
+  ranges?: MatchRange[];
 }) {
   const rawDelta = priceDelta(market);
   const delta = syntheticNo ? -rawDelta : rawDelta;
@@ -984,11 +1775,9 @@ function OutcomeRow({
 
   // Binary events read best as "Yes" rows; multi-outcome events name
   // their leg ("France", "Atlanta"). The synthetic row is always "No".
-  const legLabel = syntheticNo
-    ? "No"
-    : market.title && market.title.toLowerCase() !== "yes"
-      ? market.title
-      : "Yes";
+  // outcomeLabel is shared with the search matcher so highlight offsets
+  // always line up with what's rendered.
+  const legLabel = syntheticNo ? "No" : outcomeLabel(market);
 
   // The No side of a binary market is the complement of yes_price.
   const shownPct = syntheticNo
@@ -998,11 +1787,15 @@ function OutcomeRow({
   return (
     <button
       type="button"
-      onClick={() => onOpenDetail(market)}
+      onClick={(e) => {
+        // The whole card is a click target now (B1) — keep the row its own.
+        e.stopPropagation();
+        onOpenDetail(market);
+      }}
       className="flex w-full cursor-pointer items-center gap-1.5 rounded-md border border-edge/30 bg-base-100/40 px-2 py-1.5 text-left transition-colors hover:border-edge/60 hover:bg-surface-hover"
     >
       <span className="min-w-0 flex-1 truncate text-ui-meta text-fg-2">
-        {legLabel}
+        <Highlight text={legLabel} ranges={syntheticNo ? undefined : ranges} />
       </span>
       {shouldShowOnFeed(display.showDelta) && (
         <span

--- a/desktop/src/channels/predictions/MarketDetail.tsx
+++ b/desktop/src/channels/predictions/MarketDetail.tsx
@@ -10,7 +10,7 @@
  */
 import { useEffect, useMemo, useState } from "react";
 import { clsx } from "clsx";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, queryOptions } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-shell";
 import {
   X,
@@ -27,8 +27,11 @@ import {
   formatCloseCountdown,
   relativeTime,
 } from "../../utils/format";
-import { predictionsCandlesticksOptions } from "../../api/queries";
-import type { PredictionCandle } from "../../api/queries";
+import { authFetch } from "../../api/client";
+import type {
+  PredictionCandle,
+  PredictionCandlesticksResponse,
+} from "../../api/queries";
 import {
   formatProbability,
   formatSpread,
@@ -37,10 +40,16 @@ import {
 } from "./view";
 import { getHistory, sparklinePoints, trend } from "./sparkline";
 import { describeAlert, type AlertComparator, type PredictionAlert } from "./watchlist";
+import { outcomeLabel } from "./search";
+import ProbabilityPill from "./ProbabilityPill";
 import type { Prediction } from "../../types";
 
 interface MarketDetailProps {
   market: Prediction;
+  /** Every live leg of this market's event, price-sorted (B2). The modal
+   *  lists them all when there's more than one; tapping switches markets. */
+  siblings?: Prediction[];
+  onSelectMarket?: (market: Prediction) => void;
   now: number;
   watched: boolean;
   onToggleWatch: () => void;
@@ -58,8 +67,31 @@ interface MarketDetailProps {
 const SPARK_W = 280;
 const SPARK_H = 56;
 
+/**
+ * Channel-owned candlesticks query. The route is `Auth: true`, so this MUST
+ * go through `authFetch` — the shared `predictionsCandlesticksOptions` used
+ * the unauthenticated `request()` and has 401'd on every call since the
+ * #220 auth fix closed the fail-open gateway hole (see ui-review/NOTES.md,
+ * A1). Same query key + staleTime as before (mirrors the server's 5-min
+ * Redis TTL).
+ */
+function candlesticksOptions(ticker: string) {
+  return queryOptions({
+    queryKey: ["predictions-candlesticks", ticker],
+    queryFn: () =>
+      authFetch<PredictionCandlesticksResponse>(
+        `/predictions/candlesticks/${encodeURIComponent(ticker)}`,
+      ),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+    enabled: ticker.length > 0,
+  });
+}
+
 export default function MarketDetail({
   market,
+  siblings = [],
+  onSelectMarket,
   now,
   watched,
   onToggleWatch,
@@ -90,9 +122,11 @@ export default function MarketDetail({
   // Real price history (v1.1.4): ~7 days of hourly candles via the
   // Kalshi proxy. The live tick-accumulator sparkline stays as the
   // fallback when the fetch fails or a market has no trade history.
-  const { data: candleData, isLoading: candlesLoading } = useQuery(
-    predictionsCandlesticksOptions(market.ticker),
-  );
+  const {
+    data: candleData,
+    isLoading: candlesLoading,
+    isError: candlesError,
+  } = useQuery(candlesticksOptions(market.ticker));
   const candlePts = useMemo(() => {
     const rows: PredictionCandle[] = candleData?.candlesticks ?? [];
     const pts: { t: number; v: number }[] = [];
@@ -203,9 +237,27 @@ export default function MarketDetail({
                   strokeLinecap="round"
                 />
               </svg>
+            ) : candlesError ? (
+              // Fetch failed (offline, signed out, upstream hiccup) — say
+              // so instead of implying the market has no history.
+              <div className="flex h-[56px] flex-col items-center justify-center gap-0.5 rounded-lg border border-dashed border-edge/50 bg-base-100/40">
+                <span className="text-[11px] font-medium text-fg-3">
+                  Price history unavailable right now
+                </span>
+                <span className="text-[10px] text-fg-4">
+                  Live price still updates below
+                </span>
+              </div>
             ) : (
-              <div className="flex h-[56px] items-center justify-center rounded-lg bg-base-100/40 text-[11px] text-fg-4">
-                Tracking price live… history builds as the market moves
+              // Fetch succeeded but the market has <2 traded hours — a
+              // genuinely fresh market. History accumulates from here.
+              <div className="flex h-[56px] flex-col items-center justify-center gap-0.5 rounded-lg border border-dashed border-edge/50 bg-base-100/40">
+                <span className="text-[11px] font-medium text-fg-3">
+                  No trade history yet
+                </span>
+                <span className="text-[10px] text-fg-4">
+                  Tracking live — the chart builds as this market trades
+                </span>
               </div>
             )}
           </div>
@@ -235,6 +287,52 @@ export default function MarketDetail({
               tone={resolved && market.result ? (market.result.toLowerCase() === "yes" ? "up" : "down") : "flat"}
             />
           </div>
+
+          {/* All outcomes (B2): every live leg of the event, highest price
+              first, current one pinned visually. Tapping switches the modal
+              to that leg — how ">2 outcome" events reveal their full list. */}
+          {siblings.length >= 2 && onSelectMarket && (
+            <div className="border-t border-edge/30 px-4 py-3">
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-fg-3">
+                All outcomes
+                <span className="ml-1.5 font-mono text-[10px] font-normal text-fg-4">
+                  {siblings.length}
+                </span>
+              </div>
+              <ul className="flex flex-col gap-1">
+                {siblings.map((s) => {
+                  const current = s.id === market.id;
+                  return (
+                    <li key={s.id}>
+                      <button
+                        type="button"
+                        aria-current={current || undefined}
+                        onClick={() => {
+                          if (!current) onSelectMarket(s);
+                        }}
+                        className={clsx(
+                          "flex w-full items-center gap-2 rounded-lg border px-2.5 py-1.5 text-left text-[12px] transition-colors",
+                          current
+                            ? "cursor-default border-accent/40 bg-accent/8"
+                            : "cursor-pointer border-edge/30 bg-base-100/40 hover:border-edge/60 hover:bg-surface-hover",
+                        )}
+                      >
+                        <span
+                          className={clsx(
+                            "min-w-0 flex-1 truncate",
+                            current ? "font-medium text-fg" : "text-fg-2",
+                          )}
+                        >
+                          {outcomeLabel(s)}
+                        </span>
+                        <ProbabilityPill pct={s.yes_price} delta={priceDelta(s)} size="sm" />
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
 
           {/* Alerts */}
           <div className="border-t border-edge/30 px-4 py-3">

--- a/desktop/src/channels/predictions/MyPositionsPanel.tsx
+++ b/desktop/src/channels/predictions/MyPositionsPanel.tsx
@@ -214,9 +214,16 @@ export default function MyPositionsPanel({ markets, hex }: MyPositionsPanelProps
   const sortedPositions = sortPositionsByValue(portfolio.positions, prices);
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto">
+    // Page-scroll layout: the Source page owns the scroll (an inner
+    // `overflow-y-auto` here created a dead scrollport in-app — same fix
+    // as the FeedTab control bar). The summary scrolls with the content:
+    // pinning it under the sticky switcher needs a hardcoded offset that
+    // drifts with the bar's height, and it never pinned in prod anyway.
+    // ponytail: if stacked pinning is ever wanted, share the bar height
+    // via a CSS var instead of a px literal.
+    <div className="flex min-h-full flex-1 flex-col">
       {/* Summary header */}
-      <div className="sticky top-0 z-10 border-b border-edge/30 bg-surface px-4 py-3">
+      <div className="border-b border-edge/30 bg-surface px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div>
             <div className="text-[11px] uppercase tracking-wide text-fg-3">Account value</div>

--- a/desktop/src/channels/predictions/preview/preview.tsx
+++ b/desktop/src/channels/predictions/preview/preview.tsx
@@ -36,9 +36,177 @@ const params = new URLSearchParams(window.location.search);
 const theme = params.get("theme") ?? "scrollr-light";
 const density =
   params.get("density") === "compact" ? ("compact" as const) : ("comfort" as const);
+/** `?demo=1`: inject synthetic start_times, a >2-leg event and a candles
+ *  fetch shim so the LIVE badge, "Starts in" countdown, "+N more" and the
+ *  history chart are photographable — states today's payload can't produce
+ *  (see ui-review/NOTES.md, B3 + shared-code log). Dev harness only. */
+const demo = params.get("demo") === "1";
+
+// ── Tauri bridge mock (harness-only) ─────────────────────────────
+// Makes `isKalshiAvailable()` true in the browser so the Markets/Positions
+// switcher renders and the My Positions panel is drivable with a mocked
+// open-position portfolio (A2 verification). Unknown commands reject —
+// every channel caller already tolerates that.
+function installTauriMock(predictions: Prediction[]): void {
+  const lead = predictions[0];
+  const second =
+    predictions.find(
+      (p) => p.ticker !== lead?.ticker && p.event_ticker !== lead?.event_ticker,
+    ) ?? lead;
+  const portfolio = {
+    balance_cents: 148_250,
+    positions: [
+      {
+        ticker: lead?.ticker ?? "DEMO-T1",
+        position: 15,
+        side: "yes",
+        count: 15,
+        exposure_cents: 15 * Math.max(1, (lead?.yes_price ?? 47) - 3),
+        realized_pnl_cents: 0,
+        total_traded_cents: 705,
+        fees_paid_cents: 7,
+        resting_orders_count: 0,
+      },
+      {
+        ticker: second?.ticker ?? "DEMO-T2",
+        position: -4,
+        side: "no",
+        count: 4,
+        exposure_cents: 4 * Math.max(1, 100 - (second?.yes_price ?? 58) - 2),
+        realized_pnl_cents: 120,
+        total_traded_cents: 168,
+        fees_paid_cents: 2,
+        resting_orders_count: 1,
+      },
+    ],
+    fills: [
+      {
+        ticker: lead?.ticker ?? "DEMO-T1",
+        side: "yes",
+        action: "buy",
+        count: 15,
+        price_cents: Math.max(1, (lead?.yes_price ?? 47) - 3),
+        is_taker: true,
+        created_time: new Date(Date.now() - 42 * 60_000).toISOString(),
+      },
+      {
+        ticker: second?.ticker ?? "DEMO-T2",
+        side: "no",
+        action: "buy",
+        count: 4,
+        price_cents: Math.max(1, 100 - (second?.yes_price ?? 58) - 2),
+        is_taker: false,
+        created_time: new Date(Date.now() - 3 * 3600_000).toISOString(),
+      },
+    ],
+    resting_orders: [
+      {
+        ticker: second?.ticker ?? "DEMO-T2",
+        side: "no",
+        action: "buy",
+        price_cents: 35,
+        remaining_count: 6,
+        created_time: new Date(Date.now() - 60 * 60_000).toISOString(),
+      },
+    ],
+  };
+
+  const commands: Record<string, () => unknown> = {
+    kalshi_status: () => ({ connected: true, key_id: "DEMO-KEY", env: "demo" }),
+    kalshi_portfolio: () => portfolio,
+    kalshi_start_user_stream: () => undefined,
+    kalshi_stop_user_stream: () => undefined,
+    kalshi_disconnect: () => undefined,
+    "plugin:shell|open": () => undefined,
+  };
+
+  (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {
+    // @tauri-apps/api v2 entry points used by the channel.
+    invoke: (cmd: string) =>
+      cmd in commands
+        ? Promise.resolve(commands[cmd]())
+        : Promise.reject(new Error(`mock: unhandled command ${cmd}`)),
+    transformCallback: () => 0,
+    metadata: { currentWindow: { label: "preview" }, currentWebview: { label: "preview" } },
+  };
+}
+
+// ── Demo-state injection (?demo=1) ───────────────────────────────
+
+function injectDemoStates(predictions: Prediction[]): Prediction[] {
+  const now = Date.now();
+  const iso = (offsetMs: number) => new Date(now + offsetMs).toISOString();
+  const rows = predictions.map((p) => ({ ...p })) as (Prediction & {
+    start_time?: string;
+  })[];
+
+  // Group indices per event, in payload order.
+  const byEvent = new Map<string, number[]>();
+  rows.forEach((p, i) => {
+    const key = p.event_ticker || p.ticker;
+    byEvent.set(key, [...(byEvent.get(key) ?? []), i]);
+  });
+  const twoLeg = [...byEvent.values()].filter((idx) => idx.length === 2);
+
+  // 1. LIVE: first two-leg event — started 30m ago, closes in 3h.
+  if (twoLeg[0]) {
+    for (const i of twoLeg[0]) {
+      rows[i].start_time = iso(-30 * 60_000);
+      rows[i].close_time = iso(3 * 3600_000);
+    }
+  }
+  // 2. Starts soon: second two-leg event — starts in 3h.
+  if (twoLeg[1]) {
+    for (const i of twoLeg[1]) {
+      rows[i].start_time = iso(3 * 3600_000);
+      rows[i].close_time = iso(2 * 24 * 3600_000);
+    }
+  }
+  // 3. Multi-outcome: third two-leg event gains two synthetic legs so the
+  //    card truncates ("+2 more") and the detail lists all four by price.
+  if (twoLeg[2]) {
+    const [a] = twoLeg[2];
+    const base = rows[a];
+    const clone = (n: number, title: string, price: number): Prediction & {
+      start_time?: string;
+    } => ({
+      ...base,
+      id: `${base.id}-demo${n}`,
+      ticker: `${base.ticker}-DEMO${n}`,
+      title,
+      subtitle: title,
+      yes_price: price,
+      prev_yes_price: price - (n === 3 ? 2 : -1),
+      event_rank: 2 + n,
+    });
+    rows.push(clone(3, "Field (any other)", 9), clone(4, "No winner declared", 4));
+  }
+  return rows;
+}
+
+/** Real-shape candles (matching the probed Kalshi payload) for the demo:
+ *  seeded straight into the query cache per ticker, since the real fetch
+ *  needs the authed prod API the browser harness doesn't have. */
+function demoCandles(): { candlesticks: unknown[] } {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const candlesticks = Array.from({ length: 168 }, (_, i) => {
+    const t = nowSec - (168 - i) * 3600;
+    const v = 0.47 + 0.13 * Math.sin(i / 14) + 0.04 * Math.sin(i / 3.1);
+    return {
+      end_period_ts: t,
+      price: { close_dollars: v.toFixed(4), mean_dollars: v.toFixed(4) },
+      volume_fp: "12.00",
+    };
+  });
+  return { candlesticks };
+}
 
 function main(): void {
-  const predictions = fixture as unknown as Prediction[];
+  let predictions = fixture as unknown as Prediction[];
+  if (demo) {
+    predictions = injectDemoStates(predictions);
+  }
+  installTauriMock(predictions);
 
   // Queries disabled: the seeded snapshot IS the dataset. Keeps screenshots
   // deterministic and avoids the authenticated /dashboard path entirely.
@@ -49,6 +217,13 @@ function main(): void {
     data: { predictions },
   });
   queryClient.setQueryData(predictionsCatalogOptions().queryKey, []);
+  if (demo) {
+    // Pre-fill the per-ticker candlesticks cache so the detail chart
+    // renders (staleTime keeps the seeded data fresh; no fetch fires).
+    for (const p of predictions) {
+      queryClient.setQueryData(["predictions-candlesticks", p.ticker], demoCandles());
+    }
+  }
 
   const prefs = {
     channelDisplay: {
@@ -93,10 +268,13 @@ function main(): void {
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <ShellContext.Provider value={shell}>
+          {/* Page-scroll like the app: PageLayout's feed mode scrolls the
+              PAGE, not the FeedTab — the harness must mirror that or
+              sticky bugs hide (they did; see NOTES.md). */}
           <div
             id="app-shell"
             data-theme={theme}
-            className="h-screen overflow-hidden bg-surface text-fg font-sans"
+            className="h-screen overflow-y-auto scrollbar-thin bg-surface text-fg font-sans"
           >
             <FeedTab
               mode={density}

--- a/desktop/src/channels/predictions/search.test.ts
+++ b/desktop/src/channels/predictions/search.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from "vitest";
+import {
+  editDistance,
+  matchToken,
+  mergeRanges,
+  tokenize,
+  matchEvent,
+  searchEvents,
+  outcomeLabel,
+} from "./search";
+import { groupByEvent } from "./view";
+import type { Prediction } from "../../types";
+
+// ── Fixtures ────────────────────────────────────────────────────
+
+function mk(partial: Partial<Prediction> & { id: string }): Prediction {
+  return {
+    source: "kalshi",
+    ticker: partial.id,
+    title: partial.id,
+    yes_price: 50,
+    updated_at: "2026-01-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+/** A small universe: binary politics event, multi-outcome sports event,
+ *  economics event with a subtitle leg. */
+const MARKETS: Prediction[] = [
+  mk({
+    id: "kalshi:GOVSHUT-26",
+    event_ticker: "GOVSHUT",
+    event_title: "Government shutdown before August?",
+    title: "Yes",
+    category: "Politics",
+  }),
+  mk({
+    id: "kalshi:NBA-ATL",
+    event_ticker: "NBACHAMP",
+    event_title: "NBA Champion 2027?",
+    title: "Atlanta",
+    category: "Sports",
+    event_rank: 1,
+  }),
+  mk({
+    id: "kalshi:NBA-OKC",
+    event_ticker: "NBACHAMP",
+    event_title: "NBA Champion 2027?",
+    title: "Oklahoma City",
+    category: "Sports",
+    event_rank: 2,
+  }),
+  mk({
+    id: "kalshi:FED-DEC",
+    event_ticker: "FEDCUT",
+    event_title: "Fed rate cut in December?",
+    title: "Yes",
+    subtitle: "25bps or more",
+    category: "Economics",
+  }),
+];
+
+function events() {
+  return groupByEvent(MARKETS);
+}
+
+const catOf = (ev: { category?: string }) => ev.category;
+
+function hitTickers(query: string): string[] {
+  const hits = searchEvents(query, events(), catOf);
+  return hits ? [...hits.keys()] : [];
+}
+
+// ── editDistance ────────────────────────────────────────────────
+
+describe("editDistance", () => {
+  it("is 0 for identical strings", () => {
+    expect(editDistance("trump", "trump", 2)).toBe(0);
+  });
+
+  it("counts substitution, insertion, deletion as 1", () => {
+    expect(editDistance("goverment", "government", 2)).toBe(1); // insertion
+    expect(editDistance("shutdwon", "shutdown", 2)).toBe(1); // transposition
+    expect(editDistance("fedd", "fed", 2)).toBe(1); // deletion
+    expect(editDistance("chanpion", "champion", 2)).toBe(1); // substitution
+  });
+
+  it("counts adjacent transposition as a single edit (OSA)", () => {
+    expect(editDistance("bidne", "biden", 1)).toBe(1);
+  });
+
+  it("returns cap+1 when the distance exceeds the cap", () => {
+    expect(editDistance("zebra", "politics", 1)).toBe(2);
+    expect(editDistance("abc", "xyz", 2)).toBe(3);
+  });
+});
+
+// ── matchToken ──────────────────────────────────────────────────
+
+describe("matchToken", () => {
+  it("finds exact substrings with the correct range", () => {
+    expect(matchToken("champion", "NBA Champion 2027?")).toEqual([[4, 12]]);
+  });
+
+  it("is case-insensitive over the text (token is pre-lowercased)", () => {
+    expect(matchToken("nba", "NBA Champion 2027?")).toEqual([[0, 3]]);
+  });
+
+  it("matches prefixes via substring", () => {
+    expect(matchToken("champ", "NBA Champion 2027?")).toEqual([[4, 9]]);
+  });
+
+  it("tolerates one typo in medium tokens", () => {
+    expect(matchToken("goverment", "Government shutdown?")).toEqual([[0, 10]]);
+  });
+
+  it("tolerates a typo'd prefix of a longer word", () => {
+    // "presedent" (9, budget 2) vs "presidential": the whole word is too
+    // long (length gap 3) but its 9-char prefix "president" is 1 edit away.
+    expect(matchToken("presedent", "Presidential election 2028")).toEqual([
+      [0, 9],
+    ]);
+  });
+
+  it("requires exact match for short tokens", () => {
+    expect(matchToken("fde", "Fed rate cut?")).toBeNull();
+    expect(matchToken("fed", "Fed rate cut?")).toEqual([[0, 3]]);
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(matchToken("zebra", "Government shutdown?")).toBeNull();
+  });
+});
+
+// ── mergeRanges ─────────────────────────────────────────────────
+
+describe("mergeRanges", () => {
+  it("merges overlapping and touching ranges and sorts", () => {
+    expect(
+      mergeRanges([
+        [5, 9],
+        [0, 3],
+        [8, 12],
+        [3, 4],
+      ]),
+    ).toEqual([
+      [0, 4],
+      [5, 12],
+    ]);
+  });
+
+  it("passes disjoint ranges through sorted", () => {
+    expect(
+      mergeRanges([
+        [10, 12],
+        [0, 2],
+      ]),
+    ).toEqual([
+      [0, 2],
+      [10, 12],
+    ]);
+  });
+});
+
+// ── outcomeLabel ────────────────────────────────────────────────
+
+describe("outcomeLabel", () => {
+  it("uses the leg title for multi-outcome legs", () => {
+    expect(outcomeLabel(mk({ id: "x", title: "Atlanta" }))).toBe("Atlanta");
+  });
+
+  it("normalizes yes-legs (any case, or empty) to 'Yes'", () => {
+    expect(outcomeLabel(mk({ id: "x", title: "YES" }))).toBe("Yes");
+    expect(outcomeLabel(mk({ id: "x", title: "" }))).toBe("Yes");
+  });
+});
+
+// ── matchEvent / searchEvents ───────────────────────────────────
+
+describe("searchEvents", () => {
+  it("matches exact words in the event title", () => {
+    expect(hitTickers("shutdown")).toEqual(["GOVSHUT"]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(hitTickers("SHUTDOWN")).toEqual(["GOVSHUT"]);
+    expect(hitTickers("nba")).toEqual(["NBACHAMP"]);
+  });
+
+  it("matches with a typo (fuzzy)", () => {
+    expect(hitTickers("shutdwon")).toEqual(["GOVSHUT"]); // transposition
+    expect(hitTickers("goverment")).toEqual(["GOVSHUT"]); // missing letter
+  });
+
+  it("matches the category", () => {
+    expect(hitTickers("politics")).toEqual(["GOVSHUT"]);
+    expect(hitTickers("sports")).toEqual(["NBACHAMP"]);
+  });
+
+  it("matches outcome names", () => {
+    expect(hitTickers("atlanta")).toEqual(["NBACHAMP"]);
+    expect(hitTickers("oklahoma")).toEqual(["NBACHAMP"]);
+  });
+
+  it("matches outcome subtitles (no highlight ranges required)", () => {
+    expect(hitTickers("25bps")).toEqual(["FEDCUT"]);
+  });
+
+  it("ANDs multiple tokens across fields", () => {
+    // "champion" (title) + "atlanta" (outcome) both hit NBACHAMP.
+    expect(hitTickers("champion atlanta")).toEqual(["NBACHAMP"]);
+    // Both tokens match SOME event, but no single event has both.
+    expect(hitTickers("shutdown atlanta")).toEqual([]);
+  });
+
+  it("returns no hits for garbage queries", () => {
+    expect(hitTickers("zzzzqqq")).toEqual([]);
+  });
+
+  it("returns null (search inactive) for empty/whitespace queries", () => {
+    expect(searchEvents("", events(), catOf)).toBeNull();
+    expect(searchEvents("   ", events(), catOf)).toBeNull();
+  });
+
+  it("preserves input (browse) order — filter, never re-rank", () => {
+    expect(hitTickers("yes")).toEqual(["GOVSHUT", "FEDCUT"]);
+  });
+
+  it("reports highlight ranges for title, category, and outcomes", () => {
+    const hit = matchEvent(
+      tokenize("champion atlanta"),
+      events().find((e) => e.eventTicker === "NBACHAMP")!,
+      "Sports",
+    );
+    expect(hit).not.toBeNull();
+    expect(hit!.titleRanges).toEqual([[4, 12]]);
+    expect(hit!.outcomeRanges["kalshi:NBA-ATL"]).toEqual([[0, 7]]);
+  });
+
+  it("highlights the category when it matched", () => {
+    const hit = matchEvent(
+      tokenize("economics"),
+      events().find((e) => e.eventTicker === "FEDCUT")!,
+      "Economics",
+    );
+    expect(hit).not.toBeNull();
+    expect(hit!.categoryRanges).toEqual([[0, 9]]);
+  });
+});

--- a/desktop/src/channels/predictions/search.ts
+++ b/desktop/src/channels/predictions/search.ts
@@ -1,0 +1,218 @@
+/**
+ * Predictions market search — pure matching logic (no React).
+ *
+ * CLIENT-SIDE ONLY by design: the dashboard payload already carries the full
+ * curated market universe (~240 rows), and Kalshi trade-api/v2 exposes no
+ * text-search parameter (verified against docs.kalshi.com 2026-07-15 — GET
+ * /markets and GET /events accept only structured ticker/status/timestamp
+ * filters). See ui-review/NOTES.md for the full decision log.
+ *
+ * Matching model, per whitespace-separated query token (AND across tokens,
+ * any field satisfies a token):
+ *   1. exact substring (case-insensitive) — covers prefix/infix,
+ *   2. typo tolerance per word: bounded Damerau-Levenshtein (OSA) against
+ *      each word, and against the word's prefix for longer words, with the
+ *      edit budget scaled by token length (<4 exact, 4–7 → 1 edit, ≥8 → 2).
+ * Fields: event title, outcome labels (+subtitle), category.
+ * Results keep the browse ordering — search filters in place, it never
+ * re-ranks. Highlight ranges index into the ORIGINAL strings.
+ */
+import type { Prediction } from "../../types";
+import type { PredictionEvent } from "./view";
+
+/** Half-open [start, end) index range into the original string. */
+export type MatchRange = [start: number, end: number];
+
+export interface EventSearchHit {
+  /** Ranges within `event.title`. */
+  titleRanges: MatchRange[];
+  /** Ranges within the category label. */
+  categoryRanges: MatchRange[];
+  /** market.id → ranges within `outcomeLabel(market)`. */
+  outcomeRanges: Record<string, MatchRange[]>;
+}
+
+/**
+ * The label an outcome row renders — binary legs read "Yes", multi-outcome
+ * legs use their own title ("Atlanta", "France"). SINGLE SOURCE for both
+ * the card row and the matcher, so highlight offsets can never drift.
+ */
+export function outcomeLabel(m: Prediction): string {
+  return m.title && m.title.toLowerCase() !== "yes" ? m.title : "Yes";
+}
+
+/** Edit budget by token length — short tokens must match exactly. */
+function maxEdits(len: number): number {
+  if (len < 4) return 0;
+  if (len <= 7) return 1;
+  return 2;
+}
+
+/**
+ * Bounded Damerau-Levenshtein (optimal string alignment: substitution,
+ * insertion, deletion, adjacent transposition each cost 1). Returns
+ * `cap + 1` as soon as the distance provably exceeds `cap`. Inputs are
+ * single words (short); the O(len²) DP is fine at this scale.
+ */
+export function editDistance(a: string, b: string, cap: number): number {
+  if (a === b) return 0;
+  const la = a.length;
+  const lb = b.length;
+  if (Math.abs(la - lb) > cap) return cap + 1;
+
+  // Three rolling rows (previous-previous needed for transposition).
+  let prevPrev: number[] = [];
+  let prev: number[] = Array.from({ length: lb + 1 }, (_, j) => j);
+  let curr: number[] = new Array<number>(lb + 1);
+
+  for (let i = 1; i <= la; i++) {
+    curr[0] = i;
+    let rowMin = curr[0];
+    for (let j = 1; j <= lb; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      let v = Math.min(
+        prev[j] + 1, // deletion
+        curr[j - 1] + 1, // insertion
+        prev[j - 1] + cost, // substitution
+      );
+      if (
+        i > 1 &&
+        j > 1 &&
+        a[i - 1] === b[j - 2] &&
+        a[i - 2] === b[j - 1]
+      ) {
+        v = Math.min(v, prevPrev[j - 2] + 1); // transposition
+      }
+      curr[j] = v;
+      if (v < rowMin) rowMin = v;
+    }
+    if (rowMin > cap) return cap + 1;
+    [prevPrev, prev, curr] = [prev, curr, prevPrev];
+  }
+  const d = prev[lb];
+  return d > cap ? cap + 1 : d;
+}
+
+/** Merge overlapping/touching ranges, sorted by start. */
+export function mergeRanges(ranges: MatchRange[]): MatchRange[] {
+  if (ranges.length <= 1) return [...ranges].sort((x, y) => x[0] - y[0]);
+  const sorted = [...ranges].sort((x, y) => x[0] - y[0]);
+  const out: MatchRange[] = [sorted[0]];
+  for (let i = 1; i < sorted.length; i++) {
+    const last = out[out.length - 1];
+    const next = sorted[i];
+    if (next[0] <= last[1]) {
+      last[1] = Math.max(last[1], next[1]);
+    } else {
+      out.push([next[0], next[1]]);
+    }
+  }
+  return out;
+}
+
+const WORD_RE = /[\p{L}\p{N}]+/gu;
+
+/**
+ * Match one lowercase query token against a text. Returns highlight ranges
+ * (indices into `text`) or null. Substring first, then per-word typo match.
+ */
+export function matchToken(token: string, text: string): MatchRange[] | null {
+  if (!token || !text) return null;
+  const lower = text.toLowerCase();
+  const idx = lower.indexOf(token);
+  if (idx >= 0) return [[idx, idx + token.length]];
+
+  const cap = maxEdits(token.length);
+  if (cap === 0) return null;
+
+  WORD_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WORD_RE.exec(lower))) {
+    const word = m[0];
+    if (editDistance(token, word, cap) <= cap) {
+      return [[m.index, m.index + word.length]];
+    }
+    // Typo'd prefix of a longer word ("electon" → "elections").
+    if (
+      word.length > token.length &&
+      editDistance(token, word.slice(0, token.length), cap) <= cap
+    ) {
+      return [[m.index, m.index + token.length]];
+    }
+  }
+  return null;
+}
+
+export function tokenize(query: string): string[] {
+  return query.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Match a query against one event. Every token must match at least one
+ * field (title / category / any outcome label or subtitle); ranges are
+ * collected for every field a token hit, so all occurrences highlight.
+ */
+export function matchEvent(
+  tokens: string[],
+  event: PredictionEvent,
+  category: string | undefined,
+): EventSearchHit | null {
+  const titleRanges: MatchRange[] = [];
+  const categoryRanges: MatchRange[] = [];
+  const outcomeRanges: Record<string, MatchRange[]> = {};
+
+  for (const token of tokens) {
+    let matched = false;
+    const t = matchToken(token, event.title);
+    if (t) {
+      titleRanges.push(...t);
+      matched = true;
+    }
+    if (category) {
+      const c = matchToken(token, category);
+      if (c) {
+        categoryRanges.push(...c);
+        matched = true;
+      }
+    }
+    for (const outcome of event.outcomes) {
+      const r = matchToken(token, outcomeLabel(outcome));
+      if (r) {
+        (outcomeRanges[outcome.id] ??= []).push(...r);
+        matched = true;
+      } else if (outcome.subtitle && matchToken(token, outcome.subtitle)) {
+        // Subtitle isn't rendered on the card — counts as a match, no ranges.
+        matched = true;
+      }
+    }
+    if (!matched) return null;
+  }
+
+  for (const id of Object.keys(outcomeRanges)) {
+    outcomeRanges[id] = mergeRanges(outcomeRanges[id]);
+  }
+  return {
+    titleRanges: mergeRanges(titleRanges),
+    categoryRanges: mergeRanges(categoryRanges),
+    outcomeRanges,
+  };
+}
+
+/**
+ * Filter an event list by a free-text query. Returns eventTicker → hit for
+ * matching events, or null when the query has no tokens (no search active).
+ */
+export function searchEvents(
+  query: string,
+  events: PredictionEvent[],
+  categoryOf: (event: PredictionEvent) => string | undefined,
+): Map<string, EventSearchHit> | null {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return null;
+  const hits = new Map<string, EventSearchHit>();
+  for (const event of events) {
+    const hit = matchEvent(tokens, event, categoryOf(event));
+    if (hit) hits.set(event.eventTicker, hit);
+  }
+  return hits;
+}

--- a/desktop/src/channels/predictions/view.test.ts
+++ b/desktop/src/channels/predictions/view.test.ts
@@ -13,7 +13,11 @@ import {
   marketLabel,
   isResolved,
   selectResolvedToday,
+  outcomesByPrice,
+  cardOutcomes,
+  timeIndicator,
   TICKER_FALLBACK_LIMIT,
+  type MaybeStarts,
 } from "./view";
 import type { Prediction } from "../../types";
 import type { PredictionsDisplayPrefs } from "../../preferences";
@@ -58,6 +62,134 @@ describe("priceDelta", () => {
     expect(
       priceDelta(mk({ id: "A", yes_price: undefined as unknown as number, prev_yes_price: 20 })),
     ).toBe(-20);
+  });
+});
+
+// ── outcomesByPrice / cardOutcomes (B2) ─────────────────────────
+
+describe("outcomesByPrice", () => {
+  it("orders legs by implied probability, highest first", () => {
+    const legs = [
+      mk({ id: "low", yes_price: 10, event_rank: 1 }),
+      mk({ id: "high", yes_price: 80, event_rank: 3 }),
+      mk({ id: "mid", yes_price: 40, event_rank: 2 }),
+    ];
+    expect(outcomesByPrice(legs).map((m) => m.id)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("breaks price ties by rank then ticker so order never jitters", () => {
+    const legs = [
+      mk({ id: "b-tick", yes_price: 50, event_rank: 2 }),
+      mk({ id: "a-tick", yes_price: 50, event_rank: 2 }),
+      mk({ id: "ranked", yes_price: 50, event_rank: 1 }),
+    ];
+    expect(outcomesByPrice(legs).map((m) => m.id)).toEqual([
+      "ranked",
+      "a-tick",
+      "b-tick",
+    ]);
+    // Stable under re-sort (same input, same output).
+    expect(outcomesByPrice(legs)).toEqual(outcomesByPrice(legs));
+  });
+
+  it("does not mutate its input", () => {
+    const legs = [mk({ id: "a", yes_price: 1 }), mk({ id: "b", yes_price: 9 })];
+    outcomesByPrice(legs);
+    expect(legs.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("cardOutcomes", () => {
+  it("shows the top two by price and counts the rest as extra", () => {
+    const legs = [
+      mk({ id: "third", yes_price: 20 }),
+      mk({ id: "first", yes_price: 70 }),
+      mk({ id: "fourth", yes_price: 5 }),
+      mk({ id: "second", yes_price: 60 }),
+    ];
+    const { visible, extra } = cardOutcomes(legs);
+    expect(visible.map((m) => m.id)).toEqual(["first", "second"]);
+    expect(extra).toBe(2);
+  });
+
+  it("two-leg events show both with zero extra (no layout change)", () => {
+    const legs = [mk({ id: "a", yes_price: 30 }), mk({ id: "b", yes_price: 70 })];
+    const { visible, extra } = cardOutcomes(legs);
+    expect(visible).toHaveLength(2);
+    expect(extra).toBe(0);
+  });
+
+  it("single-leg events keep one visible row and zero extra", () => {
+    const { visible, extra } = cardOutcomes([mk({ id: "solo", yes_price: 50 })]);
+    expect(visible).toHaveLength(1);
+    expect(extra).toBe(0);
+  });
+});
+
+// ── timeIndicator (B3) ──────────────────────────────────────────
+
+describe("timeIndicator", () => {
+  const now = Date.parse("2026-07-15T12:00:00Z");
+  const hours = (n: number) =>
+    new Date(now + n * 3600 * 1000).toISOString();
+  const withStart = (
+    partial: Partial<Prediction> & { id: string },
+    start?: string,
+  ): MaybeStarts => ({ ...mk(partial), start_time: start });
+
+  it("LIVE once the event started and the market hasn't closed", () => {
+    const m = withStart({ id: "m", close_time: hours(2) }, hours(-1));
+    expect(timeIndicator(m, now)).toEqual({ kind: "live" });
+  });
+
+  it("LIVE with a start but no close_time (still in progress)", () => {
+    const m = withStart({ id: "m", close_time: undefined }, hours(-1));
+    expect(timeIndicator(m, now)).toEqual({ kind: "live" });
+  });
+
+  it("counts down to starts within 24h", () => {
+    const m = withStart({ id: "m", close_time: hours(48) }, hours(3));
+    expect(timeIndicator(m, now)).toEqual({
+      kind: "starts",
+      label: "Starts in 3h",
+    });
+  });
+
+  it("beyond the 24h window the close label wins", () => {
+    const m = withStart({ id: "m", close_time: hours(48) }, hours(25));
+    expect(timeIndicator(m, now)).toEqual({
+      kind: "closes",
+      label: "Closes 2d",
+    });
+  });
+
+  it("NO start_time → always the close label (no fabricated starts)", () => {
+    const m = mk({ id: "m", close_time: hours(3) });
+    expect(timeIndicator(m, now)).toEqual({ kind: "closes", label: "Closes 3h" });
+  });
+
+  it("an unparseable start_time falls back to the close label", () => {
+    const m = withStart({ id: "m", close_time: hours(5) }, "not-a-date");
+    expect(timeIndicator(m, now)).toEqual({ kind: "closes", label: "Closes 5h" });
+  });
+
+  it("Closed beats LIVE once the market's close has passed", () => {
+    const m = withStart({ id: "m", close_time: hours(-1) }, hours(-3));
+    expect(timeIndicator(m, now)).toEqual({ kind: "closed" });
+  });
+
+  it("resolved markets get no indicator (settlement is its own row)", () => {
+    const m = withStart(
+      { id: "m", result: "yes", close_time: hours(2) },
+      hours(-1),
+    );
+    expect(timeIndicator(m, now)).toEqual({ kind: "none" });
+  });
+
+  it("no close_time and no start_time → none", () => {
+    expect(timeIndicator(mk({ id: "m", close_time: undefined }), now)).toEqual({
+      kind: "none",
+    });
   });
 });
 

--- a/desktop/src/channels/predictions/view.ts
+++ b/desktop/src/channels/predictions/view.ts
@@ -7,6 +7,7 @@
  */
 import type { Prediction } from "../../types";
 import type { PredictionsDisplayPrefs } from "../../preferences";
+import { formatCloseCountdown } from "../../utils/format";
 
 /** "trending" = trailing-24h volume (v1.1.5) — falls back to all-time
  *  volume on old payloads that don't carry `volume_24h`. */
@@ -272,6 +273,97 @@ export function groupEventsByCategory(
   return Array.from(byCategory.values()).sort(
     (a, b) => b.volume24h - a.volume24h,
   );
+}
+
+// ── Multi-outcome cards (B2, version-bump pass) ──────────────────
+
+/** Outcome rows a card shows before "+N more" takes over. */
+export const CARD_OUTCOME_LIMIT = 2;
+
+/**
+ * Real legs ordered by implied probability, highest first. Ties break by
+ * event rank (most-liquid first) then ticker, so equal prices never jitter
+ * between live ticks. Used by cards (top slice) and the detail view (full
+ * list).
+ */
+export function outcomesByPrice(outcomes: Prediction[]): Prediction[] {
+  return [...outcomes].sort(
+    (a, b) =>
+      num(b.yes_price) - num(a.yes_price) ||
+      (a.event_rank ?? 1) - (b.event_rank ?? 1) ||
+      a.ticker.localeCompare(b.ticker),
+  );
+}
+
+/**
+ * The card's outcome slice: top `limit` legs by price plus how many were
+ * hidden ("+N more"). Today the server ships at most two legs per event, so
+ * `extra` is always 0 in prod — the mechanism is tested and ready for the
+ * leg-cap lift (ui-review/NOTES.md, shared-code log #3).
+ */
+export function cardOutcomes(
+  outcomes: Prediction[],
+  limit: number = CARD_OUTCOME_LIMIT,
+): { visible: Prediction[]; extra: number } {
+  const sorted = outcomesByPrice(outcomes);
+  return {
+    visible: sorted.slice(0, limit),
+    extra: Math.max(0, sorted.length - limit),
+  };
+}
+
+// ── Time indicators (B3, version-bump pass) ──────────────────────
+
+/**
+ * NO payload today carries an event start time (see ui-review/NOTES.md, B3
+ * findings) — this optional field is typed channel-locally so the indicator
+ * logic is ready the day the backend ships one. Never derived or guessed.
+ */
+export type MaybeStarts = Prediction & { start_time?: string | null };
+
+export type TimeIndicator =
+  | { kind: "live" }
+  | { kind: "starts"; label: string }
+  | { kind: "closes"; label: string }
+  | { kind: "closed" }
+  | { kind: "none" };
+
+const STARTS_SOON_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Pick the card's time indicator, in priority order:
+ *   1. LIVE — the event has started (`start_time` ≤ now) and the market
+ *      hasn't closed or resolved. Close/settlement is the only end signal
+ *      the data has, so LIVE persists until one of them arrives.
+ *   2. "Starts in 3h" — a known start within the next 24h.
+ *   3. "Closes 5d" / "Closed" — the existing close label; ALWAYS the
+ *      fallback when no start-time field exists for a market (the
+ *      no-fabrication rule).
+ * Resolved markets get "none" — settlement stamps are their own row.
+ */
+export function timeIndicator(p: MaybeStarts, now: number): TimeIndicator {
+  if (isResolved(p)) return { kind: "none" };
+
+  const closeLabel = formatCloseCountdown(p.close_time, now);
+  if (closeLabel === "Closed") return { kind: "closed" };
+
+  if (p.start_time) {
+    const start = new Date(p.start_time).getTime();
+    if (Number.isFinite(start)) {
+      const untilStart = start - now;
+      if (untilStart <= 0) return { kind: "live" };
+      if (untilStart <= STARTS_SOON_WINDOW_MS) {
+        return {
+          kind: "starts",
+          label: `Starts in ${formatCloseCountdown(p.start_time, now)}`,
+        };
+      }
+    }
+  }
+
+  return closeLabel
+    ? { kind: "closes", label: `Closes ${closeLabel}` }
+    : { kind: "none" };
 }
 
 // ── Display formatting (cents == implied probability) ────────────

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,6 +15,7 @@ stays at 1.1.0 and nobody gets force-updated.
 | ~~v1.1.3~~ | Time Controls | ✅ **Shipped 2026-07-03** — day windows for sports/news + 7-day score retention (+ pricing-page overhaul rode along) | M |
 | ~~v1.1.4~~ | Kalshi Grows Up | ✅ **Shipped 2026-07-03** — event cards, watchlist-first ticker, real history charts (+ the fair-share finals fix) | M |
 | ~~v1.1.5~~ | Kalshi Cleans Up | ✅ **Shipped 2026-07-14** — sweep reconciliation ends the stale-market feed; lens-based browse, stars-only personalization, server config retired | M–L |
+| ~~v1.1.6~~ | Kalshi Fixed Up | ✅ **Shipped 2026-07-15** — history charts + My Positions un-broken (Kalshi fp migration), market search, multi-category filter, whole-card UX | M |
 | v1.2.0 | Double-Decker 2.0 | Multi-row ticker rebuilt around widgets | L |
 | — | Website rides along | Pricing rewrite shipped with v1.1.2–3; screenshots now unblocked (post-v1.1.4) | S–M |
 
@@ -218,6 +219,41 @@ The v1.1.4 follow-through, in two stacked PRs (#223 backend, #224 desktop):
 chip until the next poll drops it; a starred market that falls out of the
 top-240 while still trading leaves the payload (favorites union retired) —
 the watchlist labels it "no longer tracked".
+
+---
+
+## ✅ v1.1.6 — Kalshi Fixed Up (shipped 2026-07-15, `desktop-v1.1.6`)
+
+Two production bugs root-caused and fixed, plus the browse-UX pass —
+all inside the channel/widget scope (full evidence trail lives in the
+local `ui-review/NOTES.md` decision log; follow-ups filed as REL-5/6/7):
+
+- **History charts were 401ing on every market** — the candlesticks fetch
+  never sent auth against an `Auth: true` route; it only ever worked
+  through the fail-open hole hotfix #220 closed. Channel now owns an
+  `authFetch` query + distinct "unavailable" vs "no trades yet" fallbacks.
+- **My Positions showed zero with open positions** — Kalshi completed its
+  fixed-point migration (`position_fp`/`count_fp`/`outcome_side`; integer
+  twins removed) and the desktop parser had `*_dollars` fallbacks for
+  money but none for counts, so every position normalized to flat. Parser
+  now reads both shapes (mocked-response Rust tests), `count_filter`
+  corrected, `limit=1000`.
+- **Browse UX:** client-side market search (typo-tolerant, "/" focus);
+  whole-card click targets with hover/pressed affordance; fully clickable
+  section headers; multi-select category filter composing with search and
+  every lens; sticky control bar with pinned elevation + early collapse
+  into an animated filter menu (<1024px container); price-sorted outcomes
+  with "+N more" and an all-outcomes list in the detail modal; LIVE badge
+  + "Starts in Xh" indicator logic (dormant until the payload ships a
+  start-time field — REL-6 — close labels everywhere per the
+  no-fabrication rule).
+- **Layout lessons encoded in tests:** sticky must pin against the page
+  scroller (no dead inner scrollports), geometry assertions over
+  class-list assertions, focus rings inherit the parent's border-radius.
+
+**Known issues accepted:** "+N more" can't trigger until the server ships
+>2 legs per event (REL-5); signed-out users still get the chart fallback
+(candlesticks route stays authed — REL-7).
 
 ---
 


### PR DESCRIPTION
## What broke and why

**Every market history chart has been silently 401ing since #220.** The candlesticks fetch used the unauthenticated `request()` helper against a route registered `Auth: true` — it shipped during the fail-open window #220 closed hours later, and only ever *looked* alive because high-churn markets built the in-session tick-sparkline fallback. Verified against prod (unauthenticated candlesticks → 401, catalog → 200). Fix: channel-owned `authFetch` query in MarketDetail + distinct fallbacks for fetch-failed vs no-trades-yet.

**My Positions rendered empty against funded accounts.** Kalshi finished its fixed-point migration — `position_fp`/`count_fp`/`remaining_count_fp` strings, integer twins removed, `side`→`outcome_side`, `resting_orders_count` gone (confirmed via OpenAPI docs + live market-data probe). The desktop model had `*_dollars` fallbacks for money but none for counts → every position parsed flat → dropped by the zero-filter. Balance stayed correct (dollars fallback), which is what made it look like a UI bug. Fix in `src-tauri/kalshi`: legacy-first count parsing with `*_fp` fallback, `outcome_side`, corrected `count_filter`, `limit=1000`, and mocked current-shape response tests.

## UX pass (rode with the fixes)

Market search (client-side, typo-tolerant), multi-select category filter with an animated popover (stable options across lenses, composes with search), whole-card click targets + fully clickable section headers, price-sorted outcomes with "+N more" and an all-outcomes switcher in the detail modal, LIVE/"Starts in Xh" indicator logic (dormant until a start-time field ships — REL-6; no fabricated starts), sticky control bar that actually pins in-app (the old inner `overflow-y-auto` was a dead scrollport swallowing `sticky`) with elevation-when-stuck and early collapse into a filter menu below 1024px container width.

## Verification

- 58/58 Playwright checks (system Edge) against the channel harness at 1440/960/720/375 — includes geometry assertions (bar actually pins, menus fit the viewport) after class-list-only checks let the sticky bug through
- vitest 494/494 (~40 new: search matcher, outcome sort/truncation, time-indicator selection), `tsc --noEmit` clean
- cargo kalshi tests 13/13 (4 new fixed-point mocked-response tests)
- Harness additions (dev-only): Tauri-bridge mock so the positions page is drivable in a browser; `?demo=1` injects LIVE/countdown/multi-leg states prod can't produce yet

## Scope

Kalshi channel/widget files only (`desktop/src/channels/predictions/**`, `desktop/src-tauri/src/kalshi/**`) + release chore (version bump, ROADMAP). Shared-code follow-ups deliberately logged instead of made: REL-5 (server leg cap), REL-6 (start-time source), REL-7 (dead shared query + candlesticks route auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)