### PR TITLE
Decommission dead subscriber-set machinery; docs to ADR-0002 reality [REL-17]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,12 +119,12 @@ Components are rendered at build time in a Node environment. Any module-scope ac
 
 - `gofmt` formatting. No custom linter. Go 1.25 across all modules.
 - All use Fiber v2, pgx v5, go-redis v9.
-- **Module isolation is absolute.** Each Go API has its own `go.mod`. No shared packages. Code duplication between channels is intentional — do not extract shared libraries.
-- Core API: `core/` sub-package, package-level vars (`DBPool`, `Rdb`), `Server` struct.
-- Channel APIs: flat `main` package, `App` struct holding deps (`db *pgxpool.Pool`, `rdb *redis.Client`).
+- Two Go modules: `api/` (core, incl. the folded widget sources) and `channels/fantasy/api/`. No shared packages between them — fantasy keeps the HTTP-only contract (ADR-0002 retired the old five-module duplication rule).
+- Core API: `core/` sub-package, package-level vars (`DBPool`, `Rdb`), `Server` struct. Widget sources register in `localSources` (`api/core/sources.go`).
+- Fantasy API: flat `main` package, `App` struct holding deps (`db *pgxpool.Pool`, `rdb *redis.Client`).
 - Naming: PascalCase exports, camelCase unexported, short receivers (`s *Server`, `a *App`), `snake_case` JSON tags. Constants are PascalCase, grouped with `=====` comment separators.
 - Error handling: `if err != nil` returns. `fmt.Errorf("context: %w", err)` wrapping. `log.Printf("[Context] message: %v", err)` with bracketed prefixes. `log.Fatalf` for startup failures. HTTP errors via `ErrorResponse` struct.
-- Registration: channels self-register in Redis with 30s TTL, 20s heartbeat.
+- Registration: fantasy self-registers in Redis with 30s TTL, 20s heartbeat.
 - **Keep `api/core/extension_auth.go` and `/extension/token` routes** — the desktop app uses these for PKCE auth despite the legacy naming.
 
 ## Code Style — Rust
@@ -147,17 +147,12 @@ Components are rendered at build time in a Node environment. Any module-scope ac
 
 ## Architecture Rules
 
-> **Note:** Rules 1–3 are superseded for first-party widget sources by
-> [ADR-0002](docs/adr/0002-consolidate-widget-read-apis.md) — the finance,
-> sports, rss, and predictions Go read APIs are being folded into core-api
-> (Linear project "Backend consolidation", REL-10..17). Until each fold
-> lands, the rules below still describe the deployed system. Fantasy and
-> all Rust ingestion services keep the isolation model permanently.
+(Reshaped by [ADR-0002](docs/adr/0002-consolidate-widget-read-apis.md), July 2026.)
 
-1. **Core API has zero channel-specific code.** Discovers channels via Redis, proxies routes dynamically.
-2. **Channel isolation is absolute.** Each channel owns its Go API, ingestion service, configs, and Docker Compose.
-3. **HTTP-only contract.** No shared Go interfaces or types. Core proxies `/{name}/*` with `X-User-Sub` header. Channels never validate JWTs.
-4. **Topic-based CDC PubSub**: Core dispatches CDC events via Redis topic-based PubSub (O(1) per event).
+1. **Widget read APIs live in core.** Finance, sports, rss, and predictions are served natively by `api/core/{finance,sports,rss,predictions}.go` behind the `localSource` seam (`api/core/sources.go`): native routes registered ahead of the dynamic proxy, plus in-process dashboard/health/lifecycle hooks. Adding a data source = a Go package in core + (usually) a Rust ingester.
+2. **Ingestion is isolated.** Each source's poller is a separate Rust service with its own schedule, quota blast radius, and rollout cadence (fantasy ingests in-process in Go). Core reaches ingesters only via `INTERNAL_{SOURCE}_URL` health probes, plus the predictions candlesticks pass-through.
+3. **Fantasy is the one proxied channel service.** It self-registers in Redis (30s TTL heartbeat), is discovered and proxied dynamically, and trusts the `X-User-Sub` header core injects after JWT validation — it never sees tokens. The HTTP-only contract and module isolation still apply to it.
+4. **Topic-based CDC PubSub**: Core maps CDC events to topics in-process and dispatches via Redis PubSub (O(1) per event); every replica fans out to its own SSE clients (ADR-0001).
 5. **Desktop is the primary product.** The website serves marketing, auth, and billing only.
 
 ## Error Monitoring — Sentry

--- a/api/core/channels.go
+++ b/api/core/channels.go
@@ -60,173 +60,6 @@ func CountEnabledChannels(ctx context.Context, logtoSub string) (int, error) {
 	return n, err
 }
 
-// SyncChannelSubscriptions rebuilds Redis subscription sets for a user from their
-// current channels in the database. Called on dashboard load and after channel CRUD.
-func SyncChannelSubscriptions(logtoSub string) {
-	channels, err := GetUserChannels(logtoSub)
-	if err != nil {
-		log.Printf("[Channels] Failed to sync subscriptions for %s: %v", logtoSub, err)
-		return
-	}
-
-	ctx := context.Background()
-
-	// Compute DESIRED membership first, across all widgets, then apply.
-	// Split widgets share source-level subscriber sets (sports_nfl and
-	// sports_nba both live in channel:subscribers:sports), so per-row
-	// add/remove is order-dependent: a disabled sibling iterated after an
-	// enabled one would remove the subscription the enabled widget needs.
-	// The set semantics are "member iff ANY enabled widget uses it".
-	wantSource := map[string]bool{} // source -> any enabled widget?
-	wantLeague := map[string]bool{} // league -> any enabled sports widget?
-	for _, ch := range channels {
-		source := DataSourceForWidget(ch.ChannelType)
-		if source == "" {
-			continue
-		}
-		if _, seen := wantSource[source]; !seen {
-			wantSource[source] = false
-		}
-		if ch.Enabled {
-			wantSource[source] = true
-		}
-		if source == "sports" {
-			for _, league := range extractSportsLeaguesFromConfig(ch.Config) {
-				if _, seen := wantLeague[league]; !seen {
-					wantLeague[league] = false
-				}
-				if ch.Enabled {
-					wantLeague[league] = true
-				}
-			}
-		}
-	}
-
-	for source, want := range wantSource {
-		setKey := RedisChannelSubscribersPrefix + source
-		if want {
-			AddSubscriber(ctx, setKey, logtoSub)
-		} else {
-			RemoveSubscriber(ctx, setKey, logtoSub)
-		}
-	}
-	var addLeagues, removeLeagues []string
-	for league, want := range wantLeague {
-		if want {
-			addLeagues = append(addLeagues, SportsLeagueSubscribersPrefix+league)
-		} else {
-			removeLeagues = append(removeLeagues, SportsLeagueSubscribersPrefix+league)
-		}
-	}
-	if len(addLeagues) > 0 {
-		if err := AddSubscriberMulti(ctx, addLeagues, logtoSub); err != nil {
-			log.Printf("[Channels] Failed to sync sports league subscriptions for %s: %v", logtoSub, err)
-		}
-	}
-	if len(removeLeagues) > 0 {
-		if err := RemoveSubscriberMulti(ctx, removeLeagues, logtoSub); err != nil {
-			log.Printf("[Channels] Failed to remove sports league subscriptions for %s: %v", logtoSub, err)
-		}
-	}
-
-	// Call channel lifecycle hooks via HTTP (per widget, as before).
-	for _, ch := range channels {
-		callChannelLifecycle(ctx, ch.ChannelType, "sync", logtoSub, ch.Config, nil, &ch.Enabled)
-	}
-}
-
-// addChannelSubscriptions adds Redis subscription entries for a newly created/enabled channel.
-// For sports, this also adds the user to all per-league subscriber sets.
-// Also updates the in-memory topic registry for active SSE connections.
-func addChannelSubscriptions(ctx context.Context, logtoSub, channelType string, config map[string]interface{}) {
-	source := DataSourceForWidget(channelType)
-	AddSubscriber(ctx, RedisChannelSubscribersPrefix+source, logtoSub)
-
-	// Sports: populate per-league subscriber sets for user's configured leagues.
-	if source == "sports" {
-		leagues := extractSportsLeaguesFromConfig(config)
-		if len(leagues) > 0 {
-			leagueKeys := make([]string, len(leagues))
-			for i, league := range leagues {
-				leagueKeys[i] = SportsLeagueSubscribersPrefix + league
-			}
-			if err := AddSubscriberMulti(ctx, leagueKeys, logtoSub); err != nil {
-				log.Printf("[Channels] Failed to add sports league subscriptions for %s: %v", logtoSub, err)
-			}
-		}
-	}
-
-	// Rebuild topic subscriptions on every replica holding an SSE
-	// connection for this user (Redis control message, ADR-0001)
-	NotifyTopicSubscriptionChange(logtoSub)
-
-	enabled := true
-	callChannelLifecycle(ctx, channelType, "sync", logtoSub, config, nil, &enabled)
-}
-
-// removeChannelSubscriptions removes Redis subscription entries for a deleted/disabled channel.
-// For sports, this also removes the user from per-league subscriber sets.
-// Also updates the in-memory topic registry for active SSE connections.
-//
-// Split widgets share source-level (and can share league-level) subscriber
-// sets, so removals are guarded on the user's REMAINING enabled widgets:
-// disabling sports_nba must not yank channel:subscribers:sports while
-// sports_nfl is still enabled. Both callers (UpdateChannel disable,
-// DeleteChannel) update the DB before calling this, so GetUserChannels
-// reflects the post-removal state. On a listing error we skip the removals
-// entirely — a stale subscription self-heals on the next sync; a wrongly
-// dropped one silently kills live data for the surviving widgets.
-func removeChannelSubscriptions(ctx context.Context, logtoSub, channelType string, config map[string]interface{}) {
-	source := DataSourceForWidget(channelType)
-
-	remaining, err := GetUserChannels(logtoSub)
-	if err != nil {
-		log.Printf("[Channels] Skipping subscription removal for %s/%s (listing failed: %v)", logtoSub, channelType, err)
-	} else {
-		sourceStillNeeded := false
-		keptLeagues := map[string]bool{}
-		for _, ch := range remaining {
-			if !ch.Enabled || ch.ChannelType == channelType {
-				continue
-			}
-			chSource := DataSourceForWidget(ch.ChannelType)
-			if chSource == source {
-				sourceStillNeeded = true
-			}
-			if chSource == "sports" {
-				for _, league := range extractSportsLeaguesFromConfig(ch.Config) {
-					keptLeagues[league] = true
-				}
-			}
-		}
-
-		if !sourceStillNeeded {
-			RemoveSubscriber(ctx, RedisChannelSubscribersPrefix+source, logtoSub)
-		}
-		if source == "sports" {
-			var stale []string
-			for _, league := range extractSportsLeaguesFromConfig(config) {
-				if !keptLeagues[league] {
-					stale = append(stale, SportsLeagueSubscribersPrefix+league)
-				}
-			}
-			if len(stale) > 0 {
-				if err := RemoveSubscriberMulti(ctx, stale, logtoSub); err != nil {
-					log.Printf("[Channels] Failed to remove sports league subscriptions for %s: %v", logtoSub, err)
-				}
-			}
-		}
-	}
-
-	// Rebuild topic subscriptions on every replica so active SSE
-	// connections stop receiving this channel (Redis control message,
-	// ADR-0001)
-	NotifyTopicSubscriptionChange(logtoSub)
-
-	enabled := false
-	callChannelLifecycle(ctx, channelType, "sync", logtoSub, config, nil, &enabled)
-}
-
 // callChannelLifecycle sends a lifecycle event to a channel if it has the channel_lifecycle capability.
 func callChannelLifecycle(ctx context.Context, channelType, event, userSub string, config, oldConfig map[string]interface{}, enabled *bool) {
 	// Resolve to the backing data source so widget types (e.g. "news") reach
@@ -357,8 +190,8 @@ func CreateChannel(c *fiber.Ctx) error {
 		})
 	}
 	// Utility widgets (clock/weather/…) live in desktop preferences, not
-	// user_channels. A row for one would land in a bogus "" subscriber set
-	// and double-count against the slot cap (once here, once via
+	// user_channels. A row for one has no backing data source and would
+	// double-count against the slot cap (once here, once via
 	// local_widgets), so reject it outright.
 	if IsUtilityWidgetType(req.ChannelType) {
 		return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
@@ -447,13 +280,14 @@ func CreateChannel(c *fiber.Ctx) error {
 		ch.Config = map[string]interface{}{}
 	}
 
-	// Maintain Redis subscription sets
+	// Rebuild SSE topic subscriptions on every replica holding a
+	// connection for this user (Redis control message, ADR-0001)
 	ctx := context.Background()
 	if ch.Enabled {
-		addChannelSubscriptions(ctx, userID, ch.ChannelType, ch.Config)
+		NotifyTopicSubscriptionChange(userID)
 	}
 
-	// Call OnChannelCreated hook via HTTP
+	// Call OnChannelCreated hook (in-process for local sources)
 	callChannelLifecycle(ctx, ch.ChannelType, "created", userID, ch.Config, nil, nil)
 
 	// Invalidate dashboard cache so next poll gets fresh data
@@ -622,15 +456,12 @@ func UpdateChannel(c *fiber.Ctx) error {
 		ch.Config = map[string]interface{}{}
 	}
 
-	// Maintain Redis subscription sets based on new enabled state
+	// Rebuild SSE topic subscriptions on every replica holding a
+	// connection for this user (Redis control message, ADR-0001)
 	ctx := context.Background()
-	if ch.Enabled {
-		addChannelSubscriptions(ctx, userID, ch.ChannelType, ch.Config)
-	} else {
-		removeChannelSubscriptions(ctx, userID, ch.ChannelType, ch.Config)
-	}
+	NotifyTopicSubscriptionChange(userID)
 
-	// Call OnChannelUpdated hook via HTTP
+	// Call OnChannelUpdated hook (in-process for local sources)
 	callChannelLifecycle(ctx, channelType, "updated", userID, ch.Config, oldConfig, nil)
 
 	// Invalidate dashboard cache so next poll gets fresh data
@@ -687,9 +518,11 @@ func DeleteChannel(c *fiber.Ctx) error {
 	if config == nil {
 		config = map[string]interface{}{}
 	}
-	removeChannelSubscriptions(ctx, userID, channelType, config)
+	// Rebuild SSE topic subscriptions on every replica so active
+	// connections stop receiving this channel (ADR-0001)
+	NotifyTopicSubscriptionChange(userID)
 
-	// Call OnChannelDeleted hook via HTTP
+	// Call OnChannelDeleted hook (in-process for local sources)
 	callChannelLifecycle(ctx, channelType, "deleted", userID, config, nil, nil)
 
 	// Invalidate dashboard cache so next poll gets fresh data
@@ -722,22 +555,9 @@ func PruneWidgetsForTier(ctx context.Context, logtoSub, tier string) {
 		log.Printf("[Prune] Failed to list widgets for %s: %v", logtoSub, err)
 		return
 	}
-	kept, pruned := partitionWidgetsForCap(channels, *max)
+	_, pruned := partitionWidgetsForCap(channels, *max)
 	if len(pruned) == 0 {
 		return
-	}
-
-	// Sources and sports leagues the surviving widgets still need. Split
-	// widgets share source-level subscriber sets (sports_nfl and
-	// sports_nba both live in channel:subscribers:sports), so a pruned
-	// widget must not yank a subscription a kept sibling depends on.
-	keptSources := map[string]bool{}
-	keptLeagues := map[string]bool{}
-	for _, ch := range kept {
-		keptSources[DataSourceForWidget(ch.ChannelType)] = true
-		for _, lg := range extractSportsLeaguesFromConfig(ch.Config) {
-			keptLeagues[lg] = true
-		}
 	}
 
 	for _, ch := range pruned {
@@ -750,28 +570,6 @@ func PruneWidgetsForTier(ctx context.Context, logtoSub, tier string) {
 			continue
 		}
 		log.Printf("[Prune] Disabled %s/%s: tier %s allows %d widget slots", logtoSub, ch.ChannelType, tier, *max)
-
-		source := DataSourceForWidget(ch.ChannelType)
-		if !keptSources[source] {
-			RemoveSubscriber(ctx, RedisChannelSubscribersPrefix+source, logtoSub)
-		}
-		if source == "sports" {
-			var stale []string
-			for _, lg := range extractSportsLeaguesFromConfig(ch.Config) {
-				if !keptLeagues[lg] {
-					stale = append(stale, SportsLeagueSubscribersPrefix+lg)
-				}
-			}
-			if len(stale) > 0 {
-				if err := RemoveSubscriberMulti(ctx, stale, logtoSub); err != nil {
-					log.Printf("[Prune] Failed to remove league subscriptions for %s: %v", logtoSub, err)
-				}
-			}
-		}
-
-		// Tell the backing service this widget went dark.
-		enabled := false
-		callChannelLifecycle(ctx, ch.ChannelType, "sync", logtoSub, ch.Config, nil, &enabled)
 	}
 
 	// Rebuild SSE topics on every replica holding a connection for this
@@ -796,27 +594,4 @@ func partitionWidgetsForCap(channels []Channel, max int) (kept, pruned []Channel
 		}
 	}
 	return kept, pruned
-}
-
-// extractSportsLeaguesFromConfig reads the "leagues" array from a sports
-// channel's config JSONB map. Config shape: {"leagues": ["NFL", "NBA", ...]}
-func extractSportsLeaguesFromConfig(config map[string]interface{}) []string {
-	if config == nil {
-		return nil
-	}
-	raw, ok := config["leagues"]
-	if !ok {
-		return nil
-	}
-	arr, ok := raw.([]interface{})
-	if !ok {
-		return nil
-	}
-	leagues := make([]string, 0, len(arr))
-	for _, v := range arr {
-		if s, ok := v.(string); ok && s != "" {
-			leagues = append(leagues, s)
-		}
-	}
-	return leagues
 }

--- a/api/core/channels_test.go
+++ b/api/core/channels_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestExtractSportsLeaguesFromConfig(t *testing.T) {
+func TestExtractLeaguesFromConfig(t *testing.T) {
 	tests := []struct {
 		name   string
 		config map[string]interface{}
@@ -80,20 +80,20 @@ func TestExtractSportsLeaguesFromConfig(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := extractSportsLeaguesFromConfig(tc.config)
+			got := extractLeaguesFromConfig(tc.config)
 			if tc.want == nil {
 				if got != nil {
-					t.Errorf("extractSportsLeaguesFromConfig = %v, want nil", got)
+					t.Errorf("extractLeaguesFromConfig = %v, want nil", got)
 				}
 				return
 			}
 			if len(got) != len(tc.want) {
-				t.Errorf("extractSportsLeaguesFromConfig = %v, want %v", got, tc.want)
+				t.Errorf("extractLeaguesFromConfig = %v, want %v", got, tc.want)
 				return
 			}
 			for i := range got {
 				if got[i] != tc.want[i] {
-					t.Errorf("extractSportsLeaguesFromConfig[%d] = %q, want %q", i, got[i], tc.want[i])
+					t.Errorf("extractLeaguesFromConfig[%d] = %q, want %q", i, got[i], tc.want[i])
 				}
 			}
 		})

--- a/api/core/constants.go
+++ b/api/core/constants.go
@@ -93,15 +93,8 @@ const (
 // =============================================================================
 
 const (
-	RedisChannelSubscribersPrefix = "channel:subscribers:"
-	RedisEventsUserPrefix         = "events:user:"
-	RedisDashboardCachePrefix     = "cache:dashboard:"
-
-	// SportsLeagueSubscribersPrefix is the per-league subscriber set prefix.
-	// Keys: sports:subscribers:league:{NFL}, sports:subscribers:league:{NBA}, etc.
-	// Used by the core API for subscriber management and the sports channel for
-	// per-league CDC fan-out routing.
-	SportsLeagueSubscribersPrefix = "sports:subscribers:league:"
+	RedisEventsUserPrefix     = "events:user:"
+	RedisDashboardCachePrefix = "cache:dashboard:"
 )
 
 // =============================================================================

--- a/api/core/discovery.go
+++ b/api/core/discovery.go
@@ -65,7 +65,10 @@ func (d *Discovery) run(ctx context.Context) {
 func (d *Discovery) refresh() {
 	ctx := context.Background()
 
-	// Scan for all channel:* keys
+	// Scan for all channel:* keys. Historical note: this pattern used to
+	// overlap the channel:subscribers:* sets (surviving only because GET
+	// on a SET errors and is skipped below); those sets were retired with
+	// ADR-0002, so the pattern now matches registrations only.
 	var cursor uint64
 	channels := make(map[string]*ChannelInfo)
 

--- a/api/core/redis.go
+++ b/api/core/redis.go
@@ -116,51 +116,6 @@ func InvalidateUserCaches(userSub string) {
 	}
 }
 
-// --- Subscription Set Helpers ---
-// Used to track which users subscribe to which data types.
-// Keys follow the convention:
-//   channel:subscribers:{type}  (e.g. channel:subscribers:finance)
-//   rss:subscribers:{feed_url}  (e.g. rss:subscribers:https://example.com/feed.xml)
-
-// AddSubscriber adds a user to a subscription set.
-func AddSubscriber(ctx context.Context, setKey, userSub string) error {
-	return Rdb.SAdd(ctx, setKey, userSub).Err()
-}
-
-// RemoveSubscriber removes a user from a subscription set.
-func RemoveSubscriber(ctx context.Context, setKey, userSub string) error {
-	return Rdb.SRem(ctx, setKey, userSub).Err()
-}
-
-// AddSubscriberMulti adds a user to multiple subscription sets in a single
-// pipeline round-trip. Used for sports per-league sets where a single subscribe
-// action touches 8+ Redis keys.
-func AddSubscriberMulti(ctx context.Context, setKeys []string, userSub string) error {
-	if len(setKeys) == 0 {
-		return nil
-	}
-	pipe := Rdb.Pipeline()
-	for _, key := range setKeys {
-		pipe.SAdd(ctx, key, userSub)
-	}
-	_, err := pipe.Exec(ctx)
-	return err
-}
-
-// RemoveSubscriberMulti removes a user from multiple subscription sets in a
-// single pipeline round-trip.
-func RemoveSubscriberMulti(ctx context.Context, setKeys []string, userSub string) error {
-	if len(setKeys) == 0 {
-		return nil
-	}
-	pipe := Rdb.Pipeline()
-	for _, key := range setKeys {
-		pipe.SRem(ctx, key, userSub)
-	}
-	_, err := pipe.Exec(ctx)
-	return err
-}
-
 // --- AI Triage: Recent Ticket Summaries ---
 // Sliding window of the last N ticket summaries, used as context when
 // asking Claude to dupe-detect against recent submissions. Keyed by a

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -439,9 +439,6 @@ func (s *Server) getDashboard(c *fiber.Ctx) error {
 			}
 		}
 
-		// Warm Redis subscription sets from current DB state
-		go SyncChannelSubscriptions(userID)
-
 		// 3. Fetch dashboard data from each enabled channel via HTTP (parallel)
 		dashboardClient := &http.Client{Timeout: HealthCheckTimeout}
 		var targets []*ChannelInfo

--- a/api/core/sports_test.go
+++ b/api/core/sports_test.go
@@ -29,40 +29,6 @@ func TestFairShareSideSplit(t *testing.T) {
 	}
 }
 
-func TestExtractLeaguesFromConfig(t *testing.T) {
-	tests := []struct {
-		name   string
-		config map[string]interface{}
-		want   []string
-	}{
-		{name: "nil config", config: nil, want: nil},
-		{
-			name:   "valid leagues",
-			config: map[string]interface{}{"leagues": []interface{}{"NFL", "NBA"}},
-			want:   []string{"NFL", "NBA"},
-		},
-		{
-			name:   "empty strings filtered",
-			config: map[string]interface{}{"leagues": []interface{}{"NFL", "", "MLB"}},
-			want:   []string{"NFL", "MLB"},
-		},
-		{name: "no leagues field", config: map[string]interface{}{"other": 1}, want: nil},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := extractLeaguesFromConfig(tc.config)
-			if len(got) != len(tc.want) {
-				t.Fatalf("extractLeaguesFromConfig = %v, want %v", got, tc.want)
-			}
-			for i := range got {
-				if got[i] != tc.want[i] {
-					t.Errorf("extractLeaguesFromConfig[%d] = %q, want %q", i, got[i], tc.want[i])
-				}
-			}
-		})
-	}
-}
-
 func TestExtractFavoriteTeamsFromConfig(t *testing.T) {
 	got := extractFavoriteTeamsFromConfig([]byte(`{"favoriteTeams":{"NFL":{"teamId":12,"teamName":"Kansas City Chiefs"}}}`))
 	if len(got) != 1 || got["NFL"].TeamName != "Kansas City Chiefs" || got["NFL"].TeamID != 12 {

--- a/myscrollr.com/src/routes/architecture.tsx
+++ b/myscrollr.com/src/routes/architecture.tsx
@@ -111,10 +111,10 @@ const PIPELINE_STEPS: Array<PipelineStep> = [
     Icon: Cpu,
     title: 'Ingestion Services',
     description:
-      'Three independent Rust services collect, normalize, and write data to PostgreSQL. Each runs its own schedule and connection strategy.',
+      'Four independent Rust services collect, normalize, and write data to PostgreSQL. Each runs its own schedule and connection strategy.',
     hex: HEX.info,
     label: 'PROCESS',
-    items: ['Finance :3001', 'Sports :3002', 'RSS :3004'],
+    items: ['Finance :3001', 'Sports :3002', 'RSS :3004', 'Kalshi :3005'],
     Watermark: Cpu,
   },
   {
@@ -131,10 +131,10 @@ const PIPELINE_STEPS: Array<PipelineStep> = [
     Icon: Radio,
     title: 'Real-time Delivery',
     description:
-      'Core API routes CDC records to channel APIs, which return affected user lists. Core publishes to per-user Redis channels via SSE.',
+      'Core API maps each CDC record to a topic in-process and publishes via Redis pub/sub. Every replica fans out to its own SSE clients.',
     hex: HEX.accent,
     label: 'DELIVER',
-    items: ['CDC Routing', 'Redis Pub/Sub', 'SSE Stream', 'Per-user'],
+    items: ['Topic Routing', 'Redis Pub/Sub', 'SSE Stream', 'Per-user'],
     Watermark: Radio,
   },
 ]
@@ -168,8 +168,8 @@ const CDC_FLOW: Array<CdcStep> = [
     hex: HEX.primary,
   },
   {
-    label: 'Channel API',
-    detail: 'POST /internal/cdc → users[]',
+    label: 'Topic Router',
+    detail: 'record → cdc:{source}:{key}',
     Icon: Cable,
     hex: HEX.info,
   },
@@ -204,17 +204,17 @@ interface Principle {
 const PRINCIPLES: Array<Principle> = [
   {
     Icon: Box,
-    title: 'Decoupled Channels',
+    title: 'Isolated Ingestion',
     description:
-      'Each channel is a fully self-contained unit with its own Go API, Rust service, frontend components, and config. No shared code between channels.',
+      'Each data source has its own Rust ingestion service with an independent schedule, quota budget, and crash blast radius. Widget read APIs live inside the core gateway.',
     hex: HEX.primary,
     Watermark: Box,
   },
   {
     Icon: Shield,
-    title: 'Zero-trust Proxying',
+    title: 'Zero-trust Gateway',
     description:
-      'Core API validates JWTs and injects X-User-Sub headers. Integration APIs never see tokens — they trust the core gateway.',
+      'Core API validates JWTs at the edge. The one proxied service (Fantasy) never sees tokens — it trusts identity headers injected by the gateway.',
     hex: HEX.secondary,
     Watermark: Shield,
   },
@@ -222,7 +222,7 @@ const PRINCIPLES: Array<Principle> = [
     Icon: RefreshCw,
     title: 'Self-registration',
     description:
-      'Channel APIs register in Redis on startup with a 30s TTL heartbeat. Core discovers them dynamically — no hardcoded routes.',
+      'The Fantasy service registers in Redis on startup with a 30s TTL heartbeat and is discovered dynamically. First-party widget sources are served natively by core.',
     hex: HEX.info,
     Watermark: RefreshCw,
   },
@@ -256,7 +256,7 @@ const TECH_STACK: Array<TechGroup> = [
     Icon: Server,
     hex: HEX.primary,
     items: [
-      { name: 'Go 1.22', detail: 'Fiber v2, pgx, Redis' },
+      { name: 'Go 1.25', detail: 'Fiber v2, pgx, Redis' },
       { name: 'SSE Hub', detail: 'Per-user Redis Pub/Sub channels' },
       { name: 'Logto', detail: 'Self-hosted OIDC, JWT validation' },
     ],
@@ -311,9 +311,9 @@ const TECH_STACK: Array<TechGroup> = [
     Icon: Cloud,
     hex: HEX.info,
     items: [
-      { name: 'Coolify', detail: 'Self-hosted PaaS' },
-      { name: 'Docker Compose', detail: 'Per-integration bundles' },
-      { name: 'Nixpacks', detail: 'Frontend builds' },
+      { name: 'Kubernetes', detail: 'DigitalOcean DOKS + DOCR' },
+      { name: 'GitHub Actions', detail: 'Build, deploy, smoke test' },
+      { name: 'nginx + cert-manager', detail: 'Ingress, TLS' },
     ],
     Watermark: Cloud,
   },


### PR DESCRIPTION
## Summary

The final ADR-0002 sweep (**-316 lines net**). With all three folds live and verified, this deletes the core-side half of the subscriber-set subsystem — the writers whose readers died with the folds (pre-verified write-only by REL-10 / ADR-0002 Appendix A) — and brings every doc surface in line with the deployed system.

**Code:**
- `SyncChannelSubscriptions` + `add`/`removeChannelSubscriptions` collapse to their single live behavior: `NotifyTopicSubscriptionChange`, the ADR-0001 SSE resubscribe control message. CRUD paths call it directly now; the `getDashboard` set-warm goroutine and `PruneWidgetsForTier`'s set bookkeeping are gone; the `"sync"` lifecycle event (set-warming only) is no longer dispatched.
- `redis.go` loses the four subscriber-set helpers; `constants.go` loses both set-key prefixes.
- `extractSportsLeaguesFromConfig` — the third copy of the leagues extractor and an audit shrink item — deleted; its thorough test now covers the shared `extractLeaguesFromConfig`.
- `discovery.go` documents that the `channel:*` scan no longer shares a namespace with subscriber sets.

**Docs:**
- **AGENTS.md Architecture Rules rewritten** for the post-fold model: widget read APIs in core behind the `localSource` seam, isolated Rust ingestion, fantasy as the one proxied/self-registering service. Go style section updated (two modules; the five-way duplication rule formally retired).
- **Marketing `/architecture` page**: four Rust ingesters (Kalshi was missing entirely), in-process topic routing replaces the dead `POST /internal/cdc` flow step, principles reworded truthfully, and the deployment stack corrected from the pre-April Coolify/Nixpacks story to **DOKS + GitHub Actions + nginx/cert-manager**. Rendered and verified in the Vite preview (content assertions green; the hydration warning in dev is the pre-existing theme-class mismatch, untouched).
- cdc-runbook needed nothing further (already core-centric after REL-12's table-count fix).

## Post-merge one-time Redis cleanup

Core wrote `channel:subscribers:*` and `sports:subscribers:league:*` **without TTLs**, so the retired sets never expire on their own. After deploy, SCAN+DEL both patterns (I can run this via a temporary redis-cli pod). The service-side `finance/rss:subscribers:*` sets had 7-day TTLs and age out unaided.

## Verification

- `go build`, `go vet`, `go test -count=1 ./...` green; website `tsc` green; architecture page verified rendering in preview
- Exit criteria from the issue: cluster already at 7 workloads; a widget-source change now rebuilds only core-api; production-readiness list matches the deployed set; docs match reality

Closes REL-17 — and with it, the ADR-0002 project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)