### PR TITLE
In-widget config PR 1: predictions completes itself [REL-33]

### DIFF
--- a/desktop/scripts/verify-kalshi.mjs
+++ b/desktop/scripts/verify-kalshi.mjs
@@ -199,6 +199,48 @@ async function run() {
     await page.close();
   }
 
+  // ════ 1440px — gear popover (in-widget Display settings) ═════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · gear popover ==");
+
+    const gear = page.locator('[aria-label="Predictions settings"]');
+    check("gear renders in the bar", (await gear.count()) === 1);
+    await gear.click();
+    await page.waitForSelector('[role="menu"]');
+    await page.waitForTimeout(250);
+    check(
+      "display grid renders in the popover",
+      (await page.locator('[role="menu"] [role="grid"]').count()) === 1,
+    );
+
+    // Toggling Volume off the Feed hides card footers live; the popover
+    // stays open (settings rows are not dismiss-on-click menu items).
+    const volBefore = await page.locator("text=/^Vol /").count();
+    await page.locator('[role="menu"] [aria-label="Hide Volume on Feed"]').click();
+    await page.waitForTimeout(250);
+    check("popover stays open on toggle", (await page.locator('[role="menu"]').count()) === 1);
+    const volAfter = await page.locator("text=/^Vol /").count();
+    check(
+      "volume toggle hides card volume live",
+      volBefore > 0 && volAfter === 0,
+      `${volBefore} -> ${volAfter}`,
+    );
+    await page.locator('[role="menu"] [aria-label="Show Volume on Feed"]').click();
+    await page.waitForTimeout(250);
+    check(
+      "volume toggle restores card volume",
+      (await page.locator("text=/^Vol /").count()) === volBefore,
+    );
+    await page.screenshot({ path: `${OUT}/vb-18-gear-popover-1440.png` });
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(250);
+    check("Esc closes the gear popover", (await page.locator('[role="menu"]').count()) === 0);
+
+    check("no console errors (gear page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
   // ════ 1440px — B4 sticky elevation ═══════════════════════════════
   {
     const { page, consoleErrors } = await newPage(browser, 1440, 900);

--- a/desktop/src/channels/predictions/FeedTab.tsx
+++ b/desktop/src/channels/predictions/FeedTab.tsx
@@ -29,7 +29,9 @@ import {
   Clock,
   Search,
 } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { channelsApi } from "../../api/client";
 import { dashboardQueryOptions, predictionsCatalogOptions } from "../../api/queries";
 import {
   formatCompactNumber,
@@ -52,6 +54,8 @@ import {
 } from "../../components/widget-bar/Segmented";
 import { SearchBox, useSlashFocus } from "../../components/widget-bar/SearchBox";
 import { MultiSelectMenu } from "../../components/widget-bar/MultiSelectMenu";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import DisplayItemsGrid from "../../components/settings/DisplayItemsGrid";
 import MyPositionsPanel from "./MyPositionsPanel";
 import MarketDetail from "./MarketDetail";
 import ProbabilityPill from "./ProbabilityPill";
@@ -138,6 +142,29 @@ const VIEW_OPTIONS: SegmentedOption<FeedView>[] = [
   { value: "positions", label: "Positions", icon: Wallet },
 ];
 
+/** Ticker fallback choices — mirrors PredictionsDisplayPrefs.defaultSort
+ *  minus "alpha" (nobody wants an alphabetical ticker rail). */
+const TICKER_FALLBACKS: {
+  value: PredictionsDisplayPrefs["defaultSort"];
+  label: string;
+  hint: string;
+}[] = [
+  { value: "trending", label: "Trending", hint: "hottest by 24h volume" },
+  { value: "movers", label: "Movers", hint: "biggest probability swings" },
+  { value: "closing", label: "Closing soon", hint: "nearest to close" },
+];
+
+const DENSITY_OPTIONS: SegmentedOption<"comfort" | "compact">[] = [
+  { value: "comfort", label: "Comfort" },
+  { value: "compact", label: "Compact" },
+];
+
+/** Pre-v1.1.5 server-side config keys (see the migration effect). */
+interface LegacyPredictionsConfig {
+  categories?: string[];
+  favorites?: string[];
+}
+
 // ── Display helpers ──────────────────────────────────────────────
 
 /** Signed delta with arrow glyph ("▲ 4" / "▼ 3" / "—"). */
@@ -210,6 +237,66 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
     setAlerts(persistRemoveAlert(id));
   }, []);
 
+  // ── One-time legacy config migration (v1.1.5) ─────────────────
+  // Pre-v1.1.5 configs carried `categories` (server-side universe filter)
+  // and `favorites` (hidden watchlist mirror). Import favorites into the
+  // local stars, then clear BOTH keys in one write so the server stops
+  // narrowing this user's payload. Lives on the FEED mount (moved off the
+  // Configure page) so it reaches users who never open Configure — a
+  // lingering server `categories` filter would silently hide markets.
+  const queryClient = useQueryClient();
+  const channelRow = useMemo(
+    () =>
+      (dashboard?.channels ?? []).find(
+        (ch) => ch.channel_type === "predictions",
+      ),
+    [dashboard?.channels],
+  );
+  const migratedRef = useRef(false);
+  useEffect(() => {
+    // Wait for the dashboard row — running before it loads would burn the
+    // once-per-mount guard on a no-op.
+    if (migratedRef.current || !channelRow) return;
+    migratedRef.current = true;
+
+    const config = (channelRow.config ?? {}) as LegacyPredictionsConfig;
+    const favorites = Array.isArray(config.favorites) ? config.favorites : [];
+    const categories = Array.isArray(config.categories) ? config.categories : [];
+    if (favorites.length === 0 && categories.length === 0) return;
+
+    // 1) Absorb legacy pins/mirror into the local watchlist.
+    if (favorites.length > 0) {
+      const current = getWatchlist();
+      const merged = Array.from(new Set([...current, ...favorites]));
+      const imported = merged.length - current.length;
+      if (imported > 0) {
+        saveWatchlist(merged);
+        setWatchlist(merged);
+        toast.success(
+          `Moved ${imported} pinned market${imported === 1 ? "" : "s"} to your watchlist`,
+          { description: "Stars are the one list now — managed right here." },
+        );
+      }
+    }
+
+    // 2) Clear both legacy keys in a single write (two racing updates
+    //    would each send a stale merged config and resurrect the other
+    //    key). The API keeps honoring these fields for old clients; this
+    //    client simply stops using them.
+    void channelsApi
+      .update(channelRow.channel_type, {
+        config: { ...(channelRow.config ?? {}), categories: [], favorites: [] },
+      })
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+      })
+      .catch(() => {
+        // Non-fatal: the server filter just lingers until the next visit
+        // retries. The feed itself is fully functional either way.
+        migratedRef.current = false;
+      });
+  }, [channelRow, queryClient]);
+
   // ── Lens + category filter + market-detail modal ──────────────
   const [lens, setLens] = useState<PredictionsLens>("trending");
   // Multi-select category filter (empty = all). "View all" on a section
@@ -236,6 +323,21 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
   const resolvedToday = useMemo(
     () => selectResolvedToday(markets, now),
     [markets, now],
+  );
+
+  // Starred tickers with no live row — they left the curated set, so the
+  // lens grid can't show them. A quiet list under the Watchlist lens keeps
+  // them legible (and removable) instead of silently shrinking the stars.
+  const staleStars = useMemo(
+    () => watchlist.filter((t) => !markets.some((m) => m.ticker === t)),
+    [watchlist, markets],
+  );
+  const staleTitleFor = useCallback(
+    (ticker: string): string => {
+      const entry = catalog?.find((c) => c.ticker === ticker);
+      return entry?.title || ticker;
+    },
+    [catalog],
   );
 
   // id → category lookup from the catalog (keyed by Kalshi ticker, which
@@ -488,7 +590,7 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
     // that swallowed the bar's `sticky` in the real app — the bar only
     // pins against the ancestor that actually scrolls. (RSS uses the same
     // page-scroll structure.)
-    <div ref={containerRef} className="flex min-h-full flex-col">
+    <div ref={containerRef} className="relative flex min-h-full flex-col">
       {/* ONE control bar: view switcher (segmented, Tauri-only) · lens
           pills + category select · search · freshness. WidgetBar owns the
           sticky @container shell and the pinned-elevation sentinel. At
@@ -571,8 +673,17 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
                 <FreshnessPill lastUpdated={latestUpdated} label="odds" />
               </span>
             )}
+            <PredictionsGear />
           </div>
         </WidgetBar>
+      )}
+
+      {/* Compact density has no bar — float the gear so the widget keeps
+          a settings surface (and a way back to comfort) in every mode. */}
+      {!isComfort && (
+        <div className="absolute right-2 top-2 z-10 rounded-lg bg-surface shadow-soft-sm">
+          <PredictionsGear />
+        </div>
       )}
 
       {/* Market browse / grids */}
@@ -766,6 +877,39 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
         </>
       )}
 
+      {/* Stale stars — starred markets that left the curated set. The
+          lens grid can't render them (no live row), so a quiet list keeps
+          them visible and removable. */}
+      {isComfort && lens === "watchlist" && staleStars.length > 0 && (
+        <div className="flex flex-col gap-1 px-3 pb-3 pt-1">
+          <span className="text-ui-chip font-medium uppercase tracking-wide text-fg-4">
+            No longer tracked
+          </span>
+          {staleStars.map((ticker) => (
+            <div
+              key={ticker}
+              className="flex items-center gap-2 rounded-lg border border-edge/30 bg-base-100/40 px-2.5 py-1.5"
+            >
+              <Star size={12} className="shrink-0 fill-current text-fg-4" />
+              <span
+                className="min-w-0 flex-1 truncate text-ui-meta text-fg-4"
+                title={staleTitleFor(ticker)}
+              >
+                {staleTitleFor(ticker)}
+              </span>
+              <button
+                type="button"
+                onClick={() => toggleWatch(ticker)}
+                aria-label={`Remove ${ticker} from watchlist`}
+                className="shrink-0 rounded-md px-2 py-0.5 text-ui-chip font-medium text-fg-4 transition-colors hover:bg-error/10 hover:text-error cursor-pointer"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Market-detail modal */}
       {liveDetail && (
         <MarketDetail
@@ -782,6 +926,94 @@ function PredictionsFeedTab({ mode: callerMode, feedContext, onConfigure }: Feed
         />
       )}
     </div>
+  );
+}
+
+// ── Gear popover (in-widget settings, PR 1 of the configure-page
+//    retirement) ──────────────────────────────────────────────────
+//
+// The same patchDisplay writes as the Configure page's Display section —
+// the page keeps working (parity) until the teardown PR deletes it.
+
+function PredictionsGear() {
+  const { prefs, onPrefsChange } = useShell();
+  const dp = prefs.channelDisplay.predictions;
+
+  const patchDisplay = useCallback(
+    (patch: Partial<PredictionsDisplayPrefs>) => {
+      onPrefsChange({
+        ...prefs,
+        channelDisplay: {
+          ...prefs.channelDisplay,
+          predictions: { ...prefs.channelDisplay.predictions, ...patch },
+        },
+      });
+    },
+    [prefs, onPrefsChange],
+  );
+
+  return (
+    <GearMenu ariaLabel="Predictions settings" panelClassName="right-0 w-80">
+      <MenuHeading>Display</MenuHeading>
+      <div className="px-1 pb-1">
+        <DisplayItemsGrid
+          sections={[
+            {
+              rows: [
+                {
+                  key: "showDelta",
+                  label: "Probability delta",
+                  description: "▲/▼ move vs the previous price",
+                  value: dp.showDelta,
+                },
+                {
+                  key: "showCategory",
+                  label: "Category badge",
+                  description: "Politics, Sports, Economics, …",
+                  value: dp.showCategory,
+                },
+                {
+                  key: "showVolume",
+                  label: "Volume",
+                  description: "Trailing-24h contract volume",
+                  value: dp.showVolume,
+                },
+                {
+                  key: "showCloseTime",
+                  label: "Close countdown",
+                  description: "Time until the market closes",
+                  value: dp.showCloseTime,
+                },
+              ],
+            },
+          ]}
+          onChange={(changes) =>
+            patchDisplay(changes as Partial<PredictionsDisplayPrefs>)
+          }
+        />
+      </div>
+      <MenuHeading>Feed density</MenuHeading>
+      <div className="px-1 pb-1">
+        <Segmented
+          ariaLabel="Feed density"
+          value={dp.feedDensity ?? "comfort"}
+          onChange={(d) => patchDisplay({ feedDensity: d })}
+          options={DENSITY_OPTIONS}
+        />
+      </div>
+      <MenuHeading>Ticker without stars</MenuHeading>
+      {TICKER_FALLBACKS.map((opt) => (
+        <MenuRow
+          key={opt.value}
+          role="menuitemradio"
+          selected={(dp.defaultSort ?? "trending") === opt.value}
+          onClick={() => patchDisplay({ defaultSort: opt.value })}
+        >
+          {opt.label}
+          <span className="text-fg-4"> · {opt.hint}</span>
+        </MenuRow>
+      ))}
+    </GearMenu>
   );
 }
 

--- a/desktop/src/channels/predictions/preview/preview.tsx
+++ b/desktop/src/channels/predictions/preview/preview.tsx
@@ -12,7 +12,7 @@
  * No Tauri APIs are exercised: `isKalshiAvailable()` is false in a browser,
  * and the pref store falls back gracefully. See index.html for usage.
  */
-import { StrictMode } from "react";
+import { StrictMode, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../../../style.css";
@@ -225,7 +225,7 @@ function main(): void {
     }
   }
 
-  const prefs = {
+  const initialPrefs = {
     channelDisplay: {
       predictions: {
         ...migratePredictionsDisplay(undefined),
@@ -235,9 +235,7 @@ function main(): void {
   } as unknown as AppPreferences;
 
   const noop = (): void => {};
-  const shell = {
-    prefs,
-    onPrefsChange: noop,
+  const shellBase = {
     authenticated: false,
     tier: "free",
     subscriptionInfo: null,
@@ -254,7 +252,7 @@ function main(): void {
     onDeleteChannel: noop,
     onToggleWidget: noop,
     onSelectItem: noop,
-  } as unknown as ShellState;
+  };
 
   const feedContext = {
     __hasConfig: true,
@@ -264,8 +262,16 @@ function main(): void {
 
   const FeedTab = predictionsChannel.FeedTab;
 
-  createRoot(document.getElementById("root")!).render(
-    <StrictMode>
+  // Prefs are STATE so the in-widget gear popover's writes re-render the
+  // feed like the real shell (persistence itself is Tauri-only).
+  function Harness() {
+    const [prefs, setPrefs] = useState<AppPreferences>(initialPrefs);
+    const shell = {
+      ...shellBase,
+      prefs,
+      onPrefsChange: setPrefs,
+    } as unknown as ShellState;
+    return (
       <QueryClientProvider client={queryClient}>
         <ShellContext.Provider value={shell}>
           {/* Page-scroll like the app: PageLayout's feed mode scrolls the
@@ -285,6 +291,12 @@ function main(): void {
           </div>
         </ShellContext.Provider>
       </QueryClientProvider>
+    );
+  }
+
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <Harness />
     </StrictMode>,
   );
 }


### PR DESCRIPTION
Stacked on #232 (PR 0 — widget-bar primitives). Predictions is the model widget; this PR gives it everything the Configure page had, in-widget, so the page can die in PR 7. The Configure page keeps working unchanged until then (parity, temporary duplication by design).

Linear: REL-33

## Changes

- **Legacy migration moved to the feed mount.** The one-time v1.1.5 favorites/categories migration (import legacy pins → local stars, clear both server keys in one write) ran only when the Configure panel mounted — deleting the page would strand users who never opened it, with a lingering server `categories` filter silently narrowing their payload. It now runs on the FeedTab mount, guarded until the dashboard channel row actually loads so the once-per-mount ref isn't burned on a no-op.
- **Gear popover** (right cluster of the bar): Display grid (probability delta / category badge / volume / close countdown, Feed+Ticker columns), feed-density `Segmented`, ticker-fallback radios — identical `patchDisplay` writes to the panel's.
- **Compact density keeps a config path**: the same gear floats top-right when the feed renders compact (no bar there). Without this, switching to compact via the gear would strand you post-teardown — Home is unaffected (it renders `PredictionsRows`, not this FeedTab).
- **Stale stars**: starred markets that left the curated set can't render in the Watchlist lens grid; they now show as a quiet "No longer tracked" list with Remove, instead of silently vanishing.
- **Harness**: prefs are React state now (gear writes re-render like the real shell); `verify-kalshi.mjs` grows a gear-popover section.

## Verification

- `npx tsc --noEmit` clean; `npx vitest run` 490/490
- `verify-kalshi.mjs` ALL PASS (65 checks; new: gear renders, display grid in popover, live volume toggle off/on, popover stays open on toggle, Esc closes)
- `verify-search.mjs` 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)