### PR TITLE
In-widget config PR 2: finance bar + Symbols view + scroll fix [REL-34]

### DIFF
--- a/desktop/scripts/verify-finance.mjs
+++ b/desktop/scripts/verify-finance.mjs
@@ -1,0 +1,293 @@
+/**
+ * Playwright verification for the finance widget bar + Symbols view
+ * (in-widget config pass, PR 2). Drives the finance preview harness
+ * (real FeedTab + inline fixture) at 1440 / 960 / 720 / 375.
+ *
+ * Run with the vite dev server on :5174:
+ *   node desktop/scripts/verify-finance.mjs
+ * (needs `npm i playwright` somewhere on the resolve path; uses system Edge)
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const BASE = "http://localhost:5174/src/channels/finance/preview/index.html";
+const OUT = process.env.UI_REVIEW_OUT ?? "ui-review-out";
+mkdirSync(OUT, { recursive: true });
+
+let failures = 0;
+function check(name, cond, extra = "") {
+  if (cond) console.log(`  PASS ${name}`);
+  else {
+    failures++;
+    console.log(`  FAIL ${name} ${extra}`);
+  }
+}
+
+const ROW = ".grid a"; // TradeItem anchors
+const SEARCH = '[aria-label="Search symbols"]';
+
+function watchConsole(page, consoleErrors) {
+  const benign = /Failed to load resource|Store write failed|Token unavailable/;
+  page.on("console", (msg) => {
+    if (msg.type() === "error" && !benign.test(msg.text())) consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+}
+
+async function newPage(browser, width, height, query = "") {
+  const page = await browser.newPage({ viewport: { width, height } });
+  const consoleErrors = [];
+  watchConsole(page, consoleErrors);
+  await page.goto(`${BASE}${query}`, { waitUntil: "networkidle" });
+  await page.waitForSelector(ROW);
+  return { page, consoleErrors };
+}
+
+async function run() {
+  const browser = await chromium.launch({ channel: "msedge", headless: true });
+
+  // ════ 1440px — bar anatomy + filters ═════════════════════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · bar anatomy ==");
+
+    check("view switch renders", (await page.locator('[aria-label="Finance view"] [role="tab"]').count()) === 2);
+    check("direction pills visible", await page.locator('button:has-text("Gainers")').first().isVisible());
+    check("sort menu present", (await page.locator('[aria-label="Sort symbols"]').count()) === 1);
+    check("category menu present", (await page.locator('[aria-label="Filter by category"]').count()) === 1);
+    check("search present", (await page.locator(SEARCH).count()) === 1);
+    check("gear present", (await page.locator('[aria-label="Finance settings"]').count()) === 1);
+    check("no chips/counts bands (one bar only)", (await page.locator("text=/\\d+ up/").count()) === 0);
+    const rowsAll = await page.locator(ROW).count();
+    check("feed rows render", rowsAll > 10, `rows=${rowsAll}`);
+    await page.screenshot({ path: `${OUT}/fin-01-bar-1440.png` });
+
+    // Direction filter: every visible row is a loser (counts are capped
+    // by the 20-row page, so assert content, not count).
+    await page.locator('button:has-text("Losers")').first().click();
+    await page.waitForTimeout(200);
+    const loserRows = await page.locator(ROW).allInnerTexts();
+    check(
+      "Losers filter shows only losers",
+      loserRows.length > 0 && loserRows.every((t) => t.includes("-")),
+      `rows=${loserRows.length}`,
+    );
+    await page.locator('button:has-text("All")').first().click();
+    await page.waitForTimeout(200);
+
+    // Category menu: counts in rows, multi-select stays open.
+    const catTrigger = page.locator('[aria-label="Filter by category"]');
+    await catTrigger.click();
+    await page.waitForSelector('[role="menu"]');
+    await page.waitForTimeout(250);
+    const catRows = await page.locator('[role="menu"] [role="menuitemcheckbox"]').count();
+    check("category rows listed", catRows >= 4, `rows=${catRows}`);
+    const firstRowText = await page.locator('[role="menu"] [role="menuitemcheckbox"]').first().innerText();
+    check("category rows carry counts", /\d/.test(firstRowText), firstRowText);
+    await page.locator('[role="menu"] [role="menuitemcheckbox"]:has-text("Tech")').click();
+    check("menu stays open after toggle", (await page.locator('[role="menu"]').count()) === 1);
+    await page.waitForTimeout(200);
+    const techRows = await page.locator(ROW).allInnerTexts();
+    check(
+      "category filter shows only that category",
+      techRows.length > 0 && techRows.every((t) => t.includes("Tech")),
+      `rows=${techRows.length}`,
+    );
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(250);
+    check("Esc closes category menu", (await page.locator('[role="menu"]').count()) === 0);
+    await page.screenshot({ path: `${OUT}/fin-02-category-1440.png` });
+    await catTrigger.click();
+    await page.locator('[role="menu"] [role="menuitemradio"]:has-text("All categories")').click();
+    await page.keyboard.press("Escape");
+
+    // Sort menu switches ordering.
+    await page.locator('[aria-label="Sort symbols"]').click();
+    await page.waitForSelector('[role="menu"]');
+    await page.locator('[role="menu"] [role="menuitemradio"]:has-text("% Change")').click();
+    await page.waitForTimeout(250);
+    check("sort menu closes on pick", (await page.locator('[role="menu"]').count()) === 0);
+    const firstPct = await page.locator(ROW).first().innerText();
+    check("sort by % puts a gainer first", firstPct.includes("+"), firstPct.replace(/\n/g, " | "));
+
+    // Search: plain substring on symbol.
+    await page.click(SEARCH);
+    await page.keyboard.type("TSLA", { delay: 0 });
+    await page.waitForTimeout(250);
+    const searchRows = await page.locator(ROW).allInnerTexts();
+    check(
+      "search narrows to matching symbols",
+      searchRows.length > 0 &&
+        searchRows.length < rowsAll &&
+        searchRows.every((t) => t.includes("TSLA")),
+      `rows=${searchRows.length}`,
+    );
+    await page.keyboard.press("Escape");
+    check("first Esc clears query", (await page.inputValue(SEARCH)) === "");
+    await page.keyboard.press("Escape");
+    check("second Esc blurs", await page.locator(SEARCH).evaluate((el) => document.activeElement !== el));
+
+    check("no console errors (bar page)", consoleErrors.length === 0, consoleErrors.slice(0, 3).join(" | "));
+    await page.close();
+  }
+
+  // ════ 1440px — sticky pin (bounding box, not classlist) ══════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · sticky bar ==");
+
+    const bar = page.locator("div.sticky.top-0");
+    check("bar starts un-elevated", !(await bar.getAttribute("class")).includes("backdrop-blur-sm"));
+
+    // Render the whole list so there is real scroll travel, then reset
+    // to the top before measuring (Load more leaves the page scrolled).
+    for (let i = 0; i < 10; i++) {
+      const more = page.locator('button:has-text("Load more")');
+      if ((await more.count()) === 0) break;
+      await more.click();
+      await page.waitForTimeout(100);
+    }
+    await page.evaluate(() => {
+      document.querySelector("#root .overflow-y-auto").scrollTop = 0;
+    });
+    await page.waitForTimeout(250);
+    const rowBefore = await page.locator(ROW).first().boundingBox();
+
+    await page.evaluate(() => {
+      document.querySelector("#root .overflow-y-auto").scrollTop = 400;
+    });
+    await page.waitForTimeout(250);
+
+    const barBox = await bar.boundingBox();
+    const rowAfter = await page.locator(ROW).first().boundingBox();
+    check(
+      "bar pins while content scrolls ≥300px",
+      barBox && barBox.y <= 1 && rowBefore && rowAfter && rowAfter.y < rowBefore.y - 300,
+      `bar.y=${barBox?.y} row ${rowBefore?.y}->${rowAfter?.y}`,
+    );
+    check("bar elevates once stuck", (await bar.getAttribute("class")).includes("backdrop-blur-sm"));
+    await page.screenshot({ path: `${OUT}/fin-03-sticky-1440.png` });
+
+    await page.evaluate(() => {
+      document.querySelector("#root .overflow-y-auto").scrollTop = 0;
+    });
+    await page.waitForTimeout(250);
+    check("elevation clears at top", !(await bar.getAttribute("class")).includes("backdrop-blur-sm"));
+
+    check("no console errors (sticky page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  // ════ 1440px — gear popover + density round-trip ═════════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · gear + density ==");
+
+    const gear = page.locator('[aria-label="Finance settings"]');
+    await gear.click();
+    await page.waitForSelector('[role="menu"]');
+    await page.waitForTimeout(250);
+    check("display grid renders in popover", (await page.locator('[role="menu"] [role="grid"]').count()) === 1);
+
+    // Toggle "% change" off the feed → change spans disappear live.
+    const pctBefore = await page.locator(`${ROW} >> text=/%/`).count();
+    await page.locator('[role="menu"] [aria-label="Hide % change on Feed"]').click();
+    await page.waitForTimeout(250);
+    check("popover stays open on toggle", (await page.locator('[role="menu"]').count()) === 1);
+    const pctAfter = await page.locator(`${ROW} >> text=/%/`).count();
+    check("%-change toggle hides values live", pctBefore > 0 && pctAfter === 0, `${pctBefore} -> ${pctAfter}`);
+    await page.locator('[role="menu"] [aria-label="Show % change on Feed"]').click();
+    await page.waitForTimeout(250);
+    check("%-change restored", (await page.locator(`${ROW} >> text=/%/`).count()) === pctBefore);
+    await page.screenshot({ path: `${OUT}/fin-04-gear-1440.png` });
+
+    // Density: comfort → compact kills the bar but keeps a floating gear
+    // (the way back), compact → comfort restores the bar.
+    await page.locator('[role="menu"] [role="tab"]:has-text("Compact")').click();
+    await page.waitForTimeout(300);
+    check("compact: bar gone", (await page.locator('[aria-label="Finance view"]').count()) === 0);
+    const floatingGear = page.locator('[aria-label="Finance settings"]');
+    check("compact: floating gear present", (await floatingGear.count()) === 1);
+    await page.screenshot({ path: `${OUT}/fin-05-compact-floating-gear-1440.png` });
+    await floatingGear.click();
+    await page.waitForSelector('[role="menu"]');
+    await page.locator('[role="menu"] [role="tab"]:has-text("Comfort")').click();
+    await page.waitForTimeout(300);
+    check("comfort restored via floating gear", (await page.locator('[aria-label="Finance view"]').count()) === 1);
+
+    check("no console errors (gear page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  // ════ 1440px — Symbols view (render-only) ════════════════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · Symbols view ==");
+
+    await page.locator('[role="tab"]:has-text("Symbols")').click();
+    await page.waitForSelector("text=Click a row to add or remove");
+    const listRows = await page.locator('[role="listitem"]').count();
+    check("symbol manager renders rows", listRows > 10, `rows=${listRows}`);
+    check("crypto scoped out (stocks widget)", (await page.locator('[role="listitem"]:has-text("BTC/USD")').count()) === 0);
+    check("no tier cap in header", !(await page.locator("#root").innerText()).includes(" / "));
+    const firstRow = page.locator('[role="listitem"]').first();
+    check(
+      "tracked rows sort first",
+      (await firstRow.getAttribute("aria-label"))?.startsWith("Remove "),
+      await firstRow.getAttribute("aria-label"),
+    );
+    await page.screenshot({ path: `${OUT}/fin-06-symbols-1440.png` });
+
+    // Back to the feed.
+    await page.locator('[role="tab"]:has-text("Feed")').click();
+    await page.waitForSelector(ROW);
+    check("Feed tab returns to the grid", (await page.locator(ROW).count()) > 10);
+
+    check("no console errors (symbols page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  // ════ Narrow widths — collapse-before-clip ═══════════════════════
+  for (const width of [960, 720, 375]) {
+    const { page, consoleErrors } = await newPage(browser, width, 812);
+    console.log(`== ${width}px · collapsed filters ==`);
+
+    check(`pills hidden at ${width}`, !(await page.locator('button:has-text("Gainers")').first().isVisible()));
+    const filterBtn = page.locator('[aria-label="Filters"]');
+    check(`filter button visible at ${width}`, await filterBtn.isVisible());
+    const clipped = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    check(`no horizontal clipping at ${width}`, !clipped);
+
+    await filterBtn.click();
+    await page.waitForSelector('[role="menu"]');
+    await page.waitForTimeout(250);
+    // innerText reflects the CSS uppercase transform on headings.
+    const menuText = (await page.locator('[role="menu"]').innerText()).toUpperCase();
+    check(
+      `menu lists Direction/Sort/Category at ${width}`,
+      menuText.includes("DIRECTION") && menuText.includes("SORT") && menuText.includes("CATEGORY"),
+    );
+    const menuBox = await page.locator('[role="menu"]').boundingBox();
+    check(
+      `menu fits inside the viewport at ${width}`,
+      menuBox && menuBox.x >= 0 && menuBox.x + menuBox.width <= width,
+      JSON.stringify(menuBox),
+    );
+    await page.keyboard.press("Escape");
+    if (width === 375) await page.screenshot({ path: `${OUT}/fin-07-collapsed-375.png` });
+
+    check(`no console errors (${width})`, consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/desktop/src/channels/finance/ConfigPanel.tsx
+++ b/desktop/src/channels/finance/ConfigPanel.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "@tanstack/react-query";
 import SymbolManager from "./SymbolManager";
 import { useChannelConfig } from "../../hooks/useChannelConfig";
 import { financeCatalogOptions, dashboardQueryOptions } from "../../api/queries";
-import { getLimit } from "../../tierLimits";
 import { assetClassForWidget } from "../../marketplace";
 import type { Channel } from "../../api/client";
 import type { Trade } from "../../types";
@@ -25,7 +24,6 @@ interface FinanceChannelConfig {
 
 export default function FinanceConfigPanel({
   channel,
-  subscriptionTier,
 }: FinanceConfigPanelProps) {
   const channelType = channel.channel_type;
   const assetClass = assetClassForWidget(channelType);
@@ -35,7 +33,6 @@ export default function FinanceConfigPanel({
   const config = channel.config as FinanceChannelConfig;
   const symbols = Array.isArray(config?.symbols) ? config.symbols : [];
   const symbolSet = useMemo(() => new Set(symbols), [symbols]);
-  const maxSymbols = getLimit(subscriptionTier, "symbols");
 
   // ── Queries ────────────────────────────────────────────────────
 
@@ -68,10 +65,9 @@ export default function FinanceConfigPanel({
   const addSymbol = useCallback(
     (sym: string) => {
       if (symbolSet.has(sym)) return;
-      if (symbols.length >= maxSymbols) return;
       updateItems([...symbols, sym]);
     },
-    [symbols, symbolSet, updateItems, maxSymbols],
+    [symbols, symbolSet, updateItems],
   );
 
   const removeSymbol = useCallback(
@@ -112,8 +108,6 @@ export default function FinanceConfigPanel({
           onRemove={removeSymbol}
           loading={catalogLoading}
           error={catalogError}
-          maxSymbols={maxSymbols}
-          subscriptionTier={subscriptionTier}
           saving={saving}
         />
       </div>

--- a/desktop/src/channels/finance/FeedTab.tsx
+++ b/desktop/src/channels/finance/FeedTab.tsx
@@ -5,23 +5,46 @@
  * via the desktop CDC/SSE pipeline. Supports compact and comfort
  * display modes with price flash animations on change.
  *
- * Controls bar provides direction filter pills (All / Gainers / Losers),
- * sort dropdown, and category filter. Summary bar shows up/down/unchanged
- * counts. Dismissible filter chips appear when category filters are active.
+ * ONE Kalshi-style control bar (widget-bar primitives): Feed/Symbols
+ * segmented view switch · direction pills · sort + category menus ·
+ * symbol search · freshness · gear popover. The Symbols view mounts the
+ * full SymbolManager in-feed — the Configure page's job, in-widget.
+ * Counts live in menu rows (no summary band); filters collapse into one
+ * Filter button at narrow widths.
  */
 import { memo, useMemo, useRef, useEffect, useState, useCallback } from "react";
 import { clsx } from "clsx";
-import { TrendingUp } from "lucide-react";
+import { AnimatePresence } from "motion/react";
+import { TrendingUp, LineChart, ListChecks } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { dashboardQueryOptions, financeCatalogOptions } from "../../api/queries";
 import { formatPrice, formatChange, relativeTime } from "../../utils/format";
 import EmptyChannelState from "../../components/EmptyChannelState";
 import FreshnessPill from "../../components/FreshnessPill";
-import CategoryFilter from "../rss/CategoryFilter";
+import { WidgetBar, BarDivider, BarPill } from "../../components/widget-bar/Bar";
+import {
+  useDismiss,
+  MenuPanel,
+  MenuHeading,
+  MenuRow,
+  FilterTrigger,
+} from "../../components/widget-bar/Menu";
+import {
+  Segmented,
+  type SegmentedOption,
+} from "../../components/widget-bar/Segmented";
+import { SearchBox, useSlashFocus } from "../../components/widget-bar/SearchBox";
+import { MultiSelectMenu } from "../../components/widget-bar/MultiSelectMenu";
+import { SelectMenu } from "../../components/widget-bar/SelectMenu";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import DisplayItemsGrid from "../../components/settings/DisplayItemsGrid";
+import SymbolManager from "./SymbolManager";
+import { useChannelConfig } from "../../hooks/useChannelConfig";
 import { useShell } from "../../shell-context";
 import { useNow } from "../../hooks/useNow";
 import { applyFinancePipeline, type FinanceSortKey, type FinanceDirectionFilter } from "./view";
 import type { Trade, FeedTabProps, ChannelManifest } from "../../types";
+import type { ChannelType } from "../../api/client";
 import { assetClassForWidget } from "../../marketplace";
 import { shouldShowOnFeed } from "../../preferences";
 import type { FinanceDisplayPrefs } from "../../preferences";
@@ -64,6 +87,24 @@ const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: "price", label: "Price" },
   { value: "change", label: "% Change" },
   { value: "updated", label: "Last Updated" },
+];
+
+type FinanceView = "feed" | "symbols";
+
+/** Feed / Symbols — options for the Segmented view switch. The Symbols
+ *  view is the Configure page's symbol picker, mounted in-feed. */
+const VIEW_OPTIONS: SegmentedOption<FinanceView>[] = [
+  { value: "feed", label: "Feed", icon: LineChart },
+  { value: "symbols", label: "Symbols", icon: ListChecks },
+];
+
+interface FinanceChannelConfig {
+  symbols?: string[];
+}
+
+const DENSITY_OPTIONS: SegmentedOption<"comfort" | "compact">[] = [
+  { value: "comfort", label: "Comfort" },
+  { value: "compact", label: "Compact" },
 ];
 
 const PAGE_SIZE = 20;
@@ -133,7 +174,9 @@ function FinanceFeedTab({ mode: callerMode, feedContext, onConfigure, widgetId }
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [trades, categoryMap]);
 
-  // ── Filter / sort state ──────────────────────────────────────
+  // ── Filter / sort / view state ───────────────────────────────
+  const isComfort = mode === "comfort";
+  const [view, setView] = useState<FinanceView>("feed");
   const [directionFilter, setDirectionFilter] = useState<DirectionFilter>("all");
   const [sortKey, setSortKey] = useState<SortKey>(() => dp.defaultSort ?? "alpha");
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
@@ -149,24 +192,28 @@ function FinanceFeedTab({ mode: callerMode, feedContext, onConfigure, widgetId }
 
   const clearCategories = useCallback(() => setSelectedCategories(new Set()), []);
 
+  // ── Symbol search (plain substring — no fuzzy matcher here) ──
+  const [query, setQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  useSlashFocus(searchInputRef, isComfort && view === "feed");
+
   const clearAllFilters = useCallback(() => {
     setDirectionFilter("all");
     setSelectedCategories(new Set());
+    setQuery("");
   }, []);
-
-  const hasFilters = directionFilter !== "all" || selectedCategories.size > 0;
 
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-  }, [directionFilter, selectedCategories, sortKey]);
+  }, [directionFilter, selectedCategories, sortKey, query]);
 
   // ── Data pipeline ────────────────────────────────────────────
   // Shared with the ticker via `applyFinancePipeline` so `defaultSort`
   // from the Display tab takes effect in both places.
-  const filtered = useMemo(
+  const piped = useMemo(
     () =>
       applyFinancePipeline(trades, {
         directionFilter,
@@ -175,6 +222,15 @@ function FinanceFeedTab({ mode: callerMode, feedContext, onConfigure, widgetId }
         sortKey,
       }),
     [trades, directionFilter, selectedCategories, categoryMap, sortKey],
+  );
+
+  const searchQ = query.trim().toLowerCase();
+  const filtered = useMemo(
+    () =>
+      searchQ
+        ? piped.filter((t) => t.symbol.toLowerCase().includes(searchQ))
+        : piped,
+    [piped, searchQ],
   );
 
   // ── Pagination (incremental "load more") ─────────────────────
@@ -196,127 +252,149 @@ function FinanceFeedTab({ mode: callerMode, feedContext, onConfigure, widgetId }
     return latest > 0 ? new Date(latest).toISOString() : null;
   }, [filtered]);
 
-  // ── Summary counts ───────────────────────────────────────────
-  const { upCount, downCount, unchangedCount } = useMemo(() => {
+  // ── Direction counts (menu rows — the summary band is gone) ──
+  // Counted over the widget-scoped universe, not the filtered list, so
+  // the Gainers/Losers rows stay stable while a direction is selected.
+  const directionCounts = useMemo(() => {
     let up = 0;
     let down = 0;
-    let unchanged = 0;
-    for (const t of filtered) {
+    for (const t of trades) {
       if (t.direction === "up") up++;
       else if (t.direction === "down") down++;
-      else unchanged++;
     }
-    return { upCount: up, downCount: down, unchangedCount: unchanged };
-  }, [filtered]);
+    return { all: trades.length, gainers: up, losers: down };
+  }, [trades]);
 
-  // ── Empty state (no data at all) ─────────────────────────────
-  if (trades.length === 0) {
-    return (
-      <EmptyChannelState
-        refreshing={Boolean(feedContext.__refreshing)}
-        icon={TrendingUp}
-        noun="stocks or crypto"
-        hasConfig={!!feedContext.__hasConfig}
-        dashboardLoaded={!!feedContext.__dashboardLoaded}
-        loadingNoun="prices"
-        actionHint="choose what to track"
-        onConfigure={onConfigure}
-      />
-    );
-  }
+  const channelType = (widgetId ?? "finance") as ChannelType;
+  const showEmpty = trades.length === 0;
+  const showSymbols = isComfort && view === "symbols";
 
   return (
-    <div ref={containerRef} className="flex flex-col h-full overflow-y-auto">
-      {/* Controls bar */}
-      <div className="sticky top-0 z-20 bg-surface border-b border-edge/30 px-3 py-2 flex items-center gap-2">
-        {/* Direction filter pills — left side */}
-        <div className="flex gap-1">
-          {DIRECTION_OPTIONS.map((opt) => (
-            <button
-              key={opt.value}
-              onClick={() => setDirectionFilter(opt.value)}
-              className={clsx(
-                "px-2.5 py-1 rounded-full text-ui-meta font-medium transition-colors cursor-pointer",
-                directionFilter === opt.value
-                  ? "bg-accent/15 text-accent"
-                  : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
-              )}
-            >
-              {opt.label}
-            </button>
-          ))}
-        </div>
+    // NO inner scroll container: the Source page (PageLayout) owns the
+    // scroll — an inner scrollport that never scrolls swallows `sticky`
+    // (the bar never actually pinned here before this fix).
+    <div ref={containerRef} className="relative flex min-h-full flex-col">
+      {isComfort && (
+        <WidgetBar>
+          <Segmented
+            ariaLabel="Finance view"
+            value={view}
+            onChange={setView}
+            options={VIEW_OPTIONS}
+          />
 
-        {latestUpdated && <FreshnessPill lastUpdated={latestUpdated} label="price" />}
-
-        {/* Sort + category filter — right side */}
-        <div className="flex items-center gap-2 ml-auto">
-          <select
-            value={sortKey}
-            onChange={(e) => setSortKey(e.target.value as SortKey)}
-            className="bg-surface-2 border border-edge/40 rounded-md px-2 py-1.5 text-ui-meta text-fg-2 cursor-pointer outline-none focus:border-accent/60"
-          >
-            {SORT_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-          {categoryList.length > 0 && (
-            <CategoryFilter
-              categories={categoryList}
-              selected={selectedCategories}
-              onToggle={toggleCategory}
-              onClearAll={clearCategories}
-              alignRight
-            />
-          )}
-        </div>
-      </div>
-
-      {/* Filter chips */}
-      {selectedCategories.size > 0 && (
-        <div className="flex items-center gap-1.5 px-3 py-1.5 bg-surface border-b border-edge/30 flex-wrap">
-          {Array.from(selectedCategories).map((cat) => (
-            <button
-              key={cat}
-              onClick={() => toggleCategory(cat)}
-              className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent/15 text-accent text-ui-chip hover:bg-accent/25 transition-colors cursor-pointer"
-            >
-              <span className="truncate max-w-[120px]">{cat}</span>
-              <span className="text-accent/60">&times;</span>
-            </button>
-          ))}
-          <button
-            onClick={clearCategories}
-            className="px-2 py-0.5 text-ui-chip text-fg-3 hover:text-fg-2 transition-colors cursor-pointer"
-          >
-            Clear all
-          </button>
-        </div>
-      )}
-
-      {/* Summary bar */}
-      {filtered.length > 0 && (
-        <div className="px-3 py-1 bg-surface border-b border-edge/30 font-mono text-ui-chip tabular-nums flex items-center gap-1.5">
-          <span className="text-fg-3">{filtered.length} symbols</span>
-          <span className="text-fg-3">&middot;</span>
-          <span className="text-up">{upCount} up</span>
-          <span className="text-fg-3">&middot;</span>
-          <span className="text-down">{downCount} down</span>
-          {unchangedCount > 0 && (
+          {view === "feed" && !showEmpty ? (
             <>
-              <span className="text-fg-3">&middot;</span>
-              <span className="text-fg-3">{unchangedCount} unchanged</span>
+              <BarDivider />
+
+              {/* Wide: open direction pills. Collapse BEFORE clipping. */}
+              <div className="scrollbar-none hidden min-w-0 items-center gap-1 overflow-x-auto @5xl:flex">
+                {DIRECTION_OPTIONS.map((opt) => (
+                  <BarPill
+                    key={opt.value}
+                    active={directionFilter === opt.value}
+                    onClick={() => setDirectionFilter(opt.value)}
+                  >
+                    {opt.label}
+                  </BarPill>
+                ))}
+              </div>
+
+              {/* Narrow: direction + sort + categories in one Filter menu. */}
+              <div className="@5xl:hidden">
+                <FinanceFilterMenu
+                  directionFilter={directionFilter}
+                  onPickDirection={setDirectionFilter}
+                  directionCounts={directionCounts}
+                  sortKey={sortKey}
+                  onPickSort={setSortKey}
+                  categories={categoryList}
+                  selectedCategories={selectedCategories}
+                  onToggleCategory={toggleCategory}
+                  onClearCategories={clearCategories}
+                />
+              </div>
+
+              <div className="ml-auto flex min-w-0 shrink items-center gap-2">
+                <span className="hidden @5xl:block">
+                  <SelectMenu
+                    value={sortKey}
+                    options={SORT_OPTIONS}
+                    onChange={setSortKey}
+                    ariaLabel="Sort symbols"
+                    prefix="Sort"
+                  />
+                </span>
+                {categoryList.length > 0 && (
+                  <span className="hidden @5xl:block">
+                    <MultiSelectMenu
+                      options={categoryList.map((c) => c.name)}
+                      counts={Object.fromEntries(
+                        categoryList.map((c) => [c.name, c.count]),
+                      )}
+                      selected={Array.from(selectedCategories)}
+                      onToggle={toggleCategory}
+                      onClear={clearCategories}
+                      noun="categories"
+                      ariaLabel="Filter by category"
+                    />
+                  </span>
+                )}
+                <SearchBox
+                  inputRef={searchInputRef}
+                  query={query}
+                  onQueryChange={setQuery}
+                  resultCount={searchQ ? filtered.length : null}
+                  ariaLabel="Search symbols"
+                  noun="symbols"
+                />
+                {latestUpdated && (
+                  <span className="hidden @xl:block">
+                    <FreshnessPill lastUpdated={latestUpdated} label="price" />
+                  </span>
+                )}
+                <FinanceGear />
+              </div>
             </>
+          ) : (
+            <div className="ml-auto">
+              <FinanceGear />
+            </div>
           )}
+        </WidgetBar>
+      )}
+
+      {/* Compact density has no bar — float the gear so the widget keeps
+          a settings surface (and a way back to comfort) in every mode. */}
+      {!isComfort && (
+        <div className="absolute right-2 top-2 z-10 rounded-lg bg-surface shadow-soft-sm">
+          <FinanceGear />
         </div>
       )}
 
-      {/* Trade grid */}
-      {filtered.length === 0 ? (
+      {showSymbols ? (
+        <FinanceSymbolsPanel channelType={channelType} assetClass={assetClass} />
+      ) : showEmpty ? (
+        <div className="flex flex-1 flex-col justify-center">
+          <EmptyChannelState
+            refreshing={Boolean(feedContext.__refreshing)}
+            icon={TrendingUp}
+            noun="stocks or crypto"
+            hasConfig={!!feedContext.__hasConfig}
+            dashboardLoaded={!!feedContext.__dashboardLoaded}
+            loadingNoun="prices"
+            actionHint="choose what to track"
+            actionLabel={isComfort ? "Choose symbols to track" : undefined}
+            onConfigure={isComfort ? () => setView("symbols") : onConfigure}
+          />
+        </div>
+      ) : filtered.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 gap-3">
-          <p className="text-[12px] text-fg-3">No symbols match your filters</p>
+          <p className="text-[12px] text-fg-3">
+            {searchQ
+              ? `No symbols match “${query.trim()}”`
+              : "No symbols match your filters"}
+          </p>
           <button
             onClick={clearAllFilters}
             className="px-3 py-1.5 rounded-md text-ui-meta font-medium text-accent bg-accent/10 hover:bg-accent/20 transition-colors cursor-pointer"
@@ -364,6 +442,272 @@ function FinanceFeedTab({ mode: callerMode, feedContext, onConfigure, widgetId }
           )}
         </>
       )}
+    </div>
+  );
+}
+
+// ── Filter menu (narrow-width collapse) ─────────────────────────
+
+function FinanceFilterMenu({
+  directionFilter,
+  onPickDirection,
+  directionCounts,
+  sortKey,
+  onPickSort,
+  categories,
+  selectedCategories,
+  onToggleCategory,
+  onClearCategories,
+}: {
+  directionFilter: DirectionFilter;
+  onPickDirection: (d: DirectionFilter) => void;
+  directionCounts: { all: number; gainers: number; losers: number };
+  sortKey: SortKey;
+  onPickSort: (s: SortKey) => void;
+  categories: { name: string; count: number }[];
+  selectedCategories: Set<string>;
+  onToggleCategory: (c: string) => void;
+  onClearCategories: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useDismiss(rootRef, open, close);
+
+  const activeCount =
+    (directionFilter !== "all" ? 1 : 0) + selectedCategories.size;
+
+  return (
+    // NOT position:relative — the dropdown anchors to the sticky bar so
+    // it spans the channel width instead of clipping at narrow widths.
+    <div ref={rootRef} className="shrink-0 rounded-lg">
+      <FilterTrigger
+        open={open}
+        badgeCount={activeCount}
+        onClick={() => setOpen((o) => !o)}
+      />
+      <AnimatePresence>
+        {open && (
+          <MenuPanel className="inset-x-2">
+            <MenuHeading>Direction</MenuHeading>
+            {DIRECTION_OPTIONS.map((opt) => (
+              <MenuRow
+                key={opt.value}
+                selected={directionFilter === opt.value}
+                onClick={() => onPickDirection(opt.value)}
+                role="menuitemradio"
+                count={directionCounts[opt.value]}
+              >
+                {opt.label}
+              </MenuRow>
+            ))}
+            <MenuHeading>Sort</MenuHeading>
+            {SORT_OPTIONS.map((opt) => (
+              <MenuRow
+                key={opt.value}
+                selected={sortKey === opt.value}
+                onClick={() => onPickSort(opt.value)}
+                role="menuitemradio"
+              >
+                {opt.label}
+              </MenuRow>
+            ))}
+            {categories.length > 0 && (
+              <>
+                <MenuHeading>Category</MenuHeading>
+                <MenuRow
+                  selected={selectedCategories.size === 0}
+                  onClick={onClearCategories}
+                  role="menuitemradio"
+                >
+                  All categories
+                </MenuRow>
+                {categories.map((c) => (
+                  <MenuRow
+                    key={c.name}
+                    selected={selectedCategories.has(c.name)}
+                    onClick={() => onToggleCategory(c.name)}
+                    role="menuitemcheckbox"
+                    count={c.count}
+                  >
+                    {c.name}
+                  </MenuRow>
+                ))}
+              </>
+            )}
+          </MenuPanel>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Gear popover (display prefs — previously orphaned) ──────────
+//
+// showChange / showPrevClose / showLastUpdated, default sort, and feed
+// density had NO edit surface since the per-channel Display pages were
+// removed (2026-06-30) — the ticker and feed read them, nothing wrote
+// them. The gear reclaims them.
+
+function FinanceGear() {
+  const { prefs, onPrefsChange } = useShell();
+  const dp = prefs.channelDisplay.finance;
+
+  const patchDisplay = useCallback(
+    (patch: Partial<FinanceDisplayPrefs>) => {
+      onPrefsChange({
+        ...prefs,
+        channelDisplay: {
+          ...prefs.channelDisplay,
+          finance: { ...prefs.channelDisplay.finance, ...patch },
+        },
+      });
+    },
+    [prefs, onPrefsChange],
+  );
+
+  return (
+    <GearMenu ariaLabel="Finance settings" panelClassName="right-0 w-80">
+      <MenuHeading>Display</MenuHeading>
+      <div className="px-1 pb-1">
+        <DisplayItemsGrid
+          sections={[
+            {
+              rows: [
+                {
+                  key: "showChange",
+                  label: "% change",
+                  description: "Signed percentage move",
+                  value: dp.showChange,
+                },
+                {
+                  key: "showPrevClose",
+                  label: "Previous close",
+                  description: "Prior session's closing price",
+                  value: dp.showPrevClose,
+                },
+                {
+                  key: "showLastUpdated",
+                  label: "Last updated",
+                  description: "Time since the latest price tick",
+                  value: dp.showLastUpdated,
+                },
+              ],
+            },
+          ]}
+          onChange={(changes) =>
+            patchDisplay(changes as Partial<FinanceDisplayPrefs>)
+          }
+        />
+      </div>
+      <MenuHeading>Feed density</MenuHeading>
+      <div className="px-1 pb-1">
+        <Segmented
+          ariaLabel="Feed density"
+          value={dp.feedDensity ?? "comfort"}
+          onChange={(d) => patchDisplay({ feedDensity: d })}
+          options={DENSITY_OPTIONS}
+        />
+      </div>
+      <MenuHeading>Default sort</MenuHeading>
+      {SORT_OPTIONS.map((opt) => (
+        <MenuRow
+          key={opt.value}
+          role="menuitemradio"
+          selected={(dp.defaultSort ?? "alpha") === opt.value}
+          onClick={() => patchDisplay({ defaultSort: opt.value })}
+        >
+          {opt.label}
+        </MenuRow>
+      ))}
+    </GearMenu>
+  );
+}
+
+// ── Symbols view (the Configure page's picker, mounted in-feed) ─
+
+function FinanceSymbolsPanel({
+  channelType,
+  assetClass,
+}: {
+  channelType: ChannelType;
+  assetClass: ReturnType<typeof assetClassForWidget>;
+}) {
+  const { error, setError, saving, updateItems } =
+    useChannelConfig<string[]>(channelType, "symbols");
+
+  const { data: dashboard } = useQuery(dashboardQueryOptions());
+  const {
+    data: fullCatalog = [],
+    isLoading: catalogLoading,
+    isError: catalogError,
+  } = useQuery(financeCatalogOptions());
+
+  const channelRow = (dashboard?.channels ?? []).find(
+    (ch) => ch.channel_type === channelType,
+  );
+  const config = (channelRow?.config ?? {}) as FinanceChannelConfig;
+  const symbols = useMemo(
+    () => (Array.isArray(config.symbols) ? config.symbols : []),
+    [config.symbols],
+  );
+  const symbolSet = useMemo(() => new Set(symbols), [symbols]);
+
+  // Scope the picker to this widget's asset class — the "Crypto" category
+  // for the crypto widget, everything else for stocks.
+  const catalog = useMemo(() => {
+    if (!assetClass) return fullCatalog;
+    return fullCatalog.filter((item) =>
+      assetClass === "crypto"
+        ? item.category === "Crypto"
+        : item.category !== "Crypto",
+    );
+  }, [fullCatalog, assetClass]);
+
+  const trades = useMemo(
+    () => (dashboard?.data?.finance as Trade[] | undefined) ?? [],
+    [dashboard?.data?.finance],
+  );
+
+  const addSymbol = useCallback(
+    (sym: string) => {
+      if (symbolSet.has(sym)) return;
+      updateItems([...symbols, sym]);
+    },
+    [symbols, symbolSet, updateItems],
+  );
+
+  const removeSymbol = useCallback(
+    (sym: string) => {
+      updateItems(symbols.filter((s) => s !== sym));
+    },
+    [symbols, updateItems],
+  );
+
+  return (
+    <div className="flex flex-1 flex-col gap-3 p-3">
+      {error && (
+        <div className="shrink-0 px-3 py-2 rounded-lg bg-error/10 border border-error/20 text-[11px] text-error flex items-center justify-between">
+          <span>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            aria-label="Dismiss error"
+            className="text-error/60 hover:text-error cursor-pointer"
+          >
+            ×
+          </button>
+        </div>
+      )}
+      <SymbolManager
+        symbols={symbols}
+        catalog={catalog}
+        trades={trades}
+        onAdd={addSymbol}
+        onRemove={removeSymbol}
+        loading={catalogLoading}
+        error={catalogError}
+        saving={saving}
+      />
     </div>
   );
 }

--- a/desktop/src/channels/finance/SymbolManager.tsx
+++ b/desktop/src/channels/finance/SymbolManager.tsx
@@ -26,13 +26,11 @@ import {
 import clsx from "clsx";
 import { motion } from "motion/react";
 import Tooltip from "../../components/Tooltip";
-import UpgradePrompt from "../../components/UpgradePrompt";
 import EmptySection from "../../components/layout/EmptySection";
-import CategoryFilter from "../rss/CategoryFilter";
+import { MultiSelectMenu } from "../../components/widget-bar/MultiSelectMenu";
 import { formatPrice, formatChange } from "../../utils/format";
 import type { TrackedSymbol } from "../../api/queries";
 import type { Trade } from "../../types";
-import type { SubscriptionTier } from "../../auth";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -50,9 +48,6 @@ interface SymbolManagerProps {
   /** Catalog query state. */
   loading: boolean;
   error: boolean;
-  /** Tier-limit info. */
-  maxSymbols: number;
-  subscriptionTier: SubscriptionTier;
   /** Whether a save mutation is in-flight (disables row toggles). */
   saving: boolean;
 }
@@ -81,8 +76,6 @@ export default function SymbolManager({
   onRemove,
   loading,
   error,
-  maxSymbols,
-  subscriptionTier,
   saving,
 }: SymbolManagerProps) {
   // ── Local UI state ─────────────────────────────────────────────
@@ -101,7 +94,6 @@ export default function SymbolManager({
     () => new Map(trades.map((t) => [t.symbol, t])),
     [trades],
   );
-  const atLimit = symbols.length >= maxSymbols;
 
   // Categories with counts — drives the dropdown filter.
   const categories = useMemo(() => {
@@ -124,6 +116,15 @@ export default function SymbolManager({
       (s) => catalogSet.has(s) && !trackedSet.has(s),
     );
   }, [catalog, trackedSet, symbols.length]);
+
+  const categoryNames = useMemo(
+    () => categories.map((c) => c.name),
+    [categories],
+  );
+  const categoryCounts = useMemo(
+    () => Object.fromEntries(categories.map((c) => [c.name, c.count])),
+    [categories],
+  );
 
   // Filter + sort the unified list.
   const filtered = useMemo(() => {
@@ -210,11 +211,11 @@ export default function SymbolManager({
       if (saving) return;
       if (trackedSet.has(symbol)) {
         onRemove(symbol);
-      } else if (!atLimit) {
+      } else {
         onAdd(symbol);
       }
     },
-    [trackedSet, atLimit, saving, onAdd, onRemove],
+    [trackedSet, saving, onAdd, onRemove],
   );
 
   const toggleCategory = useCallback((cat: string) => {
@@ -238,45 +239,25 @@ export default function SymbolManager({
     );
   }
 
-  const showAtLimitWarning = atLimit;
-
   return (
     // Fill the available height. Header / controls are pinned via
     // shrink-0; only the list panel scrolls. PageLayout's fillHeight
     // mode disables outer page scroll on the configure route, so this
-    // is the single scrollable region for the user.
+    // is the single scrollable region for the user. Mounted in-feed
+    // (unconstrained height) the list simply grows and the page scrolls.
     <div className="h-full flex flex-col gap-3 pb-5 min-h-0">
       {/* ── Header ─────────────────────────────────────────────── */}
       <div className="shrink-0 flex items-center justify-between gap-3">
         <div className="flex items-center gap-2 min-w-0">
           <h3 className="text-sm font-semibold text-fg">Symbols</h3>
-          <span
-            className={clsx(
-              "px-1.5 py-px rounded-full text-ui-chip font-medium tabular-nums",
-              atLimit
-                ? "bg-warn/15 text-warn"
-                : "bg-accent/15 text-accent",
-            )}
-          >
+          <span className="px-1.5 py-px rounded-full text-ui-chip font-medium tabular-nums bg-accent/15 text-accent">
             {symbols.length}
-            {maxSymbols !== Infinity && ` / ${maxSymbols}`}
           </span>
         </div>
         <p className="text-ui-meta text-fg-3 truncate">
           Click a row to add or remove
         </p>
       </div>
-
-      {showAtLimitWarning && (
-        <div className="shrink-0">
-          <UpgradePrompt
-            current={symbols.length}
-            max={maxSymbols}
-            noun="symbols"
-            tier={subscriptionTier}
-          />
-        </div>
-      )}
 
       {/* ── Quick-add chips (only on near-empty watchlist) ────── */}
       {quickAddChips.length > 0 && (
@@ -288,7 +269,7 @@ export default function SymbolManager({
             <button
               key={sym}
               onClick={() => onAdd(sym)}
-              disabled={atLimit || saving}
+              disabled={saving}
               className={clsx(
                 "flex items-center gap-1 px-2 py-0.5 rounded-md border text-ui-chip font-mono",
                 "transition-all duration-150 active:scale-90",
@@ -328,12 +309,14 @@ export default function SymbolManager({
           )}
         </div>
 
-        <CategoryFilter
-          categories={categories}
-          selected={selectedCategories}
+        <MultiSelectMenu
+          options={categoryNames}
+          counts={categoryCounts}
+          selected={Array.from(selectedCategories)}
           onToggle={toggleCategory}
-          onClearAll={() => setSelectedCategories(new Set())}
-          alignRight
+          onClear={() => setSelectedCategories(new Set())}
+          noun="categories"
+          ariaLabel="Filter by category"
         />
 
         <Tooltip
@@ -431,7 +414,6 @@ export default function SymbolManager({
               entry={sym}
               tracked={trackedSet.has(sym.symbol)}
               trade={tradeMap.get(sym.symbol)}
-              atLimit={atLimit}
               saving={saving}
               onToggle={() => toggleSymbol(sym.symbol)}
             />
@@ -448,7 +430,6 @@ interface SymbolRowProps {
   entry: TrackedSymbol;
   tracked: boolean;
   trade: Trade | undefined;
-  atLimit: boolean;
   saving: boolean;
   onToggle: () => void;
 }
@@ -457,13 +438,9 @@ function SymbolRow({
   entry,
   tracked,
   trade,
-  atLimit,
   saving,
   onToggle,
 }: SymbolRowProps) {
-  // Untracked rows at the limit are visually muted and click is a
-  // no-op (the toggle handler bails). Tracked rows are always clickable.
-  const blocked = !tracked && atLimit;
   const pctChange =
     trade?.percentage_change != null
       ? parseFloat(String(trade.percentage_change))
@@ -474,22 +451,18 @@ function SymbolRow({
       type="button"
       role="listitem"
       onClick={onToggle}
-      disabled={saving || blocked}
+      disabled={saving}
       aria-label={
         tracked
           ? `Remove ${entry.symbol} from watchlist`
-          : blocked
-            ? `${entry.symbol} — at watchlist limit`
-            : `Add ${entry.symbol} to watchlist`
+          : `Add ${entry.symbol} to watchlist`
       }
       className={clsx(
         "w-full flex items-center gap-2.5 px-3 py-2 text-left transition-all duration-150 group",
         "active:scale-[0.995]",
         tracked
           ? "bg-accent/[0.04] hover:bg-accent/[0.08]"
-          : blocked
-            ? "opacity-40 cursor-not-allowed"
-            : "hover:bg-base-200/50 cursor-pointer",
+          : "hover:bg-base-200/50 cursor-pointer",
         saving && "cursor-wait",
       )}
     >

--- a/desktop/src/channels/finance/preview/index.html
+++ b/desktop/src/channels/finance/preview/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<!--
+  Finance channel PREVIEW HARNESS — dev-only, browser-only.
+
+  Mounts the real FinanceFeedTab in a plain browser (no Tauri) against a
+  deterministic inline fixture, so the widget bar / Symbols view can be
+  screenshotted and asserted at arbitrary viewport widths without driving
+  the native window. Served by the normal `npm run dev` Vite server:
+
+      http://localhost:5174/src/channels/finance/preview/index.html
+
+  Query params: ?theme=scrollr-dark   (default scrollr-light)
+                ?density=compact      (default comfort)
+                ?widget=finance_crypto (default finance_stocks)
+  Not part of the production build (vite build uses explicit rollup inputs).
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Finance channel preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./preview.tsx"></script>
+  </body>
+</html>

--- a/desktop/src/channels/finance/preview/preview.tsx
+++ b/desktop/src/channels/finance/preview/preview.tsx
@@ -1,0 +1,194 @@
+/**
+ * Finance channel preview harness — dev-only, browser-only entry.
+ *
+ * Mounts the REAL FinanceFeedTab (no mocks of channel code) in a plain
+ * browser with the minimum scaffolding it needs: the app stylesheet, a
+ * ShellContext with STATEFUL display prefs (gear writes re-render like
+ * the real shell), and a TanStack Query cache seeded once with a
+ * deterministic inline fixture (queries disabled — static data; live
+ * behavior is verified in Tauri).
+ *
+ * Mirrors channels/predictions/preview/ — see that harness for the
+ * pattern rationale. Symbol ADD/REMOVE mutations are not exercised here
+ * (no authenticated API in a browser); the Symbols view is asserted
+ * render-only, and persistence rides the same useChannelConfig hook the
+ * Configure page has always used.
+ */
+// FIRST: evaluate the channel registry before ../FeedTab. FinanceFeedTab
+// imports marketplace → registry → (eager glob) every channel FeedTab; if
+// this entry starts at ../FeedTab instead, that cycle re-enters the
+// half-evaluated module and throws a TDZ ReferenceError. The real app
+// always evaluates the registry first — mirror it.
+import "../../registry";
+import { StrictMode, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import "../../../style.css";
+import { ShellContext, type ShellState } from "../../../shell-context";
+import {
+  dashboardQueryOptions,
+  financeCatalogOptions,
+  type TrackedSymbol,
+} from "../../../api/queries";
+import {
+  migrateFinanceDisplay,
+  type AppPreferences,
+} from "../../../preferences";
+import { financeChannel } from "../FeedTab";
+import type { ChannelType } from "../../../api/client";
+import type { FeedTabProps, Trade } from "../../../types";
+
+const params = new URLSearchParams(window.location.search);
+const theme = params.get("theme") ?? "scrollr-light";
+const density =
+  params.get("density") === "compact" ? ("compact" as const) : ("comfort" as const);
+const widgetId = params.get("widget") ?? "finance_stocks";
+
+// ── Deterministic fixture ────────────────────────────────────────
+// Fabricated inline: finance rows have no per-market nuances worth a
+// snapshot file (prices are static in the harness anyway).
+
+const CATEGORIES: [string, string[]][] = [
+  ["Tech", ["AAPL", "MSFT", "GOOG", "AMZN", "META", "NVDA", "AMD", "INTC", "CRM", "ORCL"]],
+  ["Auto", ["TSLA", "F", "GM", "RIVN", "TM"]],
+  ["Energy", ["XOM", "CVX", "SHEL", "BP"]],
+  ["Retail", ["WMT", "COST", "TGT", "HD"]],
+  ["ETF", ["SPY", "QQQ", "VTI", "DIA", "IWM"]],
+  ["Crypto", ["BTC/USD", "ETH/USD", "SOL/USD", "DOGE/USD"]],
+];
+
+const catalog: TrackedSymbol[] = CATEGORIES.flatMap(([category, symbols]) =>
+  symbols.flatMap((symbol) => {
+    const base = {
+      symbol,
+      name: `${symbol.replace("/USD", "")} ${category === "Crypto" ? "" : "Inc."}`.trim(),
+      category,
+    };
+    // Pad the universe (~130 rows) so the feed scrolls well past the
+    // viewport — the sticky-pin check needs ≥300px of travel.
+    const variants = Array.from({ length: 3 }, (_, n) => ({
+      ...base,
+      symbol: `${symbol}${n + 2}`,
+      name: `${base.name} ${n + 2}`,
+    }));
+    return [base, ...variants];
+  }),
+);
+
+// Stable pseudo-random price/change per symbol (index-seeded, no RNG).
+const trades: Trade[] = catalog.map((entry, i) => {
+  const price = 20 + ((i * 37) % 400) + 0.25;
+  const pct = (((i * 13) % 90) - 40) / 10; // -4.0 … +4.9, mixed signs
+  return {
+    id: i + 1,
+    symbol: entry.symbol,
+    price,
+    previous_close: price - pct,
+    percentage_change: pct.toFixed(2),
+    direction: pct > 0 ? "up" : pct < 0 ? "down" : undefined,
+    last_updated: "2026-07-17T12:00:00Z",
+    link: "https://www.google.com/finance",
+  };
+});
+
+const tracked = catalog
+  .filter((c) => c.category !== "Crypto")
+  .slice(0, 12)
+  .map((c) => c.symbol);
+
+function main(): void {
+  // Queries disabled: the seeded snapshot IS the dataset.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { enabled: false, retry: false } },
+  });
+  queryClient.setQueryData(dashboardQueryOptions().queryKey, {
+    data: { finance: trades },
+    channels: [
+      {
+        id: 1,
+        channel_type: widgetId as ChannelType,
+        enabled: true,
+        ticker_enabled: true,
+        created_at: "2026-07-17T00:00:00Z",
+        updated_at: "2026-07-17T00:00:00Z",
+        logto_sub: "preview",
+        config: { symbols: tracked },
+      },
+    ],
+  });
+  queryClient.setQueryData(financeCatalogOptions().queryKey, catalog);
+
+  const initialPrefs = {
+    channelDisplay: {
+      finance: {
+        ...migrateFinanceDisplay(undefined),
+        feedDensity: density,
+      },
+    },
+  } as unknown as AppPreferences;
+
+  const noop = (): void => {};
+  const shellBase = {
+    authenticated: false,
+    tier: "free",
+    subscriptionInfo: null,
+    onLogin: noop,
+    onLogout: noop,
+    autostartEnabled: false,
+    onAutostartChange: noop,
+    appVersion: "preview",
+    allChannelManifests: [],
+    allWidgets: [],
+    onToggleChannelTicker: noop,
+    onToggleWidgetTicker: noop,
+    onAddChannel: noop,
+    onDeleteChannel: noop,
+    onToggleWidget: noop,
+    onSelectItem: noop,
+  };
+
+  const feedContext = {
+    __hasConfig: true,
+    __dashboardLoaded: true,
+    __refreshing: false,
+  } as FeedTabProps["feedContext"];
+
+  const FeedTab = financeChannel.FeedTab;
+
+  function Harness() {
+    const [prefs, setPrefs] = useState<AppPreferences>(initialPrefs);
+    const shell = {
+      ...shellBase,
+      prefs,
+      onPrefsChange: setPrefs,
+    } as unknown as ShellState;
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ShellContext.Provider value={shell}>
+          {/* Page-scroll like the app: PageLayout's feed mode scrolls the
+              PAGE, not the FeedTab (sticky pins against this scroller). */}
+          <div
+            id="app-shell"
+            data-theme={theme}
+            className="h-screen overflow-y-auto scrollbar-thin bg-surface text-fg font-sans"
+          >
+            <FeedTab
+              mode={density}
+              feedContext={feedContext}
+              onConfigure={noop}
+              widgetId={widgetId}
+            />
+          </div>
+        </ShellContext.Provider>
+      </QueryClientProvider>
+    );
+  }
+
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <Harness />
+    </StrictMode>,
+  );
+}
+
+main();

--- a/desktop/src/components/EmptyChannelState.tsx
+++ b/desktop/src/components/EmptyChannelState.tsx
@@ -37,10 +37,15 @@ interface EmptyChannelStateProps {
   /** Hint text for the action (e.g. "choose what to track", "pick your leagues"). */
   actionHint?: string;
   /**
-   * Navigate to the channel's Configure sub-tab. Wired in
-   * `routes/channel.$type.$tab.tsx`. When provided, the hint becomes a
-   * one-tap button; the surrounding copy still teaches the user the
-   * Options-pill path so they can do it themselves next time.
+   * Full button label override. Widgets whose config lives in-widget
+   * (post configure-page) pass this so the CTA doesn't say "Open
+   * Configure" while actually opening an in-feed view.
+   */
+  actionLabel?: string;
+  /**
+   * The CTA action. Historically "navigate to the Configure sub-tab";
+   * in-widget-config channels pass their own in-feed action (with
+   * `actionLabel`). When provided, the hint becomes a one-tap button.
    */
   onConfigure?: () => void;
 }
@@ -53,6 +58,7 @@ export default function EmptyChannelState({
   refreshing,
   loadingNoun,
   actionHint,
+  actionLabel,
   onConfigure,
 }: EmptyChannelStateProps) {
   return (
@@ -82,7 +88,7 @@ export default function EmptyChannelState({
                 "transition-colors active:scale-[0.97]",
               )}
             >
-              Open Configure to {actionHint ?? `add ${noun}`}
+              {actionLabel ?? `Open Configure to ${actionHint ?? `add ${noun}`}`}
             </button>
           ) : null}
           <p className="text-[11px] text-fg-4/80 text-center max-w-sm leading-relaxed">


### PR DESCRIPTION
Stacked on #233. Finance was the worst offender (dead-scrollport sticky, three stacked control bands, orphaned display prefs) — it now gets the full Kalshi-grade bar and its Configure page's symbol picker in-feed.

Linear: REL-34

## Changes

- **Scroll fix**: FeedTab root loses `h-full overflow-y-auto` for `flex min-h-full flex-col` — PageLayout owns scrolling, the bar genuinely pins (same fix class as the v1.1.6 Kalshi one; verified by bounding box, not classlist).
- **One bar** (`WidgetBar`): `Segmented [Feed | Symbols]` · direction `BarPill`s · sort `SelectMenu` · categories `MultiSelectMenu` with per-row counts · `SearchBox` (plain substring on symbol, `/` focus, two-stage Esc) · `FreshnessPill` · gear. Chips row + summary counts band **deleted** — counts live in menu rows. Narrow widths collapse to a `FilterTrigger` menu (Direction with counts / Sort / Category with counts) anchored to the bar.
- **Symbols view**: the Symbols segment mounts `SymbolManager` in-feed with the ConfigPanel's exact wiring (`useChannelConfig "symbols"`, catalog query, asset-class scoping — crypto widget sees only Crypto, stocks everything else). Empty state's CTA opens it in-widget ("Choose symbols to track", new `actionLabel` prop on EmptyChannelState).
- **De-tiered SymbolManager** (per-feature caps retired 2026-07-02): `maxSymbols`/`subscriptionTier`/`atLimit`/UpgradePrompt gone; its category dropdown now uses the shared MultiSelectMenu instead of rss's CategoryFilter (which PR 7 deletes). ConfigPanel call site updated — the page keeps working until teardown.
- **Gear popover** reclaims prefs that had NO edit surface since the display pages were removed (2026-06-30): % change / previous close / last updated venue grid, default sort, feed density. Compact density floats the gear top-right (config path in every mode; verified round-trip comfort→compact→comfort via the floating gear).
- **New harness + suite**: `channels/finance/preview/` (mirrors the predictions harness; stateful prefs, deterministic ~130-row fixture) and `scripts/verify-finance.mjs`.

## Verification

- `npx tsc --noEmit` clean; `npx vitest run` 490/490
- `verify-finance.mjs` **57/57 PASS** at 1440/960/720/375: bar anatomy, direction/category/sort/search behavior, bounding-box sticky pin + elevation, live gear toggles, density round-trip, Symbols-view scoping + de-tiering, collapse-before-clip, viewport-fit menus, console-error gates
- `verify-kalshi.mjs` + `verify-search.mjs` still ALL PASS (shared primitives untouched behaviorally)
- Config-write persistence rides the same `useChannelConfig` mutation the Configure page has always used (shared hook, optimistic + rollback) — a quick add/remove smoke in the Tauri app before merge is still worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)