### PR TITLE
In-widget config PR 3: RSS bar + Feeds segment [REL-35]

### DIFF
--- a/desktop/scripts/verify-rss.mjs
+++ b/desktop/scripts/verify-rss.mjs
@@ -1,0 +1,261 @@
+/**
+ * Playwright verification for the News/RSS widget bar + Feeds view
+ * (in-widget config pass, PR 3). Drives the rss preview harness at
+ * 1440 / 960 / 720 / 375.
+ *
+ * Run with the vite dev server on :5174:
+ *   node desktop/scripts/verify-rss.mjs
+ *
+ * Note: gear + Feeds view are asserted render-only — their writes ride
+ * useChannelConfig (authenticated API mutation), which a plain browser
+ * can't exercise. showAll / filters / sort are pure client state and
+ * are exercised for real.
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const BASE = "http://localhost:5174/src/channels/rss/preview/index.html";
+const OUT = process.env.UI_REVIEW_OUT ?? "ui-review-out";
+mkdirSync(OUT, { recursive: true });
+
+let failures = 0;
+function check(name, cond, extra = "") {
+  if (cond) console.log(`  PASS ${name}`);
+  else {
+    failures++;
+    console.log(`  FAIL ${name} ${extra}`);
+  }
+}
+
+const ROW = ".grid a"; // RssArticle anchors
+
+function watchConsole(page, consoleErrors) {
+  const benign = /Failed to load resource|Store write failed|Token unavailable/;
+  page.on("console", (msg) => {
+    if (msg.type() === "error" && !benign.test(msg.text())) consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+}
+
+async function newPage(browser, width, height, query = "") {
+  const page = await browser.newPage({ viewport: { width, height } });
+  const consoleErrors = [];
+  watchConsole(page, consoleErrors);
+  await page.goto(`${BASE}${query}`, { waitUntil: "networkidle" });
+  await page.waitForSelector(ROW);
+  return { page, consoleErrors };
+}
+
+async function run() {
+  const browser = await chromium.launch({ channel: "msedge", headless: true });
+
+  // ════ 1440px — bar anatomy + filters (rss_custom) ════════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · bar anatomy (rss_custom) ==");
+
+    check("view switch renders", (await page.locator('[aria-label="News view"] [role="tab"]').count()) === 2);
+    check("sort menu present", (await page.locator('[aria-label="Sort articles"]').count()) === 1);
+    check("sources menu present", (await page.locator('[aria-label="Filter by source"]').count()) === 1);
+    check("category menu present", (await page.locator('[aria-label="Filter by category"]').count()) === 1);
+    check("gear present", (await page.locator('[aria-label="News settings"]').count()) === 1);
+    const bodyText = await page.locator("#root").innerText();
+    check("old limit band gone (footer only)", !bodyText.includes("Showing 5 per source"));
+    const rowsAll = await page.locator(ROW).count();
+    check("article rows render", rowsAll >= 20, `rows=${rowsAll}`);
+    await page.screenshot({ path: `${OUT}/rss-01-bar-1440.png` });
+
+    // Per-source cap → footer "Show all" reveals; inverse restores.
+    const showAllBtn = page.locator('button:has-text("Show all")');
+    check("Show all lives at the list footer", (await showAllBtn.count()) === 1);
+    await showAllBtn.click();
+    await page.waitForTimeout(200);
+    const rowsExpanded = await page.locator(ROW).count();
+    check("Show all reveals hidden articles", rowsExpanded > rowsAll, `${rowsAll} -> ${rowsExpanded}`);
+    const limitBtn = page.locator('button:has-text("Limit to 5 per source")');
+    check("limit affordance replaces it", (await limitBtn.count()) === 1);
+    await limitBtn.click();
+    await page.waitForTimeout(200);
+    check("limit restores the cap", (await page.locator(ROW).count()) === rowsAll);
+
+    // Sources menu: counts, multi-select stays open, filters rows.
+    await page.locator('[aria-label="Filter by source"]').click();
+    await page.waitForSelector('[role="menu"]');
+    await page.waitForTimeout(250);
+    const srcRows = await page.locator('[role="menu"] [role="menuitemcheckbox"]').allTextContents();
+    check("source rows carry counts", srcRows.length >= 5 && srcRows.every((t) => /\d/.test(t)), srcRows.join(","));
+    await page.locator('[role="menu"] [role="menuitemcheckbox"]:has-text("BBC News")').click();
+    check("menu stays open after toggle", (await page.locator('[role="menu"]').count()) === 1);
+    await page.waitForTimeout(200);
+    const bbcRows = await page.locator(ROW).allInnerTexts();
+    check(
+      "source filter narrows to that source",
+      bbcRows.length > 0 && bbcRows.every((t) => t.includes("BBC")),
+      `rows=${bbcRows.length}`,
+    );
+    await page.locator('[role="menu"] [role="menuitemradio"]:has-text("All sources")').click();
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(250);
+
+    // Category menu filters via feed categories.
+    await page.locator('[aria-label="Filter by category"]').click();
+    await page.waitForSelector('[role="menu"]');
+    await page.locator('[role="menu"] [role="menuitemcheckbox"]:has-text("Tech")').click();
+    await page.waitForTimeout(200);
+    const techRows = await page.locator(ROW).allInnerTexts();
+    check(
+      "category filter narrows to tech feeds",
+      techRows.length > 0 && techRows.every((t) => /Verge|Ars|Hacker/i.test(t)),
+      `rows=${techRows.length}`,
+    );
+    await page.locator('[role="menu"] [role="menuitemradio"]:has-text("All categories")').click();
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(250);
+
+    // Sort: By Source renders group headers with overflow affordances.
+    await page.locator('[aria-label="Sort articles"]').click();
+    await page.waitForSelector('[role="menu"]');
+    await page.locator('[role="menu"] [role="menuitemradio"]:has-text("By Source")').click();
+    await page.waitForTimeout(250);
+    check("sort menu closes on pick", (await page.locator('[role="menu"]').count()) === 0);
+    check("By Source renders group headers", (await page.locator('button:has-text("more")').count()) >= 3);
+    await page.screenshot({ path: `${OUT}/rss-02-by-source-1440.png` });
+
+    check("no console errors (bar page)", consoleErrors.length === 0, consoleErrors.slice(0, 3).join(" | "));
+    await page.close();
+  }
+
+  // ════ 1440px — sticky pin (bounding box) ═════════════════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · sticky bar ==");
+
+    const bar = page.locator("div.sticky.top-0");
+    check("bar starts un-elevated", !(await bar.getAttribute("class")).includes("backdrop-blur-sm"));
+    const rowBefore = await page.locator(ROW).first().boundingBox();
+
+    await page.evaluate(() => {
+      document.querySelector("#root .overflow-y-auto").scrollTop = 400;
+    });
+    await page.waitForTimeout(250);
+
+    const barBox = await bar.boundingBox();
+    const rowAfter = await page.locator(ROW).first().boundingBox();
+    check(
+      "bar pins while content scrolls ≥300px",
+      barBox && barBox.y <= 1 && rowBefore && rowAfter && rowAfter.y < rowBefore.y - 300,
+      `bar.y=${barBox?.y} row ${rowBefore?.y}->${rowAfter?.y}`,
+    );
+    check("bar elevates once stuck", (await bar.getAttribute("class")).includes("backdrop-blur-sm"));
+    await page.screenshot({ path: `${OUT}/rss-03-sticky-1440.png` });
+
+    check("no console errors (sticky page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  // ════ 1440px — gear (render-only) + Feeds view ═══════════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · gear + Feeds view ==");
+
+    await page.locator('[aria-label="News settings"]').click();
+    await page.waitForSelector('[role="menu"]');
+    await page.waitForTimeout(250);
+    const gearText = (await page.locator('[role="menu"]').innerText()).toUpperCase();
+    check(
+      "gear lists time window + display toggles",
+      gearText.includes("TIME WINDOW") &&
+        gearText.includes("ARTICLE DESCRIPTIONS") &&
+        gearText.includes("TIMESTAMPS"),
+    );
+    await page.screenshot({ path: `${OUT}/rss-04-gear-1440.png` });
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(250);
+
+    // Feeds view (rss_custom only): the Configure page's manager, in-feed.
+    await page.locator('[role="tab"]:has-text("Feeds")').click();
+    await page.waitForSelector('button:has-text("Custom feed")');
+    const feedRows = await page.locator('[role="listitem"]').count();
+    check("feed manager renders rows", feedRows >= 5, `rows=${feedRows}`);
+    check("custom feed is badged", (await page.locator('[role="listitem"]:has-text("My Blog") >> text=custom').count()) === 1);
+    check("no tier caps in header", !(await page.locator("#root").innerText()).includes(" / "));
+    await page.screenshot({ path: `${OUT}/rss-05-feeds-view-1440.png` });
+
+    await page.locator('[role="tab"]:has-text("Articles")').click();
+    await page.waitForSelector(ROW);
+    check("Articles tab returns to the list", (await page.locator(ROW).count()) > 10);
+
+    check("no console errors (gear/feeds page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  // ════ 1440px — curated single-feed widget (news_bbc) ═════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900, "?widget=news_bbc");
+    console.log("== 1440px · curated widget (news_bbc) ==");
+
+    check("NO view switch (intrinsic feed)", (await page.locator('[aria-label="News view"]').count()) === 0);
+    check("NO sources menu (single source)", (await page.locator('[aria-label="Filter by source"]').count()) === 0);
+    check("gear still present", (await page.locator('[aria-label="News settings"]').count()) === 1);
+    const rows = await page.locator(ROW).allInnerTexts();
+    check("scoped to the widget's feed", rows.length > 0 && rows.every((t) => t.includes("BBC")), `rows=${rows.length}`);
+    await page.screenshot({ path: `${OUT}/rss-06-curated-1440.png` });
+
+    check("no console errors (curated page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  // ════ Narrow widths ══════════════════════════════════════════════
+  // The rss cluster is light: inline menus hold to @2xl (672px
+  // container) and collapse into the Filter button below it.
+  for (const { width, collapsed } of [
+    { width: 960, collapsed: false },
+    { width: 720, collapsed: false },
+    { width: 375, collapsed: true },
+  ]) {
+    const { page, consoleErrors } = await newPage(browser, width, 812);
+    console.log(`== ${width}px · ${collapsed ? "collapsed" : "inline"} controls ==`);
+
+    const clipped = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    check(`no horizontal clipping at ${width}`, !clipped);
+
+    if (collapsed) {
+      check(`inline menus hidden at ${width}`, !(await page.locator('[aria-label="Sort articles"]').isVisible()));
+      const filterBtn = page.locator('[aria-label="Filters"]');
+      check(`filter button visible at ${width}`, await filterBtn.isVisible());
+      await filterBtn.click();
+      await page.waitForSelector('[role="menu"]');
+      await page.waitForTimeout(250);
+      const menuText = (await page.locator('[role="menu"]').innerText()).toUpperCase();
+      check(
+        `menu lists Sort/Sources/Category at ${width}`,
+        menuText.includes("SORT") && menuText.includes("SOURCES") && menuText.includes("CATEGORY"),
+      );
+      const menuBox = await page.locator('[role="menu"]').boundingBox();
+      check(
+        `menu fits inside the viewport at ${width}`,
+        menuBox && menuBox.x >= 0 && menuBox.x + menuBox.width <= width,
+        JSON.stringify(menuBox),
+      );
+      await page.keyboard.press("Escape");
+      await page.screenshot({ path: `${OUT}/rss-07-collapsed-${width}.png` });
+    } else {
+      check(`inline menus visible at ${width}`, await page.locator('[aria-label="Sort articles"]').isVisible());
+      check(`no filter button at ${width}`, !(await page.locator('[aria-label="Filters"]').isVisible()));
+    }
+
+    check(`no console errors (${width})`, consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/desktop/src/channels/rss/ConfigPanel.tsx
+++ b/desktop/src/channels/rss/ConfigPanel.tsx
@@ -7,7 +7,6 @@ import { ArticleAgeControl } from "../../components/TimeWindowControl";
 import { rssCatalogOptions } from "../../api/queries";
 import { useChannelConfig } from "../../hooks/useChannelConfig";
 import { useShell } from "../../shell-context";
-import { getLimit } from "../../tierLimits";
 import type { RssDisplayPrefs } from "../../preferences";
 import type { Channel, RssChannelConfig } from "../../api/client";
 import type { SubscriptionTier } from "../../auth";
@@ -124,13 +123,6 @@ function RssFeedConfig({
   const feeds = Array.isArray(rssConfig?.feeds) ? rssConfig.feeds : [];
   const feedUrlSet = useMemo(() => new Set(feeds.map((f) => f.url)), [feeds]);
 
-  const maxFeeds = getLimit(subscriptionTier, "feeds");
-  const maxCustomFeeds = getLimit(subscriptionTier, "customFeeds");
-  const customFeedCount = useMemo(
-    () => feeds.filter((f) => f.is_custom).length,
-    [feeds],
-  );
-
   // Two catalogs: "clean" (curated, healthy feeds for browsing) and
   // "all" (includes failing feeds + the user's customs, used for
   // health badges on rows the user has already subscribed to).
@@ -146,13 +138,12 @@ function RssFeedConfig({
 
   const addCatalogFeed = useCallback(
     (url: string) => {
-      if (feeds.length >= maxFeeds) return;
       const allFeeds = [...catalog, ...catalogAll];
       const feed = allFeeds.find((f) => f.url === url);
       if (!feed || feedUrlSet.has(url)) return;
       updateItems([...feeds, { name: feed.name, url: feed.url }]);
     },
-    [catalog, catalogAll, feeds, feedUrlSet, updateItems, maxFeeds],
+    [catalog, catalogAll, feeds, feedUrlSet, updateItems],
   );
 
   const removeFeed = useCallback(
@@ -164,15 +155,13 @@ function RssFeedConfig({
 
   const addCustomFeed = useCallback(
     (name: string, url: string) => {
-      if (feeds.length >= maxFeeds) return;
-      if (customFeedCount >= maxCustomFeeds) return;
       if (feedUrlSet.has(url)) {
         toast.error("This feed is already added");
         return;
       }
       updateItems([...feeds, { name, url, is_custom: true }]);
     },
-    [feeds, feedUrlSet, updateItems, maxFeeds, maxCustomFeeds, customFeedCount],
+    [feeds, feedUrlSet, updateItems],
   );
 
   return (
@@ -214,10 +203,6 @@ function RssFeedConfig({
           onRemove={removeFeed}
           loading={catalogLoading}
           error={catalogError}
-          maxFeeds={maxFeeds}
-          maxCustomFeeds={maxCustomFeeds}
-          customCount={customFeedCount}
-          subscriptionTier={subscriptionTier}
           saving={saving}
         />
       </div>

--- a/desktop/src/channels/rss/FeedManager.tsx
+++ b/desktop/src/channels/rss/FeedManager.tsx
@@ -21,11 +21,9 @@ import {
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";
 import Tooltip from "../../components/Tooltip";
-import UpgradePrompt from "../../components/UpgradePrompt";
 import EmptySection from "../../components/layout/EmptySection";
-import CategoryFilter from "./CategoryFilter";
+import { MultiSelectMenu } from "../../components/widget-bar/MultiSelectMenu";
 import type { TrackedFeed } from "../../api/client";
-import type { SubscriptionTier } from "../../auth";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -44,10 +42,6 @@ interface FeedManagerProps {
   onRemove: (url: string) => void;
   loading: boolean;
   error: boolean;
-  maxFeeds: number;
-  maxCustomFeeds: number;
-  customCount: number;
-  subscriptionTier: SubscriptionTier;
   saving: boolean;
 }
 
@@ -74,10 +68,6 @@ export default function FeedManager({
   onRemove,
   loading,
   error,
-  maxFeeds,
-  maxCustomFeeds,
-  customCount,
-  subscriptionTier,
   saving,
 }: FeedManagerProps) {
   const [search, setSearch] = useState("");
@@ -100,9 +90,6 @@ export default function FeedManager({
     () => new Map(catalogAll.map((f) => [f.url, f])),
     [catalogAll],
   );
-
-  const atFeedLimit = feeds.length >= maxFeeds;
-  const atCustomLimit = customCount >= maxCustomFeeds;
 
   // Build the unified list: every catalog feed + any custom feeds
   // not already in the catalog.
@@ -212,11 +199,11 @@ export default function FeedManager({
       if (saving) return;
       if (feed.isTracked) {
         onRemove(feed.url);
-      } else if (!atFeedLimit) {
+      } else {
         onAddCatalog(feed.url);
       }
     },
-    [saving, atFeedLimit, onAddCatalog, onRemove],
+    [saving, onAddCatalog, onRemove],
   );
 
   const toggleCategory = useCallback((cat: string) => {
@@ -258,43 +245,24 @@ export default function FeedManager({
       <div className="shrink-0 flex items-center justify-between gap-3">
         <div className="flex items-center gap-2 min-w-0">
           <h3 className="text-sm font-semibold text-fg">Feeds</h3>
-          <span
-            className={clsx(
-              "px-1.5 py-px rounded-full text-ui-chip font-medium tabular-nums",
-              atFeedLimit ? "bg-warn/15 text-warn" : "bg-accent/15 text-accent",
-            )}
-          >
+          <span className="px-1.5 py-px rounded-full text-ui-chip font-medium tabular-nums bg-accent/15 text-accent">
             {feeds.length}
-            {maxFeeds !== Infinity && ` / ${maxFeeds}`}
           </span>
         </div>
-        {!atFeedLimit && maxCustomFeeds > 0 && (
-          <button
-            onClick={() => setShowCustomForm((v) => !v)}
-            className={clsx(
-              "flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border text-ui-meta font-medium",
-              "transition-all duration-150 active:scale-95",
-              showCustomForm
-                ? "border-accent/50 bg-accent/10 text-accent"
-                : "border-edge/40 text-fg-3 hover:text-accent hover:border-accent/40",
-            )}
-          >
-            <Plus size={11} />
-            Custom feed
-          </button>
-        )}
+        <button
+          onClick={() => setShowCustomForm((v) => !v)}
+          className={clsx(
+            "flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border text-ui-meta font-medium",
+            "transition-all duration-150 active:scale-95",
+            showCustomForm
+              ? "border-accent/50 bg-accent/10 text-accent"
+              : "border-edge/40 text-fg-3 hover:text-accent hover:border-accent/40",
+          )}
+        >
+          <Plus size={11} />
+          Custom feed
+        </button>
       </div>
-
-      {atFeedLimit && (
-        <div className="shrink-0">
-          <UpgradePrompt
-            current={feeds.length}
-            max={maxFeeds}
-            noun="feeds"
-            tier={subscriptionTier}
-          />
-        </div>
-      )}
 
       <AnimatePresence initial={false}>
         {showCustomForm && (
@@ -310,52 +278,36 @@ export default function FeedManager({
                 <span className="text-ui-section uppercase tracking-wider font-bold text-fg-3">
                   Add your own feed
                 </span>
-                {maxCustomFeeds !== Infinity && (
-                  <span className="text-ui-chip text-fg-3 tabular-nums">
-                    {customCount}/{maxCustomFeeds} custom
-                  </span>
-                )}
               </div>
-              {atCustomLimit ? (
-                <UpgradePrompt
-                  current={customCount}
-                  max={maxCustomFeeds}
-                  noun="custom feeds"
-                  tier={subscriptionTier}
+              <div className="flex flex-col sm:flex-row gap-2">
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="Feed name"
+                  className="flex-1 px-2.5 py-1.5 rounded-md bg-base-200 border border-edge/40 text-ui-meta font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/60 transition-colors"
                 />
-              ) : (
-                <>
-                  <div className="flex flex-col sm:flex-row gap-2">
-                    <input
-                      type="text"
-                      value={newName}
-                      onChange={(e) => setNewName(e.target.value)}
-                      placeholder="Feed name"
-                      className="flex-1 px-2.5 py-1.5 rounded-md bg-base-200 border border-edge/40 text-ui-meta font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/60 transition-colors"
-                    />
-                    <input
-                      type="url"
-                      value={newUrl}
-                      onChange={(e) => setNewUrl(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleAddCustom();
-                      }}
-                      placeholder="https://..."
-                      className="flex-[2] px-2.5 py-1.5 rounded-md bg-base-200 border border-edge/40 text-ui-meta font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/60 transition-colors"
-                    />
-                    <button
-                      onClick={handleAddCustom}
-                      disabled={saving || !newName.trim() || !newUrl.trim()}
-                      className="px-2.5 py-1.5 rounded-md bg-accent/10 text-accent border border-accent/30 hover:bg-accent/20 transition-all duration-150 active:scale-95 flex items-center gap-1 disabled:opacity-30 cursor-pointer"
-                    >
-                      <Plus size={11} />
-                      <span className="text-ui-meta font-medium">Add</span>
-                    </button>
-                  </div>
-                  {urlError && (
-                    <p className="text-ui-meta text-error/80">{urlError}</p>
-                  )}
-                </>
+                <input
+                  type="url"
+                  value={newUrl}
+                  onChange={(e) => setNewUrl(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleAddCustom();
+                  }}
+                  placeholder="https://..."
+                  className="flex-[2] px-2.5 py-1.5 rounded-md bg-base-200 border border-edge/40 text-ui-meta font-mono text-fg-2 placeholder:text-fg-4 focus:outline-none focus:border-accent/60 transition-colors"
+                />
+                <button
+                  onClick={handleAddCustom}
+                  disabled={saving || !newName.trim() || !newUrl.trim()}
+                  className="px-2.5 py-1.5 rounded-md bg-accent/10 text-accent border border-accent/30 hover:bg-accent/20 transition-all duration-150 active:scale-95 flex items-center gap-1 disabled:opacity-30 cursor-pointer"
+                >
+                  <Plus size={11} />
+                  <span className="text-ui-meta font-medium">Add</span>
+                </button>
+              </div>
+              {urlError && (
+                <p className="text-ui-meta text-error/80">{urlError}</p>
               )}
             </div>
           </motion.div>
@@ -386,12 +338,14 @@ export default function FeedManager({
           )}
         </div>
 
-        <CategoryFilter
-          categories={categories}
-          selected={selectedCategories}
+        <MultiSelectMenu
+          options={categories.map((c) => c.name)}
+          counts={Object.fromEntries(categories.map((c) => [c.name, c.count]))}
+          selected={Array.from(selectedCategories)}
           onToggle={toggleCategory}
-          onClearAll={() => setSelectedCategories(new Set())}
-          alignRight
+          onClear={() => setSelectedCategories(new Set())}
+          noun="categories"
+          ariaLabel="Filter by category"
         />
 
         <Tooltip
@@ -486,7 +440,6 @@ export default function FeedManager({
                 key={feed.url}
                 feed={feed}
                 trackedSubscription={tracked}
-                atLimit={atFeedLimit}
                 saving={saving}
                 onToggle={() => toggleFeed(feed)}
               />
@@ -503,14 +456,12 @@ export default function FeedManager({
 interface FeedRowProps {
   feed: UnifiedFeed;
   trackedSubscription: SubscribedFeed | undefined;
-  atLimit: boolean;
   saving: boolean;
   onToggle: () => void;
 }
 
-function FeedRow({ feed, atLimit, saving, onToggle }: FeedRowProps) {
+function FeedRow({ feed, saving, onToggle }: FeedRowProps) {
   const tracked = feed.isTracked;
-  const blocked = !tracked && atLimit;
   const health = feedHealth(feed);
 
   return (
@@ -518,21 +469,13 @@ function FeedRow({ feed, atLimit, saving, onToggle }: FeedRowProps) {
       type="button"
       role="listitem"
       onClick={onToggle}
-      disabled={saving || blocked}
-      aria-label={
-        tracked
-          ? `Remove ${feed.name}`
-          : blocked
-            ? `${feed.name} — at feed limit`
-            : `Add ${feed.name}`
-      }
+      disabled={saving}
+      aria-label={tracked ? `Remove ${feed.name}` : `Add ${feed.name}`}
       className={clsx(
         "w-full flex items-center gap-2.5 px-3 py-2 text-left transition-all duration-150 group active:scale-[0.995]",
         tracked
           ? "bg-accent/[0.04] hover:bg-accent/[0.08]"
-          : blocked
-            ? "opacity-40 cursor-not-allowed"
-            : "hover:bg-base-200/50 cursor-pointer",
+          : "hover:bg-base-200/50 cursor-pointer",
         saving && "cursor-wait",
       )}
     >

--- a/desktop/src/channels/rss/FeedTab.tsx
+++ b/desktop/src/channels/rss/FeedTab.tsx
@@ -4,16 +4,43 @@
  * Renders a filterable, sortable list of RSS articles with per-source
  * limiting, category badges, and real-time updates via the desktop
  * CDC/SSE pipeline.
+ *
+ * ONE Kalshi-style control bar (widget-bar primitives): Articles/Feeds
+ * segmented switch (rss_custom only — curated widgets have an intrinsic
+ * feed) · sort SelectMenu · source/category MultiSelectMenus with counts
+ * · freshness · gear popover (time window + display toggles, written as
+ * the per-widget config.display override). The Feeds view mounts the
+ * full FeedManager in-feed. Per-source "Show all" lives at the list
+ * FOOTER as content, not chrome.
  */
-import { memo, useMemo, useState, useCallback, useRef, useEffect } from "react";
-import { Rss, ChevronDown, ChevronUp } from "lucide-react";
+import { memo, useMemo, useState, useCallback, useRef } from "react";
+import { Rss, ChevronDown, ChevronUp, Newspaper } from "lucide-react";
 import { clsx } from "clsx";
 import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { dashboardQueryOptions, rssCatalogOptions } from "../../api/queries";
 import { relativeTime, truncate } from "../../utils/format";
 import EmptyChannelState from "../../components/EmptyChannelState";
 import FreshnessPill from "../../components/FreshnessPill";
-import CategoryFilter from "./CategoryFilter";
+import { WidgetBar } from "../../components/widget-bar/Bar";
+import {
+  useDismiss,
+  MenuPanel,
+  MenuHeading,
+  MenuRow,
+  FilterTrigger,
+} from "../../components/widget-bar/Menu";
+import {
+  Segmented,
+  type SegmentedOption,
+} from "../../components/widget-bar/Segmented";
+import { MultiSelectMenu } from "../../components/widget-bar/MultiSelectMenu";
+import { SelectMenu } from "../../components/widget-bar/SelectMenu";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import { ToggleRow } from "../../components/settings/SettingsControls";
+import { ArticleAgeControl } from "../../components/TimeWindowControl";
+import FeedManager from "./FeedManager";
+import { useChannelConfig } from "../../hooks/useChannelConfig";
 import { useShell } from "../../shell-context";
 import { useNow } from "../../hooks/useNow";
 import { applyRssPipeline, type RssSortOrder, distinctSourceCount } from "./view";
@@ -23,8 +50,10 @@ import type {
   FeedMode,
   ChannelManifest,
 } from "../../types";
+import type { ChannelType, RssChannelConfig } from "../../api/client";
 import { shouldShowOnFeed } from "../../preferences";
 import type { RssDisplayPrefs } from "../../preferences";
+import { AnimatePresence } from "motion/react";
 
 // ── Channel manifest ─────────────────────────────────────────────
 
@@ -52,100 +81,20 @@ export const rssChannel: ChannelManifest = {
 
 type SortOrder = RssSortOrder;
 
-// ── SourceFilter ─────────────────────────────────────────────────
+const SORT_OPTIONS: { value: SortOrder; label: string }[] = [
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "by-source", label: "By Source" },
+];
 
-interface SourceFilterProps {
-  sources: string[];
-  selected: Set<string>;
-  onToggle: (source: string) => void;
-  onClearAll: () => void;
-}
+type RssView = "articles" | "feeds";
 
-function SourceFilter({ sources, selected, onToggle, onClearAll }: SourceFilterProps) {
-  const [open, setOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  const activeCount = selected.size;
-
-  return (
-    <div ref={wrapperRef} className="relative">
-      <button
-        onClick={() => setOpen(!open)}
-        className={clsx(
-          "flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border text-ui-meta transition-colors cursor-pointer whitespace-nowrap",
-          activeCount > 0
-            ? "border-accent/50 text-accent"
-            : "border-edge/40 text-fg-3 hover:text-fg-2 hover:border-edge/60",
-        )}
-      >
-        <Rss size={12} />
-        <span>Sources</span>
-        {activeCount > 0 && (
-          <span className="bg-accent/20 text-accent rounded-full px-1.5 text-ui-chip font-medium">
-            {activeCount}
-          </span>
-        )}
-      </button>
-
-      {open && (
-        <div className="absolute top-full mt-1 left-0 w-52 bg-surface-2 border border-edge/50 rounded-lg shadow-lg z-[5] py-1 max-h-64 overflow-y-auto">
-          {sources.map((source) => {
-            const isActive = selected.has(source);
-            return (
-              <button
-                key={source}
-                onClick={() => onToggle(source)}
-                className={clsx(
-                  "flex items-center gap-2 w-full px-3 py-1.5 text-left text-ui-meta transition-colors cursor-pointer",
-                  isActive
-                    ? "text-fg-2"
-                    : "text-fg-4 hover:text-fg-3",
-                )}
-              >
-                <span
-                  className={clsx(
-                    "w-3.5 h-3.5 rounded border flex items-center justify-center text-ui-chip shrink-0",
-                    isActive
-                      ? "bg-accent/25 border-accent/50 text-accent"
-                      : "border-edge/50",
-                  )}
-                >
-                  {isActive && "\u2713"}
-                </span>
-                <span className="flex-1 truncate">{source}</span>
-              </button>
-            );
-          })}
-          {activeCount > 0 && (
-            <>
-              <div className="h-px bg-edge/40 my-1" />
-              <button
-                onClick={() => {
-                  onClearAll();
-                  setOpen(false);
-                }}
-                className="w-full px-3 py-1.5 text-left text-ui-meta text-fg-3 hover:text-fg-2 transition-colors cursor-pointer"
-              >
-                Clear all filters
-              </button>
-            </>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
+/** Articles / Feeds — options for the Segmented view switch. The Feeds
+ *  view (rss_custom only) is the Configure page's manager, in-feed. */
+const VIEW_OPTIONS: SegmentedOption<RssView>[] = [
+  { value: "articles", label: "Articles", icon: Newspaper },
+  { value: "feeds", label: "Feeds", icon: Rss },
+];
 
 // ── FeedTab ──────────────────────────────────────────────────────
 
@@ -244,12 +193,41 @@ function RssFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProps) 
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [rssItems, categoryMap]);
 
-  // ── Filter / sort state ──────────────────────────────────────
+  // ── View / filter / sort state ───────────────────────────────
+  const isComfort = mode === "comfort";
+  // Only rss_custom manages feeds; curated news widgets have an
+  // intrinsic feed (and legacy coarse rows were consumed by migrations
+  // 000015/000016 — they can't exist).
+  const isCustom = widgetId === "rss_custom";
+  const [view, setView] = useState<RssView>("articles");
   const [selectedSources, setSelectedSources] = useState<Set<string>>(new Set());
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
   const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
   const [expandedSources, setExpandedSources] = useState<Set<string>>(new Set());
   const [showAll, setShowAll] = useState(false);
+
+  // Per-source article counts — menu rows carry the numbers now.
+  const sourceCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const item of rssItems) {
+      counts[item.source_name] = (counts[item.source_name] ?? 0) + 1;
+    }
+    return counts;
+  }, [rssItems]);
+
+  const displayOverride = useMemo(
+    () =>
+      (channel?.config as { display?: Partial<RssDisplayPrefs> } | undefined)
+        ?.display ?? {},
+    [channel?.config],
+  );
+  const channelType = (channel?.channel_type ?? widgetId ?? "rss") as ChannelType;
+
+  const pickSort = useCallback((next: SortOrder) => {
+    setSortOrder(next);
+    setShowAll(false);
+    setExpandedSources(new Set());
+  }, []);
 
   const toggleSource = useCallback((source: string) => {
     setSelectedSources((prev) => {
@@ -374,172 +352,455 @@ function RssFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProps) 
     return entries;
   }, [visibleItems, overflowCounts, expandedSources, categoryMap, isBySource]);
 
-  // ── Empty state (no data at all) ─────────────────────────────
-  if (rssItems.length === 0) {
-    return (
-      <EmptyChannelState
-        refreshing={Boolean(feedContext.__refreshing)}
-        icon={Rss}
-        noun="feeds"
-        hasConfig={!!feedContext.__hasConfig}
-        dashboardLoaded={!!dashboardLoaded}
-        loadingNoun="articles"
-        actionHint="add websites"
-        onConfigure={onConfigure}
-      />
-    );
-  }
+  const showEmpty = rssItems.length === 0;
+  const showFeedsView = isComfort && isCustom && view === "feeds";
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Controls bar */}
-      <div className="sticky top-0 z-20 bg-surface border-b border-edge/40 px-3 py-2 flex items-center gap-2 flex-wrap">
-        {allSources.length > 1 && (
-          <SourceFilter
-            sources={allSources}
-            selected={selectedSources}
-            onToggle={toggleSource}
-            onClearAll={clearSources}
-          />
-        )}
-        <CategoryFilter
-          categories={categoryList}
-          selected={selectedCategories}
-          onToggle={toggleCategory}
-          onClearAll={clearCategories}
-        />
-        {latestUpdated && <FreshnessPill lastUpdated={latestUpdated} label="article" />}
-        <div className="ml-auto">
-          <select
-            value={sortOrder}
-            onChange={(e) => {
-              setSortOrder(e.target.value as SortOrder);
-              setShowAll(false);
-              setExpandedSources(new Set());
-            }}
-            className="bg-surface-2 border border-edge/40 rounded-md px-2 py-1.5 text-ui-meta text-fg-2 cursor-pointer outline-none focus:border-accent/60"
-          >
-            <option value="newest">Newest</option>
-            <option value="oldest">Oldest</option>
-            <option value="by-source">By Source</option>
-          </select>
-        </div>
-      </div>
-
-      {/* Filter chips */}
-      {hasFilters && (
-        <div className="flex items-center gap-1.5 px-3 py-1.5 bg-surface border-b border-edge/30 flex-wrap">
-          {Array.from(selectedSources).map((s) => (
-            <button
-              key={`src:${s}`}
-              onClick={() => toggleSource(s)}
-              className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent/15 text-accent text-ui-chip hover:bg-accent/25 transition-colors cursor-pointer"
-            >
-              <span className="truncate max-w-[120px]">{s}</span>
-              <span className="text-accent/60">&times;</span>
-            </button>
-          ))}
-          {Array.from(selectedCategories).map((c) => (
-            <button
-              key={`cat:${c}`}
-              onClick={() => toggleCategory(c)}
-              className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-purple-500/15 text-purple-400 text-ui-chip hover:bg-purple-500/25 transition-colors cursor-pointer"
-            >
-              <span className="truncate max-w-[120px]">{c}</span>
-              <span className="text-purple-400/60">&times;</span>
-            </button>
-          ))}
-          <button
-            onClick={clearAllFilters}
-            className="px-2 py-0.5 text-ui-chip text-fg-3 hover:text-fg-2 transition-colors cursor-pointer"
-          >
-            Clear all
-          </button>
-        </div>
-      )}
-
-      {/* Per-source limit info bar (chronological sorts only).
-          Both bars are multi-source-only: single-outlet widgets have no
-          per-source concept anymore (v1.1.1 smart removal), so a legacy
-          per-source pref must not resurface a pointless toggle there. */}
-      {multiSource && !isBySource && totalHidden > 0 && !showAll && (
-        <div className="flex items-center justify-between px-3 py-1.5 bg-surface-2 border-b border-edge/30 text-ui-meta text-fg-3">
-          <span>
-            Showing {dp.articlesPerSource} per source &middot;{" "}
-            <span className="tabular-nums">{totalHidden}</span> articles hidden
-          </span>
-          <button
-            onClick={() => setShowAll(true)}
-            className="text-accent hover:text-accent/80 transition-colors cursor-pointer font-medium"
-          >
-            Show all
-          </button>
-        </div>
-      )}
-      {multiSource && !isBySource && showAll && totalHidden === 0 && dp.articlesPerSource > 0 && (
-        <div className="flex items-center justify-between px-3 py-1.5 bg-surface-2 border-b border-edge/30 text-ui-meta text-fg-3">
-          <span>Showing all articles</span>
-          <button
-            onClick={() => setShowAll(false)}
-            className="text-accent hover:text-accent/80 transition-colors cursor-pointer font-medium"
-          >
-            Limit to {dp.articlesPerSource} per source
-          </button>
-        </div>
-      )}
-
-      {/* No-results state */}
-      {visibleItems.length === 0 && hasFilters && (
-        <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
-          <Rss size={28} className="text-fg-3" />
-          <p className="text-sm text-fg-4">No articles match your filters</p>
-          <button
-            onClick={clearAllFilters}
-            className="text-xs text-accent hover:text-accent/80 transition-colors cursor-pointer"
-          >
-            Clear filters
-          </button>
-        </div>
-      )}
-
-      {/* Article list */}
-      {visibleItems.length > 0 && (
-        <div
-          className={clsx(
-            "grid gap-px bg-edge flex-1",
-            mode === "compact"
-              ? "grid-cols-1"
-              : "grid-cols-1 sm:grid-cols-2",
+    // NO inner scroll container: the Source page (PageLayout) owns the
+    // scroll — sticky pins against it.
+    <div className="flex min-h-full flex-col">
+      {isComfort && (
+        <WidgetBar>
+          {isCustom && (
+            <Segmented
+              ariaLabel="News view"
+              value={view}
+              onChange={setView}
+              options={VIEW_OPTIONS}
+            />
           )}
-        >
-          {renderList.map((entry) => {
-            if (entry.kind === "source-header") {
-              return (
-                <SourceHeader
-                  key={`hdr:${entry.source}`}
-                  source={entry.source}
-                  category={categoryMap.get(
-                    rssItems.find((i) => i.source_name === entry.source)?.feed_url ?? "",
-                  )}
-                  overflow={entry.overflow}
-                  expanded={entry.expanded}
-                  onToggle={() => toggleExpanded(entry.source)}
+
+          {view === "articles" && !showEmpty ? (
+            <div className="ml-auto flex min-w-0 shrink items-center gap-2">
+              {/* Wide: the three menus inline. Collapse BEFORE clipping. */}
+              <span className="hidden items-center gap-2 @2xl:flex">
+                <SelectMenu
+                  value={sortOrder}
+                  options={SORT_OPTIONS}
+                  onChange={pickSort}
+                  ariaLabel="Sort articles"
+                  prefix="Sort"
                 />
-              );
-            }
-            return (
-              <RssArticle
-                key={`${entry.item.feed_url}:${entry.item.guid}`}
-                item={entry.item}
-                mode={mode}
-                display={dp}
-                category={entry.category}
-                now={now}
+                {allSources.length > 1 && (
+                  <MultiSelectMenu
+                    options={allSources}
+                    counts={sourceCounts}
+                    selected={Array.from(selectedSources)}
+                    onToggle={toggleSource}
+                    onClear={clearSources}
+                    noun="sources"
+                    ariaLabel="Filter by source"
+                  />
+                )}
+                {categoryList.length > 0 && (
+                  <MultiSelectMenu
+                    options={categoryList.map((c) => c.name)}
+                    counts={Object.fromEntries(
+                      categoryList.map((c) => [c.name, c.count]),
+                    )}
+                    selected={Array.from(selectedCategories)}
+                    onToggle={toggleCategory}
+                    onClear={clearCategories}
+                    noun="categories"
+                    ariaLabel="Filter by category"
+                  />
+                )}
+              </span>
+              {/* Narrow: one Filter menu. */}
+              <span className="@2xl:hidden">
+                <RssFilterMenu
+                  sortOrder={sortOrder}
+                  onPickSort={pickSort}
+                  sources={allSources}
+                  sourceCounts={sourceCounts}
+                  selectedSources={selectedSources}
+                  onToggleSource={toggleSource}
+                  onClearSources={clearSources}
+                  categories={categoryList}
+                  selectedCategories={selectedCategories}
+                  onToggleCategory={toggleCategory}
+                  onClearCategories={clearCategories}
+                />
+              </span>
+              {latestUpdated && (
+                <span className="hidden @xl:block">
+                  <FreshnessPill lastUpdated={latestUpdated} label="article" />
+                </span>
+              )}
+              <RssGear
+                channelType={channelType}
+                override={displayOverride}
+                globalRss={prefs.channelDisplay.rss}
               />
-            );
-          })}
+            </div>
+          ) : (
+            <div className="ml-auto">
+              <RssGear
+                channelType={channelType}
+                override={displayOverride}
+                globalRss={prefs.channelDisplay.rss}
+              />
+            </div>
+          )}
+        </WidgetBar>
+      )}
+
+      {showFeedsView ? (
+        <RssFeedsPanel
+          channelType={channelType}
+          channelConfig={channel?.config as RssChannelConfig | undefined}
+        />
+      ) : showEmpty ? (
+        <div className="flex flex-1 flex-col justify-center">
+          <EmptyChannelState
+            refreshing={Boolean(feedContext.__refreshing)}
+            icon={Rss}
+            noun="feeds"
+            hasConfig={!!feedContext.__hasConfig}
+            dashboardLoaded={!!dashboardLoaded}
+            loadingNoun="articles"
+            actionHint="add websites"
+            actionLabel={isComfort && isCustom ? "Add feeds" : undefined}
+            onConfigure={
+              isComfort && isCustom ? () => setView("feeds") : onConfigure
+            }
+          />
+        </div>
+      ) : (
+        <>
+          {/* No-results state */}
+          {visibleItems.length === 0 && hasFilters && (
+            <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+              <Rss size={28} className="text-fg-3" />
+              <p className="text-sm text-fg-4">No articles match your filters</p>
+              <button
+                onClick={clearAllFilters}
+                className="text-xs text-accent hover:text-accent/80 transition-colors cursor-pointer"
+              >
+                Clear filters
+              </button>
+            </div>
+          )}
+
+          {/* Article list */}
+          {visibleItems.length > 0 && (
+            <div
+              className={clsx(
+                "grid gap-px bg-edge",
+                mode === "compact"
+                  ? "grid-cols-1"
+                  : "grid-cols-1 sm:grid-cols-2",
+              )}
+            >
+              {renderList.map((entry) => {
+                if (entry.kind === "source-header") {
+                  return (
+                    <SourceHeader
+                      key={`hdr:${entry.source}`}
+                      source={entry.source}
+                      category={categoryMap.get(
+                        rssItems.find((i) => i.source_name === entry.source)?.feed_url ?? "",
+                      )}
+                      overflow={entry.overflow}
+                      expanded={entry.expanded}
+                      onToggle={() => toggleExpanded(entry.source)}
+                    />
+                  );
+                }
+                return (
+                  <RssArticle
+                    key={`${entry.item.feed_url}:${entry.item.guid}`}
+                    item={entry.item}
+                    mode={mode}
+                    display={dp}
+                    category={entry.category}
+                    now={now}
+                  />
+                );
+              })}
+            </div>
+          )}
+
+          {/* Per-source limit — list FOOTER content, not chrome (the old
+              info bands above the list are gone). Multi-source only:
+              single-outlet widgets have no per-source concept. */}
+          {multiSource && !isBySource && totalHidden > 0 && !showAll && (
+            <div className="flex items-center justify-center gap-3 px-3 py-3">
+              <button
+                onClick={() => setShowAll(true)}
+                className="px-4 py-1.5 rounded-md text-xs font-medium text-accent bg-accent/10 hover:bg-accent/20 transition-colors cursor-pointer"
+              >
+                Show all
+              </button>
+              <span className="text-xs text-fg-3 tabular-nums font-mono">
+                {totalHidden} hidden · {dp.articlesPerSource} per source
+              </span>
+            </div>
+          )}
+          {multiSource && !isBySource && showAll && totalHidden === 0 && dp.articlesPerSource > 0 && (
+            <div className="flex items-center justify-center px-3 py-3">
+              <button
+                onClick={() => setShowAll(false)}
+                className="px-4 py-1.5 rounded-md text-xs font-medium text-accent bg-accent/10 hover:bg-accent/20 transition-colors cursor-pointer"
+              >
+                Limit to {dp.articlesPerSource} per source
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Filter menu (narrow-width collapse) ─────────────────────────
+
+function RssFilterMenu({
+  sortOrder,
+  onPickSort,
+  sources,
+  sourceCounts,
+  selectedSources,
+  onToggleSource,
+  onClearSources,
+  categories,
+  selectedCategories,
+  onToggleCategory,
+  onClearCategories,
+}: {
+  sortOrder: SortOrder;
+  onPickSort: (s: SortOrder) => void;
+  sources: string[];
+  sourceCounts: Record<string, number>;
+  selectedSources: Set<string>;
+  onToggleSource: (s: string) => void;
+  onClearSources: () => void;
+  categories: { name: string; count: number }[];
+  selectedCategories: Set<string>;
+  onToggleCategory: (c: string) => void;
+  onClearCategories: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useDismiss(rootRef, open, close);
+
+  const activeCount = selectedSources.size + selectedCategories.size;
+
+  return (
+    // NOT position:relative — the dropdown anchors to the sticky bar so
+    // it spans the channel width instead of clipping at narrow widths.
+    <div ref={rootRef} className="shrink-0 rounded-lg">
+      <FilterTrigger
+        open={open}
+        badgeCount={activeCount}
+        onClick={() => setOpen((o) => !o)}
+      />
+      <AnimatePresence>
+        {open && (
+          <MenuPanel className="inset-x-2">
+            <MenuHeading>Sort</MenuHeading>
+            {SORT_OPTIONS.map((opt) => (
+              <MenuRow
+                key={opt.value}
+                selected={sortOrder === opt.value}
+                onClick={() => onPickSort(opt.value)}
+                role="menuitemradio"
+              >
+                {opt.label}
+              </MenuRow>
+            ))}
+            {sources.length > 1 && (
+              <>
+                <MenuHeading>Sources</MenuHeading>
+                <MenuRow
+                  selected={selectedSources.size === 0}
+                  onClick={onClearSources}
+                  role="menuitemradio"
+                >
+                  All sources
+                </MenuRow>
+                {sources.map((s) => (
+                  <MenuRow
+                    key={s}
+                    selected={selectedSources.has(s)}
+                    onClick={() => onToggleSource(s)}
+                    role="menuitemcheckbox"
+                    count={sourceCounts[s]}
+                  >
+                    {s}
+                  </MenuRow>
+                ))}
+              </>
+            )}
+            {categories.length > 0 && (
+              <>
+                <MenuHeading>Category</MenuHeading>
+                <MenuRow
+                  selected={selectedCategories.size === 0}
+                  onClick={onClearCategories}
+                  role="menuitemradio"
+                >
+                  All categories
+                </MenuRow>
+                {categories.map((c) => (
+                  <MenuRow
+                    key={c.name}
+                    selected={selectedCategories.has(c.name)}
+                    onClick={() => onToggleCategory(c.name)}
+                    role="menuitemcheckbox"
+                    count={c.count}
+                  >
+                    {c.name}
+                  </MenuRow>
+                ))}
+              </>
+            )}
+          </MenuPanel>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Gear popover (per-widget display override) ──────────────────
+//
+// Same writes as the Configure page: the time window + display toggles
+// live in this widget's `config.display` override (NOT the global shell
+// prefs), merged over the global rss display everywhere it's read.
+
+function RssGear({
+  channelType,
+  override,
+  globalRss,
+}: {
+  channelType: ChannelType;
+  override: Partial<RssDisplayPrefs>;
+  globalRss: RssDisplayPrefs;
+}) {
+  const { updateItems: updateDisplay } = useChannelConfig<
+    Partial<RssDisplayPrefs>
+  >(channelType, "display");
+
+  const effDescription = override.showDescription ?? globalRss.showDescription;
+  const effTimestamps = override.showTimestamps ?? globalRss.showTimestamps;
+
+  return (
+    <GearMenu ariaLabel="News settings" panelClassName="right-0 w-80">
+      <MenuHeading>Time window</MenuHeading>
+      <div className="px-1 pb-1">
+        <ArticleAgeControl
+          maxAgeDays={override.maxArticleAgeDays ?? globalRss.maxArticleAgeDays}
+          onChange={(days) =>
+            updateDisplay({ ...override, maxArticleAgeDays: days })
+          }
+        />
+      </div>
+      <MenuHeading>Display</MenuHeading>
+      <ToggleRow
+        label="Article descriptions"
+        description="Show a short summary under each headline"
+        checked={effDescription !== "off"}
+        onChange={(c) =>
+          updateDisplay({ ...override, showDescription: c ? "both" : "off" })
+        }
+      />
+      <ToggleRow
+        label="Timestamps"
+        description="Show how long ago each article was published"
+        checked={effTimestamps !== "off"}
+        onChange={(c) =>
+          updateDisplay({ ...override, showTimestamps: c ? "both" : "off" })
+        }
+      />
+    </GearMenu>
+  );
+}
+
+// ── Feeds view (the Configure page's manager, mounted in-feed) ──
+
+function RssFeedsPanel({
+  channelType,
+  channelConfig,
+}: {
+  channelType: ChannelType;
+  channelConfig: RssChannelConfig | undefined;
+}) {
+  const { error, setError, saving, updateItems } = useChannelConfig<
+    Array<{ name: string; url: string; is_custom?: boolean }>
+  >(channelType, "feeds");
+
+  const feeds = useMemo(
+    () => (Array.isArray(channelConfig?.feeds) ? channelConfig.feeds : []),
+    [channelConfig?.feeds],
+  );
+  const feedUrlSet = useMemo(() => new Set(feeds.map((f) => f.url)), [feeds]);
+
+  // Two catalogs: "clean" (curated, healthy feeds for browsing) and
+  // "all" (includes failing feeds + the user's customs, used for
+  // health badges on rows the user has already subscribed to).
+  const {
+    data: catalog = [],
+    isLoading: catalogLoading,
+    isError: catalogError,
+  } = useQuery(rssCatalogOptions());
+  const { data: catalogAll = [] } = useQuery(
+    rssCatalogOptions({ includeFailing: true }),
+  );
+
+  const addCatalogFeed = useCallback(
+    (url: string) => {
+      const allFeeds = [...catalog, ...catalogAll];
+      const feed = allFeeds.find((f) => f.url === url);
+      if (!feed || feedUrlSet.has(url)) return;
+      updateItems([...feeds, { name: feed.name, url: feed.url }]);
+    },
+    [catalog, catalogAll, feeds, feedUrlSet, updateItems],
+  );
+
+  const removeFeed = useCallback(
+    (url: string) => {
+      updateItems(feeds.filter((f) => f.url !== url));
+    },
+    [feeds, updateItems],
+  );
+
+  const addCustomFeed = useCallback(
+    (name: string, url: string) => {
+      if (feedUrlSet.has(url)) {
+        toast.error("This feed is already added");
+        return;
+      }
+      updateItems([...feeds, { name, url, is_custom: true }]);
+    },
+    [feeds, feedUrlSet, updateItems],
+  );
+
+  return (
+    <div className="flex flex-1 flex-col gap-3 p-3">
+      {error && (
+        <div className="shrink-0 px-3 py-2 rounded-lg bg-error/10 border border-error/20 text-[11px] text-error flex items-center justify-between">
+          <span>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            aria-label="Dismiss error"
+            className="text-error/60 hover:text-error cursor-pointer"
+          >
+            ×
+          </button>
         </div>
       )}
+      <FeedManager
+        feeds={feeds}
+        catalog={catalog}
+        catalogAll={catalogAll}
+        onAddCatalog={addCatalogFeed}
+        onAddCustom={addCustomFeed}
+        onRemove={removeFeed}
+        loading={catalogLoading}
+        error={catalogError}
+        saving={saving}
+      />
     </div>
   );
 }

--- a/desktop/src/channels/rss/preview/index.html
+++ b/desktop/src/channels/rss/preview/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<!--
+  News/RSS channel PREVIEW HARNESS — dev-only, browser-only.
+
+  Mounts the real RssFeedTab in a plain browser (no Tauri) against a
+  deterministic inline fixture, so the widget bar / Feeds view can be
+  screenshotted and asserted at arbitrary viewport widths. Served by the
+  normal `npm run dev` Vite server:
+
+      http://localhost:5174/src/channels/rss/preview/index.html
+
+  Query params: ?theme=scrollr-dark  (default scrollr-light)
+                ?widget=news_bbc     (default rss_custom)
+  Not part of the production build (vite build uses explicit rollup inputs).
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>News channel preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./preview.tsx"></script>
+  </body>
+</html>

--- a/desktop/src/channels/rss/preview/preview.tsx
+++ b/desktop/src/channels/rss/preview/preview.tsx
@@ -1,0 +1,186 @@
+/**
+ * News/RSS channel preview harness — dev-only, browser-only entry.
+ *
+ * Mirrors channels/finance/preview/ (see that harness + the predictions
+ * one for the pattern rationale): the REAL RssFeedTab with STATEFUL
+ * prefs and a seeded, disabled query cache. Feed ADD/REMOVE mutations
+ * are not exercised (no authenticated API in a browser) — the Feeds
+ * view is asserted render-only.
+ */
+// FIRST: evaluate the channel registry before ../FeedTab (module-cycle
+// guard — see the finance harness for the full explanation).
+import "../../registry";
+import { StrictMode, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import "../../../style.css";
+import { ShellContext, type ShellState } from "../../../shell-context";
+import { dashboardQueryOptions, rssCatalogOptions } from "../../../api/queries";
+import { migrateRssDisplay, type AppPreferences } from "../../../preferences";
+import { rssChannel } from "../FeedTab";
+import type { ChannelType, TrackedFeed } from "../../../api/client";
+import type { FeedTabProps, RssItem } from "../../../types";
+
+const params = new URLSearchParams(window.location.search);
+const theme = params.get("theme") ?? "scrollr-light";
+const widgetId = params.get("widget") ?? "rss_custom";
+
+// ── Deterministic fixture ────────────────────────────────────────
+
+const FEEDS: { name: string; url: string; category: string; custom?: boolean }[] = [
+  { name: "BBC News", url: "https://feeds.bbci.co.uk/news/rss.xml", category: "World" },
+  { name: "The Verge", url: "https://www.theverge.com/rss/index.xml", category: "Tech" },
+  { name: "Ars Technica", url: "https://arstechnica.com/feed/", category: "Tech" },
+  { name: "ESPN", url: "https://www.espn.com/espn/rss/news", category: "Sports" },
+  { name: "Hacker News", url: "https://news.ycombinator.com/rss", category: "Tech" },
+  { name: "My Blog", url: "https://example.com/feed.xml", category: "Custom", custom: true },
+];
+
+const catalog: TrackedFeed[] = FEEDS.filter((f) => !f.custom).map((f, i) => ({
+  url: f.url,
+  name: f.name,
+  category: f.category,
+  is_default: true,
+  consecutive_failures: 0,
+  last_success_at: new Date(Date.now() - (i + 1) * 3_600_000).toISOString(),
+}));
+
+const catalogAll: TrackedFeed[] = [
+  ...catalog,
+  {
+    url: "https://example.com/feed.xml",
+    name: "My Blog",
+    category: "Custom",
+    is_default: false,
+    consecutive_failures: 2,
+    last_error: "HTTP 503",
+    last_success_at: new Date(Date.now() - 96 * 3_600_000).toISOString(),
+  },
+];
+
+// ~14 articles per feed, ages staggered hours apart so Newest/Oldest
+// and the per-source cap all have something to bite on. Relative to
+// now so the article-age window never silently empties the harness.
+const rssItems: RssItem[] = FEEDS.flatMap((feed, fi) =>
+  Array.from({ length: 14 }, (_, ai) => {
+    const stamp = new Date(
+      Date.now() - (ai * 5 + fi) * 3_600_000,
+    ).toISOString();
+    return {
+      id: fi * 100 + ai,
+      feed_url: feed.url,
+      guid: `${feed.name}-${ai}`,
+      title: `${feed.name} headline ${ai + 1}: the ${feed.category.toLowerCase()} story`,
+      link: "https://example.com/article",
+      description: `Deterministic harness copy for ${feed.name} article ${ai + 1} — long enough to render a two-line description block in comfort mode.`,
+      source_name: feed.name,
+      published_at: stamp,
+      created_at: stamp,
+      updated_at: stamp,
+    };
+  }),
+);
+
+function main(): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { enabled: false, retry: false } },
+  });
+  const channelRow = (type: string, feeds: typeof FEEDS) => ({
+    id: 1,
+    channel_type: type as ChannelType,
+    enabled: true,
+    ticker_enabled: true,
+    created_at: "2026-07-17T00:00:00Z",
+    updated_at: "2026-07-17T00:00:00Z",
+    logto_sub: "preview",
+    config: {
+      feeds: feeds.map((f) => ({ name: f.name, url: f.url, is_custom: f.custom })),
+    },
+  });
+  queryClient.setQueryData(dashboardQueryOptions().queryKey, {
+    data: { rss: rssItems },
+    channels: [
+      channelRow("rss_custom", FEEDS),
+      channelRow("news_bbc", FEEDS.slice(0, 1)),
+    ],
+  });
+  queryClient.setQueryData(rssCatalogOptions().queryKey, catalog);
+  queryClient.setQueryData(
+    rssCatalogOptions({ includeFailing: true }).queryKey,
+    catalogAll,
+  );
+
+  const initialPrefs = {
+    channelDisplay: {
+      rss: {
+        ...migrateRssDisplay(undefined),
+        // Legacy-style per-source cap so the "Show all" footer has
+        // something to reveal (the modern default is 0 = show all).
+        articlesPerSource: 5,
+      },
+    },
+  } as unknown as AppPreferences;
+
+  const noop = (): void => {};
+  const shellBase = {
+    authenticated: false,
+    tier: "free",
+    subscriptionInfo: null,
+    onLogin: noop,
+    onLogout: noop,
+    autostartEnabled: false,
+    onAutostartChange: noop,
+    appVersion: "preview",
+    allChannelManifests: [],
+    allWidgets: [],
+    onToggleChannelTicker: noop,
+    onToggleWidgetTicker: noop,
+    onAddChannel: noop,
+    onDeleteChannel: noop,
+    onToggleWidget: noop,
+    onSelectItem: noop,
+  };
+
+  const feedContext = {
+    __hasConfig: true,
+    __dashboardLoaded: true,
+    __refreshing: false,
+  } as FeedTabProps["feedContext"];
+
+  const FeedTab = rssChannel.FeedTab;
+
+  function Harness() {
+    const [prefs, setPrefs] = useState<AppPreferences>(initialPrefs);
+    const shell = {
+      ...shellBase,
+      prefs,
+      onPrefsChange: setPrefs,
+    } as unknown as ShellState;
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ShellContext.Provider value={shell}>
+          <div
+            id="app-shell"
+            data-theme={theme}
+            className="h-screen overflow-y-auto scrollbar-thin bg-surface text-fg font-sans"
+          >
+            <FeedTab
+              mode="comfort"
+              feedContext={feedContext}
+              onConfigure={noop}
+              widgetId={widgetId}
+            />
+          </div>
+        </ShellContext.Provider>
+      </QueryClientProvider>
+    );
+  }
+
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <Harness />
+    </StrictMode>,
+  );
+}
+
+main();


### PR DESCRIPTION
Stacked on #234. News/RSS gets the bar and its Configure page's feed manager in-feed.

Linear: REL-35

## Changes

- **One bar**: `Segmented [Articles | Feeds]` — the Feeds segment exists for `rss_custom` ONLY (curated news widgets have an intrinsic feed; coarse `news` rows were consumed by migrations 000015/000016 and can't exist) · sort `SelectMenu` · sources `MultiSelectMenu` (multi-source only) + categories `MultiSelectMenu`, both with per-row counts · `FreshnessPill` · gear. Below `@2xl` the menus collapse into one `FilterTrigger` menu anchored to the bar.
- **Bands die, footer lives**: the dismissible chips row and both per-source-limit info bands are gone. "Show all (N hidden)" / "Limit to N per source" moved to the **list footer** as content — same idiom as Load more.
- **Feeds view**: mounts `FeedManager` in-feed with the ConfigPanel's exact wiring (`useChannelConfig "feeds"`, clean + include-failing catalogs for health badges, custom-URL add with duplicate toast). Empty state on rss_custom opens it ("Add feeds").
- **Gear popover** = the per-widget `config.display` override, same writes as the page: `ArticleAgeControl` time window + description/timestamp toggles.
- **De-tiered FeedManager** (caps Infinity since 2026-07-02): tier props/atLimit/UpgradePrompts deleted; its category dropdown now uses the shared MultiSelectMenu (rss `CategoryFilter` has no consumers left — PR 7 deletes the file). Old bespoke `SourceFilter` deleted outright. ConfigPanel updated, still functional until teardown.
- **Skipped by plan**: rss SearchBox (new feature, not config relocation — ~10-line add later now that the shared SearchBox exists).

## Verification

- `npx tsc --noEmit` clean; `npx vitest run` 490/490
- New harness `channels/rss/preview/` (rss_custom + news_bbc channel rows, relative-time fixture so the article-age window can't empty it) + `scripts/verify-rss.mjs`: **50/50 PASS** — footer Show-all round-trip, source/category filtering with counts, By-Source group headers, curated-widget scoping (no switcher, no sources menu), bounding-box sticky pin + elevation, collapse threshold at 375, viewport-fit menus, console gates
- `verify-finance.mjs`, `verify-kalshi.mjs`, `verify-search.mjs` all still green
- Gear + feed add/remove writes ride the same `useChannelConfig` mutations the Configure page has always used (render-only in the harness; quick live-app smoke before merge recommended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)