### PR TITLE
In-widget config PR 4: sports bar + gear popover [REL-36]

### DIFF
--- a/desktop/scripts/verify-sports.mjs
+++ b/desktop/scripts/verify-sports.mjs
@@ -1,0 +1,196 @@
+/**
+ * Playwright verification for the sports widget bar + gear popover
+ * (in-widget config pass, PR 4). Drives the sports preview harness at
+ * 1440 / 960 / 720 / 375.
+ *
+ * Run with the vite dev server on :5174:
+ *   node desktop/scripts/verify-sports.mjs
+ *
+ * Gear contents are asserted render-only (useSportsConfig mutates via
+ * the authed API); status pills / tabs are pure client state and are
+ * exercised for real.
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const BASE = "http://localhost:5174/src/channels/sports/preview/index.html";
+const OUT = process.env.UI_REVIEW_OUT ?? "ui-review-out";
+mkdirSync(OUT, { recursive: true });
+
+let failures = 0;
+function check(name, cond, extra = "") {
+  if (cond) console.log(`  PASS ${name}`);
+  else {
+    failures++;
+    console.log(`  FAIL ${name} ${extra}`);
+  }
+}
+
+function watchConsole(page, consoleErrors) {
+  const benign = /Failed to load resource|Store write failed|Token unavailable/;
+  page.on("console", (msg) => {
+    if (msg.type() === "error" && !benign.test(msg.text())) consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+}
+
+async function newPage(browser, width, height, query = "") {
+  const page = await browser.newPage({ viewport: { width, height } });
+  const consoleErrors = [];
+  watchConsole(page, consoleErrors);
+  await page.goto(`${BASE}${query}`, { waitUntil: "networkidle" });
+  await page.waitForSelector('[aria-label="Sports view"]');
+  return { page, consoleErrors };
+}
+
+async function run() {
+  const browser = await chromium.launch({ channel: "msedge", headless: true });
+
+  // ════ 1440px — bar anatomy + status filter + tabs ════════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · bar anatomy ==");
+
+    check("segmented tabs render", (await page.locator('[aria-label="Sports view"] [role="tab"]').count()) === 3);
+    check("status pills visible", await page.locator('button:has-text("Upcoming")').first().isVisible());
+    check("gear present", (await page.locator('[aria-label="Sports settings"]').count()) === 1);
+    check("no league filter (single-league widget)", (await page.locator('button:has-text("Leagues")').count()) === 0);
+    await page.screenshot({ path: `${OUT}/sp-01-bar-1440.png` });
+
+    // Status pills narrow the scoreboard.
+    const allCards = await page.locator("#root a[href]").count();
+    check("score cards render", allCards > 5, `cards=${allCards}`);
+    await page.locator('button:has-text("Live")').first().click();
+    await page.waitForTimeout(250);
+    const liveCards = await page.locator("#root a[href]").count();
+    check("Live filter narrows cards", liveCards > 0 && liveCards < allCards, `${allCards} -> ${liveCards}`);
+    await page.locator('button:has-text("All")').first().click();
+    await page.waitForTimeout(250);
+
+    // Tabs switch; standings hides pills + freshness.
+    await page.locator('[role="tab"]:has-text("Schedule")').click();
+    await page.waitForTimeout(250);
+    check("Schedule tab renders", (await page.locator("#root").innerText()).length > 100);
+    check("pills still present on Schedule", await page.locator('button:has-text("Upcoming")').first().isVisible());
+    await page.locator('[role="tab"]:has-text("Standings")').click();
+    await page.waitForTimeout(250);
+    check("pills hidden on Standings", !(await page.locator('button:has-text("Upcoming")').first().isVisible()));
+    await page.locator('[role="tab"]:has-text("Scores")').click();
+    await page.waitForTimeout(250);
+
+    check("no console errors (bar page)", consoleErrors.length === 0, consoleErrors.slice(0, 3).join(" | "));
+    await page.close();
+  }
+
+  // ════ 1440px — sticky pin (bounding box) ═════════════════════════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · sticky bar ==");
+
+    const bar = page.locator("div.sticky.top-0");
+    check("bar starts un-elevated", !(await bar.getAttribute("class")).includes("backdrop-blur-sm"));
+    const cardBefore = await page.locator("#root a[href]").first().boundingBox();
+
+    await page.evaluate(() => {
+      document.querySelector("#root .overflow-y-auto").scrollTop = 400;
+    });
+    await page.waitForTimeout(250);
+
+    const barBox = await bar.boundingBox();
+    const cardAfter = await page.locator("#root a[href]").first().boundingBox();
+    check(
+      "bar pins while content scrolls ≥300px",
+      barBox && barBox.y <= 1 && cardBefore && cardAfter && cardAfter.y < cardBefore.y - 300,
+      `bar.y=${barBox?.y} card ${cardBefore?.y}->${cardAfter?.y}`,
+    );
+    check("bar elevates once stuck", (await bar.getAttribute("class")).includes("backdrop-blur-sm"));
+    await page.screenshot({ path: `${OUT}/sp-02-sticky-1440.png` });
+
+    check("no console errors (sticky page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  // ════ 1440px — gear popover (the per-league Configure page) ══════
+  {
+    const { page, consoleErrors } = await newPage(browser, 1440, 900);
+    console.log("== 1440px · gear popover ==");
+
+    await page.locator('[aria-label="Sports settings"]').click();
+    await page.waitForSelector('[role="menu"]');
+    await page.waitForTimeout(300);
+    const gearText = (await page.locator('[role="menu"]').innerText()).toUpperCase();
+    check(
+      "gear lists favorite team + window + display",
+      gearText.includes("FAVORITE NFL TEAM") &&
+        gearText.includes("TIME WINDOW") &&
+        gearText.includes("TEAM LOGOS") &&
+        gearText.includes("GAME TIMER"),
+    );
+
+    // Teams fetched (from the seeded cache) on first open: the select
+    // lists the league's teams with the favorite selected.
+    const teamSelect = page.locator('[role="menu"] select[aria-label="Team"]');
+    check("team select renders", (await teamSelect.count()) === 1);
+    const optionCount = await teamSelect.locator("option").count();
+    check("team select lists the league's teams", optionCount === 17, `options=${optionCount}`);
+    const selected = await teamSelect.inputValue();
+    check("favorite team pre-selected", selected === "1", `value=${selected}`);
+    await page.screenshot({ path: `${OUT}/sp-03-gear-1440.png` });
+
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(250);
+    check("Esc closes the gear", (await page.locator('[role="menu"]').count()) === 0);
+
+    check("no console errors (gear page)", consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  // ════ Narrow widths — status pills collapse into the Filter menu ═
+  for (const width of [960, 720, 375]) {
+    const { page, consoleErrors } = await newPage(browser, width, 812);
+    console.log(`== ${width}px · collapse ==`);
+
+    const clipped = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    check(`no horizontal clipping at ${width}`, !clipped);
+
+    const collapsed = width < 672 + 24; // @2xl container threshold + px
+    if (collapsed) {
+      check(`pills hidden at ${width}`, !(await page.locator('button:has-text("Upcoming")').first().isVisible()));
+      const filterBtn = page.locator('[aria-label="Filters"]');
+      check(`filter button visible at ${width}`, await filterBtn.isVisible());
+      await filterBtn.click();
+      await page.waitForSelector('[role="menu"]');
+      await page.waitForTimeout(250);
+      const rows = await page.locator('[role="menu"] [role="menuitemradio"]').allTextContents();
+      check(
+        `status rows carry counts at ${width}`,
+        rows.length === 4 && rows.every((t) => /\d/.test(t)),
+        rows.join(","),
+      );
+      const menuBox = await page.locator('[role="menu"]').boundingBox();
+      check(
+        `menu fits inside the viewport at ${width}`,
+        menuBox && menuBox.x >= 0 && menuBox.x + menuBox.width <= width,
+        JSON.stringify(menuBox),
+      );
+      await page.keyboard.press("Escape");
+      await page.screenshot({ path: `${OUT}/sp-04-collapsed-${width}.png` });
+    } else {
+      check(`pills visible at ${width}`, await page.locator('button:has-text("Upcoming")').first().isVisible());
+    }
+
+    check(`no console errors (${width})`, consoleErrors.length === 0, consoleErrors.join(" | "));
+    await page.close();
+  }
+
+  await browser.close();
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/desktop/src/channels/sports/FeedTab.tsx
+++ b/desktop/src/channels/sports/FeedTab.tsx
@@ -6,15 +6,20 @@
  * Schedule filters upcoming pre-games by date.
  * Standings fetches league standings from the API.
  *
- * Controls bar between the tab bar and content provides:
- *   - LeagueFilter dropdown (filter games by league)
- *   - StatusFilter pill buttons (All / Live / Upcoming / Final)
+ * ONE Kalshi-style control bar (widget-bar primitives): Segmented
+ * [Scores | Schedule | Standings] · status BarPills (collapsing into a
+ * Filter menu at narrow widths, counts in the rows) · freshness · gear
+ * popover. The gear IS the per-league Configure page: favorite team
+ * (teams fetched on first open), day-range time window, logo/timer
+ * toggles — all via useSportsConfig. No league management: per-league
+ * widgets have an intrinsic league, and coarse `sports` rows can't
+ * exist post-migration-000014.
  */
-import { useState, useMemo, useRef, useEffect, useCallback } from "react";
-import { clsx } from "clsx";
-import { Trophy, Filter } from "lucide-react";
+import { useState, useMemo, useRef, useCallback } from "react";
+import { Trophy } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { sportsFullQueryOptions } from "../../api/queries";
+import { sportsFullQueryOptions, sportsTeamsOptions } from "../../api/queries";
+import type { TeamInfo } from "../../api/queries";
 import { useSportsConfig } from "../../hooks/useSportsConfig";
 import { dataWidgetDef } from "../../marketplace";
 import { ScoresTab } from "./ScoresTab";
@@ -22,6 +27,24 @@ import { ScheduleTab } from "./ScheduleTab";
 import { StandingsTab } from "./StandingsTab";
 import EmptyChannelState from "../../components/EmptyChannelState";
 import FreshnessPill from "../../components/FreshnessPill";
+import { WidgetBar, BarDivider, BarPill } from "../../components/widget-bar/Bar";
+import {
+  useDismiss,
+  MenuPanel,
+  MenuHeading,
+  MenuRow,
+  FilterTrigger,
+} from "../../components/widget-bar/Menu";
+import {
+  Segmented,
+  type SegmentedOption,
+} from "../../components/widget-bar/Segmented";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import { SelectRow, ToggleRow } from "../../components/settings/SettingsControls";
+import { DayRangeControl } from "../../components/TimeWindowControl";
+import { SPORTS_WINDOW_MAX_DAYS } from "./view";
+import { isLive, isPre, isFinal } from "../../utils/gameHelpers";
+import { AnimatePresence } from "motion/react";
 import type { FeedTabProps, ChannelManifest } from "../../types";
 import type { FavoriteTeam } from "../../hooks/useSportsConfig";
 
@@ -52,100 +75,11 @@ export const sportsChannel: ChannelManifest = {
 type SportsTab = "scores" | "schedule" | "standings";
 export type StatusFilter = "all" | "live" | "upcoming" | "final";
 
-// ── LeagueFilter ─────────────────────────────────────────────────
-
-interface LeagueFilterProps {
-  leagues: string[];
-  selected: Set<string>;
-  onToggle: (league: string) => void;
-  onClearAll: () => void;
-}
-
-function LeagueFilter({ leagues, selected, onToggle, onClearAll }: LeagueFilterProps) {
-  const [open, setOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  const activeCount = selected.size;
-
-  if (leagues.length === 0) return null;
-
-  return (
-    <div ref={wrapperRef} className="relative">
-      <button
-        onClick={() => setOpen(!open)}
-        className={clsx(
-          "flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border text-ui-meta transition-colors cursor-pointer whitespace-nowrap",
-          activeCount > 0
-            ? "border-accent/50 text-accent"
-            : "border-edge/40 text-fg-3 hover:text-fg-2 hover:border-edge/60",
-        )}
-      >
-        <Filter size={12} />
-        <span>Leagues</span>
-        {activeCount > 0 && (
-          <span className="bg-accent/20 text-accent rounded-full px-1.5 text-ui-chip font-medium">
-            {activeCount}
-          </span>
-        )}
-      </button>
-
-      {open && (
-        <div className="absolute top-full mt-1 right-0 w-52 bg-surface-2 border border-edge/50 rounded-lg shadow-lg z-[5] py-1 max-h-64 overflow-y-auto">
-          {leagues.map((league) => {
-            const isActive = selected.has(league);
-            return (
-              <button
-                key={league}
-                onClick={() => onToggle(league)}
-                className={clsx(
-                    "flex items-center gap-2 w-full px-3 py-1.5 text-left text-ui-meta transition-colors cursor-pointer",
-                  isActive ? "text-fg-2" : "text-fg-3 hover:text-fg-2",
-                )}
-              >
-                <span
-                  className={clsx(
-                    "w-3.5 h-3.5 rounded border flex items-center justify-center text-ui-chip shrink-0",
-                    isActive
-                      ? "bg-accent/25 border-accent/50 text-accent"
-                      : "border-edge/50",
-                  )}
-                >
-                  {isActive && "\u2713"}
-                </span>
-                <span className="flex-1 truncate">{league}</span>
-              </button>
-            );
-          })}
-          {activeCount > 0 && (
-            <>
-              <div className="h-px bg-edge/40 my-1" />
-              <button
-                onClick={() => {
-                  onClearAll();
-                  setOpen(false);
-                }}
-                className="w-full px-3 py-1.5 text-left text-ui-meta text-fg-3 hover:text-fg-2 transition-colors cursor-pointer"
-              >
-                Clear all filters
-              </button>
-            </>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
+const TAB_OPTIONS: SegmentedOption<SportsTab>[] = [
+  { value: "scores", label: "Scores" },
+  { value: "schedule", label: "Schedule" },
+  { value: "standings", label: "Standings" },
+];
 
 // ── StatusFilter pills ───────────────────────────────────────────
 
@@ -155,6 +89,12 @@ const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: "upcoming", label: "Upcoming" },
   { value: "final", label: "Final" },
 ];
+
+// Per-league widgets are single-league by construction (and coarse
+// `sports` rows can't exist post-migration-000014), so the old in-feed
+// league filter is gone; the tab components still accept a set — always
+// empty until their props get slimmed in the teardown pass.
+const EMPTY_LEAGUE_FILTER = new Set<string>();
 
 // ── Helper: build set of favorite team names ─────────────────────
 
@@ -171,12 +111,11 @@ function buildFavoriteSet(favorites: Record<string, FavoriteTeam>): Set<string> 
 function SportsFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProps) {
   const [tab, setTab] = useState<SportsTab>("scores");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  const [leagueFilter, setLeagueFilter] = useState<Set<string>>(new Set());
   const { leagues, display, favoriteTeams } = useSportsConfig(widgetId ?? "sports");
+  const isComfort = mode === "comfort";
 
   // A per-league widget (sports_nfl) scopes the whole page to its one league:
-  // its league is intrinsic, so we filter the shared /sports payload down and
-  // hide the league-filter dropdown (nothing to filter within one league).
+  // its league is intrinsic, so we filter the shared /sports payload down.
   const scopedLeague = useMemo(() => {
     const l = widgetId ? dataWidgetDef(widgetId)?.addConfig?.leagues : undefined;
     return Array.isArray(l) && typeof l[0] === "string" ? (l[0] as string) : undefined;
@@ -184,24 +123,12 @@ function SportsFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProp
 
   // Full channel page reads from /sports directly (not /dashboard), which
   // returns every game for the user's selected leagues without per-league
-  // fair-share capping. The page's status filter chips (plus a league filter
-  // on the coarse channel) let the user narrow down by hand.
+  // fair-share capping. The bar's status pills narrow down by hand.
   const { data: sportsData } = useQuery(sportsFullQueryOptions());
   const games = useMemo(() => {
     const all = sportsData?.sports ?? [];
     return scopedLeague ? all.filter((g) => g.league === scopedLeague) : all;
   }, [sportsData?.sports, scopedLeague]);
-
-  // Unique leagues from current games for the filter dropdown. Empty for a
-  // single-league widget, which hides the filter (LeagueFilter renders null).
-  const availableLeagues = useMemo(() => {
-    if (scopedLeague) return [];
-    const set = new Set<string>();
-    for (const g of games) {
-      if (g.league) set.add(g.league);
-    }
-    return Array.from(set).sort();
-  }, [games, scopedLeague]);
 
   // Favorite team names as a Set for fast lookup
   const favoriteTeamNames = useMemo(
@@ -220,117 +147,256 @@ function SportsFeedTab({ mode, feedContext, onConfigure, widgetId }: FeedTabProp
     return latest > 0 ? new Date(latest).toISOString() : null;
   }, [games]);
 
-  const toggleLeague = useCallback((league: string) => {
-    setLeagueFilter((prev) => {
-      const next = new Set(prev);
-      if (next.has(league)) next.delete(league);
-      else next.add(league);
-      return next;
-    });
-  }, []);
+  // Status counts for the collapsed Filter menu rows.
+  const statusCounts = useMemo(() => {
+    let live = 0;
+    let upcoming = 0;
+    let final = 0;
+    for (const g of games) {
+      if (isLive(g)) live++;
+      else if (isPre(g)) upcoming++;
+      else if (isFinal(g)) final++;
+    }
+    return { all: games.length, live, upcoming, final };
+  }, [games]);
 
-  const clearLeagueFilter = useCallback(() => {
-    setLeagueFilter(new Set());
-  }, []);
-
-  if (games.length === 0 && leagues.length === 0) {
-    return (
-      <EmptyChannelState
-        refreshing={Boolean(feedContext.__refreshing)}
-        icon={Trophy}
-        noun="leagues"
-        hasConfig={!!feedContext.__hasConfig}
-        dashboardLoaded={!!feedContext.__dashboardLoaded}
-        loadingNoun="scores"
-        actionHint="pick your leagues"
-        onConfigure={onConfigure}
-      />
-    );
-  }
+  const showEmpty = games.length === 0 && leagues.length === 0;
 
   return (
-    <div>
-      {/* Navigation + controls — single bar */}
-      <div className="sticky top-0 z-10 flex items-center px-3 py-2 bg-surface border-b border-edge/30">
-        {/* Tabs — far left */}
-        <div className="flex gap-1">
-          {(["scores", "schedule", "standings"] as const).map((t) => (
-            <button
-              key={t}
-              onClick={() => setTab(t)}
-              className={clsx(
-                "px-3 py-1.5 rounded-lg text-xs font-medium transition-colors",
-                tab === t
-                  ? "bg-accent/10 text-accent"
-                  : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
-              )}
-            >
-              {t === "scores" ? "Scores" : t === "schedule" ? "Schedule" : "Standings"}
-            </button>
-          ))}
+    // NO inner scroll container: the Source page (PageLayout) owns the
+    // scroll — sticky pins against it.
+    <div className="flex min-h-full flex-col">
+      {isComfort && (
+        <WidgetBar>
+          <Segmented
+            ariaLabel="Sports view"
+            value={tab}
+            onChange={setTab}
+            options={TAB_OPTIONS}
+          />
+
+          {tab !== "standings" && !showEmpty && (
+            <>
+              <BarDivider />
+              {/* Wide: open status pills. Collapse BEFORE clipping. */}
+              <div className="scrollbar-none hidden min-w-0 items-center gap-1 overflow-x-auto @2xl:flex">
+                {STATUS_OPTIONS.map((opt) => (
+                  <BarPill
+                    key={opt.value}
+                    active={statusFilter === opt.value}
+                    onClick={() => setStatusFilter(opt.value)}
+                  >
+                    {opt.label}
+                  </BarPill>
+                ))}
+              </div>
+              {/* Narrow: status radios in one Filter menu (with counts). */}
+              <div className="@2xl:hidden">
+                <SportsFilterMenu
+                  statusFilter={statusFilter}
+                  onPickStatus={setStatusFilter}
+                  counts={statusCounts}
+                />
+              </div>
+            </>
+          )}
+
+          <div className="ml-auto flex min-w-0 shrink items-center gap-2">
+            {tab !== "standings" && latestUpdated && (
+              <span className="hidden @xl:block">
+                <FreshnessPill lastUpdated={latestUpdated} label="score" />
+              </span>
+            )}
+            {scopedLeague && (
+              <SportsGear
+                channelType={widgetId ?? "sports"}
+                league={scopedLeague}
+              />
+            )}
+          </div>
+        </WidgetBar>
+      )}
+
+      {showEmpty ? (
+        <div className="flex flex-1 flex-col justify-center">
+          <EmptyChannelState
+            refreshing={Boolean(feedContext.__refreshing)}
+            icon={Trophy}
+            noun="leagues"
+            hasConfig={!!feedContext.__hasConfig}
+            dashboardLoaded={!!feedContext.__dashboardLoaded}
+            loadingNoun="scores"
+            actionHint="pick your leagues"
+            onConfigure={onConfigure}
+          />
         </div>
-
-        {tab !== "standings" && latestUpdated && (
-          <div className="ml-2">
-            <FreshnessPill lastUpdated={latestUpdated} label="score" />
-          </div>
-        )}
-
-        {/* Status pills + league filter — far right (scores & schedule only) */}
-        {tab !== "standings" && (
-          <div className="flex items-center gap-2 ml-auto">
-            <div className="flex gap-1">
-              {STATUS_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  onClick={() => setStatusFilter(opt.value)}
-                  className={clsx(
-                    "px-2.5 py-1 rounded-full text-ui-meta font-medium transition-colors cursor-pointer",
-                    statusFilter === opt.value
-                      ? "bg-accent/15 text-accent"
-                      : "text-fg-3 hover:text-fg-2 hover:bg-surface-hover",
-                  )}
-                >
-                  {opt.label}
-                </button>
-              ))}
-            </div>
-            <LeagueFilter
-              leagues={availableLeagues}
-              selected={leagueFilter}
-              onToggle={toggleLeague}
-              onClearAll={clearLeagueFilter}
+      ) : (
+        <>
+          {/* Tab content */}
+          {tab === "scores" && (
+            <ScoresTab
+              games={games}
+              mode={mode}
+              display={display}
+              favoriteTeams={favoriteTeamNames}
+              leagueFilter={EMPTY_LEAGUE_FILTER}
+              statusFilter={statusFilter}
             />
-          </div>
-        )}
-      </div>
-
-      {/* Tab content */}
-      {tab === "scores" && (
-        <ScoresTab
-          games={games}
-          mode={mode}
-          display={display}
-          favoriteTeams={favoriteTeamNames}
-          leagueFilter={leagueFilter}
-          statusFilter={statusFilter}
-        />
-      )}
-      {tab === "schedule" && (
-        <ScheduleTab
-          games={games}
-          display={display}
-          favoriteTeams={favoriteTeamNames}
-          leagueFilter={leagueFilter}
-          statusFilter={statusFilter}
-        />
-      )}
-      {tab === "standings" && (
-        <StandingsTab
-          leagues={leagues}
-          favoriteTeams={favoriteTeamNames}
-        />
+          )}
+          {tab === "schedule" && (
+            <ScheduleTab
+              games={games}
+              display={display}
+              favoriteTeams={favoriteTeamNames}
+              leagueFilter={EMPTY_LEAGUE_FILTER}
+              statusFilter={statusFilter}
+            />
+          )}
+          {tab === "standings" && (
+            <StandingsTab
+              leagues={leagues}
+              favoriteTeams={favoriteTeamNames}
+            />
+          )}
+        </>
       )}
     </div>
+  );
+}
+
+// ── Filter menu (narrow-width collapse) ─────────────────────────
+
+function SportsFilterMenu({
+  statusFilter,
+  onPickStatus,
+  counts,
+}: {
+  statusFilter: StatusFilter;
+  onPickStatus: (s: StatusFilter) => void;
+  counts: { all: number; live: number; upcoming: number; final: number };
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useDismiss(rootRef, open, close);
+
+  return (
+    // NOT position:relative — the dropdown anchors to the sticky bar so
+    // it spans the channel width instead of clipping at narrow widths.
+    <div ref={rootRef} className="shrink-0 rounded-lg">
+      <FilterTrigger
+        open={open}
+        badgeCount={statusFilter !== "all" ? 1 : 0}
+        onClick={() => setOpen((o) => !o)}
+      />
+      <AnimatePresence>
+        {open && (
+          <MenuPanel className="inset-x-2">
+            <MenuHeading>Status</MenuHeading>
+            {STATUS_OPTIONS.map((opt) => (
+              <MenuRow
+                key={opt.value}
+                selected={statusFilter === opt.value}
+                onClick={() => onPickStatus(opt.value)}
+                role="menuitemradio"
+                count={counts[opt.value]}
+              >
+                {opt.label}
+              </MenuRow>
+            ))}
+          </MenuPanel>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Gear popover (the per-league Configure page, in-widget) ─────
+
+function SportsGear({
+  channelType,
+  league,
+}: {
+  channelType: string;
+  league: string;
+}) {
+  return (
+    <GearMenu ariaLabel="Sports settings" panelClassName="right-0 w-80">
+      {/* Contents mount when the popover opens — the teams list is only
+          fetched on first open, not on every feed visit. */}
+      <SportsGearContents channelType={channelType} league={league} />
+    </GearMenu>
+  );
+}
+
+function SportsGearContents({
+  channelType,
+  league,
+}: {
+  channelType: string;
+  league: string;
+}) {
+  const { display, favoriteTeams, setDisplay, setFavoriteTeam, saving } =
+    useSportsConfig(channelType);
+
+  const favorite = favoriteTeams[league];
+  const { data: teamsData, isLoading: teamsLoading } = useQuery(
+    sportsTeamsOptions(league),
+  );
+  const teams: TeamInfo[] = useMemo(() => teamsData?.teams ?? [], [teamsData]);
+
+  const teamOptions = useMemo(
+    () => [
+      { value: "", label: teamsLoading ? "Loading teams…" : "No favorite" },
+      ...teams.map((t) => ({ value: String(t.external_id), label: t.name })),
+    ],
+    [teams, teamsLoading],
+  );
+
+  const onPickTeam = useCallback(
+    (id: string) => {
+      if (!id) {
+        setFavoriteTeam(league, null);
+        return;
+      }
+      const t = teams.find((x) => String(x.external_id) === id);
+      if (t) setFavoriteTeam(league, { teamId: t.external_id, teamName: t.name });
+    },
+    [teams, league, setFavoriteTeam],
+  );
+
+  return (
+    <>
+      <MenuHeading>Favorite {league} team</MenuHeading>
+      <SelectRow
+        label="Team"
+        description="Sorts to the top with a highlight"
+        value={String(favorite?.teamId ?? "")}
+        options={teamOptions}
+        onChange={onPickTeam}
+      />
+      <MenuHeading>Time window</MenuHeading>
+      <div className="px-1 pb-1">
+        <DayRangeControl
+          daysBack={display.daysBack}
+          daysAhead={display.daysAhead}
+          max={SPORTS_WINDOW_MAX_DAYS}
+          disabled={saving}
+          onChange={(next) => setDisplay(next)}
+        />
+      </div>
+      <MenuHeading>Display</MenuHeading>
+      <ToggleRow
+        label="Team logos"
+        checked={display.showLogos !== "off"}
+        onChange={(c) => setDisplay({ showLogos: c ? "both" : "off" })}
+      />
+      <ToggleRow
+        label="Game timer"
+        description="Show the live clock / countdown"
+        checked={display.showTimer !== "off"}
+        onChange={(c) => setDisplay({ showTimer: c ? "both" : "off" })}
+      />
+    </>
   );
 }

--- a/desktop/src/channels/sports/preview/index.html
+++ b/desktop/src/channels/sports/preview/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!--
+  Sports channel PREVIEW HARNESS — dev-only, browser-only.
+
+  Mounts the real SportsFeedTab in a plain browser (no Tauri) against a
+  deterministic inline fixture, so the widget bar / gear popover can be
+  screenshotted and asserted at arbitrary viewport widths. Served by the
+  normal `npm run dev` Vite server:
+
+      http://localhost:5174/src/channels/sports/preview/index.html
+
+  Query params: ?theme=scrollr-dark  (default scrollr-light)
+  Not part of the production build (vite build uses explicit rollup inputs).
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sports channel preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./preview.tsx"></script>
+  </body>
+</html>

--- a/desktop/src/channels/sports/preview/preview.tsx
+++ b/desktop/src/channels/sports/preview/preview.tsx
@@ -1,0 +1,200 @@
+/**
+ * Sports channel preview harness — dev-only, browser-only entry.
+ *
+ * Mirrors channels/finance/preview/ (see that harness for the pattern
+ * rationale). Sports additionally needs ShellDataContext: useSportsConfig
+ * reads the channel rows from it, not from ShellContext. Gear writes are
+ * asserted render-only (useSportsConfig mutates via the authed API).
+ */
+// FIRST: evaluate the channel registry before ../FeedTab (module-cycle
+// guard — see the finance harness for the full explanation).
+import "../../registry";
+import { StrictMode, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import "../../../style.css";
+import {
+  ShellContext,
+  ShellDataContext,
+  type ShellState,
+  type ShellDataState,
+} from "../../../shell-context";
+import {
+  dashboardQueryOptions,
+  sportsFullQueryOptions,
+  sportsTeamsOptions,
+  type TeamInfo,
+} from "../../../api/queries";
+import type { AppPreferences } from "../../../preferences";
+import { sportsChannel } from "../FeedTab";
+import type { Channel, ChannelType } from "../../../api/client";
+import type { FeedTabProps, Game } from "../../../types";
+
+const params = new URLSearchParams(window.location.search);
+const theme = params.get("theme") ?? "scrollr-light";
+const widgetId = "sports_nfl";
+
+// ── Deterministic fixture ────────────────────────────────────────
+
+const NFL_TEAMS = [
+  "Kansas City Chiefs",
+  "Buffalo Bills",
+  "Philadelphia Eagles",
+  "Dallas Cowboys",
+  "San Francisco 49ers",
+  "Detroit Lions",
+  "Baltimore Ravens",
+  "Green Bay Packers",
+  "Miami Dolphins",
+  "New York Jets",
+  "Cincinnati Bengals",
+  "Houston Texans",
+  "Seattle Seahawks",
+  "Los Angeles Rams",
+  "Minnesota Vikings",
+  "Chicago Bears",
+];
+
+const teams: TeamInfo[] = NFL_TEAMS.map((name, i) => ({
+  league: "NFL",
+  external_id: i + 1,
+  name,
+  code: name.split(" ").pop()!.slice(0, 3).toUpperCase(),
+  logo: "",
+}));
+
+// 72 games (¼ live, ½ upcoming, ¼ final) — staggered around now so the
+// schedule grouping and the day-window filter always have content, and
+// tall enough that the scoreboard scrolls well past the viewport (the
+// sticky-pin check needs ≥300px of travel).
+const games: Game[] = Array.from({ length: 72 }, (_, i) => {
+  const state = i % 4 === 0 ? "in_progress" : i % 4 === 1 || i % 4 === 2 ? "pre" : "final";
+  const home = teams[(i * 2) % teams.length];
+  const away = teams[(i * 2 + 1) % teams.length];
+  const hoursOff = state === "pre" ? (i % 48) + 2 : -((i % 24) + 1);
+  return {
+    id: i + 1,
+    league: "NFL",
+    sport: "football",
+    external_game_id: `nfl-${i + 1}`,
+    link: "https://example.com/game",
+    home_team_name: home.name,
+    home_team_logo: "",
+    home_team_score: state === "pre" ? 0 : 14 + (i % 21),
+    home_team_code: home.code,
+    away_team_name: away.name,
+    away_team_logo: "",
+    away_team_score: state === "pre" ? 0 : 10 + ((i * 3) % 24),
+    away_team_code: away.code,
+    start_time: new Date(Date.now() + hoursOff * 3_600_000).toISOString(),
+    state,
+    short_detail: state === "in_progress" ? "Q3 4:12" : undefined,
+    timer: state === "in_progress" ? "Q3 4:12" : undefined,
+    updated_at: new Date(Date.now() - 60_000).toISOString(),
+  };
+});
+
+const channelRow = {
+  id: 1,
+  channel_type: widgetId as ChannelType,
+  enabled: true,
+  ticker_enabled: true,
+  created_at: "2026-07-17T00:00:00Z",
+  updated_at: "2026-07-17T00:00:00Z",
+  logto_sub: "preview",
+  config: {
+    leagues: ["NFL"],
+    favoriteTeams: {
+      NFL: { teamId: 1, teamName: "Kansas City Chiefs" },
+    },
+  },
+} as unknown as Channel & { logto_sub: string };
+
+function main(): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { enabled: false, retry: false } },
+  });
+  queryClient.setQueryData(dashboardQueryOptions().queryKey, {
+    data: {},
+    channels: [channelRow],
+  });
+  queryClient.setQueryData(sportsFullQueryOptions().queryKey, {
+    sports: games,
+    meta: { leagues: [] },
+  });
+  queryClient.setQueryData(sportsTeamsOptions("NFL").queryKey, { teams });
+
+  const initialPrefs = {
+    channelDisplay: {},
+  } as unknown as AppPreferences;
+
+  const noop = (): void => {};
+  const shellBase = {
+    authenticated: false,
+    tier: "free",
+    subscriptionInfo: null,
+    onLogin: noop,
+    onLogout: noop,
+    autostartEnabled: false,
+    onAutostartChange: noop,
+    appVersion: "preview",
+    allChannelManifests: [],
+    allWidgets: [],
+    onToggleChannelTicker: noop,
+    onToggleWidgetTicker: noop,
+    onAddChannel: noop,
+    onDeleteChannel: noop,
+    onToggleWidget: noop,
+    onSelectItem: noop,
+  };
+
+  const shellData: ShellDataState = {
+    channels: [channelRow],
+    dashboard: undefined,
+  };
+
+  const feedContext = {
+    __hasConfig: true,
+    __dashboardLoaded: true,
+    __refreshing: false,
+  } as FeedTabProps["feedContext"];
+
+  const FeedTab = sportsChannel.FeedTab;
+
+  function Harness() {
+    const [prefs, setPrefs] = useState<AppPreferences>(initialPrefs);
+    const shell = {
+      ...shellBase,
+      prefs,
+      onPrefsChange: setPrefs,
+    } as unknown as ShellState;
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ShellContext.Provider value={shell}>
+          <ShellDataContext.Provider value={shellData}>
+            <div
+              id="app-shell"
+              data-theme={theme}
+              className="h-screen overflow-y-auto scrollbar-thin bg-surface text-fg font-sans"
+            >
+              <FeedTab
+                mode="comfort"
+                feedContext={feedContext}
+                onConfigure={noop}
+                widgetId={widgetId}
+              />
+            </div>
+          </ShellDataContext.Provider>
+        </ShellContext.Provider>
+      </QueryClientProvider>
+    );
+  }
+
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <Harness />
+    </StrictMode>,
+  );
+}
+
+main();


### PR DESCRIPTION
Stacked on #235. Sports was shrunk by the plan review: no league management to migrate (coarse `sports` rows provably can't exist post-migration-000014), so the whole Configure page fits in a gear popover.

Linear: REL-36

## Changes

- **One bar**: `Segmented [Scores | Schedule | Standings]` · status `BarPill`s (Scores/Schedule only) · `FreshnessPill` · gear. Below `@2xl` the pills collapse into a `FilterTrigger` menu — status radios with live/upcoming/final **counts** in the rows.
- **Sticky rule**: root becomes `flex min-h-full flex-col`; the bar is a real pinning `WidgetBar` with sentinel elevation (the old bar was sticky-in-name inside a plain div).
- **Gear popover = the per-league Configure page**: favorite-team `SelectRow` (options from `sportsTeamsOptions(league)`, fetched on FIRST OPEN — the popover's contents mount lazily), `DayRangeControl` (shared TimeWindowControl — kept, it was wrongly on an earlier delete map), team-logos + game-timer `ToggleRow`s. All writes via `useSportsConfig`, identical to the panel's.
- **League management deleted, not migrated**: the in-feed `LeagueFilter` could only render for a legacy coarse row, which can't exist — deleted now; `LeagueManager` + the Configure page follow in PR 7. Tab components keep their `leagueFilter` prop (fed a stable empty set) until teardown slims them.

## Verification

- `npx tsc --noEmit` clean; `npx vitest run` 490/490
- New harness `channels/sports/preview/` (72-game NFL fixture around now; provides ShellDataContext, which `useSportsConfig` reads) + `scripts/verify-sports.mjs`: **32/32 PASS** — segmented tabs, status filtering, standings hides pills, bounding-box sticky pin, gear anatomy incl. 17-option team select with the favorite pre-selected, collapse + counts at 375, viewport-fit menus, console gates
- `verify-rss` / `verify-finance` / `verify-kalshi` / `verify-search` all still green
- Gear writes ride the same `useSportsConfig` mutation as the Configure page (render-only in the harness; live-app smoke before merge recommended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)