### PR TITLE
In-widget config PR 6: utility widgets ×6 gear popovers [REL-38]

### DIFF
--- a/desktop/src/widgets/clock/ConfigPanel.tsx
+++ b/desktop/src/widgets/clock/ConfigPanel.tsx
@@ -1,104 +1,20 @@
-import { useCallback } from "react";
-import {
-  Section,
-  ToggleRow,
-  SegmentedRow,
-} from "../../components/settings/SettingsControls";
-import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
-import TickerPinSection from "../../components/settings/TickerPinSection";
-import { useWidgetConfig } from "../../hooks/useWidgetConfig";
-import { useTickerExclusion } from "../../hooks/useTickerExclusion";
-import { useStoreData } from "../../hooks/useStoreData";
-import { setStore } from "../../lib/store";
-import { DEFAULT_CLOCK_TICKER } from "../../preferences";
-import { LS_CLOCK_FORMAT, LS_CLOCK_TIMEZONES } from "../../constants";
-import { loadTimezones, loadFormat, tzLabel } from "./storage";
+/**
+ * Clock ConfigPanel — thin wrapper (in-widget config pass, PR 6).
+ * The settings body moved to ./Settings.tsx, which the FeedTab now
+ * mounts in a gear popover; this page renders the same component until
+ * the configure-page teardown deletes it.
+ */
+import ClockSettings from "./Settings";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
-type ClockFormat = "12h" | "24h";
-
-const FORMAT_OPTIONS: { value: ClockFormat; label: string }[] = [
-  { value: "12h", label: "12h" },
-  { value: "24h", label: "24h" },
-];
-
-export default function ClockConfigPanel({
-  prefs,
-  onPrefsChange,
-}: WidgetConfigPanelProps) {
-  const { config, update, setTicker } = useWidgetConfig("clock", prefs, onPrefsChange);
-  const [format, setFormatState] = useStoreData(LS_CLOCK_FORMAT, loadFormat);
-  const [timezones] = useStoreData(LS_CLOCK_TIMEZONES, loadTimezones);
-  const { isExcluded: isTimezoneExcluded, toggle: toggleTimezone } =
-    useTickerExclusion(config.ticker.excludedTimezones, "excludedTimezones", setTicker);
-
-  const handleFormatChange = useCallback(
-    (v: ClockFormat) => {
-      setFormatState(v);
-      setStore(LS_CLOCK_FORMAT, v);
-    },
-    [],
-  );
-
-  const resetAll = useCallback(() => {
-    update({
-      ticker: { ...DEFAULT_CLOCK_TICKER },
-    });
-    setStore(LS_CLOCK_FORMAT, "12h");
-    setFormatState("12h");
-  }, [update]);
-
-  const clockIcon = (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-clock)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="12" cy="12" r="10" />
-      <polyline points="12 6 12 12 16 14" />
-    </svg>
-  );
-
+export default function ClockConfigPanel(props: WidgetConfigPanelProps) {
   return (
-    <ConfigPanelLayout
-      icon={clockIcon}
-      hex="var(--color-widget-clock)"
-      title="Clock Settings"
-      subtitle="Local time and world clocks"
-      onReset={resetAll}
-    >
-      {/* Ticker */}
-      <Section title="Ticker">
-        <SegmentedRow
-          label="Time format"
-          description="12-hour or 24-hour clock"
-          value={format}
-          options={FORMAT_OPTIONS}
-          onChange={handleFormatChange}
-        />
-        <ToggleRow
-          label="Local time"
-          description="Show your local clock on the scrolling ticker"
-          checked={config.ticker.localTime}
-          onChange={(v) => setTicker({ localTime: v })}
-        />
-        <ToggleRow
-          label="Show world clocks"
-          description="Include configured timezones on the ticker"
-          checked={config.ticker.showTimezones}
-          onChange={(v) => setTicker({ showTimezones: v })}
-        />
-        {config.ticker.showTimezones && timezones.map((tz) => (
-          <ToggleRow
-            key={tz}
-            label={tzLabel(tz)}
-            checked={!isTimezoneExcluded(tz)}
-            onChange={() => toggleTimezone(tz)}
-          />
-        ))}
-        {config.ticker.showTimezones && timezones.length === 0 && (
-          <div className="px-3 py-2.5 text-[11px] text-fg-4">
-            Add world clocks in the Clock tab to see them here.
-          </div>
-        )}
-        <TickerPinSection widgetId="clock" prefs={prefs} onPrefsChange={onPrefsChange} />
-      </Section>
-    </ConfigPanelLayout>
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
+        <div className="w-full max-w-2xl mx-auto pb-8">
+          <ClockSettings {...props} />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/desktop/src/widgets/clock/FeedTab.tsx
+++ b/desktop/src/widgets/clock/FeedTab.tsx
@@ -1,5 +1,8 @@
 import { Clock } from "lucide-react";
 import { WorldClock } from "./WorldClock";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import { useShell } from "../../shell-context";
+import ClockSettings from "./Settings";
 import type { FeedTabProps, WidgetManifest } from "../../types";
 
 export const clockWidget: WidgetManifest = {
@@ -22,7 +25,31 @@ export const clockWidget: WidgetManifest = {
   FeedTab: ClockFeedTab,
 };
 
-function ClockFeedTab({ mode }: FeedTabProps) {
+function ClockFeedTab(props: FeedTabProps) {
+  return (
+    <div className="relative flex min-h-full flex-col">
+      {/* Comfort mode floats the gear top-right — the widget's settings
+          surface once the Configure page dies. */}
+      {props.mode === "comfort" && (
+        <div className="absolute right-3 top-3 z-10">
+          <ClockGear />
+        </div>
+      )}
+      <ClockFeedBody {...props} />
+    </div>
+  );
+}
+
+function ClockGear() {
+  const { prefs, onPrefsChange } = useShell();
+  return (
+    <GearMenu ariaLabel="Clock settings" panelClassName="right-0 w-80">
+      <ClockSettings prefs={prefs} onPrefsChange={onPrefsChange} />
+    </GearMenu>
+  );
+}
+
+function ClockFeedBody({ mode }: FeedTabProps) {
   return (
     <div className="p-3">
       <WorldClock compact={mode === "compact"} />

--- a/desktop/src/widgets/clock/Settings.tsx
+++ b/desktop/src/widgets/clock/Settings.tsx
@@ -1,0 +1,95 @@
+/** Clock settings surface — rendered inside the in-feed gear popover and (until teardown) the Configure page. */
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SegmentedRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { useTickerExclusion } from "../../hooks/useTickerExclusion";
+import { useStoreData } from "../../hooks/useStoreData";
+import { setStore } from "../../lib/store";
+import { DEFAULT_CLOCK_TICKER } from "../../preferences";
+import { LS_CLOCK_FORMAT, LS_CLOCK_TIMEZONES } from "../../constants";
+import { loadTimezones, loadFormat, tzLabel } from "./storage";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+
+type ClockFormat = "12h" | "24h";
+
+const FORMAT_OPTIONS: { value: ClockFormat; label: string }[] = [
+  { value: "12h", label: "12h" },
+  { value: "24h", label: "24h" },
+];
+
+export default function ClockSettings({
+  prefs,
+  onPrefsChange,
+}: WidgetConfigPanelProps) {
+  const { config, update, setTicker } = useWidgetConfig("clock", prefs, onPrefsChange);
+  const [format, setFormatState] = useStoreData(LS_CLOCK_FORMAT, loadFormat);
+  const [timezones] = useStoreData(LS_CLOCK_TIMEZONES, loadTimezones);
+  const { isExcluded: isTimezoneExcluded, toggle: toggleTimezone } =
+    useTickerExclusion(config.ticker.excludedTimezones, "excludedTimezones", setTicker);
+
+  const handleFormatChange = useCallback(
+    (v: ClockFormat) => {
+      setFormatState(v);
+      setStore(LS_CLOCK_FORMAT, v);
+    },
+    [],
+  );
+
+  const resetAll = useCallback(() => {
+    update({
+      ticker: { ...DEFAULT_CLOCK_TICKER },
+    });
+    setStore(LS_CLOCK_FORMAT, "12h");
+    setFormatState("12h");
+  }, [update]);
+
+  return (
+    <>
+      {/* Ticker */}
+      <Section title="Ticker">
+        <SegmentedRow
+          label="Time format"
+          description="12-hour or 24-hour clock"
+          value={format}
+          options={FORMAT_OPTIONS}
+          onChange={handleFormatChange}
+        />
+        <ToggleRow
+          label="Local time"
+          description="Show your local clock on the scrolling ticker"
+          checked={config.ticker.localTime}
+          onChange={(v) => setTicker({ localTime: v })}
+        />
+        <ToggleRow
+          label="Show world clocks"
+          description="Include configured timezones on the ticker"
+          checked={config.ticker.showTimezones}
+          onChange={(v) => setTicker({ showTimezones: v })}
+        />
+        {config.ticker.showTimezones && timezones.map((tz) => (
+          <ToggleRow
+            key={tz}
+            label={tzLabel(tz)}
+            checked={!isTimezoneExcluded(tz)}
+            onChange={() => toggleTimezone(tz)}
+          />
+        ))}
+        {config.ticker.showTimezones && timezones.length === 0 && (
+          <div className="px-3 py-2.5 text-[11px] text-fg-4">
+            Add world clocks in the Clock tab to see them here.
+          </div>
+        )}
+        <TickerPinSection widgetId="clock" prefs={prefs} onPrefsChange={onPrefsChange} />
+      </Section>
+      <div className="flex items-center justify-end px-3 pb-1 pt-2">
+        <ResetButton onClick={resetAll} />
+      </div>
+    </>
+  );
+}

--- a/desktop/src/widgets/github/ConfigPanel.tsx
+++ b/desktop/src/widgets/github/ConfigPanel.tsx
@@ -1,87 +1,20 @@
-import { useCallback } from "react";
-import {
-  Section,
-  ToggleRow,
-  SliderRow,
-} from "../../components/settings/SettingsControls";
-import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
-import TickerPinSection from "../../components/settings/TickerPinSection";
-import { useWidgetConfig } from "../../hooks/useWidgetConfig";
-import { useTickerExclusion } from "../../hooks/useTickerExclusion";
-import { useStoreData } from "../../hooks/useStoreData";
-import { DEFAULT_GITHUB_TICKER } from "../../preferences";
-import { formatPollInterval } from "../../utils/format";
-import { LS_GITHUB_REPOS } from "../../constants";
-import { loadRepoData, repoKey, CI_STATUS_LABELS } from "./types";
+/**
+ * GitHub ConfigPanel — thin wrapper (in-widget config pass, PR 6).
+ * The settings body moved to ./Settings.tsx, which the FeedTab now
+ * mounts in a gear popover; this page renders the same component until
+ * the configure-page teardown deletes it.
+ */
+import GitHubSettings from "./Settings";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
-export default function GitHubConfigPanel({
-  prefs,
-  onPrefsChange,
-}: WidgetConfigPanelProps) {
-  const { config, update, setTicker } = useWidgetConfig("github", prefs, onPrefsChange);
-  const [repoData] = useStoreData(LS_GITHUB_REPOS, loadRepoData);
-  const { isExcluded: isRepoExcluded, toggle: toggleRepo } =
-    useTickerExclusion(config.ticker.excludedRepos, "excludedRepos", setTicker);
-
-  const resetAll = useCallback(() => {
-    update({
-      pollInterval: 120,
-      ticker: { ...DEFAULT_GITHUB_TICKER },
-    });
-  }, [update]);
-
-  const githubIcon = (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-github)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
-      <path d="M9 18c-4.51 2-5-2-7-2" />
-    </svg>
-  );
-
+export default function GitHubConfigPanel(props: WidgetConfigPanelProps) {
   return (
-    <ConfigPanelLayout
-      icon={githubIcon}
-      hex="var(--color-widget-github)"
-      title="GitHub Settings"
-      subtitle="CI/Actions status for your repos"
-      onReset={resetAll}
-    >
-      <Section title="Ticker">
-        {config.repos.map((r) => {
-          const key = repoKey(r);
-          const rd = repoData.find((d) => repoKey(d) === key);
-          const statusLabel = rd ? CI_STATUS_LABELS[rd.status] ?? "Unknown" : "Loading";
-          const workflow = rd?.workflowName ? ` \u00B7 ${rd.workflowName}` : "";
-          return (
-            <ToggleRow
-              key={key}
-              label={key}
-              description={`${statusLabel}${workflow}`}
-              checked={!isRepoExcluded(key)}
-              onChange={() => toggleRepo(key)}
-            />
-          );
-        })}
-        {config.repos.length === 0 && (
-          <div className="px-3 py-2.5 text-[11px] text-fg-4">
-            Add repos in the GitHub tab to choose what shows on the ticker.
-          </div>
-        )}
-        <TickerPinSection widgetId="github" prefs={prefs} onPrefsChange={onPrefsChange} />
-      </Section>
-
-      <Section title="Polling">
-        <SliderRow
-          label="Refresh interval"
-          description="How often to check workflow status"
-          value={config.pollInterval}
-          min={60}
-          max={300}
-          step={30}
-          displayValue={formatPollInterval(config.pollInterval)}
-          onChange={(v) => update({ pollInterval: v })}
-        />
-      </Section>
-    </ConfigPanelLayout>
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
+        <div className="w-full max-w-2xl mx-auto pb-8">
+          <GitHubSettings {...props} />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/desktop/src/widgets/github/FeedTab.tsx
+++ b/desktop/src/widgets/github/FeedTab.tsx
@@ -22,6 +22,8 @@ import {
   CI_STATUS_TEXT,
 } from "./types";
 import { useShell } from "../../shell-context";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import GitHubSettings from "./Settings";
 import { savePrefs, updateWidgetPrefs } from "../../preferences";
 import { useSyncedQuery } from "../../hooks/useSyncedQuery";
 import { LS_GITHUB_REPOS } from "../../constants";
@@ -51,7 +53,31 @@ export const githubWidget: WidgetManifest = {
 
 // ── FeedTab ─────────────────────────────────────────────────────
 
-function GitHubFeedTab({ mode: feedMode }: FeedTabProps) {
+function GitHubFeedTab(props: FeedTabProps) {
+  return (
+    <div className="relative flex min-h-full flex-col">
+      {/* Comfort mode floats the gear top-right — the widget's settings
+          surface once the Configure page dies. */}
+      {props.mode === "comfort" && (
+        <div className="absolute right-3 top-3 z-10">
+          <GitHubGear />
+        </div>
+      )}
+      <GitHubFeedBody {...props} />
+    </div>
+  );
+}
+
+function GitHubGear() {
+  const { prefs, onPrefsChange } = useShell();
+  return (
+    <GearMenu ariaLabel="GitHub settings" panelClassName="right-0 w-80">
+      <GitHubSettings prefs={prefs} onPrefsChange={onPrefsChange} />
+    </GearMenu>
+  );
+}
+
+function GitHubFeedBody({ mode: feedMode }: FeedTabProps) {
   const compact = feedMode === "compact";
   const shell = useShell();
   const configRepos = shell.prefs.widgets.github.repos;

--- a/desktop/src/widgets/github/Settings.tsx
+++ b/desktop/src/widgets/github/Settings.tsx
@@ -1,0 +1,79 @@
+/** GitHub settings surface — rendered inside the in-feed gear popover and (until teardown) the Configure page. */
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SliderRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { useTickerExclusion } from "../../hooks/useTickerExclusion";
+import { useStoreData } from "../../hooks/useStoreData";
+import { DEFAULT_GITHUB_TICKER } from "../../preferences";
+import { formatPollInterval } from "../../utils/format";
+import { LS_GITHUB_REPOS } from "../../constants";
+import { loadRepoData, repoKey, CI_STATUS_LABELS } from "./types";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+
+export default function GitHubSettings({
+  prefs,
+  onPrefsChange,
+}: WidgetConfigPanelProps) {
+  const { config, update, setTicker } = useWidgetConfig("github", prefs, onPrefsChange);
+  const [repoData] = useStoreData(LS_GITHUB_REPOS, loadRepoData);
+  const { isExcluded: isRepoExcluded, toggle: toggleRepo } =
+    useTickerExclusion(config.ticker.excludedRepos, "excludedRepos", setTicker);
+
+  const resetAll = useCallback(() => {
+    update({
+      pollInterval: 120,
+      ticker: { ...DEFAULT_GITHUB_TICKER },
+    });
+  }, [update]);
+
+  return (
+    <>
+      <Section title="Ticker">
+        {config.repos.map((r) => {
+          const key = repoKey(r);
+          const rd = repoData.find((d) => repoKey(d) === key);
+          const statusLabel = rd ? CI_STATUS_LABELS[rd.status] ?? "Unknown" : "Loading";
+          const workflow = rd?.workflowName ? ` · ${rd.workflowName}` : "";
+          return (
+            <ToggleRow
+              key={key}
+              label={key}
+              description={`${statusLabel}${workflow}`}
+              checked={!isRepoExcluded(key)}
+              onChange={() => toggleRepo(key)}
+            />
+          );
+        })}
+        {config.repos.length === 0 && (
+          <div className="px-3 py-2.5 text-[11px] text-fg-4">
+            Add repos in the GitHub tab to choose what shows on the ticker.
+          </div>
+        )}
+        <TickerPinSection widgetId="github" prefs={prefs} onPrefsChange={onPrefsChange} />
+      </Section>
+
+      <Section title="Polling">
+        <SliderRow
+          label="Refresh interval"
+          description="How often to check workflow status"
+          value={config.pollInterval}
+          min={60}
+          max={300}
+          step={30}
+          displayValue={formatPollInterval(config.pollInterval)}
+          onChange={(v) => update({ pollInterval: v })}
+        />
+      </Section>
+
+      <div className="flex items-center justify-end px-3 pb-1 pt-2">
+        <ResetButton onClick={resetAll} />
+      </div>
+    </>
+  );
+}

--- a/desktop/src/widgets/sysmon/ConfigPanel.tsx
+++ b/desktop/src/widgets/sysmon/ConfigPanel.tsx
@@ -1,104 +1,20 @@
-import { useCallback } from "react";
-import {
-  Section,
-  ToggleRow,
-  SegmentedRow,
-} from "../../components/settings/SettingsControls";
-import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
-import TickerPinSection from "../../components/settings/TickerPinSection";
-import { useWidgetConfig } from "../../hooks/useWidgetConfig";
-import { DEFAULT_SYSMON_TICKER } from "../../preferences";
-import type { TempUnit } from "../../preferences";
+/**
+ * Sysmon ConfigPanel — thin wrapper (in-widget config pass, PR 6).
+ * The settings body moved to ./Settings.tsx, which the FeedTab now
+ * mounts in a gear popover; this page renders the same component until
+ * the configure-page teardown deletes it.
+ */
+import SysmonSettings from "./Settings";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
-const REFRESH_OPTIONS: { value: string; label: string }[] = [
-  { value: "1", label: "1s" },
-  { value: "2", label: "2s" },
-  { value: "3", label: "3s" },
-  { value: "5", label: "5s" },
-];
-
-const TEMP_OPTIONS: { value: TempUnit; label: string }[] = [
-  { value: "celsius", label: "\u00B0C" },
-  { value: "fahrenheit", label: "\u00B0F" },
-];
-
-export default function SysmonConfigPanel({
-  prefs,
-  onPrefsChange,
-}: WidgetConfigPanelProps) {
-  const { config, update, setTicker } = useWidgetConfig("sysmon", prefs, onPrefsChange);
-
-  const resetAll = useCallback(() => {
-    update({
-      refreshInterval: 2,
-      tempUnit: "celsius",
-      ticker: { ...DEFAULT_SYSMON_TICKER },
-    });
-  }, [update]);
-
-  const sysmonIcon = (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-sysmon)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="4" y="4" width="16" height="16" rx="2" />
-      <rect x="9" y="9" width="6" height="6" />
-      <path d="M15 2v2" /><path d="M15 20v2" />
-      <path d="M2 15h2" /><path d="M2 9h2" />
-      <path d="M20 15h2" /><path d="M20 9h2" />
-      <path d="M9 2v2" /><path d="M9 20v2" />
-    </svg>
-  );
-
+export default function SysmonConfigPanel(props: WidgetConfigPanelProps) {
   return (
-    <ConfigPanelLayout
-      icon={sysmonIcon}
-      hex="var(--color-widget-sysmon)"
-      title="System Monitor Settings"
-      subtitle="CPU, memory, GPU, and network stats"
-      onReset={resetAll}
-    >
-      <Section title="Ticker">
-        <ToggleRow
-          label="CPU usage"
-          description="Show how busy your processor is on the ticker"
-          checked={config.ticker.cpu}
-          onChange={(v) => setTicker({ cpu: v })}
-        />
-        <ToggleRow
-          label="Memory usage"
-          description="Show how much memory is being used on the ticker"
-          checked={config.ticker.memory}
-          onChange={(v) => setTicker({ memory: v })}
-        />
-        <ToggleRow
-          label="GPU usage"
-          description="Show how busy your graphics card is on the ticker"
-          checked={config.ticker.gpu}
-          onChange={(v) => setTicker({ gpu: v })}
-        />
-        <ToggleRow
-          label="GPU power draw"
-          description="Show graphics card wattage on the ticker"
-          checked={config.ticker.gpuPower}
-          onChange={(v) => setTicker({ gpuPower: v })}
-        />
-        <TickerPinSection widgetId="sysmon" prefs={prefs} onPrefsChange={onPrefsChange} />
-      </Section>
-
-      <Section title="Display">
-        <SegmentedRow
-          label="Update speed"
-          description="How often the numbers update"
-          value={String(config.refreshInterval)}
-          options={REFRESH_OPTIONS}
-          onChange={(v) => update({ refreshInterval: Number(v) })}
-        />
-        <SegmentedRow
-          label="Temperature"
-          value={config.tempUnit}
-          options={TEMP_OPTIONS}
-          onChange={(v) => update({ tempUnit: v })}
-        />
-      </Section>
-    </ConfigPanelLayout>
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
+        <div className="w-full max-w-2xl mx-auto pb-8">
+          <SysmonSettings {...props} />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/desktop/src/widgets/sysmon/FeedTab.tsx
+++ b/desktop/src/widgets/sysmon/FeedTab.tsx
@@ -1,5 +1,8 @@
 import { Activity } from "lucide-react";
 import type { FeedTabProps, WidgetManifest } from "../../types";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import { useShell } from "../../shell-context";
+import SysmonSettings from "./Settings";
 import { useSysmonData } from "../../hooks/useSysmonData";
 import { formatBytes, formatUptime } from "../../utils/format";
 import { findCpuTemp, findGpuTemp, usageColor, usageColorClass, tempColorClass, formatFreq, formatWatts, formatRate } from "./utils";
@@ -26,7 +29,31 @@ function DetailLine({ items }: { items: (string | null | undefined)[] }) {
 
 // ── FeedTab Component ───────────────────────────────────────────
 
-function SysmonFeedTab({ mode: feedMode }: FeedTabProps) {
+function SysmonFeedTab(props: FeedTabProps) {
+  return (
+    <div className="relative flex min-h-full flex-col">
+      {/* Comfort mode floats the gear top-right — the widget's settings
+          surface once the Configure page dies. */}
+      {props.mode === "comfort" && (
+        <div className="absolute right-3 top-3 z-10">
+          <SysmonGear />
+        </div>
+      )}
+      <SysmonFeedBody {...props} />
+    </div>
+  );
+}
+
+function SysmonGear() {
+  const { prefs, onPrefsChange } = useShell();
+  return (
+    <GearMenu ariaLabel="System monitor settings" panelClassName="right-0 w-80">
+      <SysmonSettings prefs={prefs} onPrefsChange={onPrefsChange} />
+    </GearMenu>
+  );
+}
+
+function SysmonFeedBody({ mode: feedMode }: FeedTabProps) {
   const compact = feedMode === "compact";
   const info = useSysmonData(POLL_INTERVAL);
 

--- a/desktop/src/widgets/sysmon/Settings.tsx
+++ b/desktop/src/widgets/sysmon/Settings.tsx
@@ -1,0 +1,91 @@
+/** Sysmon settings surface — rendered inside the in-feed gear popover and (until teardown) the Configure page. */
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SegmentedRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { DEFAULT_SYSMON_TICKER } from "../../preferences";
+import type { TempUnit } from "../../preferences";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+
+const REFRESH_OPTIONS: { value: string; label: string }[] = [
+  { value: "1", label: "1s" },
+  { value: "2", label: "2s" },
+  { value: "3", label: "3s" },
+  { value: "5", label: "5s" },
+];
+
+const TEMP_OPTIONS: { value: TempUnit; label: string }[] = [
+  { value: "celsius", label: "\u00B0C" },
+  { value: "fahrenheit", label: "\u00B0F" },
+];
+
+export default function SysmonSettings({
+  prefs,
+  onPrefsChange,
+}: WidgetConfigPanelProps) {
+  const { config, update, setTicker } = useWidgetConfig("sysmon", prefs, onPrefsChange);
+
+  const resetAll = useCallback(() => {
+    update({
+      refreshInterval: 2,
+      tempUnit: "celsius",
+      ticker: { ...DEFAULT_SYSMON_TICKER },
+    });
+  }, [update]);
+
+  return (
+    <>
+      <Section title="Ticker">
+        <ToggleRow
+          label="CPU usage"
+          description="Show how busy your processor is on the ticker"
+          checked={config.ticker.cpu}
+          onChange={(v) => setTicker({ cpu: v })}
+        />
+        <ToggleRow
+          label="Memory usage"
+          description="Show how much memory is being used on the ticker"
+          checked={config.ticker.memory}
+          onChange={(v) => setTicker({ memory: v })}
+        />
+        <ToggleRow
+          label="GPU usage"
+          description="Show how busy your graphics card is on the ticker"
+          checked={config.ticker.gpu}
+          onChange={(v) => setTicker({ gpu: v })}
+        />
+        <ToggleRow
+          label="GPU power draw"
+          description="Show graphics card wattage on the ticker"
+          checked={config.ticker.gpuPower}
+          onChange={(v) => setTicker({ gpuPower: v })}
+        />
+        <TickerPinSection widgetId="sysmon" prefs={prefs} onPrefsChange={onPrefsChange} />
+      </Section>
+
+      <Section title="Display">
+        <SegmentedRow
+          label="Update speed"
+          description="How often the numbers update"
+          value={String(config.refreshInterval)}
+          options={REFRESH_OPTIONS}
+          onChange={(v) => update({ refreshInterval: Number(v) })}
+        />
+        <SegmentedRow
+          label="Temperature"
+          value={config.tempUnit}
+          options={TEMP_OPTIONS}
+          onChange={(v) => update({ tempUnit: v })}
+        />
+      </Section>
+      <div className="flex items-center justify-end px-3 pb-1 pt-2">
+        <ResetButton onClick={resetAll} />
+      </div>
+    </>
+  );
+}

--- a/desktop/src/widgets/timer/ConfigPanel.tsx
+++ b/desktop/src/widgets/timer/ConfigPanel.tsx
@@ -1,107 +1,20 @@
-import { useCallback } from "react";
-import {
-  Section,
-  ToggleRow,
-  SegmentedRow,
-  SliderRow,
-} from "../../components/settings/SettingsControls";
-import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
-import TickerPinSection from "../../components/settings/TickerPinSection";
-import { useWidgetConfig } from "../../hooks/useWidgetConfig";
-import { DEFAULT_TIMER_TICKER, DEFAULT_TIMER_POMODORO } from "../../preferences";
-import type { TimerPomodoroConfig } from "../../preferences";
+/**
+ * Timer ConfigPanel — thin wrapper (in-widget config pass, PR 6).
+ * The settings body moved to ./Settings.tsx, which the FeedTab now
+ * mounts in a gear popover; this page renders the same component until
+ * the configure-page teardown deletes it.
+ */
+import TimerSettings from "./Settings";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
-const LONG_BREAK_OPTIONS = [
-  { value: "2", label: "2" },
-  { value: "3", label: "3" },
-  { value: "4", label: "4" },
-  { value: "5", label: "5" },
-  { value: "6", label: "6" },
-];
-
-export default function TimerConfigPanel({
-  prefs,
-  onPrefsChange,
-}: WidgetConfigPanelProps) {
-  const { config, update, setTicker } = useWidgetConfig("timer", prefs, onPrefsChange);
-
-  const setPomodoro = useCallback(
-    (patch: Partial<TimerPomodoroConfig>) => {
-      update({ pomodoro: { ...config.pomodoro, ...patch } });
-    },
-    [update, config.pomodoro],
-  );
-
-  const resetAll = useCallback(() => {
-    update({
-      ticker: { ...DEFAULT_TIMER_TICKER },
-      pomodoro: { ...DEFAULT_TIMER_POMODORO },
-    });
-  }, [update]);
-
-  const timerIcon = (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-timer)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M10 2h4" />
-      <path d="M12 14l3-3" />
-      <circle cx="12" cy="14" r="8" />
-    </svg>
-  );
-
+export default function TimerConfigPanel(props: WidgetConfigPanelProps) {
   return (
-    <ConfigPanelLayout
-      icon={timerIcon}
-      hex="var(--color-widget-timer)"
-      title="Timer Settings"
-      subtitle="Pomodoro, countdown, and stopwatch"
-      onReset={resetAll}
-    >
-      <Section title="Ticker">
-        <ToggleRow
-          label="Active timer"
-          description="Show running or paused timers on the scrolling ticker"
-          checked={config.ticker.activeTimer}
-          onChange={(v) => setTicker({ activeTimer: v })}
-        />
-        <TickerPinSection widgetId="timer" prefs={prefs} onPrefsChange={onPrefsChange} />
-      </Section>
-
-      <Section title="Pomodoro">
-        <SliderRow
-          label="Work session"
-          value={config.pomodoro.workMins}
-          min={10}
-          max={60}
-          step={5}
-          displayValue={`${config.pomodoro.workMins} min`}
-          onChange={(v) => setPomodoro({ workMins: v })}
-        />
-        <SliderRow
-          label="Short break"
-          value={config.pomodoro.shortBreakMins}
-          min={1}
-          max={15}
-          step={1}
-          displayValue={`${config.pomodoro.shortBreakMins} min`}
-          onChange={(v) => setPomodoro({ shortBreakMins: v })}
-        />
-        <SliderRow
-          label="Long break"
-          value={config.pomodoro.longBreakMins}
-          min={5}
-          max={30}
-          step={5}
-          displayValue={`${config.pomodoro.longBreakMins} min`}
-          onChange={(v) => setPomodoro({ longBreakMins: v })}
-        />
-        <SegmentedRow
-          label="Long break every"
-          description="Sessions before a long break"
-          value={String(config.pomodoro.longBreakEvery)}
-          options={LONG_BREAK_OPTIONS}
-          onChange={(v) => setPomodoro({ longBreakEvery: Number(v) })}
-        />
-      </Section>
-    </ConfigPanelLayout>
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
+        <div className="w-full max-w-2xl mx-auto pb-8">
+          <TimerSettings {...props} />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/desktop/src/widgets/timer/FeedTab.tsx
+++ b/desktop/src/widgets/timer/FeedTab.tsx
@@ -1,5 +1,8 @@
 import { TimerReset } from "lucide-react";
 import { Timer } from "./Timer";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import { useShell } from "../../shell-context";
+import TimerSettings from "./Settings";
 import type { FeedTabProps, WidgetManifest } from "../../types";
 
 export const timerWidget: WidgetManifest = {
@@ -22,7 +25,31 @@ export const timerWidget: WidgetManifest = {
   FeedTab: TimerFeedTab,
 };
 
-function TimerFeedTab({ mode }: FeedTabProps) {
+function TimerFeedTab(props: FeedTabProps) {
+  return (
+    <div className="relative flex min-h-full flex-col">
+      {/* Comfort mode floats the gear top-right — the widget's settings
+          surface once the Configure page dies. */}
+      {props.mode === "comfort" && (
+        <div className="absolute right-3 top-3 z-10">
+          <TimerGear />
+        </div>
+      )}
+      <TimerFeedBody {...props} />
+    </div>
+  );
+}
+
+function TimerGear() {
+  const { prefs, onPrefsChange } = useShell();
+  return (
+    <GearMenu ariaLabel="Timer settings" panelClassName="right-0 w-80">
+      <TimerSettings prefs={prefs} onPrefsChange={onPrefsChange} />
+    </GearMenu>
+  );
+}
+
+function TimerFeedBody({ mode }: FeedTabProps) {
   return (
     <div className="p-3">
       <Timer compact={mode === "compact"} />

--- a/desktop/src/widgets/timer/Settings.tsx
+++ b/desktop/src/widgets/timer/Settings.tsx
@@ -1,0 +1,97 @@
+/** Timer settings surface — rendered inside the in-feed gear popover and (until teardown) the Configure page. */
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SegmentedRow,
+  SliderRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { DEFAULT_TIMER_TICKER, DEFAULT_TIMER_POMODORO } from "../../preferences";
+import type { TimerPomodoroConfig } from "../../preferences";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+
+const LONG_BREAK_OPTIONS = [
+  { value: "2", label: "2" },
+  { value: "3", label: "3" },
+  { value: "4", label: "4" },
+  { value: "5", label: "5" },
+  { value: "6", label: "6" },
+];
+
+export default function TimerSettings({
+  prefs,
+  onPrefsChange,
+}: WidgetConfigPanelProps) {
+  const { config, update, setTicker } = useWidgetConfig("timer", prefs, onPrefsChange);
+
+  const setPomodoro = useCallback(
+    (patch: Partial<TimerPomodoroConfig>) => {
+      update({ pomodoro: { ...config.pomodoro, ...patch } });
+    },
+    [update, config.pomodoro],
+  );
+
+  const resetAll = useCallback(() => {
+    update({
+      ticker: { ...DEFAULT_TIMER_TICKER },
+      pomodoro: { ...DEFAULT_TIMER_POMODORO },
+    });
+  }, [update]);
+
+  return (
+    <>
+      <Section title="Ticker">
+        <ToggleRow
+          label="Active timer"
+          description="Show running or paused timers on the scrolling ticker"
+          checked={config.ticker.activeTimer}
+          onChange={(v) => setTicker({ activeTimer: v })}
+        />
+        <TickerPinSection widgetId="timer" prefs={prefs} onPrefsChange={onPrefsChange} />
+      </Section>
+
+      <Section title="Pomodoro">
+        <SliderRow
+          label="Work session"
+          value={config.pomodoro.workMins}
+          min={10}
+          max={60}
+          step={5}
+          displayValue={`${config.pomodoro.workMins} min`}
+          onChange={(v) => setPomodoro({ workMins: v })}
+        />
+        <SliderRow
+          label="Short break"
+          value={config.pomodoro.shortBreakMins}
+          min={1}
+          max={15}
+          step={1}
+          displayValue={`${config.pomodoro.shortBreakMins} min`}
+          onChange={(v) => setPomodoro({ shortBreakMins: v })}
+        />
+        <SliderRow
+          label="Long break"
+          value={config.pomodoro.longBreakMins}
+          min={5}
+          max={30}
+          step={5}
+          displayValue={`${config.pomodoro.longBreakMins} min`}
+          onChange={(v) => setPomodoro({ longBreakMins: v })}
+        />
+        <SegmentedRow
+          label="Long break every"
+          description="Sessions before a long break"
+          value={String(config.pomodoro.longBreakEvery)}
+          options={LONG_BREAK_OPTIONS}
+          onChange={(v) => setPomodoro({ longBreakEvery: Number(v) })}
+        />
+      </Section>
+      <div className="flex items-center justify-end px-3 pb-1 pt-2">
+        <ResetButton onClick={resetAll} />
+      </div>
+    </>
+  );
+}

--- a/desktop/src/widgets/uptime/ConfigPanel.tsx
+++ b/desktop/src/widgets/uptime/ConfigPanel.tsx
@@ -1,84 +1,20 @@
-import { useCallback } from "react";
-import {
-  Section,
-  ToggleRow,
-  SliderRow,
-} from "../../components/settings/SettingsControls";
-import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
-import TickerPinSection from "../../components/settings/TickerPinSection";
-import { useWidgetConfig } from "../../hooks/useWidgetConfig";
-import { useTickerExclusion } from "../../hooks/useTickerExclusion";
-import { useStoreData } from "../../hooks/useStoreData";
-import { DEFAULT_UPTIME_TICKER } from "../../preferences";
-import { formatPollInterval } from "../../utils/format";
-import { LS_UPTIME_MONITORS } from "../../constants";
-import { loadMonitors } from "./types";
+/**
+ * Uptime ConfigPanel — thin wrapper (in-widget config pass, PR 6).
+ * The settings body moved to ./Settings.tsx, which the FeedTab now
+ * mounts in a gear popover; this page renders the same component until
+ * the configure-page teardown deletes it.
+ */
+import UptimeSettings from "./Settings";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
-export default function UptimeConfigPanel({
-  prefs,
-  onPrefsChange,
-}: WidgetConfigPanelProps) {
-  const { config, update, setTicker } = useWidgetConfig("uptime", prefs, onPrefsChange);
-  const [monitors] = useStoreData(LS_UPTIME_MONITORS, loadMonitors);
-  const { isExcluded: isMonitorExcluded, toggle: toggleMonitor } =
-    useTickerExclusion(config.ticker.excludedMonitors, "excludedMonitors", setTicker);
-
-  const resetAll = useCallback(() => {
-    update({
-      pollInterval: 60,
-      ticker: { ...DEFAULT_UPTIME_TICKER },
-    });
-  }, [update]);
-
-  const uptimeIcon = (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-uptime)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2" />
-    </svg>
-  );
-
+export default function UptimeConfigPanel(props: WidgetConfigPanelProps) {
   return (
-    <ConfigPanelLayout
-      icon={uptimeIcon}
-      hex="var(--color-widget-uptime)"
-      title="Uptime Settings"
-      subtitle="Monitor status from Uptime Kuma"
-      onReset={resetAll}
-    >
-      <Section title="Ticker">
-        {monitors.map((monitor) => {
-          const statusLabel = monitor.status.charAt(0).toUpperCase() + monitor.status.slice(1);
-          const uptime = monitor.uptimePercent != null ? `${monitor.uptimePercent.toFixed(1)}%` : "";
-          return (
-            <ToggleRow
-              key={monitor.id}
-              label={monitor.name}
-              description={[statusLabel, uptime].filter(Boolean).join(" \u00B7 ")}
-              checked={!isMonitorExcluded(monitor.id)}
-              onChange={() => toggleMonitor(monitor.id)}
-            />
-          );
-        })}
-        {monitors.length === 0 && (
-          <div className="px-3 py-2.5 text-[11px] text-fg-4">
-            Connect to Uptime Kuma in the feed tab to choose what shows on the ticker.
-          </div>
-        )}
-        <TickerPinSection widgetId="uptime" prefs={prefs} onPrefsChange={onPrefsChange} />
-      </Section>
-
-      <Section title="Polling">
-        <SliderRow
-          label="Refresh interval"
-          description="How often to check monitor status"
-          value={config.pollInterval}
-          min={30}
-          max={300}
-          step={30}
-          displayValue={formatPollInterval(config.pollInterval)}
-          onChange={(v) => update({ pollInterval: v })}
-        />
-      </Section>
-    </ConfigPanelLayout>
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
+        <div className="w-full max-w-2xl mx-auto pb-8">
+          <UptimeSettings {...props} />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/desktop/src/widgets/uptime/FeedTab.tsx
+++ b/desktop/src/widgets/uptime/FeedTab.tsx
@@ -19,6 +19,8 @@ import type { KumaMonitor } from "./types";
 import { fetchKumaStatus, loadMonitors, saveMonitors, MONITOR_STATUS_LABELS, MONITOR_STATUS_COLORS, MONITOR_STATUS_TEXT } from "./types";
 import { toast } from "sonner";
 import { useShell } from "../../shell-context";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import UptimeSettings from "./Settings";
 import { savePrefs, updateWidgetPrefs } from "../../preferences";
 import { useSyncedQuery } from "../../hooks/useSyncedQuery";
 import { LS_UPTIME_MONITORS } from "../../constants";
@@ -48,7 +50,31 @@ export const uptimeWidget: WidgetManifest = {
 
 // ── FeedTab ─────────────────────────────────────────────────────
 
-function UptimeFeedTab({ mode: feedMode }: FeedTabProps) {
+function UptimeFeedTab(props: FeedTabProps) {
+  return (
+    <div className="relative flex min-h-full flex-col">
+      {/* Comfort mode floats the gear top-right — the widget's settings
+          surface once the Configure page dies. */}
+      {props.mode === "comfort" && (
+        <div className="absolute right-3 top-3 z-10">
+          <UptimeGear />
+        </div>
+      )}
+      <UptimeFeedBody {...props} />
+    </div>
+  );
+}
+
+function UptimeGear() {
+  const { prefs, onPrefsChange } = useShell();
+  return (
+    <GearMenu ariaLabel="Uptime settings" panelClassName="right-0 w-80">
+      <UptimeSettings prefs={prefs} onPrefsChange={onPrefsChange} />
+    </GearMenu>
+  );
+}
+
+function UptimeFeedBody({ mode: feedMode }: FeedTabProps) {
   const compact = feedMode === "compact";
   const shell = useShell();
   const queryClient = useQueryClient();

--- a/desktop/src/widgets/uptime/Settings.tsx
+++ b/desktop/src/widgets/uptime/Settings.tsx
@@ -1,0 +1,77 @@
+/** Uptime settings surface — rendered inside the in-feed gear popover and (until teardown) the Configure page. */
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SliderRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { useTickerExclusion } from "../../hooks/useTickerExclusion";
+import { useStoreData } from "../../hooks/useStoreData";
+import { DEFAULT_UPTIME_TICKER } from "../../preferences";
+import { formatPollInterval } from "../../utils/format";
+import { LS_UPTIME_MONITORS } from "../../constants";
+import { loadMonitors } from "./types";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+
+export default function UptimeSettings({
+  prefs,
+  onPrefsChange,
+}: WidgetConfigPanelProps) {
+  const { config, update, setTicker } = useWidgetConfig("uptime", prefs, onPrefsChange);
+  const [monitors] = useStoreData(LS_UPTIME_MONITORS, loadMonitors);
+  const { isExcluded: isMonitorExcluded, toggle: toggleMonitor } =
+    useTickerExclusion(config.ticker.excludedMonitors, "excludedMonitors", setTicker);
+
+  const resetAll = useCallback(() => {
+    update({
+      pollInterval: 60,
+      ticker: { ...DEFAULT_UPTIME_TICKER },
+    });
+  }, [update]);
+
+  return (
+    <>
+      <Section title="Ticker">
+        {monitors.map((monitor) => {
+          const statusLabel = monitor.status.charAt(0).toUpperCase() + monitor.status.slice(1);
+          const uptime = monitor.uptimePercent != null ? `${monitor.uptimePercent.toFixed(1)}%` : "";
+          return (
+            <ToggleRow
+              key={monitor.id}
+              label={monitor.name}
+              description={[statusLabel, uptime].filter(Boolean).join(" · ")}
+              checked={!isMonitorExcluded(monitor.id)}
+              onChange={() => toggleMonitor(monitor.id)}
+            />
+          );
+        })}
+        {monitors.length === 0 && (
+          <div className="px-3 py-2.5 text-[11px] text-fg-4">
+            Connect to Uptime Kuma in the feed tab to choose what shows on the ticker.
+          </div>
+        )}
+        <TickerPinSection widgetId="uptime" prefs={prefs} onPrefsChange={onPrefsChange} />
+      </Section>
+
+      <Section title="Polling">
+        <SliderRow
+          label="Refresh interval"
+          description="How often to check monitor status"
+          value={config.pollInterval}
+          min={30}
+          max={300}
+          step={30}
+          displayValue={formatPollInterval(config.pollInterval)}
+          onChange={(v) => update({ pollInterval: v })}
+        />
+      </Section>
+
+      <div className="flex items-center justify-end px-3 pb-1 pt-2">
+        <ResetButton onClick={resetAll} />
+      </div>
+    </>
+  );
+}

--- a/desktop/src/widgets/weather/ConfigPanel.tsx
+++ b/desktop/src/widgets/weather/ConfigPanel.tsx
@@ -1,94 +1,20 @@
-import { useCallback } from "react";
-import {
-  Section,
-  ToggleRow,
-  SegmentedRow,
-} from "../../components/settings/SettingsControls";
-import ConfigPanelLayout from "../../components/settings/ConfigPanelLayout";
-import TickerPinSection from "../../components/settings/TickerPinSection";
-import { useWidgetConfig } from "../../hooks/useWidgetConfig";
-import { useTickerExclusion } from "../../hooks/useTickerExclusion";
-import { useStoreData } from "../../hooks/useStoreData";
-import { setStore } from "../../lib/store";
-import { DEFAULT_WEATHER_TICKER } from "../../preferences";
-import { LS_WEATHER_CITIES, LS_WEATHER_UNIT } from "../../constants";
-import { loadCities, loadUnit } from "./types";
-import type { TempUnit } from "../../preferences";
-import type { SavedCity } from "./types";
+/**
+ * Weather ConfigPanel — thin wrapper (in-widget config pass, PR 6).
+ * The settings body moved to ./Settings.tsx, which the FeedTab now
+ * mounts in a gear popover; this page renders the same component until
+ * the configure-page teardown deletes it.
+ */
+import WeatherSettings from "./Settings";
 import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
 
-function cityName(city: SavedCity): string {
-  return city.location.name;
-}
-
-const UNIT_OPTIONS: { value: TempUnit; label: string }[] = [
-  { value: "fahrenheit", label: "\u00B0F" },
-  { value: "celsius", label: "\u00B0C" },
-];
-
-export default function WeatherConfigPanel({
-  prefs,
-  onPrefsChange,
-}: WidgetConfigPanelProps) {
-  const { config, update, setTicker } = useWidgetConfig("weather", prefs, onPrefsChange);
-  const [cities] = useStoreData(LS_WEATHER_CITIES, loadCities);
-  const [unit, setUnitState] = useStoreData(LS_WEATHER_UNIT, loadUnit);
-  const { isExcluded: isCityExcluded, toggle: toggleCity } =
-    useTickerExclusion(config.ticker.excludedCities, "excludedCities", setTicker);
-
-  const handleUnitChange = useCallback((v: TempUnit) => {
-    setUnitState(v);
-    setStore(LS_WEATHER_UNIT, v);
-  }, []);
-
-  const resetAll = useCallback(() => {
-    update({
-      ticker: { ...DEFAULT_WEATHER_TICKER },
-    });
-    setStore(LS_WEATHER_UNIT, "fahrenheit");
-    setUnitState("fahrenheit");
-  }, [update]);
-
-  const weatherIcon = (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-widget-weather)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" />
-    </svg>
-  );
-
+export default function WeatherConfigPanel(props: WidgetConfigPanelProps) {
   return (
-    <ConfigPanelLayout
-      icon={weatherIcon}
-      hex="var(--color-widget-weather)"
-      title="Weather Settings"
-      subtitle="Current conditions for your saved cities"
-      onReset={resetAll}
-    >
-      <Section title="Ticker">
-        {cities.map((city) => (
-          <ToggleRow
-            key={cityName(city)}
-            label={cityName(city)}
-            description={[city.location.admin1, city.location.country].filter(Boolean).join(", ")}
-            checked={!isCityExcluded(cityName(city))}
-            onChange={() => toggleCity(cityName(city))}
-          />
-        ))}
-        {cities.length === 0 && (
-          <div className="px-3 py-2.5 text-[11px] text-fg-4">
-            Add cities in the Weather tab to choose what shows on the ticker.
-          </div>
-        )}
-        <TickerPinSection widgetId="weather" prefs={prefs} onPrefsChange={onPrefsChange} />
-      </Section>
-
-      <Section title="Display">
-        <SegmentedRow
-          label="Units"
-          value={unit}
-          options={UNIT_OPTIONS}
-          onChange={handleUnitChange}
-        />
-      </Section>
-    </ConfigPanelLayout>
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
+        <div className="w-full max-w-2xl mx-auto pb-8">
+          <WeatherSettings {...props} />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/desktop/src/widgets/weather/FeedTab.tsx
+++ b/desktop/src/widgets/weather/FeedTab.tsx
@@ -11,6 +11,9 @@ import Tooltip from "../../components/Tooltip";
 import { CloudSun } from "lucide-react";
 import { WeatherCard } from "./WeatherCard";
 import { CitySearch } from "./CitySearch";
+import { GearMenu } from "../../components/widget-bar/GearMenu";
+import { useShell } from "../../shell-context";
+import WeatherSettings from "./Settings";
 import { weatherQueryOptions, queryKeys } from "../../api/queries";
 import type { FeedTabProps, WidgetManifest } from "../../types";
 import type { WeatherLocation } from "./types";
@@ -42,7 +45,31 @@ export const weatherWidget: WidgetManifest = {
 
 // ── FeedTab ─────────────────────────────────────────────────────
 
-function WeatherFeedTab({ mode: feedMode }: FeedTabProps) {
+function WeatherFeedTab(props: FeedTabProps) {
+  return (
+    <div className="relative flex min-h-full flex-col">
+      {/* Comfort mode floats the gear top-right — the widget's settings
+          surface once the Configure page dies. */}
+      {props.mode === "comfort" && (
+        <div className="absolute right-3 top-3 z-10">
+          <WeatherGear />
+        </div>
+      )}
+      <WeatherFeedBody {...props} />
+    </div>
+  );
+}
+
+function WeatherGear() {
+  const { prefs, onPrefsChange } = useShell();
+  return (
+    <GearMenu ariaLabel="Weather settings" panelClassName="right-0 w-80">
+      <WeatherSettings prefs={prefs} onPrefsChange={onPrefsChange} />
+    </GearMenu>
+  );
+}
+
+function WeatherFeedBody({ mode: feedMode }: FeedTabProps) {
   const compact = feedMode === "compact";
 
   // Weather data from TanStack Query — shared cache with __root.tsx observer

--- a/desktop/src/widgets/weather/Settings.tsx
+++ b/desktop/src/widgets/weather/Settings.tsx
@@ -1,0 +1,89 @@
+/**
+ * Weather settings surface — rendered inside the in-feed gear popover
+ * and (until teardown) the Configure page.
+ */
+import { useCallback } from "react";
+import {
+  Section,
+  ToggleRow,
+  SegmentedRow,
+  ResetButton,
+} from "../../components/settings/SettingsControls";
+import TickerPinSection from "../../components/settings/TickerPinSection";
+import { useWidgetConfig } from "../../hooks/useWidgetConfig";
+import { useTickerExclusion } from "../../hooks/useTickerExclusion";
+import { useStoreData } from "../../hooks/useStoreData";
+import { setStore } from "../../lib/store";
+import { DEFAULT_WEATHER_TICKER } from "../../preferences";
+import { LS_WEATHER_CITIES, LS_WEATHER_UNIT } from "../../constants";
+import { loadCities, loadUnit } from "./types";
+import type { TempUnit } from "../../preferences";
+import type { SavedCity } from "./types";
+import type { WidgetConfigPanelProps } from "../../hooks/useWidgetConfig";
+
+function cityName(city: SavedCity): string {
+  return city.location.name;
+}
+
+const UNIT_OPTIONS: { value: TempUnit; label: string }[] = [
+  { value: "fahrenheit", label: "°F" },
+  { value: "celsius", label: "°C" },
+];
+
+export default function WeatherSettings({
+  prefs,
+  onPrefsChange,
+}: WidgetConfigPanelProps) {
+  const { config, update, setTicker } = useWidgetConfig("weather", prefs, onPrefsChange);
+  const [cities] = useStoreData(LS_WEATHER_CITIES, loadCities);
+  const [unit, setUnitState] = useStoreData(LS_WEATHER_UNIT, loadUnit);
+  const { isExcluded: isCityExcluded, toggle: toggleCity } =
+    useTickerExclusion(config.ticker.excludedCities, "excludedCities", setTicker);
+
+  const handleUnitChange = useCallback((v: TempUnit) => {
+    setUnitState(v);
+    setStore(LS_WEATHER_UNIT, v);
+  }, []);
+
+  const resetAll = useCallback(() => {
+    update({
+      ticker: { ...DEFAULT_WEATHER_TICKER },
+    });
+    setStore(LS_WEATHER_UNIT, "fahrenheit");
+    setUnitState("fahrenheit");
+  }, [update]);
+
+  return (
+    <>
+      <Section title="Ticker">
+        {cities.map((city) => (
+          <ToggleRow
+            key={cityName(city)}
+            label={cityName(city)}
+            description={[city.location.admin1, city.location.country].filter(Boolean).join(", ")}
+            checked={!isCityExcluded(cityName(city))}
+            onChange={() => toggleCity(cityName(city))}
+          />
+        ))}
+        {cities.length === 0 && (
+          <div className="px-3 py-2.5 text-[11px] text-fg-4">
+            Add cities in the Weather tab to choose what shows on the ticker.
+          </div>
+        )}
+        <TickerPinSection widgetId="weather" prefs={prefs} onPrefsChange={onPrefsChange} />
+      </Section>
+
+      <Section title="Display">
+        <SegmentedRow
+          label="Units"
+          value={unit}
+          options={UNIT_OPTIONS}
+          onChange={handleUnitChange}
+        />
+      </Section>
+      <div className="flex items-center justify-end px-3 pb-1 pt-2">
+        <ResetButton onClick={resetAll} />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Stacked on #237. The six utility widgets get proportionate treatment — no bars, just a gear popover floating over the feed, exactly as planned.

Linear: REL-38

## Changes (×6: clock, timer, weather, sysmon, uptime, github)

- **`widgets/<id>/Settings.tsx`** — the ConfigPanel's hooks and `Section` rows moved verbatim (every popover keeps its `TickerPinSection`), minus the `ConfigPanelLayout` chrome; reset is a bottom `ResetButton` row inside the settings body.
- **FeedTab** — comfort mode floats the gear: `<div className="absolute right-3 top-3"><GearMenu>…</GearMenu></div>` over a `relative min-h-full` column. The feed body is byte-identical, just renamed `<X>FeedBody`; feed-side add flows (add-timezone, CitySearch, Kuma/repo setup) already lived in the feed and are untouched.
- **ConfigPanel** — thin scroll-chrome wrapper rendering the same Settings component, so the Configure page stays at parity until PR 7 deletes it (along with `ConfigPanelLayout`).

## Verification

- `npx tsc --noEmit` clean; `npx vitest run` 490/490
- All five Playwright suites (kalshi/search/finance/rss/sports) still ALL PASS
- Pattern conformity: all six FeedTabs carry the identical wrapper/gear/body structure; all six Settings files end in the reset row; grep-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)