### PR TITLE
In-widget config PR 11: Customize page + Claude-desktop sidebar IA [REL-44]

### DIFF
--- a/desktop/src/components/Sidebar.test.tsx
+++ b/desktop/src/components/Sidebar.test.tsx
@@ -26,8 +26,7 @@ function renderSidebar(opts: {
   }));
   render(
     <Sidebar
-      isSettings={false}
-      isTicker={false}
+      isCustomize={false}
       isAccount={false}
       isMarketplace={false}
       isSupport={false}
@@ -37,8 +36,7 @@ function renderSidebar(opts: {
       sources={sources}
       onNavigateHome={onNavigateHome}
       onNavigateToMarketplace={onNavigateToMarketplace}
-      onNavigateToSettings={() => {}}
-      onNavigateToTicker={() => {}}
+      onNavigateToCustomize={() => {}}
       onNavigateToAccount={() => {}}
       onNavigateToSupport={() => {}}
       onSelectItem={() => {}}

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -7,7 +7,7 @@
  *   │ Sports     │
  *   │ + 2/3      │  ← slot chip: add-source CTA + cap meter in one
  *   │    ⋮       │
- *   │ [Account ▾]│⇤│  ← footer chip: Settings/Ticker/Account/Support
+ *   │ [Account ▾]│⇤│  ← footer chip: Account/Support menu
  *   └────────────┘      menu + collapse toggle
  *
  * Home navigation lives on the Scrollr brand mark in the TopBar;
@@ -31,8 +31,8 @@ import {
   PanelLeftOpen,
   Plus,
   RadioTower,
-  Settings,
   Settings2,
+  SlidersHorizontal,
   Trash2,
   UserCircle,
 } from "lucide-react";
@@ -99,10 +99,8 @@ function SourceGlyph({ source }: { source: SidebarSource }) {
 }
 
 interface SidebarProps {
-  /** Whether the settings page is active. */
-  isSettings: boolean;
-  /** Whether the ticker settings page is active. */
-  isTicker: boolean;
+  /** Whether the Customize page (merged Settings + Ticker) is active. */
+  isCustomize: boolean;
   /** Whether the account page is active. */
   isAccount: boolean;
   /** Whether the catalog page is active. Drives the "+ Add source"
@@ -124,10 +122,8 @@ interface SidebarProps {
   onNavigateHome: () => void;
   /** Navigate to the catalog page (used by "+ Add source"). */
   onNavigateToMarketplace: () => void;
-  /** Navigate to the settings page. */
-  onNavigateToSettings: () => void;
-  /** Navigate to the ticker page. */
-  onNavigateToTicker: () => void;
+  /** Navigate to the Customize page (merged Settings + Ticker). */
+  onNavigateToCustomize: () => void;
   /** Navigate to the account page. */
   onNavigateToAccount: () => void;
   /** Navigate to the support page. */
@@ -147,8 +143,7 @@ interface SidebarProps {
 // ── Component ───────────────────────────────────────────────────
 
 export default function Sidebar({
-  isSettings,
-  isTicker,
+  isCustomize,
   isAccount,
   isMarketplace,
   isSupport,
@@ -158,8 +153,7 @@ export default function Sidebar({
   sources,
   onNavigateHome,
   onNavigateToMarketplace,
-  onNavigateToSettings,
-  onNavigateToTicker,
+  onNavigateToCustomize,
   onNavigateToAccount,
   onNavigateToSupport,
   onSelectItem,
@@ -195,6 +189,26 @@ export default function Sidebar({
         collapsed ? "w-[48px]" : "w-[200px]",
       )}
     >
+      {/* ── App destinations — Home + Customize above the sources,
+          Claude-desktop style: the rail leads with where you GO, then
+          lists what you FOLLOW. */}
+      <NavGroup ariaLabel="App" heading="" collapsed={collapsed}>
+        <NavItem
+          icon={<Home size={15} />}
+          label="Home"
+          active={isFeed}
+          collapsed={collapsed}
+          onClick={onNavigateHome}
+        />
+        <NavItem
+          icon={<SlidersHorizontal size={15} />}
+          label="Customize"
+          active={isCustomize}
+          collapsed={collapsed}
+          onClick={onNavigateToCustomize}
+        />
+      </NavGroup>
+
       {/* ── Sources ─────────────────────────────────────────────
           The user's enabled channels and widgets in canonical
           order. Scrollable when long. */}
@@ -204,16 +218,6 @@ export default function Sidebar({
         collapsed={collapsed}
         className="flex-1 overflow-y-auto scrollbar-thin"
       >
-        {/* Home — pinned above the user's sources so the rail always
-            has an anchor, even with zero sources. */}
-        <NavItem
-          icon={<Home size={15} />}
-          label="Home"
-          active={isFeed}
-          collapsed={collapsed}
-          onClick={onNavigateHome}
-        />
-
         {sources.map((source) => (
           <NavItem
             key={source.id}
@@ -242,9 +246,8 @@ export default function Sidebar({
 
       {/* ── Workspace ─────────────────────────────────────────── */}
       {/* ── Footer: account chip + collapse ─────────────────────
-          Everything app-level (Settings, Ticker, Account, Support)
-          lives behind one chip menu — the sidebar's rows stay
-          reserved for sources. */}
+          Account + Support live behind one chip menu — Customize is
+          a top-level rail item, and the sources own the rows. */}
       <div
         className={clsx(
           "shrink-0 py-2",
@@ -260,23 +263,10 @@ export default function Sidebar({
             <AccountChip
               collapsed={collapsed}
               tierLabel={TIER_LABELS[tier]}
-              active={isSettings || isTicker || isAccount || isSupport}
+              active={isAccount || isSupport}
             />
           }
           items={[
-            {
-              key: "settings",
-              label: "Settings",
-              icon: Settings,
-              onSelect: onNavigateToSettings,
-            },
-            {
-              key: "ticker",
-              label: "Ticker",
-              icon: RadioTower,
-              onSelect: onNavigateToTicker,
-            },
-            { key: "d1", divider: true },
             {
               key: "account",
               label: "Account",
@@ -384,7 +374,7 @@ function NavGroup({
         className,
       )}
     >
-      {!collapsed && (
+      {!collapsed && heading && (
         <h2 className="px-2.5 mb-1 text-ui-section">{heading}</h2>
       )}
       {children}
@@ -553,7 +543,7 @@ function SlotChip({
 }
 
 // ── Account chip ────────────────────────────────────────────────
-// Footer trigger for the app-level menu (Settings/Ticker/Account/
+// Footer trigger for the app-level menu (Account/
 // Support). floating-ui injects ref + aria handlers via cloneElement,
 // so this is a forwardRef-compatible button (same pattern as the
 // TopBar's MoreTabsTrigger). `active` marks that one of the menu's

--- a/desktop/src/routeTree.gen.ts
+++ b/desktop/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as StatusRouteImport } from './routes/status'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ReleasesRouteImport } from './routes/releases'
 import { Route as FeedRouteImport } from './routes/feed'
+import { Route as CustomizeRouteImport } from './routes/customize'
 import { Route as CatalogRouteImport } from './routes/catalog'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as IndexRouteImport } from './routes/index'
@@ -52,6 +53,11 @@ const FeedRoute = FeedRouteImport.update({
   path: '/feed',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CustomizeRoute = CustomizeRouteImport.update({
+  id: '/customize',
+  path: '/customize',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CatalogRoute = CatalogRouteImport.update({
   id: '/catalog',
   path: '/catalog',
@@ -87,6 +93,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/catalog': typeof CatalogRoute
+  '/customize': typeof CustomizeRoute
   '/feed': typeof FeedRoute
   '/releases': typeof ReleasesRoute
   '/settings': typeof SettingsRoute
@@ -101,6 +108,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/catalog': typeof CatalogRoute
+  '/customize': typeof CustomizeRoute
   '/feed': typeof FeedRoute
   '/releases': typeof ReleasesRoute
   '/settings': typeof SettingsRoute
@@ -116,6 +124,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/catalog': typeof CatalogRoute
+  '/customize': typeof CustomizeRoute
   '/feed': typeof FeedRoute
   '/releases': typeof ReleasesRoute
   '/settings': typeof SettingsRoute
@@ -132,6 +141,7 @@ export interface FileRouteTypes {
     | '/'
     | '/account'
     | '/catalog'
+    | '/customize'
     | '/feed'
     | '/releases'
     | '/settings'
@@ -146,6 +156,7 @@ export interface FileRouteTypes {
     | '/'
     | '/account'
     | '/catalog'
+    | '/customize'
     | '/feed'
     | '/releases'
     | '/settings'
@@ -160,6 +171,7 @@ export interface FileRouteTypes {
     | '/'
     | '/account'
     | '/catalog'
+    | '/customize'
     | '/feed'
     | '/releases'
     | '/settings'
@@ -175,6 +187,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AccountRoute: typeof AccountRoute
   CatalogRoute: typeof CatalogRoute
+  CustomizeRoute: typeof CustomizeRoute
   FeedRoute: typeof FeedRoute
   ReleasesRoute: typeof ReleasesRoute
   SettingsRoute: typeof SettingsRoute
@@ -230,6 +243,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FeedRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/customize': {
+      id: '/customize'
+      path: '/customize'
+      fullPath: '/customize'
+      preLoaderRoute: typeof CustomizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/catalog': {
       id: '/catalog'
       path: '/catalog'
@@ -279,6 +299,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AccountRoute: AccountRoute,
   CatalogRoute: CatalogRoute,
+  CustomizeRoute: CustomizeRoute,
   FeedRoute: FeedRoute,
   ReleasesRoute: ReleasesRoute,
   SettingsRoute: SettingsRoute,

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -118,56 +118,49 @@ function parseRoute(pathname: string) {
     return {
       activeItem: "",
       isChannel: false, isWidget: false, isFeed: true,
-      isSettings: false, isTicker: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
+      isCustomize: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
     };
   }
   if (kind === "channel" && itemId) {
     return {
       activeItem: itemId,
       isChannel: true, isWidget: false, isFeed: false,
-      isSettings: false, isTicker: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
+      isCustomize: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
     };
   }
   if (kind === "widget" && itemId) {
     return {
       activeItem: itemId,
       isChannel: false, isWidget: true, isFeed: false,
-      isSettings: false, isTicker: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
+      isCustomize: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
     };
   }
   if (kind === "catalog") {
     return {
       activeItem: "",
       isChannel: false, isWidget: false, isFeed: false,
-      isSettings: false, isTicker: false, isAccount: false, isMarketplace: true, isSupport: false, isReleases: false, isStatus: false,
+      isCustomize: false, isAccount: false, isMarketplace: true, isSupport: false, isReleases: false, isStatus: false,
     };
   }
-  if (kind === "settings") {
+  if (kind === "customize") {
     return {
-      activeItem: "settings",
+      activeItem: "customize",
       isChannel: false, isWidget: false, isFeed: false,
-      isSettings: true, isTicker: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
-    };
-  }
-  if (kind === "ticker") {
-    return {
-      activeItem: "ticker",
-      isChannel: false, isWidget: false, isFeed: false,
-      isSettings: false, isTicker: true, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
+      isCustomize: true, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
     };
   }
   if (kind === "account") {
     return {
       activeItem: "account",
       isChannel: false, isWidget: false, isFeed: false,
-      isSettings: false, isTicker: false, isAccount: true, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
+      isCustomize: false, isAccount: true, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
     };
   }
   if (kind === "support") {
     return {
       activeItem: "",
       isChannel: false, isWidget: false, isFeed: false,
-      isSettings: false, isTicker: false, isAccount: false, isMarketplace: false, isSupport: true, isReleases: false, isStatus: false,
+      isCustomize: false, isAccount: false, isMarketplace: false, isSupport: true, isReleases: false, isStatus: false,
     };
   }
   // Releases and status need their own branches: the fallback below
@@ -176,20 +169,20 @@ function parseRoute(pathname: string) {
     return {
       activeItem: "",
       isChannel: false, isWidget: false, isFeed: false,
-      isSettings: false, isTicker: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: true, isStatus: false,
+      isCustomize: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: true, isStatus: false,
     };
   }
   if (kind === "status") {
     return {
       activeItem: "",
       isChannel: false, isWidget: false, isFeed: false,
-      isSettings: false, isTicker: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: true,
+      isCustomize: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: true,
     };
   }
   return {
     activeItem: "",
     isChannel: false, isWidget: false, isFeed: true,
-    isSettings: false, isTicker: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
+    isCustomize: false, isAccount: false, isMarketplace: false, isSupport: false, isReleases: false, isStatus: false,
   };
 }
 
@@ -555,7 +548,7 @@ function RootLayout() {
   const handleSelectItem = useCallback(
     (id: string) => {
       if (id === "settings") {
-        navigate({ to: "/settings" });
+        navigate({ to: "/customize", search: { tab: "app" } });
         return;
       }
       if (channelsRef.current.some((ch) => ch.channel_type === id)) {
@@ -574,8 +567,7 @@ function RootLayout() {
   const handleNavigateToFeed = useCallback(() => navigate({ to: "/feed" }), [navigate]);
   const handleNavigateToReleases = useCallback(() => navigate({ to: "/releases" }), [navigate]);
   const handleNavigateToStatus = useCallback(() => navigate({ to: "/status" }), [navigate]);
-  const handleNavigateToSettings = useCallback(() => navigate({ to: "/settings" }), [navigate]);
-  const handleNavigateToTicker = useCallback(() => navigate({ to: "/ticker" }), [navigate]);
+  const handleNavigateToCustomize = useCallback(() => navigate({ to: "/customize" }), [navigate]);
   const handleNavigateToAccount = useCallback(() => navigate({ to: "/account" }), [navigate]);
   const handleNavigateToMarketplace = useCallback(() => navigate({ to: "/catalog" }), [navigate]);
   const handleNavigateToSupport = useCallback(() => navigate({ to: "/support" }), [navigate]);
@@ -717,7 +709,7 @@ function RootLayout() {
       // Ctrl+, → open settings
       if ((e.ctrlKey || e.metaKey) && e.key === ",") {
         e.preventDefault();
-        navigate({ to: "/settings" });
+        navigate({ to: "/customize", search: { tab: "app" } });
         return;
       }
 
@@ -771,7 +763,7 @@ function RootLayout() {
           navigate({ to: "/feed" });
           return;
         }
-        if (route.isSettings) {
+        if (route.isCustomize) {
           navigate({ to: "/feed" });
         }
       }
@@ -905,8 +897,7 @@ function RootLayout() {
               symmetric gap-1.5 read as lopsided padding around both). */}
           <div className="flex flex-1 min-h-0 overflow-hidden pr-1.5 pb-1.5">
             <Sidebar
-              isSettings={route.isSettings}
-              isTicker={route.isTicker}
+              isCustomize={route.isCustomize}
               isAccount={route.isAccount}
               isMarketplace={route.isMarketplace}
               isSupport={route.isSupport}
@@ -916,8 +907,7 @@ function RootLayout() {
               sources={sidebarSources}
               onNavigateHome={handleNavigateToFeed}
               onNavigateToMarketplace={handleNavigateToMarketplace}
-              onNavigateToSettings={handleNavigateToSettings}
-              onNavigateToTicker={handleNavigateToTicker}
+              onNavigateToCustomize={handleNavigateToCustomize}
               onNavigateToAccount={handleNavigateToAccount}
               onNavigateToSupport={handleNavigateToSupport}
               onSelectItem={handleSelectPinned}
@@ -935,7 +925,8 @@ function RootLayout() {
                  route.isChannel ||
                  route.isWidget ||
                  route.isFeed ||
-                 route.isMarketplace
+                 route.isMarketplace ||
+                 route.isCustomize
                }
              >
               <ConnectionBanner deliveryMode={deliveryMode} />

--- a/desktop/src/routes/customize.tsx
+++ b/desktop/src/routes/customize.tsx
@@ -1,0 +1,91 @@
+/**
+ * Customize route — every surface-level presentation control in one
+ * place (REL-44). Completes the REL-41 principle: content is
+ * widget-level (each widget's bar), presentation is surface-level
+ * (here). Two sections behind the standard WCB Segmented:
+ *
+ *   Ticker — the row-layout manager (the old /ticker page)
+ *   App    — appearance, window, startup, updates, about (the old
+ *            /settings page)
+ *
+ * Account stays its own page: it's identity, not presentation.
+ * /settings and /ticker redirect here (tab preselected).
+ */
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import RouteError from "../components/RouteError";
+import PageLayout from "../components/layout/PageLayout";
+import { WidgetBar } from "../components/widget-bar/Bar";
+import {
+  Segmented,
+  type SegmentedOption,
+} from "../components/widget-bar/Segmented";
+import TickerSettings from "../components/settings/TickerSettings";
+import GeneralSettings from "../components/settings/GeneralSettings";
+import { useShell } from "../shell-context";
+import { resetCategory, type AppPreferences } from "../preferences";
+
+type CustomizeTab = "ticker" | "app";
+
+const TAB_OPTIONS: SegmentedOption<CustomizeTab>[] = [
+  { value: "ticker", label: "Ticker" },
+  { value: "app", label: "App" },
+];
+
+export const Route = createFileRoute("/customize")({
+  component: CustomizeRoute,
+  errorComponent: RouteError,
+  validateSearch: (search: Record<string, unknown>): { tab?: CustomizeTab } =>
+    search.tab === "app" || search.tab === "ticker"
+      ? { tab: search.tab }
+      : {},
+});
+
+function CustomizeRoute() {
+  const shell = useShell();
+  const { prefs, onPrefsChange } = shell;
+  const { tab: initialTab } = Route.useSearch();
+  const [tab, setTab] = useState<CustomizeTab>(initialTab ?? "ticker");
+
+  return (
+    <PageLayout title="Customize" width="wide" stableChrome>
+      {/* Same WCB chrome as every other page — the Segmented is the
+          section switch. */}
+      <WidgetBar>
+        <Segmented
+          ariaLabel="Customize section"
+          value={tab}
+          onChange={setTab}
+          options={TAB_OPTIONS}
+        />
+      </WidgetBar>
+
+      <div className="pt-4">
+        {tab === "ticker" ? (
+          <TickerSettings prefs={prefs} onPrefsChange={onPrefsChange} />
+        ) : (
+          <GeneralSettings
+            appearance={prefs.appearance}
+            window_={prefs.window}
+            startup={prefs.startup}
+            onAppearanceChange={(appearance) =>
+              onPrefsChange({ ...prefs, appearance })
+            }
+            onWindowChange={(window_) =>
+              onPrefsChange({ ...prefs, window: window_ })
+            }
+            onStartupChange={(startup) => onPrefsChange({ ...prefs, startup })}
+            onReset={() => {
+              let next: AppPreferences = resetCategory(prefs, "appearance");
+              next = resetCategory(next, "window");
+              onPrefsChange(next);
+            }}
+            autostartEnabled={shell.autostartEnabled}
+            onAutostartChange={shell.onAutostartChange}
+            appVersion={shell.appVersion}
+          />
+        )}
+      </div>
+    </PageLayout>
+  );
+}

--- a/desktop/src/routes/customize.tsx
+++ b/desktop/src/routes/customize.tsx
@@ -12,7 +12,7 @@
  * /settings and /ticker redirect here (tab preselected).
  */
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import RouteError from "../components/RouteError";
 import PageLayout from "../components/layout/PageLayout";
 import { WidgetBar } from "../components/widget-bar/Bar";
@@ -44,8 +44,14 @@ export const Route = createFileRoute("/customize")({
 function CustomizeRoute() {
   const shell = useShell();
   const { prefs, onPrefsChange } = shell;
-  const { tab: initialTab } = Route.useSearch();
-  const [tab, setTab] = useState<CustomizeTab>(initialTab ?? "ticker");
+  const { tab: searchTab } = Route.useSearch();
+  const [tab, setTab] = useState<CustomizeTab>(searchTab ?? "ticker");
+  // Search-only navigations don't remount the component — without this,
+  // Ctrl+, / the tray Settings item / the /settings shim are no-ops when
+  // the user is already sitting on /customize.
+  useEffect(() => {
+    if (searchTab) setTab(searchTab);
+  }, [searchTab]);
 
   return (
     <PageLayout title="Customize" width="wide" stableChrome>

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -142,7 +142,7 @@ function HomePage() {
   );
 
   const openTickerSettings = useCallback(() => {
-    navigate({ to: "/ticker" });
+    navigate({ to: "/customize" });
   }, [navigate]);
 
   // Resolve each enabled channel row to a render manifest — the coarse source's

--- a/desktop/src/routes/settings.tsx
+++ b/desktop/src/routes/settings.tsx
@@ -1,57 +1,12 @@
 /**
- * Settings route — flat app settings page.
- *
- * Ticker and Account now live as top-level sidebar destinations; this
- * route owns only appearance, window, startup, shortcuts, updates, and
- * about settings.
+ * Settings route — redirect shim. The page merged into /customize
+ * (App tab) in REL-44; the path survives for stored lastRoute values,
+ * old deep links, and muscle memory.
  */
-import { createFileRoute } from "@tanstack/react-router";
-import RouteError from "../components/RouteError";
-import { useShell } from "../shell-context";
-import GeneralSettings from "../components/settings/GeneralSettings";
-import PageLayout from "../components/layout/PageLayout";
-import { resetCategory, type AppPreferences } from "../preferences";
-
-// ── Route ───────────────────────────────────────────────────────
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/settings")({
-  component: SettingsRoute,
-  errorComponent: RouteError,
+  beforeLoad: () => {
+    throw redirect({ to: "/customize", search: { tab: "app" } });
+  },
 });
-
-// ── Component ───────────────────────────────────────────────────
-
-function SettingsRoute() {
-  const shell = useShell();
-  const { prefs, onPrefsChange } = shell;
-
-  return (
-    <PageLayout
-      title="Settings"
-      width="wide"
-    >
-      <GeneralSettings
-        appearance={prefs.appearance}
-        window_={prefs.window}
-        startup={prefs.startup}
-        onAppearanceChange={(appearance) =>
-          onPrefsChange({ ...prefs, appearance })
-        }
-        onWindowChange={(window_) =>
-          onPrefsChange({ ...prefs, window: window_ })
-        }
-        onStartupChange={(startup) =>
-          onPrefsChange({ ...prefs, startup })
-        }
-        onReset={() => {
-          let next: AppPreferences = resetCategory(prefs, "appearance");
-          next = resetCategory(next, "window");
-          onPrefsChange(next);
-        }}
-        autostartEnabled={shell.autostartEnabled}
-        onAutostartChange={shell.onAutostartChange}
-        appVersion={shell.appVersion}
-      />
-    </PageLayout>
-  );
-}

--- a/desktop/src/routes/ticker.tsx
+++ b/desktop/src/routes/ticker.tsx
@@ -1,20 +1,12 @@
-import { createFileRoute } from "@tanstack/react-router";
-import RouteError from "../components/RouteError";
-import PageLayout from "../components/layout/PageLayout";
-import TickerSettings from "../components/settings/TickerSettings";
-import { useShell } from "../shell-context";
+/**
+ * Ticker route — redirect shim. The page merged into /customize
+ * (Ticker tab, the default) in REL-44; the path survives for stored
+ * lastRoute values, tray/ticker-window deep links, and muscle memory.
+ */
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/ticker")({
-  component: TickerRoute,
-  errorComponent: RouteError,
+  beforeLoad: () => {
+    throw redirect({ to: "/customize" });
+  },
 });
-
-function TickerRoute() {
-  const { prefs, onPrefsChange } = useShell();
-
-  return (
-    <PageLayout title="Ticker" width="wide">
-      <TickerSettings prefs={prefs} onPrefsChange={onPrefsChange} />
-    </PageLayout>
-  );
-}


### PR DESCRIPTION
## Summary

Part 11 — **stacked on #242**; merge last. Implements the Claude-desktop-style IA the user asked for, and completes the REL-41 settings principle.

### Sidebar

The rail now leads with where you GO, then what you FOLLOW:
- **Home** and a new **Customize** item are top-level destinations above the Sources group (Home moves out of it).
- The footer account chip slims to **Account + Support** — Settings and Ticker entries are gone (their pages merged).

### /customize

One page for every surface-level presentation control, in standard WCB chrome (Segmented sections, persistent chassis, stableChrome transitions):
- **Ticker** (default): the row-layout manager — the old /ticker page.
- **App**: appearance, window, startup, updates, about — the old /settings page.

Account stays its own page: identity, not presentation. "Content is widget-level, presentation is surface-level" now has exactly two homes: each widget's bar, and Customize.

### Compatibility

`/settings` and `/ticker` are redirect shims (settings preselects the App tab) — stored `lastRoute` values, the ticker window's `scrollr:navigate` deep-link, and old muscle memory all keep working. `parseRoute`'s `isSettings`/`isTicker` collapse into `isCustomize`.

## Verification

tsc clean · vitest 495/495 (Sidebar tests updated for the new props). Tauri-only surface — manual smoke: sidebar order (Home, Customize, then Sources), both Customize tabs render and write, `/ticker` deep-link from the ticker window lands on Customize→Ticker, boot with lastRoute=/settings lands on Customize→App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)