### PR TITLE
In-widget config PR 12: widget normalization + Support WCB + consistency pass [REL-49]

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.20",
+  "version": "1.1.8",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4621,7 +4621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.8"
+version = "1.1.9"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -496,7 +496,7 @@ export default function App() {
    */
   const handleOpenChannel = useCallback(
     (channelId: string) => {
-      navigateMainWindow(`/channel/${channelId}/feed`);
+      navigateMainWindow(`/widget/${channelId}`);
     },
     [navigateMainWindow],
   );

--- a/desktop/src/channels/finance/FeedTab.tsx
+++ b/desktop/src/channels/finance/FeedTab.tsx
@@ -726,14 +726,27 @@ const TradeItem = memo(function TradeItem({ trade, mode, display, category, now 
       className={clsx(
         FEED_CARD,
         FEED_CARD_INTERACTIVE,
-        "flex items-center justify-between border-l-2",
-        flash === "up" && "bg-up/6",
-        flash === "down" && "bg-down/6",
+        "relative flex items-center justify-between overflow-hidden border-l-2",
         isUp && "border-l-up/40",
         isDown && "border-l-down/40",
         !isUp && !isDown && "border-l-transparent",
       )}
     >
+      {/* Price-flash tint on its OWN overlay: the slow 700ms fade the
+          cards had pre-unification, decoupled from the shell's 150ms
+          hover transition (a bg class on the card also fought
+          FEED_CARD's bg utility on stylesheet order). */}
+      <span
+        aria-hidden
+        className={clsx(
+          "pointer-events-none absolute inset-0 transition-colors duration-700",
+          flash === "up"
+            ? "bg-up/6"
+            : flash === "down"
+              ? "bg-down/6"
+              : "bg-transparent",
+        )}
+      />
       <div className="flex flex-col gap-0.5">
         <span className="font-mono font-bold text-sm text-fg tracking-wide">
           {trade.symbol}

--- a/desktop/src/channels/sports/GameItem.tsx
+++ b/desktop/src/channels/sports/GameItem.tsx
@@ -148,6 +148,7 @@ export const GameItem = memo(function GameItem({
       className={clsx(
         FEED_CARD,
         hasLink ? FEED_CARD_INTERACTIVE : FEED_CARD_STATIC,
+        "relative overflow-hidden",
         // Accent border layered on the shell: favorite+live > live > favorite
         isFavorite && live
           ? "border-l-2 border-l-[#f97316]/60"
@@ -156,9 +157,19 @@ export const GameItem = memo(function GameItem({
             : isFavorite
               ? "border-l-2 border-l-[#f97316]/30"
               : null,
-        flash && "bg-live/8",
       )}
     >
+      {/* Score-flash tint on its OWN overlay: the slow 700ms fade the
+          cards had pre-unification, decoupled from the shell's 150ms
+          hover transition (a bg class on the card also fought
+          FEED_CARD's bg utility on stylesheet order). */}
+      <span
+        aria-hidden
+        className={clsx(
+          "pointer-events-none absolute inset-0 transition-colors duration-700",
+          flash ? "bg-live/8" : "bg-transparent",
+        )}
+      />
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {showLogos && (

--- a/desktop/src/components/EmptyChannelState.tsx
+++ b/desktop/src/components/EmptyChannelState.tsx
@@ -87,8 +87,8 @@ export default function EmptyChannelState({
             widget.
           </p>
           <p className="text-[11px] text-fg-4/70 text-center max-w-sm leading-relaxed">
-            Looking for a different source? Use{" "}
-            <span className="text-fg-3 font-semibold">+ Add source</span> in the
+            Looking for a different widget? Use{" "}
+            <span className="text-fg-3 font-semibold">+ Add widget</span> in the
             sidebar to browse the catalog.
           </p>
         </>

--- a/desktop/src/components/OverflowMenu.tsx
+++ b/desktop/src/components/OverflowMenu.tsx
@@ -159,7 +159,7 @@ export default function OverflowMenu({
       aria-haspopup="menu"
       aria-expanded={isOpen}
       className={clsx(
-        "flex items-center gap-1.5 h-7 px-2 rounded-md text-[11px] font-medium transition-colors",
+        "flex items-center gap-1.5 h-7 px-2 rounded-md text-ui-chip font-medium transition-colors",
         isOpen
           ? "bg-accent/15 text-accent"
           : "text-fg-3 hover:text-fg hover:bg-surface-hover",
@@ -170,7 +170,7 @@ export default function OverflowMenu({
       <ChevronDown
         size={11}
         style={{
-          transition: "transform 500ms var(--ease-snap)",
+          transition: "transform 300ms var(--ease-snap)",
           transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
         }}
       />
@@ -235,7 +235,7 @@ export default function OverflowMenu({
                       },
                     })}
                     className={clsx(
-                      "flex items-center gap-2.5 w-full px-3 py-2 text-left text-[12px] transition-colors outline-none",
+                      "flex items-center gap-2.5 w-full px-3 py-2 text-left text-ui-meta transition-colors outline-none",
                       item.disabled && "opacity-40 cursor-not-allowed",
                       !item.disabled && item.destructive
                         ? isActive

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -836,29 +836,18 @@ export default function ScrollrTicker({
               })}
             </div>
           </div>
-          {/* Secondary row: teaching tip pointing at the "Options"
-              pill in the TopBar. Hidden on the compact ticker (h-11
-              ≈ 44px) because there's no room for a second line without
-              cramping; comfort mode (h-16 ≈ 64px) has plenty. The
-              equivalent tip is also shown on every channel's empty
-              feed (see EmptyChannelState.tsx), so users still discover
-              the pill there even when this row is suppressed. */}
+          {/* Secondary row: teaching tip pointing at the widget's own
+              top bar (the one settings surface). Hidden on the compact
+              ticker (h-11 ≈ 44px) because there's no room for a second
+              line without cramping; comfort mode (h-16 ≈ 64px) has
+              plenty. */}
           {comfort && (
             <p className="text-[10px] text-fg-4/80 shrink-0 leading-tight hidden md:inline-flex items-center gap-1">
               <span className="text-fg-4">Tip:</span>
-              <span>open a source and click</span>
-              <span
-                className={clsx(
-                  "inline-flex items-center gap-1 align-baseline",
-                  "px-1 py-px rounded",
-                  "bg-fg-4/10 text-fg-2 font-semibold",
-                )}
-              >
-                <Settings2 size={8} strokeWidth={2.5} aria-hidden="true" />
-                Options
-                <ChevronDown size={8} strokeWidth={2.5} aria-hidden="true" />
+              <span>
+                every widget&rsquo;s settings live in the bar at the top of
+                its page.
               </span>
-              <span>in the title bar to do this yourself next time.</span>
             </p>
           )}
         </div>
@@ -871,7 +860,7 @@ export default function ScrollrTicker({
       <div className={containerClass}>
         <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-primary/20 to-transparent z-10" />
         <div className="flex items-center justify-center w-full h-full px-4 text-ui-meta font-mono text-fg-3">
-          <span>This row has no sources to show. Edit it in Settings &rarr; Ticker.</span>
+          <span>This row has no widgets to show. Edit it in Customize &rarr; Ticker.</span>
         </div>
       </div>
     );

--- a/desktop/src/components/Sidebar.test.tsx
+++ b/desktop/src/components/Sidebar.test.tsx
@@ -53,7 +53,7 @@ describe("Sidebar slot chip", () => {
     renderSidebar({ tier: "free", sourceCount: 2 });
     expect(
       screen.getByRole("button", {
-        name: "2 of 3 slots used — add a source",
+        name: "2 of 3 slots used — add a widget",
       }),
     ).toBeInTheDocument();
   });
@@ -70,7 +70,7 @@ describe("Sidebar slot chip", () => {
   it("shows a plain add affordance on unlimited tiers", () => {
     renderSidebar({ tier: "uplink_ultimate", sourceCount: 5 });
     expect(
-      screen.getByRole("button", { name: "Add a source" }),
+      screen.getByRole("button", { name: "Add a widget" }),
     ).toBeInTheDocument();
   });
 
@@ -81,7 +81,7 @@ describe("Sidebar slot chip", () => {
     });
     fireEvent.click(
       screen.getByRole("button", {
-        name: "2 of 3 slots used — add a source",
+        name: "2 of 3 slots used — add a widget",
       }),
     );
     expect(onNavigateToMarketplace).toHaveBeenCalledOnce();
@@ -90,7 +90,7 @@ describe("Sidebar slot chip", () => {
   it("renders exactly one add affordance (no ghost rows, no top CTA)", () => {
     renderSidebar({ tier: "free", sourceCount: 1 });
     const addButtons = screen.queryAllByRole("button", {
-      name: /add a source|add source|empty slot/i,
+      name: /add a widget|add source|empty slot/i,
     });
     expect(addButtons).toHaveLength(1);
   });

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -207,14 +207,23 @@ export default function Sidebar({
           collapsed={collapsed}
           onClick={onNavigateToCustomize}
         />
+        {/* Add-widget affordance rides with the app destinations —
+            adding is something you DO, not something you follow. */}
+        <SlotChip
+          collapsed={collapsed}
+          used={sources.length}
+          cap={slotCap}
+          active={isMarketplace}
+          onClick={onNavigateToMarketplace}
+        />
       </NavGroup>
 
       {/* ── Sources ─────────────────────────────────────────────
           The user's enabled channels and widgets in canonical
           order. Scrollable when long. */}
       <NavGroup
-        ariaLabel="Sources"
-        heading="Sources"
+        ariaLabel="Widgets"
+        heading="Widgets"
         collapsed={collapsed}
         className="flex-1 overflow-y-auto scrollbar-thin"
       >
@@ -233,15 +242,6 @@ export default function Sidebar({
           />
         ))}
 
-        {/* Slot chip — the single add-source affordance, with the
-            cap woven in (status + action in one control). */}
-        <SlotChip
-          collapsed={collapsed}
-          used={sources.length}
-          cap={slotCap}
-          active={isMarketplace}
-          onClick={onNavigateToMarketplace}
-        />
       </NavGroup>
 
       {/* ── Workspace ─────────────────────────────────────────── */}
@@ -472,10 +472,10 @@ function SlotChip({
   const showDots = collapsed && finite && cap <= 6;
 
   const label = !finite
-    ? "Add a source"
+    ? "Add a widget"
     : atCap
       ? `All ${cap} slots used — get more slots`
-      : `${used} of ${cap} slots used — add a source`;
+      : `${used} of ${cap} slots used — add a widget`;
 
   return (
     <Tooltip content={collapsed ? label : undefined} side="right">
@@ -528,7 +528,7 @@ function SlotChip({
         {!collapsed && (
           <>
             <span className="relative z-10 truncate">
-              {atCap ? "Get more slots" : "Add source"}
+              {atCap ? "Get more slots" : "Add widget"}
             </span>
             {finite && (
               <span className="relative z-10 ml-auto shrink-0 text-ui-meta text-fg-4">

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -592,7 +592,7 @@ const AccountChip = forwardRef(function AccountChip(
       <span
         className={clsx(
           "shrink-0 flex items-center justify-center rounded-full",
-          "bg-accent/15 text-accent text-[11px] font-semibold",
+          "bg-accent/15 text-accent text-ui-chip font-semibold",
           collapsed ? "w-6 h-6" : "w-7 h-7",
         )}
       >

--- a/desktop/src/components/TickerLayoutSummary.tsx
+++ b/desktop/src/components/TickerLayoutSummary.tsx
@@ -91,12 +91,12 @@ export default function TickerLayoutSummary({
 
         <div className="flex-1" />
 
-        <Tooltip content="Open the full ticker editor in Settings" side="top">
+        <Tooltip content="Open the full ticker editor in Customize" side="top">
           <button
             type="button"
             onClick={onOpenSettings}
             className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-ui-meta font-medium text-fg-3 hover:text-accent transition-colors"
-            aria-label="Open the full ticker layout editor in Settings"
+            aria-label="Open the full ticker layout editor in Customize"
           >
             <SettingsIcon size={11} />
             Manage

--- a/desktop/src/components/TickerLayoutSummary.tsx
+++ b/desktop/src/components/TickerLayoutSummary.tsx
@@ -17,7 +17,6 @@
  *   does not mutate ticker layout; Settings → Ticker is the sole editor.
  */
 import { Settings as SettingsIcon } from "lucide-react";
-import clsx from "clsx";
 import Tooltip from "./Tooltip";
 import type { TickerRowConfig } from "../preferences";
 import type { ChannelManifest, WidgetManifest } from "../types";
@@ -148,7 +147,7 @@ export default function TickerLayoutSummary({
           cap is below the absolute max. If they're on Pro/Ultimate at 3
           rows, no hint (they've already maxed out). */}
       {atTierCap && (
-        <p className={clsx("mt-2 text-ui-chip font-mono text-fg-3")}>
+        <p className="mt-2 text-ui-chip font-mono text-fg-3">
           {tierMaxRows === 1
             ? "Upgrade to Uplink for a second ticker row."
             : "Upgrade to Uplink Pro for a third ticker row."}

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -28,7 +28,7 @@ import ConnectionIndicator from "./ConnectionIndicator";
 import ScrollLogo from "./ScrollLogo";
 import OverflowMenu from "./OverflowMenu";
 import type { OverflowMenuItem } from "./OverflowMenu";
-import { usePageIdentity, type PageTabStrip } from "./layout/page-context";
+import { usePageIdentity } from "./layout/page-context";
 import type { DeliveryHealth } from "../hooks/useDeliveryHealth";
 
 // ── Props ───────────────────────────────────────────────────────
@@ -192,10 +192,9 @@ export default function TopBar({
                 </span>
               )}
 
-              {/* Subtitle slot — suppressed when tab pills are
-                  showing (the active pill is the subtitle). */}
+              {/* Subtitle slot. */}
               <AnimatePresence mode="popLayout" initial={false}>
-                {page.subtitle && !page.tabs && (
+                {page.subtitle && (
                   <motion.div
                     key={page.subtitle}
                     initial={{ opacity: 0, x: -6, filter: "blur(2px)" }}
@@ -215,18 +214,10 @@ export default function TopBar({
               </AnimatePresence>
             </div>
 
-            {/* Inline tab strip — sibling navigation as a segmented
-                pill control. Renders only when the page publishes
-                `tabs`. The strip itself takes flex-1 so it owns all
-                available space (which is also what the adaptive
-                overflow measurement needs to decide how many pills
-                fit). When there are no tabs, an empty spacer fills
-                the gap so Options pins to the right edge. */}
-            {page.tabs ? (
-              <InlineTabStrip tabs={page.tabs} />
-            ) : (
-              <div className="flex-1 min-w-0" aria-hidden />
-            )}
+            {/* Spacer — sibling navigation lives in each page's WCB
+                Segmented now (the TopBar tab strip died with its last
+                consumer, Support, in REL-49). Options pins right. */}
+            <div className="flex-1 min-w-0" aria-hidden />
 
             {/* "Options" pill — the sole trigger for page-level menus. */}
             {page.menuItems?.length ? (
@@ -291,240 +282,4 @@ export default function TopBar({
     </div>
   );
 }
-
-// ── Inline tab strip ─────────────────────────────────────────────
-//
-// Compact segmented pill control that lives inline in the TopBar to
-// expose sibling-tab navigation (Settings: Appearance/Ticker/Account,
-// Catalog: All/Channels/Widgets, Support sections, etc.). Replaces the
-// full-width content-area tab band that wasted vertical space.
-//
-// Adaptive overflow: when the available width can't fit every pill,
-// the tail collapses into a "More ▾" menu. The active tab is always
-// kept visible — if it would be in the overflow slice, earlier tabs
-// are pushed into overflow instead so users always see where they
-// currently are.
-//
-// Measurement uses an off-screen ghost row to learn each pill's
-// natural width, then walks the list deciding what fits. A
-// ResizeObserver on the container re-runs the calculation when the
-// window or the breadcrumb width changes.
-
-function InlineTabStrip({ tabs }: { tabs: PageTabStrip }) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const ghostRef = useRef<HTMLDivElement | null>(null);
-
-  // Number of leading items currently rendered inline. The rest go
-  // into the overflow menu. Starts at items.length so the first
-  // render shows every pill; ResizeObserver immediately corrects it
-  // if there isn't enough room.
-  const [visibleCount, setVisibleCount] = useState(tabs.items.length);
-
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    const ghost = ghostRef.current;
-    if (!container || !ghost) return;
-
-    const recompute = () => {
-      const available = container.clientWidth;
-      if (available <= 0) return;
-
-      // Measure each ghost pill + the ghost "More" trigger.
-      const pillNodes = Array.from(
-        ghost.querySelectorAll<HTMLElement>("[data-pill-index]"),
-      );
-      const widths = pillNodes.map((n) => n.offsetWidth);
-      const moreNode = ghost.querySelector<HTMLElement>("[data-pill-more]");
-      const moreWidth = moreNode?.offsetWidth ?? 0;
-
-      // Gap between pills in the rendered strip (gap-0.5 = 2px).
-      const gap = 2;
-
-      // First, can everything fit without "More"?
-      const total = widths.reduce(
-        (sum, w, i) => sum + w + (i > 0 ? gap : 0),
-        0,
-      );
-      if (total <= available) {
-        setVisibleCount(widths.length);
-        return;
-      }
-
-      // Otherwise reserve room for the "More" trigger and pack from
-      // the left until the next pill won't fit.
-      let used = moreWidth + gap;
-      let fit = 0;
-      for (let i = 0; i < widths.length; i++) {
-        const next = widths[i] + (fit > 0 ? gap : 0);
-        if (used + next > available) break;
-        used += next;
-        fit += 1;
-      }
-
-      // Guarantee at least one inline pill so the strip never
-      // collapses entirely (the More menu would still work, but the
-      // user loses the visual anchor).
-      setVisibleCount(Math.max(1, fit));
-    };
-
-    recompute();
-    const ro = new ResizeObserver(recompute);
-    ro.observe(container);
-    return () => ro.disconnect();
-  }, [tabs.items]);
-
-  // If the active tab would land in the overflow slice, shift the
-  // visible window so it stays in view. We do this by re-ordering:
-  // the displayed pills are the first `visibleCount` items, BUT we
-  // swap the active tab into that slice if it isn't there.
-  const activeIndex = tabs.items.findIndex((t) => t.key === tabs.activeKey);
-  const inlineSet = (() => {
-    const visible = tabs.items.slice(0, visibleCount);
-    if (activeIndex < 0 || activeIndex < visibleCount) {
-      return { visible, overflow: tabs.items.slice(visibleCount) };
-    }
-    // Active is in overflow — swap it with the last visible slot so
-    // the active pill is always rendered inline.
-    const swapped = visible.slice(0, -1);
-    swapped.push(tabs.items[activeIndex]);
-    const overflow = tabs.items.filter((t) => !swapped.includes(t));
-    return { visible: swapped, overflow };
-  })();
-
-  const overflowMenuItems: OverflowMenuItem[] = inlineSet.overflow.map((t) => ({
-    key: t.key,
-    label: t.label,
-    hint: t.description,
-    onSelect: () => tabs.onChange(t.key),
-  }));
-
-  return (
-    <div
-      ref={containerRef}
-      className="relative flex items-center min-w-0 flex-1"
-    >
-      {/* Visible strip. */}
-      <nav
-        aria-label={tabs.ariaLabel ?? "Page sections"}
-        className="flex items-center gap-0.5 h-7 px-0.5 rounded-md bg-surface-1/60 border border-edge/40 max-w-full"
-      >
-        {inlineSet.visible.map((tab) => (
-          <TabPill
-            key={tab.key}
-            label={tab.label}
-            description={tab.description}
-            isActive={tab.key === tabs.activeKey}
-            onSelect={() => tabs.onChange(tab.key)}
-          />
-        ))}
-        {inlineSet.overflow.length > 0 && (
-          <OverflowMenu
-            items={overflowMenuItems}
-            triggerLabel="More sections"
-            trigger={<MoreTabsTrigger />}
-            placement="bottom-end"
-          />
-        )}
-      </nav>
-
-      {/* Ghost row — off-screen, used only for width measurement.
-          Mirrors the styles of the real pills + trigger so widths
-          match. aria-hidden so AT doesn't see duplicates. */}
-      <div
-        ref={ghostRef}
-        aria-hidden
-        className="absolute left-0 top-0 invisible pointer-events-none flex items-center gap-0.5 h-7 px-0.5"
-        style={{ visibility: "hidden" }}
-      >
-        {tabs.items.map((tab, i) => (
-          <span
-            key={tab.key}
-            data-pill-index={i}
-            className="relative h-6 px-2.5 rounded text-[11px] font-medium whitespace-nowrap"
-          >
-            {tab.label}
-          </span>
-        ))}
-        <span
-          data-pill-more
-          className="flex items-center gap-1 h-6 px-2 rounded text-[11px] font-medium whitespace-nowrap"
-        >
-          More
-          <ChevronDown size={11} />
-        </span>
-      </div>
-    </div>
-  );
-}
-
-// Single pill button. Extracted so the visible strip and the ghost
-// row can share the same dimensions without duplicating className.
-function TabPill({
-  label,
-  description,
-  isActive,
-  onSelect,
-}: {
-  label: string;
-  description?: string;
-  isActive: boolean;
-  onSelect: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-current={isActive ? "page" : undefined}
-      title={description}
-      className={clsx(
-        "relative h-6 px-2.5 rounded text-[11px] font-medium transition-colors whitespace-nowrap",
-        isActive ? "text-fg" : "text-fg-3 hover:text-fg-2",
-      )}
-    >
-      {isActive && (
-        <motion.span
-          layoutId="topbar-tab-active"
-          transition={{ type: "spring", stiffness: 500, damping: 38 }}
-          // z-0 + z-10 on the label: all pills and labels share one
-          // stacking context, so without explicit layers the sliding
-          // pill paints by DOM order — moving RIGHT it lives in a
-          // later button and covered earlier labels mid-flight.
-          className="absolute inset-0 z-0 rounded bg-surface-3 shadow-sm"
-        />
-      )}
-      <span className="relative z-10">{label}</span>
-    </button>
-  );
-}
-
-// "More ▾" trigger styled to match TabPill so it visually belongs to
-// the same segmented control. floating-ui injects a ref + handlers
-// via cloneElement, so this is a forwardRef-compatible button.
-const MoreTabsTrigger = forwardRef(function MoreTabsTrigger(
-  props: ButtonHTMLAttributes<HTMLButtonElement>,
-  ref: Ref<HTMLButtonElement>,
-) {
-  const isOpen =
-    props["aria-expanded"] === true || props["aria-expanded"] === "true";
-  return (
-    <button
-      ref={ref}
-      type="button"
-      {...props}
-      className={clsx(
-        "flex items-center gap-1 h-6 px-2 rounded text-[11px] font-medium transition-colors whitespace-nowrap",
-        isOpen ? "bg-surface-3 text-fg" : "text-fg-3 hover:text-fg-2",
-      )}
-    >
-      More
-      <ChevronDown
-        size={11}
-        style={{
-          transition: "transform 300ms var(--ease-snap)",
-          transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
-        }}
-      />
-    </button>
-  );
-});
 

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -200,7 +200,7 @@ export default function TopBar({
                     initial={{ opacity: 0, x: -6, filter: "blur(2px)" }}
                     animate={{ opacity: 1, x: 0, filter: "blur(0px)" }}
                     exit={{ opacity: 0, x: -6, filter: "blur(2px)" }}
-                    transition={{ duration: 0.22, ease: [0.22, 0.61, 0.36, 1] }}
+                    transition={{ duration: 0.18, ease: [0.22, 0.61, 0.36, 1] }}
                     className="flex items-center gap-1.5 min-w-0"
                   >
                     <span className="text-fg-4 shrink-0" aria-hidden>
@@ -251,7 +251,7 @@ export default function TopBar({
             aria-checked={tickerOn}
             onClick={onToggleTicker}
             className={clsx(
-              "flex items-center gap-1.5 h-7 px-2.5 rounded-md text-ui-chip font-medium transition-all duration-200 active:scale-95",
+              "flex items-center gap-1.5 h-7 px-2.5 rounded-md text-ui-chip font-medium transition-all duration-150 active:scale-95",
               tickerOn
                 ? "bg-accent/15 text-accent hover:bg-accent/20"
                 : "text-fg-4 hover:text-fg-2 hover:bg-surface-hover",

--- a/desktop/src/components/layout/PageLayout.tsx
+++ b/desktop/src/components/layout/PageLayout.tsx
@@ -18,7 +18,7 @@
 import { useLayoutEffect, useRef, type ReactNode } from "react";
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";
-import { useRegisterPageIdentity, type PageTabStrip } from "./page-context";
+import { useRegisterPageIdentity } from "./page-context";
 import type { OverflowMenuItem } from "../OverflowMenu";
 
 // ── Props ───────────────────────────────────────────────────────
@@ -50,14 +50,6 @@ interface PageLayoutProps {
    * need a raw icon button without a menu.
    */
   entityAction?: ReactNode;
-
-  /**
-   * Optional sibling-tab strip. Rendered as a compact segmented
-   * control inline in the TopBar (NOT a full-width band in the
-   * content area). Used by Settings, Catalog, and Support section
-   * views to expose sibling navigation.
-   */
-  tabs?: PageTabStrip;
 
   /** Page content. */
   children: ReactNode;
@@ -110,7 +102,6 @@ export default function PageLayout({
   menuItems,
   menuLabel,
   entityAction,
-  tabs,
   children,
   footer,
   width = "narrow",
@@ -125,7 +116,6 @@ export default function PageLayout({
     parentLabel,
     onParentClick,
     onTitleClick,
-    tabs,
     menuItems,
     menuLabel,
     entityAction,
@@ -138,7 +128,7 @@ export default function PageLayout({
   //    (subtitle changes).
   //  - Settings/Catalog/Support animate when switching tab pills
   //    (activeKey changes) even though title stays the same.
-  const contentKey = `${title}::${subtitle ?? ""}::${tabs?.activeKey ?? ""}`;
+  const contentKey = `${title}::${subtitle ?? ""}`;
 
   // Each content identity is a fresh page: reset the scroll container.
   // Without this the scroller (which persists across same-route source

--- a/desktop/src/components/layout/page-context.tsx
+++ b/desktop/src/components/layout/page-context.tsx
@@ -14,25 +14,10 @@ import { createContext, useContext, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import type { OverflowMenuItem } from "../OverflowMenu";
 
-export interface PageTabStrip {
-  /** Tab descriptors. */
-  items: Array<{
-    key: string;
-    label: string;
-    /** Optional tooltip / aria description. */
-    description?: string;
-  }>;
-  activeKey: string;
-  onChange: (key: string) => void;
-  /** Aria label for the tab strip nav. Default: "Page sections". */
-  ariaLabel?: string;
-}
-
 export interface PageIdentity {
   /** Page title, e.g. "Sports", "Settings", "Catalog". */
   title: string;
-  /** Optional 1-line subtitle / tagline. Suppressed when `tabs` is
-   *  set — the active tab pill carries the same information. */
+  /** Optional 1-line subtitle / tagline. */
   subtitle?: string;
   /**
    * For source pages, the parent breadcrumb label (e.g. "Home"). Used
@@ -49,13 +34,6 @@ export interface PageIdentity {
    * text.
    */
   onTitleClick?: () => void;
-  /**
-   * Optional sibling-tab navigation rendered inline in the TopBar as a
-   * compact segmented pill group. Used by Settings, Catalog, Support
-   * sections — anywhere a route has sibling views that should be
-   * one-click reachable.
-   */
-  tabs?: PageTabStrip;
   /**
    * Optional contextual menu items. When provided, the TopBar renders
    * an "Options" pill button after the breadcrumb. Clicking the pill
@@ -116,18 +94,12 @@ export function useRegisterPageIdentity(identity: PageIdentity) {
         )
         .join("|")
     : "";
-  const tabsKey = identity.tabs
-    ? `${identity.tabs.activeKey}::${identity.tabs.items
-        .map((t) => `${t.key}:${t.label}`)
-        .join("|")}`
-    : "";
   const key = JSON.stringify({
     title: identity.title,
     subtitle: identity.subtitle,
     parentLabel: identity.parentLabel,
     menuLabel: identity.menuLabel,
     menuKey,
-    tabsKey,
   });
   useEffect(() => {
     ctx?.setIdentity(identity);
@@ -139,6 +111,5 @@ export function useRegisterPageIdentity(identity: PageIdentity) {
     identity.onParentClick,
     identity.onTitleClick,
     identity.menuItems,
-    identity.tabs,
   ]);
 }

--- a/desktop/src/components/marketplace/CatalogCard.tsx
+++ b/desktop/src/components/marketplace/CatalogCard.tsx
@@ -39,7 +39,7 @@ export default function CatalogCard({ item, enabled, onInfo }: CatalogCardProps)
       }}
       className={clsx(
         "group/card relative flex flex-col overflow-hidden rounded-xl border border-edge/40 bg-base-150/30 p-4 cursor-pointer",
-        "transition-all duration-200 hover:-translate-y-0.5 hover:shadow-soft-sm hover:border-edge/60 hover:bg-base-150/50",
+        "transition-all duration-150 hover:-translate-y-0.5 hover:shadow-soft-sm hover:border-edge/60 hover:bg-base-150/50",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50",
         // Added cards de-emphasized so new content stays prominent.
         enabled && "opacity-80 hover:opacity-100",

--- a/desktop/src/components/settings/GeneralSettings.tsx
+++ b/desktop/src/components/settings/GeneralSettings.tsx
@@ -309,7 +309,7 @@ export default function GeneralSettings({
 // Customization is intentionally out of scope for now.
 
 const SHORTCUTS: { keys: string[]; label: string }[] = [
-  { keys: ["⌘/Ctrl", ","], label: "Open settings" },
+  { keys: ["⌘/Ctrl", ","], label: "Open Customize" },
   { keys: ["⌘/Ctrl", "T"], label: "Toggle ticker visibility" },
   { keys: ["⌘/Ctrl", "Shift", "T"], label: "Cycle theme (light → dark → auto)" },
   { keys: ["Esc"], label: "Back / close current view" },

--- a/desktop/src/components/settings/ProfileField.tsx
+++ b/desktop/src/components/settings/ProfileField.tsx
@@ -91,7 +91,7 @@ export default function ProfileField({
               if (e.key === "Enter") handleSave();
               if (e.key === "Escape") handleCancel();
             }}
-            className="flex-1 px-2.5 py-1.5 text-xs bg-base-300 border border-edge rounded-md text-fg focus:outline-none focus:border-accent/60 disabled:opacity-60"
+            className="flex-1 px-2.5 py-1.5 text-ui-meta bg-base-300 border border-edge rounded-md text-fg focus:outline-none focus:border-accent/60 disabled:opacity-60"
           />
           <button
             onClick={handleSave}
@@ -120,7 +120,7 @@ export default function ProfileField({
         </div>
       ) : (
         <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-fg-2 truncate min-w-0 flex-1">
+          <span className="text-ui-meta text-fg-2 truncate min-w-0 flex-1">
             {value || (
               <span className="italic text-fg-4">
                 {placeholder ?? "Not set"}
@@ -129,14 +129,14 @@ export default function ProfileField({
           </span>
           <button
             onClick={() => setEditing(true)}
-            className="shrink-0 flex items-center gap-1 px-2 py-1 text-[11px] font-medium text-fg-4 hover:text-fg-2 hover:bg-base-300 rounded-md transition-colors"
+            className="shrink-0 flex items-center gap-1 px-2 py-1 text-ui-chip font-medium text-fg-4 hover:text-fg-2 hover:bg-base-300 rounded-md transition-colors"
           >
             <Pencil size={10} /> Edit
           </button>
         </div>
       )}
       {error && (
-        <p className="mt-1.5 text-[11px] text-error/80 leading-snug">{error}</p>
+        <p className="mt-1.5 text-ui-chip text-error/80">{error}</p>
       )}
     </div>
   );

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -170,7 +170,7 @@ export function SegmentedRow<T extends string>({
             aria-checked={value === opt.value}
             onClick={() => onChange(opt.value)}
             className={clsx(
-              "px-2.5 py-1 text-ui-chip font-medium rounded-md transition-all duration-200 active:scale-95 cursor-pointer leading-none",
+              "px-2.5 py-1 text-ui-chip font-medium rounded-md transition-all duration-150 active:scale-95 cursor-pointer leading-none",
               value === opt.value
                 ? "bg-base-300 text-fg shadow-sm"
                 : "text-fg-3 hover:text-fg-2",
@@ -279,7 +279,7 @@ export function VenueRow({ label, description, value, onChange }: VenueRowProps)
               aria-checked={selected}
               onClick={() => onChange(opt.value)}
               className={clsx(
-                "px-2.5 py-1 text-ui-chip font-medium rounded-md transition-all duration-200 cursor-pointer leading-none",
+                "px-2.5 py-1 text-ui-chip font-medium rounded-md transition-all duration-150 cursor-pointer leading-none",
                 selected && opt.value === "off"
                   ? "bg-base-300/60 text-fg-3 shadow-sm"
                   : selected

--- a/desktop/src/components/settings/TickerSettings.tsx
+++ b/desktop/src/components/settings/TickerSettings.tsx
@@ -378,7 +378,7 @@ function RowCard({
         </div>
         {sources.length === 0 ? (
           <div className="text-ui-meta font-mono text-fg-3 py-2">
-            No sources or widgets enabled. Enable some in the main settings first.
+            No widgets added yet. Add some from the Catalog first.
           </div>
         ) : (
           <div className="grid grid-cols-2 gap-1.5">

--- a/desktop/src/components/settings/TickerSettings.tsx
+++ b/desktop/src/components/settings/TickerSettings.tsx
@@ -356,7 +356,7 @@ function RowCard({
     <div className="rounded-xl border border-edge/40 bg-surface-2/30 p-3">
       {/* Row header */}
       <div className="flex items-center justify-between mb-2">
-        <span className="text-ui-section font-mono font-semibold uppercase tracking-wider text-fg-3">
+        <span className="text-ui-section font-mono">
           Row {rowIndex + 1}
         </span>
         {canRemove && (
@@ -373,7 +373,7 @@ function RowCard({
 
       {/* Sources grid */}
       <div>
-        <div className="text-ui-section font-mono uppercase tracking-wider text-fg-3 mb-1.5">
+        <div className="text-ui-section font-mono mb-1.5">
           Sources {showingAll && <span className="text-fg-3">(all visible)</span>}
         </div>
         {sources.length === 0 ? (

--- a/desktop/src/components/support/BillingHelpSection.tsx
+++ b/desktop/src/components/support/BillingHelpSection.tsx
@@ -38,7 +38,7 @@ export default function BillingHelpSection() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       {/* Quick Actions */}
       <div className="grid grid-cols-2 gap-3">
         {/* Manage Subscription */}
@@ -46,7 +46,7 @@ export default function BillingHelpSection() {
           <button
             onClick={handleManageSubscription}
             disabled={portalLoading}
-            className="flex items-start gap-3 rounded-xl border border-edge/35 bg-base-150/35 p-4 text-left transition-colors hover:bg-base-150/55 disabled:opacity-50"
+            className="flex items-start gap-3 rounded-xl border border-edge/35 bg-base-150/35 p-4 text-left transition-colors hover:bg-base-150/55 disabled:opacity-50 cursor-pointer"
           >
             <Settings size={18} className="mt-0.5 shrink-0 text-accent" />
             <div className="min-w-0">
@@ -73,7 +73,7 @@ export default function BillingHelpSection() {
         {/* View Plans */}
         <button
           onClick={handleViewPlans}
-          className="flex items-start gap-3 rounded-xl border border-edge/35 bg-base-150/35 p-4 text-left transition-colors hover:bg-base-150/55"
+          className="flex items-start gap-3 rounded-xl border border-edge/35 bg-base-150/35 p-4 text-left transition-colors hover:bg-base-150/55 cursor-pointer"
         >
           <ExternalLink size={18} className="mt-0.5 shrink-0 text-accent" />
           <div className="min-w-0">
@@ -97,7 +97,7 @@ export default function BillingHelpSection() {
               >
                 <button
                   onClick={() => toggleFaq(i)}
-                  className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left hover:bg-base-150/50"
+                  className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left hover:bg-base-150/50 cursor-pointer"
                 >
                   <span className="text-ui-body font-medium">
                     {item.question}

--- a/desktop/src/components/support/ContactForm.tsx
+++ b/desktop/src/components/support/ContactForm.tsx
@@ -39,7 +39,7 @@ const CATEGORY_OPTIONS: { value: Category; label: string; icon: typeof Bug }[] =
   { value: "feedback", label: "General Feedback", icon: MessageSquare },
   { value: "billing", label: "Billing & Subscription", icon: CreditCard },
   { value: "account", label: "Account & Login", icon: UserCog },
-  { value: "channel", label: "Source Help", icon: Radio },
+  { value: "channel", label: "Widget Help", icon: Radio },
 ];
 
 const FREQUENCY_OPTIONS: { value: Frequency; label: string }[] = [
@@ -76,8 +76,8 @@ const HEADER_CONFIG: Record<Category, { title: string; subtitle: string }> = {
     subtitle: "Issues with signing in, password, or account settings",
   },
   channel: {
-    title: "Source Help",
-    subtitle: "Issues with a specific data source",
+    title: "Widget Help",
+    subtitle: "Issues with a specific widget",
   },
 };
 
@@ -87,7 +87,7 @@ const SUBMIT_LABELS: Record<Category, string> = {
   feedback: "Submit Feedback",
   billing: "Submit Billing Question",
   account: "Submit Account Question",
-  channel: "Submit Source Issue",
+  channel: "Submit Widget Issue",
 };
 
 const SUCCESS_MESSAGES: Record<Category, string> = {
@@ -96,7 +96,7 @@ const SUCCESS_MESSAGES: Record<Category, string> = {
   feedback: "Feedback submitted — thanks for sharing",
   billing: "Billing question submitted — we'll follow up by email",
   account: "Account question submitted — we'll follow up by email",
-  channel: "Source issue submitted — we'll follow up by email",
+  channel: "Widget issue submitted — we'll follow up by email",
 };
 
 const MAX_FILES = 5;
@@ -650,13 +650,13 @@ export default function ContactForm({ onBack }: ContactFormProps) {
         {category === "channel" && (
           <>
             <div>
-              <label className={labelClass}>Which source?</label>
+              <label className={labelClass}>Which widget?</label>
               <select
                 value={channelSelection}
                 onChange={(e) => setChannelSelection(e.target.value)}
                 className={inputClass}
               >
-                <option value="">Select a source...</option>
+                <option value="">Select a widget...</option>
                 <option value="Finance">Finance</option>
                 <option value="Sports">Sports</option>
                 <option value="RSS">RSS</option>
@@ -670,7 +670,7 @@ export default function ContactForm({ onBack }: ContactFormProps) {
                 onChange={(e) => setDescription(e.target.value)}
                 rows={5}
                 required
-                placeholder="What's happening with this source?"
+                placeholder="What's happening with this widget?"
                 className={inputClass}
               />
             </div>

--- a/desktop/src/components/support/FeatureGuidesSection.tsx
+++ b/desktop/src/components/support/FeatureGuidesSection.tsx
@@ -25,7 +25,7 @@ export default function FeatureGuidesSection() {
     <div className="space-y-6">
       {/* Data sources */}
       <div>
-        <p className="mb-2 text-ui-section">Data Sources</p>
+        <p className="mb-2 text-ui-section">Data Widgets</p>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {channels.map((ch) => (
             <GuideCard

--- a/desktop/src/components/support/FeatureGuidesSection.tsx
+++ b/desktop/src/components/support/FeatureGuidesSection.tsx
@@ -22,10 +22,10 @@ export default function FeatureGuidesSection() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       {/* Data sources */}
       <div>
-        <p className="mb-2 text-ui-section">Data Widgets</p>
+        <p className="mb-3 text-ui-section">Data Widgets</p>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {channels.map((ch) => (
             <GuideCard
@@ -41,7 +41,7 @@ export default function FeatureGuidesSection() {
 
       {/* Widgets */}
       <div>
-        <p className="mb-2 text-ui-section">Widgets</p>
+        <p className="mb-3 text-ui-section">Widgets</p>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {widgets.map((w) => (
             <GuideCard
@@ -75,7 +75,7 @@ function GuideCard({
     <div className="overflow-hidden rounded-xl border border-edge/35 bg-base-150/35">
       <button
         onClick={onToggle}
-        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-base-150/50"
+        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-base-150/50 cursor-pointer"
       >
         <span className="shrink-0" style={{ color: manifest.hex }}>
           <Icon size={18} />

--- a/desktop/src/components/support/TroubleshootingSection.tsx
+++ b/desktop/src/components/support/TroubleshootingSection.tsx
@@ -61,7 +61,7 @@ export default function TroubleshootingSection() {
                 </div>
                 <div>
                   <p className="text-ui-section">Steps to fix</p>
-                  <ol className="mt-1.5 list-inside list-decimal space-y-1 text-ui-muted">
+                  <ol className="mt-1.5 list-inside list-decimal space-y-1 text-ui-meta">
                     {article.steps.map((step, j) => (
                       <li key={j}>{step}</li>
                     ))}

--- a/desktop/src/components/support/support-content.ts
+++ b/desktop/src/components/support/support-content.ts
@@ -11,7 +11,7 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "Is Scrollr free?",
     answer:
-      "Yes. The free tier gives you real-time data across all four data sources with generous limits and no ads. Upgrade to Uplink for more capacity, or Uplink Ultimate for live streaming data and unlimited everything.",
+      "Yes. The free tier gives you real-time data across all widgets with generous limits and no ads. Upgrade to Uplink for more capacity, or Uplink Ultimate for live streaming data and unlimited everything.",
   },
   {
     question: "Does it affect my computer's performance?",
@@ -21,7 +21,7 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "Is my data private?",
     answer:
-      "Scrollr contains zero analytics, zero tracking pixels, and zero telemetry. Your source configurations and preferences are stored on your device. The only server-side data is your account profile and subscription status.",
+      "Scrollr contains zero analytics, zero tracking pixels, and zero telemetry. Your widget configurations and preferences are stored on your device. The only server-side data is your account profile and subscription status.",
   },
   {
     question: "What platforms are supported?",
@@ -31,17 +31,17 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "Do I need an account?",
     answer:
-      "You can browse widgets and explore the app without signing in. An account is needed to add data sources (Finance, Sports, News, Fantasy) and to sync your setup.",
+      "You can browse widgets and explore the app without signing in. An account is needed to add widgets (Finance, Sports, News, Fantasy) and to sync your setup.",
   },
   {
     question: "What data does Scrollr show?",
     answer:
-      "Four data sources: live stock and crypto prices (Finance), scores across 20+ leagues (Sports), articles from RSS feeds (News), and Yahoo Fantasy Sports leagues (Fantasy). Plus utility widgets for weather, clocks, system monitoring, uptime, and GitHub Actions.",
+      "Widgets showing live stock and crypto prices (Finance), scores across 20+ leagues (Sports), articles from RSS feeds (News), and Yahoo Fantasy Sports leagues (Fantasy). Plus utility widgets for weather, clocks, system monitoring, uptime, and GitHub Actions.",
   },
   {
     question: "Can I customize the feed?",
     answer:
-      "Extensively. Move the ticker to the top or bottom of the screen by right-clicking it (or using the up/down chevron in the hover toolbar). In Settings > Ticker you can change the detail level (Compact / Detailed), add ticker rows, and adjust speed. Within each source you can filter, sort, and toggle individual data points on or off under Options > Configure source.",
+      "Extensively. Move the ticker to the top or bottom of the screen by right-clicking it (or using the up/down chevron in the hover toolbar). In Customize > Ticker you can lay out which widgets appear on which ticker rows. And every widget's settings live right in its top bar — filter, sort, and pick what to track from the controls on the widget's own page.",
   },
   {
     question: "Is Scrollr open source?",
@@ -56,7 +56,7 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "Can I use Scrollr on multiple monitors?",
     answer:
-      "Yes. The ticker spans the full width of whichever monitor the Scrollr window is currently on. To move it to a different monitor, drag the main window onto that monitor — the ticker follows. There's no monitor selector inside Settings; the ticker uses your OS's active-monitor placement.",
+      "Yes. The ticker spans the full width of whichever monitor the Scrollr window is currently on. To move it to a different monitor, drag the main window onto that monitor — the ticker follows. There's no monitor selector inside Customize; the ticker uses your OS's active-monitor placement.",
   },
   {
     question: "How does live data work vs. polling?",
@@ -87,7 +87,7 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
     ],
     steps: [
       "Check your internet connection.",
-      "Try signing out (Settings > Account) then signing in again.",
+      "Try signing out (avatar chip in the sidebar footer > Account) then signing in again.",
       "If the browser shows an error page, close it and retry from the app.",
       "If the problem persists, report a bug from the Contact Us section — diagnostics will help us investigate.",
     ],
@@ -95,13 +95,13 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
   {
     title: "Data not loading / feed shows empty",
     symptoms: [
-      "Source added but shows \"No data right now\"",
+      "Widget added but shows \"No data right now\"",
       "Ticker shows empty slots where data should be",
     ],
     steps: [
-      "Open the source and click Options > Configure to verify items are added (symbols, leagues, or feeds).",
-      "Check that you're signed in (Settings > Account).",
-      "Try switching away from and back to the feed tab.",
+      "Open the widget and check its top bar to verify items are added (symbols, leagues, or feeds).",
+      "Check that you're signed in (avatar chip in the sidebar footer > Account).",
+      "Try switching away from and back to the widget's page.",
       "Check your internet connection.",
     ],
   },
@@ -113,7 +113,7 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
     ],
     steps: [
       "Press Ctrl+T (Cmd+T on macOS) to toggle ticker visibility.",
-      "Or go to Settings > Ticker and turn on \"Enable ticker\".",
+      "Or go to Customize > Ticker and turn on \"Enable ticker\".",
       "Or click the Ticker toggle in the title bar (next to the Pin button).",
       "Or right-click the system tray icon and choose \"Toggle Ticker\".",
     ],
@@ -151,14 +151,14 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
     steps: [
       "Scores update via polling based on your plan tier. Free: 60s, Uplink: 30s, Uplink Pro: 10s, Uplink Ultimate: live SSE.",
       "Check your current delivery mode in the title bar (next to the Pin button) — green dot is Live, normal dot is Polling.",
-      "Try switching to a different tab and back.",
+      "Try switching to a different widget and back.",
     ],
   },
   {
-    title: "Can't add sources",
+    title: "Can't add widgets",
     symptoms: [
       "Clicking \"Add\" in the Catalog shows an error toast",
-      "\"Failed to create channel\" message",
+      "An error message appears instead of the new widget",
     ],
     steps: [
       "Sign out and sign back in to refresh your session.",
@@ -172,7 +172,7 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
       "Some feeds show data but others don't",
     ],
     steps: [
-      "Open the News source, then Options > Configure source. Each tracked feed has a colored health dot — green is healthy, amber is stale, red is failing.",
+      "Open the News widget and switch to the Feeds view. Each tracked feed has a colored health dot — green is healthy, amber is stale, red is failing.",
       "Some feeds may be temporarily down. Try adding a different feed to verify your connection works.",
       "Custom feeds must be valid RSS or Atom URLs.",
     ],
@@ -195,7 +195,7 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
       "High CPU usage from Scrollr",
     ],
     steps: [
-      "Try reducing ticker rows in Settings > Ticker.",
+      "Try reducing ticker rows in Customize > Ticker.",
       "Reduce the number of tracked symbols, feeds, or leagues.",
       "Check the System Monitor widget for overall CPU/memory usage.",
       "Restart the app if it has been running for a long time.",
@@ -216,31 +216,31 @@ export const GETTING_STARTED_STEPS: GettingStartedStep[] = [
     title: "Sign In",
     iconName: "LogIn",
     description:
-      "Create an account or sign in to sync your sources and settings. Free accounts get full access to all features with generous limits.",
+      "Create an account or sign in to sync your widgets and settings. Free accounts get full access to all features with generous limits.",
   },
   {
-    title: "Add Sources",
+    title: "Add Widgets",
     iconName: "LayoutGrid",
     description:
-      "Open the Catalog from the sidebar to browse available data sources. Add Finance for stock prices, Sports for live scores, News for RSS feeds, or Fantasy for Yahoo leagues.",
+      "Click \"+ Add widget\" in the sidebar (or open the Catalog) to browse available widgets. Add Finance for stock prices, Sports for live scores, News for RSS feeds, or Fantasy for Yahoo leagues.",
   },
   {
-    title: "Configure Your Feeds",
+    title: "Configure Your Widgets",
     iconName: "Settings",
     description:
-      "Each source has a Configure view where you pick what to track. Open a source, click Options in the title bar, then Configure source — add stock symbols, select sports leagues, subscribe to news feeds, or connect your Yahoo account.",
+      "Every setting lives in the widget's own top bar. Open a widget and use the controls there — type in Finance's search box to add stock symbols, pick a favorite team in Sports, choose feeds and categories in News, or connect your Yahoo account from Fantasy's Account pill.",
   },
   {
     title: "Customize the Ticker",
     iconName: "Monitor",
     description:
-      "The ticker bar runs across your screen showing live data. Open Settings > Ticker to change the detail level (Compact / Detailed), add ticker rows, and adjust speed. To move the ticker to the top or bottom of the screen, right-click it or use the up/down chevron in the hover toolbar.",
+      "The ticker bar runs across your screen showing live data. Open Customize > Ticker (or press Ctrl+,) to lay out which widgets appear on which ticker rows. To move the ticker to the top or bottom of the screen, right-click it or use the up/down chevron in the hover toolbar.",
   },
   {
     title: "Explore Widgets",
     iconName: "Puzzle",
     description:
-      "Add utility widgets like Weather, Clock, System Monitor, Uptime Kuma, or GitHub Actions from the Catalog. Widgets appear on your ticker alongside channel data.",
+      "Add utility widgets like Weather, Clock, System Monitor, Uptime Kuma, or GitHub Actions from the Catalog. They appear on your ticker alongside your other widgets.",
   },
   {
     title: "Upgrade Your Plan",
@@ -256,12 +256,12 @@ export const BILLING_FAQ: FAQItem[] = [
   {
     question: "How do I upgrade my plan?",
     answer:
-      "Open the Catalog or go to Settings > Account and click \"Upgrade\". You'll be directed to our website to complete checkout with Stripe.",
+      "Open the Catalog or go to your Account page (avatar chip in the sidebar footer) and click \"Upgrade\". You'll be directed to our website to complete checkout with Stripe.",
   },
   {
     question: "How do I cancel my subscription?",
     answer:
-      "Go to Settings > Account and click \"Manage Subscription\". Paid subscriptions cancel at the end of the billing period so you keep access until then. Trials cancel immediately.",
+      "Go to your Account page (avatar chip in the sidebar footer) and click \"Manage Subscription\". Paid subscriptions cancel at the end of the billing period so you keep access until then. Trials cancel immediately.",
   },
   {
     question: "What happens when my trial ends?",
@@ -276,7 +276,7 @@ export const BILLING_FAQ: FAQItem[] = [
   {
     question: "How do I update my payment method?",
     answer:
-      "Click \"Manage Subscription\" in Settings > Account to open the Stripe billing portal where you can update your card.",
+      "Click \"Manage Subscription\" on your Account page (avatar chip in the sidebar footer) to open the Stripe billing portal where you can update your card.",
   },
   {
     question: "I was charged incorrectly",

--- a/desktop/src/hooks/useAddWidget.ts
+++ b/desktop/src/hooks/useAddWidget.ts
@@ -140,7 +140,7 @@ export function useAddWidget(): (item: CatalogItem) => Promise<void> {
               previous,
             );
             const message =
-              err instanceof Error ? err.message : "Failed to add channel";
+              err instanceof Error ? err.message : "Failed to add widget";
             toast.error(`Couldn't add ${item.name}: ${message}`);
           });
       } else {

--- a/desktop/src/hooks/useAddWidget.ts
+++ b/desktop/src/hooks/useAddWidget.ts
@@ -85,8 +85,8 @@ export function useAddWidget(): (item: CatalogItem) => Promise<void> {
         // Navigate immediately — the channel page's queries will fire
         // in parallel with the create call below.
         navigate({
-          to: "/channel/$type",
-          params: { type: item.id },
+          to: "/widget/$id",
+          params: { id: item.id },
         });
         toast.success(`${item.name} added`);
 

--- a/desktop/src/hooks/useChannelActions.ts
+++ b/desktop/src/hooks/useChannelActions.ts
@@ -55,8 +55,8 @@ export function useChannelActions(): ChannelActions {
         // bug: invalidate it or the mounted feed never refetches.
         queryClient.invalidateQueries({ queryKey: ["sports", "full"] });
         navigate({
-          to: "/channel/$type",
-          params: { type: channelType },
+          to: "/widget/$id",
+          params: { id: channelType },
         });
         toast.success(`${channelName[channelType] ?? channelType} added`);
       } catch (err) {

--- a/desktop/src/marketplace.ts
+++ b/desktop/src/marketplace.ts
@@ -117,7 +117,7 @@ const DATA_WIDGETS: DataWidgetDef[] = [
     addConfig: { symbols: [], asset_class: "stock" },
     about: "Real-time stock and ETF prices for the tickers you follow. Your watchlist streams live as the market moves — no brokerage app open, no tab to babysit.",
     usage: [
-      "Add the tickers you want to watch from the Symbols view.",
+      "Type a ticker in the top bar's search to add or remove it.",
       "Quotes stream in real time during market hours.",
       "Pin it to keep your watchlist always visible.",
     ],
@@ -128,7 +128,7 @@ const DATA_WIDGETS: DataWidgetDef[] = [
     addConfig: { symbols: [], asset_class: "crypto" },
     about: "Live crypto prices for the coins you track, streamed around the clock. From BTC and ETH to the long tail, your picks update the moment the market does.",
     usage: [
-      "Add the coins you want to watch from the Symbols view.",
+      "Type a coin in the top bar's search to add or remove it.",
       "Prices stream 24/7 — crypto never closes.",
       "Pin it so every big move catches your eye.",
     ],

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -926,7 +926,8 @@ function RootLayout() {
                  route.isWidget ||
                  route.isFeed ||
                  route.isMarketplace ||
-                 route.isCustomize
+                 route.isCustomize ||
+                 route.isSupport
                }
              >
               <ConnectionBanner deliveryMode={deliveryMode} />

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -552,7 +552,7 @@ function RootLayout() {
         return;
       }
       if (channelsRef.current.some((ch) => ch.channel_type === id)) {
-        navigate({ to: "/channel/$type", params: { type: id } });
+        navigate({ to: "/widget/$id", params: { id: id } });
         return;
       }
       if (getWidget(id)) {
@@ -575,7 +575,7 @@ function RootLayout() {
   const handleSelectPinned = useCallback(
     (id: string, kind: "channel" | "widget") => {
       if (kind === "channel") {
-        navigate({ to: "/channel/$type", params: { type: id } });
+        navigate({ to: "/widget/$id", params: { id: id } });
       } else {
         navigate({ to: "/widget/$id", params: { id } });
       }
@@ -754,7 +754,7 @@ function RootLayout() {
           const tab = segments[2];
           if (tab && tab !== "feed") {
             if (route.isChannel) {
-              navigate({ to: "/channel/$type", params: { type: route.activeItem } });
+              navigate({ to: "/widget/$id", params: { id: route.activeItem } });
             } else {
               navigate({ to: "/widget/$id", params: { id: route.activeItem } });
             }

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -275,8 +275,11 @@ function CatalogPage() {
           />
         </div>
       </WidgetBar>
+      {/* mt-4 on the first band(s) = the pt-4 gap every WCB page keeps
+          under the bar (adjacent margins collapse, so both carrying it
+          is safe whichever renders first). */}
       {dashboardError && (
-        <div className="mb-4">
+        <div className="mt-4 mb-5">
           <QueryErrorBanner error={dashboardError} />
         </div>
       )}
@@ -290,7 +293,7 @@ function CatalogPage() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.25, delay: 0.02, ease: [0.22, 0.61, 0.36, 1] }}
         className={clsx(
-          "mb-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-3 rounded-xl border px-4 py-3",
+          "mt-4 mb-5 flex flex-wrap items-center justify-between gap-x-4 gap-y-3 rounded-xl border px-4 py-3",
           slots.atCapacity && slots.finite
             ? "border-warn/25 bg-warn/[0.06]"
             : "border-edge/40 bg-base-150/30",
@@ -349,7 +352,7 @@ function CatalogPage() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            transition={{ duration: 0.15 }}
+            transition={{ duration: 0.18, ease: [0.22, 0.61, 0.36, 1] }}
           >
             {/* ── Your widgets ── */}
             {yourItems.length > 0 && (

--- a/desktop/src/routes/channel.$type.tsx
+++ b/desktop/src/routes/channel.$type.tsx
@@ -1,109 +1,13 @@
 /**
- * Channel route — renders the channel feed.
- *
- * URL: /channel/:type  (type: "finance_stocks", "sports_nfl", …)
- *
- * The configuration tab is gone — every setting lives inside the widget
- * itself (its top bar). Source-level actions (remove) are in the
- * header bar's Options pill.
+ * Channel route — redirect shim. Every source renders at /widget/$id
+ * since REL-49 (one route = one word: widgets); this path survives for
+ * stored lastRoute values, ticker-chip deep links, and old muscle
+ * memory.
  */
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import RouteError from "../components/RouteError";
-import SourcePageLayout, { SourceNotFound } from "../components/SourcePageLayout";
-import { useQuery } from "@tanstack/react-query";
-import { widgetManifest } from "../marketplace";
-import { dashboardQueryOptions } from "../api/queries";
-import type { DashboardResponse, ChannelManifest } from "../types";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/channel/$type")({
-  loader: ({ context: { queryClient } }) =>
-    queryClient.ensureQueryData(dashboardQueryOptions()),
-  component: ChannelRoute,
-  pendingComponent: ChannelPending,
-  errorComponent: RouteError,
+  beforeLoad: ({ params }) => {
+    throw redirect({ to: "/widget/$id", params: { id: params.type } });
+  },
 });
-
-function ChannelRoute() {
-  const { type } = Route.useParams();
-  const navigate = useNavigate();
-
-  // Resolve the widget id (e.g. "sports_nfl", "finance_stocks") to its coarse
-  // source manifest, which owns the FeedTab. Also resolves legacy coarse ids.
-  const channel = widgetManifest(type) as ChannelManifest | undefined;
-  const { data: dashboard, isFetching: dashboardFetching } = useQuery(dashboardQueryOptions());
-
-  if (!channel) {
-    return <SourceNotFound kind="Channel" name={type} />;
-  }
-
-  return (
-    <SourcePageLayout
-      name={channel.name}
-      onBack={() => navigate({ to: "/feed" })}
-    >
-      <ChannelFeedTab
-        type={type}
-        dashboard={dashboard}
-        dashboardFetching={dashboardFetching}
-        channel={channel}
-      />
-    </SourcePageLayout>
-  );
-}
-
-function ChannelFeedTab({
-  type,
-  dashboard,
-  dashboardFetching,
-  channel,
-}: {
-  type: string;
-  dashboard: DashboardResponse | undefined;
-  dashboardFetching: boolean;
-  channel: ChannelManifest;
-}) {
-  // An optimistic add row (id < 0, seeded by useAddWidget while the
-  // create request is in flight) can't have data yet — treat it as
-  // refreshing so the empty-state CTA never flashes in the gap before
-  // the post-create refetch starts (v1.1.1 round 3).
-  const pendingAdd = (dashboard?.channels ?? []).some(
-    (ch) => ch.channel_type === type && ch.id < 0,
-  );
-
-  const feedContext = {
-    __dashboardLoaded: dashboard !== undefined,
-    __refreshing: dashboardFetching || pendingAdd,
-    __hasConfig: (dashboard?.channels ?? []).some(
-      (ch) => ch.channel_type === type && ch.enabled,
-    ),
-  };
-
-  return (
-    <channel.FeedTab mode="comfort" widgetId={type} feedContext={feedContext} />
-  );
-}
-
-function ChannelPending() {
-  return (
-    <div className="flex flex-col gap-3 p-6">
-      {Array.from({ length: 6 }, (_, i) => (
-        <div
-          key={i}
-          className="flex items-center gap-3 motion-safe:animate-pulse"
-        >
-          <div className="w-8 h-8 rounded-lg bg-surface-2" />
-          <div className="flex-1 space-y-2">
-            <div
-              className="h-3 rounded bg-surface-2"
-              style={{ width: `${55 + ((i * 17) % 35)}%` }}
-            />
-            <div
-              className="h-2 rounded bg-surface-2/60"
-              style={{ width: `${30 + ((i * 23) % 40)}%` }}
-            />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -290,22 +290,22 @@ function HomePage() {
               }
               onViewAll={() =>
                 navigate({
-                  to: "/channel/$type",
-                  params: { type: ch.channel_type },
+                  to: "/widget/$id",
+                  params: { id: ch.channel_type },
                 })
               }
               onRowClick={() =>
                 navigate({
-                  to: "/channel/$type",
-                  params: { type: ch.channel_type },
+                  to: "/widget/$id",
+                  params: { id: ch.channel_type },
                 })
               }
               // Config lives inside the widget now — every CTA lands on
               // the feed, where the bar carries the configuration.
               onConfigure={() =>
                 navigate({
-                  to: "/channel/$type",
-                  params: { type: ch.channel_type },
+                  to: "/widget/$id",
+                  params: { id: ch.channel_type },
                 })
               }
             />

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -201,8 +201,9 @@ function HomePage() {
           max-w-6xl) so it lines up with Catalog and every other
           wide route. The inner wrapper just owns vertical rhythm
           between sections (space-y-5, no dangling margin on the
-          last child). */}
-      <div className="space-y-5">
+          last child). Content under the WCB starts at pt-4, same as
+          Customize/Support; the bar-less empty state doesn't. */}
+      <div className={clsx("space-y-5", hasAnySources && "pt-4")}>
       {/* Empty state — hero. Shown when the user has no channels and
           no enabled widgets. Disappears the moment they add their
           first source. This IS the post-wizard first-run experience —
@@ -216,7 +217,7 @@ function HomePage() {
             authenticated ? (
               <button
                 onClick={() => navigate({ to: "/catalog" })}
-                className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg text-sm font-semibold bg-accent text-surface hover:bg-accent/90 transition-all duration-200 active:scale-95 hover:shadow-glow-sm"
+                className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg text-sm font-semibold bg-accent text-surface hover:bg-accent/90 transition-all duration-150 active:scale-95 hover:shadow-glow-sm"
               >
                 <Plus size={15} strokeWidth={2.5} />
                 Browse the Catalog
@@ -224,7 +225,7 @@ function HomePage() {
             ) : (
               <button
                 onClick={onLogin}
-                className="px-5 py-2.5 rounded-lg text-sm font-semibold bg-accent text-surface hover:bg-accent/90 transition-all duration-200 active:scale-95 hover:shadow-glow-sm"
+                className="px-5 py-2.5 rounded-lg text-sm font-semibold bg-accent text-surface hover:bg-accent/90 transition-all duration-150 active:scale-95 hover:shadow-glow-sm"
               >
                 Sign in to get started
               </button>
@@ -253,18 +254,6 @@ function HomePage() {
           page reveals its data instead of slamming everything in
           at once. */}
       {orderedChannels.map(({ ch, manifest }, idx) => {
-        // Normalize the dashboard payload to a flat array per channel.
-        // Most channels are already arrays; Fantasy is { leagues: [...] }
-        // because each league entry carries matchups/standings/rosters at
-        // the top level. Without this unwrap the Home dashboard would
-        // think Fantasy is empty even when leagues are imported, while
-        // the standalone Feed view (which unwraps correctly) shows them.
-        const source = sourceForWidget(ch.channel_type) ?? ch.channel_type;
-        const channelData = scopeSourceData(
-          source,
-          normalizeChannelData(source, dashboard?.data?.[source]),
-          ch.config as Record<string, unknown> | undefined,
-        );
         return (
           <motion.div
             key={ch.channel_type}
@@ -505,12 +494,12 @@ function ChannelSection({
         {!editing && (
           <button
             onClick={onViewAll}
-            className="group flex items-center gap-1 text-[11px] font-medium text-fg-4 hover:text-fg-2 transition-all duration-150 active:scale-95"
+            className="group flex items-center gap-1 text-ui-chip font-medium text-fg-4 hover:text-fg-2 transition-all duration-150 active:scale-95"
           >
             View all
             <ChevronRight
               size={12}
-              className="transition-transform duration-200 group-hover:translate-x-0.5"
+              className="transition-transform duration-150 group-hover:translate-x-0.5"
             />
           </button>
         )}
@@ -530,13 +519,13 @@ function ChannelSection({
             className="rounded-lg border border-accent/20 bg-accent/[0.03] overflow-hidden divide-y divide-edge/10 mb-3"
           >
             <div className="px-4 py-2 flex items-center justify-between">
-              <span className="text-[11px] font-medium text-fg-3">
+              <span className="text-ui-chip font-medium text-fg-3">
                 Choose up to {MAX_PREVIEW} to show on Home
               </span>
               {hasSelections && (
                 <button
                   onClick={() => onSelectionChange([])}
-                  className="text-[11px] font-medium text-fg-4 hover:text-fg-2 transition-colors active:scale-95"
+                  className="text-ui-chip font-medium text-fg-4 hover:text-fg-2 transition-colors active:scale-95"
                 >
                   Clear all
                 </button>
@@ -575,7 +564,7 @@ function ChannelSection({
                       </motion.span>
                     )}
                   </span>
-                  <span className="text-xs text-fg truncate flex-1">
+                  <span className="text-ui-meta text-fg truncate flex-1">
                     {getGroupLabel(source, key, channelData)}
                   </span>
                 </button>
@@ -700,7 +689,7 @@ function PredictionsRows({ data, onConfigure }: { data: unknown; onConfigure: ()
         const isUp = delta > 0;
         return (
           <div key={p.id} className="flex items-center px-4 py-2.5 gap-4">
-            <span className="text-xs text-fg-2 truncate flex-1">
+            <span className="text-ui-meta text-fg-2 truncate flex-1">
               {p.event_title || p.title}
             </span>
             {/* Fixed delta slot + fixed-width pill — the channel's own
@@ -785,13 +774,13 @@ function SportsRows({
                   className="w-4 h-4 shrink-0 object-contain"
                 />
               )}
-              <span className="text-xs text-fg-2 truncate">
+              <span className="text-ui-meta text-fg-2 truncate">
                 {g.away_team_name || g.away_team_code}
               </span>
               <span className="text-xs text-fg-3 tabular-nums shrink-0">
                 {g.away_team_score} – {g.home_team_score}
               </span>
-              <span className="text-xs text-fg-2 truncate">
+              <span className="text-ui-meta text-fg-2 truncate">
                 {g.home_team_name || g.home_team_code}
               </span>
               {g.home_team_logo && (
@@ -838,7 +827,7 @@ function RssRows({ data, filter, onConfigure }: { data: unknown; filter: string[
     <>
       {sorted.map((item) => (
         <div key={item.id} className="flex items-center px-4 py-2.5 gap-3">
-          <span className="text-xs text-fg flex-1 truncate">{item.title}</span>
+          <span className="text-ui-meta text-fg flex-1 truncate">{item.title}</span>
           <span className="text-[10px] text-fg-4 shrink-0">
             {item.source_name}
           </span>
@@ -880,7 +869,7 @@ function FantasyRows({ data, filter, onConfigure }: { data: unknown; filter: str
 
         return (
           <div key={i} className="flex items-center px-4 py-2.5 gap-3">
-            <span className="text-xs text-fg flex-1 truncate">{name}</span>
+            <span className="text-ui-meta text-fg flex-1 truncate">{name}</span>
             {hasMatchup && (
               <span className="text-xs text-fg-3 tabular-nums">
                 {String(myScore)} – {String(oppScore)}
@@ -912,7 +901,7 @@ function EmptyDataRow({
   const hint = channelType ? EMPTY_HINTS[channelType] : undefined;
   return (
     <div className="px-4 py-5 text-center">
-      <p className="text-xs text-fg-3 font-medium mb-1">
+      <p className="text-ui-meta text-fg-3 font-medium mb-1">
         {hint?.message ?? "Nothing to show"}
       </p>
       {hint && onConfigure && (
@@ -921,7 +910,7 @@ function EmptyDataRow({
             e.stopPropagation();
             onConfigure();
           }}
-          className="inline-flex items-center gap-1.5 text-[11px] text-accent hover:text-accent/80 transition-colors"
+          className="inline-flex items-center gap-1.5 text-ui-chip text-accent hover:text-accent/80 transition-colors"
         >
           <Settings size={11} />
           Open {hint.name}
@@ -947,7 +936,7 @@ function WidgetStrip({
   return (
     <section>
       <div className="flex items-center gap-3 mb-3">
-        <h3 className="text-[11px] font-mono font-semibold text-fg-4 uppercase tracking-wider flex-1">
+        <h3 className="text-ui-section font-mono font-semibold text-fg-4 uppercase tracking-wider flex-1">
           Widgets
         </h3>
       </div>
@@ -997,7 +986,7 @@ function WidgetChip({
         <span style={{ color: widget.hex }} className="shrink-0">
           <Icon size={14} />
         </span>
-        <span className="text-xs font-medium text-fg truncate flex-1">
+        <span className="text-ui-meta font-medium text-fg truncate flex-1">
           {widget.tabLabel}
         </span>
         <TickerStatusBadge label={tickerStatus} />

--- a/desktop/src/routes/releases.tsx
+++ b/desktop/src/routes/releases.tsx
@@ -387,7 +387,7 @@ function EmptyState() {
       </p>
       <button
         onClick={() => open(RELEASES_PAGE_URL).catch(() => {})}
-        className="mt-4 flex items-center gap-1.5 rounded-lg bg-accent/10 px-3.5 py-1.5 text-ui-body font-semibold text-accent transition-all duration-150 hover:bg-accent/[0.16] active:scale-[0.98] cursor-pointer"
+        className="mt-4 flex items-center gap-1.5 rounded-lg bg-accent/10 px-3.5 py-1.5 text-ui-body font-semibold text-accent transition-all duration-150 hover:bg-accent/20 active:scale-[0.98] cursor-pointer"
       >
         <ExternalLink size={14} />
         View releases on GitHub

--- a/desktop/src/routes/status.tsx
+++ b/desktop/src/routes/status.tsx
@@ -241,7 +241,7 @@ function StatusPage() {
                   </span>
                   <span
                     className={clsx(
-                      "flex items-center gap-1.5 h-5 px-2 rounded-full text-[11px] font-medium shrink-0",
+                      "flex items-center gap-1.5 h-5 px-2 rounded-full text-ui-chip font-medium shrink-0",
                       ok
                         ? "bg-success/10 text-success"
                         : "bg-error/10 text-error",

--- a/desktop/src/routes/support.tsx
+++ b/desktop/src/routes/support.tsx
@@ -15,6 +15,11 @@
  */
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { WidgetBar } from "../components/widget-bar/Bar";
+import {
+  Segmented,
+  type SegmentedOption,
+} from "../components/widget-bar/Segmented";
 import SupportHub from "../components/support/SupportHub";
 import GettingStartedSection from "../components/support/GettingStartedSection";
 import FAQSection from "../components/support/FAQSection";
@@ -64,22 +69,24 @@ const SECTION_LONG_TITLES: Record<SectionId, string> = {
 function SupportPage() {
   const [activeSection, setActiveSection] = useState<SectionId | null>(null);
 
-  // Hub view — search + category cards.
+  // Hub view — search + category cards. No bar; the cards ARE the
+  // navigation (the chassis hides at zero rows).
   if (!activeSection) {
     return (
       <PageLayout
         title="Support"
         subtitle="Find help, file bugs, or contact us"
         width="wide"
+        stableChrome
       >
         <SupportHub onSelectSection={setActiveSection} />
       </PageLayout>
     );
   }
 
-  // Section view — TopBar shows "Support / <section>" breadcrumb;
-  // an in-page tab band lets users switch laterally between sections
-  // without bouncing through the hub.
+  // Section view — the WCB Segmented is the lateral section switch
+  // (same chrome idiom as Customize/Catalog; the old TopBar tab band
+  // is gone). TopBar still shows the "Support / <section>" breadcrumb.
   return (
     <PageLayout
       title={SECTION_LONG_TITLES[activeSection]}
@@ -91,15 +98,22 @@ function SupportPage() {
       parentLabel="Support"
       onParentClick={() => setActiveSection(null)}
       width="wide"
-      tabs={{
-        items: SECTION_ORDER.map((id) => ({
-          key: id,
-          label: SECTION_TITLES[id],
-        })),
-        activeKey: activeSection,
-        onChange: (key) => setActiveSection(key as SectionId),
-      }}
+      stableChrome
     >
+      <WidgetBar>
+        <Segmented
+          ariaLabel="Support section"
+          value={activeSection}
+          onChange={setActiveSection}
+          options={SECTION_ORDER.map(
+            (id): SegmentedOption<SectionId> => ({
+              value: id,
+              label: SECTION_TITLES[id],
+            }),
+          )}
+        />
+      </WidgetBar>
+      <div className="pt-4">
       {activeSection === "getting-started" && <GettingStartedSection />}
       {activeSection === "faq" && <FAQSection />}
       {activeSection === "troubleshooting" && <TroubleshootingSection />}
@@ -108,6 +122,7 @@ function SupportPage() {
       {activeSection === "contact" && (
         <ContactForm onBack={() => setActiveSection(null)} />
       )}
+      </div>
     </PageLayout>
   );
 }

--- a/desktop/src/routes/widget.$id.index.tsx
+++ b/desktop/src/routes/widget.$id.index.tsx
@@ -1,20 +1,34 @@
 /**
- * Widget route — renders the widget feed.
+ * Widget route — THE source page. Every widget renders here (REL-49):
+ * data widgets (finance_stocks, sports_nfl, news_bbc, predictions, …)
+ * and local utilities (clock, weather, sysmon, uptime, github, timer).
+ * /channel/$type is a redirect shim onto this route.
  *
- * URL: /widget/:id  (id: "clock" | "weather" | "sysmon" | "uptime" | "github" | "timer")
+ * One route for every source means every swap is a same-route swap —
+ * PageLayout stays mounted and the full stableChrome choreography
+ * (bar roll + feed crossfade) plays on ALL transitions. The old
+ * channel/widget route split made cross-kind swaps hard-cut.
  *
- * The configuration tab is gone — every setting lives inside the widget
- * itself (its top bar). NOTE: this is deliberately an INDEX route
- * (widget.$id.index.tsx, not widget.$id.tsx) so it doesn't become
- * widget.$id.info.tsx's layout parent and demand an Outlet.
+ * NOTE: this is deliberately an INDEX route (widget.$id.index.tsx,
+ * not widget.$id.tsx) so it doesn't become widget.$id.info.tsx's
+ * layout parent and demand an Outlet.
  */
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
 import RouteError from "../components/RouteError";
 import SourcePageLayout, { SourceNotFound } from "../components/SourcePageLayout";
+import { widgetManifest } from "../marketplace";
 import { getWidget } from "../widgets/registry";
+import { dashboardQueryOptions } from "../api/queries";
+import type { ChannelManifest, WidgetManifest } from "../types";
 
 export const Route = createFileRoute("/widget/$id/")({
+  // Data widgets need the dashboard; ensuring it here is harmless for
+  // utilities (the shell keeps it warm anyway).
+  loader: ({ context: { queryClient } }) =>
+    queryClient.ensureQueryData(dashboardQueryOptions()),
   component: WidgetRoute,
+  pendingComponent: WidgetPending,
   errorComponent: RouteError,
 });
 
@@ -22,24 +36,87 @@ function WidgetRoute() {
   const { id } = Route.useParams();
   const navigate = useNavigate();
 
-  const widget = getWidget(id);
-  if (!widget) {
+  // Resolves data widgets (per-league/per-feed splits + legacy coarse
+  // ids) AND local utilities.
+  const manifest = widgetManifest(id) as
+    | ChannelManifest
+    | WidgetManifest
+    | undefined;
+
+  if (!manifest) {
     return <SourceNotFound kind="Widget" name={id} />;
   }
 
   return (
-    <SourcePageLayout
-      name={widget.name}
-      onBack={() => navigate({ to: "/feed" })}
-    >
-      {/* No local entrance wrapper: SourcePageLayout's stableChrome
-          container already provides the fade-up (a second motion.div
-          here compounded the entrance and made widgets feel different
-          from channels). h-full preserved — the stableChrome container
-          doesn't provide it in noContentPadding mode. */}
+    <SourcePageLayout name={manifest.name} onBack={() => navigate({ to: "/feed" })}>
       <div className="h-full">
-        <widget.FeedTab mode="comfort" feedContext={{ __dashboardLoaded: true }} />
+        <WidgetFeed id={id} manifest={manifest} />
       </div>
     </SourcePageLayout>
+  );
+}
+
+function WidgetFeed({
+  id,
+  manifest,
+}: {
+  id: string;
+  manifest: ChannelManifest | WidgetManifest;
+}) {
+  const { data: dashboard, isFetching: dashboardFetching } = useQuery(
+    dashboardQueryOptions(),
+  );
+
+  // Local utilities have no server row — their data is always "loaded".
+  if (getWidget(id)) {
+    return (
+      <manifest.FeedTab mode="comfort" feedContext={{ __dashboardLoaded: true }} />
+    );
+  }
+
+  // Data widgets: dashboard-driven feed context. An optimistic add row
+  // (id < 0, seeded by useAddWidget while the create request is in
+  // flight) can't have data yet — treat it as refreshing so the
+  // empty-state CTA never flashes in the gap before the post-create
+  // refetch starts (v1.1.1 round 3).
+  const pendingAdd = (dashboard?.channels ?? []).some(
+    (ch) => ch.channel_type === id && ch.id < 0,
+  );
+
+  const feedContext = {
+    __dashboardLoaded: dashboard !== undefined,
+    __refreshing: dashboardFetching || pendingAdd,
+    __hasConfig: (dashboard?.channels ?? []).some(
+      (ch) => ch.channel_type === id && ch.enabled,
+    ),
+  };
+
+  return (
+    <manifest.FeedTab mode="comfort" widgetId={id} feedContext={feedContext} />
+  );
+}
+
+function WidgetPending() {
+  return (
+    <div className="flex flex-col gap-3 p-6">
+      {Array.from({ length: 6 }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 motion-safe:animate-pulse"
+        >
+          <div className="w-8 h-8 rounded-lg bg-surface-2" />
+          <div className="flex-1 space-y-2">
+            <div
+              className="h-3 rounded bg-surface-2"
+              style={{ width: `${55 + ((i * 17) % 35)}%` }}
+            />
+            <div
+              className="h-2 rounded bg-surface-2/60"
+              style={{ width: `${30 + ((i * 23) % 40)}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }

--- a/desktop/src/routes/widget.$id.info.tsx
+++ b/desktop/src/routes/widget.$id.info.tsx
@@ -148,7 +148,7 @@ function WidgetInfoPage() {
 
   const openWidget = () => {
     if (item.kind === "data") {
-      navigate({ to: "/channel/$type", params: { type: item.id } });
+      navigate({ to: "/widget/$id", params: { id: item.id } });
     } else {
       navigate({ to: "/widget/$id", params: { id: item.id } });
     }

--- a/desktop/src/routes/widget.$id.info.tsx
+++ b/desktop/src/routes/widget.$id.info.tsx
@@ -273,7 +273,7 @@ function WidgetInfoPage() {
                     Open
                     <ChevronRight
                       size={15}
-                      className="transition-transform duration-200 group-hover/btn:translate-x-0.5"
+                      className="transition-transform duration-150 group-hover/btn:translate-x-0.5"
                     />
                   </button>
                 </>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,8 @@ stays at 1.1.0 and nobody gets force-updated.
 | ~~v1.1.5~~ | Kalshi Cleans Up | ✅ **Shipped 2026-07-14** — sweep reconciliation ends the stale-market feed; lens-based browse, stars-only personalization, server config retired | M–L |
 | ~~v1.1.6~~ | Kalshi Fixed Up | ✅ **Shipped 2026-07-15** — history charts + My Positions un-broken (Kalshi fp migration), market search, multi-category filter, whole-card UX | M |
 | ~~v1.1.7~~ | Spring Cleaning | ✅ **Shipped 2026-07-16** — under-the-hood release: backend consolidated into core (ADR-0002), simpler undo, Kalshi connect slimmed to prod-only, compact-number polish | S |
-| v1.1.8 | A Fresh Coat | Claude-desktop-style chrome (single-row title bar, inset canvas, icon-dock sidebar + account chip), Home row + What's New, status page, and realtime SSE unlocked for every tier (client gate fix) | M |
+| ~~v1.1.8~~ | A Fresh Coat | ✅ **Shipped 2026-07-17** — Claude-desktop-style chrome (single-row title bar, inset canvas, icon-dock sidebar + account chip), Home row + What's New, status page, and realtime SSE unlocked for every tier (client gate fix) | M |
+| ~~v1.1.9~~ | One Bar | ✅ **Shipped 2026-07-18** — Configure pages and gear menus retired: every widget's controls live in its own persistent top bar; Customize page (Settings+Ticker merged), search-to-add symbols, unified feed cards + brand logos, everything-is-a-widget IA, Support rewritten | L |
 | v1.2.0 | Double-Decker 2.0 | Multi-row ticker rebuilt around widgets | L |
 | — | Website rides along | Pricing rewrite shipped with v1.1.2–3; screenshots now unblocked (post-v1.1.4) | S–M |
 


### PR DESCRIPTION
## Summary

Part 12 (final) — **stacked on #243**; merge last. The overnight ship-readiness batch.

### Widget normalization ("widgets are the only thing the user should know")
- `/widget/$id` is THE source route — resolves data widgets and utilities via `widgetManifest()`, with the dashboard loader + optimistic-add feedContext. `/channel/$type` is a redirect shim. **Every source swap is now a same-route swap, so the cross-kind hard-cut is structurally gone.**
- Sidebar: "+ Add widget" moves into the top cluster below Customize; the group is headed **Widgets**; user-visible copy says widget everywhere.
- Price/score flashes get dedicated 700ms-fade overlays (decoupled from the 150ms card hover transition, and out of the bg-utility cascade fight).

### Support + copy
- Support sections join the WCB (Segmented + stableChrome; hub stays barless). That was the TopBar tab strip's last consumer → InlineTabStrip/TabPill/MoreTabsTrigger/ghost-measurement/PageTabStrip/`tabs` prop all deleted (~230 lines).
- All support content (FAQ/troubleshooting/getting-started/billing/contact) rewritten to the current IA — no more "Settings → Ticker", "Options → Configure source", or "Symbols view" anywhere. Ticker-window strings, finance usage copy, aria labels, and the Ctrl+, label all updated.

### Release hygiene
- `package.json` 1.0.20 → 1.1.8: vite feeds it to the Sentry release tag, so prod events have been mislabeled since 1.0.20.
- App-wide consistency pass (7-agent normalization): ui-* type tokens, pt-4 under every bar, mb-5 rhythm, 150ms interactive / 0.18s content timing. Entrance choreography kept.

## Verification
tsc clean · vitest 495/495 · five Playwright suites green after every commit in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)