### PR TITLE
Idiom drift: native selects, focus-ring duel, Home tiles [REL-47]

### DIFF
--- a/desktop/src/channels/predictions/MarketDetail.tsx
+++ b/desktop/src/channels/predictions/MarketDetail.tsx
@@ -42,6 +42,7 @@ import { getHistory, sparklinePoints, trend } from "./sparkline";
 import { describeAlert, type AlertComparator, type PredictionAlert } from "./watchlist";
 import { outcomeLabel } from "./search";
 import ProbabilityPill from "./ProbabilityPill";
+import { SelectMenu } from "../../components/widget-bar/SelectMenu";
 import type { Prediction } from "../../types";
 
 interface MarketDetailProps {
@@ -530,15 +531,16 @@ function AlertForm({ onAdd }: { onAdd: (comparator: AlertComparator, threshold: 
   return (
     <div className="flex items-center gap-1.5">
       <span className="text-[12px] text-fg-3">Alert me when</span>
-      <select
+      <SelectMenu
         value={comparator}
-        onChange={(e) => setComparator(e.target.value as AlertComparator)}
-        aria-label="Alert direction"
-        className="rounded-md border border-edge/50 bg-base-100 px-1.5 py-1 text-[12px] text-fg-2 outline-none focus:border-accent/60 cursor-pointer"
-      >
-        <option value="above">above</option>
-        <option value="below">below</option>
-      </select>
+        options={[
+          { value: "above", label: "above" },
+          { value: "below", label: "below" },
+        ]}
+        onChange={setComparator}
+        ariaLabel="Alert direction"
+        align="left"
+      />
       <div className="flex items-center rounded-md border border-edge/50 bg-base-100 px-1.5 focus-within:border-accent/60">
         <input
           type="number"

--- a/desktop/src/channels/rss/FeedManager.tsx
+++ b/desktop/src/channels/rss/FeedManager.tsx
@@ -23,6 +23,7 @@ import { motion, AnimatePresence } from "motion/react";
 import Tooltip from "../../components/Tooltip";
 import EmptySection from "../../components/layout/EmptySection";
 import { MultiSelectMenu } from "../../components/widget-bar/MultiSelectMenu";
+import { SelectMenu } from "../../components/widget-bar/SelectMenu";
 import type { TrackedFeed } from "../../api/client";
 
 // ── Types ────────────────────────────────────────────────────────
@@ -377,17 +378,18 @@ export default function FeedManager({
           </button>
         </Tooltip>
 
-        <select
+        <SelectMenu
           value={sort}
-          onChange={(e) => setSort(e.target.value as SortKey)}
-          className="px-2 py-1.5 rounded-md bg-base-200 border border-edge/40 text-ui-meta text-fg-2 focus:outline-none focus:border-accent/60 transition-colors cursor-pointer appearance-none"
-          aria-label="Sort feeds"
-        >
-          <option value="default">Tracked first</option>
-          <option value="name">Name</option>
-          <option value="category">Category</option>
-          <option value="activity">Last activity</option>
-        </select>
+          options={[
+            { value: "default", label: "Tracked first" },
+            { value: "name", label: "Name" },
+            { value: "category", label: "Category" },
+            { value: "activity", label: "Last activity" },
+          ]}
+          onChange={setSort}
+          ariaLabel="Sort feeds"
+          prefix="Sort"
+        />
       </div>
 
       {selectedCategories.size > 0 && (

--- a/desktop/src/channels/sports/StandingsTab.tsx
+++ b/desktop/src/channels/sports/StandingsTab.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { clsx } from "clsx";
 import { ChevronDown } from "lucide-react";
 import TeamLogo from "../../components/TeamLogo";
+import { SelectMenu } from "../../components/widget-bar/SelectMenu";
 import { standingsOptions } from "../../api/queries";
 import type { Standing } from "../../api/queries";
 
@@ -228,15 +229,14 @@ export function StandingsTab({ leagues, favoriteTeams }: StandingsTabProps) {
     <div>
       {/* League selector */}
       <div className="px-3 py-2 border-b border-edge/30 bg-surface">
-        <select
+        <SelectMenu
           value={selected}
-          onChange={(e) => setSelected(e.target.value)}
-          className="bg-surface-hover text-fg-2 text-xs rounded px-2 py-1 border border-edge/30 focus:outline-none focus:border-accent/60"
-        >
-          {leagues.map((l) => (
-            <option key={l} value={l}>{l}</option>
-          ))}
-        </select>
+          options={leagues.map((l) => ({ value: l, label: l }))}
+          onChange={setSelected}
+          ariaLabel="League"
+          prefix="League"
+          align="left"
+        />
       </div>
 
       {/* Content */}

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -1,6 +1,7 @@
 import { clsx } from "clsx";
 import { motion } from "motion/react";
 import Tooltip from "../Tooltip";
+import { SelectMenu } from "../widget-bar/SelectMenu";
 
 // ── Section heading ─────────────────────────────────────────────
 // Open layout: just a label + thin divider. No bordered card.
@@ -208,24 +209,14 @@ export function SelectRow<T extends string>({
       <div className="flex flex-col gap-0.5">
         <SettingLabel label={label} description={description} />
       </div>
-      <select
-        aria-label={label}
-        value={value}
-        onChange={(e) => onChange(e.target.value as T)}
-        className="shrink-0 ml-4 px-2.5 py-1 text-ui-chip font-medium rounded-md bg-base-200 border border-edge/40 text-fg focus:outline-none focus:border-accent/60 transition-colors cursor-pointer appearance-none pr-7 bg-no-repeat bg-right"
-        style={{
-          backgroundImage:
-            "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 4.5l3 3 3-3' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>\")",
-          backgroundPosition: "right 6px center",
-          backgroundSize: "12px",
-        }}
-      >
-        {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
-        ))}
-      </select>
+      <div className="shrink-0 ml-4">
+        <SelectMenu
+          value={value}
+          options={options}
+          onChange={onChange}
+          ariaLabel={label}
+        />
+      </div>
     </div>
   );
 }

--- a/desktop/src/components/support/ContactForm.tsx
+++ b/desktop/src/components/support/ContactForm.tsx
@@ -12,6 +12,7 @@ import { Bug, Lightbulb, MessageSquare, CreditCard, UserCog, Radio, Paperclip, X
 import clsx from "clsx";
 import { toast } from "sonner";
 import { authFetch, ApiError } from "../../api/client";
+import { SelectMenu } from "../widget-bar/SelectMenu";
 import { getUserIdentity, isAuthenticated } from "../../auth";
 
 // ── Types ────────────────────────────────────────────────────────
@@ -651,17 +652,19 @@ export default function ContactForm({ onBack }: ContactFormProps) {
           <>
             <div>
               <label className={labelClass}>Which widget?</label>
-              <select
+              <SelectMenu
                 value={channelSelection}
-                onChange={(e) => setChannelSelection(e.target.value)}
-                className={inputClass}
-              >
-                <option value="">Select a widget...</option>
-                <option value="Finance">Finance</option>
-                <option value="Sports">Sports</option>
-                <option value="RSS">RSS</option>
-                <option value="Fantasy">Fantasy</option>
-              </select>
+                options={[
+                  { value: "", label: "Select a widget..." },
+                  { value: "Finance", label: "Finance" },
+                  { value: "Sports", label: "Sports" },
+                  { value: "RSS", label: "RSS" },
+                  { value: "Fantasy", label: "Fantasy" },
+                ]}
+                onChange={setChannelSelection}
+                ariaLabel="Which widget?"
+                align="left"
+              />
             </div>
             <div>
               <label className={labelClass}>Describe your issue</label>

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -21,6 +21,7 @@ import SportsEmptyState from "../channels/sports/EmptyState";
 import RouteError from "../components/RouteError";
 import Tooltip from "../components/Tooltip";
 import { WidgetBar, BarPill } from "../components/widget-bar/Bar";
+import { FEED_CARD, FEED_CARD_INTERACTIVE } from "../components/feedCard";
 import TickerLayoutSummary from "../components/TickerLayoutSummary";
 import PageLayout from "../components/layout/PageLayout";
 import EmptySection from "../components/layout/EmptySection";
@@ -980,7 +981,11 @@ function WidgetChip({
           onClick();
         }
       }}
-      className="group rounded-lg border bg-base-200/40 border-edge/20 hover:bg-base-200/60 p-3 transition-colors text-left cursor-pointer w-full"
+      className={clsx(
+        FEED_CARD,
+        FEED_CARD_INTERACTIVE,
+        "group w-full text-left",
+      )}
     >
       <div className="flex items-center gap-2 mb-1.5">
         <span style={{ color: widget.hex }} className="shrink-0">

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -1030,11 +1030,6 @@ body {
   color: var(--color-fg);
 }
 
-*:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 55%, transparent);
-}
-
 /* ── Desktop window layout ────────────────────────────────────── */
 /* The desktop shell is a flex column that fills the viewport.
    Top-to-bottom: Ticker → Taskbar (FeedBar header) → Canvas (FeedBar content).
@@ -1274,9 +1269,13 @@ textarea:focus-visible,
 [role="switch"]:focus-visible,
 [role="radio"]:focus-visible,
 [tabindex]:focus-visible {
+  /* No border-radius override: outlines follow the element's own
+     radius natively in modern Chromium; inheriting the PARENT's
+     radius drew wrong-corner rings on square-parented controls.
+     (This is also the app's ONLY focus ring — the old universal
+     box-shadow ring double-drew on every keyboard focus.) */
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-  border-radius: inherit;
 }
 
 /* ── Reduced motion ─────────────────────────────────────────────── */


### PR DESCRIPTION
Post-ship cleanup: five native selects → SelectMenu popovers (SelectRow API preserved), one focus-ring system (box-shadow ring deleted, border-radius:inherit dropped for native radius-following), Home WidgetChip tiles on FEED_CARD. Sports tab stickiness deliberately skipped (transient filter, would need a server write per click). Gates: tsc, vitest 490/490, five suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)