### PR TITLE
fix(desktop): complete REL-40 rename so catalog data widgets register [REL-50]

### DIFF
--- a/desktop/src/datawidgets/fantasy/FeedTab.tsx
+++ b/desktop/src/datawidgets/fantasy/FeedTab.tsx
@@ -51,12 +51,12 @@ import type { FeedTabProps, DataWidgetManifest } from "../../types";
 import type { FantasySubTab } from "../../preferences";
 import type { LeagueResponse, MyLeaguesResponse } from "./types";
 
-/** DataWidgetRow accent — kept in sync with `fantasyChannel.hex`. */
+/** DataWidgetRow accent — kept in sync with `fantasyDataWidget.hex`. */
 const FANTASY_HEX = "#6366f1";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
-export const fantasyChannel: DataWidgetManifest = {
+export const fantasyDataWidget: DataWidgetManifest = {
   id: "fantasy",
   name: "Fantasy",
   tabLabel: "Fantasy",

--- a/desktop/src/datawidgets/finance/FeedTab.tsx
+++ b/desktop/src/datawidgets/finance/FeedTab.tsx
@@ -45,7 +45,7 @@ import type { FinanceDisplayPrefs } from "../../preferences";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
-export const financeChannel: DataWidgetManifest = {
+export const financeDataWidget: DataWidgetManifest = {
   id: "finance",
   name: "Finance",
   tabLabel: "Finance",

--- a/desktop/src/datawidgets/finance/preview/preview.tsx
+++ b/desktop/src/datawidgets/finance/preview/preview.tsx
@@ -34,7 +34,7 @@ import {
   migrateFinanceDisplay,
   type AppPreferences,
 } from "../../../preferences";
-import { financeChannel } from "../FeedTab";
+import { financeDataWidget } from "../FeedTab";
 import type { DataWidgetType } from "../../../api/client";
 import type { FeedTabProps, Trade } from "../../../types";
 
@@ -152,7 +152,7 @@ function main(): void {
     __refreshing: false,
   } as FeedTabProps["feedContext"];
 
-  const FeedTab = financeChannel.FeedTab;
+  const FeedTab = financeDataWidget.FeedTab;
 
   function Harness() {
     const [prefs, setPrefs] = useState<AppPreferences>(initialPrefs);

--- a/desktop/src/datawidgets/predictions/FeedTab.tsx
+++ b/desktop/src/datawidgets/predictions/FeedTab.tsx
@@ -100,7 +100,7 @@ import type { PredictionsDisplayPrefs } from "../../preferences";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
-export const predictionsChannel: DataWidgetManifest = {
+export const predictionsDataWidget: DataWidgetManifest = {
   id: "predictions",
   name: "Predictions",
   tabLabel: "Predict",
@@ -127,7 +127,7 @@ export const predictionsChannel: DataWidgetManifest = {
 const PAGE_SIZE = 20;
 const LOAD_MORE_INCREMENT = 20;
 
-/** DataWidgetRow accent — kept in sync with `predictionsChannel.hex` and the
+/** DataWidgetRow accent — kept in sync with `predictionsDataWidget.hex` and the
  *  marketplace catalog color (v1.1.5 unified the old indigo/teal split). */
 const PREDICTIONS_HEX = "#1fc9a0";
 

--- a/desktop/src/datawidgets/predictions/preview/preview.tsx
+++ b/desktop/src/datawidgets/predictions/preview/preview.tsx
@@ -25,7 +25,7 @@ import {
   migratePredictionsDisplay,
   type AppPreferences,
 } from "../../../preferences";
-import { predictionsChannel } from "../FeedTab";
+import { predictionsDataWidget } from "../FeedTab";
 import type { FeedTabProps, Prediction } from "../../../types";
 // Static snapshot of the local predictions API (:8085 has no CORS; the
 // fixture keeps screenshots deterministic anyway). Refresh with:
@@ -259,7 +259,7 @@ function main(): void {
     __refreshing: false,
   } as FeedTabProps["feedContext"];
 
-  const FeedTab = predictionsChannel.FeedTab;
+  const FeedTab = predictionsDataWidget.FeedTab;
 
   // Prefs are STATE so the in-widget bar's writes re-render the
   // feed like the real shell (persistence itself is Tauri-only).

--- a/desktop/src/datawidgets/registry.test.ts
+++ b/desktop/src/datawidgets/registry.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+
+import { getDataWidget, getAllDataWidgets } from "./registry";
+import { getCatalogItems } from "../marketplace";
+
+// Regression guard for REL-50: the registry matches manifest exports by name
+// suffix (createRegistry(..., "DataWidget", ...)). If the suffix and the
+// `*DataWidget` export names ever drift apart again, NO data-widget source
+// registers, and every data catalog item is silently dropped — the Catalog
+// page collapses to Utilities only. tsc can't see this (runtime glob match),
+// so assert it here.
+const DATA_SOURCES = ["finance", "sports", "fantasy", "rss", "predictions"] as const;
+
+describe("datawidget registry", () => {
+  it("registers every data-widget source", () => {
+    for (const id of DATA_SOURCES) {
+      expect(getDataWidget(id), `source "${id}" not registered`).toBeDefined();
+    }
+    expect(getAllDataWidgets().length).toBe(DATA_SOURCES.length);
+  });
+
+  it("surfaces data widgets in every category of the catalog", () => {
+    const byCategory = new Set(getCatalogItems().map((it) => it.category));
+    for (const c of ["finance", "sports", "news", "fantasy", "predictions"]) {
+      expect(byCategory.has(c as never), `category "${c}" has no catalog items`).toBe(true);
+    }
+  });
+});

--- a/desktop/src/datawidgets/registry.ts
+++ b/desktop/src/datawidgets/registry.ts
@@ -1,8 +1,8 @@
 /**
- * Desktop-local channel registry.
+ * Desktop-local data-widget registry.
  *
- * Discovers channel FeedTab components at build time from this
- * directory. Each channel module exports a named `{id}DataWidgetRow`
+ * Discovers data-widget FeedTab components at build time from this
+ * directory. Each module exports a named `{id}DataWidget` manifest
  * conforming to DataWidgetManifest.
  */
 import { createRegistry } from "../lib/createRegistry";
@@ -18,11 +18,11 @@ const { get, getAll, ORDER } = createRegistry<DataWidgetManifest>(
   ["finance", "sports", "fantasy", "rss", "predictions"],
 );
 
-/** Look up a channel by id. */
+/** Look up a data widget by id. */
 export const getDataWidget = get;
 
-/** Get all registered channels in canonical order. */
+/** Get all registered data widgets in canonical order. */
 export const getAllDataWidgets = getAll;
 
-/** Canonical display order for channel tabs. */
-export const CHANNEL_ORDER = ORDER;
+/** Canonical display order for data-widget tabs. */
+export const DATA_WIDGET_ORDER = ORDER;

--- a/desktop/src/datawidgets/rss/FeedTab.tsx
+++ b/desktop/src/datawidgets/rss/FeedTab.tsx
@@ -55,7 +55,7 @@ import { AnimatePresence } from "motion/react";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
-export const rssChannel: DataWidgetManifest = {
+export const rssDataWidget: DataWidgetManifest = {
   id: "rss",
   name: "News",
   tabLabel: "News",

--- a/desktop/src/datawidgets/rss/preview/preview.tsx
+++ b/desktop/src/datawidgets/rss/preview/preview.tsx
@@ -17,7 +17,7 @@ import "../../../style.css";
 import { ShellContext, type ShellState } from "../../../shell-context";
 import { dashboardQueryOptions, rssCatalogOptions } from "../../../api/queries";
 import { migrateRssDisplay, type AppPreferences } from "../../../preferences";
-import { rssChannel } from "../FeedTab";
+import { rssDataWidget } from "../FeedTab";
 import type { DataWidgetType, TrackedFeed } from "../../../api/client";
 import type { FeedTabProps, RssItem } from "../../../types";
 
@@ -147,7 +147,7 @@ function main(): void {
     __refreshing: false,
   } as FeedTabProps["feedContext"];
 
-  const FeedTab = rssChannel.FeedTab;
+  const FeedTab = rssDataWidget.FeedTab;
 
   function Harness() {
     const [prefs, setPrefs] = useState<AppPreferences>(initialPrefs);

--- a/desktop/src/datawidgets/sports/FeedTab.tsx
+++ b/desktop/src/datawidgets/sports/FeedTab.tsx
@@ -45,7 +45,7 @@ import type { FavoriteTeam } from "../../hooks/useSportsConfig";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
-export const sportsChannel: DataWidgetManifest = {
+export const sportsDataWidget: DataWidgetManifest = {
   id: "sports",
   name: "Sports",
   tabLabel: "Sports",

--- a/desktop/src/datawidgets/sports/preview/preview.tsx
+++ b/desktop/src/datawidgets/sports/preview/preview.tsx
@@ -26,7 +26,7 @@ import {
   type TeamInfo,
 } from "../../../api/queries";
 import type { AppPreferences } from "../../../preferences";
-import { sportsChannel } from "../FeedTab";
+import { sportsDataWidget } from "../FeedTab";
 import type { DataWidgetRow, DataWidgetType } from "../../../api/client";
 import type { FeedTabProps, Game } from "../../../types";
 
@@ -159,7 +159,7 @@ function main(): void {
     __refreshing: false,
   } as FeedTabProps["feedContext"];
 
-  const FeedTab = sportsChannel.FeedTab;
+  const FeedTab = sportsDataWidget.FeedTab;
 
   function Harness() {
     const [prefs, setPrefs] = useState<AppPreferences>(initialPrefs);

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -218,7 +218,7 @@ function RootLayout() {
 
   const channels: DataWidgetRow[] = useMemo(() => dashboard?.channels ?? [], [dashboard]);
 
-  // Filter to enabled channels only — Sidebar handles sorting by CHANNEL_ORDER
+  // Filter to enabled widgets only — Sidebar handles sorting by DATA_WIDGET_ORDER
   const enabledDataWidgets = useMemo(
     () => channels.filter((ch) => ch.enabled),
     [channels],


### PR DESCRIPTION
## Problem

On the Catalog page, every category filter except **Utility** showed "Nothing here" — but only in dev; released builds were fine.

## Root cause

REL-40 (#248) flipped the datawidget registry's export-name match suffix from `"Channel"` → `"DataWidget"` in `desktop/src/datawidgets/registry.ts`, but the five manifest const exports were never renamed — they stayed `financeChannel`, `sportsChannel`, `fantasyChannel`, `rssChannel`, `predictionsChannel`. So `exportName.endsWith("DataWidget")` matched nothing → no data-widget source registered → `buildDataItem()` dropped every data catalog item (source unresolved → `null`). Only local utility widgets survived. Released builds predate the rename, hence green there.

## Fix (completes the deferred rename — everything is a "widget" now)

- Renamed the 5 manifest exports `*Channel` → `*DataWidget` (finance/sports/fantasy/rss/predictions `FeedTab.tsx`)
- Updated the 4 `preview.tsx` importers + 2 stale hex-sync comments
- Restored registry suffix to `"DataWidget"`; `CHANNEL_ORDER` → `DATA_WIDGET_ORDER`; fixed stale registry + `__root.tsx` doc comments
- **Wire vocabulary deliberately untouched** per REL-40: `channel_type`, `dashboard.channels`, `/users/me/channels` routes, `isChannelTickerEnabled`, `RssChannelConfig`, ticker-row helpers, fantasy channel-discovery

## Tests

- New `registry.test.ts` guards glob registration + `getCatalogItems()` category coverage — the runtime suffix mismatch tsc can't catch.
- Playwright runtime check drove the real registry glob → `getCatalogItems()` via the dev server: all data categories now populate (sports 14, finance 2, news 11, fantasy 1, predictions 1) vs utility-only before.
- `tsc --noEmit` clean; vitest 494/494.

Closes REL-50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)