### PR TITLE
fix: correct the stale api.myscrollr.relentnet.dev host

### DIFF
--- a/api/internal/platform/constants.go
+++ b/api/internal/platform/constants.go
@@ -127,6 +127,6 @@ const (
 const (
 	HSTSMaxAge            = 5184000
 	DefaultPort           = "8080"
-	DefaultAllowedOrigins = "https://myscrollr.com,https://api.myscrollr.relentnet.dev"
+	DefaultAllowedOrigins = "https://myscrollr.com,https://api.myscrollr.com"
 	DefaultFrontendURL    = "https://myscrollr.com"
 )

--- a/api/main.go
+++ b/api/main.go
@@ -29,8 +29,8 @@ func envOr(key, fallback string) string {
 
 // @title Scrollr API
 // @version 2.0
-// @description Gateway API for Scrollr — routes requests to self-registered channel services.
-// @host api.myscrollr.relentnet.dev
+// @description Core API for Scrollr — serves the widget catalog, widget CRUD, reads, SSE, billing and accounts. Proxies the one remaining discovered service (fantasy).
+// @host api.myscrollr.com
 // @BasePath /
 // @securityDefinitions.apikey LogtoAuth
 // @in header

--- a/channels/fantasy/api/fantasy.go
+++ b/channels/fantasy/api/fantasy.go
@@ -59,7 +59,7 @@ func resolveFrontendURL() string {
 	}
 
 	// ALLOWED_ORIGINS is a comma-separated list of origins the core gateway
-	// accepts (e.g. "https://myscrollr.relentnet.dev,https://myscrollr.com").
+	// accepts (e.g. "https://myscrollr.com,https://api.myscrollr.com").
 	// The first entry is typically the primary frontend.
 	if origins := strings.TrimSpace(os.Getenv("ALLOWED_ORIGINS")); origins != "" {
 		first := strings.SplitN(origins, ",", 2)[0]

--- a/myscrollr.com/src/sentry.ts
+++ b/myscrollr.com/src/sentry.ts
@@ -11,7 +11,7 @@ declare const __APP_VERSION__: string
  * - No request bodies or headers
  * - No user emails or usernames
  * - Filesystem paths in stack frames are scrubbed to `~`
- * - Trace propagation locked to api.myscrollr.relentnet.dev — never to
+ * - Trace propagation locked to api.myscrollr.com — never to
  *   Stripe, Logto, or any third party
  *
  * SSR safety: the entire init body is gated on `typeof window !== 'undefined'`


### PR DESCRIPTION
The API is served at `api.myscrollr.com` — that's what the ingress binds (`myscrollr.com`, `www.myscrollr.com`, `api.myscrollr.com`). The old `relentnet.dev` host is answered by something else entirely and returns `no available server`.

**How this was found:** I used it to smoke-test the production deploy of #250 and got 503s on every endpoint. It looked like a total outage — the cluster was in fact completely healthy. A stale host in a doc annotation cost real diagnosis time during a migration window, which is the worst possible moment for a doc to lie.

## Changed

- **`api/main.go`** — the swagger `@host`. Also its `@description`, which still called this a gateway that "routes requests to self-registered channel services" — three ADRs out of date. It now describes what core actually does.
- **`api/internal/platform/constants.go`** — `DefaultAllowedOrigins`, the CORS fallback. Unused in production (`configmap-core.yaml` sets `ALLOWED_ORIGINS` explicitly) but wrong for local dev and any future deploy that omits it.
- **Comments** in `myscrollr.com/src/sentry.ts` and `channels/fantasy/api/fantasy.go`.

## Deliberately not touched

- **Sentry's `tracePropagationTargets`** is `/^https:\/\/api\.myscrollr\./` — a regex that already matches the real host. Tracing was never broken; only the comment above it was misleading. I checked the code rather than trusting the comment.
- **The dated specs under `docs/superpowers/`** keep the old host. They record what was true when they were written.

## Verified

`go build ./...` and `go test ./...` green, both clients typecheck, web tests pass.

One note on gofmt: the committed blobs are LF and gofmt-clean (verified against `git show`). A local `gofmt -l` on Windows flags these files only because the working copy has CRLF line endings — CI never sees that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
