### PR TITLE
release: desktop v1.1.10 — The Unification, and force the update

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4621,7 +4621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.9"
+version = "1.1.10"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,8 +5,12 @@ first-pass runthrough of the live release. Versions are intent, not promises —
 can merge or split as work reveals itself.*
 
 **The through-line:** v1.1.0 shipped the widget *model*; these releases make every
-surface actually behave like it. None of them are breaking — `MIN_DESKTOP_VERSION`
-stays at 1.1.0 and nobody gets force-updated.
+surface actually behave like it.
+
+v1.1.1–v1.1.9 were all non-breaking, with `MIN_DESKTOP_VERSION` pinned at 1.1.0.
+**v1.1.10 breaks that.** The unification renamed the wire with no compat seam, so
+`MIN_DESKTOP_VERSION` moves to 1.1.10 and every older install is force-updated —
+it has to be, since older builds cannot talk to the API at all.
 
 | Version | Codename | Theme | Size |
 |---|---|---|---|
@@ -19,6 +23,7 @@ stays at 1.1.0 and nobody gets force-updated.
 | ~~v1.1.7~~ | Spring Cleaning | ✅ **Shipped 2026-07-16** — under-the-hood release: backend consolidated into core (ADR-0002), simpler undo, Kalshi connect slimmed to prod-only, compact-number polish | S |
 | ~~v1.1.8~~ | A Fresh Coat | ✅ **Shipped 2026-07-17** — Claude-desktop-style chrome (single-row title bar, inset canvas, icon-dock sidebar + account chip), Home row + What's New, status page, and realtime SSE unlocked for every tier (client gate fix) | M |
 | ~~v1.1.9~~ | One Bar | ✅ **Shipped 2026-07-18** — Configure pages and gear menus retired: every widget's controls live in its own persistent top bar; Customize page (Settings+Ticker merged), search-to-add symbols, unified feed cards + brand logos, everything-is-a-widget IA, Support rewritten | L |
+| ~~v1.1.10~~ | The Unification | ✅ **Shipped 2026-07-21** — one vocabulary end to end: server-authoritative widget catalog (`GET /catalog`), core owns all schema, wire renamed with no compat seam, generic ticker dispatch, TS types generated from the Go structs. **Forced update** — older builds cannot reach this API | L |
 | v1.2.0 | Double-Decker 2.0 | Multi-row ticker rebuilt around widgets | L |
 | — | Website rides along | Pricing rewrite shipped with v1.1.2–3; screenshots now unblocked (post-v1.1.4) | S–M |
 

--- a/k8s/configmap-core.yaml
+++ b/k8s/configmap-core.yaml
@@ -7,9 +7,13 @@ data:
   # Derived URLs (replaces COOLIFY_FQDN build arg)
   API_URL: "https://api.myscrollr.com"
   # Oldest desktop version the API supports; served at /app/min-version.
-  # 1.1.0 = the widget/slot release (migration 000014 reshapes user data
-  # in ways older clients can't render). Bump on future breaking deploys.
-  MIN_DESKTOP_VERSION: "1.1.0"
+  # 1.1.10 = the unification release. The wire was renamed with no compat
+  # seam (channel_type -> widget_type, channels -> widgets, ticker_enabled,
+  # /users/me/widgets), so anything older cannot talk to this API at all —
+  # it 404s on widget CRUD and misreads every dashboard payload. Gating here
+  # turns that into the update overlay instead of a silently broken app.
+  # Bump on future breaking deploys.
+  MIN_DESKTOP_VERSION: "1.1.10"
   LOGTO_URL: "https://auth.myscrollr.com/oidc"
   LOGTO_JWKS_URL: "https://auth.myscrollr.com/oidc/jwks"
   LOGTO_ENDPOINT: "https://auth.myscrollr.com"


### PR DESCRIPTION
Cuts desktop **v1.1.10** and moves `MIN_DESKTOP_VERSION` to match.

## Why this is urgent

**Every build up to and including v1.1.9 is currently broken against production.** The unification (#250) renamed the wire with no compat seam:

| v1.1.9 sends / expects | Server today |
|---|---|
| `GET/POST/PUT/DELETE /users/me/channels` | **404** |
| `dashboard.channels` | sends `widgets` |
| `channel_type` | sends `widget_type` |
| `visible` | sends `ticker_enabled` |

`MIN_DESKTOP_VERSION` has sat at `1.1.0` since the widget/slot release, so v1.1.9 sails straight through the update gate while being completely incompatible. The result is an app that looks broken for no stated reason — which is exactly what happened when we smoke-tested after the deploy.

With this bump, older installs get the `UpdateRequiredOverlay` instead. That's the truthful behaviour, and it's what the gate was built for.

## Version choice

`1.1.10`, not `1.2.0`, per the house rule stated in ROADMAP:

> *patch = the same app, better — fixes, refinements, even sizable ones. Minor = something new to learn.*

The unification adds nothing for a user to learn — no new UI, no new interaction model. It's a patch by that definition, and it keeps `v1.2.0` reserved for Double-Decker 2.0, which has its own spec. **The forced update is carried by the gate, not by the version number.**

Say the word if you'd rather signal it as a minor; it's a one-line change in four files.

## Changed

- `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`, `desktop/src-tauri/Cargo.toml`, `desktop/src-tauri/Cargo.lock` → `1.1.10`
- `k8s/configmap-core.yaml` → `MIN_DESKTOP_VERSION: "1.1.10"`, with a comment explaining exactly what older clients can't do
- `docs/ROADMAP.md` → records v1.1.10, and corrects the now-false claim that no post-1.1.0 release is breaking

## One trap worth flagging

`Cargo.lock` contains **two** `version = "1.1.9"` entries — `scrollr-desktop` and, coincidentally, the third-party `flate2` crate. A blanket find-and-replace corrupts the lockfile. Only the `scrollr-desktop` entry is changed here; `flate2` is deliberately left at 1.1.9.

## After merge

`desktop-release.yml` builds Linux/macOS/Windows and creates a **draft** release tagged `desktop-v1.1.10` with a placeholder body. It needs real notes written and then publishing — this PR doesn't do that.

`k8s/configmap-core.yaml` changed, so the deploy's `kubectl apply` step runs this time (it was skipped for #250/#251). That applies the manifests including `replicas`, which is fine now that everything is scaled up and healthy.

## Verified

All four version files agree at 1.1.10, `cargo metadata` resolves it, JSON and YAML parse, desktop `tsc` clean, 513 tests pass. Nothing in the codebase pins the old version (only two historical comments mention it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
