### PR TITLE
fix(desktop): v1.1.10 stored the dashboard payload under the retired \channels\ key

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4621,7 +4621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.10"
+version = "1.1.11"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -320,7 +320,7 @@ export interface UserOverview {
     };
   };
   subscription: SubscriptionInfo | null;
-  channels: {
+  widgets: {
     total: number;
     enabled: number;
     by_type: Array<{

--- a/desktop/src/api/queries.ts
+++ b/desktop/src/api/queries.ts
@@ -53,14 +53,14 @@ export function userOverviewQueryOptions() {
 
 async function fetchDashboard(): Promise<DashboardResponse> {
   // Demo mode: talk to the no-auth bridge directly (it serves /dashboard with
-  // channels[] and ignores Authorization), so the live Kalshi demo works
+  // widgets[] and ignores Authorization), so the live Kalshi demo works
   // signed-out with zero infra. See channels/predictions/LOCAL_DEV.md.
   if (DEMO) {
     const demo = await request<{
       data: DashboardResponse["data"];
       widgets?: DashboardResponse["widgets"];
     }>("/dashboard");
-    return { data: demo.data, channels: demo.widgets } as DashboardResponse;
+    return { data: demo.data, widgets: demo.widgets } as DashboardResponse;
   }
 
   // Try authenticated path if token is valid OR a refresh token can restore the session.
@@ -80,7 +80,7 @@ async function fetchDashboard(): Promise<DashboardResponse> {
       }>("/dashboard");
       return {
         data: data.data,
-        channels: data.widgets,
+        widgets: data.widgets,
         preferences: data.preferences,
       } as DashboardResponse;
     } catch {

--- a/desktop/src/hooks/optimisticDashboard.test.ts
+++ b/desktop/src/hooks/optimisticDashboard.test.ts
@@ -1,48 +1,61 @@
 import { describe, it, expect } from "vitest";
 
 /**
- * Regression guard for a bug class TypeScript structurally cannot catch.
+ * Guard for a bug class TypeScript structurally cannot catch.
  *
- * The optimistic-update hooks write back into the dashboard cache with
- * `return { ...old, <key>: rows }`. When the wire field was renamed
- * `channels` → `widgets`, four of these kept writing `channels`. Nothing
- * failed: excess-property checking does not apply through a spread, and an
- * `as DashboardResponse` cast silenced the rest. The effect would have been
- * silent — adding a widget or changing its config simply would not update
- * the UI until the next refetch.
+ * Anything that builds a `DashboardResponse` writes it as an object
+ * literal — `{ ...old, widgets: rows }` in the optimistic hooks,
+ * `{ data, widgets, preferences } as DashboardResponse` in the query.
+ * When the wire field was renamed `channels` → `widgets`, several of these
+ * kept writing `channels`, and nothing failed: excess-property checking
+ * does not apply through a spread, and an `as DashboardResponse` cast
+ * silences it outright. The effect is silent — the sidebar, the account
+ * page and the ticker all read `dashboard.widgets`, get `undefined`, and
+ * render empty while the widget pages keep working.
  *
- * So this asserts on the source text, read through Vite's `?raw` glob (no
- * node types needed). Crude, but it catches exactly what the compiler is
- * blind to, and it costs nothing.
+ * That shipped. `queries.ts` fetched `data.widgets` and stored it under
+ * `channels`, so `dashboard.widgets` was *always* undefined in v1.1.10.
+ *
+ * This scans every file that mentions DashboardResponse rather than a
+ * hand-kept list of filenames — the first version of this guard enumerated
+ * four hooks and missed queries.ts for exactly that reason.
  */
-const sources = import.meta.glob<string>(
-  ["./useAddWidget.ts", "./useSportsConfig.ts", "./useDataWidgetConfig.ts", "./useDashboardCDC.ts"],
-  { query: "?raw", import: "default", eager: true },
+const sources = import.meta.glob<string>("../**/*.{ts,tsx}", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
+
+/**
+ * `ShellDataState` has its own legitimate `channels` field, unrelated to
+ * the wire. Anything else assigning a `channels:` key alongside
+ * DashboardResponse is the bug.
+ */
+const ALLOWED = new Set([
+  "../shell-context.ts",
+  "../datawidgets/sports/preview/preview.tsx",
+]);
+
+const builders = Object.entries(sources).filter(
+  ([path, src]) => src.includes("DashboardResponse") && !path.endsWith(".test.ts"),
 );
 
-describe("optimistic dashboard writes", () => {
-  it("covers every hook that writes the dashboard cache", () => {
-    expect(Object.keys(sources)).toHaveLength(4);
+describe("dashboard payload keys", () => {
+  it("finds the files that build a DashboardResponse", () => {
+    // Sanity: if this drops to zero the glob broke and the guard is vacuous.
+    expect(builders.length).toBeGreaterThan(3);
   });
 
-  for (const [path, src] of Object.entries(sources)) {
-    it(`${path} writes the dashboard's widgets key, not a stale one`, () => {
-      // `channels` as an object-literal KEY is writing a field
-      // DashboardResponse no longer has. Reading one is fine — ShellDataState
-      // legitimately has its own `channels`, so these hooks destructure and
-      // call `.find()` on it; neither of those puts a colon after the name.
+  for (const [path, src] of builders) {
+    if (ALLOWED.has(path)) continue;
+    it(`${path} uses the widgets key, not the retired channels one`, () => {
       const stale = src.match(/\bchannels\s*:/g);
       expect(
         stale,
-        `${path} assigns a "channels" key; DashboardResponse uses "widgets"`,
+        `${path} assigns a "channels" key. DashboardResponse and the ` +
+          `overview payload both use "widgets" — a stale key here is invisible ` +
+          `to tsc and silently empties the sidebar.`,
       ).toBeNull();
-
-      // And each hook must actually write widgets, so this cannot pass on a
-      // file that stopped updating the cache altogether.
-      expect(
-        /\bwidgets\b/.test(src),
-        `${path} never mentions widgets — did the cache write get dropped?`,
-      ).toBe(true);
     });
   }
 });

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,6 +24,7 @@ it has to be, since older builds cannot talk to the API at all.
 | ~~v1.1.8~~ | A Fresh Coat | ✅ **Shipped 2026-07-17** — Claude-desktop-style chrome (single-row title bar, inset canvas, icon-dock sidebar + account chip), Home row + What's New, status page, and realtime SSE unlocked for every tier (client gate fix) | M |
 | ~~v1.1.9~~ | One Bar | ✅ **Shipped 2026-07-18** — Configure pages and gear menus retired: every widget's controls live in its own persistent top bar; Customize page (Settings+Ticker merged), search-to-add symbols, unified feed cards + brand logos, everything-is-a-widget IA, Support rewritten | L |
 | ~~v1.1.10~~ | The Unification | ✅ **Shipped 2026-07-21** — one vocabulary end to end: server-authoritative widget catalog (`GET /catalog`), core owns all schema, wire renamed with no compat seam, generic ticker dispatch, TS types generated from the Go structs. **Forced update** — older builds cannot reach this API | L |
+| ~~v1.1.11~~ | The Unification, actually working | ✅ **Shipped 2026-07-21** — fixes the v1.1.10 regression that stored the dashboard payload under the retired `channels` key, leaving the sidebar and account page empty. **Forced update** — v1.1.10 is unusable | XS |
 | v1.2.0 | Double-Decker 2.0 | Multi-row ticker rebuilt around widgets | L |
 | — | Website rides along | Pricing rewrite shipped with v1.1.2–3; screenshots now unblocked (post-v1.1.4) | S–M |
 

--- a/k8s/configmap-core.yaml
+++ b/k8s/configmap-core.yaml
@@ -7,13 +7,15 @@ data:
   # Derived URLs (replaces COOLIFY_FQDN build arg)
   API_URL: "https://api.myscrollr.com"
   # Oldest desktop version the API supports; served at /app/min-version.
-  # 1.1.10 = the unification release. The wire was renamed with no compat
-  # seam (channel_type -> widget_type, channels -> widgets, ticker_enabled,
-  # /users/me/widgets), so anything older cannot talk to this API at all —
-  # it 404s on widget CRUD and misreads every dashboard payload. Gating here
-  # turns that into the update overlay instead of a silently broken app.
+  # 1.1.11 = the unification release + the dashboard-payload fix.
+  #   1.1.10 renamed the wire with no compat seam (channel_type ->
+  #   widget_type, channels -> widgets, ticker_enabled), so anything
+  #   older cannot talk to this API at all.
+  #   1.1.10 itself shipped a bug that stored the dashboard payload under
+  #   the retired `channels` key, leaving the sidebar and account page
+  #   empty, so it is gated too.
   # Bump on future breaking deploys.
-  MIN_DESKTOP_VERSION: "1.1.10"
+  MIN_DESKTOP_VERSION: "1.1.11"
   LOGTO_URL: "https://auth.myscrollr.com/oidc"
   LOGTO_JWKS_URL: "https://auth.myscrollr.com/oidc/jwks"
   LOGTO_ENDPOINT: "https://auth.myscrollr.com"


### PR DESCRIPTION
**v1.1.10 ships with an empty sidebar and an empty account page.** This fixes it and cuts v1.1.11.

## The bug

`api/queries.ts` fetched `data.widgets` from the server, then stored it under `channels`:

```ts
return {
  data: data.data,
  channels: data.widgets,     // ← key no longer exists on DashboardResponse
  preferences: data.preferences,
} as DashboardResponse;
```

So `dashboard.widgets` was **always** `undefined`. The sidebar, account page and ticker all read it and rendered nothing — while widget *pages* kept working, because those fetch `/finance` and friends directly.

That is exactly the reported symptom: *"widgets work when added, but don''t show up in the sidebar or my account, and re-adding says already added."* The rows were being created correctly the whole time; nothing could see them.

A second instance of the same mistake: `UserOverview` still typed its summary as `channels`, where the server now sends `widgets`.

## Why nothing caught it

Both are fallout from the Phase 3d rename in #250, and each defeated a different safety net:

- **The regex that did the rename** was `$`-anchored in multiline mode against **CRLF** files, so `channels: {\r` never matched `channels: \{$`. The edit silently did not apply.
- **`tsc` could not see either one.** The query result is cast `as DashboardResponse`, which suppresses excess-property checking outright. The overview type was internally consistent with its readers — just wrong versus the server.
- **The guard written for this exact bug class missed it**, because it enumerated four hook filenames by hand. `queries.ts` was not on the list.

## The guard, fixed properly

Rewritten to scan **every file that mentions `DashboardResponse`** instead of a hand-kept list, with an explicit allowlist for `ShellDataState`''s legitimate `channels` field. Coverage goes from 4 files to 14.

Verified it catches this bug by reintroducing it — it fails naming `../api/queries.ts` and explaining why the key is wrong.

## Shipping

Cut as **1.1.11** with `MIN_DESKTOP_VERSION` moved to match. v1.1.10 is unusable rather than merely outdated, so it should be force-updated past.

## Verified

Desktop `tsc` clean, **522 tests** pass, and no stale `channels:` key remains anywhere outside `ShellDataState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)