### PR TITLE
fix(deploy): stop kubectl apply from unpinning every service image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -313,6 +313,29 @@ jobs:
       - name: Configure kubectl
         run: doctl kubernetes cluster kubeconfig save scrollr-cluster
 
+      # Every deployment manifest hardcodes `:latest` as its image, which is
+      # only meaningful when creating a deployment on a fresh cluster. On an
+      # existing cluster `kubectl apply` rewrites the running image back to
+      # `:latest`, silently unpinning it: both the old and new ReplicaSets
+      # then record `:latest`, so `kubectl rollout undo` resolves to the
+      # newest image and a rollback does nothing. Only services this build
+      # also rebuilt get re-pinned by "Roll out updated images", so a
+      # k8s-only change unpins everything else. Record what is actually
+      # running so the rollout step can restore it.
+      - name: Record live image tags
+        if: needs.detect-changes.outputs.k8s == 'true'
+        run: |
+          : > /tmp/live-images.env
+          for svc in core-api website finance-service sports-service rss-service fantasy-api predictions-service; do
+            img="$(kubectl get deployment/${svc} -n scrollr \
+              -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+            case "$img" in
+              *:sha-*) echo "${svc}=${img}" >> /tmp/live-images.env ;;
+              *) echo "${svc}: not pinned (running '${img:-nothing}') — nothing to preserve" ;;
+            esac
+          done
+          echo "Recorded pins:"; cat /tmp/live-images.env
+
       - name: Apply K8s config changes
         if: needs.detect-changes.outputs.k8s == 'true'
         run: |
@@ -416,8 +439,28 @@ jobs:
             fi
 
             if [ "$K8S_CHANGED" = "true" ]; then
-              echo "Restarting ${service} to pick up Kubernetes config changes"
-              kubectl rollout restart deployment/${service} -n scrollr
+              # `kubectl apply` just reset this service to `:latest`. Restore
+              # the tag it was actually running (recorded before the apply);
+              # that is itself a spec change, so it rolls the pods and picks
+              # up the config change we applied. Only fall back to a bare
+              # restart when there was no pinned tag to restore.
+              pinned=""
+              if [ -f /tmp/live-images.env ]; then
+                pinned="$(sed -n "s|^${service}=||p" /tmp/live-images.env)"
+              fi
+
+              if [ -n "$pinned" ]; then
+                echo "Re-pinning ${service} to ${pinned} (apply had reset it to :latest)"
+                kubectl set image deployment/${service} \
+                  ${service}="${pinned}" \
+                  -n scrollr
+                # If the image already matched, no new rollout is triggered
+                # and the config change still needs a restart.
+                kubectl rollout restart deployment/${service} -n scrollr
+              else
+                echo "Restarting ${service} to pick up Kubernetes config changes"
+                kubectl rollout restart deployment/${service} -n scrollr
+              fi
               wait_for_rollout "$service"
             fi
           }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.0.20",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.0.20",
+      "version": "1.1.11",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",


### PR DESCRIPTION
Six of the seven deployments were running `registry.digitalocean.com/scrollr/<svc>:latest` rather than a pinned sha. `website` was the only survivor, and only by accident.

## The mechanism

Every manifest in `k8s/` hardcodes `image: .../<svc>:latest`. That is right for a fresh cluster and wrong for an existing one: `kubectl apply` rewrites the running image back to `:latest`, and the rollout step only re-pins services *this build rebuilt*. So any PR touching `k8s/**` unpins every service it did not also rebuild.

`website` kept its pin because the v1.1.11 release trigger rebuilt it *after* #254 applied the manifests.

## Why it matters

Not the running code -- a `:latest` tag defaults to `imagePullPolicy: Always`, so the pods do pull current images. The cost is that the cluster stops recording *which* build it runs, and both the old and new ReplicaSets say `:latest`. `kubectl rollout undo` then resolves to the newest image, so **a rollback silently does nothing**.

## The fix

Record each deployment's live tag before the apply; restore it in the rollout step for services this build did not rebuild. Manifests keep `:latest` as the bootstrap default -- correct for a fresh cluster, where there is no live tag to preserve.

The `rollout restart` after the re-pin is redundant today (re-pinning is always a real spec change, since apply just set `:latest`), but it keeps config changes rolling if a manifest is ever pinned to a sha.

## Verification

Bash parsing checked locally: extraction is correct for hyphenated service names and images containing `/` and `:`, empty for an absent service, and the `*:sha-*` glob correctly classifies `:latest` as not-pinned. YAML parses, step ordering confirmed (`Configure kubectl` -> `Record live image tags` -> `Apply K8s config changes`).

This PR does not touch `k8s/**` or any service source, so merging it exercises no rollout.

## Note: this does not re-pin the current cluster

The fix preserves pins; it cannot invent one where none exists. All six unpinned services stay on `:latest` until something rebuilds them. Cleanest correction is a manual `workflow_dispatch` run with `services=all`, which rebuilds all seven from current main and pins each to that sha.

## Also

`desktop/package-lock.json` root version was stale at `1.0.20` since before v1.1.0 -- drifted across ~11 releases. Cosmetic (nothing reads it; `npm ci` only checks dependency agreement), now synced to `1.1.11`. No drift guard added: a test for a cosmetic field is the speculative work this repo avoids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)