### PR TITLE
fix(deploy): preserve any pin, not just the pipeline's own tag scheme

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -329,9 +329,14 @@ jobs:
           for svc in core-api website finance-service sports-service rss-service fantasy-api predictions-service; do
             img="$(kubectl get deployment/${svc} -n scrollr \
               -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+            # Preserve anything that is not the `:latest` placeholder: the
+            # `:sha-<commit>` tags this pipeline pushes, a `@sha256:` digest,
+            # or a tag pinned by hand during an incident. An image with no
+            # tag at all is implicitly `:latest`, so it counts as unpinned.
             case "$img" in
-              *:sha-*) echo "${svc}=${img}" >> /tmp/live-images.env ;;
-              *) echo "${svc}: not pinned (running '${img:-nothing}') — nothing to preserve" ;;
+              ""|*:latest) echo "${svc}: not pinned (running '${img:-nothing}') — nothing to preserve" ;;
+              *:*) echo "${svc}=${img}" >> /tmp/live-images.env ;;
+              *) echo "${svc}: untagged (implicitly :latest) — nothing to preserve" ;;
             esac
           done
           echo "Recorded pins:"; cat /tmp/live-images.env


### PR DESCRIPTION
Follow-up to #255.

That PR recorded a live image as "pinned" only if it matched `*:sha-*` -- the tag scheme this pipeline pushes. Anything pinned another way reads as unpinned and gets reset to `:latest` by the next `kubectl apply`. That is the same failure #255 fixed, narrowed to precisely the cases where a human had intervened:

- a `@sha256:` digest pin (the no-rebuild way to pin an already-running image)
- a tag pinned by hand during an incident

Both are exactly when you least want the pipeline quietly undoing you.

Now preserves anything that is not the `:latest` placeholder; an untagged image is implicitly `:latest`, so it still counts as unpinned.

Verified against all six shapes -- `:latest`, `:sha-<commit>`, `@sha256:<digest>`, a manual `:hotfix-manual` tag, untagged, and empty -- each classified correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)