### PR TITLE
fix(gents): stop the drift guard failing on every Windows checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,9 @@ Makefile   text eol=lf
 # SQL migrations are embedded and checksummed (sqlx / golang-migrate); pin LF
 # so a Windows CRLF checkout can't drift a migration's checksum vs CI/prod.
 *.sql      text eol=lf
+
+# Generated wire types are compared byte-for-byte against the generator's
+# output by TestGeneratedTypesAreCurrent, which emits LF. Same rule as the
+# migrations above: a CRLF checkout would fail the guard on every Windows
+# clone while passing in CI.
+*.generated.ts  text eol=lf

--- a/api/cmd/gents/gents_test.go
+++ b/api/cmd/gents/gents_test.go
@@ -25,13 +25,26 @@ func TestGeneratedTypesAreCurrent(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v (run `go -C api run ./cmd/gents`)", out, err)
 		}
-		if string(got) == want {
+		if normalizeEOL(string(got)) == want {
 			continue
 		}
 		t.Errorf("%s is stale — a Go wire struct changed but the generated "+
 			"types were not regenerated. Run:\n\n    go -C api run ./cmd/gents\n\n%s",
-			out, firstDiff(string(got), want))
+			out, firstDiff(normalizeEOL(string(got)), want))
 	}
+}
+
+// The generator always emits LF, but git checks these files out with CRLF on
+// Windows (`git ls-files --eol` reports `i/lf w/crlf`). Comparing raw bytes
+// therefore failed on every Windows working tree while passing in CI — a
+// guard that cries wolf on the developer's own machine is a guard that gets
+// ignored. Compare content, not line endings.
+//
+// `.gitattributes` also pins `*.generated.ts` to LF so the checked-out file
+// matches the generator byte-for-byte; this normalization keeps the guard
+// honest regardless of how any given clone is configured.
+func normalizeEOL(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
 }
 
 // A custom MarshalJSON silently invalidates everything generated from


### PR DESCRIPTION
`TestGeneratedTypesAreCurrent` compares the generator output byte-for-byte against the committed types. The generator emits LF; git checks these files out with CRLF on Windows:

```
$ git ls-files --eol desktop/src/types/api.generated.ts
i/lf    w/crlf    desktop/src/types/api.generated.ts
```

So the guard failed on **every Windows working tree** while passing in CI. Its own failure message was the tell -- `first difference at line 1` printing two identical-looking lines.

A guard that cries wolf on the developer machine is a guard that gets ignored, which defeats the point of pinning the generated types in the first place.

## Fix

Normalize line endings before comparing, and pin `*.generated.ts` to LF in `.gitattributes`. That file already does exactly this for `*.sql`, for the same underlying reason -- migrations are checksummed, generated types are content-compared, and a CRLF checkout breaks both.

## Verified

- Before: `FAIL github.com/.../api/cmd/gents` on Windows
- After: `ok github.com/.../api/cmd/gents`, full suite green across all 9 packages
- `git ls-files --eol` now reports `w/lf attr/text eol=lf` for both generated files
- Desktop suite unaffected: 522 tests / 34 files passing

Note: `gofmt -l` flags 83 of 84 `.go` files on a Windows checkout for the same CRLF reason. That is pre-existing and not addressed here -- CI runs on Linux where it is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)