### PR TITLE
refactor: complete the widget model - vocabulary into stored data, and delete `kind`

### DIFF
--- a/api/CHANNELS.md
+++ b/api/CHANNELS.md
@@ -14,7 +14,6 @@ One user-facing primitive, one price lever:
 ```
 Source  (invisible plumbing: finance, sports, rss, predictions, fantasy)
    └─ Widget   (the ONLY thing a user picks: "NFL", "Crypto", "BBC News")
-        ├─ kind: data (CDC-backed) | utility (local-only)
         └─ costs exactly 1 slot
 ```
 
@@ -23,13 +22,21 @@ is which ingester feeds it and which renderer draws it — routing, never a
 grouping the user perceives. `category` is a cosmetic filter tag on a
 widget, deliberately independent of its source.
 
+**A widget is data-backed iff it has a source.** One with a source gets a
+`user_widgets` row and a CDC feed; one without (clock, weather, …) lives in
+desktop preferences. There is no separate `kind` field — it existed, carried
+exactly this fact, and meant two things to keep in sync plus a third name
+for the same idea (the cosmetic `utility` category). Ask
+`IsUtilityWidgetType(id)` server-side or `isUtilityWidget(id)` in the
+client.
+
 Full reasoning in [`../docs/VISION.md`](../docs/VISION.md); this is the
 practical version.
 
 ## The catalog is the authority
 
 `api/internal/platform/widgets.go` holds every widget — id, name,
-description, kind, source, category, color, logo, default config, required
+description, source, category, color, logo, default config, required
 tier, and copy. `GET /catalog` serves it. Both clients fetch it and render
 generically.
 
@@ -53,7 +60,7 @@ Two artifacts ride along, both generated and both guarded by a Go test:
    `api/internal/platform/widgets.go`.
 2. Regenerate the snapshot and types:
    ```sh
-   curl -s localhost:8080/catalog | python -m json.tool > desktop/src/catalog.snapshot.json
+   go -C api test ./internal/widgets -run TestCatalogSnapshot -update
    go -C api run ./cmd/gents
    ```
 3. `go -C api test ./...` — the drift guards check both.

--- a/api/internal/platform/widgets.go
+++ b/api/internal/platform/widgets.go
@@ -19,25 +19,22 @@ import "strings"
 // well (see widgetSourcePrefixes), so a widget id this catalog does not
 // enumerate still routes correctly rather than 404ing.
 
-// WidgetKind distinguishes data-backed widgets from local-only utilities.
-type WidgetKind string
-
-const (
-	WidgetData    WidgetKind = "data"    // backed by a data source + CDC
-	WidgetUtility WidgetKind = "utility" // local-only (clock, weather, …)
-)
-
 // WidgetDef is one catalog entry. Every widget costs exactly one slot, so
 // there is no per-widget price — RequiredTier gates availability only, and
 // is "free" for everything today (slots are the one lever, VISION §6).
 type WidgetDef struct {
-	ID          string     `json:"id"`
-	Name        string     `json:"name"`
-	Description string     `json:"description"`
-	Kind        WidgetKind `json:"kind"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 
 	// Source is the backing ingester / CDC topic and the renderer key.
 	// Empty for utilities. Never shown to the user.
+	//
+	// Source alone says whether a widget is data-backed: a data widget has
+	// one, a utility does not. There used to be a separate `kind` field
+	// carrying the same fact, which meant two things to keep in sync and
+	// three names for one distinction (kind, source, and the "utility"
+	// category). Ask `Source == ""` instead — see IsUtilityWidgetType.
 	Source string `json:"source,omitempty"`
 
 	// Category is a cosmetic catalog filter tag with no behavioral effect.
@@ -95,7 +92,7 @@ var catalog = []WidgetDef{
 	// ── Finance — the finance source split by asset class ──────────────
 	{
 		ID: "finance_stocks", Name: "Stocks", Category: "finance", Source: "finance",
-		Kind: WidgetData, Color: "#16a34a",
+		Color: "#16a34a",
 		Description:   "Live stock & ETF prices for the symbols you pick.",
 		DefaultConfig: map[string]any{"symbols": []string{}, "asset_class": "stock"},
 		About:         "Real-time stock and ETF prices for the tickers you follow. Your watchlist streams live as the market moves — no brokerage app open, no tab to babysit.",
@@ -107,7 +104,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "finance_crypto", Name: "Crypto", Category: "finance", Source: "finance",
-		Kind: WidgetData, Color: "#f7931a",
+		Color: "#f7931a",
 		Description:   "Live crypto prices for the coins you pick.",
 		DefaultConfig: map[string]any{"symbols": []string{}, "asset_class": "crypto"},
 		About:         "Live crypto prices for the coins you track, streamed around the clock. From BTC and ETH to the long tail, your picks update the moment the market does.",
@@ -121,35 +118,35 @@ var catalog = []WidgetDef{
 	// ── Sports — one widget per league ─────────────────────────────────
 	{
 		ID: "sports_nfl", Name: "NFL", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#013369", LogoURL: "https://icon.horse/icon/nfl.com",
+		Color: "#013369", LogoURL: "https://icon.horse/icon/nfl.com",
 		Description:   "Live NFL scores and game states.",
 		DefaultConfig: map[string]any{"leagues": []string{"NFL"}}, Usage: usageTeamSport,
 		About: "Live NFL scores, quarters, and game clock for every matchup on the slate. Follow the whole week or zero in on your team.",
 	},
 	{
 		ID: "sports_nba", Name: "NBA", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#c9082a", LogoURL: "https://icon.horse/icon/nba.com",
+		Color: "#c9082a", LogoURL: "https://icon.horse/icon/nba.com",
 		Description:   "Live NBA scores and game states.",
 		DefaultConfig: map[string]any{"leagues": []string{"NBA"}}, Usage: usageTeamSport,
 		About: "Live NBA scores and game state across the association — every quarter, every buzzer-beater, as it happens.",
 	},
 	{
 		ID: "sports_nhl", Name: "NHL", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#111827", LogoURL: "https://icon.horse/icon/nhl.com",
+		Color: "#111827", LogoURL: "https://icon.horse/icon/nhl.com",
 		Description:   "Live NHL scores and game states.",
 		DefaultConfig: map[string]any{"leagues": []string{"NHL"}}, Usage: usageTeamSport,
 		About: "Live NHL scores and period-by-period game state for every game on the ice.",
 	},
 	{
 		ID: "sports_mlb", Name: "MLB", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#002d72", LogoURL: "https://icon.horse/icon/mlb.com",
+		Color: "#002d72", LogoURL: "https://icon.horse/icon/mlb.com",
 		Description:   "Live MLB scores and game states.",
 		DefaultConfig: map[string]any{"leagues": []string{"MLB"}}, Usage: usageTeamSport,
 		About: "Live MLB scores, innings, and game state across the league, all season long.",
 	},
 	{
 		ID: "sports_f1", Name: "F1", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#e10600", LogoURL: "https://icon.horse/icon/formula1.com",
+		Color: "#e10600", LogoURL: "https://icon.horse/icon/formula1.com",
 		Description:   "Formula 1 race weekends and results.",
 		DefaultConfig: map[string]any{"leagues": []string{"Formula 1"}},
 		About:         "Formula 1 race weekends — practice, qualifying, and the Grand Prix result the moment the checkered flag drops.",
@@ -161,7 +158,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "sports_worldcup", Name: "World Cup", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#2e7d46", LogoURL: "https://icon.horse/icon/fifa.com",
+		Color: "#2e7d46", LogoURL: "https://icon.horse/icon/fifa.com",
 		Description:   "FIFA World Cup fixtures and scores.",
 		DefaultConfig: map[string]any{"leagues": []string{"FIFA World Cup"}},
 		About:         "Every FIFA World Cup fixture and live score, through the group stage and into the knockouts.",
@@ -173,42 +170,42 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "sports_ncaaf", Name: "NCAA Football", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#0b427a", LogoURL: "https://icon.horse/icon/ncaa.com",
+		Color: "#0b427a", LogoURL: "https://icon.horse/icon/ncaa.com",
 		Description:   "Live college football scores across the FBS.",
 		DefaultConfig: map[string]any{"leagues": []string{"NCAA Football"}}, Usage: usageTeamSport,
 		About: "Live college football scores across the FBS — Saturday slates, rivalry week, and bowl season.",
 	},
 	{
 		ID: "sports_ncaab", Name: "NCAA Basketball", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#d2691e", LogoURL: "https://icon.horse/icon/ncaa.com",
+		Color: "#d2691e", LogoURL: "https://icon.horse/icon/ncaa.com",
 		Description:   "Live college basketball scores and the road to March.",
 		DefaultConfig: map[string]any{"leagues": []string{"NCAA Basketball"}}, Usage: usageTeamSport,
 		About: "Live college basketball scores through conference play and all the way into March Madness.",
 	},
 	{
 		ID: "sports_premierleague", Name: "Premier League", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#37003c", LogoURL: "https://icon.horse/icon/premierleague.com",
+		Color: "#37003c", LogoURL: "https://icon.horse/icon/premierleague.com",
 		Description:   "Live scores from England's Premier League.",
 		DefaultConfig: map[string]any{"leagues": []string{"Premier League"}}, Usage: usageTeamSport,
 		About: "Live scores from England's Premier League — all 20 clubs, every matchweek.",
 	},
 	{
 		ID: "sports_laliga", Name: "La Liga", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#e2001a", LogoURL: "https://icon.horse/icon/laliga.com",
+		Color: "#e2001a", LogoURL: "https://icon.horse/icon/laliga.com",
 		Description:   "Live scores from Spain's La Liga.",
 		DefaultConfig: map[string]any{"leagues": []string{"La Liga"}}, Usage: usageTeamSport,
 		About: "Live scores from Spain's La Liga, from the title race to the relegation scrap.",
 	},
 	{
 		ID: "sports_mls", Name: "MLS", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#001838", LogoURL: "https://icon.horse/icon/mlssoccer.com",
+		Color: "#001838", LogoURL: "https://icon.horse/icon/mlssoccer.com",
 		Description:   "Live Major League Soccer scores.",
 		DefaultConfig: map[string]any{"leagues": []string{"MLS"}}, Usage: usageTeamSport,
 		About: "Live Major League Soccer scores across the Eastern and Western conferences.",
 	},
 	{
 		ID: "sports_championsleague", Name: "Champions League", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#0e1e5b", LogoURL: "https://icon.horse/icon/uefa.com",
+		Color: "#0e1e5b", LogoURL: "https://icon.horse/icon/uefa.com",
 		Description:   "Live UEFA Champions League scores.",
 		DefaultConfig: map[string]any{"leagues": []string{"Champions League"}}, Usage: usageTeamSport,
 		About: "Live UEFA Champions League scores through the league phase and into the knockout rounds.",
@@ -217,7 +214,7 @@ var catalog = []WidgetDef{
 		// icon.horse returns a blank image for ufc.com, so this is pinned to
 		// DuckDuckGo's icon CDN, which serves the real opaque wordmark.
 		ID: "sports_ufc", Name: "UFC", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#d20a0a", LogoLight: true,
+		Color: "#d20a0a", LogoLight: true,
 		LogoURL:       "https://icons.duckduckgo.com/ip3/ufc.com.ico",
 		Description:   "UFC fight cards and results.",
 		DefaultConfig: map[string]any{"leagues": []string{"UFC"}},
@@ -230,7 +227,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "sports_afl", Name: "AFL", Category: "sports", Source: "sports",
-		Kind: WidgetData, Color: "#003da5", LogoURL: "https://icon.horse/icon/afl.com.au",
+		Color: "#003da5", LogoURL: "https://icon.horse/icon/afl.com.au",
 		Description:   "Live Australian Football League scores.",
 		DefaultConfig: map[string]any{"leagues": []string{"AFL"}}, Usage: usageTeamSport,
 		About: "Live Australian Football League scores across the home-and-away season and finals.",
@@ -239,7 +236,7 @@ var catalog = []WidgetDef{
 	// ── News — curated feeds, each its own widget over the rss source ───
 	{
 		ID: "news_bbc", Name: "BBC News", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#b80000", LogoURL: "https://icon.horse/icon/bbc.com",
+		Color: "#b80000", LogoURL: "https://icon.horse/icon/bbc.com",
 		Description: "World, UK and breaking news from the BBC.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "BBC News", "url": "https://feeds.bbci.co.uk/news/rss.xml"},
@@ -249,7 +246,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_npr", Name: "NPR", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#4667de", LogoURL: "https://icon.horse/icon/npr.org",
+		Color: "#4667de", LogoURL: "https://icon.horse/icon/npr.org",
 		Description: "US and world news, analysis and reporting from NPR.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "NPR News", "url": "https://feeds.npr.org/1001/rss.xml"},
@@ -259,7 +256,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_guardian", Name: "The Guardian", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#052962", LogoURL: "https://icon.horse/icon/theguardian.com",
+		Color: "#052962", LogoURL: "https://icon.horse/icon/theguardian.com",
 		Description: "Independent world news, opinion and reporting.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "The Guardian", "url": "https://www.theguardian.com/world/rss"},
@@ -269,7 +266,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_aljazeera", Name: "Al Jazeera", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#e8a33d", LogoURL: "https://icon.horse/icon/aljazeera.com",
+		Color: "#e8a33d", LogoURL: "https://icon.horse/icon/aljazeera.com",
 		Description: "Breaking news from the Middle East and around the world.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "Al Jazeera", "url": "https://www.aljazeera.com/xml/rss/all.xml"},
@@ -279,7 +276,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_propublica", Name: "ProPublica", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#c8102e", LogoURL: "https://icon.horse/icon/propublica.org",
+		Color: "#c8102e", LogoURL: "https://icon.horse/icon/propublica.org",
 		Description: "Investigative journalism in the public interest.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "ProPublica", "url": "https://feeds.propublica.org/propublica/main"},
@@ -289,7 +286,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_bloomberg", Name: "Bloomberg", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#1a1a2e", LogoURL: "https://icon.horse/icon/bloomberg.com",
+		Color: "#1a1a2e", LogoURL: "https://icon.horse/icon/bloomberg.com",
 		Description: "Global markets, finance and business news.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "Bloomberg Markets", "url": "https://feeds.bloomberg.com/markets/news.rss"},
@@ -299,7 +296,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_cnbc", Name: "CNBC", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#005594", LogoURL: "https://icon.horse/icon/cnbc.com",
+		Color: "#005594", LogoURL: "https://icon.horse/icon/cnbc.com",
 		Description: "Markets, business and finance headlines.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "CNBC Top News", "url": "https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=100003114"},
@@ -309,7 +306,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_nasa", Name: "NASA", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#0b3d91", LogoURL: "https://icon.horse/icon/nasa.gov",
+		Color: "#0b3d91", LogoURL: "https://icon.horse/icon/nasa.gov",
 		Description: "Space, science and mission news from NASA.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "NASA Breaking News", "url": "https://www.nasa.gov/news-release/feed/"},
@@ -319,7 +316,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_hackernews", Name: "Hacker News", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#ff6600", LogoURL: "https://icon.horse/icon/news.ycombinator.com",
+		Color: "#ff6600", LogoURL: "https://icon.horse/icon/news.ycombinator.com",
 		Description: "Top stories from the Hacker News front page.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "Hacker News", "url": "https://hnrss.org/frontpage"},
@@ -329,7 +326,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_theverge", Name: "The Verge", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#5200ff", LogoURL: "https://icon.horse/icon/theverge.com",
+		Color: "#5200ff", LogoURL: "https://icon.horse/icon/theverge.com",
 		Description: "Technology, science, art and culture.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "The Verge", "url": "https://www.theverge.com/rss/index.xml"},
@@ -339,7 +336,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "rss_custom", Name: "Custom RSS", Category: "news", Source: "rss",
-		Kind: WidgetData, Color: "#ee802f",
+		Color: "#ee802f",
 		Description:   "Follow any RSS or Atom feed by pasting its URL.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{}},
 		About:         "Bring your own feeds. Paste any RSS or Atom URL and Scrollr streams its latest items alongside everything else.",
@@ -354,7 +351,7 @@ var catalog = []WidgetDef{
 	{
 		// The tier gate was retired in v1.1.2 — the slot is the only lever.
 		ID: "fantasy_yahoo", Name: "Yahoo Fantasy", Category: "fantasy", Source: "fantasy",
-		Kind: WidgetData, Color: "#6001d2", LogoURL: "https://icon.horse/icon/yahoo.com",
+		Color: "#6001d2", LogoURL: "https://icon.horse/icon/yahoo.com",
 		Description: "Your Yahoo Fantasy leagues, matchups, and standings.",
 		About:       "Your Yahoo Fantasy leagues in the ticker — live scoring, matchups, and standings without ever opening the app.",
 		Usage: []string{
@@ -366,7 +363,7 @@ var catalog = []WidgetDef{
 	{
 		// icon.horse returns a blank image for kalshi.com; pinned like UFC.
 		ID: "predictions", Name: "Kalshi", Category: "predictions", Source: "predictions",
-		Kind: WidgetData, Color: "#1fc9a0",
+		Color: "#1fc9a0",
 		LogoURL:     "https://icons.duckduckgo.com/ip3/kalshi.com.ico",
 		Description: "Live odds from the Kalshi prediction market.",
 		About:       "Live odds from Kalshi, the regulated US prediction market — a real-time read on elections, economic prints, and the events in the news.",
@@ -379,28 +376,28 @@ var catalog = []WidgetDef{
 
 	// ── Utilities — local-only, no data source, but still cost a slot ───
 	{
-		ID: "clock", Name: "Clock", Category: "utility", Kind: WidgetUtility, Color: "#6366f1",
+		ID: "clock", Name: "Clock", Category: "utility", Color: "#6366f1",
 		Description: "Local time and world clocks",
 	},
 	{
-		ID: "timer", Name: "Timer", Category: "utility", Kind: WidgetUtility, Color: "#f59e0b",
+		ID: "timer", Name: "Timer", Category: "utility", Color: "#f59e0b",
 		Description: "Pomodoro, countdown, and stopwatch tools",
 	},
 	{
-		ID: "weather", Name: "Weather", Category: "utility", Kind: WidgetUtility, Color: "#0ea5e9",
+		ID: "weather", Name: "Weather", Category: "utility", Color: "#0ea5e9",
 		Description: "Current conditions for your locations",
 	},
 	{
-		ID: "sysmon", Name: "System Monitor", Category: "utility", Kind: WidgetUtility, Color: "#06b6d4",
+		ID: "sysmon", Name: "System Monitor", Category: "utility", Color: "#06b6d4",
 		Description: "Live CPU, memory, and GPU stats",
 	},
 	{
-		ID: "uptime", Name: "Uptime", Category: "utility", Kind: WidgetUtility, Color: "#10b981",
+		ID: "uptime", Name: "Uptime", Category: "utility", Color: "#10b981",
 		Description: "Monitor status from Uptime Kuma",
 		LogoURL:     "https://icon.horse/icon/uptime.kuma.pet",
 	},
 	{
-		ID: "github", Name: "GitHub", Category: "utility", Kind: WidgetUtility, Color: "#f97316",
+		ID: "github", Name: "GitHub", Category: "utility", Color: "#f97316",
 		Description: "CI/Actions status for your repos",
 		LogoURL:     "https://icon.horse/icon/github.com",
 	},
@@ -477,5 +474,5 @@ func IsKnownWidgetType(widgetType string) bool {
 // row, once via local_widgets).
 func IsUtilityWidgetType(widgetType string) bool {
 	def, ok := widgetByID[widgetType]
-	return ok && def.Kind == WidgetUtility
+	return ok && def.Source == ""
 }

--- a/api/internal/platform/widgets_test.go
+++ b/api/internal/platform/widgets_test.go
@@ -27,25 +27,19 @@ func TestCatalogIsWellFormed(t *testing.T) {
 			t.Errorf("catalog[%d] (%q): Order = %d, want %d", i, w.ID, w.Order, i)
 		}
 
-		switch w.Kind {
-		case WidgetData:
-			// Source is the renderer key AND the CDC route; without it the
-			// widget cannot render or receive data.
-			if w.Source == "" {
-				t.Errorf("catalog %q: data widget has no source", w.ID)
-			}
+		// Source is the whole data/utility distinction: a data widget has
+		// one (it is the renderer key AND the CDC route), a utility does
+		// not. This used to switch on a separate `kind` field and assert
+		// the two agreed; with `kind` gone there is nothing to disagree.
+		if w.Source != "" {
 			if got := DataSourceForWidget(w.ID); got != w.Source {
 				t.Errorf("catalog %q: DataSourceForWidget = %q, want %q", w.ID, got, w.Source)
 			}
-		case WidgetUtility:
-			if w.Source != "" {
-				t.Errorf("catalog %q: utility must have no source, got %q", w.ID, w.Source)
+			if IsUtilityWidgetType(w.ID) {
+				t.Errorf("catalog %q: has source %q but reports as a utility", w.ID, w.Source)
 			}
-			if !IsUtilityWidgetType(w.ID) {
-				t.Errorf("catalog %q: not reported as a utility", w.ID)
-			}
-		default:
-			t.Errorf("catalog %q: unknown kind %q", w.ID, w.Kind)
+		} else if !IsUtilityWidgetType(w.ID) {
+			t.Errorf("catalog %q: has no source but does not report as a utility", w.ID)
 		}
 
 		if !IsKnownWidgetType(w.ID) {

--- a/api/internal/support/ai_triage.go
+++ b/api/internal/support/ai_triage.go
@@ -88,7 +88,7 @@ const (
 // category.
 type TriageResult struct {
 	Category       string `json:"category"`
-	Channel        string `json:"channel,omitempty"`
+	Widget         string `json:"widget,omitempty"`
 	Priority       string `json:"priority"`
 	Summary        string `json:"summary"`
 	DuplicateOf    string `json:"duplicate_of,omitempty"`
@@ -112,7 +112,7 @@ type TriageInput struct {
 	Subject         string
 	Body            string
 	RecentSummaries []RecentTicketSummary
-	Channel         string // user-picked channel hint, if any
+	Widget          string // user-picked widget hint, if any
 
 	// Reply-loop fields. Populated when this triage is for a user's
 	// follow-up message on an existing ticket (via the osTicket
@@ -251,9 +251,9 @@ func buildTriagePrompt(input TriageInput, body string) string {
 		recentJSON = []byte("[]")
 	}
 
-	channelHint := ""
-	if input.Channel != "" {
-		channelHint = fmt.Sprintf("Channel hint from user: %s\n", input.Channel)
+	widgetHint := ""
+	if input.Widget != "" {
+		widgetHint = fmt.Sprintf("Widget hint from user: %s\n", input.Widget)
 	}
 
 	// Reply-context block. When this triage is for a user follow-up
@@ -353,8 +353,8 @@ OUTPUT FORMAT — STRICT:
 
 JSON SCHEMA:
 {
-  "category": "bug|feature|feedback|billing|account|channel",
-  "channel": "finance|sports|rss|fantasy" or null,
+  "category": "bug|feature|feedback|billing|account|widget",
+  "widget": "the widget catalog name, e.g. NFL / Crypto / BBC News" or null,
   "priority": "low|normal|high|emergency",
   "summary": "...",
   "duplicate_of": "ticket-number" or null,
@@ -383,7 +383,7 @@ Body:
 		input.UserEmail,
 		input.UserName,
 		input.UserCategory,
-		channelHint,
+		widgetHint,
 		input.Subject,
 		body,
 	)

--- a/api/internal/support/discord.go
+++ b/api/internal/support/discord.go
@@ -212,7 +212,7 @@ var supportForumTagSpecs = []supportForumTagSpec{
 	{"feedback", "💬"},
 	{"billing", "💳"},
 	{"account", "👤"},
-	{"channel", "📡"},
+	{"widget", "📡"},
 }
 
 // tagIDByName caches the resolved tag IDs after ensureSupportForumTags

--- a/api/internal/support/handlers_discord_interactions.go
+++ b/api/internal/support/handlers_discord_interactions.go
@@ -821,7 +821,7 @@ func handleDiscordTicketCommand(c *fiber.Ctx, ix *discordInteraction) error {
 	const q = `
 		SELECT id, ticket_number, user_email, user_name, original_subject,
 			   user_message_html, draft_body_html, ai_summary, ai_category,
-			   ai_priority, ai_channel, ai_duplicate_of, ai_confidence, status,
+			   ai_priority, ai_widget, ai_duplicate_of, ai_confidence, status,
 			   edited_body_html, decided_at, sent_at, created_at, should_close
 		FROM support_drafts
 		WHERE ticket_number = $1
@@ -829,10 +829,10 @@ func handleDiscordTicketCommand(c *fiber.Ctx, ix *discordInteraction) error {
 		LIMIT 1
 	`
 	var d SupportDraft
-	var userName, userMsg, summary, category, priority, channel, dupOf, confidence, editedBody *string
+	var userName, userMsg, summary, category, priority, widget, dupOf, confidence, editedBody *string
 	err := platform.DBPool.QueryRow(ctx, q, ticketNumber).Scan(
 		&d.ID, &d.TicketNumber, &d.UserEmail, &userName, &d.OriginalSubject,
-		&userMsg, &d.DraftBodyHTML, &summary, &category, &priority, &channel,
+		&userMsg, &d.DraftBodyHTML, &summary, &category, &priority, &widget,
 		&dupOf, &confidence, &d.Status, &editedBody,
 		&d.DecidedAt, &d.SentAt, &d.CreatedAt, &d.ShouldClose,
 	)
@@ -860,8 +860,8 @@ func handleDiscordTicketCommand(c *fiber.Ctx, ix *discordInteraction) error {
 	if priority != nil {
 		d.AIPriority = *priority
 	}
-	if channel != nil {
-		d.AIChannel = *channel
+	if widget != nil {
+		d.AIWidget = *widget
 	}
 	if dupOf != nil {
 		d.AIDuplicateOf = *dupOf

--- a/api/internal/support/handlers_osticket_webhook.go
+++ b/api/internal/support/handlers_osticket_webhook.go
@@ -186,7 +186,7 @@ func processReplyTriageAsync(ev osTicketThreadMessageEvent) {
 		AISummary:             triage.Summary,
 		AICategory:            triage.Category,
 		AIPriority:            triage.Priority,
-		AIChannel:             triage.Channel,
+		AIWidget:              triage.Widget,
 		AIDuplicateOf:         triage.DuplicateOf,
 		AIConfidence:          triage.Confidence,
 		OSTicketThreadEntryID: ev.ThreadEntryID,

--- a/api/internal/support/support.go
+++ b/api/internal/support/support.go
@@ -32,7 +32,7 @@ type SupportTicketRequest struct {
 	Attachments      []TicketAttachment     `json:"attachments,omitempty"`
 	Email            string                 `json:"email,omitempty"`
 	Name             string                 `json:"name,omitempty"`
-	Channel          string                 `json:"channel,omitempty"`
+	Widget           string                 `json:"widget,omitempty"`
 }
 
 type TicketAttachment struct {
@@ -162,12 +162,12 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 		subjectPrefix = "Billing: "
 	case "account":
 		subjectPrefix = "Account: "
-	case "channel":
-		ch := strings.TrimSpace(req.Channel)
-		if ch != "" {
-			subjectPrefix = fmt.Sprintf("Channel Help (%s): ", ch)
+	case "widget":
+		w := strings.TrimSpace(req.Widget)
+		if w != "" {
+			subjectPrefix = fmt.Sprintf("Widget Help (%s): ", w)
 		} else {
-			subjectPrefix = "Channel Help: "
+			subjectPrefix = "Widget Help: "
 		}
 	default:
 		subjectPrefix = "Bug Report: "
@@ -203,12 +203,12 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 	case "account":
 		body.WriteString("<h3>Account &amp; Login</h3>")
 		body.WriteString(fmt.Sprintf("<p>%s</p>", escapeHTML(req.Description)))
-	case "channel":
-		ch := strings.TrimSpace(req.Channel)
-		if ch != "" {
-			body.WriteString(fmt.Sprintf("<h3>Channel Help — %s</h3>", escapeHTML(ch)))
+	case "widget":
+		w := strings.TrimSpace(req.Widget)
+		if w != "" {
+			body.WriteString(fmt.Sprintf("<h3>Widget Help — %s</h3>", escapeHTML(w)))
 		} else {
-			body.WriteString("<h3>Channel Help</h3>")
+			body.WriteString("<h3>Widget Help</h3>")
 		}
 		body.WriteString(fmt.Sprintf("<p>%s</p>", escapeHTML(req.Description)))
 	default:
@@ -248,7 +248,7 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 		Subject:         subject,
 		Body:            originalBody,
 		RecentSummaries: recentSummaries,
-		Channel:         req.Channel,
+		Widget:          req.Widget,
 	})
 
 	// Resolve effective category — use AI's pick only on high confidence.
@@ -390,7 +390,7 @@ func persistTriageSideEffects(ticketNumber, userEmail, userName, subject, origin
 			AISummary:       triage.Summary,
 			AICategory:      triage.Category,
 			AIPriority:      triage.Priority,
-			AIChannel:       triage.Channel,
+			AIWidget:        triage.Widget,
 			AIDuplicateOf:   triage.DuplicateOf,
 			AIConfidence:    triage.Confidence,
 			ShouldClose:     triage.ShouldClose,

--- a/api/internal/support/support_drafts.go
+++ b/api/internal/support/support_drafts.go
@@ -42,7 +42,7 @@ type SupportDraft struct {
 	AISummary             string
 	AICategory            string
 	AIPriority            string
-	AIChannel             string
+	AIWidget              string
 	AIDuplicateOf         string
 	AIConfidence          string
 	Status                string
@@ -71,7 +71,7 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 			(ticket_number, user_email, user_name, original_subject,
 			 user_message_html,
 			 draft_body_html, ai_summary, ai_category, ai_priority,
-			 ai_channel, ai_duplicate_of, ai_confidence, status,
+			 ai_widget, ai_duplicate_of, ai_confidence, status,
 			 osticket_thread_entry_id, should_close)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'pending',$13,$14)
 		RETURNING id, created_at
@@ -100,7 +100,7 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 		draft.AISummary,
 		draft.AICategory,
 		draft.AIPriority,
-		draft.AIChannel,
+		draft.AIWidget,
 		draft.AIDuplicateOf,
 		draft.AIConfidence,
 		entryID,
@@ -121,17 +121,17 @@ func loadSupportDraft(ctx context.Context, id int64) (*SupportDraft, error) {
 		SELECT id, ticket_number, user_email, user_name, original_subject,
 			   user_message_html,
 			   draft_body_html, ai_summary, ai_category, ai_priority,
-			   ai_channel, ai_duplicate_of, ai_confidence, status,
+			   ai_widget, ai_duplicate_of, ai_confidence, status,
 			   edited_body_html, decided_at, sent_at, created_at,
 			   should_close
 		FROM support_drafts WHERE id = $1
 	`
 	var d SupportDraft
-	var userName, userMsg, summary, category, priority, channel, dupOf, confidence, editedBody *string
+	var userName, userMsg, summary, category, priority, widget, dupOf, confidence, editedBody *string
 	err := platform.DBPool.QueryRow(ctx, q, id).Scan(
 		&d.ID, &d.TicketNumber, &d.UserEmail, &userName, &d.OriginalSubject,
 		&userMsg,
-		&d.DraftBodyHTML, &summary, &category, &priority, &channel,
+		&d.DraftBodyHTML, &summary, &category, &priority, &widget,
 		&dupOf, &confidence, &d.Status,
 		&editedBody, &d.DecidedAt, &d.SentAt, &d.CreatedAt,
 		&d.ShouldClose,
@@ -157,8 +157,8 @@ func loadSupportDraft(ctx context.Context, id int64) (*SupportDraft, error) {
 	if priority != nil {
 		d.AIPriority = *priority
 	}
-	if channel != nil {
-		d.AIChannel = *channel
+	if widget != nil {
+		d.AIWidget = *widget
 	}
 	if dupOf != nil {
 		d.AIDuplicateOf = *dupOf

--- a/api/internal/widgets/catalog_snapshot_test.go
+++ b/api/internal/widgets/catalog_snapshot_test.go
@@ -2,10 +2,20 @@ package widgets
 
 import (
 	"encoding/json"
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// Regenerate the bundled snapshot instead of asserting against it:
+//
+//	go -C api test ./internal/widgets -run TestCatalogSnapshot -update
+//
+// Replaces the previous instruction to curl a running server and pipe it
+// through python — that needed a booted API with a live database just to
+// re-emit a value this package already computes.
+var updateSnapshot = flag.Bool("update", false, "rewrite desktop/src/catalog.snapshot.json from this catalog")
 
 // The desktop bundles desktop/src/catalog.snapshot.json so the ticker renders
 // offline and on first run (VISION §4.2, constraint 1). That snapshot is
@@ -17,11 +27,24 @@ import (
 // authority, a test pins the other to it, and CI fails on whichever was left
 // behind.
 //
-// To regenerate after changing the catalog:
-//
-//	curl -s localhost:8080/catalog | python -m json.tool > desktop/src/catalog.snapshot.json
+// To regenerate after changing the catalog, re-run this test with -update
+// (see the flag above).
 func TestCatalogSnapshotMatchesServer(t *testing.T) {
 	path := filepath.Join("..", "..", "..", "desktop", "src", "catalog.snapshot.json")
+
+	if *updateSnapshot {
+		catalogOnce.Do(buildCatalog)
+		out, err := json.MarshalIndent(catalogBody, "", "    ")
+		if err != nil {
+			t.Fatalf("marshal catalog: %v", err)
+		}
+		if err := os.WriteFile(path, append(out, '\n'), 0o644); err != nil {
+			t.Fatalf("write snapshot: %v", err)
+		}
+		t.Logf("regenerated %s (%d widgets, version %s)", path, len(catalogBody.Widgets), catalogBody.Version)
+		return
+	}
+
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read bundled snapshot: %v", err)

--- a/api/migrations/000003_support_ai_widget.down.sql
+++ b/api/migrations/000003_support_ai_widget.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE support_drafts RENAME COLUMN ai_widget TO ai_channel;

--- a/api/migrations/000003_support_ai_widget.up.sql
+++ b/api/migrations/000003_support_ai_widget.up.sql
@@ -1,0 +1,15 @@
+-- One vocabulary, all the way down (VISION §4.4) — the support surface.
+--
+-- The support ticket category named "channel" always meant "help with a
+-- specific widget": its UI label was already "Widget Help" and its picker
+-- already asked "Which widget?". Only the stored value, the wire field and
+-- this column still said channel.
+--
+-- `ai_channel` holds the triage model's guess at which widget a ticket is
+-- about. Renamed alongside SupportRequest.Widget and TriageResult.Widget,
+-- which move in the same release.
+--
+-- A rename, not an add + backfill + drop: every reader moves together and
+-- there are no users to stage this for. Existing rows keep their values.
+
+ALTER TABLE support_drafts RENAME COLUMN ai_channel TO ai_widget;

--- a/desktop/src/catalog.snapshot.json
+++ b/desktop/src/catalog.snapshot.json
@@ -1,748 +1,713 @@
 {
-  "version": "b829a2836f8fd6fe",
-  "widgets": [
-    {
-      "id": "finance_stocks",
-      "name": "Stocks",
-      "description": "Live stock & ETF prices for the symbols you pick.",
-      "kind": "data",
-      "source": "finance",
-      "category": "finance",
-      "color": "#16a34a",
-      "default_config": {
-        "asset_class": "stock",
-        "symbols": []
-      },
-      "required_tier": "free",
-      "about": "Real-time stock and ETF prices for the tickers you follow. Your watchlist streams live as the market moves — no brokerage app open, no tab to babysit.",
-      "usage": [
-        "Type a ticker in the top bar's search to add or remove it.",
-        "Quotes stream in real time during market hours.",
-        "Pin it to keep your watchlist always visible."
-      ],
-      "order": 0
-    },
-    {
-      "id": "finance_crypto",
-      "name": "Crypto",
-      "description": "Live crypto prices for the coins you pick.",
-      "kind": "data",
-      "source": "finance",
-      "category": "finance",
-      "color": "#f7931a",
-      "default_config": {
-        "asset_class": "crypto",
-        "symbols": []
-      },
-      "required_tier": "free",
-      "about": "Live crypto prices for the coins you track, streamed around the clock. From BTC and ETH to the long tail, your picks update the moment the market does.",
-      "usage": [
-        "Type a coin in the top bar's search to add or remove it.",
-        "Prices stream 24/7 — crypto never closes.",
-        "Pin it so every big move catches your eye."
-      ],
-      "order": 1
-    },
-    {
-      "id": "sports_nfl",
-      "name": "NFL",
-      "description": "Live NFL scores and game states.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#013369",
-      "logo_url": "https://icon.horse/icon/nfl.com",
-      "default_config": {
-        "leagues": [
-          "NFL"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live NFL scores, quarters, and game clock for every matchup on the slate. Follow the whole week or zero in on your team.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 2
-    },
-    {
-      "id": "sports_nba",
-      "name": "NBA",
-      "description": "Live NBA scores and game states.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#c9082a",
-      "logo_url": "https://icon.horse/icon/nba.com",
-      "default_config": {
-        "leagues": [
-          "NBA"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live NBA scores and game state across the association — every quarter, every buzzer-beater, as it happens.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 3
-    },
-    {
-      "id": "sports_nhl",
-      "name": "NHL",
-      "description": "Live NHL scores and game states.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#111827",
-      "logo_url": "https://icon.horse/icon/nhl.com",
-      "default_config": {
-        "leagues": [
-          "NHL"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live NHL scores and period-by-period game state for every game on the ice.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 4
-    },
-    {
-      "id": "sports_mlb",
-      "name": "MLB",
-      "description": "Live MLB scores and game states.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#002d72",
-      "logo_url": "https://icon.horse/icon/mlb.com",
-      "default_config": {
-        "leagues": [
-          "MLB"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live MLB scores, innings, and game state across the league, all season long.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 5
-    },
-    {
-      "id": "sports_f1",
-      "name": "F1",
-      "description": "Formula 1 race weekends and results.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#e10600",
-      "logo_url": "https://icon.horse/icon/formula1.com",
-      "default_config": {
-        "leagues": [
-          "Formula 1"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Formula 1 race weekends — practice, qualifying, and the Grand Prix result the moment the checkered flag drops.",
-      "usage": [
-        "Practice, qualifying, and race results update through the weekend.",
-        "See the podium the second the race ends.",
-        "Pin it during a Grand Prix to follow every session."
-      ],
-      "order": 6
-    },
-    {
-      "id": "sports_worldcup",
-      "name": "World Cup",
-      "description": "FIFA World Cup fixtures and scores.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#2e7d46",
-      "logo_url": "https://icon.horse/icon/fifa.com",
-      "default_config": {
-        "leagues": [
-          "FIFA World Cup"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Every FIFA World Cup fixture and live score, through the group stage and into the knockouts.",
-      "usage": [
-        "Live scores through the group stage and knockout rounds.",
-        "Every fixture on the calendar, updated automatically.",
-        "Pin it during the tournament so you never miss a goal."
-      ],
-      "order": 7
-    },
-    {
-      "id": "sports_ncaaf",
-      "name": "NCAA Football",
-      "description": "Live college football scores across the FBS.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#0b427a",
-      "logo_url": "https://icon.horse/icon/ncaa.com",
-      "default_config": {
-        "leagues": [
-          "NCAA Football"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live college football scores across the FBS — Saturday slates, rivalry week, and bowl season.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 8
-    },
-    {
-      "id": "sports_ncaab",
-      "name": "NCAA Basketball",
-      "description": "Live college basketball scores and the road to March.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#d2691e",
-      "logo_url": "https://icon.horse/icon/ncaa.com",
-      "default_config": {
-        "leagues": [
-          "NCAA Basketball"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live college basketball scores through conference play and all the way into March Madness.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 9
-    },
-    {
-      "id": "sports_premierleague",
-      "name": "Premier League",
-      "description": "Live scores from England's Premier League.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#37003c",
-      "logo_url": "https://icon.horse/icon/premierleague.com",
-      "default_config": {
-        "leagues": [
-          "Premier League"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live scores from England's Premier League — all 20 clubs, every matchweek.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 10
-    },
-    {
-      "id": "sports_laliga",
-      "name": "La Liga",
-      "description": "Live scores from Spain's La Liga.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#e2001a",
-      "logo_url": "https://icon.horse/icon/laliga.com",
-      "default_config": {
-        "leagues": [
-          "La Liga"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live scores from Spain's La Liga, from the title race to the relegation scrap.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 11
-    },
-    {
-      "id": "sports_mls",
-      "name": "MLS",
-      "description": "Live Major League Soccer scores.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#001838",
-      "logo_url": "https://icon.horse/icon/mlssoccer.com",
-      "default_config": {
-        "leagues": [
-          "MLS"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live Major League Soccer scores across the Eastern and Western conferences.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 12
-    },
-    {
-      "id": "sports_championsleague",
-      "name": "Champions League",
-      "description": "Live UEFA Champions League scores.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#0e1e5b",
-      "logo_url": "https://icon.horse/icon/uefa.com",
-      "default_config": {
-        "leagues": [
-          "Champions League"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live UEFA Champions League scores through the league phase and into the knockout rounds.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 13
-    },
-    {
-      "id": "sports_ufc",
-      "name": "UFC",
-      "description": "UFC fight cards and results.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#d20a0a",
-      "logo_url": "https://icons.duckduckgo.com/ip3/ufc.com.ico",
-      "logo_light": true,
-      "default_config": {
-        "leagues": [
-          "UFC"
-        ]
-      },
-      "required_tier": "free",
-      "about": "UFC fight cards and results — main card and prelims, bout by bout on event nights.",
-      "usage": [
-        "Fight results update bout by bout on event nights.",
-        "Follow the main card and prelims in one place.",
-        "Pin it during an event to catch every finish."
-      ],
-      "order": 14
-    },
-    {
-      "id": "sports_afl",
-      "name": "AFL",
-      "description": "Live Australian Football League scores.",
-      "kind": "data",
-      "source": "sports",
-      "category": "sports",
-      "color": "#003da5",
-      "logo_url": "https://icon.horse/icon/afl.com.au",
-      "default_config": {
-        "leagues": [
-          "AFL"
-        ]
-      },
-      "required_tier": "free",
-      "about": "Live Australian Football League scores across the home-and-away season and finals.",
-      "usage": [
-        "Live scores and game state update automatically.",
-        "Set a favorite team from the top bar to keep it front and center.",
-        "Pin it on game days so scores stay on screen."
-      ],
-      "order": 15
-    },
-    {
-      "id": "news_bbc",
-      "name": "BBC News",
-      "description": "World, UK and breaking news from the BBC.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#b80000",
-      "logo_url": "https://icon.horse/icon/bbc.com",
-      "default_config": {
-        "feeds": [
-          {
+    "version": "da25b9393217edf6",
+    "widgets": [
+        {
+            "id": "finance_stocks",
+            "name": "Stocks",
+            "description": "Live stock \u0026 ETF prices for the symbols you pick.",
+            "source": "finance",
+            "category": "finance",
+            "color": "#16a34a",
+            "default_config": {
+                "asset_class": "stock",
+                "symbols": []
+            },
+            "required_tier": "free",
+            "about": "Real-time stock and ETF prices for the tickers you follow. Your watchlist streams live as the market moves — no brokerage app open, no tab to babysit.",
+            "usage": [
+                "Type a ticker in the top bar's search to add or remove it.",
+                "Quotes stream in real time during market hours.",
+                "Pin it to keep your watchlist always visible."
+            ],
+            "order": 0
+        },
+        {
+            "id": "finance_crypto",
+            "name": "Crypto",
+            "description": "Live crypto prices for the coins you pick.",
+            "source": "finance",
+            "category": "finance",
+            "color": "#f7931a",
+            "default_config": {
+                "asset_class": "crypto",
+                "symbols": []
+            },
+            "required_tier": "free",
+            "about": "Live crypto prices for the coins you track, streamed around the clock. From BTC and ETH to the long tail, your picks update the moment the market does.",
+            "usage": [
+                "Type a coin in the top bar's search to add or remove it.",
+                "Prices stream 24/7 — crypto never closes.",
+                "Pin it so every big move catches your eye."
+            ],
+            "order": 1
+        },
+        {
+            "id": "sports_nfl",
+            "name": "NFL",
+            "description": "Live NFL scores and game states.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#013369",
+            "logo_url": "https://icon.horse/icon/nfl.com",
+            "default_config": {
+                "leagues": [
+                    "NFL"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live NFL scores, quarters, and game clock for every matchup on the slate. Follow the whole week or zero in on your team.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 2
+        },
+        {
+            "id": "sports_nba",
+            "name": "NBA",
+            "description": "Live NBA scores and game states.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#c9082a",
+            "logo_url": "https://icon.horse/icon/nba.com",
+            "default_config": {
+                "leagues": [
+                    "NBA"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live NBA scores and game state across the association — every quarter, every buzzer-beater, as it happens.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 3
+        },
+        {
+            "id": "sports_nhl",
+            "name": "NHL",
+            "description": "Live NHL scores and game states.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#111827",
+            "logo_url": "https://icon.horse/icon/nhl.com",
+            "default_config": {
+                "leagues": [
+                    "NHL"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live NHL scores and period-by-period game state for every game on the ice.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 4
+        },
+        {
+            "id": "sports_mlb",
+            "name": "MLB",
+            "description": "Live MLB scores and game states.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#002d72",
+            "logo_url": "https://icon.horse/icon/mlb.com",
+            "default_config": {
+                "leagues": [
+                    "MLB"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live MLB scores, innings, and game state across the league, all season long.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 5
+        },
+        {
+            "id": "sports_f1",
+            "name": "F1",
+            "description": "Formula 1 race weekends and results.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#e10600",
+            "logo_url": "https://icon.horse/icon/formula1.com",
+            "default_config": {
+                "leagues": [
+                    "Formula 1"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Formula 1 race weekends — practice, qualifying, and the Grand Prix result the moment the checkered flag drops.",
+            "usage": [
+                "Practice, qualifying, and race results update through the weekend.",
+                "See the podium the second the race ends.",
+                "Pin it during a Grand Prix to follow every session."
+            ],
+            "order": 6
+        },
+        {
+            "id": "sports_worldcup",
+            "name": "World Cup",
+            "description": "FIFA World Cup fixtures and scores.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#2e7d46",
+            "logo_url": "https://icon.horse/icon/fifa.com",
+            "default_config": {
+                "leagues": [
+                    "FIFA World Cup"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Every FIFA World Cup fixture and live score, through the group stage and into the knockouts.",
+            "usage": [
+                "Live scores through the group stage and knockout rounds.",
+                "Every fixture on the calendar, updated automatically.",
+                "Pin it during the tournament so you never miss a goal."
+            ],
+            "order": 7
+        },
+        {
+            "id": "sports_ncaaf",
+            "name": "NCAA Football",
+            "description": "Live college football scores across the FBS.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#0b427a",
+            "logo_url": "https://icon.horse/icon/ncaa.com",
+            "default_config": {
+                "leagues": [
+                    "NCAA Football"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live college football scores across the FBS — Saturday slates, rivalry week, and bowl season.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 8
+        },
+        {
+            "id": "sports_ncaab",
+            "name": "NCAA Basketball",
+            "description": "Live college basketball scores and the road to March.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#d2691e",
+            "logo_url": "https://icon.horse/icon/ncaa.com",
+            "default_config": {
+                "leagues": [
+                    "NCAA Basketball"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live college basketball scores through conference play and all the way into March Madness.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 9
+        },
+        {
+            "id": "sports_premierleague",
+            "name": "Premier League",
+            "description": "Live scores from England's Premier League.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#37003c",
+            "logo_url": "https://icon.horse/icon/premierleague.com",
+            "default_config": {
+                "leagues": [
+                    "Premier League"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live scores from England's Premier League — all 20 clubs, every matchweek.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 10
+        },
+        {
+            "id": "sports_laliga",
+            "name": "La Liga",
+            "description": "Live scores from Spain's La Liga.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#e2001a",
+            "logo_url": "https://icon.horse/icon/laliga.com",
+            "default_config": {
+                "leagues": [
+                    "La Liga"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live scores from Spain's La Liga, from the title race to the relegation scrap.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 11
+        },
+        {
+            "id": "sports_mls",
+            "name": "MLS",
+            "description": "Live Major League Soccer scores.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#001838",
+            "logo_url": "https://icon.horse/icon/mlssoccer.com",
+            "default_config": {
+                "leagues": [
+                    "MLS"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live Major League Soccer scores across the Eastern and Western conferences.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 12
+        },
+        {
+            "id": "sports_championsleague",
+            "name": "Champions League",
+            "description": "Live UEFA Champions League scores.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#0e1e5b",
+            "logo_url": "https://icon.horse/icon/uefa.com",
+            "default_config": {
+                "leagues": [
+                    "Champions League"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live UEFA Champions League scores through the league phase and into the knockout rounds.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 13
+        },
+        {
+            "id": "sports_ufc",
+            "name": "UFC",
+            "description": "UFC fight cards and results.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#d20a0a",
+            "logo_url": "https://icons.duckduckgo.com/ip3/ufc.com.ico",
+            "logo_light": true,
+            "default_config": {
+                "leagues": [
+                    "UFC"
+                ]
+            },
+            "required_tier": "free",
+            "about": "UFC fight cards and results — main card and prelims, bout by bout on event nights.",
+            "usage": [
+                "Fight results update bout by bout on event nights.",
+                "Follow the main card and prelims in one place.",
+                "Pin it during an event to catch every finish."
+            ],
+            "order": 14
+        },
+        {
+            "id": "sports_afl",
+            "name": "AFL",
+            "description": "Live Australian Football League scores.",
+            "source": "sports",
+            "category": "sports",
+            "color": "#003da5",
+            "logo_url": "https://icon.horse/icon/afl.com.au",
+            "default_config": {
+                "leagues": [
+                    "AFL"
+                ]
+            },
+            "required_tier": "free",
+            "about": "Live Australian Football League scores across the home-and-away season and finals.",
+            "usage": [
+                "Live scores and game state update automatically.",
+                "Set a favorite team from the top bar to keep it front and center.",
+                "Pin it on game days so scores stay on screen."
+            ],
+            "order": 15
+        },
+        {
+            "id": "news_bbc",
             "name": "BBC News",
-            "url": "https://feeds.bbci.co.uk/news/rss.xml"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Headlines from the BBC — world, UK, and breaking news from one of the most-read newsrooms on the planet.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 16
-    },
-    {
-      "id": "news_npr",
-      "name": "NPR",
-      "description": "US and world news, analysis and reporting from NPR.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#4667de",
-      "logo_url": "https://icon.horse/icon/npr.org",
-      "default_config": {
-        "feeds": [
-          {
-            "name": "NPR News",
-            "url": "https://feeds.npr.org/1001/rss.xml"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "News, analysis, and reporting from NPR, spanning US and world coverage.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 17
-    },
-    {
-      "id": "news_guardian",
-      "name": "The Guardian",
-      "description": "Independent world news, opinion and reporting.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#052962",
-      "logo_url": "https://icon.horse/icon/theguardian.com",
-      "default_config": {
-        "feeds": [
-          {
+            "description": "World, UK and breaking news from the BBC.",
+            "source": "rss",
+            "category": "news",
+            "color": "#b80000",
+            "logo_url": "https://icon.horse/icon/bbc.com",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "BBC News",
+                        "url": "https://feeds.bbci.co.uk/news/rss.xml"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Headlines from the BBC — world, UK, and breaking news from one of the most-read newsrooms on the planet.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 16
+        },
+        {
+            "id": "news_npr",
+            "name": "NPR",
+            "description": "US and world news, analysis and reporting from NPR.",
+            "source": "rss",
+            "category": "news",
+            "color": "#4667de",
+            "logo_url": "https://icon.horse/icon/npr.org",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "NPR News",
+                        "url": "https://feeds.npr.org/1001/rss.xml"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "News, analysis, and reporting from NPR, spanning US and world coverage.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 17
+        },
+        {
+            "id": "news_guardian",
             "name": "The Guardian",
-            "url": "https://www.theguardian.com/world/rss"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Independent world news, opinion, and reporting from The Guardian.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 18
-    },
-    {
-      "id": "news_aljazeera",
-      "name": "Al Jazeera",
-      "description": "Breaking news from the Middle East and around the world.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#e8a33d",
-      "logo_url": "https://icon.horse/icon/aljazeera.com",
-      "default_config": {
-        "feeds": [
-          {
+            "description": "Independent world news, opinion and reporting.",
+            "source": "rss",
+            "category": "news",
+            "color": "#052962",
+            "logo_url": "https://icon.horse/icon/theguardian.com",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "The Guardian",
+                        "url": "https://www.theguardian.com/world/rss"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Independent world news, opinion, and reporting from The Guardian.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 18
+        },
+        {
+            "id": "news_aljazeera",
             "name": "Al Jazeera",
-            "url": "https://www.aljazeera.com/xml/rss/all.xml"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Breaking news from Al Jazeera, with deep coverage of the Middle East and the Global South.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 19
-    },
-    {
-      "id": "news_propublica",
-      "name": "ProPublica",
-      "description": "Investigative journalism in the public interest.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#c8102e",
-      "logo_url": "https://icon.horse/icon/propublica.org",
-      "default_config": {
-        "feeds": [
-          {
+            "description": "Breaking news from the Middle East and around the world.",
+            "source": "rss",
+            "category": "news",
+            "color": "#e8a33d",
+            "logo_url": "https://icon.horse/icon/aljazeera.com",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "Al Jazeera",
+                        "url": "https://www.aljazeera.com/xml/rss/all.xml"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Breaking news from Al Jazeera, with deep coverage of the Middle East and the Global South.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 19
+        },
+        {
+            "id": "news_propublica",
             "name": "ProPublica",
-            "url": "https://feeds.propublica.org/propublica/main"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Investigative journalism in the public interest from the nonprofit newsroom ProPublica.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 20
-    },
-    {
-      "id": "news_bloomberg",
-      "name": "Bloomberg",
-      "description": "Global markets, finance and business news.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#1a1a2e",
-      "logo_url": "https://icon.horse/icon/bloomberg.com",
-      "default_config": {
-        "feeds": [
-          {
-            "name": "Bloomberg Markets",
-            "url": "https://feeds.bloomberg.com/markets/news.rss"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Markets, finance, and business news from Bloomberg.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 21
-    },
-    {
-      "id": "news_cnbc",
-      "name": "CNBC",
-      "description": "Markets, business and finance headlines.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#005594",
-      "logo_url": "https://icon.horse/icon/cnbc.com",
-      "default_config": {
-        "feeds": [
-          {
-            "name": "CNBC Top News",
-            "url": "https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=100003114"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Markets, business, and finance headlines from CNBC.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 22
-    },
-    {
-      "id": "news_nasa",
-      "name": "NASA",
-      "description": "Space, science and mission news from NASA.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#0b3d91",
-      "logo_url": "https://icon.horse/icon/nasa.gov",
-      "default_config": {
-        "feeds": [
-          {
-            "name": "NASA Breaking News",
-            "url": "https://www.nasa.gov/news-release/feed/"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Space, science, and mission news straight from NASA.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 23
-    },
-    {
-      "id": "news_hackernews",
-      "name": "Hacker News",
-      "description": "Top stories from the Hacker News front page.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#ff6600",
-      "logo_url": "https://icon.horse/icon/news.ycombinator.com",
-      "default_config": {
-        "feeds": [
-          {
+            "description": "Investigative journalism in the public interest.",
+            "source": "rss",
+            "category": "news",
+            "color": "#c8102e",
+            "logo_url": "https://icon.horse/icon/propublica.org",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "ProPublica",
+                        "url": "https://feeds.propublica.org/propublica/main"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Investigative journalism in the public interest from the nonprofit newsroom ProPublica.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 20
+        },
+        {
+            "id": "news_bloomberg",
+            "name": "Bloomberg",
+            "description": "Global markets, finance and business news.",
+            "source": "rss",
+            "category": "news",
+            "color": "#1a1a2e",
+            "logo_url": "https://icon.horse/icon/bloomberg.com",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "Bloomberg Markets",
+                        "url": "https://feeds.bloomberg.com/markets/news.rss"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Markets, finance, and business news from Bloomberg.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 21
+        },
+        {
+            "id": "news_cnbc",
+            "name": "CNBC",
+            "description": "Markets, business and finance headlines.",
+            "source": "rss",
+            "category": "news",
+            "color": "#005594",
+            "logo_url": "https://icon.horse/icon/cnbc.com",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "CNBC Top News",
+                        "url": "https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01\u0026id=100003114"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Markets, business, and finance headlines from CNBC.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 22
+        },
+        {
+            "id": "news_nasa",
+            "name": "NASA",
+            "description": "Space, science and mission news from NASA.",
+            "source": "rss",
+            "category": "news",
+            "color": "#0b3d91",
+            "logo_url": "https://icon.horse/icon/nasa.gov",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "NASA Breaking News",
+                        "url": "https://www.nasa.gov/news-release/feed/"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Space, science, and mission news straight from NASA.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 23
+        },
+        {
+            "id": "news_hackernews",
             "name": "Hacker News",
-            "url": "https://hnrss.org/frontpage"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Top stories from the Hacker News front page — tech, startups, and programming.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 24
-    },
-    {
-      "id": "news_theverge",
-      "name": "The Verge",
-      "description": "Technology, science, art and culture.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#5200ff",
-      "logo_url": "https://icon.horse/icon/theverge.com",
-      "default_config": {
-        "feeds": [
-          {
+            "description": "Top stories from the Hacker News front page.",
+            "source": "rss",
+            "category": "news",
+            "color": "#ff6600",
+            "logo_url": "https://icon.horse/icon/news.ycombinator.com",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "Hacker News",
+                        "url": "https://hnrss.org/frontpage"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Top stories from the Hacker News front page — tech, startups, and programming.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 24
+        },
+        {
+            "id": "news_theverge",
             "name": "The Verge",
-            "url": "https://www.theverge.com/rss/index.xml"
-          }
-        ]
-      },
-      "required_tier": "free",
-      "about": "Technology, science, art, and culture from The Verge.",
-      "usage": [
-        "Headlines refresh automatically as new stories publish.",
-        "Open any headline from the feed to read the full story.",
-        "Pin it to keep the latest news in view."
-      ],
-      "order": 25
-    },
-    {
-      "id": "rss_custom",
-      "name": "Custom RSS",
-      "description": "Follow any RSS or Atom feed by pasting its URL.",
-      "kind": "data",
-      "source": "rss",
-      "category": "news",
-      "color": "#ee802f",
-      "default_config": {
-        "feeds": []
-      },
-      "required_tier": "free",
-      "about": "Bring your own feeds. Paste any RSS or Atom URL and Scrollr streams its latest items alongside everything else.",
-      "usage": [
-        "Paste any RSS or Atom feed URL in the Feeds view.",
-        "Add as many feeds as you like — they merge into one stream.",
-        "Perfect for niche blogs, newsletters, or subreddits with a feed."
-      ],
-      "order": 26
-    },
-    {
-      "id": "fantasy_yahoo",
-      "name": "Yahoo Fantasy",
-      "description": "Your Yahoo Fantasy leagues, matchups, and standings.",
-      "kind": "data",
-      "source": "fantasy",
-      "category": "fantasy",
-      "color": "#6001d2",
-      "logo_url": "https://icon.horse/icon/yahoo.com",
-      "required_tier": "free",
-      "about": "Your Yahoo Fantasy leagues in the ticker — live scoring, matchups, and standings without ever opening the app.",
-      "usage": [
-        "Connect your Yahoo account from the top bar.",
-        "Leagues, matchups, and standings sync automatically.",
-        "Live scoring updates while your players are on the field."
-      ],
-      "order": 27
-    },
-    {
-      "id": "predictions",
-      "name": "Kalshi",
-      "description": "Live odds from the Kalshi prediction market.",
-      "kind": "data",
-      "source": "predictions",
-      "category": "predictions",
-      "color": "#1fc9a0",
-      "logo_url": "https://icons.duckduckgo.com/ip3/kalshi.com.ico",
-      "required_tier": "free",
-      "about": "Live odds from Kalshi, the regulated US prediction market — a real-time read on elections, economic prints, and the events in the news.",
-      "usage": [
-        "Live market odds update as money moves.",
-        "Follow the events and questions you care about.",
-        "Display-only — Scrollr shows the market, it never places a trade."
-      ],
-      "order": 28
-    },
-    {
-      "id": "clock",
-      "name": "Clock",
-      "description": "Local time and world clocks",
-      "kind": "utility",
-      "category": "utility",
-      "color": "#6366f1",
-      "required_tier": "free",
-      "order": 29
-    },
-    {
-      "id": "timer",
-      "name": "Timer",
-      "description": "Pomodoro, countdown, and stopwatch tools",
-      "kind": "utility",
-      "category": "utility",
-      "color": "#f59e0b",
-      "required_tier": "free",
-      "order": 30
-    },
-    {
-      "id": "weather",
-      "name": "Weather",
-      "description": "Current conditions for your locations",
-      "kind": "utility",
-      "category": "utility",
-      "color": "#0ea5e9",
-      "required_tier": "free",
-      "order": 31
-    },
-    {
-      "id": "sysmon",
-      "name": "System Monitor",
-      "description": "Live CPU, memory, and GPU stats",
-      "kind": "utility",
-      "category": "utility",
-      "color": "#06b6d4",
-      "required_tier": "free",
-      "order": 32
-    },
-    {
-      "id": "uptime",
-      "name": "Uptime",
-      "description": "Monitor status from Uptime Kuma",
-      "kind": "utility",
-      "category": "utility",
-      "color": "#10b981",
-      "logo_url": "https://icon.horse/icon/uptime.kuma.pet",
-      "required_tier": "free",
-      "order": 33
-    },
-    {
-      "id": "github",
-      "name": "GitHub",
-      "description": "CI/Actions status for your repos",
-      "kind": "utility",
-      "category": "utility",
-      "color": "#f97316",
-      "logo_url": "https://icon.horse/icon/github.com",
-      "required_tier": "free",
-      "order": 34
-    }
-  ]
+            "description": "Technology, science, art and culture.",
+            "source": "rss",
+            "category": "news",
+            "color": "#5200ff",
+            "logo_url": "https://icon.horse/icon/theverge.com",
+            "default_config": {
+                "feeds": [
+                    {
+                        "name": "The Verge",
+                        "url": "https://www.theverge.com/rss/index.xml"
+                    }
+                ]
+            },
+            "required_tier": "free",
+            "about": "Technology, science, art, and culture from The Verge.",
+            "usage": [
+                "Headlines refresh automatically as new stories publish.",
+                "Open any headline from the feed to read the full story.",
+                "Pin it to keep the latest news in view."
+            ],
+            "order": 25
+        },
+        {
+            "id": "rss_custom",
+            "name": "Custom RSS",
+            "description": "Follow any RSS or Atom feed by pasting its URL.",
+            "source": "rss",
+            "category": "news",
+            "color": "#ee802f",
+            "default_config": {
+                "feeds": []
+            },
+            "required_tier": "free",
+            "about": "Bring your own feeds. Paste any RSS or Atom URL and Scrollr streams its latest items alongside everything else.",
+            "usage": [
+                "Paste any RSS or Atom feed URL in the Feeds view.",
+                "Add as many feeds as you like — they merge into one stream.",
+                "Perfect for niche blogs, newsletters, or subreddits with a feed."
+            ],
+            "order": 26
+        },
+        {
+            "id": "fantasy_yahoo",
+            "name": "Yahoo Fantasy",
+            "description": "Your Yahoo Fantasy leagues, matchups, and standings.",
+            "source": "fantasy",
+            "category": "fantasy",
+            "color": "#6001d2",
+            "logo_url": "https://icon.horse/icon/yahoo.com",
+            "required_tier": "free",
+            "about": "Your Yahoo Fantasy leagues in the ticker — live scoring, matchups, and standings without ever opening the app.",
+            "usage": [
+                "Connect your Yahoo account from the top bar.",
+                "Leagues, matchups, and standings sync automatically.",
+                "Live scoring updates while your players are on the field."
+            ],
+            "order": 27
+        },
+        {
+            "id": "predictions",
+            "name": "Kalshi",
+            "description": "Live odds from the Kalshi prediction market.",
+            "source": "predictions",
+            "category": "predictions",
+            "color": "#1fc9a0",
+            "logo_url": "https://icons.duckduckgo.com/ip3/kalshi.com.ico",
+            "required_tier": "free",
+            "about": "Live odds from Kalshi, the regulated US prediction market — a real-time read on elections, economic prints, and the events in the news.",
+            "usage": [
+                "Live market odds update as money moves.",
+                "Follow the events and questions you care about.",
+                "Display-only — Scrollr shows the market, it never places a trade."
+            ],
+            "order": 28
+        },
+        {
+            "id": "clock",
+            "name": "Clock",
+            "description": "Local time and world clocks",
+            "category": "utility",
+            "color": "#6366f1",
+            "required_tier": "free",
+            "order": 29
+        },
+        {
+            "id": "timer",
+            "name": "Timer",
+            "description": "Pomodoro, countdown, and stopwatch tools",
+            "category": "utility",
+            "color": "#f59e0b",
+            "required_tier": "free",
+            "order": 30
+        },
+        {
+            "id": "weather",
+            "name": "Weather",
+            "description": "Current conditions for your locations",
+            "category": "utility",
+            "color": "#0ea5e9",
+            "required_tier": "free",
+            "order": 31
+        },
+        {
+            "id": "sysmon",
+            "name": "System Monitor",
+            "description": "Live CPU, memory, and GPU stats",
+            "category": "utility",
+            "color": "#06b6d4",
+            "required_tier": "free",
+            "order": 32
+        },
+        {
+            "id": "uptime",
+            "name": "Uptime",
+            "description": "Monitor status from Uptime Kuma",
+            "category": "utility",
+            "color": "#10b981",
+            "logo_url": "https://icon.horse/icon/uptime.kuma.pet",
+            "required_tier": "free",
+            "order": 33
+        },
+        {
+            "id": "github",
+            "name": "GitHub",
+            "description": "CI/Actions status for your repos",
+            "category": "utility",
+            "color": "#f97316",
+            "logo_url": "https://icon.horse/icon/github.com",
+            "required_tier": "free",
+            "order": 34
+        }
+    ]
 }

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -147,7 +147,7 @@ export default function ScrollrTicker({
   pauseOnHover = true,
   hoverSpeed = 0.3,
   mixMode = "grouped",
-  chipColorMode = "channel",
+  chipColorMode = "widget",
   widgetDisplay,
   comfort = false,
   rowIndex = 0,

--- a/desktop/src/components/chips/ConsolidatedChip.tsx
+++ b/desktop/src/components/chips/ConsolidatedChip.tsx
@@ -81,7 +81,7 @@ export default function ConsolidatedChip({
   type,
   items,
   comfort,
-  colorMode = "channel",
+  colorMode = "widget",
   pinned = false,
   onTogglePin,
   onClick,

--- a/desktop/src/components/chips/FantasyStatChip.tsx
+++ b/desktop/src/components/chips/FantasyStatChip.tsx
@@ -76,7 +76,7 @@ export default function FantasyStatChip({
   league,
   prefs,
   comfort,
-  colorMode = "channel",
+  colorMode = "widget",
   onClick,
 }: FantasyStatChipProps) {
   const c = getChipColors(colorMode, "fantasy");

--- a/desktop/src/components/chips/FollowedPlayerChip.tsx
+++ b/desktop/src/components/chips/FollowedPlayerChip.tsx
@@ -82,7 +82,7 @@ export default function FollowedPlayerChip({
   leagues,
   leagueKey,
   comfort,
-  colorMode = "channel",
+  colorMode = "widget",
   accent,
   onClick,
 }: FollowedPlayerChipProps) {

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -29,7 +29,7 @@ interface GameChipProps {
 const GameChip = memo(function GameChip({
   game,
   comfort,
-  colorMode = "channel",
+  colorMode = "widget",
   showLogos = true,
   showTimer = true,
   onClick,

--- a/desktop/src/components/chips/PredictionChip.tsx
+++ b/desktop/src/components/chips/PredictionChip.tsx
@@ -32,7 +32,7 @@ const PredictionChip = memo(
   function PredictionChip({
     prediction: p,
     comfort,
-    colorMode = "channel",
+    colorMode = "widget",
     showDelta = true,
     showCategory = true,
     showVolume = true,

--- a/desktop/src/components/chips/RssChip.tsx
+++ b/desktop/src/components/chips/RssChip.tsx
@@ -16,7 +16,7 @@ interface RssChipProps {
   onClick?: () => void;
 }
 
-const RssChip = memo(function RssChip({ item, comfort, colorMode = "channel", showSource = true, showTimestamps = true, onClick }: RssChipProps) {
+const RssChip = memo(function RssChip({ item, comfort, colorMode = "widget", showSource = true, showTimestamps = true, onClick }: RssChipProps) {
   const c = getChipColors(colorMode, "rss");
   const maxLen = comfort ? 60 : 40;
   const headline = truncate(item.title, maxLen);

--- a/desktop/src/components/chips/TradeChip.tsx
+++ b/desktop/src/components/chips/TradeChip.tsx
@@ -21,7 +21,7 @@ interface TradeChipProps {
 const TradeChip = memo(function TradeChip({
   trade,
   comfort,
-  colorMode = "channel",
+  colorMode = "widget",
   showChange = true,
   directionMarker = "arrow",
   onClick,

--- a/desktop/src/components/settings/TickerSettings.tsx
+++ b/desktop/src/components/settings/TickerSettings.tsx
@@ -70,7 +70,7 @@ const SPACING_OPTIONS: { value: TickerGap; label: string }[] = [
 ];
 
 const CHIP_COLOR_OPTIONS: { value: ChipColorMode; label: string }[] = [
-  { value: "channel", label: "Widget" },
+  { value: "widget", label: "Widget" },
   { value: "accent", label: "Theme" },
   { value: "muted", label: "Subtle" },
 ];

--- a/desktop/src/components/support/ContactForm.tsx
+++ b/desktop/src/components/support/ContactForm.tsx
@@ -1,12 +1,12 @@
 /**
  * ContactForm — unified support form with six categories:
- * Bug Report, Feature Request, General Feedback, Billing, Account, and DataWidgetRow Help.
+ * Bug Report, Feature Request, General Feedback, Billing, Account, and Widget Help.
  *
  * Bug reports collect diagnostics via `collect_diagnostics` Tauri command,
  * file attachments, and frequency. Feature requests collect priority.
  * All categories pre-fill user identity from the auth JWT when available.
  */
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Bug, Lightbulb, MessageSquare, CreditCard, UserCog, Radio, Paperclip, X, Loader2 } from "lucide-react";
 import clsx from "clsx";
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { authFetch, ApiError } from "../../api/client";
 import { SelectMenu } from "../widget-bar/SelectMenu";
 import { getUserIdentity, isAuthenticated } from "../../auth";
+import { getCatalogItems } from "../../marketplace";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -21,7 +22,7 @@ interface ContactFormProps {
   onBack: () => void;
 }
 
-type Category = "bug" | "feature" | "feedback" | "billing" | "account" | "channel";
+type Category = "bug" | "feature" | "feedback" | "billing" | "account" | "widget";
 
 interface Attachment {
   filename: string;
@@ -40,7 +41,7 @@ const CATEGORY_OPTIONS: { value: Category; label: string; icon: typeof Bug }[] =
   { value: "feedback", label: "General Feedback", icon: MessageSquare },
   { value: "billing", label: "Billing & Subscription", icon: CreditCard },
   { value: "account", label: "Account & Login", icon: UserCog },
-  { value: "channel", label: "Widget Help", icon: Radio },
+  { value: "widget", label: "Widget Help", icon: Radio },
 ];
 
 const FREQUENCY_OPTIONS: { value: Frequency; label: string }[] = [
@@ -76,7 +77,7 @@ const HEADER_CONFIG: Record<Category, { title: string; subtitle: string }> = {
     title: "Account & Login Help",
     subtitle: "Issues with signing in, password, or account settings",
   },
-  channel: {
+  widget: {
     title: "Widget Help",
     subtitle: "Issues with a specific widget",
   },
@@ -88,7 +89,7 @@ const SUBMIT_LABELS: Record<Category, string> = {
   feedback: "Submit Feedback",
   billing: "Submit Billing Question",
   account: "Submit Account Question",
-  channel: "Submit Widget Issue",
+  widget: "Submit Widget Issue",
 };
 
 const SUCCESS_MESSAGES: Record<Category, string> = {
@@ -97,7 +98,7 @@ const SUCCESS_MESSAGES: Record<Category, string> = {
   feedback: "Feedback submitted — thanks for sharing",
   billing: "Billing question submitted — we'll follow up by email",
   account: "Account question submitted — we'll follow up by email",
-  channel: "Widget issue submitted — we'll follow up by email",
+  widget: "Widget issue submitted — we'll follow up by email",
 };
 
 const MAX_FILES = 5;
@@ -140,7 +141,20 @@ export default function ContactForm({ onBack }: ContactFormProps) {
   const [priority, setPriority] = useState<Priority | null>(null);
 
   // DataWidgetRow-specific fields
-  const [channelSelection, setChannelSelection] = useState("");
+  const [widgetSelection, setWidgetSelection] = useState("");
+
+  // Driven by the catalog rather than a hardcoded list. The old options were
+  // the four coarse sources (Finance/Sports/RSS/Fantasy) under a label that
+  // already asked "Which widget?" — so a user reporting a broken NFL feed had
+  // to pick "Sports". The catalog is the authority on what a widget is, and
+  // this stays correct as widgets are added server-side.
+  const widgetOptions = useMemo(
+    () => [
+      { value: "", label: "Select a widget..." },
+      ...getCatalogItems().map((w) => ({ value: w.name, label: w.name })),
+    ],
+    [],
+  );
 
   // Attachments (bug only)
   const [files, setFiles] = useState<File[]>([]);
@@ -234,8 +248,8 @@ export default function ContactForm({ onBack }: ContactFormProps) {
       case "billing":
       case "account":
         return description.trim().length > 0;
-      case "channel":
-        return description.trim().length > 0 && channelSelection !== "";
+      case "widget":
+        return description.trim().length > 0 && widgetSelection !== "";
     }
   })();
 
@@ -280,10 +294,10 @@ export default function ContactForm({ onBack }: ContactFormProps) {
           email: email.trim() || undefined,
           name: name.trim() || undefined,
         };
-      } else if (category === "channel") {
+      } else if (category === "widget") {
         payload = {
-          category: "channel",
-          channel: channelSelection,
+          category: "widget",
+          widget: widgetSelection,
           description: description.trim(),
           email: email.trim() || undefined,
           name: name.trim() || undefined,
@@ -647,21 +661,15 @@ export default function ContactForm({ onBack }: ContactFormProps) {
           </div>
         )}
 
-        {/* ── DataWidgetRow Help fields ───────────────────────────── */}
-        {category === "channel" && (
+        {/* ── Widget Help fields ───────────────────────────── */}
+        {category === "widget" && (
           <>
             <div>
               <label className={labelClass}>Which widget?</label>
               <SelectMenu
-                value={channelSelection}
-                options={[
-                  { value: "", label: "Select a widget..." },
-                  { value: "Finance", label: "Finance" },
-                  { value: "Sports", label: "Sports" },
-                  { value: "RSS", label: "RSS" },
-                  { value: "Fantasy", label: "Fantasy" },
-                ]}
-                onChange={setChannelSelection}
+                value={widgetSelection}
+                options={widgetOptions}
+                onChange={setWidgetSelection}
                 ariaLabel="Which widget?"
                 align="left"
               />

--- a/desktop/src/hooks/useAddWidget.ts
+++ b/desktop/src/hooks/useAddWidget.ts
@@ -34,7 +34,7 @@ export function useAddWidget(): (item: CatalogItem) => Promise<void> {
 
   return useCallback(
     async (item: CatalogItem) => {
-      if (item.kind === "data") {
+      if (item.source) {
         const widgetType = item.id;
 
         // Optimistic insert: write a placeholder widget into the

--- a/desktop/src/hooks/useRemoveWidget.ts
+++ b/desktop/src/hooks/useRemoveWidget.ts
@@ -33,7 +33,7 @@ export function useRemoveWidget(
 
   return useCallback(
     async (item: CatalogItem) => {
-      if (item.kind === "data") {
+      if (item.source) {
         try {
           await dataWidgetsApi.delete(item.id);
           queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });

--- a/desktop/src/marketplace.test.ts
+++ b/desktop/src/marketplace.test.ts
@@ -95,7 +95,7 @@ describe("refreshCatalog", () => {
           id: "sports_nfl",
           name: "Renamed NFL",
           description: "from the server",
-          kind: "data",
+
           source: "sports",
           category: "sports",
           color: "#123456",

--- a/desktop/src/marketplace.ts
+++ b/desktop/src/marketplace.ts
@@ -128,11 +128,16 @@ export interface CatalogItem {
   /** Render the logo on a light tile (transparent/dark marks like UFC). */
   logoLight?: boolean;
   category: WidgetCategory;
-  /** "data" → a backend-connected widget (created via the widgets API);
-   *  "utility" → a local-only widget (stored in preferences). */
-  kind: "data" | "utility";
-  /** For data widgets: the source that owns the renderer + data
-   *  (finance | sports | rss | fantasy | predictions). */
+  /**
+   * The source that owns the renderer + data
+   * (finance | sports | rss | fantasy | predictions), or undefined for a
+   * local-only utility widget.
+   *
+   * Its presence IS the data/utility distinction — a data widget is created
+   * via the widgets API and fed by CDC, a utility lives in preferences. A
+   * separate `kind` field used to carry the same fact; two fields encoding
+   * one thing can only drift, so ask `isUtilityWidget()` instead.
+   */
   source?: string;
   /** For data widgets: config POSTed to the API on add so the backend
    *  subscribes correctly (league / asset class / feeds). */
@@ -145,6 +150,13 @@ export interface CatalogItem {
  *  unknown id. E.g. "sports_nfl" → "sports". */
 export function sourceForWidget(id: string): string | undefined {
   return byId(id)?.source;
+}
+
+/** True for a local-only widget (clock, weather, …): one with no source, so
+ *  it has no server row and no CDC feed. Unknown ids are not utilities. */
+export function isUtilityWidget(id: string): boolean {
+  const w = byId(id);
+  return w !== undefined && !w.source;
 }
 
 /** The fixed asset class ("stock" | "crypto") for a finance widget, or
@@ -188,8 +200,7 @@ export function widgetManifest(
     // is how a client newer than the catalog still renders something.
     return getDataWidget(id) ?? getWidget(id);
   }
-  if (w.kind === "utility") return getWidget(w.id);
-  if (!w.source) return undefined;
+  if (!w.source) return getWidget(w.id);
   const renderer = getDataWidget(w.source);
   if (!renderer) return undefined; // renderer this client lacks — skip
   return {
@@ -206,8 +217,7 @@ export function widgetManifest(
 function buildItem(w: CatalogWidget): CatalogItem | null {
   // Utilities own their renderer directly; data widgets borrow their
   // source's. Either way the client supplies only the icon + FeedTab.
-  const renderer =
-    w.kind === "utility" ? getWidget(w.id) : w.source && getDataWidget(w.source);
+  const renderer = !w.source ? getWidget(w.id) : getDataWidget(w.source);
   if (!renderer) return null; // renderer not registered in this client — skip
 
   return {
@@ -222,7 +232,6 @@ function buildItem(w: CatalogWidget): CatalogItem | null {
     // or tier without a client release. Narrow here, defaulting anything this
     // client doesn't recognise rather than rendering an unlabelled group.
     category: isKnownCategory(w.category) ? w.category : "utility",
-    kind: w.kind,
     source: w.source,
     addConfig: w.default_config,
     info: {

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -162,32 +162,30 @@ describe("enumToBools / boolsToEnum (DisplayLocationGrid adapter)", () => {
   });
 });
 
-describe("REL-40 channelDisplay -> widgetDisplay key migration", () => {
-  it("reads display prefs stored under the legacy channelDisplay key", () => {
+describe("widgetDisplay prefs", () => {
+  // The REL-40 back-compat read of the legacy `channelDisplay` key is gone.
+  // It existed to carry settings written by clients ≤ v1.1.9; with no users
+  // to carry, keeping it would be exactly the compat debt this rename set
+  // out to avoid. An unknown key is simply ignored and defaults apply.
+  it("reads display prefs from widgetDisplay", () => {
     storeValues.set("scrollr:settings", {
       appearance: {},
-      channelDisplay: {
-        finance: { defaultSort: "change" },
-      },
-    });
-
-    const prefs = loadPrefs();
-
-    // Released (≤ v1.1.9) clients persisted under channelDisplay; the
-    // loader must fold it into widgetDisplay so nothing is lost.
-    expect(prefs.widgetDisplay.finance.defaultSort).toBe("change");
-  });
-
-  it("prefers the new widgetDisplay key when both exist", () => {
-    storeValues.set("scrollr:settings", {
-      appearance: {},
-      channelDisplay: { finance: { defaultSort: "alpha" } },
       widgetDisplay: { finance: { defaultSort: "price" } },
     });
 
-    const prefs = loadPrefs();
+    expect(loadPrefs().widgetDisplay.finance.defaultSort).toBe("price");
+  });
 
-    expect(prefs.widgetDisplay.finance.defaultSort).toBe("price");
+  it("ignores the retired channelDisplay key and falls back to defaults", () => {
+    // "change" specifically because it is NOT the default — asserting
+    // against the default value would pass whether or not the legacy key
+    // was read.
+    storeValues.set("scrollr:settings", {
+      appearance: {},
+      channelDisplay: { finance: { defaultSort: "change" } },
+    });
+
+    expect(loadPrefs().widgetDisplay.finance.defaultSort).not.toBe("change");
   });
 });
 

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -81,7 +81,7 @@ export type TickerGap = "tight" | "normal" | "spacious";
 export type TickerMode = "compact" | "comfort";
 type DefaultView = "feed" | "dashboard" | "last";
 export type MixMode = "grouped" | "weave";
-export type ChipColorMode = "channel" | "accent" | "muted";
+export type ChipColorMode = "widget" | "accent" | "muted";
 export type TickerDirection = "left" | "right";
 export type ScrollMode = "continuous" | "step" | "flip";
 export type PinSide = "left" | "right";
@@ -561,7 +561,7 @@ const DEFAULT_TICKER: TickerPrefs = {
   tickerGap: "tight",
   tickerMode: "comfort",
   mixMode: "weave",
-  chipColors: "channel",
+  chipColors: "widget",
   tickerDirection: "left",
   scrollMode: "continuous",
   stepPause: 5,
@@ -1216,12 +1216,7 @@ export function loadPrefs(): AppPreferences {
     const source = isV1 ? migrateV1(saved) : (saved as Partial<AppPreferences>);
 
     // Deep merge with defaults so new keys are always present.
-    // REL-40 rename migration: released clients (≤ v1.1.9) persisted
-    // these prefs under "channelDisplay" — read the legacy key when the
-    // new one is absent so nobody loses their display settings. Writes
-    // always use the new key, so this self-heals on first save.
-    const savedDisplay = (source.widgetDisplay ??
-      (source as Record<string, unknown>).channelDisplay) as
+    const savedDisplay = source.widgetDisplay as
       | Partial<WidgetDisplayPrefs>
       | undefined;
     const layoutResult = migrateTickerLayout(

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -129,7 +129,7 @@ function parseRoute(pathname: string) {
   // data branch was unreachable and every widget page reported itself as a
   // utility. Ask the catalog instead.
   if (kind === "widget" && itemId) {
-    const utility = catalogItemById(itemId)?.kind === "utility";
+    const utility = !catalogItemById(itemId)?.source;
     return {
       activeItem: itemId,
       isDataWidget: !utility, isWidget: utility, isFeed: false,

--- a/desktop/src/routes/widget.$id.info.tsx
+++ b/desktop/src/routes/widget.$id.info.tsx
@@ -114,7 +114,7 @@ function WidgetInfoPage() {
   const textOn = readableTextOn(item.hex);
 
   const enabled =
-    item.kind === "data"
+    Boolean(item.source)
       ? widgets.some((c) => c.widget_type === item.id)
       : prefs.widgets.enabledWidgets.includes(item.id);
 
@@ -147,7 +147,7 @@ function WidgetInfoPage() {
   };
 
   const openWidget = () => {
-    if (item.kind === "data") {
+    if (item.source) {
       navigate({ to: "/widget/$id", params: { id: item.id } });
     } else {
       navigate({ to: "/widget/$id", params: { id: item.id } });
@@ -163,7 +163,7 @@ function WidgetInfoPage() {
     disabled?: boolean;
   };
   const primaryAction: HeroAction | null = !enabled
-    ? !authenticated && item.kind === "data"
+    ? !authenticated && Boolean(item.source)
       ? { label: "Sign in to add", onClick: onLogin }
       : tierLocked
         ? {
@@ -181,7 +181,7 @@ function WidgetInfoPage() {
               label: `Add ${item.name}`,
               onClick: () => void addWidget(item),
               add: true,
-              disabled: dashboardLoading && item.kind === "data",
+              disabled: dashboardLoading && Boolean(item.source),
             }
     : null;
 

--- a/desktop/src/types/api.generated.ts
+++ b/desktop/src/types/api.generated.ts
@@ -178,7 +178,6 @@ export interface WidgetDef {
   id: string;
   name: string;
   description: string;
-  kind: "data" | "utility";
   source?: string;
   category: string;
   color: string;

--- a/myscrollr.com/src/types/api.generated.ts
+++ b/myscrollr.com/src/types/api.generated.ts
@@ -178,7 +178,6 @@ export interface WidgetDef {
   id: string;
   name: string;
   description: string;
-  kind: "data" | "utility";
   source?: string;
   category: string;
   color: string;


### PR DESCRIPTION
Two commits, both finishing what the earlier passes deferred. With no users there is nothing to migrate for, so the old names go outright rather than behind compat reads.

## 1. The rename reaches stored data and the wire

The previous pass renamed code but stopped at anything persisted or wire-facing. Those are now done:

| Was | Now |
|---|---|
| support category `"channel"` | `"widget"` (client + server + AI triage prompt + Discord forum tag) |
| `SupportRequest.Channel`, `TriageResult.Channel` | `.Widget`, wire field `widget` |
| `support_drafts.ai_channel` | `ai_widget` (migration `000003`) |
| `ChipColorMode` value `"channel"` | `"widget"` -- persisted in `prefs.appearance.chipColors` |
| `channelDisplay` prefs key back-compat read | **deleted** |

The support category always meant "help with a specific widget" -- its label was already "Widget Help" and its picker already asked "Which widget?". Only the stored value and column still said channel.

The `channelDisplay` shim existed to carry display settings written by clients <= v1.1.9. Its tests now assert the opposite: the retired key is ignored and defaults apply.

**Bonus fix:** that picker offered the four coarse sources -- Finance, Sports, RSS, Fantasy -- so a user reporting a broken NFL feed had to answer "Sports". It now reads the catalog, and stays correct as widgets are added server-side.

## 2. `kind` deleted -- derived from `source`

Three fields encoded one distinction: `kind`, the presence of `source`, and the cosmetic `utility` category. Verified against all 35 catalog entries:

```
kind=data,    hasSource=True   -> 29
kind=utility, hasSource=False  ->  6
violations of "data <=> has source": none
```

It was exactly derivable, and could only drift out of sync.

**The distinction stays -- the field goes.** A widget with a source gets a `user_widgets` row and a CDC feed; one without lives in desktop preferences. That is real, and it is what `source` already says. `IsUtilityWidgetType(id)` / `isUtilityWidget(id)` are now the single way to ask.

Removed from the wire, the generated types, the bundled snapshot, and `CatalogItem`. The catalog test used to switch on the field and assert the two agreed; with one field there is nothing to disagree.

## Also

Snapshot regeneration required booting the API against a live database and curling `/catalog` through python, to re-emit a value the `widgets` package already computes. Replaced with a standard golden-file flag:

```sh
go -C api test ./internal/widgets -run TestCatalogSnapshot -update
```

## Verification

- Go: all 9 packages green; `go build ./...` clean
- Desktop: **523 tests / 34 files** passing, `tsc --noEmit` clean
- Website: `tsc --noEmit` clean (its `kind` is an unrelated media discriminator)
- Both generated artifacts regenerated from the Go authority, not hand-edited

## Still legitimately named "channel"

`platform.ChannelInfo` / `ChannelRoute` / the `/channels` endpoint (a discovered backend service -- fantasy), Discord's own Channel API in `discord.go`, Redis pub/sub, Kalshi's WebSocket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)