### PR TITLE
chore(release): desktop v1.1.12

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4621,7 +4621,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.11"
+version = "1.1.12"
 edition = "2021"
 description = "Scrollr desktop app — pinned live ticker for sports, finance, RSS, and Yahoo Fantasy."
 authors = ["Brandon Ruth <brandon@myscrollr.com>"]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Ships the client half of the widget-model cleanup (#258, #259).

## Why this is time-sensitive

The server half is already live, and **v1.1.11 cannot read the current catalog**. It resolves a renderer with:

```ts
w.kind === "utility" ? getWidget(w.id) : w.source && getDataWidget(w.source)
```

`kind` no longer exists, so for a utility widget both arms fall through and `buildItem` returns null. All six utility widgets -- clock, timer, weather, sysmon, uptime, github -- are currently missing from the Library on v1.1.11. This release restores them.

That is on me: I deployed the catalog change ahead of the client rather than sequencing them together.

## Also in this build

- **parseRoute fix** -- `/channel/` stopped existing when the redirect shims were deleted, so the data-widget branch was unreachable and every widget page reported itself as a *utility* widget.
- The full client vocabulary rename (~500 identifiers) and the support-form picker now reading the catalog instead of four hardcoded coarse sources.

## Version bump

`package.json`, `package-lock.json` (both root fields), `Cargo.toml`, `Cargo.lock` (the `scrollr-desktop` entry only -- verified `flate2` still reads `1.1.9`), `tauri.conf.json`.

`MIN_DESKTOP_VERSION` is deliberately **not** in this PR. It goes up after the artifacts publish -- raising the gate first would show "update required" while the download does not yet exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)