### PR TITLE
chore: raise MIN_DESKTOP_VERSION to 1.1.12

### DIFF
--- a/k8s/configmap-core.yaml
+++ b/k8s/configmap-core.yaml
@@ -15,7 +15,7 @@ data:
   #   the retired `channels` key, leaving the sidebar and account page
   #   empty, so it is gated too.
   # Bump on future breaking deploys.
-  MIN_DESKTOP_VERSION: "1.1.11"
+  MIN_DESKTOP_VERSION: "1.1.12"
   LOGTO_URL: "https://auth.myscrollr.com/oidc"
   LOGTO_JWKS_URL: "https://auth.myscrollr.com/oidc/jwks"
   LOGTO_ENDPOINT: "https://auth.myscrollr.com"


### PR DESCRIPTION
Held back from #260 deliberately: raising the gate before the artifacts published would have shown "update required" with nothing to download. `desktop-v1.1.12` is now published with 14 assets across Windows, macOS and Linux, and `latest.json` reports `1.1.12`.

1.1.11 needs forcing rather than nudging — it reads the catalog through a `kind` field the server no longer sends, so it silently drops all six utility widgets (clock, timer, weather, sysmon, uptime, github) from the Library.

Incidentally this exercises #255: it touches `k8s/**`, so `kubectl apply` will reset every deployment image to `:latest` and the rollout step must restore the recorded pins. `core-api` is on `:sha-cf78c77` going in — it should still be pinned coming out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)