### PR TITLE
test: make schema drift detectable (P5)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/scrollr_test?sslmode=disable
 
-  # ── Rust tests (3 independent jobs, run in parallel) ───────────
+  # ── Rust tests (4 independent jobs, run in parallel) ───────────
   rust-tests:
     strategy:
       fail-fast: false
@@ -103,6 +103,29 @@ jobs:
       run:
         working-directory: ${{ matrix.dir }}
 
+    # Postgres for tests/schema_contract.rs. These services write with runtime
+    # `sqlx::query`, so a core column rename compiles fine and fails only at
+    # runtime — where the error is logged, the poll loop continues, reads
+    # return an empty Vec, and /health/ready stays 200. Without a database
+    # here the contract test skips and the drift stays invisible.
+    #
+    # Each matrix entry gets its own container, so the four jobs cannot see
+    # each other's schema. The test applies core's migrations itself.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: scrollr_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v6
 
@@ -113,3 +136,5 @@ jobs:
           cache-on-failure: "true"
 
       - run: cargo test --quiet
+        env:
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/scrollr_test?sslmode=disable

--- a/api/internal/ingestread/main_test.go
+++ b/api/internal/ingestread/main_test.go
@@ -1,0 +1,16 @@
+package ingestread
+
+import (
+	"os"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// TestMain switches this package into integration mode when
+// TEST_DATABASE_URL is set: testsupport.Main applies core's migration chain
+// and initialises platform.DBPool, so the queries in this package run against
+// the real schema instead of never running at all.
+func TestMain(m *testing.M) {
+	os.Exit(testsupport.Main(m))
+}

--- a/api/internal/ingestread/rss.go
+++ b/api/internal/ingestread/rss.go
@@ -179,7 +179,12 @@ func queryUserCatalog(ctx context.Context, userSub string, includeFailing bool) 
 		customClauses += customFeedHealthFilter
 	}
 
-	// $1 = userSub (custom-feeds half), $2 = MaxConsecutiveFailures
+	// $1 = userSub (custom-feeds half). $2 = MaxConsecutiveFailures, but ONLY
+	// when the health filters above are appended — they are the only thing
+	// that references it. Passing it unconditionally made every
+	// includeFailing=true call fail with "expected 1 arguments, got 2", so
+	// the desktop's "show failing feeds" option returned an error and an
+	// empty catalog every time.
 	query := `
 		SELECT url, name, category, is_default, consecutive_failures, last_error, last_success_at
 		FROM tracked_feeds
@@ -202,7 +207,12 @@ func queryUserCatalog(ctx context.Context, userSub string, includeFailing bool) 
 		ORDER BY is_default DESC, category, name
 	`
 
-	rows, qErr := platform.DBPool.Query(ctx, query, userSub, MaxConsecutiveFailures)
+	args := []any{userSub}
+	if !includeFailing {
+		args = append(args, MaxConsecutiveFailures)
+	}
+
+	rows, qErr := platform.DBPool.Query(ctx, query, args...)
 	if qErr != nil {
 		return nil, qErr
 	}

--- a/api/internal/ingestread/schema_contract_test.go
+++ b/api/internal/ingestread/schema_contract_test.go
@@ -1,0 +1,79 @@
+package ingestread
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// Every read query in this package, executed against the real schema.
+//
+// These are the queries that turn stored rows into what a user sees, and
+// nothing else checks them. They are string literals, so a column rename in
+// api/migrations compiles perfectly and fails only when the query runs — at
+// which point the failure is nearly invisible: the read path logs and returns
+// an empty slice, which is indistinguishable from "this user has no data".
+// The widget renders empty, /health stays green, and the only symptom is a
+// feed that quietly stopped having anything in it.
+//
+// So the assertion is deliberately weak on data and strict on execution: an
+// empty database is fine, an error is not. Every query must still be valid
+// SQL against the schema core actually creates.
+//
+// Skips without TEST_DATABASE_URL. CI provides one.
+func TestReadQueriesMatchTheSchema(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	ctx := context.Background()
+
+	// A user with no widgets. The per-user queries should return empty, not
+	// error — that path is the one that runs on every dashboard request.
+	const noSuchUser = "logto|schema-contract-probe"
+
+	t.Run("finance", func(t *testing.T) {
+		if _, err := queryTrades(ctx); err != nil {
+			t.Errorf("queryTrades: %v", err)
+		}
+		queryTradesBySymbols(ctx, []string{"AAPL"})
+		getUserFinanceSymbols(ctx, noSuchUser)
+	})
+
+	t.Run("sports", func(t *testing.T) {
+		if _, err := querySportsGames(ctx, 20, nil); err != nil {
+			t.Errorf("querySportsGames: %v", err)
+		}
+		if _, err := queryGamesByLeagues(ctx, []string{"NFL"}, 20, nil, false); err != nil {
+			t.Errorf("queryGamesByLeagues: %v", err)
+		}
+		// fairShare = true takes a different SQL path (the side-split CTE).
+		if _, err := queryGamesByLeagues(ctx, []string{"NFL"}, 20, nil, true); err != nil {
+			t.Errorf("queryGamesByLeagues fairShare: %v", err)
+		}
+		if _, err := loadLeagueStatus(ctx, []string{"NFL"}); err != nil {
+			t.Errorf("loadLeagueStatus: %v", err)
+		}
+		loadLeagueMeta(ctx, []string{"NFL"})
+		getUserSportsLeagues(ctx, noSuchUser)
+		getUserFavoriteTeams(ctx, noSuchUser)
+	})
+
+	t.Run("rss", func(t *testing.T) {
+		if _, err := queryUserCatalog(ctx, noSuchUser, false); err != nil {
+			t.Errorf("queryUserCatalog: %v", err)
+		}
+		if _, err := queryUserCatalog(ctx, noSuchUser, true); err != nil {
+			t.Errorf("queryUserCatalog includeFailing: %v", err)
+		}
+		getUserRSSFeedURLs(ctx, noSuchUser)
+		queryRSSItems(ctx, []string{"https://example.com/feed.xml"})
+	})
+
+	t.Run("predictions", func(t *testing.T) {
+		if _, err := queryMarkets(ctx); err != nil {
+			t.Errorf("queryMarkets: %v", err)
+		}
+		queryMarketsForUser(ctx, []string{"KXPROBE"}, []string{"Politics"})
+	})
+}

--- a/channels/fantasy/api/schema_contract_test.go
+++ b/channels/fantasy/api/schema_contract_test.go
@@ -2,31 +2,62 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Fantasy no longer runs migrations — core-api owns every shared table
-// (VISION 4.3). The Rust ingesters get their drift guard from sqlx's
-// compile-time query checking; Go has no equivalent, so this test is
-// fantasy's: it asserts every column this service reads or writes still
-// exists, with a compatible type.
+// (VISION 4.3), so a core migration can silently remove something this
+// service depends on. This test is how it finds out.
+//
+// The header here used to say the Rust ingesters were covered by "sqlx's
+// compile-time query checking". They are not: they use runtime
+// `sqlx::query`, not the `query!` macro, so nothing is checked at compile
+// time. They now have tests/schema_contract.rs, built on this file's shape.
 //
 // Skips without TEST_DATABASE_URL, like the other integration tests. CI
 // provides one (.github/workflows/backend-tests.yml), so a core migration
 // that drops a column fantasy depends on fails the build there.
 //
 // When you add a column to a query in this service, add it here too.
-var schemaContract = map[string][]string{
-	"yahoo_users":        {"guid", "logto_sub", "refresh_token", "last_sync", "created_at"},
-	"yahoo_leagues":      {"league_key", "name", "game_code", "season", "data", "updated_at"},
-	"yahoo_user_leagues": {"guid", "league_key", "team_key", "team_name", "created_at"},
-	"yahoo_matchups":     {"league_key", "week", "data", "updated_at"},
-	"yahoo_rosters":      {"team_key", "league_key", "data", "updated_at"},
-	"yahoo_standings":    {"league_key", "data", "updated_at"},
+//
+// Columns carry their expected information_schema.data_type. Existence alone
+// is not enough: widening `week` from smallint or retyping `data` off jsonb
+// breaks this service just as surely as dropping the column, and an
+// existence-only check waves both through.
+var schemaContract = map[string]map[string]string{
+	"yahoo_users": {
+		"guid": "character varying", "logto_sub": "character varying",
+		"refresh_token": "text", "last_sync": "timestamp with time zone",
+		"created_at": "timestamp with time zone",
+	},
+	"yahoo_leagues": {
+		"league_key": "character varying", "name": "character varying",
+		"game_code": "character varying", "season": "character varying",
+		"data": "jsonb", "updated_at": "timestamp with time zone",
+	},
+	"yahoo_user_leagues": {
+		"guid": "character varying", "league_key": "character varying",
+		"team_key": "character varying", "team_name": "character varying",
+		"created_at": "timestamp with time zone",
+	},
+	"yahoo_matchups": {
+		"league_key": "character varying", "week": "smallint",
+		"data": "jsonb", "updated_at": "timestamp with time zone",
+	},
+	"yahoo_rosters": {
+		"team_key": "character varying", "league_key": "character varying",
+		"data": "jsonb", "updated_at": "timestamp with time zone",
+	},
+	"yahoo_standings": {
+		"league_key": "character varying", "data": "jsonb",
+		"updated_at": "timestamp with time zone",
+	},
 }
 
 func TestSchemaContract(t *testing.T) {
@@ -67,20 +98,24 @@ func TestSchemaContract(t *testing.T) {
 
 	for table, columns := range schemaContract {
 		t.Run(table, func(t *testing.T) {
-			for _, col := range columns {
-				var exists bool
+			for col, wantType := range columns {
+				var gotType string
 				err := pool.QueryRow(ctx, `
-					SELECT EXISTS (
-						SELECT 1 FROM information_schema.columns
-						WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2
-					)`, table, col).Scan(&exists)
-				if err != nil {
-					t.Fatalf("query information_schema for %s.%s: %v", table, col, err)
-				}
-				if !exists {
+					SELECT data_type FROM information_schema.columns
+					WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2
+				`, table, col).Scan(&gotType)
+				if errors.Is(err, pgx.ErrNoRows) {
 					t.Errorf("%s.%s is missing — fantasy reads or writes it, but core's "+
 						"migrations no longer create it. Add it back in api/migrations, "+
 						"or update this service and the contract above.", table, col)
+					continue
+				}
+				if err != nil {
+					t.Fatalf("query information_schema for %s.%s: %v", table, col, err)
+				}
+				if gotType != wantType {
+					t.Errorf("%s.%s is %q, expected %q — a core migration retyped a column "+
+						"fantasy depends on.", table, col, gotType, wantType)
 				}
 			}
 		})

--- a/channels/finance/service/tests/schema_contract.rs
+++ b/channels/finance/service/tests/schema_contract.rs
@@ -1,0 +1,127 @@
+//! Schema contract: every column this ingester writes must still exist, with
+//! a type that accepts what it sends.
+//!
+//! Why a test and not a compile error: this service uses runtime
+//! `sqlx::query`, not the `query!` macro, so a core column rename compiles
+//! cleanly. It then fails at runtime -- where nothing notices either. The
+//! write error is logged and the poll loop continues, reads return an empty
+//! Vec indistinguishable from "no data", and `/health/ready` stays 200
+//! because it tracks poll success, not writes. A rename in core could
+//! silently stop this source ever storing another row.
+//!
+//! Core owns every migration (VISION 4.3), so this file is how the core repo
+//! finds out it broke a downstream writer.
+//!
+//! Skips without TEST_DATABASE_URL, matching the Go integration tests. CI
+//! provides one; the test applies core's migrations itself when the database
+//! is empty, the same way channels/fantasy/api/schema_contract_test.go does.
+//!
+//! Add a column to a query in this service, add it here too.
+
+use std::collections::HashMap;
+use std::env;
+
+use sqlx::Row;
+
+/// (table, &[(column, information_schema.data_type)])
+const CONTRACT: &[(&str, &[(&str, &str)])] = &[
+    ("trades", &[
+        ("symbol", "character varying"),
+        ("price", "numeric"),
+        ("previous_close", "numeric"),
+        ("price_change", "numeric"),
+        ("percentage_change", "numeric"),
+        ("direction", "character varying"),
+    ]),
+    ("tracked_symbols", &[
+        ("symbol", "character varying"),
+        ("name", "character varying"),
+        ("category", "character varying"),
+        ("exchange", "character varying"),
+    ]),
+];
+
+#[tokio::test]
+async fn writes_match_the_live_schema() {
+    let Ok(url) = env::var("TEST_DATABASE_URL") else {
+        eprintln!("TEST_DATABASE_URL not set -- skipping schema contract");
+        return;
+    };
+
+    let pool = sqlx::PgPool::connect(&url)
+        .await
+        .expect("connect to TEST_DATABASE_URL");
+
+    ensure_schema(&pool).await;
+
+    let mut problems = Vec::new();
+    for (table, columns) in CONTRACT {
+        let rows = sqlx::query(
+            "SELECT column_name, data_type FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = $1",
+        )
+        .bind(table)
+        .fetch_all(&pool)
+        .await
+        .expect("read information_schema");
+
+        if rows.is_empty() {
+            problems.push(format!("table `{table}` does not exist"));
+            continue;
+        }
+
+        let actual: HashMap<String, String> = rows
+            .iter()
+            .map(|r| (r.get("column_name"), r.get("data_type")))
+            .collect();
+
+        for (col, want) in *columns {
+            match actual.get(*col) {
+                None => problems.push(format!("{table}.{col} is missing")),
+                Some(got) if got != want => {
+                    problems.push(format!("{table}.{col} is `{got}`, expected `{want}`"))
+                }
+                Some(_) => {}
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "schema drift between core's migrations and what this service writes:\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+/// Apply core's migration chain when the database is empty. CI hands each job
+/// a fresh Postgres and this service has no migration tool of its own.
+async fn ensure_schema(pool: &sqlx::PgPool) {
+    let probe = CONTRACT[0].0;
+    let present: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = $1)",
+    )
+    .bind(probe)
+    .fetch_one(pool)
+    .await
+    .expect("probe schema");
+    if present {
+        return;
+    }
+
+    let dir = std::path::Path::new("../../../api/migrations");
+    let mut ups: Vec<_> = std::fs::read_dir(dir)
+        .expect("core owns the schema (VISION 4.3) -- api/migrations must be readable")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.to_string_lossy().ends_with(".up.sql"))
+        .collect();
+    ups.sort();
+
+    for path in ups {
+        let sql = std::fs::read_to_string(&path).expect("read migration");
+        sqlx::raw_sql(&sql)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|e| panic!("apply {}: {e}", path.display()));
+    }
+}

--- a/channels/predictions/service/tests/schema_contract.rs
+++ b/channels/predictions/service/tests/schema_contract.rs
@@ -1,0 +1,146 @@
+//! Schema contract: every column this ingester writes must still exist, with
+//! a type that accepts what it sends.
+//!
+//! Why a test and not a compile error: this service uses runtime
+//! `sqlx::query`, not the `query!` macro, so a core column rename compiles
+//! cleanly. It then fails at runtime -- where nothing notices either. The
+//! write error is logged and the poll loop continues, reads return an empty
+//! Vec indistinguishable from "no data", and `/health/ready` stays 200
+//! because it tracks poll success, not writes. A rename in core could
+//! silently stop this source ever storing another row.
+//!
+//! Core owns every migration (VISION 4.3), so this file is how the core repo
+//! finds out it broke a downstream writer.
+//!
+//! Skips without TEST_DATABASE_URL, matching the Go integration tests. CI
+//! provides one; the test applies core's migrations itself when the database
+//! is empty, the same way channels/fantasy/api/schema_contract_test.go does.
+//!
+//! Add a column to a query in this service, add it here too.
+
+use std::collections::HashMap;
+use std::env;
+
+use sqlx::Row;
+
+/// (table, &[(column, information_schema.data_type)])
+const CONTRACT: &[(&str, &[(&str, &str)])] = &[
+    ("markets", &[
+        ("id", "text"),
+        ("source", "text"),
+        ("ticker", "text"),
+        ("event_ticker", "text"),
+        ("series_ticker", "text"),
+        ("category", "text"),
+        ("title", "text"),
+        ("subtitle", "text"),
+        ("yes_price", "integer"),
+        ("yes_bid", "integer"),
+        ("yes_ask", "integer"),
+        ("prev_yes_price", "integer"),
+        ("volume", "bigint"),
+        ("volume_24h", "bigint"),
+        ("open_interest", "bigint"),
+        ("status", "text"),
+        ("result", "text"),
+        ("is_primary", "boolean"),
+        ("open_time", "timestamp with time zone"),
+        ("close_time", "timestamp with time zone"),
+        ("link", "text"),
+        ("event_title", "text"),
+        ("event_rank", "smallint"),
+        ("in_sweep", "boolean"),
+        ("settled_at", "timestamp with time zone"),
+    ]),
+    ("tracked_markets", &[
+        ("ticker", "text"),
+        ("title", "text"),
+        ("category", "text"),
+        ("series_ticker", "text"),
+    ]),
+];
+
+#[tokio::test]
+async fn writes_match_the_live_schema() {
+    let Ok(url) = env::var("TEST_DATABASE_URL") else {
+        eprintln!("TEST_DATABASE_URL not set -- skipping schema contract");
+        return;
+    };
+
+    let pool = sqlx::PgPool::connect(&url)
+        .await
+        .expect("connect to TEST_DATABASE_URL");
+
+    ensure_schema(&pool).await;
+
+    let mut problems = Vec::new();
+    for (table, columns) in CONTRACT {
+        let rows = sqlx::query(
+            "SELECT column_name, data_type FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = $1",
+        )
+        .bind(table)
+        .fetch_all(&pool)
+        .await
+        .expect("read information_schema");
+
+        if rows.is_empty() {
+            problems.push(format!("table `{table}` does not exist"));
+            continue;
+        }
+
+        let actual: HashMap<String, String> = rows
+            .iter()
+            .map(|r| (r.get("column_name"), r.get("data_type")))
+            .collect();
+
+        for (col, want) in *columns {
+            match actual.get(*col) {
+                None => problems.push(format!("{table}.{col} is missing")),
+                Some(got) if got != want => {
+                    problems.push(format!("{table}.{col} is `{got}`, expected `{want}`"))
+                }
+                Some(_) => {}
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "schema drift between core's migrations and what this service writes:\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+/// Apply core's migration chain when the database is empty. CI hands each job
+/// a fresh Postgres and this service has no migration tool of its own.
+async fn ensure_schema(pool: &sqlx::PgPool) {
+    let probe = CONTRACT[0].0;
+    let present: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = $1)",
+    )
+    .bind(probe)
+    .fetch_one(pool)
+    .await
+    .expect("probe schema");
+    if present {
+        return;
+    }
+
+    let dir = std::path::Path::new("../../../api/migrations");
+    let mut ups: Vec<_> = std::fs::read_dir(dir)
+        .expect("core owns the schema (VISION 4.3) -- api/migrations must be readable")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.to_string_lossy().ends_with(".up.sql"))
+        .collect();
+    ups.sort();
+
+    for path in ups {
+        let sql = std::fs::read_to_string(&path).expect("read migration");
+        sqlx::raw_sql(&sql)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|e| panic!("apply {}: {e}", path.display()));
+    }
+}

--- a/channels/rss/service/tests/schema_contract.rs
+++ b/channels/rss/service/tests/schema_contract.rs
@@ -1,0 +1,130 @@
+//! Schema contract: every column this ingester writes must still exist, with
+//! a type that accepts what it sends.
+//!
+//! Why a test and not a compile error: this service uses runtime
+//! `sqlx::query`, not the `query!` macro, so a core column rename compiles
+//! cleanly. It then fails at runtime -- where nothing notices either. The
+//! write error is logged and the poll loop continues, reads return an empty
+//! Vec indistinguishable from "no data", and `/health/ready` stays 200
+//! because it tracks poll success, not writes. A rename in core could
+//! silently stop this source ever storing another row.
+//!
+//! Core owns every migration (VISION 4.3), so this file is how the core repo
+//! finds out it broke a downstream writer.
+//!
+//! Skips without TEST_DATABASE_URL, matching the Go integration tests. CI
+//! provides one; the test applies core's migrations itself when the database
+//! is empty, the same way channels/fantasy/api/schema_contract_test.go does.
+//!
+//! Add a column to a query in this service, add it here too.
+
+use std::collections::HashMap;
+use std::env;
+
+use sqlx::Row;
+
+/// (table, &[(column, information_schema.data_type)])
+const CONTRACT: &[(&str, &[(&str, &str)])] = &[
+    ("rss_items", &[
+        ("feed_url", "text"),
+        ("guid", "text"),
+        ("title", "text"),
+        ("link", "text"),
+        ("description", "text"),
+        ("source_name", "text"),
+        ("published_at", "timestamp with time zone"),
+    ]),
+    ("tracked_feeds", &[
+        ("url", "text"),
+        ("name", "text"),
+        ("category", "text"),
+        ("is_default", "boolean"),
+        ("is_enabled", "boolean"),
+        ("consecutive_failures", "integer"),
+    ]),
+];
+
+#[tokio::test]
+async fn writes_match_the_live_schema() {
+    let Ok(url) = env::var("TEST_DATABASE_URL") else {
+        eprintln!("TEST_DATABASE_URL not set -- skipping schema contract");
+        return;
+    };
+
+    let pool = sqlx::PgPool::connect(&url)
+        .await
+        .expect("connect to TEST_DATABASE_URL");
+
+    ensure_schema(&pool).await;
+
+    let mut problems = Vec::new();
+    for (table, columns) in CONTRACT {
+        let rows = sqlx::query(
+            "SELECT column_name, data_type FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = $1",
+        )
+        .bind(table)
+        .fetch_all(&pool)
+        .await
+        .expect("read information_schema");
+
+        if rows.is_empty() {
+            problems.push(format!("table `{table}` does not exist"));
+            continue;
+        }
+
+        let actual: HashMap<String, String> = rows
+            .iter()
+            .map(|r| (r.get("column_name"), r.get("data_type")))
+            .collect();
+
+        for (col, want) in *columns {
+            match actual.get(*col) {
+                None => problems.push(format!("{table}.{col} is missing")),
+                Some(got) if got != want => {
+                    problems.push(format!("{table}.{col} is `{got}`, expected `{want}`"))
+                }
+                Some(_) => {}
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "schema drift between core's migrations and what this service writes:\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+/// Apply core's migration chain when the database is empty. CI hands each job
+/// a fresh Postgres and this service has no migration tool of its own.
+async fn ensure_schema(pool: &sqlx::PgPool) {
+    let probe = CONTRACT[0].0;
+    let present: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = $1)",
+    )
+    .bind(probe)
+    .fetch_one(pool)
+    .await
+    .expect("probe schema");
+    if present {
+        return;
+    }
+
+    let dir = std::path::Path::new("../../../api/migrations");
+    let mut ups: Vec<_> = std::fs::read_dir(dir)
+        .expect("core owns the schema (VISION 4.3) -- api/migrations must be readable")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.to_string_lossy().ends_with(".up.sql"))
+        .collect();
+    ups.sort();
+
+    for path in ups {
+        let sql = std::fs::read_to_string(&path).expect("read migration");
+        sqlx::raw_sql(&sql)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|e| panic!("apply {}: {e}", path.display()));
+    }
+}

--- a/channels/sports/service/tests/schema_contract.rs
+++ b/channels/sports/service/tests/schema_contract.rs
@@ -1,0 +1,182 @@
+//! Schema contract: every column this ingester writes must still exist, with
+//! a type that accepts what it sends.
+//!
+//! Why a test and not a compile error: this service uses runtime
+//! `sqlx::query`, not the `query!` macro, so a core column rename compiles
+//! cleanly. It then fails at runtime -- where nothing notices either. The
+//! write error is logged and the poll loop continues, reads return an empty
+//! Vec indistinguishable from "no data", and `/health/ready` stays 200
+//! because it tracks poll success, not writes. A rename in core could
+//! silently stop this source ever storing another row.
+//!
+//! Core owns every migration (VISION 4.3), so this file is how the core repo
+//! finds out it broke a downstream writer.
+//!
+//! Skips without TEST_DATABASE_URL, matching the Go integration tests. CI
+//! provides one; the test applies core's migrations itself when the database
+//! is empty, the same way channels/fantasy/api/schema_contract_test.go does.
+//!
+//! Add a column to a query in this service, add it here too.
+
+use std::collections::HashMap;
+use std::env;
+
+use sqlx::Row;
+
+/// (table, &[(column, information_schema.data_type)])
+const CONTRACT: &[(&str, &[(&str, &str)])] = &[
+    ("games", &[
+        ("league", "character varying"),
+        ("sport", "character varying"),
+        ("external_game_id", "character varying"),
+        ("link", "character varying"),
+        ("home_team_name", "character varying"),
+        ("home_team_logo", "character varying"),
+        ("home_team_score", "integer"),
+        ("home_team_code", "character varying"),
+        ("away_team_name", "character varying"),
+        ("away_team_logo", "character varying"),
+        ("away_team_score", "integer"),
+        ("away_team_code", "character varying"),
+        ("start_time", "timestamp with time zone"),
+        ("short_detail", "character varying"),
+        ("state", "character varying"),
+        ("status_short", "character varying"),
+        ("status_long", "character varying"),
+        ("timer", "character varying"),
+        ("venue", "character varying"),
+        ("season", "character varying"),
+    ]),
+    ("standings", &[
+        ("league", "character varying"),
+        ("team_name", "character varying"),
+        ("team_code", "character varying"),
+        ("team_logo", "character varying"),
+        ("rank", "integer"),
+        ("wins", "integer"),
+        ("losses", "integer"),
+        ("draws", "integer"),
+        ("points", "integer"),
+        ("games_played", "integer"),
+        ("goal_diff", "integer"),
+        ("description", "character varying"),
+        ("form", "character varying"),
+        ("group_name", "character varying"),
+        ("season", "character varying"),
+        ("sport_api", "character varying"),
+        ("pct", "character varying"),
+        ("games_behind", "character varying"),
+        ("otl", "integer"),
+        ("goals_for", "integer"),
+        ("goals_against", "integer"),
+        ("points_for", "integer"),
+        ("points_against", "integer"),
+        ("streak", "character varying"),
+    ]),
+    ("teams", &[
+        ("league", "character varying"),
+        ("external_id", "integer"),
+        ("name", "character varying"),
+        ("code", "character varying"),
+        ("logo", "character varying"),
+        ("country", "character varying"),
+        ("season", "character varying"),
+    ]),
+    ("tracked_leagues", &[
+        ("name", "character varying"),
+        ("sport_api", "character varying"),
+        ("api_host", "character varying"),
+        ("league_id", "integer"),
+        ("category", "character varying"),
+        ("country", "character varying"),
+        ("logo_url", "character varying"),
+        ("season", "character varying"),
+        ("season_format", "character varying"),
+        ("offseason_months", "ARRAY"),
+    ]),
+];
+
+#[tokio::test]
+async fn writes_match_the_live_schema() {
+    let Ok(url) = env::var("TEST_DATABASE_URL") else {
+        eprintln!("TEST_DATABASE_URL not set -- skipping schema contract");
+        return;
+    };
+
+    let pool = sqlx::PgPool::connect(&url)
+        .await
+        .expect("connect to TEST_DATABASE_URL");
+
+    ensure_schema(&pool).await;
+
+    let mut problems = Vec::new();
+    for (table, columns) in CONTRACT {
+        let rows = sqlx::query(
+            "SELECT column_name, data_type FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = $1",
+        )
+        .bind(table)
+        .fetch_all(&pool)
+        .await
+        .expect("read information_schema");
+
+        if rows.is_empty() {
+            problems.push(format!("table `{table}` does not exist"));
+            continue;
+        }
+
+        let actual: HashMap<String, String> = rows
+            .iter()
+            .map(|r| (r.get("column_name"), r.get("data_type")))
+            .collect();
+
+        for (col, want) in *columns {
+            match actual.get(*col) {
+                None => problems.push(format!("{table}.{col} is missing")),
+                Some(got) if got != want => {
+                    problems.push(format!("{table}.{col} is `{got}`, expected `{want}`"))
+                }
+                Some(_) => {}
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "schema drift between core's migrations and what this service writes:\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+/// Apply core's migration chain when the database is empty. CI hands each job
+/// a fresh Postgres and this service has no migration tool of its own.
+async fn ensure_schema(pool: &sqlx::PgPool) {
+    let probe = CONTRACT[0].0;
+    let present: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = $1)",
+    )
+    .bind(probe)
+    .fetch_one(pool)
+    .await
+    .expect("probe schema");
+    if present {
+        return;
+    }
+
+    let dir = std::path::Path::new("../../../api/migrations");
+    let mut ups: Vec<_> = std::fs::read_dir(dir)
+        .expect("core owns the schema (VISION 4.3) -- api/migrations must be readable")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.to_string_lossy().ends_with(".up.sql"))
+        .collect();
+    ups.sort();
+
+    for path in ups {
+        let sql = std::fs::read_to_string(&path).expect("read migration");
+        sqlx::raw_sql(&sql)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|e| panic!("apply {}: {e}", path.display()));
+    }
+}


### PR DESCRIPTION
A core column rename is currently silent at **every** layer. Nothing catches it:

- the Rust ingesters use runtime `sqlx::query`, not the `query!` macro, so they compile fine
- `rust-tests` CI has no Postgres, so nothing runs against a schema
- `ingestread` has no DB-backed test at all
- the fantasy contract test checks existence but not type
- ingester write errors are logged and the poll loop continues
- reads return empty vecs indistinguishable from "no data"
- `/health/ready` stays 200 because it tracks poll success, not writes

A rename in core could stop a source storing rows forever and every signal would stay green.

## What this adds

**`tests/schema_contract.rs` in all four ingesters** — 10 tables, 113 columns, each asserted to exist with its expected `information_schema` data_type. The test applies core's migration chain itself when the database is empty (same approach as `channels/fantasy/api/schema_contract_test.go`), so CI needs only a container. Postgres added to the `rust-tests` matrix; each of the four jobs gets its own.

**Type assertions in the fantasy contract test.** Widening `week` off `smallint` or retyping `data` off `jsonb` breaks that service exactly as surely as dropping the column, and existence-only waved both through.

Its header also claimed the Rust ingesters were "covered by sqlx's compile-time query checking". That is the opposite of true, and is very plausibly why this gap survived review for so long — the doc asserted the coverage existed. Rewritten.

**A DB-backed test for `ingestread`** that EXECUTES every read query against the real schema. Deliberately weak on data, strict on execution: an empty database is fine, an error is not.

## It found a real bug on its first run

```
queryUserCatalog includeFailing: expected 1 arguments, got 2
```

`queryUserCatalog` always passed two arguments, but `$2` appears **only inside the health filters** — which are skipped when `includeFailing` is true. So the desktop's "show failing feeds" option has been returning an error and an empty catalog every single time it was used. Fixed by binding the second argument only when the filter referencing it is present.

## Verified against a real database, not just compiled

I ran a Postgres container rather than pushing and hoping:

- all four Rust contracts pass on a **fresh** database, proving the migration-applying path works from Rust
- fantasy and ingestread pass; full suites green in integration mode (9 api packages, fantasy, 23 Rust test binaries)
- **and the guard provably fails when it should** — renaming `trades.direction` and retyping `trades.price` to `double precision` each produce a specific named failure:

```
schema drift between core's migrations and what this service writes:
  trades.price is `double precision`, expected `numeric`
  trades.direction is missing
```

That last check matters more than the passing ones. A guard that cannot fail is the thing this repo has been bitten by twice.

Independent of #262; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)