### PR TITLE
chore: delete GetValidChannelTypes, now that nothing calls it

### DIFF
--- a/api/internal/platform/discovery.go
+++ b/api/internal/platform/discovery.go
@@ -148,19 +148,6 @@ func GetChannel(name string) *ChannelInfo {
 	return GlobalDiscovery.channels[name]
 }
 
-// GetValidChannelTypes returns a set of all registered channel names.
-// These are the valid channel types for user_widgets.
-func GetValidChannelTypes() map[string]bool {
-	GlobalDiscovery.mu.RLock()
-	defer GlobalDiscovery.mu.RUnlock()
-
-	types := make(map[string]bool, len(GlobalDiscovery.channels))
-	for name := range GlobalDiscovery.channels {
-		types[name] = true
-	}
-	return types
-}
-
 // GetChannelRoutes returns all routes from all discovered channels.
 func GetChannelRoutes() []struct {
 	Channel *ChannelInfo

--- a/api/internal/widgets/widgets.go
+++ b/api/internal/widgets/widgets.go
@@ -143,8 +143,8 @@ func CreateWidget(c *fiber.Ctx) error {
 
 	// The catalog is the only authority on what a widget is.
 	//
-	// This used to also accept anything in GetValidChannelTypes(), which is the
-	// set of DISCOVERED BACKEND SERVICES — a different concept entirely. It let
+	// This used to also accept anything registered in Redis service discovery
+	// — a different concept entirely, and a set of BACKEND SERVICES. It let
 	// widget_type "fantasy" through (the service registers under that name)
 	// while the catalog id is "fantasy_yahoo", producing a row with no catalog
 	// entry: it consumed a slot, resolved to no source, subscribed to no SSE

--- a/docs/ROLLOUT.md
+++ b/docs/ROLLOUT.md
@@ -119,11 +119,15 @@ Only cosmetic vocabulary, deliberately deferred as low-value churn:
   `desktop/src/datawidgets/` folder still carry "datawidget". Renaming the folder
   to `sources/` would match what it actually holds (the `source → renderer`
   registry), at the cost of touching every import path.
-- **`ChannelInfo`, `ChannelRoute`, `GetValidChannelTypes` and `channel_lifecycle`
-  should NOT be renamed.** They name *discovered backend services*, not widgets —
+- **`ChannelInfo`, `ChannelRoute` and `channel_lifecycle` should NOT be
+  renamed.** They name *discovered backend services*, not widgets —
   a different concept that the charter explicitly keeps (discovery/proxy stays for
   fantasy). VISION §2's complaint was that one *concept* carried six names; this is
   a second concept that legitimately owns the word.
+  *(`GetValidChannelTypes` was on this list until 2026-07-21. It is gone — not
+  renamed, deleted: its only callers were the widget create/update validators,
+  which had no business asking a service registry what a widget is. Nothing
+  else ever called it.)*
 
 **Deferred out of Phase 2, with reasons:**
 


### PR DESCRIPTION
Follow-up to #262. Removing the phantom-widget validation left this helper with zero callers.

## Why it existed

`CreateWidget` and `UpdateWidget` used it to decide whether a `widget_type` was valid — asking a registry of **discovered backend services** what counts as a widget. That is what let `widget_type: "fantasy"` through (the service registers under that name) while the catalog id is `fantasy_yahoo`, producing a row that consumed a slot and could not render. #262 made the catalog the only authority, which was its last use.

## Why deleted rather than renamed

It sat on ROLLOUT.md's "correct and deliberate, do not rename" list beside `ChannelInfo`, `ChannelRoute` and `channel_lifecycle`. That reasoning is sound and still holds for the other three — they name a *discovered backend service*, a second concept that legitimately owns the word "channel".

But that list was protecting the **name**. Nothing was defending the function once its last caller went away. `git grep` finds no remaining references outside `docs/superpowers/**`, which are date-stamped historical specs.

ROLLOUT.md's list is annotated rather than silently edited, so the next person doesn't wonder where the fourth item went.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` clean — 9/9 packages.

No release: backend-only, and this repo tags desktop releases only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)