### PR TITLE
fix: round-two audit findings, plus what an exhaustive sweep found

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,9 @@ pull request. If you just want to run the project locally, the [root
 | `channels/fantasy/api/` | The one remaining separate service (Go). Stays separate for its Yahoo OAuth session and sync loop; core proxies to it. |
 | `myscrollr.com/` | Marketing site, legal hub, billing portal (React + Vite + TanStack Router). |
 | `desktop/` | Tauri v2 desktop app — the primary product. React frontend in `desktop/src/`, Rust backend in `desktop/src-tauri/`. |
-| `k8s/` | Kubernetes manifests deployed on Coolify-managed DigitalOcean cluster. |
+| `k8s/` | Kubernetes manifests, applied to DOKS by `.github/workflows/deploy.yml`. |
 | `docs/superpowers/specs/` | Written specs for in-flight features; predate every merge. |
-| `scripts/` | Operational tooling (invite CLI, Yahoo probe, etc.). |
+| `scripts/` | Dev + ops shell tooling: local-stack helpers, Kalshi key pull, smoke tests. |
 
 `AGENTS.md` at the root has the full commands cheatsheet (build, test,
 ports).
@@ -42,8 +42,9 @@ ports).
 - Documentation improvements (typos, clearer wording, missing docs).
 - New widgets — see `api/CHANNELS.md`. Reusing an existing source is a
   server-only change: one entry in the catalog, no client release.
-- Test coverage. `go test ./...` and `cargo test` work everywhere;
-  Vitest is the target for TS.
+- Test coverage. `go test ./...` runs in the two Go modules (`api/`,
+  `channels/fantasy/api/`) and `cargo test` in each Rust crate — there is no
+  workspace at the root for either. Vitest is the target for TS.
 - Accessibility and i18n improvements.
 
 ## What we probably won't merge
@@ -160,7 +161,7 @@ per-service commands are in `AGENTS.md`. In short:
 ```sh
 cp .env.example .env                            # fill in real values
 npm install                                     # from website / desktop dirs
-go build ./... && go test ./...                 # from api / channels dirs
+go build ./... && go test ./...                 # from api/ or channels/fantasy/api/
 cargo test                                      # from each Rust service
 ```
 

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -122,7 +122,8 @@ cd api
 go run .
 ```
 Watch for: `[Auth] Initialized Logto JWKS from https://auth.myscrollr.com/oidc/jwks`,
-the migrations applying, and the server listening on `:8080`.
+the migrations applying, and the server listening on `:18080` (api/.env sets
+PORT=18080).
 Sanity check (new terminal): `curl http://localhost:18080/health`.
 
 ### 4. Start the desktop app
@@ -135,11 +136,12 @@ back to the app (PKCE callback on `127.0.0.1:19284`). You're now authenticated
 against the **local** API with your real account + tier.
 
 ### 5. Try it
-- **Add channels** from the Catalog — this hits the local API's slot check.
+- **Add widgets** from the Catalog — this hits the local API's slot check.
   Add up to your tier's cap; the next one shows **"Widget limit reached"**.
   (On an unlimited tier you won't hit it — temporarily lower a number in
-  `desktop/src/tierLimits.ts` + `api/core/tier_limits.go` to test the cap.)
-- **Configure** an added channel straight from its catalog card.
+  `desktop/src/tierLimits.ts` + `api/internal/widgets/tier_limits.go` to test
+  the cap.)
+- **Configure** an added widget straight from its catalog card.
 - Open a source page → the **Options** menu has no "Display preferences".
 
 ---
@@ -213,7 +215,7 @@ within ~10s of the fantasy API starting.
   migrate; read its logs rather than hunting for an ingester migration to
   apply by hand.
 - **Fantasy Yahoo OAuth callback.** The connect flow redirects to
-  `http://localhost:8084/fantasy/callback`; that URI must be registered in the
+  `http://localhost:8084/yahoo/callback`; that URI must be registered in the
   Yahoo app or token exchange fails. The service runs regardless.
 - **No Sequin locally** → no real-time SSE push; the desktop polls for updates.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # MyScrollr — local dev orchestration.
 #
 #   make up        Build + start the whole backend in Docker (Postgres, Redis,
-#                  Core API, and every channel), then wait until it's healthy.
+#                  Core API, fantasy-api and the four Rust ingesters), then
+#                  wait until it's healthy.
 #   make down      Stop the backend (keeps your local database).
 #   make web       Run the marketing site natively (Vite :3000).
 #   make desktop   Run the Tauri desktop app natively.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ exists to feed it.
 | [`channels/predictions/`](./channels/predictions/) | Prediction-market ingester (Kalshi) | Rust |
 | [`channels/fantasy/`](./channels/fantasy/) | Yahoo Fantasy (OAuth + sync) | Go |
 | [`k8s/`](./k8s/) | Production manifests | Kubernetes on DigitalOcean |
-| [`scripts/`](./scripts/) | Operational tooling | Mixed Go / shell |
+| [`scripts/`](./scripts/) | Operational tooling | Shell, one Node script |
 | [`docs/`](./docs/) | Charter, rollout plan, ADRs, design specs | Markdown |
 
 ## How it fits together
@@ -79,9 +79,10 @@ exists to feed it.
 - **Core API is the only service that validates JWTs**, and the only
   thing that migrates the database. The ingesters are pure writers.
 - **The widget catalog is server-authoritative.** `GET /catalog` is the
-  single definition of what widgets exist; both clients fetch it and
-  render generically. Adding a widget that reuses an existing renderer
-  is a server-only change — no client release.
+  single definition of what widgets exist. The desktop fetches it and
+  renders generically, so adding a widget that reuses an existing renderer
+  is a server-only change — no client release. The marketing site does not
+  fetch it; its widget counts are hardcoded and updated by hand.
 - **Only fantasy is still a proxied service.** Finance, sports, rss and
   predictions were folded into core by
   [ADR-0002](./docs/adr/0002-consolidate-widget-read-apis.md); Redis
@@ -114,7 +115,8 @@ docker compose -f docker-compose.local.yml up -d
 
 # 2. Core API (:8080) — applies every migration, serves the catalog
 cd api
-cp .env.example .env && $EDITOR .env
+# api/.env has no template — LOCAL_SETUP.md lists what it needs
+$EDITOR .env
 go build ./... && go test ./...
 go run .
 

--- a/api/internal/platform/database.go
+++ b/api/internal/platform/database.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"log"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -74,19 +75,26 @@ func ConnectDB() {
 	// be explicit; the table name is kept from before the consolidation so
 	// existing databases don't re-run the chain.
 	//
-	// Default to `require`, not `disable`. pgx (the pool above) negotiates TLS
-	// on its own, so a DATABASE_URL without an explicit sslmode still gave an
-	// encrypted app connection — but this appended `disable`, so the entire DDL
-	// chain ran in the clear against managed Postgres. A database that genuinely
-	// has no TLS opts out by setting sslmode explicitly — docker-compose.dev.yml
-	// already does (`...?sslmode=disable`), so local dev is unaffected.
+	// sslmode has to be inferred when the URL omits it, and the safe answer
+	// differs by host. This used to append `disable` unconditionally, which
+	// would run the whole DDL chain in the clear against a remote database.
+	// Appending `require` unconditionally is the opposite mistake: a local
+	// Postgres has no TLS, so `go run .` against localhost fails outright with
+	// nothing in the docs to explain it.
+	//
+	// So: remote defaults to require, loopback defaults to disable. An explicit
+	// sslmode in DATABASE_URL always wins (docker-compose.dev.yml sets one).
 	migrateURL := databaseURL
 	if !strings.Contains(migrateURL, "sslmode=") {
-		if strings.Contains(migrateURL, "?") {
-			migrateURL += "&sslmode=require"
-		} else {
-			migrateURL += "?sslmode=require"
+		mode := "require"
+		if isLoopbackDB(migrateURL) {
+			mode = "disable"
 		}
+		sep := "?"
+		if strings.Contains(migrateURL, "?") {
+			sep = "&"
+		}
+		migrateURL += sep + "sslmode=" + mode
 	}
 	if strings.Contains(migrateURL, "?") {
 		migrateURL += "&x-migrations-table=schema_migrations_core"
@@ -112,6 +120,24 @@ func ConnectDB() {
 	// Best-effort initial prune so the table doesn't sit with stale rows
 	// until the first periodic tick fires. Errors are logged inside.
 	pruneWebhookEvents(context.Background())
+}
+
+// isLoopbackDB reports whether a Postgres URL points at this machine, where
+// TLS is not expected. Parsed rather than substring-matched so a remote host
+// that merely contains "localhost" in a database name or password cannot be
+// mistaken for local — that would silently downgrade a production connection.
+func isLoopbackDB(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false // unparseable: assume remote, keep the secure default
+	}
+	switch h := u.Hostname(); h {
+	case "localhost", "127.0.0.1", "::1", "0.0.0.0":
+		return true
+	default:
+		// Docker's host aliases resolve to the developer's own machine.
+		return h == "host.docker.internal" || h == "postgres"
+	}
 }
 
 // pruneWebhookEvents deletes Stripe webhook event rows older than 7 days.

--- a/api/internal/platform/database_test.go
+++ b/api/internal/platform/database_test.go
@@ -1,0 +1,41 @@
+package platform
+
+import "testing"
+
+// isLoopbackDB decides whether the migration connection may skip TLS. Getting
+// it wrong in the permissive direction silently sends the whole DDL chain, and
+// the database password, in the clear to a remote host — so the interesting
+// cases are the ones that merely LOOK local.
+func TestIsLoopbackDB(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		// Genuinely local — TLS is not expected and require would just fail.
+		{"localhost", "postgres://u:p@localhost:5432/scrollr", true},
+		{"127.0.0.1", "postgres://u:p@127.0.0.1:5432/scrollr", true},
+		{"ipv6 loopback", "postgres://u:p@[::1]:5432/scrollr", true},
+		{"compose service name", "postgres://scrollr:scrollr@postgres:5432/scrollr", true},
+		{"docker host alias", "postgres://u:p@host.docker.internal:5432/scrollr", true},
+
+		// Remote — must keep the secure default.
+		{"managed postgres", "postgres://u:p@db-do-user-1.k.db.ondigitalocean.com:25060/defaultdb", false},
+
+		// The traps: "localhost" appearing somewhere that is not the host.
+		{"localhost as db name", "postgres://u:p@prod.example.com:5432/localhost", false},
+		{"localhost in password", "postgres://u:localhost@prod.example.com:5432/scrollr", false},
+		{"localhost as username", "postgres://localhost:p@prod.example.com:5432/scrollr", false},
+		{"host merely ends with localhost", "postgres://u:p@evil-localhost.example.com:5432/db", false},
+
+		// Unparseable input must not be treated as local.
+		{"garbage", "not a url at all", false},
+		{"empty", "", false},
+	}
+
+	for _, c := range cases {
+		if got := isLoopbackDB(c.url); got != c.want {
+			t.Errorf("%s: isLoopbackDB = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/channels/fantasy/.env.example
+++ b/channels/fantasy/.env.example
@@ -27,7 +27,7 @@ CHANNEL_URL=http://localhost:8084
 # exactly (including trailing slash) or token exchange will fail.
 YAHOO_CLIENT_ID=your-yahoo-client-id
 YAHOO_CLIENT_SECRET=your-yahoo-client-secret
-YAHOO_CALLBACK_URL=http://localhost:8084/fantasy/callback
+YAHOO_CALLBACK_URL=http://localhost:8084/yahoo/callback
 
 # Optional: override Yahoo endpoints (defaults are the production URLs)
 # YAHOO_AUTH_URL=https://api.login.yahoo.com/oauth2/request_auth

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -58,7 +58,13 @@ export default function App() {
 
   // Keep the ticker's widget metadata in sync with the server catalog; falls
   // back to the bundled snapshot when offline.
-  useCatalog();
+  //
+  // The version is used, not discarded. A catalog swap re-renders this
+  // component, but `installedWidgetsMeta` below is memoised on [widgets]
+  // alone — without the version in its deps it hands back the pre-refresh
+  // names, colors and icons forever. This is the fourth instance of that
+  // shape; __root.tsx, catalog.tsx and feed.tsx were the first three.
+  const catalogVersion = useCatalog();
 
   // Auth + tier state (drives refetchInterval)
   const [authenticated, setAuthenticated] = useState(() => checkAuth());
@@ -147,7 +153,7 @@ export default function App() {
         hex: m.hex,
         icon: m.icon,
       }));
-  }, [widgets]);
+  }, [widgets, catalogVersion]);
 
   // Persist active tabs when they change (side effect, not in useMemo)
   useEffect(() => {

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -18,6 +18,7 @@ import type { LeagueResponse as FantasyLeague } from "../datawidgets/fantasy/typ
 import ConsolidatedChip from "./chips/ConsolidatedChip";
 import { getWatchlist, onWatchlistChange } from "../datawidgets/predictions/watchlist";
 import { sourceForWidget } from "../marketplace";
+import { useCatalog } from "../hooks/useCatalog";
 import { getTickerSource } from "../datawidgets/tickerRegistry";
 
 // ── Module-level constants ───────────────────────────────────────
@@ -189,6 +190,10 @@ export default function ScrollrTicker({
   // Build chip arrays per widget, then combine based on mixMode.
   // Row filtering (multi-deck) happens UPSTREAM in App.tsx — activeTabs
   // here is already the per-row source list. No round-robin split.
+  // The chip builder resolves each tab through sourceForWidget(); without
+  // subscribing, a server-added widget renders with no source and is skipped.
+  const catalogVersion = useCatalog();
+
   const chips = useMemo(() => {
     const wrap = (key: string, chip: React.ReactNode) => (
       <div key={key} className="py-1">
@@ -269,7 +274,7 @@ export default function ScrollrTicker({
       : buckets.flat();
 
     return allItems;
-  }, [dashboard, activeTabs, widgetData, onChipClick, onTogglePin, pinnedWidgets, comfort, effectiveMixMode, chipColorMode, widgetDisplay, rowIndex, predictionsWatchlist]);
+  }, [dashboard, activeTabs, widgetData, onChipClick, onTogglePin, pinnedWidgets, comfort, effectiveMixMode, chipColorMode, widgetDisplay, rowIndex, predictionsWatchlist, catalogVersion]);
 
   // ── Shared refs ─────────────────────────────────────────────────
   const containerRef = useRef<HTMLDivElement>(null);

--- a/desktop/src/components/support/ContactForm.tsx
+++ b/desktop/src/components/support/ContactForm.tsx
@@ -15,6 +15,7 @@ import { authFetch, ApiError } from "../../api/client";
 import { SelectMenu } from "../widget-bar/SelectMenu";
 import { getUserIdentity, isAuthenticated } from "../../auth";
 import { getCatalogItems } from "../../marketplace";
+import { useCatalog } from "../../hooks/useCatalog";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -148,12 +149,16 @@ export default function ContactForm({ onBack }: ContactFormProps) {
   // already asked "Which widget?" — so a user reporting a broken NFL feed had
   // to pick "Sports". The catalog is the authority on what a widget is, and
   // this stays correct as widgets are added server-side.
+  // Keyed on the catalog version: with `[]` this pinned the option list to
+  // whatever the bundled snapshot held at mount, so a widget added
+  // server-side never became reportable.
+  const catalogVersion = useCatalog();
   const widgetOptions = useMemo(
     () => [
       { value: "", label: "Select a widget..." },
       ...getCatalogItems().map((w) => ({ value: w.name, label: w.name })),
     ],
-    [],
+    [catalogVersion],
   );
 
   // Attachments (bug only)

--- a/desktop/src/components/support/FeatureGuidesSection.tsx
+++ b/desktop/src/components/support/FeatureGuidesSection.tsx
@@ -5,11 +5,15 @@ import { getAllDataWidgets } from "../../datawidgets/registry";
 import { getAllWidgets } from "../../widgets/registry";
 import type { DataWidgetManifest, WidgetManifest } from "../../types";
 
+// Every widget is free — the catalog sets no RequiredTier on any of the 35
+// entries, and fantasy_yahoo carries "the tier gate was retired in v1.1.2".
+// This table said fantasy: "Uplink" and rendered an amber "Uplink required"
+// badge on the Fantasy card, telling free users to pay for what they have.
 const WIDGET_TIERS: Record<string, string> = {
   finance: "Free",
   sports: "Free",
   rss: "Free",
-  fantasy: "Uplink",
+  fantasy: "Free",
 };
 
 export default function FeatureGuidesSection() {

--- a/desktop/src/components/support/support-content.ts
+++ b/desktop/src/components/support/support-content.ts
@@ -11,7 +11,7 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "Is Scrollr free?",
     answer:
-      "Yes. The free tier gives you real-time data across all widgets with generous limits and no ads. Upgrade to Uplink for more capacity, or Uplink Ultimate for live streaming data and unlimited everything.",
+      "Yes. The free tier streams real-time data to 3 widgets at once, with no ads and no cap on what goes inside each one. Paid plans add widget slots and ticker rows — they do not unlock data, widgets, or live streaming.",
   },
   {
     question: "Does it affect my computer's performance?",
@@ -36,7 +36,7 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "What data does Scrollr show?",
     answer:
-      "Widgets showing live stock and crypto prices (Finance), scores across 20+ leagues (Sports), articles from RSS feeds (News), and Yahoo Fantasy Sports leagues (Fantasy). Plus utility widgets for weather, clocks, system monitoring, uptime, and GitHub Actions.",
+      "Widgets showing live stock and crypto prices (Finance), scores across 14 leagues (Sports), articles from RSS feeds (News), and Yahoo Fantasy Sports leagues (Fantasy). Plus utility widgets for weather, clocks, system monitoring, uptime, and GitHub Actions.",
   },
   {
     question: "Can I customize the feed?",
@@ -61,12 +61,12 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "How does live data work vs. polling?",
     answer:
-      "Free, Uplink, and Uplink Pro tiers use polling — the app fetches fresh data at regular intervals (60s on Free, 30s on Uplink, 10s on Uplink Pro). Uplink Ultimate uses a persistent SSE connection for instant live updates as data changes on the server. The current mode (Live or Polling) shows in the title bar next to the Pin button — a green dot means Live, a normal dot means Polling.",
+      "Every plan gets the same persistent SSE connection, so updates arrive the instant data changes on the server. Polling is the fallback for when that connection drops, and it is faster on paid plans: 60s on Free, 30s on Uplink, 10s on Uplink Pro (Ultimate polls at 30s because SSE carries it). The current mode shows in the title bar next to the Pin button — a green dot means Live, a normal dot means Polling.",
   },
   {
     question: "What's the difference between Uplink tiers?",
     answer:
-      "Free: 5 stock/crypto symbols, 1 news feed, 1 sports league, no fantasy leagues, 60s polling. Uplink: 25 symbols, 25 feeds, 8 sports leagues, 1 fantasy league, 30s polling. Uplink Pro: 75 symbols, 100 feeds, 20 sports leagues, 3 fantasy leagues, 10s polling. Uplink Ultimate: unlimited symbols/feeds/sports leagues, 10 fantasy leagues, live SSE streaming.",
+      "Plans differ by how many widgets run at once, and how many ticker rows you get. Free: 3 widgets, 1 row. Uplink: 6 widgets, 2 rows. Uplink Pro: 12 widgets, 3 rows. Uplink Ultimate: unlimited widgets, 3 rows with per-row speed and direction. Every plan gets every widget and unlimited items inside each one.",
   },
 ];
 
@@ -149,7 +149,7 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
       "Yesterday's games still showing as live",
     ],
     steps: [
-      "Scores update via polling based on your plan tier. Free: 60s, Uplink: 30s, Uplink Pro: 10s, Uplink Ultimate: live SSE.",
+      "Scores stream live over SSE on every plan. If that connection drops the app falls back to polling, which is plan-based: 60s on Free, 30s on Uplink, 10s on Uplink Pro.",
       "Check your current delivery mode in the title bar (next to the Pin button) — green dot is Live, normal dot is Polling.",
       "Try switching to a different widget and back.",
     ],
@@ -246,7 +246,7 @@ export const GETTING_STARTED_STEPS: GettingStartedStep[] = [
     title: "Upgrade Your Plan",
     iconName: "Zap",
     description:
-      "Free accounts have limits on symbols, feeds, and leagues. Upgrade to Uplink for more capacity, or Uplink Ultimate for live streaming data and unlimited everything.",
+      "Free accounts run 3 widgets at once. There is no limit on symbols, feeds or leagues inside a widget. Upgrade for more widget slots and ticker rows.",
   },
 ];
 

--- a/desktop/src/datawidgets/finance/FeedTab.tsx
+++ b/desktop/src/datawidgets/finance/FeedTab.tsx
@@ -36,6 +36,7 @@ import { SelectMenu } from "../../components/widget-bar/SelectMenu";
 import { useDataWidgetConfig } from "../../hooks/useDataWidgetConfig";
 import { useShell } from "../../shell-context";
 import { useNow } from "../../hooks/useNow";
+import { useCatalog } from "../../hooks/useCatalog";
 import { applyFinancePipeline, type FinanceSortKey, type FinanceDirectionFilter } from "./view";
 import type { Trade, FeedTabProps, DataWidgetManifest } from "../../types";
 import type { WidgetId } from "../../api/client";
@@ -93,6 +94,9 @@ const LOAD_MORE_INCREMENT = 20;
 // ── FeedTab ──────────────────────────────────────────────────────
 
 function FinanceFeedTab({ mode: callerMode, feedContext, widgetId }: FeedTabProps) {
+  // assetClassForWidget is read in the render body, so subscribing is all
+  // this needs — the re-render re-reads the current catalog.
+  useCatalog();
   const { prefs, onPrefsChange } = useShell();
   const dp = prefs.widgetDisplay.finance;
 

--- a/desktop/src/datawidgets/sports/FeedTab.tsx
+++ b/desktop/src/datawidgets/sports/FeedTab.tsx
@@ -19,6 +19,7 @@ import { useQuery } from "@tanstack/react-query";
 import { sportsFullQueryOptions, sportsTeamsOptions } from "../../api/queries";
 import type { TeamInfo } from "../../api/queries";
 import { useSportsConfig } from "../../hooks/useSportsConfig";
+import { useCatalog } from "../../hooks/useCatalog";
 import { addConfigForWidget } from "../../marketplace";
 import { ScoresTab } from "./ScoresTab";
 import { ScheduleTab } from "./ScheduleTab";
@@ -111,10 +112,11 @@ function SportsFeedTab({ mode, feedContext, widgetId }: FeedTabProps) {
 
   // A per-league widget (sports_nfl) scopes the whole page to its one league:
   // its league is intrinsic, so we filter the shared /sports payload down.
+  const catalogVersion = useCatalog();
   const scopedLeague = useMemo(() => {
     const l = widgetId ? addConfigForWidget(widgetId)?.leagues : undefined;
     return Array.isArray(l) && typeof l[0] === "string" ? (l[0] as string) : undefined;
-  }, [widgetId]);
+  }, [widgetId, catalogVersion]);
 
   // Full widget page reads from /sports directly (not /dashboard), which
   // returns every game for the user's selected leagues without per-league

--- a/desktop/src/hooks/useAddWidget.ts
+++ b/desktop/src/hooks/useAddWidget.ts
@@ -20,7 +20,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { defaultPinForNewWidget } from "../preferences";
-import { isUtilityWidget } from "../marketplace";
 import type { CatalogItem } from "../marketplace";
 import { dataWidgetsApi } from "../api/client";
 import type { DataWidgetRow, WidgetId } from "../api/client";
@@ -35,7 +34,12 @@ export function useAddWidget(): (item: CatalogItem) => Promise<void> {
 
   return useCallback(
     async (item: CatalogItem) => {
-      if (!isUtilityWidget(item.id)) {
+      // `item.source` rather than isUtilityWidget(item.id): the CatalogItem is
+      // already in hand, so this reads the widget the user actually clicked.
+      // Looking it up by id again would re-query mutable module state, and a
+      // catalog refresh landing between render and click would answer about a
+      // different catalog than the one that produced this item.
+      if (item.source) {
         const widgetType = item.id;
 
         // Optimistic insert: write a placeholder widget into the

--- a/desktop/src/hooks/useCatalog.ts
+++ b/desktop/src/hooks/useCatalog.ts
@@ -7,11 +7,20 @@ import {
   subscribeCatalog,
 } from "../marketplace";
 
-// The catalog refresh is a once-per-session, process-wide concern: both the
-// ticker window and the main window mount this hook, and neither should
-// trigger a second fetch. Guarded here rather than in marketplace so the
-// module stays a pure view over the catalog.
-let started = false;
+// One fetch per window, not per component. The ticker and the main window are
+// separate Tauri webviews — separate JavaScript realms with their own copy of
+// every module — so this cannot and does not dedupe across them; each window
+// fetches once. (An earlier comment here claimed otherwise.) Within a window
+// it matters, because several components call this hook.
+let fetched = false;
+
+// Bound once per window and never removed. The retry is a process-wide
+// concern, not any one component's: binding it inside the same effect that
+// owns `fetched` meant the FIRST caller registered it and that same caller's
+// unmount tore it down for everyone. Under StrictMode's mount/unmount/remount
+// that happened immediately — the listener was gone before the app finished
+// starting, and the remount saw `fetched` already true and bound nothing.
+let retryBound = false;
 
 /**
  * Keeps a component in sync with the server-authoritative widget catalog.
@@ -28,22 +37,23 @@ export function useCatalog(): string {
   const version = useSyncExternalStore(subscribeCatalog, catalogVersion);
 
   useEffect(() => {
-    if (started) return;
-    started = true;
-
-    // Retry when the machine comes back online. `started` latches before the
-    // fetch so the two windows don't both fetch — but nothing reset it on
-    // failure, so an app launched offline kept the bundled snapshot for the
-    // whole session even after the network returned. "unchanged" is a success
-    // (the server agrees with the snapshot); only "failed" is worth retrying.
-    const attempt = () => {
-      void refreshCatalog(fetchCatalog).then((result) => {
-        if (result !== "failed") window.removeEventListener("online", attempt);
+    if (!retryBound) {
+      retryBound = true;
+      // Reaching the network again is the one event worth retrying on: an app
+      // launched offline otherwise keeps the bundled snapshot for the whole
+      // session. Deliberately not cleaned up — see the note above.
+      window.addEventListener("online", () => {
+        void refreshCatalog(fetchCatalog);
       });
-    };
-    window.addEventListener("online", attempt);
-    attempt();
-    return () => window.removeEventListener("online", attempt);
+    }
+
+    if (fetched) return;
+    fetched = true;
+    void refreshCatalog(fetchCatalog).then((result) => {
+      // "unchanged" is a success — the server agrees with the snapshot. Only
+      // a real failure should let a later mount try again.
+      if (result === "failed") fetched = false;
+    });
   }, []);
 
   return version;

--- a/desktop/src/hooks/useRemoveWidget.ts
+++ b/desktop/src/hooks/useRemoveWidget.ts
@@ -16,7 +16,6 @@ import { toast } from "sonner";
 import { dataWidgetsApi } from "../api/client";
 import type { WidgetId } from "../api/client";
 import { queryKeys } from "../api/queries";
-import { isUtilityWidget } from "../marketplace";
 import type { CatalogItem } from "../marketplace";
 import { disableWidget } from "../preferences";
 import { useUndoableAction } from "./useUndoableAction";
@@ -34,7 +33,12 @@ export function useRemoveWidget(
 
   return useCallback(
     async (item: CatalogItem) => {
-      if (!isUtilityWidget(item.id)) {
+      // `item.source` rather than isUtilityWidget(item.id): the CatalogItem is
+      // already in hand, so this reads the widget the user actually clicked.
+      // Looking it up by id again would re-query mutable module state, and a
+      // catalog refresh landing between render and click would answer about a
+      // different catalog than the one that produced this item.
+      if (item.source) {
         try {
           await dataWidgetsApi.delete(item.id);
           queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });

--- a/desktop/src/marketplace.test.ts
+++ b/desktop/src/marketplace.test.ts
@@ -11,6 +11,7 @@ import {
   refreshCatalog,
   subscribeCatalog,
   canonicalOrder,
+  isUtilityWidget,
 } from "./marketplace";
 import type { CatalogPayload } from "./types";
 
@@ -170,5 +171,54 @@ describe("a widget the bundled snapshot has never seen", () => {
 
     // Locally-registered utilities the server does not list still survive.
     expect(order).toContain("clock");
+  });
+});
+
+// isUtilityWidget is the single answer to "does this widget have a server row?"
+// It routes widget pages, the add/remove flows and the shell's route parsing,
+// and it had no test at all until it already had four callers.
+describe("isUtilityWidget", () => {
+  it("distinguishes utilities from data widgets in the catalog", async () => {
+    await refreshCatalog(async () => ({
+      version: "utility-cases",
+      widgets: [
+        {
+          id: "sports_nfl", name: "NFL", description: "d", source: "sports",
+          category: "sports", color: "#013369", required_tier: "free", order: 0,
+        },
+        {
+          id: "clock", name: "Clock", description: "d",
+          category: "utility", color: "#6366f1", required_tier: "free", order: 1,
+        },
+      ],
+    }));
+
+    expect(isUtilityWidget("clock")).toBe(true);
+    expect(isUtilityWidget("sports_nfl")).toBe(false);
+  });
+
+  it("still recognises a utility the catalog has never heard of", async () => {
+    // The catalog is server-owned and refreshes at runtime, so it may legally
+    // omit a widget this build registers locally — canonicalOrder() appends
+    // exactly those. Requiring a catalog hit sent them down the data-widget
+    // path, where the page renders an "add this widget" empty state instead of
+    // the widget. Falls back to the local renderer registry.
+    await refreshCatalog(async () => ({
+      version: "catalog-without-clock",
+      widgets: [
+        {
+          id: "sports_nfl", name: "NFL", description: "d", source: "sports",
+          category: "sports", color: "#013369", required_tier: "free", order: 0,
+        },
+      ],
+    }));
+
+    expect(catalogItemById("clock")).toBeUndefined();
+    expect(isUtilityWidget("clock")).toBe(true);
+  });
+
+  it("does not claim ids nothing knows about", () => {
+    expect(isUtilityWidget("not_a_real_widget")).toBe(false);
+    expect(isUtilityWidget("")).toBe(false);
   });
 });

--- a/desktop/src/marketplace.ts
+++ b/desktop/src/marketplace.ts
@@ -159,11 +159,25 @@ export function sourceForWidget(id: string): string | undefined {
   return byId(id)?.source;
 }
 
-/** True for a local-only widget (clock, weather, …): one with no source, so
- *  it has no server row and no CDC feed. Unknown ids are not utilities. */
+/**
+ * True for a local-only widget (clock, weather, …): one with no server row and
+ * no CDC feed.
+ *
+ * Answered from the catalog first — that is the authority, and asking the
+ * renderer registry instead is what made every utility vanish in v1.1.11.
+ * But the catalog is server-owned and refreshes at runtime, so it can legally
+ * not know about a widget this build registers locally; `canonicalOrder()`
+ * appends exactly those. Requiring a catalog hit meant such a widget fell
+ * through to the data-widget path, where it renders an "add this widget"
+ * empty state instead of itself.
+ *
+ * So: catalog if it knows the id, local registry if it does not. An id
+ * neither knows is not a utility.
+ */
 export function isUtilityWidget(id: string): boolean {
   const w = byId(id);
-  return w !== undefined && !w.source;
+  if (w) return !w.source;
+  return getWidget(id) !== undefined;
 }
 
 /** The fixed asset class ("stock" | "crypto") for a finance widget, or

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -46,7 +46,7 @@ import AuthGate from "../components/onboarding/AuthGate";
 
 // Registries
 import { getAllDataWidgets } from "../datawidgets/registry";
-import { catalogItemById, widgetLogoUrl, isUtilityWidget } from "../marketplace";
+import { catalogItemById, widgetLogoUrl, isUtilityWidget, widgetManifest } from "../marketplace";
 import { DEMO } from "../config";
 import { getAllWidgets, getWidget } from "../widgets/registry";
 import { canonicalOrder } from "../marketplace";
@@ -561,11 +561,17 @@ function RootLayout() {
         navigate({ to: "/customize", search: { tab: "app" } });
         return;
       }
-      if (widgetsRef.current.some((ch) => ch.widget_type === id)) {
-        navigate({ to: "/widget/$id", params: { id: id } });
-        return;
-      }
-      if (getWidget(id)) {
+      // Guarded on the same resolver the destination page renders with, so
+      // "can I navigate there" and "can that page draw something" cannot
+      // disagree. This used to be two branches that navigated identically,
+      // the second asking the RENDERER REGISTRY whether the id was known —
+      // the substitution behind the v1.1.11 regression. It also meant a
+      // widget added server-side, which the registry has never heard of,
+      // bounced the user to /feed instead of opening.
+      if (
+        widgetsRef.current.some((ch) => ch.widget_type === id) ||
+        widgetManifest(id)
+      ) {
         navigate({ to: "/widget/$id", params: { id } });
         return;
       }

--- a/desktop/src/routes/widget.$id.index.tsx
+++ b/desktop/src/routes/widget.$id.index.tsx
@@ -19,6 +19,7 @@ import { useQuery } from "@tanstack/react-query";
 import RouteError from "../components/RouteError";
 import SourcePageLayout, { SourceNotFound } from "../components/SourcePageLayout";
 import { widgetManifest, isUtilityWidget } from "../marketplace";
+import { useCatalog } from "../hooks/useCatalog";
 import { dashboardQueryOptions } from "../api/queries";
 import type { DataWidgetManifest, WidgetManifest } from "../types";
 
@@ -38,6 +39,11 @@ function WidgetRoute() {
 
   // Resolves data widgets (per-league/per-feed splits + legacy coarse
   // ids) AND local utilities.
+  // Subscribing re-renders this page on a catalog swap; widgetManifest and
+  // isUtilityWidget below then read the current catalog rather than the one
+  // that happened to be loaded at mount.
+  useCatalog();
+
   const manifest = widgetManifest(id) as
     | DataWidgetManifest
     | WidgetManifest

--- a/desktop/src/routes/widget.$id.info.tsx
+++ b/desktop/src/routes/widget.$id.info.tsx
@@ -38,6 +38,7 @@ import { TIER_LABELS } from "../auth";
 import { dashboardQueryOptions } from "../api/queries";
 import { useShell, useShellData } from "../shell-context";
 import { getMaxWidgets } from "../tierLimits";
+import { useCatalog } from "../hooks/useCatalog";
 import { useAddWidget } from "../hooks/useAddWidget";
 import { useRemoveWidget } from "../hooks/useRemoveWidget";
 import PageLayout from "../components/layout/PageLayout";
@@ -86,6 +87,10 @@ function WidgetInfoPage() {
   const removeWidgetShared = useRemoveWidget();
   const [removing, setRemoving] = useState(false);
   const [logoFailed, setLogoFailed] = useState(false);
+
+  // Subscribing is what makes the read below re-run: a catalog swap has to
+  // re-render this component or it keeps rendering the pre-refresh catalog.
+  useCatalog();
 
   const item = catalogItemById(id);
   const backToCatalog = () => navigate({ to: "/catalog" });

--- a/myscrollr.com/public/llms-full.txt
+++ b/myscrollr.com/public/llms-full.txt
@@ -43,7 +43,7 @@ ticker rows you get.
 
 - 3 widget slots
 - 1 ticker row
-- Real-time streaming (Server-Sent Events)
+- Real-time streaming (Server-Sent Events); 60s polling fallback
 - Every widget in the catalog, including college sports and Yahoo Fantasy
 - Site filtering: blacklist only
 
@@ -51,12 +51,14 @@ ticker rows you get.
 
 - 6 widget slots
 - 2 ticker rows
+- 30s polling fallback
 - Early access to new features
 
 ### Uplink Pro — $24.99/month or $199.99/year
 
 - 12 widget slots
 - 3 ticker rows
+- 10s polling fallback
 - Custom alerts (price targets, score thresholds, keyword triggers)
 - Feed profiles, advanced controls, site filtering: blacklist + whitelist
 
@@ -128,7 +130,7 @@ Scrollr checks for updates automatically on launch. When an update is available,
 
 #### How does live data work vs. polling?
 
-Every tier uses the same persistent Server-Sent Events connection for instant updates as data changes on the server, with polling as the fallback when that connection drops. Delivery speed is not a paid feature.
+Every tier gets the same persistent Server-Sent Events connection, so updates arrive the instant data changes on the server. Polling is the fallback for when that connection drops, and its interval does vary by plan: 60s on Free, 30s on Uplink, 10s on Uplink Pro. Ultimate polls at 30s because SSE carries it.
 
 #### What's the difference between Uplink tiers?
 
@@ -138,7 +140,7 @@ Free: 3 widget slots, 1 ticker row. Uplink: 6 slots, 2 rows. Uplink Pro: 12 slot
 
 #### What does "data delivery" mean?
 
-Data arrives the instant it changes via Server-Sent Events (SSE), the same technology used by stock trading platforms — on every tier, including Free. Polling is only the fallback if that connection drops.
+Data arrives the instant it changes via Server-Sent Events (SSE), the same technology used by stock trading platforms — on every tier, including Free. Polling only matters when that connection drops, and paid plans fall back faster: 60s on Free, 30s on Uplink, 10s on Uplink Pro.
 
 #### How many symbols can I track?
 

--- a/myscrollr.com/public/llms-full.txt
+++ b/myscrollr.com/public/llms-full.txt
@@ -19,8 +19,8 @@ Core principles: zero tracking, no ads, no data brokers, source available under 
 Live data channels:
 
 - Finance: real-time stock and crypto prices from TwelveData.
-- Sports: live scores across NFL, NBA, MLB, NHL, MLS, Premier League, NCAAF, NCAAM (college sports require a paid tier).
-- News: articles from any RSS feed — built-in catalog plus custom user-added feeds (paid tiers).
+- Sports: live scores across 14 leagues — NFL, NBA, MLB, NHL, F1, UFC, AFL, World Cup, Champions League, Premier League, La Liga, MLS, NCAAF and NCAAM. All available on every tier.
+- News: articles from any RSS feed — a built-in catalog of 11 outlets plus your own URLs, on every tier.
 - Fantasy: Yahoo Fantasy Sports league standings, matchups, and roster updates.
 
 Utility widgets (no API costs, included on every tier):
@@ -34,35 +34,37 @@ Utility widgets (no API costs, included on every tier):
 
 All tiers include the full dashboard at myscrollr.com.
 
+Every tier gets every widget, real-time streaming, and unlimited depth inside
+each widget (as many symbols, feeds, leagues or fantasy teams as you like).
+Plans differ by how many widgets you can run at once — a slot — and how many
+ticker rows you get.
+
 ### Free
 
-- 5 stock/crypto symbols
-- 1 RSS feed
-- 1 sports league
-- No fantasy leagues
-- 60s polling refresh
+- 3 widget slots
+- 1 ticker row
+- Real-time streaming (Server-Sent Events)
+- Every widget in the catalog, including college sports and Yahoo Fantasy
 - Site filtering: blacklist only
 
 ### Uplink — $9.99/month or $79.99/year
 
-- 25 symbols, 25 RSS feeds, 1 custom RSS feed
-- 8 sports leagues, 1 Yahoo fantasy league
-- 30s polling refresh
+- 6 widget slots
+- 2 ticker rows
 - Early access to new features
 
 ### Uplink Pro — $24.99/month or $199.99/year
 
-- 75 symbols, 100 RSS feeds, 3 custom RSS feeds
-- 20 sports leagues, 3 Yahoo fantasy leagues
-- 10s polling refresh
+- 12 widget slots
+- 3 ticker rows
 - Custom alerts (price targets, score thresholds, keyword triggers)
 - Feed profiles, advanced controls, site filtering: blacklist + whitelist
 
 ### Uplink Ultimate — $49.99/month or $399.99/year
 
-- Unlimited symbols, RSS feeds, and sports leagues
-- 10 custom RSS feeds, 10 Yahoo fantasy leagues
-- Real-time Server-Sent Events delivery (no polling)
+- Unlimited widget slots
+- 3 ticker rows, with per-row scroll speed, direction and mode
+
 - Webhooks push alerts to Discord, Slack, or any URL
 - Data export (CSV / JSON)
 - API access for personal dashboards or automation
@@ -90,7 +92,7 @@ The questions and answers below are aggregated from the live FAQ sections on mys
 
 #### Is Scrollr free?
 
-Yes. The free tier gives you real-time data across all four channels with generous limits and no ads. Upgrade to Uplink for more capacity, or Uplink Ultimate for live streaming data and unlimited everything.
+Yes. The free tier gives you real-time streaming across every source, three widget slots, and no ads. Paid tiers add slots and ticker rows; they do not unlock data, widgets, or streaming.
 
 #### Does it affect my computer's performance?
 
@@ -126,37 +128,37 @@ Scrollr checks for updates automatically on launch. When an update is available,
 
 #### How does live data work vs. polling?
 
-Free, Uplink, and Uplink Pro tiers use polling — the app fetches fresh data at regular intervals (60s on Free, 30s on Uplink, 10s on Uplink Pro). Uplink Ultimate uses a persistent SSE connection for instant live updates as data changes on the server.
+Every tier uses the same persistent Server-Sent Events connection for instant updates as data changes on the server, with polling as the fallback when that connection drops. Delivery speed is not a paid feature.
 
 #### What's the difference between Uplink tiers?
 
-Free: 5 stock/crypto symbols, 1 news feed, 1 sports league, no fantasy leagues, 60s polling. Uplink: 25 symbols, 25 feeds, 8 sports leagues, 1 fantasy league, 30s polling. Uplink Pro: 75 symbols, 100 feeds, 20 sports leagues, 3 fantasy leagues, 10s polling. Uplink Ultimate: unlimited symbols/feeds/sports leagues, 10 fantasy leagues, live SSE streaming.
+Free: 3 widget slots, 1 ticker row. Uplink: 6 slots, 2 rows. Uplink Pro: 12 slots, 3 rows. Uplink Ultimate: unlimited slots, 3 rows with per-row customisation. Every tier gets every widget, real-time streaming, and unlimited depth inside each widget.
 
 ### Uplink pricing
 
 #### What does "data delivery" mean?
 
-Free users get data refreshed every 60 seconds via polling. Uplink cuts that to 30 seconds. Pro pushes it to 10 seconds. Ultimate eliminates polling entirely — data arrives the instant it changes via Server-Sent Events (SSE), the same technology used by stock trading platforms.
+Data arrives the instant it changes via Server-Sent Events (SSE), the same technology used by stock trading platforms — on every tier, including Free. Polling is only the fallback if that connection drops.
 
 #### How many symbols can I track?
 
-Tracked symbols are the stocks, ETFs, and crypto tickers that appear in your finance feed. Free accounts can follow up to 5 at a time. Uplink raises that to 25. Pro gives you 75 — enough for a serious portfolio. With Ultimate, there is no cap — add every ticker you care about and they all stream in real time.
+Tracked symbols are the stocks, ETFs, and crypto tickers that appear in your finance feed. There is no cap on any tier — add every ticker you care about and they all stream in real time. What a plan limits is how many widgets you run at once, not how much you put in one.
 
 #### How many RSS feeds can I follow?
 
-RSS feeds power the news channel. Free accounts can subscribe to 1 feed from the default catalog. Uplink expands that to 25, Pro to 100, giving you broad coverage across topics. Ultimate removes the limit entirely — subscribe to as many sources as you want.
+RSS feeds power the news widgets. Subscribe to as many as you want on any tier, from the built-in catalog or your own URLs.
 
 #### What are custom RSS feeds?
 
-Beyond the built-in catalog, custom feeds let you paste any RSS or Atom URL. Free accounts cannot add custom feeds. Uplink gives you 1, Pro gives you 3 — enough for niche industry sources, personal blogs, or company news. Ultimate removes the cap so you can add every source you follow.
+Beyond the built-in catalog, custom feeds let you paste any RSS or Atom URL. Available on every tier, with no cap.
 
 #### What sports leagues are included?
 
-Every tier includes live scores from the NFL, NBA, MLB, NHL, MLS, and Premier League. All paid tiers add college football (NCAAF) and college basketball (NCAAM), with scores updating at the delivery speed of your tier.
+Every tier includes live scores from all 14 league widgets — NFL, NBA, MLB, NHL, F1, UFC, AFL, World Cup, Champions League, Premier League, La Liga, MLS, and college football and basketball. No league is behind a paid tier.
 
 #### How many fantasy leagues can I connect?
 
-Scrollr syncs with Yahoo Fantasy Sports to show your standings, matchups, and roster updates. Free accounts cannot connect Yahoo leagues. Uplink supports up to 1. Pro gives you 3 — enough for multi-sport managers. Ultimate raises the cap to 10 leagues across every sport.
+Scrollr syncs with Yahoo Fantasy Sports to show your standings, matchups, and roster updates. Available on every tier, with no cap on leagues.
 
 #### What are custom alerts?
 

--- a/myscrollr.com/src/components/support/support-content.ts
+++ b/myscrollr.com/src/components/support/support-content.ts
@@ -66,7 +66,7 @@ export const FAQ_ITEMS: Array<FAQItem> = [
   {
     question: "What's the difference between Uplink tiers?",
     answer:
-      'Your plan sets how many widgets run at once: Free 3, Uplink 6, Uplink Pro 12, Uplink Ultimate unlimited — with unlimited items inside every widget on every plan. Yahoo Fantasy requires Uplink or higher. Pro adds custom alerts, feed profiles, and whitelist filtering; Ultimate adds webhooks, data export, and API access.',
+      'Your plan sets how many widgets run at once: Free 3, Uplink 6, Uplink Pro 12, Uplink Ultimate unlimited — with unlimited items inside every widget on every plan. Every widget is available on every plan, Yahoo Fantasy included. Uplink adds a second ticker row, Pro a third plus custom alerts, feed profiles and whitelist filtering; Ultimate adds per-row ticker customisation, webhooks, data export, and API access.',
   },
 ]
 

--- a/myscrollr.com/src/routes/architecture.tsx
+++ b/myscrollr.com/src/routes/architecture.tsx
@@ -230,7 +230,7 @@ const PRINCIPLES: Array<Principle> = [
     Icon: Workflow,
     title: 'Server-authoritative catalog',
     description:
-      'One catalog defines every widget, served from the API. The apps fetch it and render generically, so a new widget ships without a new release.',
+      'One catalog defines every widget, served from the API. The desktop fetches it and renders generically, so a new widget ships without a new release.',
     hex: HEX.accent,
     Watermark: Workflow,
   },

--- a/scripts/dev/wait-healthy.sh
+++ b/scripts/dev/wait-healthy.sh
@@ -37,5 +37,7 @@ for _ in $(seq 1 30); do
 done
 
 echo ""
-echo "[ready] Backend is up. Ports: core 18080 · rss 8083 · finance 8181 · sports 8082 · fantasy 8084 · predictions 8085"
+echo "[ready] Backend is up."
+echo "[ready] API:       core 18080 (serves every widget route)  ·  fantasy 8084"
+echo "[ready] Ingesters: finance 3001 · sports 3002 · rss 3004 · predictions 3005"
 echo "[ready] Front-ends:  make web   (marketing site :3000)   |   make desktop   (Tauri app)"


### PR DESCRIPTION
Fixes the second audit in the order agreed: **#4 → #2/#3 → public claims → #1/#5 → incomplete items**.

Before editing anything I ran four parallel sweeps, because the previous round fixed *3 of 4* instances of its own bug pattern — twice. That was the right call: the catalog-subscription problem had **seven** instances, not the one the audit named.

## The sweep found one of mine

`ContactForm.tsx` had `useMemo(() => [...getCatalogItems()...], [])`. **I wrote that this session**, in the same pass where I fixed the identical empty-deps bug in `catalog.tsx` three files away. It is now the seventh instance fixed, not the eighth introduced.

## What changed

**Catalog subscription (#4).** A component only sees a refresh if it calls `useCatalog()` **and** puts the version in the deps of any memo reading catalog data. Fixed in `App.tsx`, `ContactForm`, `ScrollrTicker`, `sports/FeedTab`, `finance/FeedTab`, `widget.$id.info`, `widget.$id.index`. `TickerLayoutSummary` reads the catalog too but is **not** memoised and its parent subscribes, so the re-render cascades — deliberately left alone.

**sslmode (#2).** `require` fixed an insecure default and broke `cd api && go run .`, which LOCAL_SETUP tells you to run. Now host-aware: loopback → `disable`, everything else → `require`, explicit always wins. Parsed with `net/url`, not substring-matched, so a remote host with `localhost` in its **database name or password** can't silently downgrade production. A table test covers all four such traps. This also closed the documentation gap the audit raised — there's nothing left to warn about.

**`make up` output (#3).** The last line advertised `rss 8083 / finance 8181 / sports 8082 / predictions 8085` — retired per-source Go API ports. Real ports are the ingesters' 3001/3002/3004/3005.

**Hooks (#5).** Reverted to `item.source`; the independent sweep called the re-lookup "a downgrade" and separately confirmed `widget.$id.info.tsx`'s `Boolean(item.source)` checks are "the RIGHT shape" and should not have been converted.

**`isUtilityWidget` (#1).** Required a catalog hit, so a locally-registered widget absent from the server catalog took the data path and rendered an "add this widget" empty state. Now falls back to the local registry. Three tests added — it had gone from zero callers to four with none.

Also collapsed `handleSelectItem`: two branches navigating to the same route, the second asking the renderer registry — the v1.1.11 substitution again, which bounced server-added widgets to `/feed`.

**Public claims.** The audit said "1 of 5 SSE claims fixed." The sweep found **35**, and verified each against `tier_limits.json`, `handlers_sse.go` and `platform/widgets.go`: every per-feature cap is `null`, SSE has no tier check, and all 35 widgets default to `required_tier: free` — including NCAAF, NCAAB and Yahoo Fantasy. `llms-full.txt` and `support-content.ts` now describe the real model (slots 3/6/12/unlimited, ticker rows 1/2/3/3).

**Local dev.** `channels/fantasy/.env.example` set `YAHOO_CALLBACK_URL` to `/fantasy/callback`; the handler is `/yahoo/callback`, and that value is read verbatim as the OAuth `redirect_uri`. Following the docs registered a URI that 404s and OAuth never completed.

## Deliberately not done

- **`uplink.tsx`** carries the same retired caps as paid-tier selling points, and `STATIC_TIERS` feeds them into schema.org JSON-LD for crawlers. Correcting it changes what each paid tier is advertised to include — a pricing decision, not a factual fix.
- **Consolidating all 23 utility-predicate derivations.** The dangerous ones (renderer-registry proxies) are fixed; the rest are a refactor of their own.
- Remaining stale pre-ADR-0002 topology in dev docs and `.env.example` files — listed in the commit rather than half-fixed.

## Verification

Go 9/9 + fantasy, `cargo` unaffected, `tsc` clean both frontends, **desktop 527 tests** (up 3), website 59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)