### PR TITLE
fix(tray): list the widgets the user added, not the ones we ship

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -773,8 +773,28 @@ export default function App() {
         );
       }
 
-      // Local widgets (clock, weather, …) — same row-picker pattern.
-      for (const widget of getAllWidgets()) {
+      // Local widgets (clock, weather, …) — same row-picker pattern, over the
+      // ones the user actually added.
+      //
+      // This used to iterate the whole renderer registry, which asks "does
+      // this build ship the widget" when the question is "did the user add
+      // it". A fresh install enables only `clock`, so the tray offered rows
+      // for the other five — and picking one routes through
+      // setWidgetTickerRow, which writes tickerLayout and widgetsOnTicker but
+      // never enabledWidgets. activeTabs is widgetTabs + widgetsOnTicker, so
+      // the chip really renders (sysmon needs no config to produce data)
+      // while every slot count reads enabledWidgets.length — including the
+      // one useAddWidget reports to the server. A widget on the ticker that
+      // no cap can see.
+      //
+      // The widgetsOnTicker term keeps any pre-existing orphan listed, so it
+      // stays removable rather than stranding its chip.
+      const wp = prefsRef.current.widgets;
+      for (const widget of getAllWidgets().filter(
+        (mf) =>
+          wp.enabledWidgets.includes(mf.id) ||
+          wp.widgetsOnTicker.includes(mf.id),
+      )) {
         const currentRow = getWidgetTickerRow(prefsRef.current, widget.id);
         const rowItems = await buildRowSubmenuItems(
           currentRow,

--- a/desktop/src/marketplace.ts
+++ b/desktop/src/marketplace.ts
@@ -160,6 +160,29 @@ export function sourceForWidget(id: string): string | undefined {
 }
 
 /**
+ * FOUR QUESTIONS THAT LOOK ALIKE. An audit once counted 23 "competing
+ * derivations" of this predicate across the client and proposed collapsing
+ * them onto this function. Nineteen of the twenty-one that were analysed
+ * turned out to be asking something else, and rewriting them would have
+ * introduced bugs. Before you consolidate one, work out which it needs:
+ *
+ *   (a) is this widget a utility?      -> this function. Kind, from the catalog.
+ *   (b) has the user ADDED it?         -> prefs.widgets.enabledWidgets. What the
+ *                                         slot cap counts and what nav lists.
+ *   (c) does this build have code for it?
+ *                                      -> widgets/registry.ts, or a narrower
+ *                                         local roster (ScrollrTicker's
+ *                                         WIDGET_TYPES is the key set of
+ *                                         WidgetTickerData; chipColors' map must
+ *                                         stay literal for Tailwind to scan it).
+ *   (d) is it on the ticker right now? -> prefs.widgets.widgetsOnTicker.
+ *
+ * (b), (c) and (d) are not weaker forms of (a) — a utility can be catalogued
+ * but not added, added but unrenderable, or renderable but off the ticker. The
+ * one genuine bug this analysis found was a site that needed (b) and asked (c):
+ * the tray listed every widget this build ships rather than the ones the user
+ * added, which put chips on the ticker that no slot cap could see.
+ *
  * True for a local-only widget (clock, weather, …): one with no server row and
  * no CDC feed.
  *


### PR DESCRIPTION
"Consolidate the remaining utility-predicate derivations" turned out to be the wrong goal. 21 call sites were analysed one at a time. **19 were asking a different question** than `isUtilityWidget` answers, and rewriting them would have introduced bugs. **One was a real defect.**

## The defect

The tray's ticker-row picker iterated `getAllWidgets()` — the *renderer registry* — which answers "does this build ship the widget", when the question is "did the user add it".

A fresh install enables only `clock` (`DEFAULT_WIDGETS.enabledWidgets`), while the registry holds clock/timer/weather/sysmon/uptime/github. So the tray offered rows for five widgets the user never added. Picking one routes through `setWidgetTickerRow`, which writes `tickerLayout` and `widgetsOnTicker` but **never** `enabledWidgets`. Since `activeTabs = [...widgetTabs, ...widgetsOnTicker]`, the chip renders — sysmon needs no configuration to produce data — while every slot count reads `enabledWidgets.length`, **including the one `useAddWidget` reports to the server**.

Net: a widget running on the ticker that no slot cap can see.

Now filtered to `enabledWidgets`, with a `widgetsOnTicker` term so any pre-existing orphan stays listed and therefore *removable* rather than having its chip stranded. This restores symmetry with the sidebar, Home and Customize, which all already filter on `enabledWidgets`.

## What was deliberately left alone

Documented on `isUtilityWidget` itself so the next audit does not re-flag the nineteen:

| Site | Asks | Why not `isUtilityWidget` |
|---|---|---|
| `ScrollrTicker` `WIDGET_TYPES` (×3) | does this build have a renderer | It is the key set of `WidgetTickerData` and the `ConsolidatedChip` type union. The membership test is what makes `tab as WidgetType` *sound*; `isUtilityWidget` narrows nothing, so swapping it trades a checked narrowing for two unchecked casts and lets a genuine mismatch compile clean. |
| `chipColors.ts` | — | Literal Tailwind class strings. They must exist as static source text for the scanner. |
| `feed.tsx` `getWidgetValue` | — | An id→localStorage-reader dispatch returning a *value*, not a boolean. |
| `preferences.ts`, `useTickerLayout` | utility **and** enabled | Needs both terms to pick which prefs writer runs. |
| `TickerSettings` | | A proposed rewrite went through an adversarial pass and was **refuted** — it regressed inputs the current code handles, and did not compile. |

## Verification

`tsc --noEmit` clean · 527/527 tests pass (34 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)