### PR TITLE
style(desktop): de-terminal the Home ticker strip [REL-30]

### DIFF
--- a/desktop/src/components/TickerLayoutSummary.tsx
+++ b/desktop/src/components/TickerLayoutSummary.tsx
@@ -80,12 +80,9 @@ export default function TickerLayoutSummary({
     >
       {/* Header row: count badge + CTAs */}
       <div className="flex items-center gap-3 mb-2">
-        <span className="text-ui-section font-mono font-semibold text-fg-3 uppercase tracking-wider">
-          Ticker layout
-        </span>
-        <span className="text-ui-meta font-mono text-fg-3">
-          {rowCount === 1 ? "1 row" : `${rowCount} rows`}
-          <span className="text-fg-3"> / {tierMaxRows} max</span>
+        <span className="text-ui-section">Ticker layout</span>
+        <span className="text-ui-meta text-fg-4">
+          {rowCount} of {tierMaxRows} row{tierMaxRows === 1 ? "" : "s"}
         </span>
 
         <div className="flex-1" />
@@ -110,15 +107,13 @@ export default function TickerLayoutSummary({
         {rows.map((row, idx) => (
           <li
             key={idx}
-            className="flex items-center gap-2 text-ui-meta font-mono text-fg-3"
+            className="flex items-center gap-2 text-ui-meta"
           >
-            <span className="w-12 shrink-0 text-fg-3">
+            <span className="w-12 shrink-0 text-fg-4">
               {rowCount === 1 ? "Row" : `Row ${idx + 1}`}
             </span>
             {row.sources.length === 0 ? (
-              <span className="italic text-fg-3">
-                All ticker-enabled sources
-              </span>
+              <span className="text-fg-4">All ticker-enabled sources</span>
             ) : (
               <div className="flex items-center gap-1 flex-wrap">
                 {row.sources.map((id) => (
@@ -147,7 +142,7 @@ export default function TickerLayoutSummary({
           cap is below the absolute max. If they're on Pro/Ultimate at 3
           rows, no hint (they've already maxed out). */}
       {atTierCap && (
-        <p className="mt-2 text-ui-chip font-mono text-fg-3">
+        <p className="mt-2 text-ui-meta text-fg-4">
           {tierMaxRows === 1
             ? "Upgrade to Uplink for a second ticker row."
             : "Upgrade to Uplink Pro for a third ticker row."}


### PR DESCRIPTION
@
## What

Drops the terminal-y styling from `TickerLayoutSummary` (the strip at the top of Home):

- **Section header** — loses `font-mono font-semibold uppercase tracking-wider`, now a plain `text-ui-section`
- **Count meta** — `"1 row / 3 max"` → `"1 of 3 rows"`, demoted to `text-fg-4`
- **Row labels** — lose `font-mono`, demoted to `text-fg-4`
- **Empty-row state** — loses `italic`
- **Tier-cap hint** — loses `font-mono`, `text-ui-chip` → `text-ui-meta`

The colored source chips and every behavior are untouched.

## Provenance

Recovered from an unpushed patch dated Jul 16 that never landed in any branch — found while cleaning loose untracked files out of the repo root. The original diff no longer applied (the file drifted in the v1.1.9 One Bar overhaul, which had already removed the `clsx` import the patch wanted to drop), so it was reapplied by hand against current `main`.

## Verification

- `tsc --noEmit` clean
- `vitest run` — 34 files, 527/527 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@