### PR TITLE
chore(release): desktop v1.1.13

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4600,7 +4600,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.1.12"
+version = "1.1.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.1.12"
+version = "1.1.13"
 edition = "2021"
 # std::env::home_dir (Sentry path scrubber) is only correct on Windows from 1.85+
 rust-version = "1.85"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to cut desktop v1.1.13. Ships #270 (Home ticker strip de-terminal, REL-30) and #271 (ponytail audit, REL-58).

Merging this triggers desktop-release.yml: preflight sees desktop-v1.1.13 unpublished → three-platform build → draft release. Notes get written on the draft before publishing.

No MIN_DESKTOP_VERSION raise — v1.1.12 clients are unaffected by this range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)