### PR TITLE
ci: gate desktop/src-tauri on cargo test, re-land the cleanup it blocked (REL-62)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -7,6 +7,10 @@ on:
       - "api/**"
       - "channels/**/*.go"
       - "channels/**/*.rs"
+      # The desktop app's native half (REL-62). It is Rust, so its gate
+      # lives here with every other cargo job rather than in the npm-only
+      # frontend workflow.
+      - "desktop/src-tauri/**"
       # Generated wire types (VISION 4.6): a Go test pins these to the Go
       # structs, so a hand-edit here must re-run it — same reason the
       # tier-limits snapshot triggers the frontend suite.
@@ -22,6 +26,10 @@ on:
       - "api/**"
       - "channels/**/*.go"
       - "channels/**/*.rs"
+      # The desktop app's native half (REL-62). It is Rust, so its gate
+      # lives here with every other cargo job rather than in the npm-only
+      # frontend workflow.
+      - "desktop/src-tauri/**"
       # Generated wire types (VISION 4.6): a Go test pins these to the Go
       # structs, so a hand-edit here must re-run it — same reason the
       # tier-limits snapshot triggers the frontend suite.
@@ -138,3 +146,45 @@ jobs:
       - run: cargo test --quiet
         env:
           TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/scrollr_test?sslmode=disable
+
+  # ── Desktop native tests ───────────────────────────────────────
+  # desktop/src-tauri is the app's native half — the OAuth loopback
+  # server, the window/tray commands, and the on-device Kalshi signer.
+  # It sat outside every matrix until REL-62, so its four auth-server
+  # tests ran nowhere: not here, and not on the Windows dev box either,
+  # where the test binary aborts with STATUS_ENTRYPOINT_NOT_FOUND before
+  # a single test starts.
+  #
+  # Its own job rather than a `rust-tests` matrix entry, because it needs
+  # the webkit dev headers to link and needs no Postgres — the crate
+  # never touches the database.
+  #
+  # No frontend build step: tauri.conf.json points frontendDist at
+  # ../dist, which is gitignored and absent on a fresh checkout, but
+  # tauri_build::build() compiles fine without it (verified). Adding
+  # `npm ci && npm run build` here would just duplicate the vitest job
+  # for no gain.
+  desktop-rust-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: desktop/src-tauri
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Same package set desktop-release.yml installs for its Linux build.
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Not at the repo root, so point the cache at the crate.
+          workspaces: desktop/src-tauri
+          cache-on-failure: "true"
+
+      - run: cargo test --quiet

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4628,6 +4628,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "tokio-tungstenite",
+ "url",
  "windows-sys 0.59.0",
  "wmi",
 ]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -33,6 +33,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-http = "2.5.7"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
+# Already compiled in via reqwest — declared directly so the OAuth callback
+# handler can use Url::query_pairs instead of hand-rolled percent-decoding.
+url = "2"
 futures-util = "0.3"
 tokio = { version = "1", features = ["sync", "time"] }
 tauri-plugin-autostart = "2.5.1"

--- a/desktop/src-tauri/src/commands/auth.rs
+++ b/desktop/src-tauri/src/commands/auth.rs
@@ -388,47 +388,22 @@ fn finish_auth_server(running_handle: &AuthServerRunning, stop_requested: &AuthS
 
 /// Extract a query parameter from a raw HTTP request line.
 /// Parses "GET /callback?code=xxx&state=yyy HTTP/1.1".
+///
+/// Percent- and plus-decoding come from `url`, which reqwest already pulls
+/// in and compiles into this binary. The hand-rolled decoder this replaced
+/// silently mangled malformed input — `%X` with no second hex digit
+/// consumed the next byte and substituted '0' for it — where `url` follows
+/// the WHATWG rules and leaves an invalid escape intact.
+///
+/// The request line carries only a path, so it is resolved against a dummy
+/// base to make the absolute URL the parser needs.
 fn extract_query_param(request: &str, key: &str) -> Option<String> {
     let first_line = request.lines().next()?;
     let path = first_line.split_whitespace().nth(1)?;
-    let query = path.split('?').nth(1)?;
-
-    for pair in query.split('&') {
-        let mut kv = pair.splitn(2, '=');
-        if kv.next()? == key {
-            return kv.next().map(percent_decode);
-        }
-    }
-    None
-}
-
-/// Minimal percent-decoding for OAuth callback parameters.
-/// Accumulates raw bytes so multi-byte UTF-8 sequences (e.g. %C3%A9 → é)
-/// decode correctly instead of being treated as individual codepoints.
-fn percent_decode(input: &str) -> String {
-    let mut bytes = Vec::with_capacity(input.len());
-    let mut iter = input.bytes();
-    while let Some(b) = iter.next() {
-        if b == b'%' {
-            let hi = iter.next().unwrap_or(b'0');
-            let lo = iter.next().unwrap_or(b'0');
-            let hex = [hi, lo];
-            if let Ok(s) = std::str::from_utf8(&hex) {
-                if let Ok(val) = u8::from_str_radix(s, 16) {
-                    bytes.push(val);
-                    continue;
-                }
-            }
-            bytes.push(b'%');
-            bytes.push(hi);
-            bytes.push(lo);
-        } else if b == b'+' {
-            bytes.push(b' ');
-        } else {
-            bytes.push(b);
-        }
-    }
-    String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+    let url = url::Url::parse("http://127.0.0.1").ok()?.join(path).ok()?;
+    url.query_pairs()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.into_owned())
 }
 
 #[cfg(test)]
@@ -439,6 +414,42 @@ mod tests {
     use std::sync::{atomic::AtomicBool, Arc, Mutex};
     use std::thread;
     use std::time::Duration;
+
+    // The auth-server tests below reach extract_query_param through a real
+    // socket, which only ever exercises the simple unescaped path. These
+    // cover the decoding directly — the part that moved to `url`.
+    #[test]
+    fn extract_query_param_decodes_escapes() {
+        let line = |q: &str| format!("GET /callback?{q} HTTP/1.1\r\n\r\n");
+
+        // Plain value, and a key that isn't present.
+        assert_eq!(
+            extract_query_param(&line("code=abc&state=xyz"), "code").as_deref(),
+            Some("abc")
+        );
+        assert_eq!(extract_query_param(&line("code=abc"), "state"), None);
+
+        // Percent-escapes, including a multi-byte UTF-8 sequence and an
+        // escaped '&' that must not split the pair.
+        assert_eq!(
+            extract_query_param(&line("code=a%26b&state=s"), "code").as_deref(),
+            Some("a&b")
+        );
+        assert_eq!(
+            extract_query_param(&line("code=caf%C3%A9"), "code").as_deref(),
+            Some("café")
+        );
+
+        // '+' is a space in form-encoded query strings.
+        assert_eq!(
+            extract_query_param(&line("code=a+b"), "code").as_deref(),
+            Some("a b")
+        );
+
+        // No query string at all, and a malformed request line.
+        assert_eq!(extract_query_param(&line(""), "code"), None);
+        assert_eq!(extract_query_param("GET\r\n\r\n", "code"), None);
+    }
 
     #[test]
     fn auth_server_stops_when_stop_is_requested() {


### PR DESCRIPTION
`desktop/src-tauri` — the desktop app's native half — was in no test matrix. **18 tests ran nowhere.**

Closes REL-62.

## The gap

`backend-tests.yml` covers `api`, `channels/fantasy/api`, and the four channel service crates. `desktop/src-tauri` is in neither matrix. It can't be run locally on the Windows dev box either: `cargo test --lib` compiles, then the test binary aborts with `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139, a DLL-load failure) before a single test starts — reproduces on unmodified `main`, so it's environmental, not a regression.

The issue estimated 4 orphaned tests, counting only the auth-server ones. The first green run reported **18** — the Kalshi signer and others were dark too.

The auth-server four cover the OAuth callback loopback server, a trust boundary. That gap is exactly why the REL-60 audit had to **revert** a finished −41-line cleanup: nothing anywhere could prove it didn't break sign-in.

## Commit 1 — the gate

A dedicated `desktop-rust-tests` job rather than a `rust-tests` matrix entry, because it differs on both axes the matrix shares:

- **Needs the webkit dev headers** to link — the same apt set `desktop-release.yml` installs. No other job installs them.
- **Needs no Postgres.** The crate never touches the database; a matrix entry would spin up a container for nothing.

**No frontend build step.** `tauri.conf.json` points `frontendDist` at `../dist`, which is gitignored and absent on a fresh checkout. Verified locally that `tauri_build::build()` compiles fine without it (moved `dist/` aside, touched `build.rs`, `cargo check` → exit 0), so `npm ci && npm run build` would only duplicate the vitest job.

`desktop/src-tauri/**` joins both path filters, and the workflow self-triggers on its own edits — so this PR exercised the new job. First run: **18 passed**, 3m23s cold.

## Commit 2 — the cleanup it was blocking

With the gate proven green, the reverted change re-lands on top of it. `url` is already compiled into the binary via reqwest; declaring it directly replaces 41 lines of hand-rolled percent-decoding with `Url::query_pairs`.

The old decoder also **mangled malformed input**: `%X` with no second hex digit consumed the following byte and substituted `'0'` for it. `url` follows the WHATWG rules and leaves an invalid escape intact.

Adds a direct unit test for the decoding. The four auth-server tests reach `extract_query_param` through a real socket, which only ever exercises the plain unescaped path — the new one covers escaped `&`, multi-byte UTF-8, `+` as space, a missing key, an absent query string, and a malformed request line. Second run: **19 passed**, 1m59s warm.

## Sequencing

Deliberately two commits, gate first. Bundled together, a red run wouldn't distinguish "the job is misconfigured" from "the parser change is wrong."

## Gate

All 7 checks green. `desktop-rust-tests` 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
