### PR TITLE
refactor(desktop): each source owns its Home preview (REL-63)

### DIFF
--- a/desktop/src/datawidgets/fantasy/FeedTab.tsx
+++ b/desktop/src/datawidgets/fantasy/FeedTab.tsx
@@ -50,6 +50,12 @@ import { filterEnabledLeagues, resolvePrimaryLeague } from "./view";
 import type { FeedTabProps, DataWidgetManifest } from "../../types";
 import type { FantasySubTab } from "../../preferences";
 import type { LeagueResponse, MyLeaguesResponse } from "./types";
+import {
+  FantasyHomeRows,
+  fantasyHomeGroups,
+  fantasyHomeGroupLabel,
+  normalizeFantasyHome,
+} from "./home";
 
 /** DataWidgetRow accent — kept in sync with `fantasyDataWidget.hex`. */
 const FANTASY_HEX = "#6366f1";
@@ -75,6 +81,10 @@ export const fantasyDataWidget: DataWidgetManifest = {
     ],
   },
   FeedTab: FantasyFeedTab,
+  HomeRows: FantasyHomeRows,
+  normalizeHome: normalizeFantasyHome,
+  homeGroups: fantasyHomeGroups,
+  homeGroupLabel: fantasyHomeGroupLabel,
 };
 
 // ── Helpers ──────────────────────────────────────────────────────

--- a/desktop/src/datawidgets/fantasy/home.tsx
+++ b/desktop/src/datawidgets/fantasy/home.tsx
@@ -1,0 +1,83 @@
+/**
+ * Fantasy — Home preview.
+ *
+ * The only source needing all three optional hooks: its payload is wrapped
+ * (`{ leagues: [...] }`), and its group keys are opaque league ids that have
+ * to be labelled by name.
+ */
+import { HOME_PREVIEW_MAX, HomeEmptyRow } from "../home";
+import type { HomeRowsProps } from "../../types";
+
+/** A league row as the dashboard sends it — deliberately loose; Home only
+ *  reads the handful of fields below and the shape varies by sport. */
+type LeagueRow = Record<string, unknown>;
+
+/** Group key for one league: id first, falling back to whatever names it. */
+function leagueKey(l: LeagueRow): string {
+  return String(l.league_key ?? l.league_name ?? l.name ?? "");
+}
+
+/**
+ * Fantasy wraps its rows: `{ leagues: [...] }`, not a bare array. Every other
+ * Fantasy consumer (ticker, FeedTab, player picker) already unwraps it; Home
+ * once treated the payload as flat and showed "No leagues imported yet" to
+ * users who had leagues.
+ */
+export function normalizeFantasyHome(raw: unknown): unknown[] {
+  const obj = raw as { leagues?: unknown } | undefined;
+  return Array.isArray(obj?.leagues) ? (obj.leagues as unknown[]) : [];
+}
+
+export function fantasyHomeGroups(rows: unknown[]): string[] {
+  return [...new Set((rows as LeagueRow[]).map(leagueKey).filter(Boolean))];
+}
+
+/** Chips key on the league id but must read as its name. */
+export function fantasyHomeGroupLabel(key: string, rows: unknown[]): string {
+  const league = (rows as LeagueRow[]).find(
+    (l) => String(l.league_key ?? "") === key || String(l.league_name ?? "") === key,
+  );
+  return league ? String(league.league_name ?? league.name ?? key) : key;
+}
+
+export function FantasyHomeRows({ data, filter, onConfigure }: HomeRowsProps) {
+  const leagues = data as LeagueRow[];
+  const empty = (
+    <HomeEmptyRow
+      message="No leagues imported yet"
+      openLabel="Fantasy"
+      onConfigure={onConfigure}
+    />
+  );
+  if (leagues.length === 0) return empty;
+
+  const filtered =
+    filter.length > 0
+      ? leagues.filter((l) => filter.includes(leagueKey(l)))
+      : leagues;
+
+  const preview = filtered.slice(0, HOME_PREVIEW_MAX);
+  if (preview.length === 0) return empty;
+
+  return (
+    <>
+      {preview.map((league, i) => {
+        const name = (league.league_name ?? league.name ?? "League") as string;
+        const myScore = league.my_score ?? league.team_points;
+        const oppScore = league.opp_score ?? league.opponent_points;
+        const hasMatchup = myScore != null && oppScore != null;
+
+        return (
+          <div key={i} className="flex items-center px-4 py-2.5 gap-3">
+            <span className="text-ui-meta text-fg flex-1 truncate">{name}</span>
+            {hasMatchup && (
+              <span className="text-xs text-fg-3 tabular-nums">
+                {String(myScore)} – {String(oppScore)}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/desktop/src/datawidgets/finance/FeedTab.tsx
+++ b/desktop/src/datawidgets/finance/FeedTab.tsx
@@ -44,6 +44,7 @@ import { applyFinancePipeline, type FinanceSortKey, type FinanceDirectionFilter 
 import type { Trade, FeedTabProps, DataWidgetManifest } from "../../types";
 import type { WidgetId } from "../../api/client";
 import { assetClassForWidget } from "../../marketplace";
+import { FinanceHomeRows, financeHomeGroups } from "./home";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
@@ -65,6 +66,8 @@ export const financeDataWidget: DataWidgetManifest = {
     ],
   },
   FeedTab: FinanceFeedTab,
+  HomeRows: FinanceHomeRows,
+  homeGroups: financeHomeGroups,
 };
 
 // ── Types ────────────────────────────────────────────────────────

--- a/desktop/src/datawidgets/finance/home.tsx
+++ b/desktop/src/datawidgets/finance/home.tsx
@@ -1,0 +1,68 @@
+/**
+ * Finance — Home preview. Biggest movers first, which is the "what changed"
+ * glance the Home feed is for.
+ */
+import clsx from "clsx";
+import { HOME_PREVIEW_MAX, HomeEmptyRow } from "../home";
+import type { HomeRowsProps, Trade } from "../../types";
+
+/** Filter chips are per symbol. */
+export function financeHomeGroups(rows: unknown[]): string[] {
+  return [...new Set((rows as Trade[]).map((t) => t.symbol))];
+}
+
+export function FinanceHomeRows({ data, filter, onConfigure }: HomeRowsProps) {
+  const trades = data as Trade[];
+  const empty = (
+    <HomeEmptyRow
+      message="No stocks configured yet"
+      openLabel="Finance"
+      onConfigure={onConfigure}
+    />
+  );
+  if (trades.length === 0) return empty;
+
+  const filtered =
+    filter.length > 0 ? trades.filter((t) => filter.includes(t.symbol)) : trades;
+
+  const sorted = [...filtered]
+    .sort(
+      (a, b) =>
+        Math.abs(Number(b.percentage_change ?? 0)) -
+        Math.abs(Number(a.percentage_change ?? 0)),
+    )
+    .slice(0, HOME_PREVIEW_MAX);
+
+  if (sorted.length === 0) return empty;
+
+  return (
+    <>
+      {sorted.map((t) => {
+        const pct = Number(t.percentage_change ?? 0);
+        const isUp = pct >= 0;
+        return (
+          <div key={t.symbol} className="flex items-center px-4 py-2.5 gap-4">
+            <span className="text-xs font-mono font-semibold text-fg w-20 truncate">
+              {t.symbol}
+            </span>
+            <span className="text-xs text-fg-2 tabular-nums">
+              $
+              {Number(t.price).toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
+            </span>
+            <span
+              className={clsx(
+                "text-xs font-medium tabular-nums ml-auto",
+                isUp ? "text-green-400" : "text-red-400",
+              )}
+            >
+              {isUp ? "▲" : "▼"} {Math.abs(pct).toFixed(2)}%
+            </span>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/desktop/src/datawidgets/home.test.tsx
+++ b/desktop/src/datawidgets/home.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Home preview renderers, one per data source (REL-63).
+ *
+ * `routes/feed.tsx` used to dispatch on the source name, so a broken
+ * renderer showed up as a blank card. It now renders `manifest.HomeRows`
+ * unconditionally — every source is mounted here with data and without, so
+ * a regression surfaces as a failed assertion rather than an empty Home.
+ *
+ * Each case goes through the real manifest, not a direct import, so the
+ * wiring in each FeedTab.tsx is under test too.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { getDataWidget } from "./registry";
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        () =>
+        ({ children, ...p }: React.HTMLAttributes<HTMLElement>) => <div {...p}>{children}</div>,
+    },
+  ),
+}));
+
+const rows = (source: string, data: unknown[], dashboard?: Record<string, unknown>) => {
+  const HomeRows = getDataWidget(source)!.HomeRows;
+  return render(
+    <HomeRows data={data} filter={[]} dashboard={dashboard} onConfigure={() => {}} />,
+  );
+};
+
+describe("Home previews", () => {
+  it("finance renders symbol, price and change", () => {
+    rows("finance", [
+      { symbol: "AAPL", price: 195.5, percentage_change: 1.25 },
+      { symbol: "TSLA", price: 240.1, percentage_change: -3.5 },
+    ]);
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+    // Sorted by absolute move, so TSLA (-3.5%) leads AAPL (+1.25%).
+    expect(screen.getByText(/3\.50%/)).toBeInTheDocument();
+    expect(screen.getByText(/1\.25%/)).toBeInTheDocument();
+  });
+
+  it("sports renders a game and marks the live one", () => {
+    rows("sports", [
+      {
+        id: 1,
+        league: "NFL",
+        state: "in",
+        away_team_name: "Bears",
+        home_team_name: "Packers",
+        away_team_score: 7,
+        home_team_score: 10,
+      },
+    ]);
+    expect(screen.getByText("NFL")).toBeInTheDocument();
+    expect(screen.getByText("Bears")).toBeInTheDocument();
+    expect(screen.getByText(/7\s*–\s*10/)).toBeInTheDocument();
+  });
+
+  it("rss renders headline and feed name", () => {
+    rows("rss", [
+      { id: 1, title: "A headline", source_name: "BBC", published_at: null },
+    ]);
+    expect(screen.getByText("A headline")).toBeInTheDocument();
+    expect(screen.getByText("BBC")).toBeInTheDocument();
+  });
+
+  it("fantasy renders league name and matchup score", () => {
+    rows("fantasy", [
+      { league_key: "nfl.1", league_name: "Dynasty", my_score: 101, opp_score: 98 },
+    ]);
+    expect(screen.getByText("Dynasty")).toBeInTheDocument();
+    expect(screen.getByText(/101\s*–\s*98/)).toBeInTheDocument();
+  });
+
+  it("predictions renders the market title", () => {
+    rows("predictions", [
+      {
+        id: "m1",
+        title: "Will it rain?",
+        event_title: "Weather",
+        yes_price: 62,
+        status: "active",
+      },
+    ]);
+    expect(screen.getByText("Weather")).toBeInTheDocument();
+  });
+
+  // The empty state is the path REL-63 changed most: it used to come from an
+  // EMPTY_HINTS map in feed.tsx that had no `predictions` entry, so that one
+  // silently lost its call to action. Every source now owns its own copy.
+  it.each([
+    ["finance", /no stocks/i],
+    ["rss", /no feeds/i],
+    ["fantasy", /no leagues/i],
+    ["predictions", /no markets/i],
+  ])("%s shows a specific empty state", (source, pattern) => {
+    rows(source, []);
+    expect(screen.getByText(pattern)).toBeInTheDocument();
+  });
+});
+
+describe("Home group hooks", () => {
+  it("derives filter chips from the rows", () => {
+    expect(
+      getDataWidget("finance")!.homeGroups!([
+        { symbol: "AAPL" },
+        { symbol: "TSLA" },
+        { symbol: "AAPL" },
+      ]),
+    ).toEqual(["AAPL", "TSLA"]);
+
+    expect(
+      getDataWidget("sports")!.homeGroups!([{ league: "NFL" }, { league: "NBA" }]),
+    ).toEqual(["NFL", "NBA"]);
+  });
+
+  it("predictions has no groups — one market set, nothing to slice by", () => {
+    expect(getDataWidget("predictions")!.homeGroups).toBeUndefined();
+  });
+
+  it("fantasy unwraps its payload and labels keys by league name", () => {
+    const m = getDataWidget("fantasy")!;
+    // The wrapper is the bug this hook exists for: treating the payload as a
+    // flat array showed "No leagues imported yet" to users who had leagues.
+    expect(m.normalizeHome!({ leagues: [{ league_key: "a" }] })).toHaveLength(1);
+    expect(m.normalizeHome!(undefined)).toEqual([]);
+
+    const rows = [{ league_key: "nfl.1", league_name: "Dynasty" }];
+    expect(m.homeGroups!(rows)).toEqual(["nfl.1"]);
+    expect(m.homeGroupLabel!("nfl.1", rows)).toBe("Dynasty");
+    // Unknown key falls back to the key itself rather than rendering blank.
+    expect(m.homeGroupLabel!("missing", rows)).toBe("missing");
+  });
+});

--- a/desktop/src/datawidgets/home.tsx
+++ b/desktop/src/datawidgets/home.tsx
@@ -1,0 +1,55 @@
+/**
+ * The Home feed's `source → preview` contract.
+ *
+ * Mirrors `ticker.ts`: each data source owns how it renders on Home, in its
+ * own folder (`datawidgets/{source}/home.tsx`), instead of `routes/feed.tsx`
+ * carrying an if-ladder over source names. Adding a source is a folder plus
+ * a manifest field — feed.tsx never changes.
+ *
+ * The pieces live on `DataWidgetManifest` rather than in a separate registry
+ * (which is how the ticker does it) for one reason: `widgetManifest()` spreads
+ * the per-source renderer manifest, so `WidgetSection` already holds the right
+ * manifest and needs no lookup at all.
+ */
+import { Settings } from "lucide-react";
+
+/** Rows shown per widget on Home. Also caps how many group chips you can pin. */
+export const HOME_PREVIEW_MAX = 5;
+
+/**
+ * The empty state inside a Home preview card.
+ *
+ * Each source passes its own copy. This replaced an `EMPTY_HINTS` map keyed
+ * by source name in feed.tsx — a sixth place source knowledge lived, and one
+ * that had silently gone stale: it had no `predictions` entry, so that
+ * widget's empty state lost its call to action.
+ */
+export function HomeEmptyRow({
+  message,
+  openLabel,
+  onConfigure,
+}: {
+  /** e.g. "No stocks configured yet" */
+  message: string;
+  /** Widget name for the CTA — "Open Finance". Omit to render no CTA. */
+  openLabel?: string;
+  onConfigure?: () => void;
+}) {
+  return (
+    <div className="px-4 py-5 text-center">
+      <p className="text-ui-meta text-fg-3 font-medium mb-1">{message}</p>
+      {openLabel && onConfigure && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onConfigure();
+          }}
+          className="inline-flex items-center gap-1.5 text-ui-chip text-accent hover:text-accent/80 transition-colors"
+        >
+          <Settings size={11} />
+          Open {openLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/datawidgets/predictions/FeedTab.tsx
+++ b/desktop/src/datawidgets/predictions/FeedTab.tsx
@@ -100,6 +100,7 @@ import {
 } from "./search";
 import type { Prediction, FeedTabProps, DataWidgetManifest } from "../../types";
 import type { PredictionsDisplayPrefs } from "../../preferences";
+import { PredictionsHomeRows } from "./home";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
@@ -123,6 +124,7 @@ export const predictionsDataWidget: DataWidgetManifest = {
     ],
   },
   FeedTab: PredictionsFeedTab,
+  HomeRows: PredictionsHomeRows,
 };
 
 // ── Constants ────────────────────────────────────────────────────

--- a/desktop/src/datawidgets/predictions/home.tsx
+++ b/desktop/src/datawidgets/predictions/home.tsx
@@ -1,0 +1,55 @@
+/**
+ * Predictions — Home preview. Top movers, matching the finance treatment.
+ *
+ * No group chips: a prediction widget is a single market set, so there is
+ * nothing to slice it by. Omitting `homeGroups` hides the chip row.
+ */
+import clsx from "clsx";
+import { HOME_PREVIEW_MAX, HomeEmptyRow } from "../home";
+import { isDisplayable, priceDelta } from "./view";
+import ProbabilityPill from "./ProbabilityPill";
+import type { HomeRowsProps, Prediction } from "../../types";
+
+export function PredictionsHomeRows({ data, onConfigure }: HomeRowsProps) {
+  const live = (data as Prediction[]).filter(isDisplayable);
+  if (live.length === 0) {
+    return (
+      <HomeEmptyRow
+        message="No markets tracked yet"
+        openLabel="Predictions"
+        onConfigure={onConfigure}
+      />
+    );
+  }
+
+  const sorted = [...live]
+    .sort((a, b) => Math.abs(priceDelta(b)) - Math.abs(priceDelta(a)))
+    .slice(0, HOME_PREVIEW_MAX);
+
+  return (
+    <>
+      {sorted.map((p) => {
+        const delta = priceDelta(p);
+        const isUp = delta > 0;
+        return (
+          <div key={p.id} className="flex items-center px-4 py-2.5 gap-4">
+            <span className="text-ui-meta text-fg-2 truncate flex-1">
+              {p.event_title || p.title}
+            </span>
+            {/* Fixed delta slot + fixed-width pill — the widget's own column
+                treatment, so Home previews match the feed. */}
+            <span
+              className={clsx(
+                "text-xs font-medium tabular-nums w-10 text-right",
+                isUp ? "text-green-400" : "text-red-400",
+              )}
+            >
+              {delta !== 0 ? `${isUp ? "▲" : "▼"} ${Math.abs(delta)}` : ""}
+            </span>
+            <ProbabilityPill pct={p.yes_price} delta={delta} size="sm" />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/desktop/src/datawidgets/registry.test.ts
+++ b/desktop/src/datawidgets/registry.test.ts
@@ -19,6 +19,33 @@ describe("datawidget registry", () => {
     expect(getAllDataWidgets().length).toBe(DATA_SOURCES.length);
   });
 
+  // REL-63: Home used to dispatch on source name in routes/feed.tsx, so a
+  // source without a renderer just fell through to a generic empty row. Now
+  // feed.tsx renders `manifest.HomeRows` unconditionally — a source that
+  // forgot to wire one would crash the Home page rather than degrade. The
+  // type makes it required, but the registry is populated by a runtime glob
+  // that tsc cannot see through, so assert it.
+  it("every data-widget source provides a Home renderer", () => {
+    for (const id of DATA_SOURCES) {
+      const m = getDataWidget(id);
+      expect(typeof m?.HomeRows, `source "${id}" has no HomeRows`).toBe("function");
+    }
+  });
+
+  // The optional Home hooks must be functions when present — a stray object
+  // or string would throw only when a user opened Home with that widget.
+  it("optional Home hooks are functions when defined", () => {
+    for (const id of DATA_SOURCES) {
+      const m = getDataWidget(id)!;
+      for (const hook of ["normalizeHome", "homeGroups", "homeGroupLabel"] as const) {
+        const fn = m[hook];
+        if (fn !== undefined) {
+          expect(typeof fn, `${id}.${hook} is not a function`).toBe("function");
+        }
+      }
+    }
+  });
+
   it("surfaces data widgets in every category of the catalog", () => {
     const byCategory = new Set(getCatalogItems().map((it) => it.category));
     for (const c of ["finance", "sports", "news", "fantasy", "predictions"]) {

--- a/desktop/src/datawidgets/rss/FeedTab.tsx
+++ b/desktop/src/datawidgets/rss/FeedTab.tsx
@@ -54,6 +54,7 @@ import type {
 } from "../../types";
 import type { WidgetId, RssWidgetConfig } from "../../api/client";
 import type { RssDisplayPrefs } from "../../preferences";
+import { RssHomeRows, rssHomeGroups } from "./home";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
@@ -75,6 +76,8 @@ export const rssDataWidget: DataWidgetManifest = {
     ],
   },
   FeedTab: RssFeedTab,
+  HomeRows: RssHomeRows,
+  homeGroups: rssHomeGroups,
 };
 
 // ── Sort type ────────────────────────────────────────────────────

--- a/desktop/src/datawidgets/rss/home.tsx
+++ b/desktop/src/datawidgets/rss/home.tsx
@@ -1,0 +1,52 @@
+/**
+ * News/RSS — Home preview. Newest first.
+ */
+import { HOME_PREVIEW_MAX, HomeEmptyRow } from "../home";
+import { timeAgo } from "../../utils/format";
+import type { HomeRowsProps, RssItem } from "../../types";
+
+/** Filter chips are per feed. */
+export function rssHomeGroups(rows: unknown[]): string[] {
+  return [...new Set((rows as RssItem[]).map((i) => i.source_name))];
+}
+
+export function RssHomeRows({ data, filter, onConfigure }: HomeRowsProps) {
+  const items = data as RssItem[];
+  const empty = (
+    <HomeEmptyRow
+      message="No feeds configured yet"
+      openLabel="News"
+      onConfigure={onConfigure}
+    />
+  );
+  if (items.length === 0) return empty;
+
+  const filtered =
+    filter.length > 0
+      ? items.filter((i) => filter.includes(i.source_name))
+      : items;
+
+  const sorted = [...filtered]
+    .sort((a, b) => {
+      const aTime = a.published_at ? new Date(a.published_at).getTime() : 0;
+      const bTime = b.published_at ? new Date(b.published_at).getTime() : 0;
+      return bTime - aTime;
+    })
+    .slice(0, HOME_PREVIEW_MAX);
+
+  if (sorted.length === 0) return empty;
+
+  return (
+    <>
+      {sorted.map((item) => (
+        <div key={item.id} className="flex items-center px-4 py-2.5 gap-3">
+          <span className="text-ui-meta text-fg flex-1 truncate">{item.title}</span>
+          <span className="text-[10px] text-fg-4 shrink-0">{item.source_name}</span>
+          <span className="text-[10px] text-fg-4/60 shrink-0 w-8 text-right">
+            {timeAgo(item.published_at)}
+          </span>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/desktop/src/datawidgets/sports/FeedTab.tsx
+++ b/desktop/src/datawidgets/sports/FeedTab.tsx
@@ -41,6 +41,7 @@ import { isLive, isPre, isFinal } from "../../utils/gameHelpers";
 import { latestTimestamp } from "../feedHooks";
 import type { FeedTabProps, DataWidgetManifest } from "../../types";
 import type { FavoriteTeam } from "../../hooks/useSportsConfig";
+import { SportsHomeRows, sportsHomeGroups } from "./home";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
@@ -62,6 +63,8 @@ export const sportsDataWidget: DataWidgetManifest = {
     ],
   },
   FeedTab: SportsFeedTab,
+  HomeRows: SportsHomeRows,
+  homeGroups: sportsHomeGroups,
 };
 
 // ── Types ────────────────────────────────────────────────────────

--- a/desktop/src/datawidgets/sports/home.tsx
+++ b/desktop/src/datawidgets/sports/home.tsx
@@ -1,0 +1,97 @@
+/**
+ * Sports — Home preview. Live games first, then upcoming, then finals.
+ *
+ * The only source that reads a sibling dashboard key: `sports_meta` carries
+ * per-league status so the empty state can say *why* a league is quiet
+ * (off-season, no games today) instead of just "nothing here". That's what
+ * the `dashboard` prop on HomeRowsProps exists for.
+ */
+import SportsEmptyState from "./EmptyState";
+import { HOME_PREVIEW_MAX } from "../home";
+import type { LeagueMeta } from "../../api/queries";
+import type { HomeRowsProps, Game } from "../../types";
+
+/** Filter chips are per league. */
+export function sportsHomeGroups(rows: unknown[]): string[] {
+  return [...new Set((rows as Game[]).map((g) => g.league))];
+}
+
+export function SportsHomeRows({
+  data,
+  filter,
+  dashboard,
+  onConfigure,
+}: HomeRowsProps) {
+  const games = data as Game[];
+  const meta = (dashboard?.sports_meta as { leagues?: LeagueMeta[] } | undefined)
+    ?.leagues;
+
+  // Restrict meta to the user's filter selection so the empty state speaks
+  // only about leagues they actually configured.
+  const visibleMeta: LeagueMeta[] = (meta ?? []).filter(
+    (m) => filter.length === 0 || filter.includes(m.name),
+  );
+  const empty = (
+    <SportsEmptyState leagues={visibleMeta} onConfigure={onConfigure} />
+  );
+  if (games.length === 0) return empty;
+
+  const filtered =
+    filter.length > 0 ? games.filter((g) => filter.includes(g.league)) : games;
+
+  // State priority matches the API contract: in > pre > final > postponed.
+  // Earlier versions used the legacy "post" state from the ESPN era, which
+  // never matched anything api-sports.io produces.
+  const priority: Record<string, number> = { in: 0, pre: 1, final: 2, postponed: 3 };
+  const sorted = [...filtered]
+    .sort((a, b) => (priority[a.state ?? ""] ?? 4) - (priority[b.state ?? ""] ?? 4))
+    .slice(0, HOME_PREVIEW_MAX);
+
+  if (sorted.length === 0) return empty;
+
+  return (
+    <>
+      {sorted.map((g) => {
+        const isLive = g.state === "in";
+        return (
+          <div key={g.id} className="flex items-center px-4 py-2.5 gap-3">
+            {isLive && (
+              <span className="w-1.5 h-1.5 rounded-full bg-green-400 shrink-0" />
+            )}
+            <span className="text-[10px] font-mono font-semibold text-fg-4 uppercase w-10 shrink-0 truncate">
+              {g.league}
+            </span>
+            <div className="flex items-center gap-2 flex-1 min-w-0">
+              {g.away_team_logo && (
+                <img
+                  src={g.away_team_logo}
+                  alt=""
+                  className="w-4 h-4 shrink-0 object-contain"
+                />
+              )}
+              <span className="text-ui-meta text-fg-2 truncate">
+                {g.away_team_name || g.away_team_code}
+              </span>
+              <span className="text-xs text-fg-3 tabular-nums shrink-0">
+                {g.away_team_score} – {g.home_team_score}
+              </span>
+              <span className="text-ui-meta text-fg-2 truncate">
+                {g.home_team_name || g.home_team_code}
+              </span>
+              {g.home_team_logo && (
+                <img
+                  src={g.home_team_logo}
+                  alt=""
+                  className="w-4 h-4 shrink-0 object-contain"
+                />
+              )}
+            </div>
+            <span className="text-[10px] text-fg-4 shrink-0 truncate max-w-24">
+              {g.short_detail ?? g.status_short ?? ""}
+            </span>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -17,7 +17,6 @@ import {
 } from "lucide-react";
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";
-import SportsEmptyState from "../datawidgets/sports/EmptyState";
 import RouteError from "../components/RouteError";
 import Tooltip from "../components/Tooltip";
 import { WidgetBar, BarPill } from "../components/widget-bar/Bar";
@@ -31,7 +30,6 @@ import { widgetManifest, sourceForWidget, canonicalOrder } from "../marketplace"
 import { scopeSourceData } from "../utils/widgetScope";
 import { WIDGET_ORDER } from "../widgets/registry";
 import { getStore } from "../lib/store";
-import { timeAgo } from "../utils/format";
 import { formatTemp, weatherCodeToIcon } from "../widgets/weather/types";
 import { loadMonitors } from "../widgets/uptime/types";
 import { loadRepoData } from "../widgets/github/types";
@@ -50,20 +48,7 @@ import {
   getEffectiveWidgetTickerStatus,
 } from "../utils/tickerStatus";
 import type { DataWidgetRow } from "../api/client";
-import type { LeagueMeta } from "../api/queries";
-import type {
-  DataWidgetManifest,
-  WidgetManifest,
-  Trade,
-  Game,
-  RssItem,
-  Prediction,
-} from "../types";
-import {
-  isDisplayable,
-  priceDelta,
-} from "../datawidgets/predictions/view";
-import ProbabilityPill from "../datawidgets/predictions/ProbabilityPill";
+import type { DataWidgetManifest, WidgetManifest } from "../types";
 import type { TempUnit, HomePreview } from "../preferences";
 import type { SystemInfo } from "../hooks/useSysmonData";
 import type { TimerState } from "../widgets/timer/types";
@@ -340,67 +325,6 @@ function HomePage() {
   );
 }
 
-// ── Dashboard payload normalizer ────────────────────────────────
-
-/**
- * Coerce a per-widget `/dashboard` payload to a flat array.
- *
- * Most widgets (`finance`, `sports`, `rss`) return an array directly.
- * Fantasy returns `{ leagues: [...] }` because each league entry
- * carries matchups/standings/rosters/standings at the top level and
- * the wrapper leaves room for additional sibling metadata in the
- * future.
- *
- * Other Fantasy consumers (`ScrollrTicker`, `FantasyFeedTab`,
- * `FollowedPlayersPicker`, `FantasyDisplayPanel`) already do this
- * unwrap. The Home dashboard used to treat the payload as a flat
- * array uniformly, which produced a "No leagues imported yet" empty
- * state even when the user had connected leagues. Centralizing the
- * unwrap here keeps all Home-side consumers (group extractors, row
- * renderers, hasData checks) consistent.
- */
-function normalizeWidgetData(type: string, raw: unknown): unknown[] {
-  if (type === "fantasy") {
-    const obj = raw as { leagues?: unknown } | undefined;
-    return Array.isArray(obj?.leagues) ? (obj.leagues as unknown[]) : [];
-  }
-  return Array.isArray(raw) ? (raw as unknown[]) : [];
-}
-
-// ── Group key extractors ────────────────────────────────────────
-
-function getGroups(type: string, data: unknown): string[] {
-  const arr = Array.isArray(data) ? data : [];
-  switch (type) {
-    case "finance":
-      return [...new Set((arr as Trade[]).map((t) => t.symbol))];
-    case "sports":
-      return [...new Set((arr as Game[]).map((g) => g.league))];
-    case "rss":
-      return [...new Set((arr as RssItem[]).map((i) => i.source_name))];
-    case "fantasy":
-      return [...new Set(
-        arr.map((l: Record<string, unknown>) =>
-          String(l.league_key ?? l.league_name ?? l.name ?? ""),
-        ).filter(Boolean),
-      )];
-    default:
-      return [];
-  }
-}
-
-function getGroupLabel(type: string, key: string, data: unknown): string {
-  if (type !== "fantasy") return key;
-  const arr = Array.isArray(data) ? data : [];
-  const league = arr.find(
-    (l: Record<string, unknown>) =>
-      String(l.league_key ?? "") === key || String(l.league_name ?? "") === key,
-  ) as Record<string, unknown> | undefined;
-  return league
-    ? String(league.league_name ?? league.name ?? key)
-    : key;
-}
-
 // ── DataWidgetRow section ─────────────────────────────────────────────
 
 interface WidgetSectionProps {
@@ -433,16 +357,25 @@ function WidgetSection({
   // and scope the payload to this one widget's config — an NFL widget shows only
   // NFL, finance_stocks only stocks, news_bbc only BBC. Mirrors the ticker.
   const source = sourceForWidget(type) ?? type;
-  const widgetData = useMemo(
-    () =>
-      scopeSourceData(
-        source,
-        normalizeWidgetData(source, data?.[source]),
-        widget.config as Record<string, unknown> | undefined,
-      ),
-    [source, data, widget.config],
+  // Normalizing, grouping and rendering all come off the manifest now — a
+  // source owns its own Home preview in datawidgets/{source}/home.tsx.
+  const widgetData = useMemo(() => {
+    const raw = data?.[source];
+    const rows = manifest.normalizeHome
+      ? manifest.normalizeHome(raw)
+      : Array.isArray(raw)
+        ? (raw as unknown[])
+        : [];
+    return scopeSourceData(
+      source,
+      rows,
+      widget.config as Record<string, unknown> | undefined,
+    );
+  }, [source, data, widget.config, manifest]);
+  const groups = useMemo(
+    () => manifest.homeGroups?.(widgetData) ?? [],
+    [manifest, widgetData],
   );
-  const groups = useMemo(() => getGroups(source, widgetData), [source, widgetData]);
   const hasSelections = selectedKeys.length > 0;
 
   function toggleGroup(key: string) {
@@ -570,7 +503,7 @@ function WidgetSection({
                     )}
                   </span>
                   <span className="text-ui-meta text-fg truncate flex-1">
-                    {getGroupLabel(source, key, widgetData)}
+                    {manifest.homeGroupLabel?.(key, widgetData) ?? key}
                   </span>
                 </button>
               );
@@ -591,337 +524,16 @@ function WidgetSection({
               if (e.key === "Enter") onRowClick();
             }}
           >
-            {source === "finance" && (
-              <FinanceRows data={widgetData} filter={selectedKeys} onConfigure={onConfigure} />
-            )}
-            {source === "sports" && (
-              <SportsRows
-                data={widgetData}
-                meta={(data?.sports_meta as { leagues?: LeagueMeta[] } | undefined)?.leagues}
-                filter={selectedKeys}
-                onConfigure={onConfigure}
-              />
-            )}
-            {source === "rss" && (
-              <RssRows data={widgetData} filter={selectedKeys} onConfigure={onConfigure} />
-            )}
-            {source === "fantasy" && (
-              <FantasyRows data={widgetData} filter={selectedKeys} onConfigure={onConfigure} />
-            )}
-            {source === "predictions" && (
-              <PredictionsRows data={widgetData} onConfigure={onConfigure} />
-            )}
-            {!["finance", "sports", "rss", "fantasy", "predictions"].includes(source) && (
-              <EmptyDataRow widgetType={source} onConfigure={onConfigure} />
-            )}
+            <manifest.HomeRows
+              data={widgetData}
+              filter={selectedKeys}
+              dashboard={data}
+              onConfigure={onConfigure}
+            />
           </motion.div>
         )}
       </AnimatePresence>
     </section>
-  );
-}
-
-// ── Finance rows ────────────────────────────────────────────────
-
-function FinanceRows({ data, filter, onConfigure }: { data: unknown; filter: string[]; onConfigure: () => void }) {
-  const trades = Array.isArray(data) ? (data as Trade[]) : [];
-  if (trades.length === 0) return <EmptyDataRow widgetType="finance" onConfigure={onConfigure} />;
-
-  const filtered =
-    filter.length > 0
-      ? trades.filter((t) => filter.includes(t.symbol))
-      : trades;
-
-  const sorted = [...filtered]
-    .sort(
-      (a, b) =>
-        Math.abs(Number(b.percentage_change ?? 0)) -
-        Math.abs(Number(a.percentage_change ?? 0)),
-    )
-    .slice(0, MAX_PREVIEW);
-
-  if (sorted.length === 0)
-    return <EmptyDataRow widgetType="finance" />;
-
-  return (
-    <>
-      {sorted.map((t) => {
-        const pct = Number(t.percentage_change ?? 0);
-        const isUp = pct >= 0;
-        return (
-          <div key={t.symbol} className="flex items-center px-4 py-2.5 gap-4">
-            <span className="text-xs font-mono font-semibold text-fg w-20 truncate">
-              {t.symbol}
-            </span>
-            <span className="text-xs text-fg-2 tabular-nums">
-              $
-              {Number(t.price).toLocaleString(undefined, {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              })}
-            </span>
-            <span
-              className={clsx(
-                "text-xs font-medium tabular-nums ml-auto",
-                isUp ? "text-green-400" : "text-red-400",
-              )}
-            >
-              {isUp ? "▲" : "▼"} {Math.abs(pct).toFixed(2)}%
-            </span>
-          </div>
-        );
-      })}
-    </>
-  );
-}
-
-// ── Predictions rows ────────────────────────────────────────────
-
-function PredictionsRows({ data, onConfigure }: { data: unknown; onConfigure: () => void }) {
-  const markets = Array.isArray(data) ? (data as Prediction[]) : [];
-  const live = markets.filter(isDisplayable);
-  if (live.length === 0) return <EmptyDataRow widgetType="predictions" onConfigure={onConfigure} />;
-
-  // Top movers preview — the same "what changed" glance FinanceRows gives.
-  const sorted = [...live]
-    .sort((a, b) => Math.abs(priceDelta(b)) - Math.abs(priceDelta(a)))
-    .slice(0, MAX_PREVIEW);
-
-  return (
-    <>
-      {sorted.map((p) => {
-        const delta = priceDelta(p);
-        const isUp = delta > 0;
-        return (
-          <div key={p.id} className="flex items-center px-4 py-2.5 gap-4">
-            <span className="text-ui-meta text-fg-2 truncate flex-1">
-              {p.event_title || p.title}
-            </span>
-            {/* Fixed delta slot + fixed-width pill — the widget's own
-                column treatment, so Home previews match the feed. */}
-            <span
-              className={clsx(
-                "text-xs font-medium tabular-nums w-10 text-right",
-                isUp ? "text-green-400" : "text-red-400",
-              )}
-            >
-              {delta !== 0 ? `${isUp ? "▲" : "▼"} ${Math.abs(delta)}` : ""}
-            </span>
-            <ProbabilityPill pct={p.yes_price} delta={delta} size="sm" />
-          </div>
-        );
-      })}
-    </>
-  );
-}
-
-// ── Sports rows ─────────────────────────────────────────────────
-
-function SportsRows({
-  data,
-  meta,
-  filter,
-  onConfigure,
-}: {
-  data: unknown;
-  meta: LeagueMeta[] | undefined;
-  filter: string[];
-  onConfigure: () => void;
-}) {
-  const games = Array.isArray(data) ? (data as Game[]) : [];
-  // Restrict meta to the user's filter selection so the empty-state speaks
-  // only about leagues the user has configured.
-  const visibleMeta: LeagueMeta[] = (meta ?? []).filter(
-    (m) => filter.length === 0 || filter.includes(m.name),
-  );
-
-  if (games.length === 0) {
-    return <SportsEmptyState leagues={visibleMeta} onConfigure={onConfigure} />;
-  }
-
-  const filtered =
-    filter.length > 0
-      ? games.filter((g) => filter.includes(g.league))
-      : games;
-
-  // State priority matches the API contract: in > pre > final > postponed.
-  // Earlier versions used the legacy "post" state from the ESPN era — that
-  // never matched anything the api-sports.io ingestion produces.
-  const priority: Record<string, number> = { in: 0, pre: 1, final: 2, postponed: 3 };
-  const sorted = [...filtered]
-    .sort(
-      (a, b) =>
-        (priority[a.state ?? ""] ?? 4) - (priority[b.state ?? ""] ?? 4),
-    )
-    .slice(0, MAX_PREVIEW);
-
-  if (sorted.length === 0) {
-    return <SportsEmptyState leagues={visibleMeta} onConfigure={onConfigure} />;
-  }
-
-  return (
-    <>
-      {sorted.map((g) => {
-        const isLive = g.state === "in";
-        return (
-          <div key={g.id} className="flex items-center px-4 py-2.5 gap-3">
-            {isLive && (
-              <span className="w-1.5 h-1.5 rounded-full bg-green-400 shrink-0" />
-            )}
-            <span className="text-[10px] font-mono font-semibold text-fg-4 uppercase w-10 shrink-0 truncate">
-              {g.league}
-            </span>
-            <div className="flex items-center gap-2 flex-1 min-w-0">
-              {g.away_team_logo && (
-                <img
-                  src={g.away_team_logo}
-                  alt=""
-                  className="w-4 h-4 shrink-0 object-contain"
-                />
-              )}
-              <span className="text-ui-meta text-fg-2 truncate">
-                {g.away_team_name || g.away_team_code}
-              </span>
-              <span className="text-xs text-fg-3 tabular-nums shrink-0">
-                {g.away_team_score} – {g.home_team_score}
-              </span>
-              <span className="text-ui-meta text-fg-2 truncate">
-                {g.home_team_name || g.home_team_code}
-              </span>
-              {g.home_team_logo && (
-                <img
-                  src={g.home_team_logo}
-                  alt=""
-                  className="w-4 h-4 shrink-0 object-contain"
-                />
-              )}
-            </div>
-            <span className="text-[10px] text-fg-4 shrink-0 truncate max-w-24">
-              {g.short_detail ?? g.status_short ?? ""}
-            </span>
-          </div>
-        );
-      })}
-    </>
-  );
-}
-
-// ── RSS rows ────────────────────────────────────────────────────
-
-function RssRows({ data, filter, onConfigure }: { data: unknown; filter: string[]; onConfigure: () => void }) {
-  const items = Array.isArray(data) ? (data as RssItem[]) : [];
-  if (items.length === 0) return <EmptyDataRow widgetType="rss" onConfigure={onConfigure} />;
-
-  const filtered =
-    filter.length > 0
-      ? items.filter((i) => filter.includes(i.source_name))
-      : items;
-
-  const sorted = [...filtered]
-    .sort((a, b) => {
-      const aTime = a.published_at ? new Date(a.published_at).getTime() : 0;
-      const bTime = b.published_at ? new Date(b.published_at).getTime() : 0;
-      return bTime - aTime;
-    })
-    .slice(0, MAX_PREVIEW);
-
-  if (sorted.length === 0)
-    return <EmptyDataRow widgetType="rss" />;
-
-  return (
-    <>
-      {sorted.map((item) => (
-        <div key={item.id} className="flex items-center px-4 py-2.5 gap-3">
-          <span className="text-ui-meta text-fg flex-1 truncate">{item.title}</span>
-          <span className="text-[10px] text-fg-4 shrink-0">
-            {item.source_name}
-          </span>
-          <span className="text-[10px] text-fg-4/60 shrink-0 w-8 text-right">
-            {timeAgo(item.published_at)}
-          </span>
-        </div>
-      ))}
-    </>
-  );
-}
-
-// ── Fantasy rows ────────────────────────────────────────────────
-
-function FantasyRows({ data, filter, onConfigure }: { data: unknown; filter: string[]; onConfigure: () => void }) {
-  const leagues = Array.isArray(data) ? data : [];
-  if (leagues.length === 0) return <EmptyDataRow widgetType="fantasy" onConfigure={onConfigure} />;
-
-  const filtered =
-    filter.length > 0
-      ? leagues.filter((l: Record<string, unknown>) => {
-          const key = String(l.league_key ?? l.league_name ?? l.name ?? "");
-          return filter.includes(key);
-        })
-      : leagues;
-
-  const preview = filtered.slice(0, MAX_PREVIEW);
-
-  if (preview.length === 0)
-    return <EmptyDataRow widgetType="fantasy" />;
-
-  return (
-    <>
-      {preview.map((league: Record<string, unknown>, i: number) => {
-        const name = (league.league_name ?? league.name ?? "League") as string;
-        const myScore = league.my_score ?? league.team_points;
-        const oppScore = league.opp_score ?? league.opponent_points;
-        const hasMatchup = myScore != null && oppScore != null;
-
-        return (
-          <div key={i} className="flex items-center px-4 py-2.5 gap-3">
-            <span className="text-ui-meta text-fg flex-1 truncate">{name}</span>
-            {hasMatchup && (
-              <span className="text-xs text-fg-3 tabular-nums">
-                {String(myScore)} – {String(oppScore)}
-              </span>
-            )}
-          </div>
-        );
-      })}
-    </>
-  );
-}
-
-// ── Empty data row ──────────────────────────────────────────────
-
-const EMPTY_HINTS: Record<string, { message: string; name: string }> = {
-  finance: { message: "No stocks configured yet", name: "Finance" },
-  sports: { message: "No leagues configured yet", name: "Sports" },
-  rss: { message: "No feeds configured yet", name: "News" },
-  fantasy: { message: "No leagues imported yet", name: "Fantasy" },
-};
-
-function EmptyDataRow({
-  widgetType,
-  onConfigure,
-}: {
-  widgetType?: string;
-  onConfigure?: () => void;
-}) {
-  const hint = widgetType ? EMPTY_HINTS[widgetType] : undefined;
-  return (
-    <div className="px-4 py-5 text-center">
-      <p className="text-ui-meta text-fg-3 font-medium mb-1">
-        {hint?.message ?? "Nothing to show"}
-      </p>
-      {hint && onConfigure && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onConfigure();
-          }}
-          className="inline-flex items-center gap-1.5 text-ui-chip text-accent hover:text-accent/80 transition-colors"
-        >
-          <Settings size={11} />
-          Open {hint.name}
-        </button>
-      )}
-    </div>
   );
 }
 

--- a/desktop/src/types/index.ts
+++ b/desktop/src/types/index.ts
@@ -182,6 +182,49 @@ export interface DataWidgetManifest {
   info: SourceInfo;
   /** The React component rendered for this widget's feed view. */
   FeedTab: React.ComponentType<FeedTabProps>;
+
+  // ── Home preview (see datawidgets/home.tsx) ───────────────────
+  // Each source owns how it renders on Home. Required, so adding a
+  // source cannot silently produce a blank card — TypeScript asks for
+  // it. `routes/feed.tsx` used to switch on the source name instead.
+
+  /** The preview rows for this source on the Home feed. */
+  HomeRows: React.ComponentType<HomeRowsProps>;
+
+  /**
+   * Coerce this source's raw `/dashboard` payload to a flat array.
+   * Omit when the payload is already an array (most sources); fantasy
+   * wraps its rows in `{ leagues: [...] }`.
+   */
+  normalizeHome?: (raw: unknown) => unknown[];
+
+  /**
+   * Distinct group keys for the Home filter chips — symbols, leagues,
+   * feed names. Omit for sources with no meaningful grouping and the
+   * chips are hidden.
+   */
+  homeGroups?: (rows: unknown[]) => string[];
+
+  /**
+   * Display label for a group key. Omit when the key is already
+   * human-readable; fantasy keys on `league_key` and labels by name.
+   */
+  homeGroupLabel?: (key: string, rows: unknown[]) => string;
+}
+
+/** Props every source's `HomeRows` receives. */
+export interface HomeRowsProps {
+  /** This widget's rows: normalized, then scoped to its own config. */
+  data: unknown[];
+  /** Group keys the user pinned. Empty means "no filter". */
+  filter: string[];
+  /**
+   * The whole `dashboard.data`, for the rare source that needs a sibling
+   * key — sports reads `sports_meta` to explain an empty league.
+   */
+  dashboard?: Record<string, unknown>;
+  /** Navigates to the widget's own page. */
+  onConfigure?: () => void;
 }
 
 /** Manifest describing a single widget. */


### PR DESCRIPTION
`routes/feed.tsx` carried a per-source if-ladder — the same shape `ScrollrTicker` retired when `TickerSource.chips` moved rendering into each source's own folder. Home never caught up.

Closes REL-63.

## Six places source knowledge lived

The issue named four. There were six:

1. A render ladder — `{source === "finance" && <FinanceRows …>}` ×5
2. Its negation as a fallback — `!["finance","sports","rss","fantasy","predictions"].includes(source)`
3. `normalizeWidgetData()` — fantasy's wrapped payload
4. `getGroups()` — a five-arm `switch`
5. `getGroupLabel()` — fantasy's opaque league keys
6. `EMPTY_HINTS` — a map of per-source empty copy

All six are gone. **`feed.tsx` no longer names a single data source.**

## The shape

Each source owns `datawidgets/{source}/home.tsx` and wires it through its manifest:

```ts
HomeRows: React.ComponentType<HomeRowsProps>;   // required
normalizeHome?: (raw) => unknown[];             // fantasy only
homeGroups?: (rows) => string[];                // filter chips
homeGroupLabel?: (key, rows) => string;         // fantasy only
```

**No registry, unlike the ticker.** `widgetManifest()` already spreads the per-source renderer manifest, so `WidgetSection` holds the right manifest and reads `manifest.HomeRows` directly. The ticker works from tab ids and dashboard payloads and had no manifest to hang this on — it needed `TICKER_SOURCES`. Here that would be a lookup for something already in scope.

Making `HomeRows` **required** means a new source can't ship a blank Home card — tsc asks for it, and the fallback guard disappears because there's nothing left to fall back from.

## A bug fixed in passing

`EMPTY_HINTS` had **no `predictions` entry**, so that widget's empty state fell through to a bare "Nothing to show" with no call to action, while every other source got a specific message and an Open button. It now reads "No markets tracked yet" and behaves like the rest.

That's a deliberate behaviour change, not an accident of the move — flagging it because it's the one user-visible difference in this PR.

## Verification

This is a UI refactor, so tsc and a green build prove very little. **12 new tests mount all five renderers through the real registry** — with data and empty — so the wiring inside each `FeedTab.tsx` is covered too, not just the components. Plus two registry guards, since the manifest registry is populated by a runtime glob that tsc can't see through.

**Mutation-checked**, because tests that pass on the first run deserve suspicion:

| Mutation | Result |
|---|---|
| fantasy `normalizeHome` stops unwrapping `{ leagues: [...] }` | 1 failed, 11 passed — the right one |
| predictions empty copy reverted to "Nothing to show" | 1 failed, 11 passed — the right one |

An earlier attempt at a third mutation silently failed to apply and reported a false pass; caught it by asserting the file actually changed. Worth knowing the check is only as good as its own verification.

## Gate

`tsc`, `vite build`, **518 tests** (up from 506). `feed.tsx` 1,083 → 695 lines; the rest relocated rather than deleted, so net is +252 including the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
