### PR TITLE
Title-bar brand placement and a readable selected segment (v1.3.1)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4622,7 +4622,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 # std::env::home_dir (Sentry path scrubber) is only correct on Windows from 1.85+
 rust-version = "1.85"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -107,6 +107,18 @@ export default function TopBar({
         IS_MACOS && "pl-[78px]",
       )}
     >
+      {/* ── Brand mark (Windows/Linux) ───────────────────────
+          Leads the row on the frameless platforms, where the left
+          corner is ours to use. macOS can't have it here — the traffic
+          lights are drawn over that corner — so it trails the row
+          there instead. */}
+      {!IS_MACOS && (
+        <>
+          <BrandMark />
+          <div className="w-px h-5 bg-edge/40 mx-1 shrink-0" />
+        </>
+      )}
+
       {/* ── Sidebar toggle ──────────────────────────────────
           Leads the row, ahead of Back: it acts on the rail to its
           left, so it reads as belonging to that edge rather than to
@@ -269,17 +281,15 @@ export default function TopBar({
           </button>
         </Tooltip>
 
-        {/* ── Brand mark (far right) ────────────────────────────
-            Sits right of the Ticker toggle. It used to lead the row,
-            but macOS draws the traffic lights over that corner under
-            titleBarStyle "Overlay", so the left edge belongs to them. */}
-        <div className="w-px h-5 bg-edge/40 mx-1 shrink-0" />
-        <div className="flex h-7 shrink-0 items-center gap-2 px-1.5">
-          <ScrollLogo size={20} />
-          <span className="text-ui-body font-semibold tracking-tight">
-            Scrollr
-          </span>
-        </div>
+        {/* macOS only: the brand mark trails the row because the
+            traffic lights own the left corner under titleBarStyle
+            "Overlay". Everywhere else it leads — see the top of the row. */}
+        {IS_MACOS && (
+          <>
+            <div className="w-px h-5 bg-edge/40 mx-1 shrink-0" />
+            <BrandMark />
+          </>
+        )}
       </div>
 
       {/* ── Window controls (Windows/Linux frameless only) ────
@@ -294,3 +304,18 @@ export default function TopBar({
   );
 }
 
+
+// ── Brand mark ──────────────────────────────────────────────────
+//
+// Rendered at one end of the row or the other depending on platform:
+// leading on Windows/Linux, trailing on macOS. It is the same mark
+// either way, so it lives here rather than being written twice.
+
+function BrandMark() {
+  return (
+    <div className="flex h-7 shrink-0 items-center gap-2 px-1.5">
+      <ScrollLogo size={20} />
+      <span className="text-ui-body font-semibold tracking-tight">Scrollr</span>
+    </div>
+  );
+}

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -306,7 +306,13 @@ export function SegmentedRow<T extends string>({
         <div
           role="radiogroup"
           aria-label={label}
-          className="inline-flex shrink-0 items-center gap-px rounded-lg bg-base-250/50 p-0.5"
+          // The track is a well the selected pill rises out of — that
+          // is what makes the light-mode control read as raised. In dark
+          // palettes base-250/50 lands within ~1.01 of the card it sits
+          // on, so there was no well at all and the pill had nothing to
+          // rise from. `surface` is the panel colour, always a step below
+          // the raised card, so every dark theme gets a real recess.
+          className="inline-flex shrink-0 items-center gap-px rounded-lg bg-base-250/50 dark:bg-surface p-0.5"
         >
           {options.map((opt) => (
             <button
@@ -323,20 +329,25 @@ export function SegmentedRow<T extends string>({
               )}
             >
               {value === opt.value && (
-                // The fill alone does not carry the selected state. In a
-                // light palette the drop shadow draws the pill's edge, but
-                // shadow-soft-sm is black at 25% — on a dark background it
-                // is invisible, leaving the pill and its container within
-                // ~1.05 contrast (measured worst case: solarized-dark at
-                // 1.005, i.e. literally the same color). The hairline is
-                // keyed to `fg`, which is the one token guaranteed to
-                // contrast with the surface in every palette, so it reads
-                // as an edge in both polarities rather than needing a
-                // per-theme value.
+                // Three things carry the selected state, because no one
+                // of them survives every palette: the fill returns to the
+                // card's level (rising out of the recessed track), the
+                // shadow lifts it in light palettes, and the hairline
+                // draws its edge in dark ones where a 25%-black shadow is
+                // invisible. The ring is keyed to `fg` — the one token
+                // guaranteed to contrast with the surface everywhere — and
+                // is stronger in dark, where it is doing the shadow's job
+                // as well as its own.
+                //
+                // The fill deliberately does NOT lighten in dark themes.
+                // A lighter pill (base-300) reads well but puts the
+                // semibold label below 4.5:1 in two palettes and below
+                // WCAG AA outright in solarized-dark (2.01) — trading a
+                // visibility problem for a legibility one.
                 <motion.span
                   layoutId="active-option"
                   transition={controlTransition}
-                  className="absolute inset-0 rounded-md bg-surface-raised shadow-soft-sm ring-1 ring-inset ring-fg/20"
+                  className="absolute inset-0 rounded-md bg-surface-raised shadow-soft-sm ring-1 ring-inset ring-fg/20 dark:ring-fg/30"
                 />
               )}
               <span className="relative z-10">{opt.label}</span>

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -323,10 +323,20 @@ export function SegmentedRow<T extends string>({
               )}
             >
               {value === opt.value && (
+                // The fill alone does not carry the selected state. In a
+                // light palette the drop shadow draws the pill's edge, but
+                // shadow-soft-sm is black at 25% — on a dark background it
+                // is invisible, leaving the pill and its container within
+                // ~1.05 contrast (measured worst case: solarized-dark at
+                // 1.005, i.e. literally the same color). The hairline is
+                // keyed to `fg`, which is the one token guaranteed to
+                // contrast with the surface in every palette, so it reads
+                // as an edge in both polarities rather than needing a
+                // per-theme value.
                 <motion.span
                   layoutId="active-option"
                   transition={controlTransition}
-                  className="absolute inset-0 rounded-md bg-surface-raised shadow-soft-sm"
+                  className="absolute inset-0 rounded-md bg-surface-raised shadow-soft-sm ring-1 ring-inset ring-fg/20"
                 />
               )}
               <span className="relative z-10">{opt.label}</span>


### PR DESCRIPTION
Two UI fixes reported against v1.3.0.

## Brand mark leads the row off macOS

The logo and wordmark sat at the far right on every platform, which generalised a macOS constraint too far: under `titleBarStyle: "Overlay"` the traffic lights are drawn over the left corner, so the mark had to move out of their way. Windows and Linux are frameless with our own controls on the right — their left corner was never taken. The mark now leads the row there, ahead of the sidebar toggle. macOS is unchanged.

Branches on `!IS_MACOS` rather than Windows specifically: Linux runs the same frameless layout with the same free corner, so the two want the same answer, and `IS_MACOS` is the only platform flag the app has.

## The selected segment is visible in dark themes

Reported as unreadable in scrollr-dark. The root cause turned out to be older and broader than the theme: **the active pill uses `bg-surface-raised`, the same token as the card it sits on**, so it has never had fill contrast in any palette. Light mode gets away with it because the track is a recessed well and the shadow draws an edge — the pill returning to card level then reads as rising out of that well.

Dark palettes had no well. Measured across all 20:

| | track vs. card |
|---|---|
| scrollr-dark | **1.007** — invisible |
| catppuccin-dark, dracula-dark | track was *lighter* than the card, so the selected pill read as **recessed** |

The track now recesses to `surface` in dark, which is by definition a step below the raised card. Every dark palette gets a real well (1.13–1.17, against the 1.100 light manages), and the ring goes to 30% in dark where it covers for a shadow that cannot be seen.

**Not** fixed by lightening the pill, which was the obvious move and what the original design spec suggested (`base-300`). It looks right until you check the label: it drops the semibold text below 4.5:1 in two palettes and under WCAG AA outright in solarized-dark (**2.01**), trading a visibility problem for a legibility one. Keeping the fill at card level leaves every label between 4.85 and 16.5.

## Verification

- Measured contrast across all 20 palettes for track, pill, ring edge and label
- `tsc --noEmit` clean, 503 tests pass
- macOS title bar confirmed visually unchanged
- Dark-mode result confirmed by the reporter

The Windows/Linux brand placement is code-verified only — this was developed on macOS.