### PR TITLE
Catalog becomes a store, Home becomes a briefing (v1.4.0)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4622,7 +4622,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 # std::env::home_dir (Sentry path scrubber) is only correct on Windows from 1.85+
 rust-version = "1.85"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/components/home/HomeTicker.tsx
+++ b/desktop/src/components/home/HomeTicker.tsx
@@ -1,0 +1,109 @@
+/**
+ * Home's live mini-ticker.
+ *
+ * The bar used to carry a status sentence about the ticker. This shows
+ * the ticker instead — the same chips, drifting — because "what is
+ * scrolling right now" is a question a sentence answers worse than the
+ * thing itself does.
+ *
+ * The chip sequence is rendered TWICE inside a width:max-content track
+ * and the track translates -50%. At exactly half, chip N+1 sits where
+ * chip 1 started, so the loop lands on the seam and there is no jump to
+ * hide. Duration is fixed rather than proportional to content: a
+ * constant 22s reads as a steady drift whether you have three chips or
+ * thirty.
+ */
+import { useState } from "react";
+import clsx from "clsx";
+import { Pause, Play, SlidersHorizontal } from "lucide-react";
+
+export interface TickerChip {
+  /** Widget id — chips deep-link like everything else on Home. */
+  id: string;
+  text: string;
+  hex: string;
+}
+
+export default function HomeTicker({
+  chips,
+  onManage,
+  onOpen,
+}: {
+  chips: TickerChip[];
+  onManage: () => void;
+  onOpen: (id: string) => void;
+}) {
+  const [paused, setPaused] = useState(false);
+
+  return (
+    <div className="flex items-center gap-2.5 overflow-hidden">
+      <span className="inline-flex shrink-0 items-center gap-1.5 rounded bg-accent/12 px-1.5 py-0.5 font-mono text-ui-chip font-bold text-accent">
+        <span className="size-1.5 rounded-full bg-accent motion-safe:animate-pulse" />
+        LIVE
+      </span>
+
+      <div
+        className="relative min-w-0 flex-1 overflow-hidden"
+        // Edge fade so chips arrive and leave rather than pop.
+        style={{
+          maskImage:
+            "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)",
+        }}
+      >
+        {chips.length === 0 ? (
+          <span className="text-ui-meta text-fg-4">
+            Nothing scrolling yet — add a widget below.
+          </span>
+        ) : (
+          <div
+            className={clsx(
+              "flex w-max gap-2",
+              // motion-safe only: with reduced motion the track simply
+              // sits still and stays readable.
+              "motion-safe:animate-[chipdrift_22s_linear_infinite]",
+              paused && "[animation-play-state:paused]",
+            )}
+          >
+            {[...chips, ...chips].map((c, i) => (
+              <button
+                key={`${c.id}-${i}`}
+                type="button"
+                onClick={() => onOpen(c.id)}
+                aria-hidden={i >= chips.length}
+                tabIndex={i >= chips.length ? -1 : 0}
+                className="flex h-[22px] shrink-0 cursor-pointer items-center rounded border px-2 font-mono text-ui-chip whitespace-nowrap"
+                style={{
+                  borderColor: `${c.hex}3d`,
+                  background: `${c.hex}10`,
+                }}
+              >
+                {c.text}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-0.5">
+        {chips.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setPaused((p) => !p)}
+            aria-label={paused ? "Resume ticker" : "Pause ticker"}
+            className="flex size-7 cursor-pointer items-center justify-center rounded-md text-fg-4 hover:bg-surface-hover hover:text-fg-2"
+          >
+            {paused ? <Play size={13} /> : <Pause size={13} />}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onManage}
+          aria-label="Manage ticker"
+          className="flex size-7 cursor-pointer items-center justify-center rounded-md text-fg-4 hover:bg-surface-hover hover:text-fg-2"
+        >
+          <SlidersHorizontal size={13} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/home/HomeTicker.tsx
+++ b/desktop/src/components/home/HomeTicker.tsx
@@ -14,7 +14,6 @@
  * thirty.
  */
 import { useState } from "react";
-import clsx from "clsx";
 import { Pause, Play, SlidersHorizontal } from "lucide-react";
 
 export interface TickerChip {
@@ -38,7 +37,7 @@ export default function HomeTicker({
   return (
     <div className="flex items-center gap-2.5 overflow-hidden">
       <span className="inline-flex shrink-0 items-center gap-1.5 rounded bg-accent/12 px-1.5 py-0.5 font-mono text-ui-chip font-bold text-accent">
-        <span className="size-1.5 rounded-full bg-accent motion-safe:animate-pulse" />
+        <span data-motion="pulse" className="size-1.5 rounded-full bg-accent" />
         LIVE
       </span>
 
@@ -56,13 +55,15 @@ export default function HomeTicker({
           </span>
         ) : (
           <div
-            className={clsx(
-              "flex w-max gap-2",
-              // motion-safe only: with reduced motion the track simply
-              // sits still and stays readable.
-              "motion-safe:animate-[chipdrift_22s_linear_infinite]",
-              paused && "[animation-play-state:paused]",
-            )}
+            // Attribute, not an animate-* class: the app-wide
+            // `#app-shell * { animation: none !important }` rule silences
+            // every Tailwind animation inside the app. style.css grants
+            // marquees an explicit exception keyed off this attribute,
+            // and still honours prefers-reduced-motion.
+            data-motion="marquee"
+            data-paused={paused ? "true" : "false"}
+            style={{ "--marquee-duration": "22s" } as React.CSSProperties}
+            className="flex w-max gap-2"
           >
             {[...chips, ...chips].map((c, i) => (
               <button

--- a/desktop/src/components/home/briefing.tsx
+++ b/desktop/src/components/home/briefing.tsx
@@ -98,7 +98,7 @@ export function LiveDot({ label = "LIVE" }: { label?: string }) {
     // The text is the badge. Colour alone would leave the state invisible
     // to anyone who can't separate red from grey.
     <span className="inline-flex items-center gap-1 rounded bg-error/12 px-1.5 py-0.5 font-mono text-ui-chip font-bold text-error">
-      <span className="size-1.5 rounded-full bg-error motion-safe:animate-pulse" />
+      <span data-motion="pulse" className="size-1.5 rounded-full bg-error" />
       {label}
     </span>
   );

--- a/desktop/src/components/home/briefing.tsx
+++ b/desktop/src/components/home/briefing.tsx
@@ -1,0 +1,126 @@
+/**
+ * Home briefing — the bento pieces.
+ *
+ * Consolidation here is PRESENTATION ONLY. Cards group by source so the
+ * page reads as a briefing rather than a stack of per-widget panels, but
+ * every link still targets a widget id: the Scores header carries a chip
+ * per league, Markets carries one per watchlist, rows deep-link to their
+ * owning widget. Nothing ever links to a "group", because a group is not
+ * a thing you can open, configure, or remove.
+ */
+import clsx from "clsx";
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+// ── Shared chrome ───────────────────────────────────────────────
+
+export function Card({
+  title,
+  icon,
+  meta,
+  chips,
+  footer,
+  children,
+}: {
+  title: string;
+  icon?: ReactNode;
+  /** Right-aligned status text, e.g. market hours. */
+  meta?: ReactNode;
+  /** Per-widget deep links. Never a group link. */
+  chips?: { id: string; label: string; onClick: () => void }[];
+  footer?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col overflow-hidden rounded-xl border border-edge/55 bg-surface-raised">
+      <header className="flex items-center gap-2 border-b border-fg/7 px-3.5 py-2.5">
+        {icon && <span className="shrink-0 text-fg-3">{icon}</span>}
+        <h2 className="text-ui-body font-semibold text-fg">{title}</h2>
+        <div className="ml-auto flex items-center gap-1.5">
+          {meta && <span className="text-ui-chip text-fg-4">{meta}</span>}
+          {chips?.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={c.onClick}
+              className="flex cursor-pointer items-center gap-0.5 rounded-md border border-edge/55 px-1.5 py-0.5 text-ui-chip font-medium text-fg-3 hover:border-edge hover:text-fg"
+            >
+              {c.label}
+              <ChevronRight size={10} />
+            </button>
+          ))}
+        </div>
+      </header>
+      <div className="flex-1">{children}</div>
+      {footer && (
+        <div className="flex items-center gap-1.5 border-t border-fg/7 px-3.5 py-2">
+          {footer}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** A row that stands in for a card's body when the widget isn't set up. */
+export function SetupBody({
+  message,
+  cta,
+  onCta,
+  tone = "accent",
+}: {
+  message: string;
+  cta: string;
+  onCta: () => void;
+  tone?: "accent" | "brand";
+  brandHex?: string;
+}) {
+  return (
+    <div className="flex flex-col items-start gap-2 px-3.5 py-4">
+      <p className="text-ui-meta text-fg-3">{message}</p>
+      <button
+        type="button"
+        onClick={onCta}
+        className={clsx(
+          "cursor-pointer rounded-[7px] px-2.5 py-1.5 text-ui-chip font-semibold",
+          tone === "accent"
+            ? "bg-accent/12 text-accent hover:bg-accent/20"
+            : "bg-accent-purple/15 text-accent-purple hover:bg-accent-purple/25",
+        )}
+      >
+        {cta}
+      </button>
+    </div>
+  );
+}
+
+export function LiveDot({ label = "LIVE" }: { label?: string }) {
+  return (
+    // The text is the badge. Colour alone would leave the state invisible
+    // to anyone who can't separate red from grey.
+    <span className="inline-flex items-center gap-1 rounded bg-error/12 px-1.5 py-0.5 font-mono text-ui-chip font-bold text-error">
+      <span className="size-1.5 rounded-full bg-error motion-safe:animate-pulse" />
+      {label}
+    </span>
+  );
+}
+
+export function ChangeChip({ pct }: { pct: number }) {
+  const up = pct >= 0;
+  return (
+    <span
+      className={clsx(
+        "rounded px-1.5 py-0.5 text-ui-chip font-semibold tabular-nums",
+        up ? "bg-success/10 text-success" : "bg-error/8 text-error",
+      )}
+    >
+      {up ? "+" : ""}
+      {pct.toFixed(1)}%
+    </span>
+  );
+}
+
+export function EmptyBody({ children }: { children: ReactNode }) {
+  return (
+    <p className="px-3.5 py-4 text-ui-meta text-fg-4">{children}</p>
+  );
+}

--- a/desktop/src/components/marketplace/CatalogCard.tsx
+++ b/desktop/src/components/marketplace/CatalogCard.tsx
@@ -1,117 +1,197 @@
 import { useState } from "react";
 import clsx from "clsx";
-import { Check, ChevronRight } from "lucide-react";
+import { Check, Plus } from "lucide-react";
 import type { CatalogItem } from "../../marketplace";
 import { CATEGORY_LABELS } from "../../marketplace";
 
-// ── Props ───────────────────────────────────────────────────────
+// ── Browse-AND-act card ─────────────────────────────────────────
 //
-// Browse-only card (v1.1.1 catalog redesign): the catalog shows what
-// exists; every transaction (add / remove / configure / gating) lives
-// on the widget's own info page. Clicking anywhere on the card goes
-// there. No per-card buttons, no per-card lock badges — uniform,
-// sleek, calm.
+// The catalog used to be browse-only — every transaction lived on the
+// widget's info page, one navigation away. It's a store now: the card
+// adds, and the card body opens details in a slide-over rather than
+// navigating. Two variants:
+//
+//   rich    — the default. Logo tile on a brand gradient, name, category
+//             kicker, two-line description on a vertical brand wash.
+//   compact — sports. League descriptions are boilerplate ("Live NFL
+//             scores…"), so a shelf of 14 rich cards is 14 restatements
+//             of the same sentence. Logo + name + add button, 4-across.
 
 interface CatalogCardProps {
   item: CatalogItem;
-  enabled: boolean;
-  /** Open the widget's info page — the card's single affordance. */
-  onInfo: (item: CatalogItem) => void;
+  added: boolean;
+  variant?: "rich" | "compact";
+  /** Open the detail panel. The card body is the hit target. */
+  onOpen: (item: CatalogItem) => void;
+  /**
+   * Add without leaving the page. Omitted when the item is already
+   * added; at slot capacity the caller passes a handler that opens the
+   * panel instead, where the upgrade path is explained.
+   */
+  onAdd?: (item: CatalogItem) => void;
+}
+
+// ── Logo tile ───────────────────────────────────────────────────
+
+function LogoTile({
+  item,
+  size,
+  radius,
+}: {
+  item: CatalogItem;
+  size: number;
+  radius: string;
+}) {
+  const [logoFailed, setLogoFailed] = useState(false);
+  const Icon = item.icon;
+
+  if (item.logoUrl && !logoFailed) {
+    return (
+      <img
+        src={item.logoUrl}
+        alt=""
+        loading="lazy"
+        className={clsx(
+          "shrink-0 object-contain",
+          radius,
+          // Transparent/dark marks (UFC) need a light tile or they
+          // disappear flush against a dark card.
+          item.logoLight && "bg-white p-1",
+        )}
+        style={{ width: size, height: size }}
+        onError={() => setLogoFailed(true)}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={clsx(
+        "flex shrink-0 items-center justify-center text-white",
+        radius,
+      )}
+      style={{
+        width: size,
+        height: size,
+        background: `linear-gradient(135deg, ${item.hex} 0%, ${item.hex}b8 100%)`,
+      }}
+    >
+      <Icon size={Math.round(size * 0.55)} />
+    </div>
+  );
+}
+
+// ── Add / added control ─────────────────────────────────────────
+
+function AddControl({
+  item,
+  added,
+  onAdd,
+}: {
+  item: CatalogItem;
+  added: boolean;
+  onAdd?: (item: CatalogItem) => void;
+}) {
+  if (added) {
+    return (
+      <span
+        aria-label={`${item.name} added`}
+        className="flex size-[26px] shrink-0 items-center justify-center rounded-[7px] bg-accent/14 text-accent"
+      >
+        <Check size={13} strokeWidth={3} />
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      // Named, not "Add to ticker": a screen reader running the shelf
+      // otherwise hears the same three words fourteen times.
+      aria-label={`Add ${item.name}`}
+      onClick={(e) => {
+        // The card body opens the panel; without this, adding would
+        // also open it.
+        e.stopPropagation();
+        onAdd?.(item);
+      }}
+      className="flex size-[26px] shrink-0 cursor-pointer items-center justify-center rounded-[7px] border border-edge/70 bg-transparent text-accent hover:border-accent/50 hover:bg-accent/10"
+    >
+      <Plus size={13} strokeWidth={2.5} />
+    </button>
+  );
 }
 
 // ── Component ───────────────────────────────────────────────────
 
-export default function CatalogCard({ item, enabled, onInfo }: CatalogCardProps) {
-  const [logoFailed, setLogoFailed] = useState(false);
-  const Icon = item.icon;
+export default function CatalogCard({
+  item,
+  added,
+  variant = "rich",
+  onOpen,
+  onAdd,
+}: CatalogCardProps) {
+  const shared = {
+    role: "button" as const,
+    tabIndex: 0,
+    "aria-label": `More about ${item.name}`,
+    onClick: () => onOpen(item),
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onOpen(item);
+      }
+    },
+  };
+
+  if (variant === "compact") {
+    return (
+      <div
+        {...shared}
+        className="group/card flex cursor-pointer items-center gap-2.5 rounded-[10px] border border-edge/55 bg-surface-raised px-2.5 py-2 hover:border-edge focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+      >
+        <LogoTile item={item} size={30} radius="rounded-[7px]" />
+        <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-fg">
+          {item.name}
+        </span>
+        <AddControl item={item} added={added} onAdd={onAdd} />
+      </div>
+    );
+  }
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      aria-label={`More about ${item.name}`}
-      onClick={() => onInfo(item)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onInfo(item);
-        }
-      }}
-      className={clsx(
-        "group/card relative flex flex-col overflow-hidden rounded-xl border border-edge/40 bg-base-150/30 p-4 cursor-pointer",
-        "hover:shadow-soft-sm hover:border-edge/60 hover:bg-base-150/50",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50",
-        // Added cards de-emphasized so new content stays prominent.
-        enabled && "opacity-80 hover:opacity-100",
-      )}
+      {...shared}
+      className="group/card relative flex cursor-pointer flex-col overflow-hidden rounded-xl border border-edge/55 bg-surface-raised p-3.5 hover:border-edge hover:shadow-soft-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
     >
-      {/* Brand wash — a single vertical fade of the widget's color across the
-          whole card, so there's no seam where a header band would end. */}
+      {/* Vertical brand wash — a single fade so there's no seam where a
+          header band would end. */}
       <div
-        className="pointer-events-none absolute inset-x-0 top-0 h-24"
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
         style={{
-          background: `linear-gradient(to bottom, ${item.hex}30 0%, ${item.hex}0a 45%, transparent 100%)`,
+          background: `linear-gradient(to bottom, ${item.hex}26, transparent 55%)`,
         }}
       />
 
-      {/* Content */}
       <div className="relative flex flex-1 flex-col">
-        <div className="flex items-center gap-3">
-          {item.logoUrl && !logoFailed ? (
-            <img
-              src={item.logoUrl}
-              alt=""
-              loading="lazy"
-              className={clsx(
-                "w-10 h-10 rounded-lg object-contain shrink-0",
-                // Transparent/dark marks (UFC) need a light tile or they
-                // disappear flush on a dark card.
-                item.logoLight && "bg-white p-1",
-              )}
-              onError={() => setLogoFailed(true)}
-            />
-          ) : (
-            // App-icon tile — same treatment as the sidebar's SourceGlyph
-            // fallback, so brandless widgets read as distinct logos here
-            // too (white glyph on a gradient of the brand hex).
-            <div
-              className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 text-white"
-              style={{
-                background: `linear-gradient(135deg, ${item.hex} 0%, ${item.hex}b8 100%)`,
-              }}
-            >
-              <Icon size={22} />
-            </div>
-          )}
+        <div className="flex items-start gap-3">
+          <LogoTile item={item} size={34} radius="rounded-lg" />
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-1.5">
-              <span className="text-ui-body font-semibold truncate">{item.name}</span>
-              {enabled && (
-                <span className="flex items-center gap-0.5 text-ui-chip font-medium text-success shrink-0">
-                  <Check size={10} />
-                  Added
-                </span>
-              )}
+            <div className="truncate text-ui-body font-semibold text-fg">
+              {item.name}
             </div>
-            <span className="text-ui-chip font-semibold uppercase tracking-wide text-fg-4">
+            <div className="text-ui-chip font-semibold tracking-wide text-fg-4 uppercase">
               {CATEGORY_LABELS[item.category]}
-            </span>
+            </div>
           </div>
+          <AddControl item={item} added={added} onAdd={onAdd} />
         </div>
 
-        {/* Reserve exactly two lines (leading-relaxed = 1.625 → 3.25em) so
-            1- and 2-line descriptions occupy the same height and cards stay
-            uniform. */}
-        <p className="mt-2.5 text-ui-meta leading-relaxed line-clamp-2 h-[3.25em]">
+        {/* Two reserved lines so 1- and 2-line descriptions leave cards
+            the same height across a shelf. */}
+        <p className="mt-2.5 line-clamp-2 min-h-9 text-ui-meta leading-relaxed text-fg-3">
           {item.description}
         </p>
-      </div>
-
-      {/* "Learn more" affordance — a quiet hint, not a button; the card
-          itself is the hit target. */}
-      <div className="pointer-events-none absolute bottom-3 right-3 flex items-center gap-0.5 text-ui-chip font-medium text-fg-4 opacity-0 group-hover/card:opacity-100">
-        View
-        <ChevronRight size={11} />
       </div>
     </div>
   );

--- a/desktop/src/components/marketplace/CatalogCard.tsx
+++ b/desktop/src/components/marketplace/CatalogCard.tsx
@@ -147,13 +147,28 @@ export default function CatalogCard({
     return (
       <div
         {...shared}
-        className="group/card flex cursor-pointer items-center gap-2.5 rounded-[10px] border border-edge/55 bg-surface-raised px-2.5 py-2 hover:border-edge focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+        className="group/card relative flex cursor-pointer items-center gap-2.5 overflow-hidden rounded-[10px] border border-edge/55 bg-surface-raised px-2.5 py-2 hover:border-edge focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
       >
-        <LogoTile item={item} size={30} radius="rounded-[7px]" />
-        <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-fg">
-          {item.name}
-        </span>
-        <AddControl item={item} added={added} onAdd={onAdd} />
+        {/* Horizontal brand wash. Without it these tiles are bare
+            surface-raised, which in a dark palette is a few percent off
+            the panel behind them — the row reads as floating labels with
+            no card under them. The rich variant gets its separation from
+            a vertical wash; compact needs the same help, just along its
+            own axis. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background: `linear-gradient(to right, ${item.hex}26, transparent 70%)`,
+          }}
+        />
+        <div className="relative flex w-full items-center gap-2.5">
+          <LogoTile item={item} size={30} radius="rounded-[7px]" />
+          <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-fg">
+            {item.name}
+          </span>
+          <AddControl item={item} added={added} onAdd={onAdd} />
+        </div>
       </div>
     );
   }

--- a/desktop/src/components/marketplace/WidgetPanel.tsx
+++ b/desktop/src/components/marketplace/WidgetPanel.tsx
@@ -60,7 +60,11 @@ function TickerPreview({ hex }: { hex: string }) {
   const chips = [...widths, ...widths];
   return (
     <div className="relative overflow-hidden rounded-[10px] border border-edge/60 bg-surface-raised py-2">
-      <div className="flex w-max gap-2 motion-safe:animate-[chipdrift_14s_linear_infinite]">
+      <div
+        data-motion="marquee"
+        style={{ "--marquee-duration": "14s" } as React.CSSProperties}
+        className="flex w-max gap-2"
+      >
         {chips.map((w, i) => (
           <div
             key={i}

--- a/desktop/src/components/marketplace/WidgetPanel.tsx
+++ b/desktop/src/components/marketplace/WidgetPanel.tsx
@@ -1,0 +1,393 @@
+/**
+ * WidgetPanel — the catalog's slide-over detail view.
+ *
+ * Replaces navigating to /widget/$id/info from the catalog: browsing and
+ * deciding are the same task, and a full page change threw away your
+ * scroll position in a shelf you were halfway through. The route still
+ * exists for deep links (sidebar menu, related-widget URLs); it now
+ * redirects here.
+ *
+ * Focus handling copies ConfirmDialog rather than the two hand-rolled
+ * role="dialog" overlays elsewhere in the app: a native <dialog> +
+ * showModal() gives a real focus trap and inertness for free, and
+ * onCancel + preventDefault routes Esc through our own close handler so
+ * the URL stays in step. The scrim is our own motion.div — the UA
+ * backdrop is made transparent — so it can animate with the panel.
+ *
+ * Panel state lives in the `?widget=` search param, so it deep-links,
+ * survives reload, and puts Back where a user expects it.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { Check, ChevronRight, Plus, Trash2, X } from "lucide-react";
+import clsx from "clsx";
+
+import type { CatalogItem } from "../../marketplace";
+import { CATEGORY_LABELS, readableTextOn } from "../../marketplace";
+import { slideOverMotion, backdropMotion } from "../../lib/motion";
+
+// ── Props ───────────────────────────────────────────────────────
+
+interface WidgetPanelProps {
+  item: CatalogItem | null;
+  added: boolean;
+  /** Tier too low for this widget — offer an upgrade, not an add. */
+  tierLocked: boolean;
+  /** Slots full and this one isn't added — same. */
+  slotLocked: boolean;
+  authenticated: boolean;
+  /** Same category, this widget excluded, capped by the caller. */
+  related: CatalogItem[];
+  onClose: () => void;
+  onAdd: (item: CatalogItem) => void;
+  onRemove: (item: CatalogItem) => void;
+  onOpenWidget: (item: CatalogItem) => void;
+  onSignIn: () => void;
+  onUpgrade: () => void;
+  /** Swap the panel in place when a related widget is picked. */
+  onPick: (item: CatalogItem) => void;
+}
+
+// ── Ticker preview ──────────────────────────────────────────────
+//
+// Suggestive, not literal: the real chips need live data this surface
+// does not have. A drifting row of brand-tinted placeholders answers the
+// question the hero raises — "what does this look like once it's on?" —
+// without pretending to quote a price.
+
+function TickerPreview({ hex }: { hex: string }) {
+  const widths = [86, 64, 104, 72, 92, 58];
+  const chips = [...widths, ...widths];
+  return (
+    <div className="relative overflow-hidden rounded-[10px] border border-edge/60 bg-surface-raised py-2">
+      <div className="flex w-max gap-2 motion-safe:animate-[chipdrift_14s_linear_infinite]">
+        {chips.map((w, i) => (
+          <div
+            key={i}
+            className="flex h-[26px] shrink-0 items-center gap-1.5 rounded-md border px-2.5"
+            style={{
+              width: w,
+              borderColor: `${hex}3d`,
+              background: `${hex}10`,
+            }}
+          >
+            <span
+              className="size-1.5 shrink-0 rounded-full"
+              style={{ background: hex }}
+            />
+            <span
+              className="h-[5px] flex-1 rounded-[3px] opacity-35"
+              style={{ background: hex }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Small pieces ────────────────────────────────────────────────
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="mb-2 font-mono text-ui-section text-fg-4">{children}</h3>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[10px] border border-edge/55 bg-surface-raised px-3 py-2.5">
+      <div className="mb-0.5 font-mono text-ui-section text-fg-4">{label}</div>
+      <div className="text-ui-meta font-semibold text-fg">{value}</div>
+    </div>
+  );
+}
+
+// ── Component ───────────────────────────────────────────────────
+
+export default function WidgetPanel({
+  item,
+  added,
+  tierLocked,
+  slotLocked,
+  authenticated,
+  related,
+  onClose,
+  onAdd,
+  onRemove,
+  onOpenWidget,
+  onSignIn,
+  onUpgrade,
+  onPick,
+}: WidgetPanelProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const restoreRef = useRef<HTMLElement | null>(null);
+  const [logoFailed, setLogoFailed] = useState(false);
+  const open = item !== null;
+
+  useEffect(() => {
+    if (!open) return;
+    restoreRef.current = document.activeElement as HTMLElement | null;
+    dialogRef.current?.showModal();
+  }, [open]);
+
+  // A new widget in the same panel is a new logo; without this the
+  // previous item's failure would suppress the next one's image.
+  useEffect(() => setLogoFailed(false), [item?.id]);
+
+  const textOn = useMemo(
+    () => (item ? readableTextOn(item.hex) : "#fff"),
+    [item],
+  );
+
+  return (
+    <AnimatePresence onExitComplete={() => restoreRef.current?.focus()}>
+      {open && item && (
+        <motion.dialog
+          ref={dialogRef}
+          aria-label={`${item.name} details`}
+          onCancel={(e) => {
+            e.preventDefault();
+            onClose();
+          }}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          className="fixed inset-0 z-[90] m-0 h-full max-h-none w-full max-w-none border-0 bg-transparent p-0 backdrop:bg-transparent"
+        >
+          <motion.div
+            variants={backdropMotion}
+            onClick={onClose}
+            className="absolute inset-0 bg-fg/25"
+          />
+
+          <motion.aside
+            variants={slideOverMotion}
+            className="absolute inset-y-0 right-0 flex w-full max-w-[400px] flex-col overflow-hidden border-l border-edge/70 bg-surface shadow-soft-md"
+          >
+            <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin">
+              {/* ── Brand hero ────────────────────────────────── */}
+              <div
+                className="relative overflow-hidden p-5"
+                style={{
+                  background: `linear-gradient(135deg, ${item.hex} 0%, ${item.hex}d8 100%)`,
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={onClose}
+                  aria-label="Close"
+                  className="absolute top-3 right-3 flex size-[26px] cursor-pointer items-center justify-center rounded-[7px] bg-white/25"
+                  style={{ color: textOn }}
+                >
+                  <X size={13} strokeWidth={2.5} />
+                </button>
+
+                <div className="flex items-center gap-3">
+                  {/* Colour rides on the wrapper: the catalog's IconProps
+                      has no `style`, so the glyph takes currentColor. */}
+                  <span
+                    className="flex size-13 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white shadow-soft-sm"
+                    style={{ color: item.hex }}
+                  >
+                    {item.logoUrl && !logoFailed ? (
+                      <img
+                        src={item.logoUrl}
+                        alt=""
+                        className="size-13 object-contain p-1.5"
+                        onError={() => setLogoFailed(true)}
+                      />
+                    ) : (
+                      <item.icon size={26} />
+                    )}
+                  </span>
+                  <span className="flex min-w-0 flex-col">
+                    <span
+                      className="font-mono text-ui-section opacity-75"
+                      style={{ color: textOn }}
+                    >
+                      {CATEGORY_LABELS[item.category]}
+                    </span>
+                    <span
+                      className="text-[20px] leading-tight font-extrabold"
+                      style={{ color: textOn }}
+                    >
+                      {item.name}
+                    </span>
+                  </span>
+                </div>
+
+                <p
+                  className="mt-3 mb-3.5 text-[12.5px] leading-relaxed opacity-90"
+                  style={{ color: textOn }}
+                >
+                  {item.description}
+                </p>
+
+                <div className="flex flex-wrap items-center gap-2.5">
+                  {added ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => onOpenWidget(item)}
+                        className="inline-flex cursor-pointer items-center gap-1.5 rounded-[9px] bg-white px-4 py-2 text-[12.5px] font-bold shadow-soft-sm"
+                        style={{ color: item.hex }}
+                      >
+                        Open <ChevronRight size={13} strokeWidth={2.5} />
+                      </button>
+                      <span
+                        className="inline-flex items-center gap-1.5 rounded-full bg-white/22 px-2.5 py-1 text-ui-chip font-bold"
+                        style={{ color: textOn }}
+                      >
+                        <Check size={11} strokeWidth={3} /> Added
+                      </span>
+                    </>
+                  ) : !authenticated ? (
+                    <button
+                      type="button"
+                      onClick={onSignIn}
+                      className="inline-flex cursor-pointer items-center gap-1.5 rounded-[9px] bg-white px-4 py-2 text-[12.5px] font-bold shadow-soft-sm"
+                      style={{ color: item.hex }}
+                    >
+                      Sign in to add
+                    </button>
+                  ) : tierLocked || slotLocked ? (
+                    <button
+                      type="button"
+                      onClick={onUpgrade}
+                      className="inline-flex cursor-pointer items-center gap-1.5 rounded-[9px] bg-white px-4 py-2 text-[12.5px] font-bold text-warn shadow-soft-sm"
+                    >
+                      {tierLocked
+                        ? `Upgrade to ${item.requiredTier.replace(/_/g, " ")}`
+                        : "Upgrade for more slots"}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => onAdd(item)}
+                      className="inline-flex cursor-pointer items-center gap-1.5 rounded-[9px] bg-white px-4 py-2 text-[12.5px] font-bold shadow-soft-sm"
+                      style={{ color: item.hex }}
+                    >
+                      <Plus size={13} strokeWidth={2.5} /> Add {item.name}
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* ── Ticker preview ────────────────────────────── */}
+              <div className="px-5 pt-4">
+                <SectionLabel>In your ticker</SectionLabel>
+                <TickerPreview hex={item.hex} />
+              </div>
+
+              {/* ── Facts ─────────────────────────────────────── */}
+              <div className="grid grid-cols-2 gap-2 px-5 pt-3.5">
+                <Fact label="Slot cost" value="1 slot · unlimited items" />
+                <Fact
+                  label="Plan"
+                  value={
+                    item.requiredTier === "free"
+                      ? "Every plan"
+                      : item.requiredTier.replace(/_/g, " ")
+                  }
+                />
+              </div>
+
+              {/* ── About ─────────────────────────────────────── */}
+              {item.info.about && (
+                <div className="px-5 pt-4">
+                  <SectionLabel>About</SectionLabel>
+                  <p className="text-[12.5px] leading-relaxed text-fg-2">
+                    {item.info.about}
+                  </p>
+                </div>
+              )}
+
+              {/* ── How to use it ─────────────────────────────── */}
+              {(item.info.usage?.length ?? 0) > 0 && (
+                <div className="px-5 pt-4">
+                  <SectionLabel>How to use it</SectionLabel>
+                  <div className="flex flex-col gap-1.5">
+                    {(item.info.usage ?? []).map((step, i) => (
+                      <div
+                        key={i}
+                        className="flex items-start gap-2.5 rounded-[10px] border border-edge/50 bg-surface-raised px-3 py-2.5"
+                      >
+                        <span
+                          className="flex size-5 shrink-0 items-center justify-center rounded-full text-ui-chip font-bold"
+                          style={{
+                            background: `${item.hex}1f`,
+                            color: item.hex,
+                          }}
+                        >
+                          {i + 1}
+                        </span>
+                        <span className="text-ui-meta leading-relaxed text-fg-2">
+                          {step}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* ── Remove ────────────────────────────────────── */}
+              {added && (
+                <div className="mx-5 mt-4 flex items-center justify-between gap-2.5 rounded-[10px] border border-edge/50 bg-surface-raised px-3 py-2.5">
+                  <span className="text-ui-meta text-fg-4">
+                    Removing frees the slot instantly.
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onRemove(item)}
+                    className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-[7px] bg-error/8 px-2.5 py-1.5 text-ui-chip font-semibold text-error hover:bg-error/15"
+                  >
+                    <Trash2 size={11} /> Remove
+                  </button>
+                </div>
+              )}
+
+              {/* ── More like this ────────────────────────────── */}
+              {related.length > 0 && (
+                <div className="px-5 pt-4.5 pb-5">
+                  <SectionLabel>More like this</SectionLabel>
+                  <div className="flex flex-col gap-1.5">
+                    {related.map((rel) => (
+                      <button
+                        key={rel.id}
+                        type="button"
+                        onClick={() => onPick(rel)}
+                        className={clsx(
+                          "flex w-full cursor-pointer items-center gap-2.5 rounded-[10px] border border-edge/50 bg-surface-raised px-3 py-2 text-left",
+                          "hover:border-edge",
+                        )}
+                      >
+                        <span
+                          className="flex size-[26px] shrink-0 items-center justify-center overflow-hidden rounded-[7px] text-white"
+                          style={{
+                            background: `linear-gradient(135deg, ${rel.hex} 0%, ${rel.hex}b8 100%)`,
+                          }}
+                        >
+                          <rel.icon size={14} />
+                        </span>
+                        <span className="flex min-w-0 flex-1 flex-col">
+                          <span className="truncate text-ui-meta font-semibold text-fg">
+                            {rel.name}
+                          </span>
+                          <span className="font-mono text-ui-section text-fg-4">
+                            {CATEGORY_LABELS[rel.category]}
+                          </span>
+                        </span>
+                        <ChevronRight size={12} className="shrink-0 text-fg-4" />
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </motion.aside>
+        </motion.dialog>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/desktop/src/datawidgets/finance/FeedTab.tsx
+++ b/desktop/src/datawidgets/finance/FeedTab.tsx
@@ -54,7 +54,7 @@ import {
 import type { Trade, FeedTabProps, DataWidgetManifest } from "../../types";
 import type { WidgetId } from "../../api/client";
 import { assetClassForWidget } from "../../marketplace";
-import { FinanceHomeRows } from "./home";
+import { FinanceHomeRows, financeHighlight } from "./home";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
@@ -77,6 +77,7 @@ export const financeDataWidget: DataWidgetManifest = {
   },
   FeedTab: FinanceFeedTab,
   HomeRows: FinanceHomeRows,
+  highlight: financeHighlight,
 };
 
 // ── Types ────────────────────────────────────────────────────────

--- a/desktop/src/datawidgets/finance/home.tsx
+++ b/desktop/src/datawidgets/finance/home.tsx
@@ -4,7 +4,7 @@
  */
 import clsx from "clsx";
 import { HOME_PREVIEW_MAX, HomeEmptyRow } from "../home";
-import type { HomeRowsProps, Trade } from "../../types";
+import type { HomeRowsProps, Trade, HomeHighlight } from "../../types";
 
 export function FinanceHomeRows({ data, onConfigure }: HomeRowsProps) {
   const trades = data as Trade[];
@@ -57,4 +57,34 @@ export function FinanceHomeRows({ data, onConfigure }: HomeRowsProps) {
       })}
     </>
   );
+}
+
+/**
+ * Happening now — the biggest absolute mover.
+ *
+ * Same ordering the rows below already use, so the hero and the list
+ * agree about what mattered. Absolute, not signed: a 4% drop is as much
+ * news as a 4% climb, and showing only winners would be a kind of lie.
+ */
+export function financeHighlight(data: unknown[]): HomeHighlight | null {
+  const trades = data as Trade[];
+  if (trades.length === 0) return null;
+
+  const top = [...trades].sort(
+    (a, b) =>
+      Math.abs(Number(b.percentage_change ?? 0)) -
+      Math.abs(Number(a.percentage_change ?? 0)),
+  )[0];
+  if (!top?.symbol) return null;
+
+  const pct = Number(top.percentage_change ?? 0);
+  if (!Number.isFinite(pct) || pct === 0) return null;
+
+  const price = Number(top.price);
+  return {
+    headline: `${top.symbol} ${pct > 0 ? "+" : ""}${pct.toFixed(1)}% today`,
+    sub: Number.isFinite(price)
+      ? `${price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} · top mover in your watchlist`
+      : "top mover in your watchlist",
+  };
 }

--- a/desktop/src/datawidgets/sports/FeedTab.tsx
+++ b/desktop/src/datawidgets/sports/FeedTab.tsx
@@ -35,7 +35,7 @@ import { SelectMenu } from "../../components/widget-bar/SelectMenu";
 import { latestTimestamp } from "../feedHooks";
 import type { FeedTabProps, DataWidgetManifest } from "../../types";
 import type { FavoriteTeam } from "../../hooks/useSportsConfig";
-import { SportsHomeRows } from "./home";
+import { SportsHomeRows, sportsHighlight } from "./home";
 
 // ── DataWidgetRow manifest ─────────────────────────────────────────────
 
@@ -58,6 +58,7 @@ export const sportsDataWidget: DataWidgetManifest = {
   },
   FeedTab: SportsFeedTab,
   HomeRows: SportsHomeRows,
+  highlight: sportsHighlight,
 };
 
 // ── Types ────────────────────────────────────────────────────────

--- a/desktop/src/datawidgets/sports/home.tsx
+++ b/desktop/src/datawidgets/sports/home.tsx
@@ -9,7 +9,7 @@
 import SportsEmptyState from "./EmptyState";
 import { HOME_PREVIEW_MAX } from "../home";
 import type { LeagueMeta } from "../../api/queries";
-import type { HomeRowsProps, Game } from "../../types";
+import type { HomeRowsProps, Game, HomeHighlight } from "../../types";
 
 export function SportsHomeRows({
   data,
@@ -81,4 +81,37 @@ export function SportsHomeRows({
       })}
     </>
   );
+}
+
+/**
+ * Happening now — the first genuinely live game.
+ *
+ * "in" is the only state worth interrupting for: a final already
+ * happened and an upcoming game has nothing to report yet. Returning
+ * null on a quiet slate is the point — Home shows the hero row only
+ * when there is something in it, rather than padding it with a
+ * scheduled fixture and calling that news.
+ */
+export function sportsHighlight(data: unknown[]): HomeHighlight | null {
+  const games = data as Game[];
+  const live = games.find((g) => g.state === "in");
+  if (!live) return null;
+
+  const away = live.away_team_name || live.away_team_code || "";
+  const home = live.home_team_name || live.home_team_code || "";
+  if (!away || !home) return null;
+
+  const headline =
+    live.away_team_score != null && live.home_team_score != null
+      ? `${away} ${live.away_team_score} – ${live.home_team_score} ${home}`
+      : `${away} v ${home}`;
+
+  return {
+    headline,
+    // Straight from the feed — `short_detail` is the game clock ("71'",
+    // "2nd 04:12"), with the status strings as fallbacks. Never phrased
+    // by us.
+    sub: live.short_detail || live.status_long || live.status_short || "Live",
+    live: true,
+  };
 }

--- a/desktop/src/lib/motion.ts
+++ b/desktop/src/lib/motion.ts
@@ -46,6 +46,32 @@ export const overlaySurfaceMotion: Variants = {
   },
 };
 
+/**
+ * Right-edge slide-over (the catalog's widget panel).
+ *
+ * Distinct from overlaySurfaceMotion, which rises and scales because it
+ * describes a centered modal appearing in place. A panel anchored to an
+ * edge should read as coming *from* that edge, so this translates on X
+ * only — scaling a full-height panel warps its border against the one
+ * it is sliding over.
+ */
+export const slideOverMotion: Variants = {
+  hidden: { opacity: 0, transform: "translateX(24px)" },
+  visible: {
+    opacity: 1,
+    transform: "translateX(0px)",
+    transition: {
+      opacity: { duration: 0.2, ease: appEase },
+      transform: { type: "spring", bounce: 0, visualDuration: 0.34 },
+    },
+  },
+  exit: {
+    opacity: 0,
+    transform: "translateX(16px)",
+    transition: { duration: 0.16, ease: appEase },
+  },
+};
+
 export const popoverMotion: Variants = {
   hidden: {
     opacity: 0,

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -74,7 +74,7 @@ export const Route = createFileRoute("/catalog")({
 // set up before they show you something.
 
 const SPOTLIGHT: { id: string; tagline: string }[] = [
-  { id: "finance_stocks", tagline: "Zero setup — instant quotes" },
+  { id: "finance_stocks", tagline: "Instant quotes" },
   { id: "predictions", tagline: "Read the room" },
   { id: "clock", tagline: "Always on time" },
 ];

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -1,299 +1,504 @@
-import { useState, useMemo } from "react";
+/**
+ * Catalog — browse and act.
+ *
+ * Was a browse-only grid split into "Your widgets" / "Discover", with
+ * every transaction one navigation away on the widget's info page. It's
+ * a store now: cards add in place, and details open in a slide-over so
+ * you keep your place in the shelf you were reading.
+ *
+ * Browsing All shows one shelf per category in canonical order, which
+ * beats Your/Discover for the thing people actually do here — look for a
+ * kind of thing. Filtering or searching collapses to a single section,
+ * and the "In your ticker" strip (which subsumed both the old Your
+ * section and the slot banner) hides, because at that point you are
+ * shopping, not auditing.
+ */
+import { useCallback, useMemo, useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import {
-  ArrowDownAZ,
-  Boxes,
-  Gamepad2,
-  Layers,
-  LayoutGrid,
-  LineChart,
-  Rss,
-  Search,
-  Sparkles,
-  TrendingUp,
-  Trophy,
-} from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { Check, Plus, Search } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
 import clsx from "clsx";
 
-import { getCatalogItems, CATEGORY_LABELS, canonicalOrder } from "../marketplace";
-import type { WidgetCategory, CatalogItem } from "../marketplace";
+import {
+  CATEGORY_LABELS,
+  canonicalOrder,
+  getCatalogItems,
+  readableTextOn,
+} from "../marketplace";
+import type { CatalogItem, WidgetCategory } from "../marketplace";
 import { dashboardQueryOptions } from "../api/queries";
 import { useShell, useShellData } from "../shell-context";
 import { useCatalog } from "../hooks/useCatalog";
-import {
-  SlotPills,
-  slotHeadline,
-  slotSubline,
-  useSlotUsage,
-} from "../components/SlotMeter";
+import { useAddWidget } from "../hooks/useAddWidget";
+import { useRemoveWidget } from "../hooks/useRemoveWidget";
+import { getMaxWidgets, tierMeets } from "../tierLimits";
+import { SlotPills, useSlotUsage } from "../components/SlotMeter";
 import CatalogCard from "../components/marketplace/CatalogCard";
+import WidgetPanel from "../components/marketplace/WidgetPanel";
 import QueryErrorBanner from "../components/QueryErrorBanner";
 import RouteError from "../components/RouteError";
 import PageLayout from "../components/layout/PageLayout";
-import PageSection from "../components/layout/PageSection";
+import EmptySection from "../components/layout/EmptySection";
 import { WidgetBar } from "../components/widget-bar/Bar";
 import { Segmented } from "../components/widget-bar/Segmented";
-import { SelectMenu } from "../components/widget-bar/SelectMenu";
-import EmptySection from "../components/layout/EmptySection";
 
+// ── Route ───────────────────────────────────────────────────────
+
+type FilterTab = "all" | WidgetCategory;
+
+const CATEGORY_ORDER: WidgetCategory[] = [
+  "sports",
+  "finance",
+  "news",
+  "fantasy",
+  "predictions",
+  "utility",
+];
 
 export const Route = createFileRoute("/catalog")({
   component: CatalogPage,
   errorComponent: RouteError,
+  // The open panel is a search param so it deep-links, survives reload,
+  // and gives Back somewhere sensible to go.
+  validateSearch: (search: Record<string, unknown>): { widget?: string } =>
+    typeof search.widget === "string" && search.widget
+      ? { widget: search.widget }
+      : {},
 });
 
-// ── Category filter options ─────────────────────────────────────
+// ── Spotlight ───────────────────────────────────────────────────
+//
+// Editorial, so it is hardcoded rather than derived: the point is a
+// human saying "start here", and all three are zero-config — nothing to
+// set up before they show you something.
 
-type FilterTab = "all" | WidgetCategory;
-
-const CATEGORY_ICONS: Record<WidgetCategory, LucideIcon> = {
-  sports: Trophy,
-  finance: TrendingUp,
-  news: Rss,
-  fantasy: Gamepad2,
-  predictions: LineChart,
-  utility: Boxes,
-};
-
-const FILTER_TABS: { key: FilterTab; label: string; icon: LucideIcon; hint: string }[] = [
-  { key: "all", label: "All", icon: LayoutGrid, hint: "Show every widget" },
-  ...(
-    ["sports", "finance", "news", "fantasy", "predictions", "utility"] as WidgetCategory[]
-  ).map((c) => ({
-    key: c,
-    label: CATEGORY_LABELS[c],
-    icon: CATEGORY_ICONS[c],
-    hint: `Show ${CATEGORY_LABELS[c]} widgets`,
-  })),
+const SPOTLIGHT: { id: string; tagline: string }[] = [
+  { id: "finance_stocks", tagline: "Zero setup — instant quotes" },
+  { id: "predictions", tagline: "Read the room" },
+  { id: "clock", tagline: "Always on time" },
 ];
 
-// ── Sort modes (v1.1.1 round 3): the "Your widgets"/"Discover" split
-//    replaced the old enabled-first sort, so sorting is now an explicit
-//    header control applied within each section. ──────────────────
-
-type SortMode = "featured" | "az";
-
-const SORT_OPTIONS: { key: SortMode; label: string; icon: LucideIcon }[] = [
-  { key: "featured", label: "Featured", icon: Sparkles },
-  { key: "az", label: "A–Z", icon: ArrowDownAZ },
-];
-
-function orderItems(items: CatalogItem[], sort: SortMode): CatalogItem[] {
-  if (sort === "az") return [...items].sort((a, b) => a.name.localeCompare(b.name));
-  // Resolved once per call rather than once per comparison.
-  const order = canonicalOrder();
-  return [...items].sort((a, b) => order.indexOf(a.id) - order.indexOf(b.id));
-}
-
-// ── Page component ──────────────────────────────────────────────
+// ── Page ────────────────────────────────────────────────────────
 
 function CatalogPage() {
   const navigate = useNavigate();
-  const { prefs } = useShell();
+  const { widget: openId } = Route.useSearch();
+  const { prefs, authenticated, tier, onLogin } = useShell();
   const { widgets } = useShellData();
   const { error: dashboardError } = useQuery(dashboardQueryOptions());
 
   const [filter, setFilter] = useState<FilterTab>("all");
-  const [sort, setSort] = useState<SortMode>("featured");
+  const [query, setQuery] = useState("");
 
-  // The Library is the one surface whose entire content IS the catalog, and
-  // it was the one surface not subscribed to it: an empty dep array pinned
-  // `allItems` to whatever the bundled snapshot held at mount, so a refresh
-  // swapped the catalog underneath and this never re-read it. The version
-  // string changes exactly when the catalog does.
+  const addWidget = useAddWidget();
+  const removeWidget = useRemoveWidget();
+
+  // The catalog is the one surface whose entire content IS the catalog,
+  // so it subscribes: a refresh must swap the shelves underneath it.
   const catalogVersion = useCatalog();
   const allItems = useMemo(() => getCatalogItems(), [catalogVersion]);
 
-  const enabledDataWidgetIds = useMemo(
-    () => new Set(widgets.map((ch) => ch.widget_type)),
-    [widgets],
-  );
-  const enabledWidgetIds = useMemo(
-    () => new Set(prefs.widgets.enabledWidgets),
-    [prefs.widgets.enabledWidgets],
-  );
-  const allEnabledIds = useMemo(
-    () => new Set([...enabledDataWidgetIds, ...enabledWidgetIds]),
-    [enabledDataWidgetIds, enabledWidgetIds],
+  // Deliberately two different sets. "Added" counts every row so a
+  // disabled widget still reads as added and can't be added twice; the
+  // slot meter counts enabled rows only, matching the server's gate.
+  const addedIds = useMemo(
+    () =>
+      new Set([
+        ...widgets.map((w) => w.widget_type),
+        ...prefs.widgets.enabledWidgets,
+      ]),
+    [widgets, prefs.widgets.enabledWidgets],
   );
 
-  // Widget/slot model: slot math + meter live in SlotMeter.tsx, shared
-  // with the Account page so the two surfaces can't drift (v1.1.2). At
-  // capacity, the catalog locks *new* adds (already-added items stay
-  // interactive).
   const slots = useSlotUsage();
+  const browsing = filter === "all" && query.trim() === "";
 
-  // Filter → split into "yours" vs "discover" → sort within each.
-  const { yourItems, discoverItems } = useMemo(() => {
-    const filtered =
-      filter === "all"
-        ? allItems
-        : allItems.filter((item) => item.category === filter);
-    return {
-      yourItems: orderItems(
-        filtered.filter((item) => allEnabledIds.has(item.id)),
-        sort,
-      ),
-      discoverItems: orderItems(
-        filtered.filter((item) => !allEnabledIds.has(item.id)),
-        sort,
-      ),
+  // ── Selection ─────────────────────────────────────────────────
+
+  const openItem = useMemo(
+    () => allItems.find((i) => i.id === openId) ?? null,
+    [allItems, openId],
+  );
+
+  const setOpen = useCallback(
+    (item: CatalogItem | null) => {
+      void navigate({
+        to: "/catalog",
+        search: item ? { widget: item.id } : {},
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
+  const maxSlots = getMaxWidgets(tier);
+  const capped = slots.finite && slots.used >= maxSlots;
+
+  const lockedFor = useCallback(
+    (item: CatalogItem) => {
+      const added = addedIds.has(item.id);
+      const tierLocked =
+        authenticated &&
+        item.requiredTier !== "free" &&
+        !tierMeets(tier, item.requiredTier);
+      return {
+        added,
+        tierLocked,
+        slotLocked: capped && !added && !tierLocked,
+      };
+    },
+    [addedIds, authenticated, tier, capped],
+  );
+
+  // At capacity (or gated) the + opens the panel instead of adding —
+  // the panel is where the upgrade path is explained.
+  const handleAdd = useCallback(
+    (item: CatalogItem) => {
+      const { tierLocked, slotLocked } = lockedFor(item);
+      if (!authenticated || tierLocked || slotLocked) {
+        setOpen(item);
+        return;
+      }
+      void addWidget(item);
+    },
+    [addWidget, authenticated, lockedFor, setOpen],
+  );
+
+  // ── Shelves ───────────────────────────────────────────────────
+
+  const matches = useCallback(
+    (item: CatalogItem) => {
+      const q = query.trim().toLowerCase();
+      if (!q) return true;
+      return `${item.name} ${item.description} ${CATEGORY_LABELS[item.category]}`
+        .toLowerCase()
+        .includes(q);
+    },
+    [query],
+  );
+
+  const shelves = useMemo(() => {
+    const order = canonicalOrder();
+    const rank = (i: CatalogItem) => {
+      const at = order.indexOf(i.id);
+      return at === -1 ? Number.MAX_SAFE_INTEGER : at;
     };
-  }, [allItems, filter, sort, allEnabledIds]);
+    const pool = allItems
+      .filter((i) => (filter === "all" ? true : i.category === filter))
+      .filter(matches)
+      .sort((a, b) => rank(a) - rank(b));
 
-  const cardFor = (item: CatalogItem) => (
-    <div key={item.id}>
+    if (browsing) {
+      return CATEGORY_ORDER.map((cat) => ({
+        key: cat as string,
+        title: CATEGORY_LABELS[cat],
+        items: pool.filter((i) => i.category === cat),
+      })).filter((s) => s.items.length > 0);
+    }
+    return [
+      {
+        key: "results",
+        title: filter === "all" ? "Results" : CATEGORY_LABELS[filter],
+        items: pool,
+      },
+    ].filter((s) => s.items.length > 0);
+  }, [allItems, filter, matches, browsing]);
+
+  const spotlight = useMemo(
+    () =>
+      browsing
+        ? SPOTLIGHT.map((s) => ({
+            ...s,
+            item: allItems.find((i) => i.id === s.id),
+          })).filter((s): s is typeof s & { item: CatalogItem } =>
+            Boolean(s.item),
+          )
+        : [],
+    [allItems, browsing],
+  );
+
+  const yourItems = useMemo(
+    () => allItems.filter((i) => addedIds.has(i.id)),
+    [allItems, addedIds],
+  );
+
+  const related = useMemo(() => {
+    if (!openItem) return [];
+    return allItems
+      .filter((i) => i.category === openItem.category && i.id !== openItem.id)
+      .slice(0, 3);
+  }, [allItems, openItem]);
+
+  const cardFor = (item: CatalogItem, variant: "rich" | "compact") => {
+    const { added } = lockedFor(item);
+    return (
       <CatalogCard
+        key={item.id}
         item={item}
-        enabled={allEnabledIds.has(item.id)}
-        onInfo={(it) =>
-          navigate({ to: "/widget/$id/info", params: { id: it.id } })
-        }
+        added={added}
+        variant={variant}
+        onOpen={setOpen}
+        onAdd={added ? undefined : handleAdd}
       />
-    </div>
-  );
+    );
+  };
 
-  const countChip = (n: number) => (
-    <span className="rounded-full bg-base-150 px-2 py-0.5 text-ui-chip font-semibold text-fg-3">
-      {n}
-    </span>
-  );
-
-  // ── Render ──────────────────────────────────────────────────
-  //
-  // Catalog uses an in-page tab band (category filters) in the TopBar,
-  // then a content header owning the slot budget + sort control, then
-  // two sections: what you have, and what you could add (v1.1.1 r3).
+  const gating = openItem
+    ? lockedFor(openItem)
+    : { added: false, tierLocked: false, slotLocked: false };
 
   return (
-    <PageLayout title="Catalog" width="wide" noTopPadding>
-      {/* WCB — same persistent chrome as every source page. Category
-          filter (ex-TopBar tab strip) left, sort (ex-slot-band group)
-          right, per the bar grammar. */}
+    <PageLayout
+      // While the panel is open the page IS that widget, so the title
+      // takes its name and "Catalog" steps back to being the parent —
+      // otherwise the breadcrumb reads "Catalog / Catalog".
+      title={openItem ? openItem.name : "Catalog"}
+      width="wide"
+      noTopPadding
+      parentLabel={openItem ? "Catalog" : undefined}
+      onParentClick={openItem ? () => setOpen(null) : undefined}
+    >
       <WidgetBar>
         <Segmented
           ariaLabel="Filter by category"
           value={filter}
-          onChange={(k) => setFilter(k)}
-          options={FILTER_TABS.map((t) => ({ value: t.key, label: t.label }))}
+          // Picking a category clears the query: the pill and a stale
+          // search term otherwise compose into a result set that looks
+          // like the pill is broken.
+          onChange={(k) => {
+            setFilter(k);
+            setQuery("");
+          }}
+          options={[
+            { value: "all" as FilterTab, label: "All" },
+            ...CATEGORY_ORDER.map((c) => ({
+              value: c as FilterTab,
+              label: CATEGORY_LABELS[c],
+            })),
+          ]}
         />
-        <div className="ml-auto">
-          <SelectMenu
-            ariaLabel="Sort widgets"
-            prefix="Sort"
-            value={sort}
-            onChange={setSort}
-            options={SORT_OPTIONS.map((s) => ({ value: s.key, label: s.label }))}
+        <div className="relative ml-auto w-[220px]">
+          <Search
+            size={13}
+            aria-hidden
+            className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-fg-4"
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Search widgets"
+            placeholder="Search widgets"
+            autoComplete="off"
+            className="w-full rounded-[7px] border border-edge/80 bg-surface-raised py-1.5 pr-2.5 pl-7 text-ui-meta text-fg placeholder:text-fg-4 focus:border-accent/50 focus:outline-none"
           />
         </div>
       </WidgetBar>
-      {/* mt-4 on the first band(s) = the pt-4 gap every WCB page keeps
-          under the bar (adjacent margins collapse, so both carrying it
-          is safe whichever renders first). */}
+
       {dashboardError && (
-        <div className="mt-4 mb-5">
+        <div className="mt-4">
           <QueryErrorBanner error={dashboardError} />
         </div>
       )}
 
-      {/* ── Catalog header: slot budget + sort (v1.1.1 round 3).
-          The counter lives HERE now — cards never nag, and the old
-          at-capacity banner folded into this band (warn tint +
-          Upgrade button when full). ── */}
-      <div
-        className={clsx(
-          "mt-4 mb-5 flex flex-wrap items-center justify-between gap-x-4 gap-y-3 rounded-xl border px-4 py-3",
-          slots.atCapacity && slots.finite
-            ? "border-warn/25 bg-warn/[0.06]"
-            : "border-edge/40 bg-base-150/30",
-        )}
-      >
-        <div className="flex items-center gap-3">
-          <span
-            className={clsx(
-              "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-              slots.atCapacity && slots.finite
-                ? "bg-warn/15 text-warn"
-                : "bg-accent/10 text-accent",
-            )}
-          >
-            <Layers size={16} />
-          </span>
-          <div>
-            <div className="flex items-center gap-2.5">
-              <span className="text-ui-body font-semibold text-fg-1">
-                {slotHeadline(slots)}
-              </span>
-              {/* Slot meter — one pill per slot, filled as used. */}
-              <SlotPills usage={slots} />
+      <div className="mx-auto w-full max-w-[1000px] pt-4 pb-8">
+        {/* ── In your ticker ─────────────────────────────────── */}
+        {browsing && yourItems.length > 0 && (
+          <section className="mb-5 flex flex-col gap-2.5 rounded-xl border border-edge/50 bg-base-150/45 px-3.5 py-3">
+            <div className="flex flex-wrap items-center gap-2.5">
+              <h2 className="font-mono text-ui-section text-fg-3">
+                In your ticker
+              </h2>
+              <div className="ml-auto flex items-center gap-2.5">
+                <SlotPills usage={slots} />
+                <span className="text-ui-chip text-fg-4">
+                  {slots.finite
+                    ? `${slots.used} of ${slots.max} slots free`
+                    : `${slots.used} added · unlimited slots`}
+                </span>
+                {capped && (
+                  <button
+                    type="button"
+                    onClick={() => void open("https://myscrollr.com/uplink")}
+                    className="shrink-0 cursor-pointer rounded-lg bg-warn/15 px-2.5 py-1 text-ui-chip font-semibold text-warn hover:bg-warn/25"
+                  >
+                    Upgrade
+                  </button>
+                )}
+              </div>
             </div>
-            <div className="text-ui-chip text-fg-4">{slotSubline(slots)}</div>
-          </div>
-        </div>
+            <div className="flex flex-wrap gap-2">
+              {yourItems.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => setOpen(item)}
+                  className="flex cursor-pointer items-center gap-2 rounded-lg border border-edge/55 bg-surface-raised px-2.5 py-1.5 hover:border-edge"
+                >
+                  <span
+                    className="flex size-[18px] shrink-0 items-center justify-center rounded text-white"
+                    style={{
+                      background: `linear-gradient(135deg, ${item.hex} 0%, ${item.hex}b8 100%)`,
+                    }}
+                  >
+                    <item.icon size={10} />
+                  </span>
+                  <span className="text-ui-meta font-medium text-fg">
+                    {item.name}
+                  </span>
+                  <Check size={11} strokeWidth={3} className="text-accent" />
+                </button>
+              ))}
+              {/* Ghost chips make an abstract number concrete: three
+                  empty outlines read as "room for three more" faster
+                  than "3 of 6 slots free" does. */}
+              {slots.finite &&
+                Array.from({ length: Math.max(0, slots.max - slots.used) }).map(
+                  (_, i) => (
+                    <span
+                      key={`empty-${i}`}
+                      className="flex items-center gap-2 rounded-lg border border-dashed border-edge/70 px-2.5 py-1.5 text-ui-meta text-fg-4"
+                    >
+                      empty slot
+                    </span>
+                  ),
+                )}
+            </div>
+          </section>
+        )}
 
-        <div className="flex items-center gap-2">
-          {slots.atCapacity && slots.finite && (
-            <button
-              onClick={() => void open("https://myscrollr.com/uplink")}
-              className="shrink-0 rounded-lg bg-warn/15 px-3 py-1.5 text-ui-chip font-semibold text-warn hover:bg-warn/25"
-            >
-              Upgrade
-            </button>
-          )}
-          {/* Sort control moved to the WCB (bar grammar: config
-              selects live in the bar's right cluster). */}
-        </div>
-      </div>
+        {/* ── Spotlight ──────────────────────────────────────── */}
+        {spotlight.length > 0 && (
+          <section className="mb-6">
+            <h2 className="mb-2 font-mono text-ui-section text-fg-3">
+              Spotlight
+            </h2>
+            <div className="grid grid-cols-3 gap-3">
+              {spotlight.map(({ item, tagline }) => {
+                const textOn = readableTextOn(item.hex);
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => setOpen(item)}
+                    className="flex cursor-pointer flex-col items-start gap-2.5 rounded-xl p-3.5 text-left"
+                    style={{
+                      background: `linear-gradient(135deg, ${item.hex} 0%, ${item.hex}d8 100%)`,
+                    }}
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <span
+                        className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white"
+                        style={{ color: item.hex }}
+                      >
+                        <item.icon size={18} />
+                      </span>
+                      <span className="flex min-w-0 flex-col">
+                        <span
+                          className="text-ui-body font-bold"
+                          style={{ color: textOn }}
+                        >
+                          {item.name}
+                        </span>
+                        <span
+                          className="font-mono text-ui-section opacity-80"
+                          style={{ color: textOn }}
+                        >
+                          {tagline}
+                        </span>
+                      </span>
+                    </div>
+                    <p
+                      className="text-ui-meta leading-relaxed opacity-90"
+                      style={{ color: textOn }}
+                    >
+                      {item.description}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        )}
 
-      <div>
-        {yourItems.length === 0 && discoverItems.length === 0 ? (
+        {/* ── Shelves ────────────────────────────────────────── */}
+        {shelves.length === 0 ? (
           <EmptySection
             icon={Search}
-            title="Nothing here"
-            description="No items match this filter. Try a different category."
+            title="Nothing matches"
+            description="Try a different word, or pick another category."
           />
         ) : (
-          <>
-            {/* ── Your widgets ── */}
-            {yourItems.length > 0 && (
-              <PageSection
-                variant="grid"
-                title="Your widgets"
-                badge={countChip(yourItems.length)}
+          shelves.map((shelf) => (
+            <section key={shelf.key} className="mb-6 last:mb-0">
+              <div className="mb-2 flex items-center gap-2">
+                <h2 className="font-mono text-ui-section text-fg-3">
+                  {shelf.title}
+                </h2>
+                <span className="rounded-full bg-base-150 px-2 py-0.5 text-ui-chip font-semibold text-fg-3">
+                  {shelf.items.length}
+                </span>
+              </div>
+              {/* Sports go compact: league descriptions are boilerplate,
+                  so 14 rich cards would be 14 restatements of one
+                  sentence. */}
+              <div
+                className={clsx(
+                  "grid gap-2.5",
+                  shelf.key === "sports" ? "grid-cols-4" : "grid-cols-3 gap-3",
+                )}
               >
-                <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-                  {yourItems.map(cardFor)}
-                </div>
-              </PageSection>
-            )}
+                {shelf.items.map((item) =>
+                  cardFor(item, shelf.key === "sports" ? "compact" : "rich"),
+                )}
+              </div>
+            </section>
+          ))
+        )}
 
-            {/* ── Discover new widgets ── */}
-            <PageSection
-              variant="grid"
-              title="Discover new widgets"
-              badge={
-                discoverItems.length > 0 ? countChip(discoverItems.length) : undefined
-              }
+        {/* ── Request a widget ───────────────────────────────── */}
+        {browsing && (
+          <section className="mt-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dashed border-edge/70 px-4 py-3.5">
+            <div>
+              <div className="text-ui-body font-semibold text-fg">
+                Don't see what you want?
+              </div>
+              <div className="text-ui-meta text-fg-4">
+                Tell us what you'd put in your ticker.
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void navigate({ to: "/support" })}
+              className="shrink-0 cursor-pointer rounded-[7px] border border-edge/80 px-3 py-1.5 text-ui-chip font-medium text-fg-3 hover:border-edge hover:text-fg"
             >
-              {discoverItems.length > 0 ? (
-                <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-                  {discoverItems.map(cardFor)}
-                </div>
-              ) : (
-                <EmptySection
-                  compact
-                  icon={Sparkles}
-                  title="You've added everything here"
-                  description="Check another category for more widgets."
-                />
-              )}
-            </PageSection>
-          </>
+              Request a widget
+            </button>
+          </section>
         )}
       </div>
+
+      <WidgetPanel
+        item={openItem}
+        added={gating.added}
+        tierLocked={gating.tierLocked}
+        slotLocked={gating.slotLocked}
+        authenticated={authenticated}
+        related={related}
+        onClose={() => setOpen(null)}
+        onAdd={(item) => void addWidget(item)}
+        onRemove={(item) => {
+          void removeWidget(item);
+          setOpen(null);
+        }}
+        onOpenWidget={(item) => {
+          void navigate({ to: "/widget/$id", params: { id: item.id } });
+        }}
+        onSignIn={onLogin}
+        onUpgrade={() => void open("https://myscrollr.com/uplink")}
+        onPick={setOpen}
+      />
     </PageLayout>
   );
 }

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -313,7 +313,7 @@ function HomePage() {
         {highlights.length > 0 && (
           <section className="mb-4">
             <div className="mb-2 flex items-center gap-1.5">
-              <span className="size-1.5 rounded-full bg-error motion-safe:animate-pulse" />
+              <span data-motion="pulse" className="size-1.5 rounded-full bg-error" />
               <h2 className="font-mono text-ui-section text-fg-3">
                 Happening now
               </h2>

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -1,28 +1,45 @@
 /**
- * Home route — live status dashboard.
+ * Home — the briefing.
  *
- * Shows a glanceable overview of live data from each active widget,
- * plus a compact widget status strip. Discovery and add/remove happen
- * in the Catalog (/catalog), not here.
+ * Was a flat, equal-weight list: one preview section per widget, each
+ * the same size, in catalog order. That treats "Inter Miami are level in
+ * the 71st" and "the clock says 3:36" as the same kind of fact.
+ *
+ * Now: a live mini-ticker, a greeting, a "Happening now" row for the few
+ * things worth interrupting for, then a bento grid that groups by source
+ * — Scores, Headlines, Markets, Fantasy, Kalshi, utility tiles.
+ *
+ * Four states fall out of the data rather than being modes: a busy slate
+ * fills the hero row, a quiet one drops it, unconfigured widgets keep
+ * their card but swap the body for one sentence and one CTA, and an
+ * empty account gets the welcome. Cards never disappear — a widget you
+ * added and haven't set up yet is still a widget you added.
  */
-import { useMemo, useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
-  ChevronRight,
+  Activity,
+  ArrowRight,
+  Newspaper,
   Plus,
-  Settings,
-  Sparkles,
+  TrendingUp,
+  Trophy,
 } from "lucide-react";
 import clsx from "clsx";
 import RouteError from "../components/RouteError";
-import { WidgetBar, BarPill } from "../components/widget-bar/Bar";
+import { WidgetBar } from "../components/widget-bar/Bar";
 import SectionNav from "../components/layout/SectionNav";
-import { FEED_CARD, FEED_CARD_INTERACTIVE } from "../components/feedCard";
 import PageLayout from "../components/layout/PageLayout";
-import EmptySection from "../components/layout/EmptySection";
 import { useShell, useShellData } from "../shell-context";
 import { useCatalog } from "../hooks/useCatalog";
-import { widgetManifest, sourceForWidget, canonicalOrder } from "../marketplace";
+import { useAddWidget } from "../hooks/useAddWidget";
+import {
+  widgetManifest,
+  sourceForWidget,
+  canonicalOrder,
+  getCatalogItems,
+  readableTextOn,
+} from "../marketplace";
 import { scopeSourceData } from "../utils/widgetScope";
 import { WIDGET_ORDER } from "../widgets/registry";
 import { getStore } from "../lib/store";
@@ -36,16 +53,841 @@ import {
   LS_WEATHER_UNIT,
   LS_SYSMON_DATA,
 } from "../constants";
+import HomeTicker from "../components/home/HomeTicker";
+import type { TickerChip } from "../components/home/HomeTicker";
 import {
-  formatEffectiveWidgetTickerStatus,
-  getEffectiveWidgetTickerStatus,
-} from "../utils/tickerStatus";
+  Card,
+  ChangeChip,
+  EmptyBody,
+  LiveDot,
+  SetupBody,
+} from "../components/home/briefing";
+import type { CatalogItem } from "../marketplace";
 import type { DataWidgetRow } from "../api/client";
-import type { DataWidgetManifest, WidgetManifest } from "../types";
+import type {
+  DataWidgetManifest,
+  Game,
+  HomeHighlight,
+  Trade,
+  WidgetManifest,
+} from "../types";
 import type { TempUnit } from "../preferences";
 import type { SystemInfo } from "../hooks/useSysmonData";
 import type { TimerState } from "../widgets/timer/types";
 import type { SavedCity } from "../widgets/weather/types";
+
+export const Route = createFileRoute("/feed")({
+  component: HomePage,
+  errorComponent: RouteError,
+});
+
+// ── Resolved widget ─────────────────────────────────────────────
+
+interface Resolved {
+  row: DataWidgetRow;
+  manifest: DataWidgetManifest;
+  /** Normalized, then scoped to this widget's own config. */
+  data: unknown[];
+}
+
+function greeting(d: Date): string {
+  const h = d.getHours();
+  if (h < 12) return "morning";
+  if (h < 18) return "afternoon";
+  return "evening";
+}
+
+// ── Page ────────────────────────────────────────────────────────
+
+function HomePage() {
+  const navigate = useNavigate();
+  const shell = useShell();
+  const { widgets, dashboard } = useShellData();
+  const catalogVersion = useCatalog();
+  const addWidget = useAddWidget();
+  const { allWidgets, authenticated, onLogin } = shell;
+  const enabledWidgets = shell.prefs.widgets.enabledWidgets;
+
+  const openWidget = useCallback(
+    (id: string) => void navigate({ to: "/widget/$id", params: { id } }),
+    [navigate],
+  );
+  const openTickerSettings = useCallback(
+    () => void navigate({ to: "/customize", search: { page: "ticker" } }),
+    [navigate],
+  );
+
+  // canonicalOrder() stays INSIDE the memo with catalogVersion in the
+  // deps — hoisting it to module scope pins the order to whatever the
+  // bundled snapshot held at import, so a server-added widget sorts by a
+  // stale index.
+  const resolved = useMemo<Resolved[]>(() => {
+    const order = canonicalOrder();
+    return widgets
+      .filter((r) => r.enabled)
+      .map((row) => {
+        const manifest = widgetManifest(row.widget_type) as
+          | DataWidgetManifest
+          | undefined;
+        if (!manifest) return null;
+        const source = sourceForWidget(row.widget_type);
+        const raw = source
+          ? ((dashboard?.data as Record<string, unknown> | undefined)?.[
+              source
+            ] ?? [])
+          : [];
+        const flat = manifest.normalizeHome
+          ? manifest.normalizeHome(raw)
+          : Array.isArray(raw)
+            ? raw
+            : [];
+        return {
+          row,
+          manifest,
+          data: scopeSourceData(source ?? "", flat, row.config ?? undefined),
+        };
+      })
+      .filter((x): x is Resolved => x !== null)
+      .sort(
+        (a, b) =>
+          order.indexOf(a.row.widget_type) - order.indexOf(b.row.widget_type),
+      );
+  }, [widgets, dashboard, catalogVersion]);
+
+  const utilities = useMemo(
+    () =>
+      WIDGET_ORDER.map((id) =>
+        enabledWidgets.includes(id)
+          ? (allWidgets.find((w) => w.id === id) ?? null)
+          : null,
+      ).filter(Boolean) as WidgetManifest[],
+    [enabledWidgets, allWidgets],
+  );
+
+  const bySource = useCallback(
+    (s: string) => resolved.filter((r) => sourceForWidget(r.row.widget_type) === s),
+    [resolved],
+  );
+
+  const sports = bySource("sports");
+  const finance = bySource("finance");
+  const rss = bySource("rss");
+  const fantasy = bySource("fantasy");
+  const predictions = bySource("predictions");
+
+  const hasAnything = resolved.length > 0 || utilities.length > 0;
+
+  // ── Happening now ─────────────────────────────────────────────
+  //
+  // Ask each source, keep the top three. Priority is fixed — live sport
+  // outranks a market move, which outranks everything else — because
+  // "most important" is not something a source can rank across sources.
+  const highlights = useMemo(() => {
+    const out: (HomeHighlight & { id: string; name: string; hex: string })[] = [];
+    const collect = (list: Resolved[]) => {
+      for (const r of list) {
+        const h = r.manifest.highlight?.(r.data);
+        if (h) {
+          out.push({
+            ...h,
+            id: r.row.widget_type,
+            name: r.manifest.name,
+            hex: h.hex ?? r.manifest.hex,
+          });
+        }
+      }
+    };
+    collect(sports);
+    collect(finance);
+    collect([...rss, ...fantasy, ...predictions]);
+    return out.slice(0, 3);
+  }, [sports, finance, rss, fantasy, predictions]);
+
+  // ── Ticker chips ──────────────────────────────────────────────
+  const chips = useMemo<TickerChip[]>(() => {
+    const out: TickerChip[] = [];
+    for (const r of sports) {
+      const g = (r.data as Game[])[0];
+      if (g)
+        out.push({
+          id: r.row.widget_type,
+          hex: r.manifest.hex,
+          text: `${g.away_team_code || g.away_team_name} ${g.away_team_score}–${g.home_team_score} ${g.home_team_code || g.home_team_name}`,
+        });
+    }
+    for (const r of finance) {
+      const t = (r.data as Trade[])[0];
+      if (t)
+        out.push({
+          id: r.row.widget_type,
+          hex: r.manifest.hex,
+          text: `${t.symbol} ${Number(t.percentage_change ?? 0) >= 0 ? "+" : ""}${Number(t.percentage_change ?? 0).toFixed(1)}%`,
+        });
+    }
+    for (const r of rss) {
+      const item = (r.data as { title?: string }[])[0];
+      if (item?.title)
+        out.push({
+          id: r.row.widget_type,
+          hex: r.manifest.hex,
+          text: item.title.slice(0, 42),
+        });
+    }
+    for (const u of utilities) {
+      const v = getWidgetValue(u.id);
+      if (v) out.push({ id: u.id, hex: u.hex, text: v });
+    }
+    return out;
+  }, [sports, finance, rss, utilities]);
+
+  // A widget that returned no rows AND owns a config is unconfigured —
+  // distinct from a zero-config source that simply has nothing on right
+  // now. Sports/news/predictions never appear here.
+  const needsSetup = useMemo(
+    () =>
+      [...finance, ...fantasy].filter((r) => r.data.length === 0),
+    [finance, fantasy],
+  );
+
+  // ── First run ─────────────────────────────────────────────────
+  if (!hasAnything) {
+    return (
+      <PageLayout title="Home" width="wide" noTopPadding>
+        <WidgetBar>
+          <SectionNav active="home" />
+        </WidgetBar>
+        <FirstRun
+          authenticated={authenticated}
+          onLogin={onLogin}
+          onAdd={(id) => {
+            const item = getCatalogItems().find((i) => i.id === id);
+            if (item) void addWidget(item);
+          }}
+          onBrowse={() => void navigate({ to: "/catalog" })}
+        />
+      </PageLayout>
+    );
+  }
+
+  const now = new Date();
+  const name = shell.prefs.widgets ? undefined : undefined;
+
+  return (
+    <PageLayout title="Home" width="wide" noTopPadding>
+      <WidgetBar>
+        <HomeTicker
+          chips={chips}
+          onManage={openTickerSettings}
+          onOpen={openWidget}
+        />
+      </WidgetBar>
+
+      <div className="mx-auto w-full max-w-[1100px] pt-4 pb-8">
+        {/* ── Greeting ─────────────────────────────────────── */}
+        <header className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+          <h1 className="text-[19px] leading-tight font-extrabold text-fg">
+            Good {greeting(now)}
+          </h1>
+          <span className="text-ui-meta text-fg-4">
+            {now.toLocaleDateString(undefined, {
+              weekday: "long",
+              month: "long",
+              day: "numeric",
+            })}
+          </span>
+        </header>
+
+        {/* ── Needs setup ──────────────────────────────────── */}
+        {needsSetup.length > 0 && (
+          <div className="mb-4 rounded-xl border border-warn/25 bg-warn/[0.06] px-3.5 py-2.5 text-ui-meta text-fg-2">
+            {needsSetup.length} widget{needsSetup.length === 1 ? "" : "s"} need
+            {needsSetup.length === 1 ? "s" : ""} a quick setup —{" "}
+            <span className="font-semibold">
+              {needsSetup.map((r) => r.manifest.name).join(", ")}
+            </span>{" "}
+            — they'll start scrolling the moment you configure them.
+          </div>
+        )}
+
+        {/* ── Happening now ────────────────────────────────── */}
+        {highlights.length > 0 && (
+          <section className="mb-4">
+            <div className="mb-2 flex items-center gap-1.5">
+              <span className="size-1.5 rounded-full bg-error motion-safe:animate-pulse" />
+              <h2 className="font-mono text-ui-section text-fg-3">
+                Happening now
+              </h2>
+            </div>
+            <div
+              className={clsx(
+                "grid gap-3",
+                highlights.length === 1
+                  ? "grid-cols-1"
+                  : highlights.length === 2
+                    ? "grid-cols-2"
+                    : "grid-cols-3",
+              )}
+            >
+              {highlights.map((h) => {
+                const textOn = readableTextOn(h.hex);
+                return (
+                  <button
+                    key={h.id}
+                    type="button"
+                    onClick={() => openWidget(h.id)}
+                    className="flex cursor-pointer flex-col items-start gap-1.5 rounded-xl p-3.5 text-left"
+                    style={{
+                      background: `linear-gradient(135deg, ${h.hex} 0%, ${h.hex}d8 100%)`,
+                    }}
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <span
+                        className="font-mono text-ui-section opacity-80"
+                        style={{ color: textOn }}
+                      >
+                        {h.name}
+                      </span>
+                      {h.live && <LiveDot />}
+                    </span>
+                    <span
+                      className="text-[16px] leading-tight font-extrabold tabular-nums"
+                      style={{ color: textOn }}
+                    >
+                      {h.headline}
+                    </span>
+                    <span
+                      className="text-ui-meta opacity-90"
+                      style={{ color: textOn }}
+                    >
+                      {h.sub}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* ── Bento ────────────────────────────────────────── */}
+        <BentoGrid
+          sports={sports}
+          finance={finance}
+          rss={rss}
+          fantasy={fantasy}
+          predictions={predictions}
+          utilities={utilities}
+          openWidget={openWidget}
+        />
+      </div>
+    </PageLayout>
+  );
+}
+
+// ── Bento ───────────────────────────────────────────────────────
+//
+// 3fr / 2fr. Sections render only for widgets you actually added, and
+// the grid collapses to one column when only one side has content —
+// an empty right rail would read as something failing to load.
+
+function BentoGrid({
+  sports,
+  finance,
+  rss,
+  fantasy,
+  predictions,
+  utilities,
+  openWidget,
+}: {
+  sports: Resolved[];
+  finance: Resolved[];
+  rss: Resolved[];
+  fantasy: Resolved[];
+  predictions: Resolved[];
+  utilities: WidgetManifest[];
+  openWidget: (id: string) => void;
+}) {
+  const left = sports.length > 0 || rss.length > 0 || utilities.length > 0;
+  const right =
+    finance.length > 0 || fantasy.length > 0 || predictions.length > 0;
+
+  return (
+    <div
+      className={clsx(
+        "grid items-start gap-3.5",
+        left && right ? "grid-cols-[3fr_2fr]" : "grid-cols-1",
+      )}
+    >
+      {left && (
+        <div className="flex flex-col gap-3.5">
+          {sports.length > 0 && (
+            <ScoresCard items={sports} openWidget={openWidget} />
+          )}
+          {rss.length > 0 && (
+            <HeadlinesCard items={rss} openWidget={openWidget} />
+          )}
+          {utilities.length > 0 && (
+            <UtilityTiles items={utilities} openWidget={openWidget} />
+          )}
+        </div>
+      )}
+      {right && (
+        <div className="flex flex-col gap-3.5">
+          {finance.length > 0 && (
+            <MarketsCard items={finance} openWidget={openWidget} />
+          )}
+          {fantasy.length > 0 && (
+            <FantasyCard items={fantasy} openWidget={openWidget} />
+          )}
+          {predictions.length > 0 && (
+            <KalshiCard items={predictions} openWidget={openWidget} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Scores ──────────────────────────────────────────────────────
+
+function ScoresCard({
+  items,
+  openWidget,
+}: {
+  items: Resolved[];
+  openWidget: (id: string) => void;
+}) {
+  // Merged for reading, but each row still knows which widget owns it.
+  const rows = items
+    .flatMap((r) =>
+      (r.data as Game[]).map((g) => ({ g, id: r.row.widget_type, tag: r.manifest.tabLabel })),
+    )
+    .sort((a, b) => {
+      const p: Record<string, number> = { in: 0, pre: 1, final: 2 };
+      return (p[a.g.state ?? ""] ?? 3) - (p[b.g.state ?? ""] ?? 3);
+    })
+    .slice(0, 5);
+
+  return (
+    <Card
+      title="Scores"
+      icon={<Trophy size={14} />}
+      chips={items.map((r) => ({
+        id: r.row.widget_type,
+        label: r.manifest.tabLabel,
+        onClick: () => openWidget(r.row.widget_type),
+      }))}
+    >
+      {rows.length === 0 ? (
+        <EmptyBody>No games right now.</EmptyBody>
+      ) : (
+        rows.map(({ g, id, tag }, i) => (
+          <button
+            key={`${id}-${i}`}
+            type="button"
+            onClick={() => openWidget(id)}
+            className="flex w-full cursor-pointer items-center gap-3 border-t border-fg/7 px-3.5 py-2.5 first:border-t-0 hover:bg-surface-hover/40"
+          >
+            <span className="w-9 shrink-0 font-mono text-ui-chip text-fg-4">
+              {tag}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-left text-ui-meta text-fg">
+              {g.away_team_name || g.away_team_code}{" "}
+              <span className="font-semibold tabular-nums">
+                {g.away_team_score} – {g.home_team_score}
+              </span>{" "}
+              {g.home_team_name || g.home_team_code}
+            </span>
+            {g.state === "in" ? (
+              <span className="shrink-0 font-mono text-ui-chip font-bold text-error">
+                {g.short_detail || "LIVE"}
+              </span>
+            ) : (
+              <span className="shrink-0 text-ui-chip text-fg-4">
+                {g.short_detail || g.status_short}
+              </span>
+            )}
+          </button>
+        ))
+      )}
+    </Card>
+  );
+}
+
+// ── Headlines ───────────────────────────────────────────────────
+
+function HeadlinesCard({
+  items,
+  openWidget,
+}: {
+  items: Resolved[];
+  openWidget: (id: string) => void;
+}) {
+  const rows = items
+    .flatMap((r) =>
+      (r.data as { title?: string; published?: string }[]).map((a) => ({
+        a,
+        id: r.row.widget_type,
+        src: r.manifest.tabLabel,
+        hex: r.manifest.hex,
+      })),
+    )
+    .slice(0, 4);
+
+  return (
+    <Card
+      title="Headlines"
+      icon={<Newspaper size={14} />}
+      chips={items.map((r) => ({
+        id: r.row.widget_type,
+        label: r.manifest.tabLabel,
+        onClick: () => openWidget(r.row.widget_type),
+      }))}
+    >
+      {rows.length === 0 ? (
+        <EmptyBody>No headlines yet.</EmptyBody>
+      ) : (
+        rows.map(({ a, id, src, hex }, i) => (
+          <button
+            key={`${id}-${i}`}
+            type="button"
+            onClick={() => openWidget(id)}
+            className="flex w-full cursor-pointer items-center gap-2.5 border-t border-fg/7 px-3.5 py-2.5 first:border-t-0 hover:bg-surface-hover/40"
+          >
+            <span
+              className="size-1.5 shrink-0 rounded-full"
+              style={{ background: hex }}
+            />
+            <span className="min-w-0 flex-1 truncate text-left text-ui-meta text-fg">
+              {a.title}
+            </span>
+            <span className="shrink-0 text-ui-chip text-fg-4">{src}</span>
+          </button>
+        ))
+      )}
+    </Card>
+  );
+}
+
+// ── Markets ─────────────────────────────────────────────────────
+
+function MarketsCard({
+  items,
+  openWidget,
+}: {
+  items: Resolved[];
+  openWidget: (id: string) => void;
+}) {
+  const rows = items
+    .flatMap((r) =>
+      (r.data as Trade[]).map((t) => ({ t, id: r.row.widget_type })),
+    )
+    .sort(
+      (a, b) =>
+        Math.abs(Number(b.t.percentage_change ?? 0)) -
+        Math.abs(Number(a.t.percentage_change ?? 0)),
+    )
+    .slice(0, 6);
+
+  const unconfigured = rows.length === 0;
+
+  return (
+    <Card
+      title="Markets"
+      icon={<TrendingUp size={14} />}
+      footer={items.map((r) => (
+        <button
+          key={r.row.widget_type}
+          type="button"
+          onClick={() => openWidget(r.row.widget_type)}
+          className="flex cursor-pointer items-center gap-0.5 text-ui-chip font-medium text-fg-3 hover:text-fg"
+        >
+          {r.manifest.tabLabel} watchlist
+          <ArrowRight size={10} />
+        </button>
+      ))}
+    >
+      {unconfigured ? (
+        <SetupBody
+          message="Your watchlist is empty — add a few symbols and they'll start streaming."
+          cta="Add symbols"
+          onCta={() => openWidget(items[0].row.widget_type)}
+        />
+      ) : (
+        rows.map(({ t, id }, i) => (
+          <button
+            key={`${id}-${i}`}
+            type="button"
+            onClick={() => openWidget(id)}
+            className="flex w-full cursor-pointer items-center gap-3 border-t border-fg/7 px-3.5 py-2 first:border-t-0 hover:bg-surface-hover/40"
+          >
+            <span className="w-12 shrink-0 text-left font-mono text-ui-meta font-semibold text-fg">
+              {t.symbol}
+            </span>
+            {/* The design shows a company-name column, but Trade
+                carries only symbol/price/change — no name, and inventing
+                a lookup here would put a second source of truth for
+                ticker names in the Home route. The symbol does the
+                identifying work. */}
+            <span className="min-w-0 flex-1" />
+            <span className="shrink-0 text-ui-meta tabular-nums text-fg-2">
+              {Number(t.price).toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
+            </span>
+            <ChangeChip pct={Number(t.percentage_change ?? 0)} />
+          </button>
+        ))
+      )}
+    </Card>
+  );
+}
+
+// ── Fantasy ─────────────────────────────────────────────────────
+
+function FantasyCard({
+  items,
+  openWidget,
+}: {
+  items: Resolved[];
+  openWidget: (id: string) => void;
+}) {
+  const first = items[0];
+  const leagues = first.data as Record<string, unknown>[];
+
+  return (
+    <Card
+      title={first.manifest.name}
+      icon={<Activity size={14} />}
+      chips={[
+        {
+          id: first.row.widget_type,
+          label: "Open",
+          onClick: () => openWidget(first.row.widget_type),
+        },
+      ]}
+    >
+      {leagues.length === 0 ? (
+        <SetupBody
+          message="Connect your Yahoo account to follow your matchups here."
+          cta="Connect Yahoo"
+          tone="brand"
+          onCta={() => openWidget(first.row.widget_type)}
+        />
+      ) : (
+        leagues.slice(0, 2).map((l, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => openWidget(first.row.widget_type)}
+            className="flex w-full cursor-pointer flex-col gap-1 border-t border-fg/7 px-3.5 py-2.5 text-left first:border-t-0 hover:bg-surface-hover/40"
+          >
+            <span className="truncate text-ui-meta font-semibold text-fg">
+              {String(l.league_name ?? l.name ?? "League")}
+            </span>
+            <span className="font-mono text-ui-chip tabular-nums text-fg-3">
+              {String(l.my_score ?? l.team_points ?? "—")} –{" "}
+              {String(l.opp_score ?? l.opponent_points ?? "—")}
+            </span>
+          </button>
+        ))
+      )}
+    </Card>
+  );
+}
+
+// ── Kalshi ──────────────────────────────────────────────────────
+
+function KalshiCard({
+  items,
+  openWidget,
+}: {
+  items: Resolved[];
+  openWidget: (id: string) => void;
+}) {
+  const first = items[0];
+  const markets = (first.data as Record<string, unknown>[]).slice(0, 4);
+
+  return (
+    <Card
+      title={first.manifest.name}
+      icon={<Activity size={14} />}
+      chips={[
+        {
+          id: first.row.widget_type,
+          label: "Open",
+          onClick: () => openWidget(first.row.widget_type),
+        },
+      ]}
+    >
+      {markets.length === 0 ? (
+        <EmptyBody>No markets right now.</EmptyBody>
+      ) : (
+        markets.map((m, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => openWidget(first.row.widget_type)}
+            className="flex w-full cursor-pointer items-center gap-3 border-t border-fg/7 px-3.5 py-2.5 first:border-t-0 hover:bg-surface-hover/40"
+          >
+            <span className="min-w-0 flex-1 truncate text-left text-ui-meta text-fg">
+              {String(m.title ?? m.question ?? m.ticker ?? "")}
+            </span>
+            <span className="shrink-0 font-mono text-ui-meta font-semibold tabular-nums text-fg">
+              {m.yes_price != null ? `${Number(m.yes_price)}%` : "—"}
+            </span>
+          </button>
+        ))
+      )}
+    </Card>
+  );
+}
+
+// ── Utility tiles ───────────────────────────────────────────────
+
+function UtilityTiles({
+  items,
+  openWidget,
+}: {
+  items: WidgetManifest[];
+  openWidget: (id: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3.5">
+      {items.map((w) => {
+        const value = getWidgetValue(w.id);
+        // The six sentinel strings getWidgetValue returns when a widget
+        // has nothing configured. Turning them into a CTA keeps the tile
+        // in place rather than hiding a widget the user did add.
+        const unset =
+          value === "" ||
+          value === "No cities" ||
+          value === "No monitors" ||
+          value === "No repos" ||
+          value === "Waiting for data";
+        return (
+          <button
+            key={w.id}
+            type="button"
+            onClick={() => openWidget(w.id)}
+            className="flex cursor-pointer items-center gap-2.5 rounded-xl border border-edge/55 bg-surface-raised px-3.5 py-3 text-left hover:border-edge"
+          >
+            <span
+              className="flex size-8 shrink-0 items-center justify-center rounded-lg"
+              style={{ background: `${w.hex}1f`, color: w.hex }}
+            >
+              <w.icon size={15} />
+            </span>
+            <span className="flex min-w-0 flex-col">
+              <span className="truncate text-ui-chip text-fg-4">{w.name}</span>
+              <span
+                className={clsx(
+                  "truncate text-[14px] font-bold",
+                  unset ? "text-accent" : "text-fg",
+                )}
+              >
+                {unset ? "Set it up →" : value}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── First run ───────────────────────────────────────────────────
+
+const STARTERS: { id: string; blurb: string }[] = [
+  { id: "finance_stocks", blurb: "Live quotes, zero setup." },
+  { id: "predictions", blurb: "The news, in numbers." },
+  { id: "clock", blurb: "Local time and world clocks." },
+];
+
+function FirstRun({
+  authenticated,
+  onLogin,
+  onAdd,
+  onBrowse,
+}: {
+  authenticated: boolean;
+  onLogin: () => void;
+  onAdd: (id: string) => void;
+  onBrowse: () => void;
+}) {
+  // Narrow with a predicate rather than `!` at each use: the icon is a
+  // component, and a non-null assertion cannot appear in a JSX tag name.
+  const starters = STARTERS.map((s) => ({
+    ...s,
+    item: getCatalogItems().find((i) => i.id === s.id),
+  })).filter((s): s is typeof s & { item: CatalogItem } => Boolean(s.item));
+
+  return (
+    <div className="mx-auto flex w-full max-w-[620px] flex-col items-center px-6 py-14 text-center">
+      <span className="text-[34px] leading-none font-extrabold text-accent italic">
+        S
+      </span>
+      <h1 className="mt-3 text-[19px] font-extrabold text-fg">
+        Welcome to Scrollr
+      </h1>
+      <p className="mt-1.5 text-ui-meta text-fg-3">
+        Pick something to follow and it starts scrolling immediately.
+      </p>
+
+      {authenticated ? (
+        <>
+          <div className="mt-6 grid w-full grid-cols-3 gap-3">
+            {starters.map(({ id, blurb, item }) => {
+              const Icon = item.icon;
+              return (
+              <div
+                key={id}
+                className="flex flex-col items-start gap-2 rounded-xl border border-edge/55 bg-surface-raised p-3.5 text-left"
+              >
+                <span
+                  className="flex size-9 items-center justify-center rounded-lg text-white"
+                  style={{
+                    background: `linear-gradient(135deg, ${item.hex} 0%, ${item.hex}b8 100%)`,
+                  }}
+                >
+                  <Icon size={18} />
+                </span>
+                <span className="text-ui-body font-semibold text-fg">
+                  {item.name}
+                </span>
+                <span className="text-ui-chip text-fg-4">{blurb}</span>
+                <button
+                  type="button"
+                  onClick={() => onAdd(id)}
+                  aria-label={`Add ${item.name}`}
+                  className="mt-1 flex cursor-pointer items-center gap-1 rounded-[7px] bg-accent/12 px-2.5 py-1.5 text-ui-chip font-semibold text-accent hover:bg-accent/20"
+                >
+                  <Plus size={11} strokeWidth={2.5} /> Add
+                </button>
+              </div>
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            onClick={onBrowse}
+            className="mt-5 cursor-pointer rounded-lg bg-accent px-4 py-2 text-ui-meta font-semibold text-surface hover:bg-accent/90"
+          >
+            Browse the full Catalog
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={onLogin}
+          className="mt-6 cursor-pointer rounded-lg bg-accent px-4 py-2 text-ui-meta font-semibold text-surface hover:bg-accent/90"
+        >
+          Sign in to get started
+        </button>
+      )}
+    </div>
+  );
+}
 
 function formatTimerDuration(ms: number): string {
   const totalSecs = Math.floor(Math.max(0, ms) / 1000);
@@ -78,372 +920,6 @@ function getTimerValue(): string {
 }
 
 // ── Route ───────────────────────────────────────────────────────
-
-export const Route = createFileRoute("/feed")({
-  component: HomePage,
-  errorComponent: RouteError,
-});
-
-function HomePage() {
-  const navigate = useNavigate();
-  const shell = useShell();
-  const { widgets, dashboard } = useShellData();
-  // Sort order comes from the catalog, so the memo below must re-run when it
-  // changes — otherwise a server-added widget sorts by a stale index.
-  const catalogVersion = useCatalog();
-  const {
-    allDataWidgetManifests,
-    allWidgets,
-    authenticated,
-    onLogin,
-  } = shell;
-
-  const enabledWidgets = shell.prefs.widgets.enabledWidgets;
-
-
-  const openTickerSettings = useCallback(() => {
-    // Lands on the Ticker page, not the settings default — this pill is
-    // specifically "configure the ticker".
-    navigate({ to: "/customize", search: { page: "ticker" } });
-  }, [navigate]);
-
-  // Resolve each enabled widget row to a render manifest — the coarse source's
-  // FeedTab carrying the widget's own name/id — then order by the catalog's
-  // canonical order. Handles split widgets (sports_mlb, finance_stocks, …).
-  const orderedDataWidgets = useMemo(() => {
-    const items = widgets
-      .filter((c) => c.enabled)
-      .map((ch) => {
-        const manifest = widgetManifest(ch.widget_type) as
-          | DataWidgetManifest
-          | undefined;
-        return manifest ? { ch, manifest } : null;
-      })
-      .filter(
-        (x): x is { ch: DataWidgetRow; manifest: DataWidgetManifest } => x !== null,
-      );
-    const order = canonicalOrder();
-    return items.sort(
-      (a, b) =>
-        order.indexOf(a.ch.widget_type) - order.indexOf(b.ch.widget_type),
-    );
-  }, [widgets, catalogVersion]);
-
-  const orderedWidgets = useMemo(
-    () =>
-      WIDGET_ORDER.map((id) => {
-        if (!enabledWidgets.includes(id)) return null;
-        return allWidgets.find((w) => w.id === id) ?? null;
-      }).filter(Boolean) as WidgetManifest[],
-    [enabledWidgets, allWidgets],
-  );
-
-  const hasAnySources = orderedDataWidgets.length > 0 || orderedWidgets.length > 0;
-
-  return (
-    <PageLayout
-      title="Home"
-      subtitle="Your live feed at a glance"
-      width="wide"
-      noTopPadding
-    >
-      {/* WCB — same persistent chrome as every other page. The section
-          nav is always present (it's how you leave Home for settings);
-          the ticker-manage action only appears once there's a ticker
-          worth managing. */}
-      <WidgetBar>
-        <SectionNav active="home" />
-        {hasAnySources && (
-          <div className="ml-auto">
-            <BarPill active={false} onClick={openTickerSettings}>
-              Manage ticker
-            </BarPill>
-          </div>
-        )}
-      </WidgetBar>
-      {/* Home uses the standard PageLayout chassis (px-5 py-5,
-          max-w-6xl) so it lines up with Catalog and every other
-          wide route. The inner wrapper just owns vertical rhythm
-          between sections (space-y-5, no dangling margin on the
-          last child). Content under the WCB starts at pt-4, same as
-          Customize/Support. */}
-      <div className="space-y-5 pt-4">
-      {/* Empty state — hero. Shown when the user has no widgets and
-          no enabled widgets. Disappears the moment they add their
-          first source. This IS the post-wizard first-run experience —
-          a single primary CTA, no opinionated defaults. */}
-      {!hasAnySources && (
-        <EmptySection
-          icon={Sparkles}
-          title="Welcome to Scrollr"
-          description="Your radar is empty. Add widgets from the Catalog to start tracking what matters to you."
-          action={
-            authenticated ? (
-              <button
-                onClick={() => navigate({ to: "/catalog" })}
-                className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg text-sm font-semibold bg-accent text-surface hover:bg-accent/90 hover:shadow-glow-sm"
-              >
-                <Plus size={15} strokeWidth={2.5} />
-                Browse the Catalog
-              </button>
-            ) : (
-              <button
-                onClick={onLogin}
-                className="px-5 py-2.5 rounded-lg text-sm font-semibold bg-accent text-surface hover:bg-accent/90 hover:shadow-glow-sm"
-              >
-                Sign in to get started
-              </button>
-            )
-          }
-        />
-      )}
-
-      {/* DataWidgetRow sections — stagger in on first paint so the Home
-          page reveals its data instead of slamming everything in
-          at once. */}
-      {orderedDataWidgets.map(({ ch, manifest }, idx) => {
-        return (
-          <div
-            key={ch.widget_type}
-          >
-            <WidgetSection
-              widget={ch}
-              manifest={manifest}
-              data={dashboard?.data}
-              onViewAll={() =>
-                navigate({
-                  to: "/widget/$id",
-                  params: { id: ch.widget_type },
-                })
-              }
-              onRowClick={() =>
-                navigate({
-                  to: "/widget/$id",
-                  params: { id: ch.widget_type },
-                })
-              }
-              // Config lives inside the widget now — every CTA lands on
-              // the feed, where the bar carries the configuration.
-              onConfigure={() =>
-                navigate({
-                  to: "/widget/$id",
-                  params: { id: ch.widget_type },
-                })
-              }
-            />
-          </div>
-        );
-      })}
-
-      {/* Widget strip */}
-      {orderedWidgets.length > 0 && (
-        <div
-        >
-          <WidgetStrip
-            widgets={orderedWidgets}
-            getTickerStatus={(id) =>
-              formatEffectiveWidgetTickerStatus(
-                getEffectiveWidgetTickerStatus(shell.prefs, id),
-              )
-            }
-            onNavigate={(id) =>
-              navigate({
-                to: "/widget/$id",
-                params: { id },
-              })
-            }
-          />
-        </div>
-      )}
-      </div>
-    </PageLayout>
-  );
-}
-
-// ── DataWidgetRow section ─────────────────────────────────────────────
-
-interface WidgetSectionProps {
-  widget: DataWidgetRow;
-  manifest: DataWidgetManifest;
-  data: Record<string, unknown> | undefined;
-  onViewAll: () => void;
-  onRowClick: () => void;
-  onConfigure: () => void;
-}
-
-function WidgetSection({
-  widget,
-  manifest,
-  data,
-  onViewAll,
-  onRowClick,
-  onConfigure,
-}: WidgetSectionProps) {
-  const Icon = manifest.icon;
-  const type = widget.widget_type;
-  // Resolve the widget id to its coarse source (dashboard.data is source-keyed)
-  // and scope the payload to this one widget's config — an NFL widget shows only
-  // NFL, finance_stocks only stocks, news_bbc only BBC. Mirrors the ticker.
-  const source = sourceForWidget(type) ?? type;
-  // Normalizing, grouping and rendering all come off the manifest now — a
-  // source owns its own Home preview in datawidgets/{source}/home.tsx.
-  const widgetData = useMemo(() => {
-    const raw = data?.[source];
-    const rows = manifest.normalizeHome
-      ? manifest.normalizeHome(raw)
-      : Array.isArray(raw)
-        ? (raw as unknown[])
-        : [];
-    return scopeSourceData(
-      source,
-      rows,
-      widget.config as Record<string, unknown> | undefined,
-    );
-  }, [source, data, widget.config, manifest]);
-  return (
-    <section>
-      {/* Section header */}
-      <div className="flex items-center gap-3 mb-3">
-        <div
-          className="w-7 h-7 rounded-md flex items-center justify-center shrink-0"
-          style={{ backgroundColor: `${manifest.hex}15`, color: manifest.hex }}
-        >
-          <Icon size={16} />
-        </div>
-        <span className="text-sm font-semibold text-fg flex-1">
-          {manifest.name}
-        </span>
-        <button
-          onClick={onViewAll}
-          className="group flex items-center gap-1 text-ui-chip font-medium text-fg-4 hover:text-fg-2"
-        >
-          View all
-          <ChevronRight size={12} />
-        </button>
-      </div>
-
-      {/* Ranked rows — each source picks its own most
-          interesting items; see its home.tsx. */}
-        <div
-          key="data"
-          className="rounded-lg border border-edge/20 overflow-hidden divide-y divide-edge/10 cursor-pointer hover:bg-base-200/30 "
-          onClick={onRowClick}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") onRowClick();
-          }}
-        >
-          <manifest.HomeRows
-            data={widgetData}
-            dashboard={data}
-            onConfigure={onConfigure}
-          />
-        </div>
-    </section>
-  );
-}
-
-// ── Widget strip ────────────────────────────────────────────────
-
-interface WidgetStripProps {
-  widgets: WidgetManifest[];
-  getTickerStatus: (id: string) => string;
-  onNavigate: (id: string) => void;
-}
-
-function WidgetStrip({
-  widgets,
-  getTickerStatus,
-  onNavigate,
-}: WidgetStripProps) {
-  return (
-    <section>
-      <div className="flex items-center gap-3 mb-3">
-        <h3 className="text-ui-section font-mono font-semibold text-fg-4 uppercase tracking-wider flex-1">
-          Widgets
-        </h3>
-      </div>
-
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
-        {widgets.map((widget) => (
-          <WidgetChip
-            key={widget.id}
-            widget={widget}
-            tickerStatus={getTickerStatus(widget.id)}
-            onClick={() => onNavigate(widget.id)}
-          />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-interface WidgetChipProps {
-  widget: WidgetManifest;
-  tickerStatus: string;
-  onClick: () => void;
-}
-
-function WidgetChip({
-  widget,
-  tickerStatus,
-  onClick,
-}: WidgetChipProps) {
-  const Icon = widget.icon;
-  const value = getWidgetValue(widget.id);
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onClick();
-        }
-      }}
-      className={clsx(
-        FEED_CARD,
-        FEED_CARD_INTERACTIVE,
-        "group w-full text-left",
-      )}
-    >
-      <div className="flex items-center gap-2 mb-1.5">
-        <span style={{ color: widget.hex }} className="shrink-0">
-          <Icon size={14} />
-        </span>
-        <span className="text-ui-meta font-medium text-fg truncate flex-1">
-          {widget.tabLabel}
-        </span>
-        <TickerStatusBadge label={tickerStatus} />
-      </div>
-
-      <p className="text-sm font-medium text-fg-2 tabular-nums truncate">
-        {value}
-      </p>
-    </div>
-  );
-}
-
-function TickerStatusBadge({ label }: { label: string }) {
-  const isOff = label === "Not on ticker";
-  return (
-    <span
-      className={clsx(
-        "shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
-        isOff
-          ? "border-edge/30 text-fg-4 bg-base-200/40"
-          : "border-accent/25 text-accent bg-accent/10",
-      )}
-    >
-      {label}
-    </span>
-  );
-}
-
-// ── Widget cached values ────────────────────────────────────────
 
 function getWidgetValue(id: string): string {
   switch (id) {

--- a/desktop/src/routes/feed.tsx
+++ b/desktop/src/routes/feed.tsx
@@ -799,7 +799,7 @@ function UtilityTiles({
 // ── First run ───────────────────────────────────────────────────
 
 const STARTERS: { id: string; blurb: string }[] = [
-  { id: "finance_stocks", blurb: "Live quotes, zero setup." },
+  { id: "finance_stocks", blurb: "Live quotes the moment you add it." },
   { id: "predictions", blurb: "The news, in numbers." },
   { id: "clock", blurb: "Local time and world clocks." },
 ];

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -1015,6 +1015,34 @@
   transition: none !important;
 }
 
+/* …with two narrow, opt-in exceptions.
+   The rule above is a blanket `animation: none !important`, which means
+   a Tailwind `animate-*` class inside the app silently does nothing —
+   it compiles, it lands on the element, and it never runs. The Home
+   marquee and the live badges are motion BY DESIGN (a ticker that
+   doesn't move isn't a ticker), so they opt in explicitly by attribute
+   rather than the calm default being weakened for everything.
+
+   Keep this list short. Anything added here is asserting that stillness
+   would make it wrong, not merely less lively. */
+#app-shell [data-motion="marquee"] {
+  animation: chipdrift var(--marquee-duration, 22s) linear infinite !important;
+}
+#app-shell [data-motion="marquee"][data-paused="true"] {
+  animation-play-state: paused !important;
+}
+#app-shell [data-motion="pulse"] {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite !important;
+}
+
+/* Reduced motion still wins over both. */
+@media (prefers-reduced-motion: reduce) {
+  #app-shell [data-motion="marquee"],
+  #app-shell [data-motion="pulse"] {
+    animation: none !important;
+  }
+}
+
 /* Light-mode scrollbar — applies to every theme family's light variant.
    Dark scrollbars are already covered by the base ::-webkit-scrollbar
    rule further down (which reads --color-base-300). */

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -1368,3 +1368,11 @@ input[data-contained-focus]:focus-visible {
   color: var(--color-fg);
   background: var(--color-base-200);
 }
+
+/* Catalog panel's ticker preview: the chip row is rendered twice inside
+   a width:max-content track, so translating exactly -50% lands on the
+   seam and the loop is invisible. Same trick the Home marquee uses. */
+@keyframes chipdrift {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}

--- a/desktop/src/tierLimits.ts
+++ b/desktop/src/tierLimits.ts
@@ -63,3 +63,26 @@ export function getMaxWidgets(tier: SubscriptionTier): number {
   return TIER_LIMITS[tier].maxWidgets;
 }
 
+
+/**
+ * Tier ranking, for "is this widget's required tier within reach?".
+ *
+ * Lived privately inside routes/widget.$id.info.tsx, which meant the
+ * catalog and the info page could answer the same gating question
+ * differently — exactly the drift that a shared slot helper already
+ * exists to prevent. It belongs next to getMaxWidgets.
+ */
+export const TIER_ORDER: SubscriptionTier[] = [
+  "free",
+  "uplink",
+  "uplink_pro",
+  "uplink_ultimate",
+  "super_user",
+];
+
+export function tierMeets(
+  current: SubscriptionTier,
+  required: SubscriptionTier,
+): boolean {
+  return TIER_ORDER.indexOf(current) >= TIER_ORDER.indexOf(required);
+}

--- a/desktop/src/types/index.ts
+++ b/desktop/src/types/index.ts
@@ -198,6 +198,39 @@ export interface DataWidgetManifest {
    * wraps its rows in `{ leagues: [...] }`.
    */
   normalizeHome?: (raw: unknown) => unknown[];
+
+  /**
+   * The one thing worth interrupting someone for, or null.
+   *
+   * Home's "Happening now" row asks each source this and keeps the top
+   * three. OPTIONAL on purpose, unlike HomeRows: the registries are
+   * runtime globs that tsc cannot see through, so a required member
+   * would not actually be enforced at build time for a source that
+   * forgot it — it would just be `undefined` at runtime, in a hero row,
+   * on the first screen anyone sees. Optional and explicitly checked is
+   * honest about what the type system can promise here.
+   *
+   * `data` is the SAME array HomeRows receives — normalized and scoped
+   * to this widget. Anything else and the headline will contradict the
+   * rows directly beneath it.
+   *
+   * Copy must be template-derived, never editorial: this renders as the
+   * app's own voice, and a source cannot know what is actually
+   * important to a given person.
+   */
+  highlight?: (data: unknown[]) => HomeHighlight | null;
+}
+
+/** A candidate for Home's "Happening now" row. */
+export interface HomeHighlight {
+  /** Tabular, scannable: "Inter Miami 2 – 1 LA Galaxy", "NVDA +3.4% today". */
+  headline: string;
+  /** The supporting formula line: "71' · 2nd half", "$188.52 · top mover". */
+  sub: string;
+  /** Drives the LIVE badge — and the badge always carries text, not just color. */
+  live?: boolean;
+  /** Brand hex for the card gradient. Falls back to the widget's own. */
+  hex?: string;
 }
 
 /** Props every source's `HomeRows` receives. */


### PR DESCRIPTION
Implements both parts of the Catalog + Home design handoff.

## Part 1 — Catalog

Was browse-only: the grid showed what existed, and every transaction lived one navigation away on the widget's info page. It's a store now — cards add in place, and details open in a 400px slide-over so you keep your position in the shelf you were reading.

Browsing **All** shows one shelf per category in canonical order, which beats Your/Discover for what people actually do here: look for a *kind* of thing. Filtering or searching collapses to a single section and hides the "In your ticker" strip — at that point you're shopping, not auditing. **Sports render compact** (logo + name + add, 4-across) because league descriptions are boilerplate and fourteen rich cards would be fourteen restatements of one sentence.

The panel is a native `<dialog>` + `showModal()`, copying `ConfirmDialog` rather than the two hand-rolled `role="dialog"` overlays elsewhere in the app — that buys a real focus trap, inertness, and focus restoration, and `onCancel` + `preventDefault` routes Esc through our own close handler so the URL stays in step. Open state is a `?widget=` search param, so it deep-links and survives reload.

At capacity or behind a tier, `+` opens the panel instead of adding — the panel is where the upgrade path is actually explained.

## Part 2 — Home

Was a flat list: one preview per widget, all the same size, in catalog order — which treats "Inter Miami are level in the 71st" and "the clock says 3:36" as the same kind of fact. Now a live mini-ticker, a greeting, a "Happening now" row, and a bento grid grouped by source.

The hero row runs on a new **optional** `highlight(data)` on the manifest. Optional, not required like `HomeRows`, and deliberately so: the registries are runtime globs tsc can't see through, so a required member wouldn't actually be enforced at build time — a source that forgot it would ship `undefined` into a hero card on the first screen anyone sees. It receives the *same* normalized, scoped array `HomeRows` gets, or the headline would contradict the rows beneath it.

**Consolidation is presentation-only.** Cards group by source, but every link targets a widget id — per-league chips on Scores, per-watchlist links under Markets, rows deep-link to their owner. Nothing links to a "group", because a group isn't something you can open or remove.

The four scenarios are emergent, not modes: a busy slate fills the hero row, a quiet one drops it, an unconfigured widget keeps its card and swaps the body for one sentence and one CTA, an empty account gets the welcome. Cards never disappear.

## Two bugs found during review

**The marquees didn't move.** `style.css` has carried a blanket `#app-shell * { animation: none !important }` since long before this work, under "The main app is intentionally motion-free." The Tailwind `animate-*` classes compiled, landed on the elements, and were overridden — the pulsing LIVE dots were silently dead for the same reason. Rather than weaken the default, marquees and pulses opt in by attribute, with `prefers-reduced-motion` still overriding both.

**Compact sports tiles were invisible in dark themes** — bare `surface-raised` sits a few percent off the panel behind it. They now carry the horizontal brand wash the prototype specifies.

## Deviations from the spec

- **Markets drops the company-name column**: `Trade` carries only symbol/price/change, and adding a name lookup would put a second source of truth for ticker names in the Home route.
- **`TIER_ORDER`/`tierMeets` moved** out of a private copy inside `widget.$id.info.tsx` into `tierLimits.ts`, so the catalog and info page can't answer the same gating question differently.
- **Sports highlight uses `short_detail`/`status_*`** — there's no `clock` field on `Game`; I assumed one and tsc caught it.

## Verification

- `vite build && tsc --noEmit` clean; 503 tests pass
- Both surfaces exercised in the running app: shelves, spotlight, in-your-ticker strip, compact sports, the slide-over, and Home's ticker/greeting/hero row/bento
- Marquee motion confirmed by measuring chip advance between captures 4s apart, not by trusting the CSS
- The `needs-setup` state was live on the test account, then correctly disappeared once the widget had data

Fantasy's bento card is built from its data shape rather than observed — that widget isn't on the test account. Kalshi's was verified once it was added.