### PR TITLE
ci(deploy): pass MOTION_PLUS_TOKEN to the website image build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,6 +256,12 @@ jobs:
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN_WEB }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          # Motion+ registry token for scripts/ensure-motion-plus.mjs —
+          # motion-plus is deliberately absent from package.json (public
+          # repo; the install URL embeds the token), so the website build
+          # installs it during prebuild. Builder-stage only; REQUIRED for
+          # the website build (ensure-motion-plus fails loudly without it).
+          MOTION_PLUS_TOKEN: ${{ secrets.MOTION_PLUS_TOKEN }}
           # Authenticated GitHub API for the website prebuild fetch scripts
           # (fetch-releases.mjs / fetch-latest-version.mjs) — shared runner
           # IPs exhaust the anonymous 60/hr limit. The ambient job token is
@@ -283,6 +289,7 @@ jobs:
               "VITE_SENTRY_DSN=$VITE_SENTRY_DSN" \
               "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" \
               "SENTRY_ORG=$SENTRY_ORG" \
+              "MOTION_PLUS_TOKEN=$MOTION_PLUS_TOKEN" \
               "GITHUB_TOKEN=$GH_API_TOKEN"; do
               BUILD_ARGS="$BUILD_ARGS --build-arg $arg"
             done


### PR DESCRIPTION
The production k8s deploy failed at `ensure-motion-plus` — the website image build has no Motion+ token. This wires `MOTION_PLUS_TOKEN` through the deploy workflow as a build arg, same pattern as the Sentry/Stripe secrets (builder-stage only; the nginx image never sees it). The `MOTION_PLUS_TOKEN` repo secret is already set.

Workflow-only changes don't trip the `myscrollr.com/**` change filter, so the website rebuild is dispatched manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)