### PR TITLE
Ticker chips: steady rail, animated spine, flash on a score (v1.4.1)

### DIFF
--- a/desktop/fixtures/control-panel.mjs
+++ b/desktop/fixtures/control-panel.mjs
@@ -179,6 +179,81 @@ export function controlState(payload, clients = 0) {
 }
 
 /**
+ * Scripted moments — the shots worth filming, as one click each.
+ *
+ * Clicking three buttons in the right order while also watching the
+ * screen is how you miss the take. Each of these is a timed sequence
+ * the server runs on its own, so the only thing left to do is hit
+ * record.
+ *
+ * `at` is milliseconds from the start of the sequence. Steps are
+ * DELTAS like every other operation here, so a moment can be run twice
+ * and the second run builds on the first rather than resetting it.
+ *
+ * `lead` is resolved at run time: the points needed to land 0.1 past
+ * the opponent right now. Hardcoding a number would be wrong the moment
+ * anything else on the roster moves.
+ */
+export const MOMENTS = [
+  {
+    id: "walkoff",
+    name: "Walk-off touchdown",
+    blurb: "Down late, your last live player scores, you take the lead.",
+    steps: [
+      { at: 0, kind: "points", who: "live", delta: 1.4 },
+      { at: 1400, kind: "points", who: "live", delta: "lead" },
+    ],
+  },
+  {
+    id: "surge",
+    name: "Scoring drive",
+    blurb: "Three quick gains — good for a long shot of the rail moving.",
+    steps: [
+      { at: 0, kind: "points", who: "live", delta: 0.8 },
+      { at: 1600, kind: "points", who: "live", delta: 2.1 },
+      { at: 3400, kind: "points", who: "live", delta: 6.6 },
+    ],
+  },
+  {
+    id: "heartbreak",
+    name: "They answer back",
+    blurb: "You go ahead, then the opponent scores and takes it back.",
+    steps: [
+      { at: 0, kind: "points", who: "live", delta: "lead" },
+      { at: 2200, kind: "points", who: "opp-live", delta: 7.2 },
+    ],
+  },
+  {
+    id: "injury",
+    name: "Injury scare",
+    blurb: "Your live player goes down — fires the breaking-injury chip.",
+    steps: [{ at: 0, kind: "out", who: "live" }],
+  },
+  {
+    id: "whistle",
+    name: "Final whistle",
+    blurb: "One last score, then the game goes FINAL.",
+    steps: [
+      { at: 0, kind: "points", who: "live", delta: "lead" },
+      { at: 2000, kind: "final" },
+    ],
+  },
+];
+
+/**
+ * Pick the player a moment's step applies to.
+ *
+ * Live players first — a settled player's score changing is the one
+ * thing a fantasy viewer would immediately call fake. Falls back to the
+ * highest scorer only so a moment still does something in a league with
+ * nothing left running.
+ */
+export function resolveWho(league, who) {
+  const side = who === "opp-live" ? league.theirs : league.mine;
+  return (side.find((p) => p.live) ?? side[side.length - 1])?.key ?? null;
+}
+
+/**
  * The frame that makes the app re-fetch. `yahoo_matchups` is in
  * useDashboardCDC's FANTASY_CDC_TABLES, which is what routes this down
  * the sub-second fast-path instead of the 500ms-debounced safety net.
@@ -203,6 +278,15 @@ export const PANEL_HTML = `<!doctype html>
   h1 { font-size: 16px; margin: 0 0 4px; letter-spacing: .02em; }
   .sub { color: #8b949e; margin: 0 0 20px; font-size: 12px; }
   .grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(380px, 1fr)); }
+  .moments { display: grid; gap: 10px; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); margin-bottom: 22px; }
+  .moment { text-align: left; padding: 12px 14px; border-radius: 10px; cursor: pointer;
+            background: #16241d; border: 1px solid #1f4634; color: #d7f5e6; font: inherit; }
+  .moment:hover { background: #1b2f25; border-color: #2a6349; }
+  .moment b { display: block; font-size: 14px; margin-bottom: 3px; color: #7ff0bd; }
+  .moment span { font-size: 11.5px; color: #8fb3a2; line-height: 1.35; }
+  .moment:disabled { opacity: .45; cursor: default; }
+  h2 { font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: #8b949e;
+       margin: 0 0 10px; font-weight: 600; }
   .card { background: #11151d; border: 1px solid #222a36; border-radius: 12px; padding: 16px; }
   .name { font-weight: 600; font-size: 15px; }
   .tag { font-size: 10px; letter-spacing: .08em; padding: 2px 7px; border-radius: 999px; vertical-align: 2px; margin-left: 8px; }
@@ -231,6 +315,9 @@ export const PANEL_HTML = `<!doctype html>
 </style>
 <h1>Scrollr demo control <span class="tag" id="conn">&hellip;</span></h1>
 <p class="sub">Every click re-renders the app in under a second. Seeded data &mdash; not a live game.</p>
+<h2>One-click moments</h2>
+<div class="moments" id="moments"></div>
+<h2>Manual control</h2>
 <div class="grid" id="grid"></div>
 <footer>
   <div class="row"><button class="warn" onclick="reset()">Reset everything</button></div>
@@ -249,6 +336,33 @@ async function post(body) {
   await load()
 }
 const reset = () => post({ type: 'reset' })
+
+// Baked in at serve time rather than fetched: the list is static, and
+// one fewer round trip means the buttons are live on first paint.
+const MOMENTS = ${JSON.stringify(MOMENTS)}
+
+let playing = false
+async function moment(id) {
+  if (playing) return
+  playing = true
+  render_moments()
+  await fetch('/control/moment', {
+    method: 'POST', headers: {'content-type':'application/json'},
+    body: JSON.stringify({ id }),
+  })
+  // Lock out re-entry for the length of the sequence plus a beat, so a
+  // second click can't interleave two moments into nonsense.
+  const span = Math.max(...MOMENTS.find(m => m.id === id).steps.map(s => s.at))
+  setTimeout(() => { playing = false; render_moments(); load() }, span + 1200)
+}
+
+function render_moments() {
+  document.getElementById('moments').innerHTML = MOMENTS.map(m =>
+    '<button class="moment" ' + (playing ? 'disabled ' : '') +
+    'onclick="moment(\\'' + m.id + '\\')">' +
+    '<b>' + m.name + '</b><span>' + m.blurb + '</span></button>').join('')
+}
+render_moments()
 const bump  = (league, delta) => post({ type: 'points', player: picks[league], delta })
 const rule  = (league) => post({ type: 'out', player: picks[league] })
 const final = (league) => post({ type: 'final', league })

--- a/desktop/fixtures/serve-fantasy-demo.mjs
+++ b/desktop/fixtures/serve-fantasy-demo.mjs
@@ -53,11 +53,13 @@
 
 import { createServer, request as httpRequest } from 'node:http'
 import {
+  MOMENTS,
   PANEL_HTML,
   applyControl,
   controlState,
   emptyOps,
   nudgeFrame,
+  resolveWho,
 } from './control-panel.mjs'
 
 // ── Scoring ──────────────────────────────────────────────────────
@@ -742,6 +744,48 @@ function readJson(req) {
   })
 }
 
+/**
+ * Run a scripted moment, nudging the app after every step.
+ *
+ * Fire-and-forget: the HTTP response returns immediately so the panel
+ * stays responsive while the sequence plays out over several seconds.
+ * Each step re-reads the CURRENT state, which is what lets a step ask
+ * for "whatever it takes to lead" rather than a number decided before
+ * the previous step landed.
+ */
+function runMoment(moment) {
+  for (const step of moment.steps) {
+    setTimeout(() => {
+      const state = controlState(currentPayload())
+      // Every moment acts on the one league that can carry a story:
+      // the first still live. A FINAL league has nothing left to do.
+      const league = state.leagues.find((l) => !l.final) ?? state.leagues[0]
+      if (!league) return
+
+      if (step.kind === 'final') {
+        ops.final[league.key] = true
+      } else {
+        const player = resolveWho(league, step.who)
+        if (!player) return
+        if (step.kind === 'out') {
+          ops.out[player] = true
+        } else {
+          const delta =
+            step.delta === 'lead'
+              ? round2(league.opp.points - league.me.points + 0.1)
+              : step.delta
+          // A 'lead' step when already ahead would subtract points and
+          // play the moment backwards. Nudge it forward instead.
+          const safe = step.delta === 'lead' && delta <= 0 ? 0.4 : delta
+          ops.points[player] = round2((ops.points[player] ?? 0) + safe)
+        }
+      }
+      console.log(`[fantasy-demo] moment ${moment.id} +${step.at}ms`)
+      nudgeClients()
+    }, step.at)
+  }
+}
+
 /** Panel routes. Returns true if it handled the request. */
 async function control(req, res, path) {
   if (path === '/' || path === '/control') {
@@ -752,6 +796,14 @@ async function control(req, res, path) {
   if (path === '/control/state') {
     res.writeHead(200, { 'content-type': 'application/json' })
     res.end(JSON.stringify(controlState(currentPayload(), sseClients.size)))
+    return true
+  }
+  if (path === '/control/moment') {
+    const { id } = await readJson(req)
+    const moment = MOMENTS.find((m) => m.id === id)
+    if (moment) runMoment(moment)
+    res.writeHead(moment ? 200 : 404, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ ok: !!moment }))
     return true
   }
   if (path === '/control/op') {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4622,7 +4622,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 # std::env::home_dir (Sentry path scrubber) is only correct on Windows from 1.85+
 rust-version = "1.85"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/components/chips/ChipFlash.test.tsx
+++ b/desktop/src/components/chips/ChipFlash.test.tsx
@@ -1,0 +1,59 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ChipFlash, useChangeFlash } from "./ChipFlash";
+
+/**
+ * Renders the flash driven by a value, so a test can rerender with a
+ * new one and assert on what the chip would actually show.
+ */
+function Probe({ value }: { value: number | null }) {
+  const token = useChangeFlash(value);
+  return (
+    <div data-testid="chip">
+      <ChipFlash token={token} />
+    </div>
+  );
+}
+
+const flash = (c: HTMLElement) => c.querySelector(".chip-flash");
+
+describe("useChangeFlash", () => {
+  it("does not flash on mount", () => {
+    // Every chip scrolling onto the rail has "changed" from nothing. If
+    // that counted, the whole bar would strobe on load.
+    const { getByTestId } = render(<Probe value={12.4} />);
+    expect(flash(getByTestId("chip"))).toBeNull();
+  });
+
+  it("does not flash when a value arrives for the first time", () => {
+    // FollowedPlayerChip passes null until the player resolves out of a
+    // roster. Appearing is not the same as scoring.
+    const { getByTestId, rerender } = render(<Probe value={null} />);
+    rerender(<Probe value={8.3} />);
+    expect(flash(getByTestId("chip"))).toBeNull();
+  });
+
+  it("flashes when the value changes", () => {
+    const { getByTestId, rerender } = render(<Probe value={8.3} />);
+    rerender(<Probe value={14.9} />);
+    expect(flash(getByTestId("chip"))).not.toBeNull();
+  });
+
+  it("re-keys on each change so the animation can replay", () => {
+    // A CSS animation only restarts on a fresh element, so two
+    // consecutive scores must not reuse the same node.
+    const { getByTestId, rerender } = render(<Probe value={8.3} />);
+    rerender(<Probe value={14.9} />);
+    const first = flash(getByTestId("chip"));
+    rerender(<Probe value={21.5} />);
+    expect(flash(getByTestId("chip"))).not.toBe(first);
+  });
+
+  it("stays quiet when a rerender does not move the number", () => {
+    // The dashboard refetches on a poll; an unchanged score arriving
+    // again is not an event.
+    const { getByTestId, rerender } = render(<Probe value={8.3} />);
+    rerender(<Probe value={8.3} />);
+    expect(flash(getByTestId("chip"))).toBeNull();
+  });
+});

--- a/desktop/src/components/chips/ChipFlash.tsx
+++ b/desktop/src/components/chips/ChipFlash.tsx
@@ -1,0 +1,66 @@
+/**
+ * ChipFlash — a one-shot highlight when a chip's number actually moves.
+ *
+ * NOT the same thing as `.pts-flash`, which is a 6s ambient loop meaning
+ * "this player is live". This fires once, on change, and says "that
+ * number just changed" — the difference between a heartbeat and an
+ * event. A live chip that never scores should never flash.
+ *
+ * Motion policy is inherited rather than re-decided: this is a CSS
+ * `animation`, so the `#app-shell` blanket rule stills it inside the app
+ * (the calm surface keeps its stillness) while the ticker window, which
+ * has no such rule, flashes. Same markup, correct in both.
+ */
+import { clsx } from "clsx";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Counts changes to `value`. Returns a token that increments on each
+ * one, for use as a `key`.
+ *
+ * The token exists because CSS animations only replay on a fresh
+ * element. Keying the flash overlay on it remounts just that overlay —
+ * deliberately NOT the number itself, since remounting the score would
+ * destroy the digit roll mid-flight, which is the very thing the flash
+ * is meant to draw attention to.
+ *
+ * Starts at 0 and the first render never counts: a chip scrolling onto
+ * the rail has "changed" from nothing, and flashing every chip on mount
+ * would make the whole bar strobe.
+ */
+export function useChangeFlash(value: number | null | undefined): number {
+  const [token, setToken] = useState(0);
+  const previous = useRef(value);
+
+  useEffect(() => {
+    if (previous.current !== value) {
+      if (previous.current !== undefined && previous.current !== null) {
+        setToken((n) => n + 1);
+      }
+      previous.current = value;
+    }
+  }, [value]);
+
+  return token;
+}
+
+export function ChipFlash({
+  token,
+  tone = "up",
+}: {
+  /** From `useChangeFlash`. Zero means it has never changed. */
+  token: number;
+  /** Direction of the change — a score going down shouldn't read green. */
+  tone?: "up" | "down";
+}) {
+  // Nothing has moved yet, so there is nothing to announce.
+  if (token === 0) return null;
+
+  return (
+    <span
+      key={token}
+      aria-hidden="true"
+      className={clsx("chip-flash", tone === "down" && "chip-flash-down")}
+    />
+  );
+}

--- a/desktop/src/components/chips/ChipSpine.tsx
+++ b/desktop/src/components/chips/ChipSpine.tsx
@@ -47,6 +47,16 @@ export function ChipSpine({ fill, state, tone = "accent" }: ChipSpineProps) {
         data-motion={state === "live" ? "spine-glow" : undefined}
         className={clsx(
           "absolute inset-y-0 left-0",
+          // Slide the fill rather than jumping it. The score's digits
+          // roll over ~1.8s, and a spine that snapped to its new width
+          // in one frame made the two read as unrelated — the bar had
+          // already finished before the number started.
+          //
+          // A transition, not an animation, and that matters: the
+          // `#app-shell` blanket rule kills both, so the app keeps its
+          // still bar while the ticker window slides. Same markup, right
+          // behaviour in each, no second code path.
+          "transition-[width] duration-[1600ms] ease-out",
           tone === "up" && "bg-up",
           tone === "down" && "bg-down",
           tone === "accent" && "bg-current",

--- a/desktop/src/components/chips/FantasyStatChip.tsx
+++ b/desktop/src/components/chips/FantasyStatChip.tsx
@@ -19,8 +19,14 @@ import {
   userStanding,
 } from "../../datawidgets/fantasy/types";
 import { findTopScorer } from "../../datawidgets/fantasy/playerStats";
-import { getChipColors, chipBaseClasses } from "./chipColors";
+import {
+  getChipColors,
+  chipBaseClasses,
+  stableNum,
+  NUM_WIDTH,
+} from "./chipColors";
 import { ChipSpine } from "./ChipSpine";
+import { ChipFlash, useChangeFlash } from "./ChipFlash";
 
 interface FantasyStatChipProps {
   league: LeagueResponse;
@@ -52,6 +58,13 @@ interface StatSegment {
    * accurate regardless — it's the accessible label and the fallback.
    */
   node?: ReactNode;
+  /**
+   * Characters of width to reserve, for segments whose value changes
+   * while the chip is on screen. Without it a score gaining a digit
+   * widens the chip and shoves every chip after it along the rail.
+   * Omit for segments whose text is fixed for the life of the chip.
+   */
+  width?: number;
 }
 
 /**
@@ -150,6 +163,9 @@ export default function FantasyStatChip({
         key: "score",
         text: scoreText,
         tone: scoreTone,
+        // Both sides plus the separator. Reserved as one block so the
+        // dash never walks left as a score crosses into three figures.
+        width: NUM_WIDTH.teamScore * 2 + 1,
         node: rollScore ? (
           <RollingScore myPts={myPts} oppPts={oppPts} label={scoreText} />
         ) : undefined,
@@ -173,6 +189,10 @@ export default function FantasyStatChip({
           key: "wp",
           text: `${Math.round(wp * 100)}%`,
           tone: wp >= 0.5 ? "up" : "down",
+          // 65% -> 100% gains a digit, and a win probability crossing
+          // three figures is exactly the moment the rail must hold
+          // still rather than nudge every chip along.
+          width: NUM_WIDTH.percent,
         });
       }
     }
@@ -258,6 +278,10 @@ export default function FantasyStatChip({
   })();
   const userWon = ctx ? teamScore(ctx.user) > teamScore(ctx.opponent) : false;
 
+  // Flash on the USER's score only. The opponent's moving is their
+  // business; the chip exists to answer "did anything happen to me".
+  const flashToken = useChangeFlash(ctx ? teamScore(ctx.user) : null);
+
   // ── Render ─────────────────────────────────────────────────
 
   return (
@@ -270,6 +294,7 @@ export default function FantasyStatChip({
           without parsing any of them. Pre-game it's a projection and
           renders at reduced strength; final it fills and takes the
           result's colour. */}
+      <ChipFlash token={flashToken} tone={scoreTone === "down" ? "down" : "up"} />
       {ctx && (
         <ChipSpine
           fill={spineFill ?? 0}
@@ -294,6 +319,7 @@ export default function FantasyStatChip({
         {allSegments.map((seg) => (
           <span
             key={seg.key}
+            style={seg.width ? stableNum(seg.width) : undefined}
             className={clsx(
               "tabular-nums font-medium",
               seg.tone === "up" && "text-up",
@@ -325,6 +351,7 @@ export default function FantasyStatChip({
           {secondarySegments.map((seg) => (
             <span
               key={seg.key}
+              style={seg.width ? stableNum(seg.width) : undefined}
               className={clsx(
                 "tabular-nums font-medium shrink-0",
                 seg.tone === "up" && "text-up",

--- a/desktop/src/components/chips/FollowedPlayerChip.tsx
+++ b/desktop/src/components/chips/FollowedPlayerChip.tsx
@@ -26,8 +26,14 @@ import type {
   RosterPlayer,
 } from "../../datawidgets/fantasy/types";
 import { isInjured, shortStatus } from "../../datawidgets/fantasy/playerStats";
-import { getChipColors, chipBaseClasses } from "./chipColors";
+import {
+  getChipColors,
+  chipBaseClasses,
+  stableNum,
+  NUM_WIDTH,
+} from "./chipColors";
 import { ChipSpine } from "./ChipSpine";
+import { ChipFlash, useChangeFlash } from "./ChipFlash";
 import { gameStateForPlayer } from "../../datawidgets/fantasy/types";
 
 /**
@@ -86,6 +92,12 @@ export default function FollowedPlayerChip({
   onClick,
 }: FollowedPlayerChipProps) {
   const found = findPlayerByKey(playerKey, leagues, leagueKey);
+  // Above the early return on purpose — hooks can't sit behind a
+  // conditional, and this component bails when the player isn't in any
+  // roster. Passing null while unresolved is harmless: the hook ignores
+  // a first real value, so a player appearing mid-game doesn't flash
+  // merely for existing.
+  const flashToken = useChangeFlash(found?.player.player_points ?? null);
   if (!found) return null;
 
   const { player, leagueName, ownerTeamName } = found;
@@ -127,6 +139,7 @@ export default function FollowedPlayerChip({
       className={chipBaseClasses(comfort, c, "font-mono whitespace-nowrap")}
       title={`${player.name.full}${teamAbbr ? ` (${teamAbbr})` : ""}`}
     >
+      <ChipFlash token={flashToken} tone={tone === "down" ? "down" : "up"} />
       {/* Spine: progress against this player's own projection, so the
           bar answers "are they having a good day" rather than repeating
           the raw number beside it. Hidden without a projection — a bar
@@ -170,6 +183,7 @@ export default function FollowedPlayerChip({
           </span>
         )}
         <span
+          style={stableNum(NUM_WIDTH.playerPoints)}
           className={clsx(
             "tabular-nums font-medium",
             tone === "up" && "text-up",

--- a/desktop/src/components/chips/chipColors.ts
+++ b/desktop/src/components/chips/chipColors.ts
@@ -150,6 +150,49 @@ export function getChipColors(mode: ChipColorMode, widget: string): ChipColors {
   return WIDGET_MAP[widget] ?? PURPLE;
 }
 
+// ── Stable numeric width ────────────────────────────────────────
+
+/**
+ * Reserve a fixed width for a number that changes while on screen.
+ *
+ * A score going 8.3 -> 14.9 gains a character, which widens its chip,
+ * which shifts every chip after it on the rail. The number is the one
+ * thing on a ticker guaranteed to change, so it is also the one thing
+ * that must not resize.
+ *
+ * `ch` is exact here rather than approximate: chips render in
+ * `font-mono` with `tabular-nums`, so one `ch` is one digit and the
+ * reservation is the real rendered width.
+ *
+ * Right-aligned, because a number that grows leftward from a fixed
+ * decimal point reads as counting, while one that grows rightward reads
+ * as drifting.
+ */
+export function stableNum(chars: number): React.CSSProperties {
+  return {
+    display: "inline-block",
+    minWidth: `${chars}ch`,
+    textAlign: "right",
+  };
+}
+
+/**
+ * Digits to reserve, by what the number is.
+ *
+ * Sized to the realistic ceiling rather than the theoretical one — a
+ * team that breaks 1000 points has bigger problems than a reflow, and
+ * padding every score for a case that never happens leaves a visible
+ * gap on every chip that does.
+ */
+export const NUM_WIDTH = {
+  /** Team score: "151.8", up to "999.9". */
+  teamScore: 5,
+  /** One player's points: "14.9", up to "99.9". Negative D/ST fits too. */
+  playerPoints: 4,
+  /** Win probability: "65%" up to "100%". */
+  percent: 4,
+} as const;
+
 // ── Shared chip base classes ────────────────────────────────────
 // Common className construction used by all ticker chip components.
 

--- a/desktop/src/style.css
+++ b/desktop/src/style.css
@@ -1139,6 +1139,54 @@
   }
 }
 
+/* Score-change flash — a ring and a wash across the whole chip, fired
+   once when the number moves. Distinct from .pts-flash above, which
+   loops to signal "live"; this one is an EVENT, so it must not repeat.
+
+   The ring is inset so it reads on a chip that already has a border,
+   and `border-radius: inherit` keeps it on the chip's corners rather
+   than assuming a radius that could drift from chipBaseClasses.
+
+   Not listed in the #app-shell exceptions below, deliberately: the app
+   stills it and the ticker window flashes. */
+@keyframes chipFlash {
+  0% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.chip-flash {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  opacity: 0;
+  box-shadow: inset 0 0 0 1.5px var(--color-up);
+  background-color: color-mix(in srgb, var(--color-up) 14%, transparent);
+  animation: chipFlash 900ms ease-out 1;
+}
+
+.chip-flash-down {
+  box-shadow: inset 0 0 0 1.5px var(--color-down);
+  background-color: color-mix(in srgb, var(--color-down) 14%, transparent);
+}
+
+/* No static fallback here, unlike .pts-flash. That one conveys an
+   ongoing STATE, which must survive without motion; this marks a moment
+   that has already passed, and a permanent ring on every chip that ever
+   scored would be worse than no cue at all. */
+@media (prefers-reduced-motion: reduce) {
+  .chip-flash {
+    animation: none;
+  }
+}
+
 /* The main app is intentionally motion-free. */
 #app-shell,
 #app-shell *,

--- a/promo/.gitignore
+++ b/promo/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+out/
+
+# Source clips are cut from the founder's screen recording and are large;
+# regenerate with the ffmpeg lines in src/scene/Desktop.tsx.
+public/clip-*.mp4

--- a/promo/README.md
+++ b/promo/README.md
@@ -1,0 +1,135 @@
+# Scrollr promo chips
+
+Transparent, 60fps overlays of the **real** ticker chips, for compositing
+over screen captures in DaVinci Resolve.
+
+The compositions import `FantasyStatChip` and `FollowedPlayerChip`
+straight out of `desktop/src`. They are the shipped components, not
+recreations, so an overlay cannot drift from the product — change a chip
+in the app and the next render follows. What this project owns is the
+data and the timing; the design belongs to the app.
+
+## Render
+
+```bash
+npx remotion render LeagueChip out/league-chip.mov --codec=prores --prores-profile=4444
+npx remotion render PlayerChip out/player-chip.mov --codec=prores --prores-profile=4444
+npx remotion render ScorePop  out/score-pop.mov  --codec=prores --prores-profile=4444
+```
+
+Or `npm run render:league` / `render:player` / `render:pop`, which are the
+same commands.
+
+Confirm the alpha survived:
+
+```bash
+npx remotion ffprobe out/league-chip.mov
+```
+
+You want `yuva444p12le` in the video stream line. If you see `yuv422p12le`
+— no `a` — the file is opaque and Resolve will show a black box.
+
+To eyeball a frame the way it will actually composite:
+
+```bash
+npx remotion ffmpeg -y -ss 2 -i out/league-chip.mov -frames:v 1 -pix_fmt rgba -update 1 out/frame.png
+node scripts/preview-alpha.mjs out/frame.png out/on-grey.png 70
+```
+
+A transparent PNG opened on its own tells you nothing, because the viewer
+picks the backdrop. That script forces the question.
+
+## Variants without touching code
+
+Every comp is fully prop-driven. Put the overrides in a JSON file:
+
+```json
+{
+  "leagueName": "Dynasty or Bust",
+  "teamName": "Regression Candidates",
+  "opponentName": "Air Yards Only",
+  "week": 12,
+  "status": "final",
+  "myScore": 184.5,
+  "opponentScore": 151.0,
+  "projection": 184.5,
+  "topScorer": { "name": "Allen", "team": "BUF", "position": "QB", "points": 36.9 },
+  "record": { "wins": 9, "losses": 2 },
+  "rank": 1,
+  "numTeams": 8,
+  "countUpFrom": 170.2
+}
+```
+
+then
+
+```bash
+npx remotion render LeagueChip out/dynasty.mov --codec=prores --prores-profile=4444 --props=variants/dynasty.json
+```
+
+**Use a file, not inline JSON.** `--props='{"a":1}'` works in bash and
+falls apart in PowerShell, which strips the quotes and hands Remotion
+something unparseable. A file behaves the same in every shell.
+
+## Timing contract
+
+All three comps are 6s at 60fps and **settle by frame 90 (1.5s)**, then
+hold. Everything past 90 is identical, so you can trim from the tail to
+any length without the picture changing. The one exception is the LIVE
+dot, which keeps breathing on purpose — a "LIVE" badge that has stopped
+moving reads as a screenshot.
+
+| frames | what happens |
+| ------ | ------------ |
+| 0–20   | slide up + fade in |
+| 20–70  | scores count to their final value, ease-out |
+| 26–82  | spine / underline bars fill |
+| 90+    | held |
+
+`ScorePop` is separate: it overshoots around frame 12 and settles by 34,
+so aligning comp frame 0 with a music hit puts the accent just after the
+transient, where an accent wants to sit.
+
+## Resolution
+
+Chips render at **2× their real ticker size** on oversized canvases
+(1920×640, 1280×520, 1080×520), so a 200% punch-in on a 1080p timeline is
+still sampling real pixels. The margin also clears the chip's glow and
+flash ring, which sit outside its border box — a canvas fitted tightly to
+the chip clips them, and the crop shows against moving footage.
+
+Scale is a prop, so `--props '{"scale":3}'` gives you more without
+touching the design. The chip's geometry is never changed to make it
+bigger; it is drawn at real size and scaled, which is what keeps padding
+and wrapping identical to the product.
+
+## Two things that will look wrong until you know why
+
+**The chip has no fill.** In the app its background is a 6% wash that
+reads against the dark bar behind it. Standing alone there is nothing
+behind it, so it composites as glass — border and text only. That looks
+good over calm footage and gets unreadable over busy footage. Pass
+`"plate": true` to give it the app's own surface colour as a ground.
+
+**The score digits don't roll.** `rollScore` is deliberately off. The
+roll is Motion-driven and Motion animates through WAAPI on the document
+timeline, which does not advance when Remotion steps frames — the digits
+would sit frozen mid-roll. The `countUp` helper does the same job as a
+pure function of the frame instead.
+
+## Gotchas that cost a render
+
+- **`Config.setVideoImageFormat("png")` in `remotion.config.ts` is
+  load-bearing.** JPEG frames have no alpha channel, so with jpeg the
+  encoder receives opaque images and writes an opaque file no matter what
+  codec you ask for. It fails silently: the render succeeds, the file
+  really is ProRes 4444, and only ffprobe tells you the alpha is gone.
+- **Prop types are `type` aliases, not `interface`s.** Remotion's
+  `Composition` needs props assignable to `Record<string, unknown>`, and
+  TypeScript gives an implicit index signature to type aliases but not to
+  interfaces. As an interface it fails with a `LooseComponentType` error
+  naming neither the cause nor the fix.
+- **Nothing may paint a background.** Not the AbsoluteFill, not the theme
+  wrapper, not the chip. The wrapper is `#app-shell`, never
+  `#desktop-shell` — the latter carries `height: 100vh` and its own
+  background.

--- a/promo/README.md
+++ b/promo/README.md
@@ -12,13 +12,22 @@ data and the timing; the design belongs to the app.
 ## Render
 
 ```bash
-npx remotion render LeagueChip out/league-chip.mov --codec=prores --prores-profile=4444
-npx remotion render PlayerChip out/player-chip.mov --codec=prores --prores-profile=4444
-npx remotion render ScorePop  out/score-pop.mov  --codec=prores --prores-profile=4444
+npm run render:all
 ```
 
-Or `npm run render:league` / `render:player` / `render:pop`, which are the
-same commands.
+or one at a time: `render:league`, `render:player`, `render:rail`,
+`render:pop`.
+
+| comp | canvas | what it is |
+| ---- | ------ | ---------- |
+| `LeagueChip` | 1920x640 | one league, two lines, the full matchup |
+| `PlayerChip` | 1280x520 | one player, points against projection |
+| `TickerRail` | 3840x280 | three leagues side by side, one of them scores |
+| `ScorePop` | 1080x520 | a `+13.6 PTS` pill for a music hit |
+
+`TickerRail` is 2x a 1920-wide bar: drop it on a 1080p timeline at 50%
+for a pixel-exact ticker along the top of a screen capture, or leave it
+at 100% to punch in.
 
 Confirm the alpha survived:
 
@@ -57,7 +66,7 @@ Every comp is fully prop-driven. Put the overrides in a JSON file:
   "record": { "wins": 9, "losses": 2 },
   "rank": 1,
   "numTeams": 8,
-  "countUpFrom": 170.2
+  "scoreEvents": [{ "at": 60, "points": 8.4, "kind": "big" }]
 }
 ```
 
@@ -71,24 +80,72 @@ npx remotion render LeagueChip out/dynasty.mov --codec=prores --prores-profile=4
 falls apart in PowerShell, which strips the quotes and hands Remotion
 something unparseable. A file behaves the same in every shell.
 
-## Timing contract
+## Scoring plays, not a count-up
 
-All three comps are 6s at 60fps and **settle by frame 90 (1.5s)**, then
-hold. Everything past 90 is identical, so you can trim from the tail to
-any length without the picture changing. The one exception is the LIVE
-dot, which keeps breathing on purpose — a "LIVE" badge that has stopped
-moving reads as a screenshot.
+**Fantasy points do not ramp.** A catch is +1.4 and a touchdown is +6.6,
+both delivered whole, and the gap between them is the part that hurts.
+Gliding a score from 149.9 to 157.9 reads as a dashboard refreshing;
+landing it in two discrete hits reads as two things happening on a field.
 
-| frames | what happens |
-| ------ | ------------ |
-| 0–20   | slide up + fade in |
-| 20–70  | scores count to their final value, ease-out |
-| 26–82  | spine / underline bars fill |
-| 90+    | held |
+So `scoreEvents` is the main control:
+
+```json
+"myScore": 149.9,
+"scoreEvents": [
+  { "at": 50,  "points": 1.4, "kind": "catch" },
+  { "at": 110, "points": 6.6, "kind": "td" }
+]
+```
+
+`myScore` is the total **before** the plays; each event adds to it. Kinds
+are `catch` / `fg` / `td` / `big` and only change how hard the chip
+reacts, never the arithmetic.
+
+### The shape of one hit
+
+| frames | |
+| ------ | --- |
+| −8 → 0 | **anticipation** — the chip eases *down* before the number moves |
+| 0 → 5 | **impact** — up and overshooting; the number counts in this window |
+| 5 → 30 | **settle** — decelerating back to rest |
+
+The dip is the part that matters. Eight frames is invisible if you look
+for it and unmistakable if you don't; it's the flinch before a punch, and
+without it the impact reads as a glitch rather than a blow.
+
+### What the default sequence tells
+
+The shipped defaults are a walk-off, and the middle beat is the point:
+
+- opens **149.9–151.7**, behind by 1.8
+- **f50** a catch, +1.4 → **151.3**. Still behind, by 0.4. Close enough
+  to taste and still losing is the only frame that makes a viewer lean in.
+- **f110** a touchdown, +6.6 → **157.9**, and the lead flips *inside* the
+  count. Score turns green, win% goes 73→90, the spine surges, a ring
+  flares.
+
+None of that back half is choreographed separately. **Only the score is
+animated** — win probability, spine fill and the up/down colour are all
+derived by the real chip from the matchup it is handed, so counting the
+score moves every one of them in step. Animating them by hand would have
+meant a second copy of `estimateWinProbability` living here, drifting
+from the real one the first time it was tuned.
 
 `ScorePop` is separate: it overshoots around frame 12 and settles by 34,
 so aligning comp frame 0 with a music hit puts the accent just after the
 transient, where an accent wants to sit.
+
+### Trimming
+
+Everything is 6s at 60fps. With the default events the picture is frozen
+from about **frame 192** (3.2s), leaving 168 frames of identical tail to
+trim from. That figure moves with your events — `settledAt()` in
+`scoring.ts` is the source of truth. The LIVE dot keeps breathing past it
+on purpose: a "LIVE" badge that has stopped moving reads as a screenshot.
+
+A simple `countUpFrom` still works for a chip that should just glide to a
+value. It is ignored when `scoreEvents` is set — a smooth ramp and a
+sequence of plays are two different stories and a chip can only tell one.
 
 ## Resolution
 
@@ -103,7 +160,14 @@ touching the design. The chip's geometry is never changed to make it
 bigger; it is drawn at real size and scaled, which is what keeps padding
 and wrapping identical to the product.
 
-## Two things that will look wrong until you know why
+## Three things that will look wrong until you know why
+
+**Only the chip that scored reacts.** On `TickerRail` the wash and ring
+apply to the hero chip alone while the other leagues carry on unbothered.
+That is deliberate: a whole bar lighting up reads as an app-wide alert,
+and the neighbours holding steady is exactly what makes the reacting one
+feel live. (This was a real bug first — the reaction lived on the stage
+and lit all three.)
 
 **The chip has no fill.** In the app its background is a 6% wash that
 reads against the dark bar behind it. Standing alone there is nothing

--- a/promo/README.md
+++ b/promo/README.md
@@ -22,12 +22,13 @@ or one at a time: `render:league`, `render:player`, `render:rail`,
 | ---- | ------ | ---------- |
 | `LeagueChip` | 1920x640 | one league, two lines, the full matchup |
 | `PlayerChip` | 1280x520 | one player, points against projection |
-| `TickerRail` | 3840x280 | three leagues side by side, one of them scores |
+| `TickerRail` | 3840x280 | **30s** — five leagues, five plays landing across the length |
 | `ScorePop` | 1080x520 | a `+13.6 PTS` pill for a music hit |
 
-`TickerRail` is 2x a 1920-wide bar: drop it on a 1080p timeline at 50%
-for a pixel-exact ticker along the top of a screen capture, or leave it
-at 100% to punch in.
+The first three are 6s beats. **`TickerRail` is 30s** — it is a bed, not
+a beat, meant to run along the top of a whole section rather than being
+cut to. It is 2x a 1920-wide bar: drop it on a 1080p timeline at 50% for
+a pixel-exact ticker, or leave it at 100% to punch in.
 
 Confirm the alpha survived:
 
@@ -134,6 +135,32 @@ from the real one the first time it was tuned.
 `ScorePop` is separate: it overshoots around frame 12 and settles by 34,
 so aligning comp frame 0 with a music hit puts the accent just after the
 transient, where an accent wants to sit.
+
+### The rail's rhythm
+
+Every league on the rail carries its own `scoreEvents`, so plays land on
+different chips across the 30s rather than one designated cell being the
+only thing that ever moves. Most chips never score, on purpose — a bar
+where everything is always erupting has no significant moments left.
+
+| frame | league | play | |
+| ----- | ------ | ---- | --- |
+| 120 | Sunday Money | catch +1.4 | 151.3, still behind by 0.4 |
+| 420 | Work League | TD +6.6 | extends a lead it already had |
+| **780** | **Sunday Money** | **TD +6.6** | **crosses — the shot** |
+| 1150 | College Buddies | big play +8.4 | takes a lead, flares |
+| 1500 | Waiver Wire Wars | FG +3 | |
+
+Eleven seconds pass between the catch and the touchdown with the score
+sitting 0.4 behind. That gap is deliberate and it is the most valuable
+part of the clip.
+
+**Chip count is arithmetic, not taste.** A chip is ~548px before
+scaling, the viewport holds 1920 of those, and the drift covers 630
+across the comp. Five puts ~3.5 on screen and lets the fifth arrive as
+the first leaves — so the bar never looks static and never runs out of
+rail. Change the duration or the drift and you have to re-check that
+each play still lands while its chip is on screen.
 
 ### Trimming
 

--- a/promo/README.md
+++ b/promo/README.md
@@ -169,11 +169,11 @@ and the neighbours holding steady is exactly what makes the reacting one
 feel live. (This was a real bug first — the reaction lived on the stage
 and lit all three.)
 
-**The chip has no fill.** In the app its background is a 6% wash that
-reads against the dark bar behind it. Standing alone there is nothing
-behind it, so it composites as glass — border and text only. That looks
-good over calm footage and gets unreadable over busy footage. Pass
-`"plate": true` to give it the app's own surface colour as a ground.
+**The chip is nearly transparent.** Its fill is the app's own 6% wash,
+which is subtle by design — it reads against the dark bar behind it in
+the product, and over footage it composites as tinted glass. That looks
+good over calm footage and gets hard to read over busy footage. Pass
+`"plate": true` to give it the app's surface colour as a solid ground.
 
 **The score digits don't roll.** `rollScore` is deliberately off. The
 roll is Motion-driven and Motion animates through WAAPI on the document
@@ -188,6 +188,16 @@ pure function of the frame instead.
   encoder receives opaque images and writes an opaque file no matter what
   codec you ask for. It fails silently: the render succeeds, the file
   really is ProRes 4444, and only ffprobe tells you the alpha is gone.
+- **`@source` in `src/styles.css` must cover `.ts`, not just `.tsx`.**
+  The app's own directives are `*.tsx` only, and every chip's border,
+  background and text class is a string in `chipColors.ts` — a `.ts`
+  file. Tailwind never scanned it, so `border-accent-purple/25` and
+  `bg-accent-purple/[0.06]` were never generated. That does not fail
+  loudly: the border silently fell back to Tailwind's `currentColor`
+  default, inherited the light body foreground, and drew a hard white
+  1px line on every chip, while the fill simply did not exist. The app
+  is unaffected — its Tailwind content detection walks from `desktop/`
+  and finds the `.ts` files anyway; here the detection root is `promo/`.
 - **Prop types are `type` aliases, not `interface`s.** Remotion's
   `Composition` needs props assignable to `Record<string, unknown>`, and
   TypeScript gives an implicit index signature to type aliases but not to

--- a/promo/README.md
+++ b/promo/README.md
@@ -24,6 +24,7 @@ or one at a time: `render:league`, `render:player`, `render:rail`,
 | `PlayerChip` | 1280x520 | one player, points against projection |
 | `TickerRail` | 3840x280 | **30s** — five leagues, five plays landing across the length |
 | `ScorePop` | 1080x520 | a `+13.6 PTS` pill for a music hit |
+| `ThemeRail` | 3840x280 | 5s — the same chips, rendered once per dark theme |
 
 The first three are 6s beats. **`TickerRail` is 30s** — it is a bed, not
 a beat, meant to run along the top of a whole section rather than being
@@ -48,6 +49,36 @@ node scripts/preview-alpha.mjs out/frame.png out/on-grey.png 70
 
 A transparent PNG opened on its own tells you nothing, because the viewer
 picks the backdrop. That script forces the question.
+
+## Theme montage
+
+```bash
+npm run render:themes                          # all ten
+node scripts/render-themes.mjs nord-dark       # just one
+```
+
+Ten clips into `out/themes/`, one per dark theme, 5s each. Identical in
+every respect except the palette — same leagues, same scores, the same
+play landing on the same frame — so a cut between any two reads as the
+skin changing and nothing else.
+
+Themes override `--color-accent-purple`, `--color-up` and `--color-down`
+as well as the surfaces, so the border, the score colour and the flash
+on a scoring play all change together. Gruvbox comes out warm yellow,
+Rose Pine cool blue-grey, and so on.
+
+`ThemeRail` uses three chips rather than the rail's five, and a slower
+drift: at 5s there is no time for a fourth chip to arrive, and the
+montage only works if every clip frames identically. The single play
+lands at f90 and crosses, so each theme gets the same moment.
+
+**`scrollr-dark` has no `[data-theme]` block** — it *is* the `@theme`
+default, so a list built by grepping the stylesheet finds nine and
+silently drops the house palette. The canonical list lives in
+`src/promo-chips/themes.ts`; the render script reads it and then asserts
+that every `*-dark` selector in the app's stylesheet appears in it, so
+adding a theme to the product fails loudly here instead of quietly
+shipping a montage that is missing one.
 
 ## Variants without touching code
 

--- a/promo/package-lock.json
+++ b/promo/package-lock.json
@@ -1,0 +1,4503 @@
+{
+  "name": "scrollr-promo",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scrollr-promo",
+      "version": "0.1.0",
+      "dependencies": {
+        "@remotion/cli": "^4.0.0",
+        "@remotion/tailwind-v4": "^4.0.0",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.460.0",
+        "motion": "^12.35.1",
+        "motion-plus": "https://api.motion.dev/registry.tgz?package=motion-plus&version=2.11.0&token=032997dbced0702754906e3f43111740b10beaa970fd6d26423e34e43a46acfe",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "remotion": "^4.0.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mediabunny/aac-encoder": {
+      "version": "1.50.8",
+      "resolved": "https://registry.npmjs.org/@mediabunny/aac-encoder/-/aac-encoder-1.50.8.tgz",
+      "integrity": "sha512-A5Se/LZd6RmYq/h36lBMSEsHvsyW8d0toR7FrAwpsFYbK+DVQYf90KiBT1Aw/mzLXx8/ypIOORJnd1sVZqOvJQ==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/flac-encoder": {
+      "version": "1.50.8",
+      "resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.50.8.tgz",
+      "integrity": "sha512-4cfN03SbEoQaG+eBeYFUAb1R1ALaAHzf43dXFzQTr/oO5ueqzTgBoG3coKrIvBaAMU7Vv36mrBKLX8bvTppdAQ==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/mp3-encoder": {
+      "version": "1.50.8",
+      "resolved": "https://registry.npmjs.org/@mediabunny/mp3-encoder/-/mp3-encoder-1.50.8.tgz",
+      "integrity": "sha512-eBT/H30tTu8AmZXqZ5RTpJ9VmwVlwednajuOrrWp0GS6cbGXsGMQ60Qvr3ZMIE0QDiadlEzb8/ozR+doP+MC1g==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@module-federation/error-codes": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+      "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+      "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/runtime-core": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+      "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-tools": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+      "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/webpack-bundler-runtime": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+      "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@remotion/bundler": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.507.tgz",
+      "integrity": "sha512-SECbwvydNg9XgHcKQkiiYQM92v4FHBADpTb5xlyGROWQ4qA1wySYdDfdMmd0WVQfCV1Zi9JPRDQAW8nDBW33VQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.507",
+        "@remotion/studio": "4.0.507",
+        "@remotion/studio-shared": "4.0.507",
+        "@remotion/timeline-utils": "4.0.507",
+        "@rspack/core": "1.7.11",
+        "@rspack/plugin-react-refresh": "1.6.1",
+        "css-loader": "7.1.4",
+        "esbuild": "0.28.1",
+        "react-refresh": "0.18.0",
+        "remotion": "4.0.507",
+        "style-loader": "4.0.0",
+        "webpack": "5.105.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/captions": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/captions/-/captions-4.0.507.tgz",
+      "integrity": "sha512-mS2fe1nbofJQ5vEc6dV1zJpZ06QUmKj1zqRv1TLyACQmlr8O63IP3NTAqhBQSfLYX7Kad6+83Vt2huv+PgM/+w==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/cli": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.507.tgz",
+      "integrity": "sha512-A53RU54y2wf7T00X0wcFOGoa4Dvjqc3VJFi+BgwWWtlSGsPvEmkXLsrly31GpZMXqXE1LU4IeDj1YoajY/GBOQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@remotion/bundler": "4.0.507",
+        "@remotion/media-utils": "4.0.507",
+        "@remotion/player": "4.0.507",
+        "@remotion/renderer": "4.0.507",
+        "@remotion/studio": "4.0.507",
+        "@remotion/studio-server": "4.0.507",
+        "@remotion/studio-shared": "4.0.507",
+        "dotenv": "17.3.1",
+        "minimist": "1.2.6",
+        "prompts": "2.4.2",
+        "remotion": "4.0.507",
+        "semver": "7.5.3"
+      },
+      "bin": {
+        "remotion": "remotion-cli.js",
+        "remotionb": "remotionb-cli.js",
+        "remotiond": "remotiond-cli.js"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/compositor-darwin-arm64": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.507.tgz",
+      "integrity": "sha512-MNvUNS33X3YCwalX+LbGcYXXxkWnOspX2vB7agzkHE/IKSFAG58sF9iXyp+rn6lJmCjBcaUxO7paJFxfAzjwEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-darwin-x64": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.507.tgz",
+      "integrity": "sha512-oz8Wjq42oKZwhTc2N20tBMXx7Ts3K5T+cQH6oo5PEyFgrpx1j5Lm2AQTsunlgiMhOda20Vff0ZLeiXVUR+xtuA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-gnu": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.507.tgz",
+      "integrity": "sha512-K6PCQwPE2wJlV5/nat6UrRVx7XCk5LgCRV4cQsIXyYDCvo7995KMI4KgP4DtKXcvXaQUudz9r9JuFT+KGktPwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-musl": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.507.tgz",
+      "integrity": "sha512-hKgdJm+dGcxUs/GNajUa2uH6RnphjKVvz+zLWWLdRhgPzxvPhm4ZJm9VPoyr1hmY3c84ws5qiXV30AkHtZVIVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-gnu": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.507.tgz",
+      "integrity": "sha512-5w9iYYlfp0qLohFMAAyHPR00NxiQ3SuhJyx6ck+z9pkLZLgTAKC7EWB0e8HMaC6czxPAH1F+ZbXeA1ukfM7SOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-musl": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.507.tgz",
+      "integrity": "sha512-tnieQCpBZ1uSL6z9Dk3noNwYG6wGIH3WZpMfRQZgrInJ4LhmRSzzIFx6Bb2l9QZGAkIiGKFadDFHlw0JVsJd1A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-win32-x64-msvc": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.507.tgz",
+      "integrity": "sha512-FCkZDLcPBCO2WO/MyrtMB5tpsIuqqkc7E1nY2lfY6WmRX2quGfykcsz4S9inYx/G+XybKVTgplqnyLtt9wyFnw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@remotion/licensing": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.507.tgz",
+      "integrity": "sha512-fdods4YD9c8Ww69wHdnmXpjx7W0rvct6B7gLb92cWsd+ITSUG3hKoh+NqSWXF0GK5bk8IFRmTtBAwJObxow9wA==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/media-parser": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.507.tgz",
+      "integrity": "sha512-BONx6R/0LLUSKjSgRLewb9QjZ9ZulxCct/RGPAFN8TIdeFUWxQ81Yfq1hQmUyXNBUhbfcHBEjdGnjgHCAeJkNw==",
+      "license": "Remotion License https://remotion.dev/license"
+    },
+    "node_modules/@remotion/media-utils": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.507.tgz",
+      "integrity": "sha512-Ncm9ATXVOJ7aFbGXycVAXo+ISp3PFZb2JYSnGBuzat+d03CLR3yyCzGPhovlZqhnP7UIaRJxo15I5DlUkiGxrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mediabunny": "1.50.8",
+        "remotion": "4.0.507"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/player": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.507.tgz",
+      "integrity": "sha512-ZAunyyCfOXSYh5sZrp+vFxZlSPatg5evmh7fHVCndAOWBUPIDVjdUWEM2D4i132MsN6GXasXDByi+6H0H+IkhQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.507"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/renderer": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.507.tgz",
+      "integrity": "sha512-2qw3/2va97UNvkc1R/3L471mJwXEL33E5MI+YmBVUeS7TS/G6uoB4fNNrGMFs+DPp2u2dNGAIBEUqn1TWP9zGw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/licensing": "4.0.507",
+        "@remotion/streaming": "4.0.507",
+        "execa": "5.1.1",
+        "remotion": "4.0.507",
+        "source-map": "0.8.0",
+        "ws": "8.21.0"
+      },
+      "optionalDependencies": {
+        "@remotion/compositor-darwin-arm64": "4.0.507",
+        "@remotion/compositor-darwin-x64": "4.0.507",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.507",
+        "@remotion/compositor-linux-arm64-musl": "4.0.507",
+        "@remotion/compositor-linux-x64-gnu": "4.0.507",
+        "@remotion/compositor-linux-x64-musl": "4.0.507",
+        "@remotion/compositor-win32-x64-msvc": "4.0.507"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/streaming": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.507.tgz",
+      "integrity": "sha512-RyLYm7/d3w2I0+ZiK/xNUxnDKyIkmpRFfNiSaod2cXnTw2fsbQ7xt5exJZSylvsd581ciDLeOaIN1m/u3425NA==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/studio": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.507.tgz",
+      "integrity": "sha512-6Za3v2uKItMqwiZm5Nk8la02KnPZIl+n3ctlVWmZe0kN8c9nsW3raTeYqGZyL9Bc2UXVq4J4IOWPu2etvnP/RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@remotion/captions": "4.0.507",
+        "@remotion/media-utils": "4.0.507",
+        "@remotion/player": "4.0.507",
+        "@remotion/renderer": "4.0.507",
+        "@remotion/studio-protocol": "4.0.507",
+        "@remotion/studio-shared": "4.0.507",
+        "@remotion/timeline-utils": "4.0.507",
+        "@remotion/web-renderer": "4.0.507",
+        "@remotion/zod-types": "4.0.507",
+        "mediabunny": "1.50.8",
+        "memfs": "3.4.3",
+        "open": "8.4.2",
+        "remotion": "4.0.507",
+        "semver": "7.5.3",
+        "zod": "4.4.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/studio-codemods": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-codemods/-/studio-codemods-4.0.507.tgz",
+      "integrity": "sha512-F5xSJ/UXoQqEX/63WLa94G4glUZDR5GwDoMANCjEUJmu+YlV9rVuqTGI99YbbtyL59/WBAJVMYAOHCmCMkSgpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@babel/types": "7.24.0",
+        "@remotion/studio-shared": "4.0.507",
+        "ast-types": "0.16.1",
+        "recast": "0.23.11",
+        "remotion": "4.0.507"
+      }
+    },
+    "node_modules/@remotion/studio-protocol": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-protocol/-/studio-protocol-4.0.507.tgz",
+      "integrity": "sha512-udC5R7gIODKAmMCG808O+uetgsm6aPYXK+g8ztEAAFfPho1pMoUXYUhO20ceLuWXZGMsS3A+sdow0q1eI7BZMQ==",
+      "license": "Remotion License"
+    },
+    "node_modules/@remotion/studio-server": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.507.tgz",
+      "integrity": "sha512-ZEsnEAJR3Y3jenbfO8oUMPkLfxrdI4oUuVmIZNs20xh1SWcsR3wMBPd44dK+u4CcwnJRiLMyVRhfGeK2Am9hjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@babel/types": "7.24.0",
+        "@remotion/bundler": "4.0.507",
+        "@remotion/renderer": "4.0.507",
+        "@remotion/studio-codemods": "4.0.507",
+        "@remotion/studio-protocol": "4.0.507",
+        "@remotion/studio-shared": "4.0.507",
+        "@svgr/core": "8.1.0",
+        "@svgr/plugin-jsx": "8.1.0",
+        "kiwi-schema": "0.5.0",
+        "memfs": "3.4.3",
+        "open": "8.4.2",
+        "prettier": "3.8.1",
+        "recast": "0.23.11",
+        "remotion": "4.0.507",
+        "semver": "7.5.3",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@remotion/studio-shared": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.507.tgz",
+      "integrity": "sha512-qFdI5XwIsVFFiKXx8snM+0SHi41/mfOR+tJcVHsPFzqqYTSd4Wq/4jyPfWzx89QHFkEJw1IBsl7ktpJ7pR7yhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remotion/studio-protocol": "4.0.507",
+        "remotion": "4.0.507"
+      }
+    },
+    "node_modules/@remotion/tailwind-v4": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/tailwind-v4/-/tailwind-v4-4.0.507.tgz",
+      "integrity": "sha512-oD8iEVq0R4EajZUD1vqpAEZehM9cAz8AuTeGOdgkVjKeq68/+1qsRN9P/0OWWPuujhAWJipF10tovgG+wtEVgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/webpack": "4.2.0",
+        "css-loader": "7.1.4",
+        "style-loader": "4.0.0",
+        "tailwindcss": "4.2.0"
+      },
+      "peerDependencies": {
+        "@remotion/bundler": "4.0.507"
+      }
+    },
+    "node_modules/@remotion/timeline-utils": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.507.tgz",
+      "integrity": "sha512-xPn0EIQ3/QoIF1om7g76oW/ifpW9FxU0SuLvDn96ApIbZZ8RdMYJQlCXAUpbbrxd2x6nonj40BaQiB9x+eXPsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mediabunny": "1.50.8"
+      }
+    },
+    "node_modules/@remotion/web-renderer": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.507.tgz",
+      "integrity": "sha512-fH8iZX1e0hmeJ+hPqn3RfqrDBNxMGsZZzfdyX2QpTDZ9F2kKqOkh0dQsRqaU8o+YoE8JNV/+FyYm4yyDAh9o6Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@mediabunny/aac-encoder": "1.50.8",
+        "@mediabunny/flac-encoder": "1.50.8",
+        "@mediabunny/mp3-encoder": "1.50.8",
+        "@remotion/licensing": "4.0.507",
+        "mediabunny": "1.50.8",
+        "remotion": "4.0.507"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@remotion/zod-types": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.507.tgz",
+      "integrity": "sha512-5Rezxss8eOaWq0n/P2U8GAMBQ1wav1HT+lXarqVkEmEGlv3IG7AFjrRSXnWnvm7h4eI5UhpiQ38tBS878QXSGg==",
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.507"
+      }
+    },
+    "node_modules/@rspack/binding": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.11.tgz",
+      "integrity": "sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.7.11",
+        "@rspack/binding-darwin-x64": "1.7.11",
+        "@rspack/binding-linux-arm64-gnu": "1.7.11",
+        "@rspack/binding-linux-arm64-musl": "1.7.11",
+        "@rspack/binding-linux-x64-gnu": "1.7.11",
+        "@rspack/binding-linux-x64-musl": "1.7.11",
+        "@rspack/binding-wasm32-wasi": "1.7.11",
+        "@rspack/binding-win32-arm64-msvc": "1.7.11",
+        "@rspack/binding-win32-ia32-msvc": "1.7.11",
+        "@rspack/binding-win32-x64-msvc": "1.7.11"
+      }
+    },
+    "node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.11.tgz",
+      "integrity": "sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.11.tgz",
+      "integrity": "sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.11.tgz",
+      "integrity": "sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.11.tgz",
+      "integrity": "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.11.tgz",
+      "integrity": "sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.11.tgz",
+      "integrity": "sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.11.tgz",
+      "integrity": "sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "1.0.7"
+      }
+    },
+    "node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.11.tgz",
+      "integrity": "sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.11.tgz",
+      "integrity": "sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.11.tgz",
+      "integrity": "sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/core": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.11.tgz",
+      "integrity": "sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime-tools": "0.22.0",
+        "@rspack/binding": "1.7.11",
+        "@rspack/lite-tapable": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/lite-tapable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+      "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+      "license": "MIT"
+    },
+    "node_modules/@rspack/plugin-react-refresh": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-1.6.1.tgz",
+      "integrity": "sha512-eqqW5645VG3CzGzFgNg5HqNdHVXY+567PGjtDhhrM8t67caxmsSzRmT5qfoEIfBcGgFkH9vEg7kzXwmCYQdQDw==",
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.1.4",
+        "html-entities": "^2.6.0"
+      },
+      "peerDependencies": {
+        "react-refresh": ">=0.10.0 <1.0.0",
+        "webpack-hot-middleware": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-hot-middleware": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
+      "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
+      "integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
+      "integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
+      "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
+      "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
+      "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
+      "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-transform-svg-component": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
+      "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-preset": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-8.1.0.tgz",
+      "integrity": "sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
+        "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
+        "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
+        "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
+        "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
+        "@svgr/babel-plugin-transform-svg-component": "8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/core": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
+      "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.21.3",
+        "@svgr/babel-preset": "8.1.0",
+        "camelcase": "^6.2.0",
+        "cosmiconfig": "^8.1.3",
+        "snake-case": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@svgr/hast-util-to-babel-ast": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
+      "integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.21.3",
+        "entities": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@svgr/plugin-jsx": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-8.1.0.tgz",
+      "integrity": "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.21.3",
+        "@svgr/babel-preset": "8.1.0",
+        "@svgr/hast-util-to-babel-ast": "8.0.0",
+        "svg-parser": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@svgr/core": "*"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.0.tgz",
+      "integrity": "sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.31.1",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.0.tgz",
+      "integrity": "sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.0",
+        "@tailwindcss/oxide-darwin-x64": "4.2.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.0.tgz",
+      "integrity": "sha512-F0QkHAVaW/JNBWl4CEKWdZ9PMb0khw5DCELAOnu+RtjAfx5Zgw+gqCHFvqg3AirU1IAd181fwOtJQ5I8Yx5wtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.0.tgz",
+      "integrity": "sha512-I0QylkXsBsJMZ4nkUNSR04p6+UptjcwhcVo3Zu828ikiEqHjVmQL9RuQ6uT/cVIiKpvtVA25msu/eRV97JeNSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.0.tgz",
+      "integrity": "sha512-6TmQIn4p09PBrmnkvbYQ0wbZhLtbaksCDx7Y7R3FYYx0yxNA7xg5KP7dowmQ3d2JVdabIHvs3Hx4K3d5uCf8xg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.0.tgz",
+      "integrity": "sha512-qBudxDvAa2QwGlq9y7VIzhTvp2mLJ6nD/G8/tI70DCDoneaUeLWBJaPcbfzqRIWraj+o969aDQKvKW9dvkUizw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.0.tgz",
+      "integrity": "sha512-7XKkitpy5NIjFZNUQPeUyNJNJn1CJeV7rmMR+exHfTuOsg8rxIO9eNV5TSEnqRcaOK77zQpsyUkBWmPy8FgdSg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.0.tgz",
+      "integrity": "sha512-Mff5a5Q3WoQR01pGU1gr29hHM1N93xYrKkGXfPw/aRtK4bOc331Ho4Tgfsm5WDGvpevqMpdlkCojT3qlCQbCpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.0.tgz",
+      "integrity": "sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.0.tgz",
+      "integrity": "sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.0.tgz",
+      "integrity": "sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.0.tgz",
+      "integrity": "sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.0.tgz",
+      "integrity": "sha512-2UU/15y1sWDEDNJXxEIrfWKC2Yb4YgIW5Xz2fKFqGzFWfoMHWFlfa1EJlGO2Xzjkq/tvSarh9ZTjvbxqWvLLXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.0.tgz",
+      "integrity": "sha512-CrFadmFoc+z76EV6LPG1jx6XceDsaCG3lFhyLNo/bV9ByPrE+FnBPckXQVP4XRkN76h3Fjt/a+5Er/oA/nCBvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/webpack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/webpack/-/webpack-4.2.0.tgz",
+      "integrity": "sha512-TohlILOzF/3l+Yolll9iD2b5bsLG/1TuxAXPTxJcA77YAgPyKKc5RIwj4vIjg4l9DFMidekx2Z0BWyPAle9TUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.0",
+        "@tailwindcss/oxide": "4.2.0",
+        "tailwindcss": "4.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+      "integrity": "sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-loader": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
+      "integrity": "sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.40",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
+        "webpack": "^5.27.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/css-loader/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/framer-motion": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.43.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs-monkey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+      "license": "Unlicense"
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kiwi-schema": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/kiwi-schema/-/kiwi-schema-0.5.0.tgz",
+      "integrity": "sha512-X+FpfU0yTEtc6aTHS7VwbOpvQwRt70+pXXWRI5fd6CvWhe7pSVC854TVo4Zo0x5/wwcWj+/9KUlXpdcP0dY9AA==",
+      "license": "MIT",
+      "bin": {
+        "kiwic": "cli.js"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
+      "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.31.1",
+        "lightningcss-darwin-arm64": "1.31.1",
+        "lightningcss-darwin-x64": "1.31.1",
+        "lightningcss-freebsd-x64": "1.31.1",
+        "lightningcss-linux-arm-gnueabihf": "1.31.1",
+        "lightningcss-linux-arm64-gnu": "1.31.1",
+        "lightningcss-linux-arm64-musl": "1.31.1",
+        "lightningcss-linux-x64-gnu": "1.31.1",
+        "lightningcss-linux-x64-musl": "1.31.1",
+        "lightningcss-win32-arm64-msvc": "1.31.1",
+        "lightningcss-win32-x64-msvc": "1.31.1"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
+      "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
+      "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
+      "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
+      "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
+      "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
+      "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
+      "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
+      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
+      "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
+      "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
+      "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.460.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz",
+      "integrity": "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mediabunny": {
+      "version": "1.50.8",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.50.8.tgz",
+      "integrity": "sha512-LgykLyQzhdpo0V2yw3UXmOpj+b4JAGdpHBwsPE6kjSt8Za0d1VllD+FV7EGHBcdV4+oHUAo+yrqbVAWxNSDCPQ==",
+      "license": "MPL-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.3.tgz",
+      "integrity": "sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==",
+      "license": "Unlicense",
+      "dependencies": {
+        "fs-monkey": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "license": "MIT"
+    },
+    "node_modules/motion": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.43.0.tgz",
+      "integrity": "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.43.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-plus": {
+      "version": "2.11.0",
+      "resolved": "https://api.motion.dev/registry.tgz?package=motion-plus&version=2.11.0&token=032997dbced0702754906e3f43111740b10beaa970fd6d26423e34e43a46acfe",
+      "integrity": "sha512-K4GZHArVswXsUqMvXJ109vur417x3/bGVt/0G7pcsnxcFKce0JuLIKcq1DVDpDq/ur4bWpkWbFjM29UR2unHyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion": "^12.25.0",
+        "motion-dom": "^12.25.0",
+        "motion-plus-dom": "^2.9.0",
+        "motion-utils": "^12.23.6"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-plus-dom": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/motion-plus-dom/-/motion-plus-dom-2.12.0.tgz",
+      "integrity": "sha512-8JgwbaUe5i3YF03/YtBlm0ZbOs8ihCzaZJYJr3g85P1l3AqGCZLlgJ92I/bIhwNB26jP+jY4D0Amj6mYh6Ha6g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion": "^12.25.0",
+        "motion-dom": "^12.24.11",
+        "motion-utils": "^12.24.10"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remotion": {
+      "version": "4.0.507",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.507.tgz",
+      "integrity": "sha512-g/NrnRZKJyh0isE+/0sIxKlgJl6BH5v/CJ35W4TGYR1obQZf60fHkf9CGxSBHJEw27dG1PJCgKT75YGfoCZ7tg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0.tgz",
+      "integrity": "sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.27.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.0.tgz",
+      "integrity": "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.2.tgz",
+      "integrity": "sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/watchpack": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.105.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.3.1",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/promo/package.json
+++ b/promo/package.json
@@ -8,10 +8,11 @@
     "render:league": "remotion render LeagueChip out/league-chip.mov --codec=prores --prores-profile=4444",
     "render:player": "remotion render PlayerChip out/player-chip.mov --codec=prores --prores-profile=4444",
     "render:pop": "remotion render ScorePop out/score-pop.mov --codec=prores --prores-profile=4444",
-    "render:all": "npm run render:league && npm run render:player && npm run render:pop",
+    "render:all": "npm run render:league && npm run render:player && npm run render:rail && npm run render:pop",
     "render:variant": "remotion render LeagueChip out/dynasty.mov --codec=prores --prores-profile=4444 --props=variants/dynasty.json",
     "check:alpha": "remotion ffprobe out/league-chip.mov",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "render:rail": "remotion render TickerRail out/ticker-rail.mov --codec=prores --prores-profile=4444"
   },
   "dependencies": {
     "@remotion/cli": "^4.0.0",

--- a/promo/package.json
+++ b/promo/package.json
@@ -12,7 +12,8 @@
     "render:variant": "remotion render LeagueChip out/dynasty.mov --codec=prores --prores-profile=4444 --props=variants/dynasty.json",
     "check:alpha": "remotion ffprobe out/league-chip.mov",
     "typecheck": "tsc --noEmit",
-    "render:rail": "remotion render TickerRail out/ticker-rail.mov --codec=prores --prores-profile=4444"
+    "render:rail": "remotion render TickerRail out/ticker-rail.mov --codec=prores --prores-profile=4444",
+    "render:themes": "node scripts/render-themes.mjs"
   },
   "dependencies": {
     "@remotion/cli": "^4.0.0",

--- a/promo/package.json
+++ b/promo/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "scrollr-promo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Transparent ProRes 4444 chip overlays, rendered from the real Scrollr components.",
+  "scripts": {
+    "dev": "remotion studio",
+    "render:league": "remotion render LeagueChip out/league-chip.mov --codec=prores --prores-profile=4444",
+    "render:player": "remotion render PlayerChip out/player-chip.mov --codec=prores --prores-profile=4444",
+    "render:pop": "remotion render ScorePop out/score-pop.mov --codec=prores --prores-profile=4444",
+    "render:all": "npm run render:league && npm run render:player && npm run render:pop",
+    "render:variant": "remotion render LeagueChip out/dynasty.mov --codec=prores --prores-profile=4444 --props=variants/dynasty.json",
+    "check:alpha": "remotion ffprobe out/league-chip.mov",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@remotion/cli": "^4.0.0",
+    "@remotion/tailwind-v4": "^4.0.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.460.0",
+    "motion": "^12.35.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "remotion": "^4.0.0",
+    "motion-plus": "https://api.motion.dev/registry.tgz?package=motion-plus&version=2.11.0&token=032997dbced0702754906e3f43111740b10beaa970fd6d26423e34e43a46acfe"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/promo/remotion.config.ts
+++ b/promo/remotion.config.ts
@@ -1,0 +1,80 @@
+import path from "node:path";
+import { NormalModuleReplacementPlugin } from "webpack";
+import { Config } from "@remotion/cli/config";
+import { enableTailwind } from "@remotion/tailwind-v4";
+
+/**
+ * The point of this project: promo video is rendered from the REAL
+ * chip components, not recreations. Two things have to be true for that
+ * to work, and both are configured here.
+ *
+ * 1. Tailwind, because the chips are styled entirely in it and would
+ *    otherwise render as unstyled text.
+ * 2. An alias for @tauri-apps/plugin-store, because the chips' import
+ *    chain reaches it (chips -> preferences -> lib/store) even though
+ *    no render path calls it. See stubs/tauri-store.ts.
+ * 3. Replacements for the two registry modules that build themselves
+ *    with Vite's `import.meta.glob`. Webpack cannot execute that — the
+ *    bundle dies on load with "{}.glob is not a function" before a frame
+ *    renders. See stubs/.
+ *
+ *    These use NormalModuleReplacementPlugin rather than resolve.alias,
+ *    and that is not a style choice: webpack aliases DO NOT APPLY TO
+ *    RELATIVE REQUESTS, and both modules are imported relatively from
+ *    inside desktop/src. Four increasingly specific alias attempts
+ *    failed silently before that turned up.
+ */
+Config.overrideWebpackConfig((currentConfig) => {
+  const withTailwind = enableTailwind(currentConfig);
+
+  return {
+    ...withTailwind,
+    resolve: {
+      ...withTailwind.resolve,
+      alias: {
+        ...withTailwind.resolve?.alias,
+        "@tauri-apps/plugin-store": path.resolve(
+          process.cwd(),
+          "stubs/tauri-store.ts",
+        ),
+      },
+    },
+    plugins: [
+      ...(withTailwind.plugins ?? []),
+      new NormalModuleReplacementPlugin(
+        /datawidgets[\/]registry$/,
+        path.resolve(process.cwd(), "stubs/datawidget-registry.ts"),
+      ),
+      new NormalModuleReplacementPlugin(
+        /widgets[\/]registry$/,
+        path.resolve(process.cwd(), "stubs/widget-registry.ts"),
+      ),
+    ],
+  };
+});
+
+/**
+ * PNG, not JPEG, and this is the whole ballgame for transparent output.
+ *
+ * Remotion screenshots each frame before handing it to the encoder, and
+ * JPEG has no alpha channel — so with jpeg frames the encoder receives
+ * fully opaque images and dutifully writes an opaque file, no matter
+ * what codec or pixel format you ask for. The failure is silent and
+ * completely convincing: the render succeeds, the file really is ProRes
+ * 4444, and ffprobe reports `yuv422p12le` with no hint that a setting
+ * three lines away threw the alpha away.
+ *
+ * This project was previously an opaque 2560x1440 film, where jpeg was
+ * the right call for speed. It is now transparent overlays. PNG frames
+ * are slower to encode and that cost is not optional.
+ */
+Config.setVideoImageFormat("png");
+
+/**
+ * The alpha-carrying pixel format. Needed IN ADDITION to png frames and
+ * `--prores-profile=4444`; all three have to agree or the channel is
+ * dropped somewhere along the chain.
+ */
+Config.setPixelFormat("yuva444p10le");
+
+Config.setOverwriteOutput(true);

--- a/promo/scripts/corner-bg.mjs
+++ b/promo/scripts/corner-bg.mjs
@@ -1,0 +1,122 @@
+/**
+ * Render a four-corner gradient and composite a real chip frame on it,
+ * so a background palette can be judged against the thing that has to
+ * sit on it rather than on its own.
+ *
+ *   node scripts/corner-bg.mjs <chipFrame.png> <out.png> TL TR BL BR
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { deflateSync, inflateSync } from "node:zlib";
+
+const [, , chipPath, outPath, ...corners] = process.argv;
+const [TL, TR, BL, BR] = corners.map(hex);
+
+const W = 1920;
+const H = 1080;
+
+function hex(h) {
+  const n = parseInt(h.replace("#", ""), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+// ── The gradient: bilinear between the four corners, then a radial
+// falloff toward the middle. The falloff is what keeps the centre dark
+// enough for content — without it the corner colours average to a flat
+// mid-tone exactly where the chips sit.
+const bg = new Float64Array(W * H * 3);
+for (let y = 0; y < H; y++) {
+  const v = y / (H - 1);
+  for (let x = 0; x < W; x++) {
+    const u = x / (W - 1);
+    const dx = (u - 0.5) * 2;
+    const dy = (v - 0.5) * 2;
+    // 1 at the corners, 0 in the middle.
+    const vignette = Math.min(1, Math.sqrt(dx * dx + dy * dy) / 1.15) ** 1.6;
+    for (let c = 0; c < 3; c++) {
+      const top = TL[c] * (1 - u) + TR[c] * u;
+      const bot = BL[c] * (1 - u) + BR[c] * u;
+      bg[(y * W + x) * 3 + c] = (top * (1 - v) + bot * v) * vignette;
+    }
+  }
+}
+
+// ── Grain. Gradients this dark band badly in 8-bit; a little noise is
+// what stops the contours showing as rings.
+let seed = 7;
+const rand = () => ((seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296);
+for (let i = 0; i < bg.length; i++) bg[i] += (rand() - 0.5) * 5;
+
+// ── Read the chip frame (RGBA PNG) and composite it centred.
+const png = readFileSync(chipPath);
+const cw = png.readUInt32BE(16);
+const ch = png.readUInt32BE(20);
+let off = 8;
+const idat = [];
+while (off < png.length) {
+  const len = png.readUInt32BE(off);
+  if (png.toString("ascii", off + 4, off + 8) === "IDAT")
+    idat.push(png.subarray(off + 8, off + 8 + len));
+  off += 12 + len;
+}
+const raw = inflateSync(Buffer.concat(idat));
+const stride = cw * 4;
+const chip = Buffer.alloc(ch * stride);
+let p = 0;
+for (let y = 0; y < ch; y++) {
+  const f = raw[p++];
+  for (let x = 0; x < stride; x++) {
+    const rv = raw[p + x];
+    const a = x >= 4 ? chip[y * stride + x - 4] : 0;
+    const b = y > 0 ? chip[(y - 1) * stride + x] : 0;
+    const c = x >= 4 && y > 0 ? chip[(y - 1) * stride + x - 4] : 0;
+    let out;
+    if (f === 0) out = rv;
+    else if (f === 1) out = rv + a;
+    else if (f === 2) out = rv + b;
+    else if (f === 3) out = rv + ((a + b) >> 1);
+    else {
+      const pa = Math.abs(b - c), pb = Math.abs(a - c), pc = Math.abs(a + b - 2 * c);
+      out = rv + (pa <= pb && pa <= pc ? a : pb <= pc ? b : c);
+    }
+    chip[y * stride + x] = out & 255;
+  }
+  p += stride;
+}
+
+const ox = Math.round((W - cw) / 2);
+const oy = Math.round((H - ch) / 2);
+const flat = Buffer.alloc(H * (W * 3 + 1));
+let q = 0;
+for (let y = 0; y < H; y++) {
+  flat[q++] = 0;
+  for (let x = 0; x < W; x++) {
+    const cx = x - ox;
+    const cy = y - oy;
+    let alpha = 0;
+    let src = [0, 0, 0];
+    if (cx >= 0 && cx < cw && cy >= 0 && cy < ch) {
+      const i = cy * stride + cx * 4;
+      alpha = chip[i + 3] / 255;
+      src = [chip[i], chip[i + 1], chip[i + 2]];
+    }
+    for (let c = 0; c < 3; c++) {
+      const under = Math.max(0, Math.min(255, bg[(y * W + x) * 3 + c]));
+      flat[q++] = Math.round(src[c] * alpha + under * (1 - alpha));
+    }
+  }
+}
+
+const table = Array.from({ length: 256 }, (_, n) => {
+  let c = n;
+  for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  return c >>> 0;
+});
+const crc = (b) => { let c = 0xffffffff; for (const x of b) c = table[(c ^ x) & 255] ^ (c >>> 8); return (c ^ 0xffffffff) >>> 0; };
+const chunk = (t, d) => { const l = Buffer.alloc(4); l.writeUInt32BE(d.length); const body = Buffer.concat([Buffer.from(t), d]); const c = Buffer.alloc(4); c.writeUInt32BE(crc(body)); return Buffer.concat([l, body, c]); };
+const ihdr = Buffer.alloc(13);
+ihdr.writeUInt32BE(W, 0); ihdr.writeUInt32BE(H, 4); ihdr[8] = 8; ihdr[9] = 2;
+writeFileSync(outPath, Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  chunk("IHDR", ihdr), chunk("IDAT", deflateSync(flat)), chunk("IEND", Buffer.alloc(0)),
+]));
+console.log(`wrote ${outPath}`);

--- a/promo/scripts/preview-alpha.mjs
+++ b/promo/scripts/preview-alpha.mjs
@@ -1,0 +1,106 @@
+/**
+ * Composite a transparent frame over a solid colour and write a PNG, so
+ * an overlay can be judged the way it will actually be seen.
+ *
+ * A transparent PNG opened on its own tells you almost nothing: the
+ * viewer picks the backdrop, so a chip with no plate looks fine on
+ * white and vanishes on grey. This forces the question.
+ *
+ *   node scripts/preview-alpha.mjs out/alpha-check.png out/on-grey.png 60
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { deflateSync, inflateSync } from "node:zlib";
+
+const [, , input, output, levelArg] = process.argv;
+const level = Number(levelArg ?? 60); // 0-255 grey backdrop
+
+const png = readFileSync(input);
+const width = png.readUInt32BE(16);
+const height = png.readUInt32BE(20);
+
+// ── Read: concatenate IDAT, inflate, undo per-row filters ──────────
+let offset = 8;
+const idat = [];
+while (offset < png.length) {
+  const len = png.readUInt32BE(offset);
+  const type = png.toString("ascii", offset + 4, offset + 8);
+  if (type === "IDAT") idat.push(png.subarray(offset + 8, offset + 8 + len));
+  offset += 12 + len;
+}
+const raw = inflateSync(Buffer.concat(idat));
+
+const BPP = 4;
+const stride = width * BPP;
+const rgba = Buffer.alloc(height * stride);
+let p = 0;
+for (let y = 0; y < height; y++) {
+  const filter = raw[p++];
+  for (let x = 0; x < stride; x++) {
+    const v = raw[p + x];
+    const a = x >= BPP ? rgba[y * stride + x - BPP] : 0;
+    const b = y > 0 ? rgba[(y - 1) * stride + x] : 0;
+    const c = x >= BPP && y > 0 ? rgba[(y - 1) * stride + x - BPP] : 0;
+    let out;
+    if (filter === 0) out = v;
+    else if (filter === 1) out = v + a;
+    else if (filter === 2) out = v + b;
+    else if (filter === 3) out = v + ((a + b) >> 1);
+    else {
+      const pa = Math.abs(b - c);
+      const pb = Math.abs(a - c);
+      const pc = Math.abs(a + b - 2 * c);
+      out = v + (pa <= pb && pa <= pc ? a : pb <= pc ? b : c);
+    }
+    rgba[y * stride + x] = out & 255;
+  }
+  p += stride;
+}
+
+// ── Composite over the backdrop, source-over ───────────────────────
+const flat = Buffer.alloc(height * (width * 3 + 1));
+let q = 0;
+for (let y = 0; y < height; y++) {
+  flat[q++] = 0; // filter: none
+  for (let x = 0; x < width; x++) {
+    const i = y * stride + x * BPP;
+    const alpha = rgba[i + 3] / 255;
+    for (let ch = 0; ch < 3; ch++) {
+      flat[q++] = Math.round(rgba[i + ch] * alpha + level * (1 - alpha));
+    }
+  }
+}
+
+// ── Write a minimal RGB PNG ────────────────────────────────────────
+const crcTable = Array.from({ length: 256 }, (_, n) => {
+  let c = n;
+  for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  return c >>> 0;
+});
+const crc = (buf) => {
+  let c = 0xffffffff;
+  for (const byte of buf) c = crcTable[(c ^ byte) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+};
+const chunk = (type, data) => {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length);
+  const body = Buffer.concat([Buffer.from(type, "ascii"), data]);
+  const cr = Buffer.alloc(4);
+  cr.writeUInt32BE(crc(body));
+  return Buffer.concat([len, body, cr]);
+};
+const ihdr = Buffer.alloc(13);
+ihdr.writeUInt32BE(width, 0);
+ihdr.writeUInt32BE(height, 4);
+ihdr[8] = 8; // bit depth
+ihdr[9] = 2; // colour type: RGB
+writeFileSync(
+  output,
+  Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk("IHDR", ihdr),
+    chunk("IDAT", deflateSync(flat)),
+    chunk("IEND", Buffer.alloc(0)),
+  ]),
+);
+console.log(`wrote ${output} — ${width}x${height} over grey ${level}`);

--- a/promo/scripts/render-themes.mjs
+++ b/promo/scripts/render-themes.mjs
@@ -1,0 +1,87 @@
+/**
+ * Render the same chips once per dark theme, for splicing into a
+ * montage.
+ *
+ * Ten files, identical in every respect except the palette — same
+ * leagues, same scores, same play landing on the same frame — so a cut
+ * between any two reads as the skin changing and nothing else.
+ *
+ *   npm run render:themes              # all ten
+ *   node scripts/render-themes.mjs nord-dark dracula-dark
+ *
+ * The theme list is read out of `src/promo-chips/themes.ts` by regex
+ * rather than imported. Importing a .ts from a plain .mjs needs
+ * --experimental-strip-types, which is a bad thing to hide inside an
+ * npm script; duplicating the list here would be worse. This keeps one
+ * source of truth and no build step.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+
+const themesSrc = readFileSync("src/promo-chips/themes.ts", "utf8");
+const DARK_THEMES = [
+  ...themesSrc
+    .slice(themesSrc.indexOf("DARK_THEMES"))
+    .matchAll(/"([a-z-]+-dark)"/g),
+].map((m) => m[1]);
+
+if (DARK_THEMES.length === 0) {
+  console.error("Could not read any themes from src/promo-chips/themes.ts");
+  process.exit(1);
+}
+
+/**
+ * Guard: every `[data-theme="*-dark"]` the app defines must be in the
+ * list. Add a theme to the product and this fails loudly instead of
+ * quietly shipping a montage that is missing one.
+ *
+ * `scrollr-dark` is deliberately exempt — it has no block of its own
+ * because it IS the `@theme` default.
+ */
+const css = readFileSync("../desktop/src/style.css", "utf8");
+const inCss = new Set(
+  [...css.matchAll(/\[data-theme="([a-z-]+-dark)"\]/g)].map((m) => m[1]),
+);
+const missing = [...inCss].filter((t) => !DARK_THEMES.includes(t));
+if (missing.length) {
+  console.error(
+    `These dark themes exist in the app but not in themes.ts:\n  ${missing.join("\n  ")}`,
+  );
+  process.exit(1);
+}
+
+const OUT = "out/themes";
+const TMP = "out/.theme-props.json";
+
+const only = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+const themes = only.length
+  ? DARK_THEMES.filter((t) => only.includes(t))
+  : DARK_THEMES;
+
+if (themes.length === 0) {
+  console.error(`No theme matched. Known:\n  ${DARK_THEMES.join("\n  ")}`);
+  process.exit(1);
+}
+
+mkdirSync(OUT, { recursive: true });
+
+themes.forEach((theme, i) => {
+  console.log(`\n[${i + 1}/${themes.length}] ${theme}`);
+  writeFileSync(TMP, JSON.stringify({ theme }));
+  execFileSync(
+    "npx",
+    [
+      "remotion",
+      "render",
+      "ThemeRail",
+      `${OUT}/${theme}.mov`,
+      "--codec=prores",
+      "--prores-profile=4444",
+      `--props=${TMP}`,
+    ],
+    { stdio: "inherit", shell: true },
+  );
+});
+
+rmSync(TMP, { force: true });
+console.log(`\nDone — ${themes.length} clips in ${OUT}/`);

--- a/promo/src/Root.tsx
+++ b/promo/src/Root.tsx
@@ -1,0 +1,99 @@
+/**
+ * Promo chip overlays — transparent, 60fps, for compositing in Resolve.
+ *
+ * CANVAS SIZES are deliberately much larger than the chips. Each comp
+ * renders its chip at 2x the real ticker size and leaves room around
+ * it, so a 200% punch-in on a 1080p timeline is still sampling real
+ * pixels rather than upscaling. The margin also has to clear the chip's
+ * own glow and flash ring, which sit outside its border box — a canvas
+ * fitted tightly to the chip clips them and the crop is visible against
+ * a moving background.
+ *
+ * DURATIONS are all 6s while the animation finishes by ~1.5s. The tail
+ * is there to be trimmed: every frame past 90 is identical (bar the
+ * LIVE dot, which breathes on purpose), so a cut can land anywhere.
+ */
+import { Composition } from "remotion";
+import "./styles.css";
+import { LeagueChip } from "./promo-chips/LeagueChip";
+import { PlayerChip } from "./promo-chips/PlayerChip";
+import { ScorePop } from "./promo-chips/ScorePop";
+
+const FPS = 60;
+const SIX_SECONDS = 6 * FPS;
+
+export const RemotionRoot: React.FC = () => {
+  return (
+    <>
+      <Composition
+        id="LeagueChip"
+        component={LeagueChip}
+        durationInFrames={SIX_SECONDS}
+        fps={FPS}
+        width={1920}
+        height={640}
+        defaultProps={{
+          leagueName: "The Sunday Money League",
+          teamName: "Brunch Money",
+          opponentName: "Fourth and Long",
+          week: 12,
+          status: "live" as const,
+          myScore: 151.8,
+          opponentScore: 151.7,
+          projection: 168.8,
+          topScorer: {
+            name: "Hurts",
+            team: "PHI",
+            position: "QB",
+            points: 28.1,
+          },
+          record: { wins: 8, losses: 3 },
+          rank: 2,
+          numTeams: 8,
+          streak: { type: "win" as const, value: 3 },
+          // The walk-off: starts behind on 149.9 and crosses 151.7 while
+          // the camera is on it. The crossing is the shot.
+          countUpFrom: 149.9,
+          scale: 2,
+        }}
+      />
+
+      <Composition
+        id="PlayerChip"
+        component={PlayerChip}
+        durationInFrames={SIX_SECONDS}
+        fps={FPS}
+        width={1280}
+        height={520}
+        defaultProps={{
+          name: "Achane",
+          team: "MIA",
+          position: "W/R/T",
+          points: 21.9,
+          projection: 24.0,
+          accent: "top" as const,
+          live: true,
+          countUpFrom: 8.3,
+          scale: 2,
+        }}
+      />
+
+      <Composition
+        id="ScorePop"
+        component={ScorePop}
+        durationInFrames={SIX_SECONDS}
+        fps={FPS}
+        width={1080}
+        height={520}
+        defaultProps={{
+          value: 13.6,
+          unit: "PTS",
+          tone: "up" as const,
+          showSign: true,
+          bounce: 0.34,
+          scale: 2,
+        }}
+      />
+    </>
+  );
+};

--- a/promo/src/Root.tsx
+++ b/promo/src/Root.tsx
@@ -18,6 +18,7 @@ import "./styles.css";
 import { LeagueChip } from "./promo-chips/LeagueChip";
 import { PlayerChip } from "./promo-chips/PlayerChip";
 import { ScorePop } from "./promo-chips/ScorePop";
+import { TickerRail } from "./promo-chips/TickerRail";
 
 const FPS = 60;
 const SIX_SECONDS = 6 * FPS;
@@ -38,7 +39,7 @@ export const RemotionRoot: React.FC = () => {
           opponentName: "Fourth and Long",
           week: 12,
           status: "live" as const,
-          myScore: 151.8,
+          myScore: 149.9,
           opponentScore: 151.7,
           projection: 168.8,
           topScorer: {
@@ -51,9 +52,24 @@ export const RemotionRoot: React.FC = () => {
           rank: 2,
           numTeams: 8,
           streak: { type: "win" as const, value: 3 },
-          // The walk-off: starts behind on 149.9 and crosses 151.7 while
-          // the camera is on it. The crossing is the shot.
-          countUpFrom: 149.9,
+          // THE WALK-OFF. `myScore` is the total BEFORE the plays, so
+          // the chip opens 149.9-151.7 — behind by 1.8 — and the events
+          // add to it:
+          //
+          //   f50  a catch, +1.4  -> 151.3, still behind by 0.4. This is
+          //        the beat that does the work. Close enough to taste and
+          //        still losing is the only frame in the film that makes
+          //        a viewer lean in.
+          //   f110 a touchdown, +6.6 -> 157.9, and the lead flips inside
+          //        the count. Score turns green, win% jumps, spine surges,
+          //        ring flares — all derived, none of it choreographed
+          //        separately.
+          //
+          // Settles by ~f192, leaving 168 frames of frozen tail to trim.
+          scoreEvents: [
+            { at: 50, points: 1.4, kind: "catch" as const },
+            { at: 110, points: 6.6, kind: "td" as const },
+          ],
           scale: 2,
         }}
       />
@@ -69,11 +85,96 @@ export const RemotionRoot: React.FC = () => {
           name: "Achane",
           team: "MIA",
           position: "W/R/T",
-          points: 21.9,
+          // Before the plays. The events below are the same two that
+          // move the league chip, so the two comps can be cut together
+          // and agree with each other frame for frame.
+          points: 8.3,
           projection: 24.0,
           accent: "top" as const,
           live: true,
-          countUpFrom: 8.3,
+          scoreEvents: [
+            { at: 50, points: 1.4, kind: "catch" as const },
+            { at: 110, points: 6.6, kind: "td" as const },
+          ],
+          scale: 2,
+        }}
+      />
+
+      <Composition
+        id="TickerRail"
+        component={TickerRail}
+        durationInFrames={SIX_SECONDS}
+        fps={FPS}
+        // 2x a 1920-wide bar. Drop it on a 1080p timeline at 50% for a
+        // pixel-exact bar, or leave it at 100% to punch in.
+        width={3840}
+        height={280}
+        defaultProps={{
+          hero: {
+            leagueName: "The Sunday Money League",
+            teamName: "Brunch Money",
+            opponentName: "Fourth and Long",
+            week: 12,
+            status: "live" as const,
+            myScore: 149.9,
+            opponentScore: 151.7,
+            projection: 168.8,
+            topScorer: {
+              name: "Hurts",
+              team: "PHI",
+              position: "QB",
+              points: 28.1,
+            },
+            record: { wins: 8, losses: 3 },
+            rank: 2,
+            numTeams: 8,
+            streak: { type: "win" as const, value: 3 },
+          },
+          scoreEvents: [
+            { at: 50, points: 1.4, kind: "catch" as const },
+            { at: 110, points: 6.6, kind: "td" as const },
+          ],
+          others: [
+            {
+              leagueName: "Dynasty or Bust",
+              teamName: "Regression Candidates",
+              opponentName: "Air Yards Only",
+              week: 12,
+              status: "final" as const,
+              myScore: 184.5,
+              opponentScore: 151.0,
+              projection: 184.5,
+              topScorer: {
+                name: "Allen",
+                team: "BUF",
+                position: "QB",
+                points: 36.9,
+              },
+              record: { wins: 9, losses: 2 },
+              rank: 1,
+              numTeams: 8,
+            },
+            {
+              leagueName: "Work League (Keeper)",
+              teamName: "Third and Inches",
+              opponentName: "Gridiron Ghosts",
+              week: 12,
+              status: "live" as const,
+              myScore: 90.9,
+              opponentScore: 83.6,
+              projection: 101.3,
+              topScorer: {
+                name: "St. Brown",
+                team: "DET",
+                position: "WR",
+                points: 21.9,
+              },
+              record: { wins: 6, losses: 5 },
+              rank: 4,
+              numTeams: 8,
+            },
+          ],
+          drift: 0.35,
           scale: 2,
         }}
       />

--- a/promo/src/Root.tsx
+++ b/promo/src/Root.tsx
@@ -24,6 +24,69 @@ const FPS = 60;
 const SIX_SECONDS = 6 * FPS;
 /** The rail is a bed, not a beat — it runs under a whole section. */
 const THIRTY_SECONDS = 30 * FPS;
+/** Long enough to read the chips and see one play land. */
+const FIVE_SECONDS = 5 * FPS;
+
+/**
+ * The rail used for the theme montage.
+ *
+ * Three chips rather than five: at 5s there is no time for a fourth to
+ * arrive, and the whole point is that every clip frames IDENTICALLY so
+ * a cut between two themes reads as the skin changing and nothing else.
+ * Same reason the drift is slower — over 300 frames it travels 60px,
+ * enough to look alive, not enough to reframe.
+ *
+ * One play, at f90, and it crosses. Every theme therefore gets the same
+ * moment, which is what makes the colours comparable: the flash and the
+ * lead ring are themed too, so the montage shows off `--color-up` as
+ * well as the accent.
+ */
+const THEME_RAIL_LEAGUES = [
+  {
+    leagueName: "Dynasty or Bust",
+    teamName: "Regression Candidates",
+    opponentName: "Air Yards Only",
+    week: 12,
+    status: "final" as const,
+    myScore: 184.5,
+    opponentScore: 151.0,
+    projection: 184.5,
+    topScorer: { name: "Allen", team: "BUF", position: "QB", points: 36.9 },
+    record: { wins: 9, losses: 2 },
+    rank: 1,
+    numTeams: 8,
+  },
+  {
+    leagueName: "The Sunday Money League",
+    teamName: "Brunch Money",
+    opponentName: "Fourth and Long",
+    week: 12,
+    status: "live" as const,
+    myScore: 149.9,
+    opponentScore: 151.7,
+    projection: 168.8,
+    topScorer: { name: "Hurts", team: "PHI", position: "QB", points: 28.1 },
+    record: { wins: 8, losses: 3 },
+    rank: 2,
+    numTeams: 8,
+    streak: { type: "win" as const, value: 3 },
+    scoreEvents: [{ at: 90, points: 6.6, kind: "td" as const }],
+  },
+  {
+    leagueName: "Work League (Keeper)",
+    teamName: "Third and Inches",
+    opponentName: "Gridiron Ghosts",
+    week: 12,
+    status: "live" as const,
+    myScore: 90.9,
+    opponentScore: 83.6,
+    projection: 101.3,
+    topScorer: { name: "St. Brown", team: "DET", position: "WR", points: 21.9 },
+    record: { wins: 6, losses: 5 },
+    rank: 4,
+    numTeams: 8,
+  },
+];
 
 export const RemotionRoot: React.FC = () => {
   return (
@@ -238,6 +301,24 @@ export const RemotionRoot: React.FC = () => {
           ],
           drift: 0.35,
           scale: 2,
+        }}
+      />
+
+      <Composition
+        id="ThemeRail"
+        component={TickerRail}
+        durationInFrames={FIVE_SECONDS}
+        fps={FPS}
+        width={3840}
+        height={280}
+        defaultProps={{
+          leagues: THEME_RAIL_LEAGUES,
+          drift: 0.2,
+          scale: 2,
+          // Overridden per theme by scripts/render-themes.mjs. The
+          // default is the house palette so the comp is useful on its
+          // own in the studio.
+          theme: "scrollr-dark",
         }}
       />
 

--- a/promo/src/Root.tsx
+++ b/promo/src/Root.tsx
@@ -22,6 +22,8 @@ import { TickerRail } from "./promo-chips/TickerRail";
 
 const FPS = 60;
 const SIX_SECONDS = 6 * FPS;
+/** The rail is a bed, not a beat — it runs under a whole section. */
+const THIRTY_SECONDS = 30 * FPS;
 
 export const RemotionRoot: React.FC = () => {
   return (
@@ -103,38 +105,25 @@ export const RemotionRoot: React.FC = () => {
       <Composition
         id="TickerRail"
         component={TickerRail}
-        durationInFrames={SIX_SECONDS}
+        durationInFrames={THIRTY_SECONDS}
         fps={FPS}
         // 2x a 1920-wide bar. Drop it on a 1080p timeline at 50% for a
         // pixel-exact bar, or leave it at 100% to punch in.
         width={3840}
         height={280}
         defaultProps={{
-          hero: {
-            leagueName: "The Sunday Money League",
-            teamName: "Brunch Money",
-            opponentName: "Fourth and Long",
-            week: 12,
-            status: "live" as const,
-            myScore: 149.9,
-            opponentScore: 151.7,
-            projection: 168.8,
-            topScorer: {
-              name: "Hurts",
-              team: "PHI",
-              position: "QB",
-              points: 28.1,
-            },
-            record: { wins: 8, losses: 3 },
-            rank: 2,
-            numTeams: 8,
-            streak: { type: "win" as const, value: 3 },
-          },
-          scoreEvents: [
-            { at: 50, points: 1.4, kind: "catch" as const },
-            { at: 110, points: 6.6, kind: "td" as const },
-          ],
-          others: [
+          // FIVE leagues for THIRTY seconds, and the count is arithmetic
+          // rather than taste: a chip is ~548px before scaling, the
+          // viewport is 1920 of those, and the drift covers 630 across
+          // the comp. Five puts ~3.5 on screen at once and lets the
+          // fifth arrive as the first leaves, so the bar is never static
+          // and never runs out of rail.
+          //
+          // The plays are spaced so each one lands while ITS chip is on
+          // screen, and far enough apart that each reads as its own
+          // event. Most chips never score — a bar where everything is
+          // always erupting has no significant moments left.
+          leagues: [
             {
               leagueName: "Dynasty or Bust",
               teamName: "Regression Candidates",
@@ -153,6 +142,8 @@ export const RemotionRoot: React.FC = () => {
               record: { wins: 9, losses: 2 },
               rank: 1,
               numTeams: 8,
+              // Finished. Nothing left to happen, which is the point of
+              // having it here — it is the calm the others move against.
             },
             {
               leagueName: "Work League (Keeper)",
@@ -172,6 +163,77 @@ export const RemotionRoot: React.FC = () => {
               record: { wins: 6, losses: 5 },
               rank: 4,
               numTeams: 8,
+              // Already ahead, so this one extends a lead rather than
+              // stealing one. No flare — that belongs to the crossing.
+              scoreEvents: [{ at: 420, points: 6.6, kind: "td" as const }],
+            },
+            {
+              leagueName: "The Sunday Money League",
+              teamName: "Brunch Money",
+              opponentName: "Fourth and Long",
+              week: 12,
+              status: "live" as const,
+              myScore: 149.9,
+              opponentScore: 151.7,
+              projection: 168.8,
+              topScorer: {
+                name: "Hurts",
+                team: "PHI",
+                position: "QB",
+                points: 28.1,
+              },
+              record: { wins: 8, losses: 3 },
+              rank: 2,
+              numTeams: 8,
+              streak: { type: "win" as const, value: 3 },
+              // The story. Behind by 1.8; the catch at f120 gets it to
+              // 151.3 — still behind, by 0.4 — and it sits there for
+              // eleven seconds, which is the whole point. The touchdown
+              // at f780 crosses.
+              scoreEvents: [
+                { at: 120, points: 1.4, kind: "catch" as const },
+                { at: 780, points: 6.6, kind: "td" as const },
+              ],
+            },
+            {
+              leagueName: "College Buddies",
+              teamName: "Bad Beats Only",
+              opponentName: "The Group Chat",
+              week: 12,
+              status: "live" as const,
+              myScore: 112.4,
+              opponentScore: 118.9,
+              projection: 131.2,
+              topScorer: {
+                name: "Nacua",
+                team: "LAR",
+                position: "WR",
+                points: 24.3,
+              },
+              record: { wins: 7, losses: 4 },
+              rank: 3,
+              numTeams: 10,
+              scoreEvents: [{ at: 1150, points: 8.4, kind: "big" as const }],
+            },
+            {
+              leagueName: "Waiver Wire Wars",
+              teamName: "Handcuff Central",
+              opponentName: "Streaming Service",
+              week: 12,
+              status: "live" as const,
+              myScore: 96.2,
+              opponentScore: 94.8,
+              projection: 108.7,
+              topScorer: {
+                name: "Kittle",
+                team: "SF",
+                position: "TE",
+                points: 18.6,
+              },
+              record: { wins: 5, losses: 6 },
+              rank: 6,
+              numTeams: 10,
+              scoreEvents: [{ at: 1500, points: 3, kind: "fg" as const }],
             },
           ],
           drift: 0.35,

--- a/promo/src/index.ts
+++ b/promo/src/index.ts
@@ -1,0 +1,4 @@
+import { registerRoot } from "remotion";
+import { RemotionRoot } from "./Root";
+
+registerRoot(RemotionRoot);

--- a/promo/src/promo-chips/LeagueChip.tsx
+++ b/promo/src/promo-chips/LeagueChip.tsx
@@ -1,0 +1,231 @@
+/**
+ * The two-line fantasy league chip, as a standalone transparent overlay.
+ *
+ * Renders `FantasyStatChip` from desktop/src — the shipped component,
+ * not a recreation — so the overlay cannot drift from the product. What
+ * this file owns is the DATA and the TIMING; the design is entirely the
+ * app's.
+ *
+ * THE ONE IDEA WORTH KNOWING: only the score is animated. Win
+ * probability, the spine fill and the score's up/down colour are all
+ * DERIVED by the real chip from the matchup it is handed, so counting
+ * the score up makes every one of them move in step for free. Animating
+ * them separately would have meant reimplementing
+ * `estimateWinProbability` here, and then watching the two definitions
+ * drift apart the first time the real one was tuned.
+ */
+import { useCurrentFrame } from "remotion";
+import FantasyStatChip from "../../../desktop/src/components/chips/FantasyStatChip";
+import { DEFAULT_WIDGET_DISPLAY } from "../../../desktop/src/preferences";
+import type {
+  LeagueResponse,
+  RosterPlayer,
+} from "../../../desktop/src/datawidgets/fantasy/types";
+import { Stage } from "./Stage";
+import { countUp, entrance, livePulse } from "./anim";
+
+/**
+ * A type alias, not an interface, and that is load-bearing: Remotion's
+ * `Composition` requires props assignable to `Record<string, unknown>`,
+ * and TypeScript grants an implicit index signature to type aliases but
+ * not to interfaces. As an interface this fails to compile with a
+ * `LooseComponentType` mismatch that names neither cause nor fix.
+ */
+export type LeagueChipProps = {
+  leagueName: string;
+  teamName: string;
+  opponentName: string;
+  week: number;
+  status: "live" | "final" | "pre";
+  myScore: number;
+  opponentScore: number;
+  projection: number;
+  /** Drives the "★ Lastname 28.1" segment on the second row. */
+  topScorer: { name: string; team: string; position: string; points: number };
+  record: { wins: number; losses: number; ties?: number };
+  rank: number;
+  numTeams: number;
+  streak?: { type: "win" | "loss"; value: number };
+  /**
+   * Count the score up from here. Omit to hold the final value — a chip
+   * that isn't the subject of the shot shouldn't be animating a number
+   * nobody is looking at.
+   */
+  countUpFrom?: number;
+  /** Multiplier on the chip's real ticker size. */
+  scale?: number;
+  /** Give the chip an opaque ground — see Stage. */
+  plate?: boolean;
+}
+
+export function LeagueChip(props: LeagueChipProps) {
+  const frame = useCurrentFrame();
+  const score = countUp(frame, props.myScore, props.countUpFrom);
+
+  return (
+    <Stage
+      scale={props.scale ?? 2}
+      plate={props.plate}
+      // Only a live matchup has a dot to pulse.
+      livePulse={props.status === "live" ? livePulse(frame) : undefined}
+    >
+      <div style={entrance(frame)}>
+        <FantasyStatChip
+          league={buildLeague(props, score)}
+          prefs={DEFAULT_WIDGET_DISPLAY.fantasy}
+          comfort
+          colorMode="widget"
+          // Left off deliberately. The roll is Motion-driven and Motion
+          // animates through WAAPI on the document timeline, which does
+          // not advance when Remotion steps frames — the digits would
+          // sit frozen mid-roll. `countUp` above does the same job as a
+          // pure function of the frame instead.
+          rollScore={false}
+        />
+      </div>
+    </Stage>
+  );
+}
+
+/**
+ * Flat props in, a real `LeagueResponse` out.
+ *
+ * The chip reads the MATCHUP for the score and the ROSTER for the top
+ * scorer. Those are two independent paths through the same object, so
+ * the roster is built to reconcile with the matchup total rather than
+ * being invented: the difference lands on a filler bench entry. A chip
+ * whose star player total contradicts its own score is the single most
+ * obvious tell in a freeze-frame.
+ */
+function buildLeague(p: LeagueChipProps, score: number): LeagueResponse {
+  const teamKey = "449.l.promo.t.1";
+  const oppKey = "449.l.promo.t.2";
+  const rounded = Math.round(score * 10) / 10;
+
+  return {
+    league_key: "449.l.promo",
+    name: p.leagueName,
+    game_code: "nfl",
+    season: "2025",
+    team_key: teamKey,
+    team_name: p.teamName,
+    data: {
+      num_teams: p.numTeams,
+      is_finished: p.status === "final",
+      current_week: p.week,
+      scoring_type: "head",
+    },
+    standings: [
+      {
+        team_key: teamKey,
+        team_id: 1,
+        name: p.teamName,
+        team_logo: "",
+        manager_name: "You",
+        rank: p.rank,
+        wins: p.record.wins,
+        losses: p.record.losses,
+        ties: p.record.ties ?? 0,
+        points_for: 1500,
+        streak_type: p.streak?.type ?? "win",
+        streak_value: p.streak?.value ?? 0,
+        playoff_seed: p.rank,
+        clinched_playoffs: false,
+        waiver_priority: 5,
+      },
+    ],
+    matchups: [
+      {
+        week: p.week,
+        status:
+          p.status === "final"
+            ? "postevent"
+            : p.status === "live"
+              ? "midevent"
+              : "preevent",
+        is_playoffs: false,
+        is_tied: false,
+        winner_team_key:
+          p.status === "final"
+            ? rounded > p.opponentScore
+              ? teamKey
+              : oppKey
+            : null,
+        teams: [
+          {
+            team_key: teamKey,
+            team_id: 1,
+            name: p.teamName,
+            team_logo: "",
+            manager_name: "You",
+            points: rounded,
+            projected_points: p.projection,
+          },
+          {
+            team_key: oppKey,
+            team_id: 2,
+            name: p.opponentName,
+            team_logo: "",
+            manager_name: "Rival",
+            points: p.opponentScore,
+            projected_points: Math.round(p.opponentScore * 1.08 * 10) / 10,
+          },
+        ],
+      },
+    ],
+    rosters: [
+      {
+        team_key: teamKey,
+        data: {
+          team_key: teamKey,
+          team_name: p.teamName,
+          players: roster(p, rounded),
+        },
+      },
+    ],
+  };
+}
+
+function roster(p: LeagueChipProps, score: number): RosterPlayer[] {
+  const star = player(
+    p.topScorer.name,
+    p.topScorer.team,
+    p.topScorer.position,
+    p.topScorer.points,
+  );
+  // Whatever the star didn't score, so the roster sums to the matchup.
+  // Named rather than blank because the chip's injury/top-scorer passes
+  // both walk this list and a nameless entry reads as corrupt data.
+  const rest = player(
+    "Squad",
+    p.topScorer.team,
+    "BN",
+    Math.max(0, Math.round((score - p.topScorer.points) * 10) / 10),
+  );
+  return [star, rest];
+}
+
+function player(
+  last: string,
+  team: string,
+  position: string,
+  points: number,
+): RosterPlayer {
+  return {
+    player_key: `449.p.${last.toLowerCase().replace(/\W/g, "")}`,
+    name: { full: last, first: "", last },
+    editorial_team_abbr: team,
+    display_position: position,
+    selected_position: position,
+    position_type: "O",
+    // Generated monograms only, never synthetic faces — the same rule
+    // the demo fixtures hold. Empty means the chip falls back to text.
+    image_url: "",
+    // No injury: a red "1 IR" segment is off-message on a chip that
+    // exists to sell the product.
+    status: null,
+    status_full: null,
+    injury_note: null,
+    player_points: points,
+  };
+}

--- a/promo/src/promo-chips/LeagueChip.tsx
+++ b/promo/src/promo-chips/LeagueChip.tsx
@@ -14,7 +14,7 @@
  * `estimateWinProbability` here, and then watching the two definitions
  * drift apart the first time the real one was tuned.
  */
-import { useCurrentFrame } from "remotion";
+import { useCurrentFrame, useVideoConfig } from "remotion";
 import FantasyStatChip from "../../../desktop/src/components/chips/FantasyStatChip";
 import { DEFAULT_WIDGET_DISPLAY } from "../../../desktop/src/preferences";
 import type {
@@ -22,7 +22,15 @@ import type {
   RosterPlayer,
 } from "../../../desktop/src/datawidgets/fantasy/types";
 import { Stage } from "./Stage";
+import { Reactor } from "./Reactor";
 import { countUp, entrance, livePulse } from "./anim";
+import {
+  type ScoreEvent,
+  impact,
+  leadChangeFrame,
+  leadFlare,
+  scoreAt,
+} from "./scoring";
 
 /**
  * A type alias, not an interface, and that is load-bearing: Remotion's
@@ -50,8 +58,19 @@ export type LeagueChipProps = {
    * Count the score up from here. Omit to hold the final value — a chip
    * that isn't the subject of the shot shouldn't be animating a number
    * nobody is looking at.
+   *
+   * Ignored when `scoreEvents` is set: a smooth glide and a sequence of
+   * discrete plays are two different stories and the chip can only tell
+   * one at a time.
    */
   countUpFrom?: number;
+  /**
+   * Scoring plays, each landing on its own frame. When present the
+   * chip STARTS at `myScore` and the events add to it, so `myScore` is
+   * the number before kickoff rather than after — otherwise the same
+   * total would have to be written twice and kept in sync by hand.
+   */
+  scoreEvents?: ScoreEvent[];
   /** Multiplier on the chip's real ticker size. */
   scale?: number;
   /** Give the chip an opaque ground — see Stage. */
@@ -60,7 +79,26 @@ export type LeagueChipProps = {
 
 export function LeagueChip(props: LeagueChipProps) {
   const frame = useCurrentFrame();
-  const score = countUp(frame, props.myScore, props.countUpFrom);
+  const { durationInFrames } = useVideoConfig();
+  const events = props.scoreEvents ?? [];
+  const hasEvents = events.length > 0;
+
+  const score = hasEvents
+    ? scoreAt(frame, props.myScore, events)
+    : countUp(frame, props.myScore, props.countUpFrom);
+
+  const hit = hasEvents ? impact(frame, events) : 0;
+  // The crossing is found once from the props, not tracked frame to
+  // frame, because Remotion may render frame 200 before frame 3.
+  const crossing = hasEvents
+    ? leadChangeFrame(
+        props.myScore,
+        events,
+        props.opponentScore,
+        durationInFrames,
+      )
+    : null;
+  const flare = leadFlare(frame, crossing);
 
   return (
     <Stage
@@ -70,6 +108,14 @@ export function LeagueChip(props: LeagueChipProps) {
       livePulse={props.status === "live" ? livePulse(frame) : undefined}
     >
       <div style={entrance(frame)}>
+        <Reactor
+          impact={hit}
+          // Only the upswing washes the chip; the anticipation dip is
+          // motion, not light, and tinting it green would announce the
+          // play before it has happened.
+          flash={Math.max(0, hit)}
+          flare={flare}
+        >
         <FantasyStatChip
           league={buildLeague(props, score)}
           prefs={DEFAULT_WIDGET_DISPLAY.fantasy}
@@ -80,8 +126,9 @@ export function LeagueChip(props: LeagueChipProps) {
           // not advance when Remotion steps frames — the digits would
           // sit frozen mid-roll. `countUp` above does the same job as a
           // pure function of the frame instead.
-          rollScore={false}
-        />
+            rollScore={false}
+          />
+        </Reactor>
       </div>
     </Stage>
   );
@@ -97,13 +144,20 @@ export function LeagueChip(props: LeagueChipProps) {
  * whose star player total contradicts its own score is the single most
  * obvious tell in a freeze-frame.
  */
-function buildLeague(p: LeagueChipProps, score: number): LeagueResponse {
-  const teamKey = "449.l.promo.t.1";
-  const oppKey = "449.l.promo.t.2";
+export function buildLeague(
+  p: LeagueChipProps,
+  score: number,
+): LeagueResponse {
+  // Derived from the name so a rail of chips gets distinct keys. Two
+  // chips sharing a league_key made React reuse one chip's roster for
+  // the other, which showed up as the wrong top scorer.
+  const slug = p.leagueName.toLowerCase().replace(/\W+/g, "").slice(0, 16);
+  const teamKey = `449.l.${slug}.t.1`;
+  const oppKey = `449.l.${slug}.t.2`;
   const rounded = Math.round(score * 10) / 10;
 
   return {
-    league_key: "449.l.promo",
+    league_key: `449.l.${slug}`,
     name: p.leagueName,
     game_code: "nfl",
     season: "2025",

--- a/promo/src/promo-chips/LeagueChip.tsx
+++ b/promo/src/promo-chips/LeagueChip.tsx
@@ -75,6 +75,8 @@ export type LeagueChipProps = {
   scale?: number;
   /** Give the chip an opaque ground — see Stage. */
   plate?: boolean;
+  /** `[data-theme]` palette to render under. */
+  theme?: string;
 }
 
 export function LeagueChip(props: LeagueChipProps) {
@@ -104,6 +106,7 @@ export function LeagueChip(props: LeagueChipProps) {
     <Stage
       scale={props.scale ?? 2}
       plate={props.plate}
+      theme={props.theme}
       // Only a live matchup has a dot to pulse.
       livePulse={props.status === "live" ? livePulse(frame) : undefined}
     >

--- a/promo/src/promo-chips/PlayerChip.tsx
+++ b/promo/src/promo-chips/PlayerChip.tsx
@@ -56,6 +56,8 @@ export type PlayerChipProps = {
   scale?: number;
   /** Give the chip an opaque ground — see Stage. */
   plate?: boolean;
+  /** `[data-theme]` palette to render under. */
+  theme?: string;
 }
 
 const PLAYER_KEY = "449.p.promo";
@@ -74,6 +76,7 @@ export function PlayerChip(props: PlayerChipProps) {
     <Stage
       scale={props.scale ?? 2}
       plate={props.plate}
+      theme={props.theme}
     >
       <div style={entrance(frame)}>
         <Reactor impact={hit} flash={Math.max(0, hit)}>

--- a/promo/src/promo-chips/PlayerChip.tsx
+++ b/promo/src/promo-chips/PlayerChip.tsx
@@ -1,0 +1,126 @@
+/**
+ * The single-player chip, as a standalone transparent overlay.
+ *
+ * Renders `FollowedPlayerChip` from desktop/src — again the shipped
+ * component. It looks a player up by key out of a list of leagues, so
+ * this file's job is to hand it a one-player league that resolves.
+ *
+ * Same idea as LeagueChip: only the points are animated, and the
+ * underline bar follows on its own. That bar is `ChipSpine` measuring
+ * points against the player's projection, so counting the points up
+ * fills the bar in step. Driving the bar separately would mean owning a
+ * second definition of "how is he doing", and two definitions of one
+ * thing always end up disagreeing.
+ */
+import { useCurrentFrame } from "remotion";
+import FollowedPlayerChip from "../../../desktop/src/components/chips/FollowedPlayerChip";
+import type {
+  LeagueResponse,
+  RosterPlayer,
+} from "../../../desktop/src/datawidgets/fantasy/types";
+import { Stage } from "./Stage";
+import { countUp, entrance } from "./anim";
+
+/**
+ * A type alias, not an interface, and that is load-bearing: Remotion's
+ * `Composition` requires props assignable to `Record<string, unknown>`,
+ * and TypeScript grants an implicit index signature to type aliases but
+ * not to interfaces. As an interface this fails to compile with a
+ * `LooseComponentType` mismatch that names neither cause nor fix.
+ */
+export type PlayerChipProps = {
+  name: string;
+  /** Real-team abbreviation, e.g. "MIA". */
+  team: string;
+  /** Roster slot, e.g. "RB" or "W/R/T" — drives the position badge. */
+  position: string;
+  points: number;
+  /** Fills the underline bar: points as a share of this. */
+  projection: number;
+  /**
+   * The labelled band under the name. `top` renders "TOP SCORER",
+   * `bench` "BENCH LEADER", `worst` and `injury` their own. Omit for a
+   * plain followed-player chip with no leading badge.
+   */
+  accent?: "top" | "worst" | "bench" | "injury";
+  /** Is his game running — drives the live treatment on the bar. */
+  live?: boolean;
+  countUpFrom?: number;
+  scale?: number;
+  /** Give the chip an opaque ground — see Stage. */
+  plate?: boolean;
+}
+
+const PLAYER_KEY = "449.p.promo";
+const LEAGUE_KEY = "449.l.promo";
+
+export function PlayerChip(props: PlayerChipProps) {
+  const frame = useCurrentFrame();
+  const points = countUp(frame, props.points, props.countUpFrom);
+
+  return (
+    <Stage scale={props.scale ?? 2} plate={props.plate}>
+      <div style={entrance(frame)}>
+        <FollowedPlayerChip
+          playerKey={PLAYER_KEY}
+          leagueKey={LEAGUE_KEY}
+          leagues={[buildLeague(props, points)]}
+          comfort
+          colorMode="widget"
+          accent={props.accent}
+        />
+      </div>
+    </Stage>
+  );
+}
+
+function buildLeague(p: PlayerChipProps, points: number): LeagueResponse {
+  const teamKey = `${LEAGUE_KEY}.t.1`;
+  return {
+    league_key: LEAGUE_KEY,
+    name: "Promo",
+    game_code: "nfl",
+    season: "2025",
+    team_key: teamKey,
+    team_name: "Promo",
+    data: {
+      num_teams: 8,
+      is_finished: false,
+      current_week: 12,
+      scoring_type: "head",
+    },
+    standings: null,
+    matchups: null,
+    rosters: [
+      {
+        team_key: teamKey,
+        data: {
+          team_key: teamKey,
+          team_name: "Promo",
+          players: [buildPlayer(p, points)],
+        },
+      },
+    ],
+  };
+}
+
+function buildPlayer(p: PlayerChipProps, points: number): RosterPlayer {
+  return {
+    player_key: PLAYER_KEY,
+    name: { full: p.name, first: "", last: p.name },
+    editorial_team_abbr: p.team,
+    display_position: p.position,
+    selected_position: p.position,
+    position_type: "O",
+    image_url: "",
+    // `game_state` is what the chip reads to decide live vs final, and
+    // it drives the bar's treatment. Not a Yahoo field — the fixtures
+    // are its only provider, same as in the demo rig.
+    game_state: p.live ? "Q4 2:00" : "Final",
+    status: p.accent === "injury" ? "O" : null,
+    status_full: p.accent === "injury" ? "Out" : null,
+    injury_note: null,
+    player_points: Math.round(points * 10) / 10,
+    projected_points: p.projection,
+  };
+}

--- a/promo/src/promo-chips/PlayerChip.tsx
+++ b/promo/src/promo-chips/PlayerChip.tsx
@@ -19,7 +19,9 @@ import type {
   RosterPlayer,
 } from "../../../desktop/src/datawidgets/fantasy/types";
 import { Stage } from "./Stage";
+import { Reactor } from "./Reactor";
 import { countUp, entrance } from "./anim";
+import { type ScoreEvent, impact, scoreAt } from "./scoring";
 
 /**
  * A type alias, not an interface, and that is load-bearing: Remotion's
@@ -46,6 +48,11 @@ export type PlayerChipProps = {
   /** Is his game running — drives the live treatment on the bar. */
   live?: boolean;
   countUpFrom?: number;
+  /**
+   * Scoring plays for this player. Same contract as LeagueChip:
+   * `points` is the value BEFORE the events, and each one adds to it.
+   */
+  scoreEvents?: ScoreEvent[];
   scale?: number;
   /** Give the chip an opaque ground — see Stage. */
   plate?: boolean;
@@ -56,19 +63,29 @@ const LEAGUE_KEY = "449.l.promo";
 
 export function PlayerChip(props: PlayerChipProps) {
   const frame = useCurrentFrame();
-  const points = countUp(frame, props.points, props.countUpFrom);
+  const events = props.scoreEvents ?? [];
+  const hasEvents = events.length > 0;
+  const points = hasEvents
+    ? scoreAt(frame, props.points, events)
+    : countUp(frame, props.points, props.countUpFrom);
+  const hit = hasEvents ? impact(frame, events) : 0;
 
   return (
-    <Stage scale={props.scale ?? 2} plate={props.plate}>
+    <Stage
+      scale={props.scale ?? 2}
+      plate={props.plate}
+    >
       <div style={entrance(frame)}>
+        <Reactor impact={hit} flash={Math.max(0, hit)}>
         <FollowedPlayerChip
           playerKey={PLAYER_KEY}
           leagueKey={LEAGUE_KEY}
           leagues={[buildLeague(props, points)]}
           comfort
           colorMode="widget"
-          accent={props.accent}
-        />
+            accent={props.accent}
+          />
+        </Reactor>
       </div>
     </Stage>
   );

--- a/promo/src/promo-chips/Reactor.tsx
+++ b/promo/src/promo-chips/Reactor.tsx
@@ -1,0 +1,76 @@
+/**
+ * Wraps the ONE chip that just scored and makes it react.
+ *
+ * This started life inside `Stage`, which was fine while every comp
+ * held a single chip and wrong the moment `TickerRail` arrived: the
+ * wash, the ring and the impact scale applied to the whole bar, so
+ * three leagues lit up when one of them scored. That reads as a global
+ * alert rather than a league scoring, which is the opposite of the
+ * point — the other leagues carrying on unbothered is exactly what
+ * makes the reacting one feel live.
+ *
+ * So the reaction belongs to a chip, not to a stage.
+ */
+import type { ReactNode } from "react";
+
+export function Reactor({
+  children,
+  impact = 0,
+  flash = 0,
+  flare = 0,
+}: {
+  children: ReactNode;
+  /** Envelope from `scoring.impact()`, roughly -0.3..1. */
+  impact?: number;
+  /** 0..1 wash on a scoring play. */
+  flash?: number;
+  /** 0..1 ring marking a lead change. */
+  flare?: number;
+}) {
+  const quiet = impact === 0 && flash === 0 && flare === 0;
+
+  return (
+    <div
+      style={{
+        // `inline-flex`, not `block`: the wrapper has to shrink to the
+        // chip so the overlay below covers the chip and not a
+        // full-width band of empty rail.
+        display: "inline-flex",
+        position: "relative",
+        // Scale from the centre so a reacting chip grows into its
+        // neighbours symmetrically instead of shoving the rail one way.
+        transform: quiet ? undefined : `scale(${1 + impact * 0.09})`,
+        transformOrigin: "center center",
+      }}
+    >
+      {children}
+      {(flash > 0 || flare > 0) && (
+        <span
+          aria-hidden
+          style={{
+            position: "absolute",
+            inset: 0,
+            // Matches chipBaseClasses' `rounded-sm`. Hardcoded because
+            // the chip is a sibling, not a parent, so `inherit` would
+            // pick up this wrapper's radius rather than the chip's.
+            borderRadius: 2,
+            pointerEvents: "none",
+            backgroundColor: `color-mix(in srgb, var(--color-up) ${(
+              flash * 20
+            ).toFixed(1)}%, transparent)`,
+            boxShadow:
+              flare > 0
+                ? `0 0 0 ${(flare * 2).toFixed(2)}px color-mix(in srgb, var(--color-up) ${(
+                    flare * 70
+                  ).toFixed(0)}%, transparent), 0 0 ${(flare * 26).toFixed(
+                    0,
+                  )}px color-mix(in srgb, var(--color-up) ${(flare * 45).toFixed(
+                    0,
+                  )}%, transparent)`
+                : undefined,
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/promo/src/promo-chips/ScorePop.tsx
+++ b/promo/src/promo-chips/ScorePop.tsx
@@ -1,0 +1,104 @@
+/**
+ * ScorePop — the "+13.6 PTS" pill that lands on a music hit.
+ *
+ * The only comp here with no shipped counterpart: nothing in the app is
+ * a standalone score badge, so this is built rather than reused. It
+ * still takes its colour, radius and type from the app's own CSS
+ * variables through the `#app-shell` wrapper in Stage, so it belongs to
+ * the same design system even though it isn't the same component. The
+ * alternative — picking a green and a font by eye — is how an overlay
+ * ends up subtly not matching the product it's sitting on.
+ *
+ * Timed to be CUT TO, not read: the overshoot peaks around frame 12 and
+ * is settled by 34, so lining the comp's frame 0 up with a beat puts
+ * the visual accent a fifth of a second later, which is where an accent
+ * wants to sit relative to a transient.
+ */
+import { interpolate, useCurrentFrame } from "remotion";
+import { Stage } from "./Stage";
+import { countUp, pop } from "./anim";
+
+/**
+ * A type alias, not an interface, and that is load-bearing: Remotion's
+ * `Composition` requires props assignable to `Record<string, unknown>`,
+ * and TypeScript grants an implicit index signature to type aliases but
+ * not to interfaces. As an interface this fails to compile with a
+ * `LooseComponentType` mismatch that names neither cause nor fix.
+ */
+export type ScorePopProps = {
+  /** The number on the pill. Sign is applied automatically. */
+  value: number;
+  /** Trailing label, e.g. "PTS". Omit for a bare number. */
+  unit?: string;
+  /** `up` is the brand green, `down` the loss red. */
+  tone?: "up" | "down";
+  /** Show a leading + on positive values. */
+  showSign?: boolean;
+  /** Count to `value` from here instead of arriving at it. */
+  countUpFrom?: number;
+  /** How far past its final size it overshoots. 0 disables the bounce. */
+  bounce?: number;
+  scale?: number;
+}
+
+export function ScorePop({
+  value,
+  unit = "PTS",
+  tone = "up",
+  showSign = true,
+  countUpFrom,
+  bounce = 0.34,
+  scale = 2,
+}: ScorePopProps) {
+  const frame = useCurrentFrame();
+  const shown = countUp(frame, value, countUpFrom);
+  const s = pop(frame, { bounce });
+
+  // Fades faster than it scales, so the overshoot is seen at full
+  // strength rather than arriving through a haze.
+  const opacity = interpolate(frame, [0, 8], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+
+  const color = tone === "up" ? "var(--color-up)" : "var(--color-down)";
+  const sign = showSign && shown > 0 ? "+" : "";
+
+  return (
+    <Stage scale={scale}>
+      <div
+        style={{
+          transform: `scale(${s})`,
+          opacity,
+          display: "inline-flex",
+          alignItems: "baseline",
+          gap: "0.4em",
+          padding: "0.34em 0.85em",
+          borderRadius: 999,
+          // color-mix against the token rather than a second hex, so
+          // retinting the brand green retints this too.
+          backgroundColor: `color-mix(in srgb, ${color} 16%, transparent)`,
+          border: `1.5px solid color-mix(in srgb, ${color} 45%, transparent)`,
+          color,
+          fontFamily: "var(--font-mono)",
+          fontWeight: 600,
+          fontSize: 30,
+          lineHeight: 1,
+          letterSpacing: "0.01em",
+          fontVariantNumeric: "tabular-nums",
+          whiteSpace: "nowrap",
+        }}
+      >
+        <span>
+          {sign}
+          {shown.toFixed(1)}
+        </span>
+        {unit && (
+          <span style={{ fontSize: "0.55em", letterSpacing: "0.12em" }}>
+            {unit}
+          </span>
+        )}
+      </div>
+    </Stage>
+  );
+}

--- a/promo/src/promo-chips/ScorePop.tsx
+++ b/promo/src/promo-chips/ScorePop.tsx
@@ -39,6 +39,8 @@ export type ScorePopProps = {
   /** How far past its final size it overshoots. 0 disables the bounce. */
   bounce?: number;
   scale?: number;
+  /** `[data-theme]` palette to render under. */
+  theme?: string;
 }
 
 export function ScorePop({
@@ -49,6 +51,7 @@ export function ScorePop({
   countUpFrom,
   bounce = 0.34,
   scale = 2,
+  theme,
 }: ScorePopProps) {
   const frame = useCurrentFrame();
   const shown = countUp(frame, value, countUpFrom);
@@ -65,7 +68,7 @@ export function ScorePop({
   const sign = showSign && shown > 0 ? "+" : "";
 
   return (
-    <Stage scale={scale}>
+    <Stage scale={scale} theme={theme}>
       <div
         style={{
           transform: `scale(${s})`,

--- a/promo/src/promo-chips/Stage.tsx
+++ b/promo/src/promo-chips/Stage.tsx
@@ -34,6 +34,7 @@ export function Stage({
   scale = 2,
   plate = false,
   livePulse,
+  theme = "scrollr-dark",
 }: {
   children: ReactNode;
   /** Multiplier on the chip's real ticker size. */
@@ -64,6 +65,13 @@ export function Stage({
    * than failing. It's worth it to keep the shipped component untouched.
    */
   livePulse?: number;
+  /**
+   * Which `[data-theme]` palette to render under. Every colour on the
+   * chip resolves through it — accent, up/down, surfaces — so this is
+   * the only thing that needs to change to render the same chips in a
+   * different skin.
+   */
+  theme?: string;
 }) {
   return (
     <AbsoluteFill
@@ -79,7 +87,7 @@ export function Stage({
       )}
       <div
         id="app-shell"
-        data-theme="scrollr-dark"
+        data-theme={theme}
         style={{
           // The plate is the chip's own surface token, not a picked
           // grey, so it tracks the theme rather than drifting from it.

--- a/promo/src/promo-chips/Stage.tsx
+++ b/promo/src/promo-chips/Stage.tsx
@@ -85,6 +85,9 @@ export function Stage({
           // grey, so it tracks the theme rather than drifting from it.
           background: plate ? "var(--color-surface)" : undefined,
           borderRadius: plate ? 6 : undefined,
+          // Impact rides on top of the base scale rather than replacing
+          // it, so a comp rendered at 3x still reacts by the same
+          // proportion instead of a fixed number of pixels.
           transform: `scale(${scale})`,
           // Scale about the centre so the chip stays put as `scale`
           // changes — otherwise retuning the zoom silently reframes it.

--- a/promo/src/promo-chips/Stage.tsx
+++ b/promo/src/promo-chips/Stage.tsx
@@ -1,0 +1,101 @@
+/**
+ * The transparent stage every chip composition sits on.
+ *
+ * THREE THINGS THIS EXISTS TO GET RIGHT, all of which broke a render
+ * the first time round:
+ *
+ * 1. NOTHING PAINTS A BACKGROUND. Not the AbsoluteFill, not the theme
+ *    wrapper, not the chip. ProRes 4444 carries alpha, but only for
+ *    pixels that were actually transparent — one stray `bg-*` and the
+ *    whole overlay arrives in Resolve as an opaque rectangle. The theme
+ *    wrapper below is `#app-shell`, NOT `#desktop-shell`, precisely
+ *    because the latter carries `height: 100vh` and its own background
+ *    while the former only defines colour variables.
+ *
+ * 2. SCALE, DON'T RESIZE. The chip renders at its real ticker size and
+ *    is then scaled up by transform. Rendering it "bigger" by changing
+ *    font sizes would produce a chip that is not the shipped design —
+ *    different wrapping, different padding ratios. Scaling keeps the
+ *    geometry exact and just puts more pixels behind it, which is the
+ *    whole point of an oversized canvas.
+ *
+ * 3. `#app-shell` STILLS CSS ANIMATION, AND THAT IS WANTED HERE. The
+ *    app's own keyframes (spine glow, pts flash) advance on a wall
+ *    clock, so under frame-stepping they'd either sit still or differ
+ *    between renders. Killing them means every moving thing in these
+ *    comps is driven by the frame, which is the only way a render is
+ *    reproducible.
+ */
+import type { ReactNode } from "react";
+import { AbsoluteFill } from "remotion";
+
+export function Stage({
+  children,
+  scale = 2,
+  plate = false,
+  livePulse,
+}: {
+  children: ReactNode;
+  /** Multiplier on the chip's real ticker size. */
+  scale?: number;
+  /**
+   * Put the app's own surface colour behind the chip.
+   *
+   * OFF by default, which is the honest default: in the product the
+   * chip's fill is a 6% wash that reads against the app's dark bar. As
+   * a standalone overlay there is nothing behind it, so that wash is
+   * invisible and the chip composites as glass — border and text only.
+   *
+   * That looks good over calm footage and becomes unreadable over busy
+   * footage. Turn this on and the chip carries its own ground.
+   */
+  plate?: boolean;
+  /**
+   * Opacity for the LIVE dot, 0..1, driven per frame.
+   *
+   * The dot inside FantasyStatChip is a `motion.span` whose keyframes
+   * run on Motion's own clock, and that clock does not advance when
+   * Remotion steps frames — so the dot renders static no matter what.
+   * Rather than change the product for the video's benefit, the pulse
+   * is applied from out here as a CSS variable the rule below reads.
+   *
+   * The coupling is to the dot's `bg-live` class. That is the fragile
+   * part: rename it in the app and this silently stops pulsing rather
+   * than failing. It's worth it to keep the shipped component untouched.
+   */
+  livePulse?: number;
+}) {
+  return (
+    <AbsoluteFill
+      style={{
+        // No backgroundColor. See note 1.
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {livePulse !== undefined && (
+        <style>{`#app-shell .bg-live { opacity: ${livePulse.toFixed(3)}; }`}</style>
+      )}
+      <div
+        id="app-shell"
+        data-theme="scrollr-dark"
+        style={{
+          // The plate is the chip's own surface token, not a picked
+          // grey, so it tracks the theme rather than drifting from it.
+          background: plate ? "var(--color-surface)" : undefined,
+          borderRadius: plate ? 6 : undefined,
+          transform: `scale(${scale})`,
+          // Scale about the centre so the chip stays put as `scale`
+          // changes — otherwise retuning the zoom silently reframes it.
+          transformOrigin: "center center",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {children}
+      </div>
+    </AbsoluteFill>
+  );
+}

--- a/promo/src/promo-chips/TickerRail.tsx
+++ b/promo/src/promo-chips/TickerRail.tsx
@@ -1,5 +1,6 @@
 /**
- * A row of real chips, drifting, with one of them scoring.
+ * A row of real chips, drifting, with plays landing across the whole
+ * length of it.
  *
  * The single-chip comps sell the CHIP. This one sells the PRODUCT: a
  * bar you can lay along the top of a screen capture, where the thing
@@ -7,11 +8,18 @@
  * erupts. A chip on its own can look like a notification; a rail that
  * keeps moving while one cell reacts looks like a live feed.
  *
+ * EVERY CHIP CAN SCORE. This started with one designated hero and a
+ * list of inert neighbours, which is fine for six seconds and wrong for
+ * thirty — a bar where the same cell is the only one that ever moves
+ * reads as a mock-up of a ticker rather than a ticker. Each league now
+ * carries its own `scoreEvents` and its own reaction, so the rail has a
+ * rhythm instead of a single event.
+ *
  * Drift is linear and slow on purpose. This is an overlay that will sit
  * under cuts and titles, so it has no business easing, pulsing or
- * drawing the eye on its own — the score does that.
+ * drawing the eye on its own — the scores do that.
  */
-import { useCurrentFrame } from "remotion";
+import { useCurrentFrame, useVideoConfig } from "remotion";
 import FantasyStatChip from "../../../desktop/src/components/chips/FantasyStatChip";
 import { DEFAULT_WIDGET_DISPLAY } from "../../../desktop/src/preferences";
 import { Stage } from "./Stage";
@@ -26,58 +34,37 @@ import {
   scoreAt,
 } from "./scoring";
 
+/** A league on the rail, with its own plays. */
+export type RailLeague = LeagueChipProps & {
+  /**
+   * Plays for THIS league. Omit for a chip that just sits there being
+   * alive — most of them should, most of the time, or the bar turns
+   * into a fireworks display and nothing reads as significant.
+   */
+  scoreEvents?: ScoreEvent[];
+};
+
 export type TickerRailProps = {
-  /** The chip that scores. Rendered in the middle of the rail. */
-  hero: LeagueChipProps;
-  /** Its scoring plays. */
-  scoreEvents: ScoreEvent[];
-  /** The leagues either side, which just sit there being alive. */
-  others: LeagueChipProps[];
-  /** Pixels per frame the rail travels left. */
+  leagues: RailLeague[];
+  /** Pixels per frame the rail travels left, in pre-scale units. */
   drift?: number;
-  /** Gap between chips, in pre-scale pixels — the app's own is 8. */
+  /** Gap between chips, pre-scale — the app's own is 8. */
   gap?: number;
   scale?: number;
   plate?: boolean;
 };
 
 export function TickerRail({
-  hero,
-  scoreEvents,
-  others,
+  leagues,
   drift = 0.35,
   gap = 8,
   scale = 2,
   plate = false,
 }: TickerRailProps) {
   const frame = useCurrentFrame();
-  const score = scoreAt(frame, hero.myScore, scoreEvents);
-  const hit = impact(frame, scoreEvents);
-  // Duration is not needed here: the crossing can only happen inside the
-  // events, so scanning to the last one plus its count is sufficient and
-  // avoids making this depend on the composition's length.
-  const lastEvent = scoreEvents.reduce((n, e) => Math.max(n, e.at), 0);
-  const crossing = leadChangeFrame(
-    hero.myScore,
-    scoreEvents,
-    hero.opponentScore,
-    lastEvent + 60,
-  );
-  const flare = leadFlare(frame, crossing);
-
-  // The hero sits in the middle so there is always something either
-  // side of the reaction. A rail that erupts at its own edge reads as
-  // the bar ending rather than the league scoring.
-  const middle = Math.ceil(others.length / 2);
-  const before = others.slice(0, middle);
-  const after = others.slice(middle);
 
   return (
-    <Stage
-      scale={scale}
-      plate={plate}
-      livePulse={livePulse(frame)}
-    >
+    <Stage scale={scale} plate={plate} livePulse={livePulse(frame)}>
       <div
         style={{
           ...entrance(frame),
@@ -90,20 +77,48 @@ export function TickerRail({
           transform: `translateX(${-Math.round(frame * drift)}px)`,
         }}
       >
-        {before.map((l) => (
-          <Chip key={l.leagueName} league={l} />
-        ))}
-        {/* Only the hero reacts. The rail around it holding steady is
-            what makes this read as one league scoring rather than an
-            app-wide alert. */}
-        <Reactor impact={hit} flash={Math.max(0, hit)} flare={flare}>
-          <Chip league={hero} score={score} />
-        </Reactor>
-        {after.map((l) => (
-          <Chip key={l.leagueName} league={l} />
+        {leagues.map((league) => (
+          <RailChip key={league.leagueName} league={league} />
         ))}
       </div>
     </Stage>
+  );
+}
+
+/**
+ * One cell. Owns its own score, its own reaction and its own lead
+ * change, so two leagues scoring near each other stay independent
+ * rather than sharing one envelope.
+ */
+function RailChip({ league }: { league: RailLeague }) {
+  const frame = useCurrentFrame();
+  const { durationInFrames } = useVideoConfig();
+  const events = league.scoreEvents ?? [];
+
+  if (events.length === 0) {
+    // No plays: render flat and skip the wrapper entirely. A Reactor
+    // that never fires is a transform and an overlay span per chip per
+    // frame, and on a rail this is most of them.
+    return <Chip league={league} score={league.myScore} />;
+  }
+
+  const score = scoreAt(frame, league.myScore, events);
+  const hit = impact(frame, events);
+  const crossing = leadChangeFrame(
+    league.myScore,
+    events,
+    league.opponentScore,
+    durationInFrames,
+  );
+
+  return (
+    <Reactor
+      impact={hit}
+      flash={Math.max(0, hit)}
+      flare={leadFlare(frame, crossing)}
+    >
+      <Chip league={league} score={score} />
+    </Reactor>
   );
 }
 
@@ -112,12 +127,11 @@ function Chip({
   score,
 }: {
   league: LeagueChipProps;
-  /** Overrides the static score — only the hero passes one. */
-  score?: number;
+  score: number;
 }) {
   return (
     <FantasyStatChip
-      league={buildLeague(league, score ?? league.myScore)}
+      league={buildLeague(league, score)}
       prefs={DEFAULT_WIDGET_DISPLAY.fantasy}
       comfort
       colorMode="widget"

--- a/promo/src/promo-chips/TickerRail.tsx
+++ b/promo/src/promo-chips/TickerRail.tsx
@@ -52,6 +52,8 @@ export type TickerRailProps = {
   gap?: number;
   scale?: number;
   plate?: boolean;
+  /** `[data-theme]` palette to render under. */
+  theme?: string;
 };
 
 export function TickerRail({
@@ -60,11 +62,17 @@ export function TickerRail({
   gap = 8,
   scale = 2,
   plate = false,
+  theme,
 }: TickerRailProps) {
   const frame = useCurrentFrame();
 
   return (
-    <Stage scale={scale} plate={plate} livePulse={livePulse(frame)}>
+    <Stage
+      scale={scale}
+      plate={plate}
+      theme={theme}
+      livePulse={livePulse(frame)}
+    >
       <div
         style={{
           ...entrance(frame),

--- a/promo/src/promo-chips/TickerRail.tsx
+++ b/promo/src/promo-chips/TickerRail.tsx
@@ -1,0 +1,127 @@
+/**
+ * A row of real chips, drifting, with one of them scoring.
+ *
+ * The single-chip comps sell the CHIP. This one sells the PRODUCT: a
+ * bar you can lay along the top of a screen capture, where the thing
+ * that matters is that the other leagues carry on while one of them
+ * erupts. A chip on its own can look like a notification; a rail that
+ * keeps moving while one cell reacts looks like a live feed.
+ *
+ * Drift is linear and slow on purpose. This is an overlay that will sit
+ * under cuts and titles, so it has no business easing, pulsing or
+ * drawing the eye on its own — the score does that.
+ */
+import { useCurrentFrame } from "remotion";
+import FantasyStatChip from "../../../desktop/src/components/chips/FantasyStatChip";
+import { DEFAULT_WIDGET_DISPLAY } from "../../../desktop/src/preferences";
+import { Stage } from "./Stage";
+import { Reactor } from "./Reactor";
+import { buildLeague, type LeagueChipProps } from "./LeagueChip";
+import { entrance, livePulse } from "./anim";
+import {
+  type ScoreEvent,
+  impact,
+  leadChangeFrame,
+  leadFlare,
+  scoreAt,
+} from "./scoring";
+
+export type TickerRailProps = {
+  /** The chip that scores. Rendered in the middle of the rail. */
+  hero: LeagueChipProps;
+  /** Its scoring plays. */
+  scoreEvents: ScoreEvent[];
+  /** The leagues either side, which just sit there being alive. */
+  others: LeagueChipProps[];
+  /** Pixels per frame the rail travels left. */
+  drift?: number;
+  /** Gap between chips, in pre-scale pixels — the app's own is 8. */
+  gap?: number;
+  scale?: number;
+  plate?: boolean;
+};
+
+export function TickerRail({
+  hero,
+  scoreEvents,
+  others,
+  drift = 0.35,
+  gap = 8,
+  scale = 2,
+  plate = false,
+}: TickerRailProps) {
+  const frame = useCurrentFrame();
+  const score = scoreAt(frame, hero.myScore, scoreEvents);
+  const hit = impact(frame, scoreEvents);
+  // Duration is not needed here: the crossing can only happen inside the
+  // events, so scanning to the last one plus its count is sufficient and
+  // avoids making this depend on the composition's length.
+  const lastEvent = scoreEvents.reduce((n, e) => Math.max(n, e.at), 0);
+  const crossing = leadChangeFrame(
+    hero.myScore,
+    scoreEvents,
+    hero.opponentScore,
+    lastEvent + 60,
+  );
+  const flare = leadFlare(frame, crossing);
+
+  // The hero sits in the middle so there is always something either
+  // side of the reaction. A rail that erupts at its own edge reads as
+  // the bar ending rather than the league scoring.
+  const middle = Math.ceil(others.length / 2);
+  const before = others.slice(0, middle);
+  const after = others.slice(middle);
+
+  return (
+    <Stage
+      scale={scale}
+      plate={plate}
+      livePulse={livePulse(frame)}
+    >
+      <div
+        style={{
+          ...entrance(frame),
+          display: "flex",
+          alignItems: "center",
+          gap,
+          // Whole pixels. A rail drifting on fractional offsets shimmers
+          // as the text re-hints every frame, which is invisible in
+          // isolation and obvious once it is sitting over footage.
+          transform: `translateX(${-Math.round(frame * drift)}px)`,
+        }}
+      >
+        {before.map((l) => (
+          <Chip key={l.leagueName} league={l} />
+        ))}
+        {/* Only the hero reacts. The rail around it holding steady is
+            what makes this read as one league scoring rather than an
+            app-wide alert. */}
+        <Reactor impact={hit} flash={Math.max(0, hit)} flare={flare}>
+          <Chip league={hero} score={score} />
+        </Reactor>
+        {after.map((l) => (
+          <Chip key={l.leagueName} league={l} />
+        ))}
+      </div>
+    </Stage>
+  );
+}
+
+function Chip({
+  league,
+  score,
+}: {
+  league: LeagueChipProps;
+  /** Overrides the static score — only the hero passes one. */
+  score?: number;
+}) {
+  return (
+    <FantasyStatChip
+      league={buildLeague(league, score ?? league.myScore)}
+      prefs={DEFAULT_WIDGET_DISPLAY.fantasy}
+      comfort
+      colorMode="widget"
+      rollScore={false}
+    />
+  );
+}

--- a/promo/src/promo-chips/anim.ts
+++ b/promo/src/promo-chips/anim.ts
@@ -1,0 +1,123 @@
+/**
+ * The timing contract every promo-chip composition shares.
+ *
+ * All three comps are 6s but reach their final state by ~1.5s and hold
+ * it flat for the remaining 4.5s. That is deliberate and it is for the
+ * NLE, not for looks: an overlay you trim from the tail is only safe if
+ * every frame past the settle point is identical, so a cut can land
+ * anywhere after 90 without changing what's on screen.
+ *
+ * Everything here is a pure function of the frame. Nothing uses Motion,
+ * a spring instance, or a wall clock, because Remotion renders by
+ * setting a frame and screenshotting — animations that advance on their
+ * own schedule either don't move at all or move differently on every
+ * render. That lesson cost a whole afternoon the first time.
+ */
+import { Easing, interpolate } from "remotion";
+
+/** Frames, at 60fps. */
+export const T = {
+  /** Slide-up + fade in. */
+  enterEnd: 20,
+  /** Numbers begin counting once the chip has arrived. */
+  countStart: 20,
+  countEnd: 70,
+  /** Bars fill slightly behind the numbers so they read as a result. */
+  barStart: 26,
+  barEnd: 82,
+  /**
+   * Everything is settled by here. Nothing in any comp may move after
+   * this frame — see the module note.
+   */
+  settled: 90,
+} as const;
+
+/** How far the chip travels on entrance, in canvas px before scaling. */
+const RISE = 26;
+
+/**
+ * Entrance: up and in. Returns a style, so a caller can spread it onto
+ * whatever wrapper it already has rather than nesting another div.
+ */
+export function entrance(frame: number) {
+  const t = interpolate(frame, [0, T.enterEnd], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    // Decelerating, so the chip arrives rather than stops. A linear
+    // entrance on a 20-frame move reads mechanical at 60fps.
+    easing: Easing.out(Easing.cubic),
+  });
+  return {
+    opacity: t,
+    transform: `translateY(${(1 - t) * RISE}px)`,
+  };
+}
+
+/**
+ * A number counting to its final value.
+ *
+ * `from` is optional on every comp: when it's undefined the value is
+ * simply held, because a chip that isn't the subject of the shot
+ * shouldn't be animating a number nobody is looking at.
+ */
+export function countUp(frame: number, to: number, from?: number): number {
+  if (from === undefined || from === to) return to;
+  return interpolate(frame, [T.countStart, T.countEnd], [from, to], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.out(Easing.cubic),
+  });
+}
+
+/**
+ * Bar fill, 0..1 of its target. Same shape as countUp but on its own
+ * slightly later window, so the bar trails the number it summarises
+ * instead of racing it.
+ */
+export function barFill(frame: number, to: number): number {
+  return interpolate(frame, [T.barStart, T.barEnd], [0, to], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.out(Easing.cubic),
+  });
+}
+
+/**
+ * The LIVE dot's pulse.
+ *
+ * A raw sine of the frame, which matters for two reasons: it never
+ * needs a start value, and it is continuous — so a clip trimmed at any
+ * frame past the settle point still cuts mid-breath rather than
+ * snapping. Held between 0.4 and 1.0 to match the app's own dot.
+ *
+ * This is the one thing that keeps moving after T.settled. It is a
+ * deliberate exception to the hold rule: a "LIVE" badge that has
+ * stopped breathing reads as a frozen screenshot, which is the exact
+ * impression the whole video exists to dispel.
+ */
+export function livePulse(frame: number): number {
+  const cycle = 78; // ~1.3s, the app's own period
+  return 0.4 + 0.3 * (1 + Math.sin((frame / cycle) * Math.PI * 2));
+}
+
+/**
+ * Spring overshoot for ScorePop.
+ *
+ * Hand-rolled rather than Remotion's `spring()` because this one needs
+ * to be readable and tunable by whoever is cutting the video: `bounce`
+ * is how far past 1 it goes, `settle` is when it stops. A critically
+ * damped analytic curve, sampled per frame, so it is still a pure
+ * function of the frame like everything else here.
+ */
+export function pop(
+  frame: number,
+  { delay = 0, bounce = 0.34, settle = 34 } = {},
+): number {
+  const f = frame - delay;
+  if (f <= 0) return 0;
+  if (f >= settle) return 1;
+  const t = f / settle;
+  // Decaying cosine: overshoots once, then converges on 1.
+  const decay = Math.exp(-4.2 * t);
+  return 1 + bounce * decay * -Math.cos(t * Math.PI * 2.1);
+}

--- a/promo/src/promo-chips/scoring.ts
+++ b/promo/src/promo-chips/scoring.ts
@@ -1,0 +1,202 @@
+/**
+ * Score choreography — how a number changing becomes a moment.
+ *
+ * WHY THIS REPLACED A SMOOTH COUNT-UP. Fantasy points do not ramp. A
+ * catch is +1.4 and a touchdown is +6.6, both delivered whole, and the
+ * gap between them is the part that hurts. Gliding a score from 149.9
+ * to 157.9 over a second reads as a dashboard refreshing; landing it in
+ * two discrete hits reads as two things happening on a field. The
+ * second is what the video is selling.
+ *
+ * THE SHAPE OF ONE HIT, which is where the excitement actually lives:
+ *
+ *   anticipation  the chip eases DOWN slightly before the number moves.
+ *                 Eight frames of dip is invisible if you look for it
+ *                 and unmistakable if you don't — it is the flinch
+ *                 before a punch, and without it the impact reads as a
+ *                 glitch rather than a blow.
+ *   impact        five frames up, overshooting. The number counts in
+ *                 that window, fast enough to feel struck, slow enough
+ *                 that the eye catches the digits moving.
+ *   settle        thirty frames back to rest, decelerating.
+ *
+ * Everything here is a pure function of the frame. Nothing holds state
+ * between renders, because Remotion may render frame 200 before frame 3
+ * and any accumulator would be wrong in both.
+ */
+import { Easing, interpolate } from "remotion";
+
+export type ScoreEventKind = "catch" | "fg" | "td" | "big";
+
+export type ScoreEvent = {
+  /** Frame the play lands on. */
+  at: number;
+  /** Points it adds. Negative works — fumbles happen. */
+  points: number;
+  /**
+   * Flavour. Drives how hard the chip reacts and what a ScorePop
+   * labels itself; it never changes the arithmetic.
+   */
+  kind?: ScoreEventKind;
+};
+
+/** Frames. Tuned as a set — changing one alone breaks the feel. */
+const ANTICIPATION = 8;
+const IMPACT = 5;
+const SETTLE = 30;
+/** How long the number takes to travel to its new value. */
+const COUNT = 16;
+
+/** How hard each kind hits, as a multiplier on the impact envelope. */
+const WEIGHT: Record<ScoreEventKind, number> = {
+  catch: 0.55,
+  fg: 0.75,
+  td: 1,
+  big: 1.15,
+};
+
+/**
+ * The score at a given frame: the base plus every play that has landed,
+ * with the most recent one still counting in.
+ *
+ * A sharper ease-out than the gentle cubic used elsewhere — `poly(4)`
+ * rather than `quart`, which Remotion's Easing does not expose by name.
+ * The number should arrive almost immediately and then creep the last
+ * tenth, which is what makes a total feel like it is settling rather
+ * than sliding.
+ */
+export function scoreAt(
+  frame: number,
+  base: number,
+  events: readonly ScoreEvent[],
+): number {
+  let value = base;
+  for (const e of sorted(events)) {
+    if (frame >= e.at + COUNT) {
+      value += e.points;
+    } else if (frame > e.at) {
+      value += interpolate(frame, [e.at, e.at + COUNT], [0, e.points], {
+        extrapolateLeft: "clamp",
+        extrapolateRight: "clamp",
+        easing: Easing.out(Easing.poly(4)),
+      });
+    }
+  }
+  return value;
+}
+
+/**
+ * The reaction envelope, roughly -0.3 to 1.
+ *
+ * Negative during anticipation, peaking on impact, decaying to zero.
+ * Callers map it onto whatever they want to move — scale, glow, a
+ * flash — so the whole chip reacts on one clock instead of three
+ * separately-tuned ones drifting apart.
+ *
+ * Returns the STRONGEST live envelope rather than a sum, so two plays
+ * close together read as two hits instead of one enormous one.
+ */
+export function impact(
+  frame: number,
+  events: readonly ScoreEvent[],
+): number {
+  let strongest = 0;
+  for (const e of events) {
+    const f = frame - e.at;
+    if (f < -ANTICIPATION || f > SETTLE) continue;
+    const weight = WEIGHT[e.kind ?? "td"];
+
+    const v =
+      f < 0
+        ? // Anticipation: ease down into the hit.
+          interpolate(f, [-ANTICIPATION, 0], [0, -0.3], {
+            easing: Easing.in(Easing.quad),
+          })
+        : f <= IMPACT
+          ? // Impact: from the bottom of the dip to the peak.
+            interpolate(f, [0, IMPACT], [-0.3, 1], {
+              easing: Easing.out(Easing.quad),
+            })
+          : // Settle: back to rest.
+            interpolate(f, [IMPACT, SETTLE], [1, 0], {
+              easing: Easing.out(Easing.cubic),
+            });
+
+    const scaled = v * weight;
+    if (Math.abs(scaled) > Math.abs(strongest)) strongest = scaled;
+  }
+  return strongest;
+}
+
+/**
+ * The frame the user's score crosses the opponent's, or null if it
+ * never does.
+ *
+ * Found by scanning rather than solved, because the crossing can happen
+ * mid-count inside an event and the easing makes that analytically
+ * annoying for no benefit — a few hundred evaluations of a pure
+ * function costs nothing and cannot disagree with what is rendered.
+ *
+ * This is the single most valuable frame in the whole video. Everything
+ * before it is tension and everything after is relief, and a promo that
+ * doesn't mark it is wasting the only real story it has.
+ */
+export function leadChangeFrame(
+  base: number,
+  events: readonly ScoreEvent[],
+  opponent: number,
+  duration: number,
+): number | null {
+  if (base > opponent) return null; // already ahead; there's no crossing
+  for (let f = 0; f <= duration; f++) {
+    if (scoreAt(f, base, events) > opponent) return f;
+  }
+  return null;
+}
+
+/**
+ * A decaying flare from the lead change, 0..1.
+ *
+ * Longer and softer than the per-play impact: the play is a punch and
+ * this is the aftermath. They overlap by design, so the crossing hit
+ * lands harder than the hits either side of it without needing its own
+ * special case anywhere else.
+ */
+export function leadFlare(frame: number, crossing: number | null): number {
+  if (crossing === null || frame < crossing) return 0;
+  return interpolate(frame, [crossing, crossing + 52], [1, 0], {
+    extrapolateRight: "clamp",
+    easing: Easing.out(Easing.cubic),
+  });
+}
+
+/**
+ * When everything has stopped moving.
+ *
+ * The comps promise a frozen tail so an editor can trim from the end at
+ * any point. With a sequence of plays that promise can no longer be a
+ * fixed frame 90 — it has to be derived, or a late play would silently
+ * break the guarantee the README makes.
+ */
+export function settledAt(events: readonly ScoreEvent[]): number {
+  const last = events.reduce((n, e) => Math.max(n, e.at), 0);
+  return last + Math.max(SETTLE, COUNT) + 52; // + the lead flare's tail
+}
+
+function sorted(events: readonly ScoreEvent[]): ScoreEvent[] {
+  return [...events].sort((a, b) => a.at - b.at);
+}
+
+/** Label for a ScorePop driven by the same event list. */
+export function kindLabel(kind: ScoreEventKind | undefined): string {
+  switch (kind) {
+    case "catch":
+      return "RECEPTION";
+    case "fg":
+      return "FIELD GOAL";
+    case "big":
+      return "BIG PLAY";
+    default:
+      return "TOUCHDOWN";
+  }
+}

--- a/promo/src/promo-chips/themes.ts
+++ b/promo/src/promo-chips/themes.ts
@@ -1,0 +1,28 @@
+/**
+ * The app's dark themes, as render targets.
+ *
+ * `scrollr-dark` has no `[data-theme]` block of its own in the app's
+ * stylesheet — it IS the `@theme` default, so the attribute matches
+ * nothing and the defaults apply. That is why it is written here by
+ * hand rather than scraped from the CSS: a list built by grepping for
+ * `[data-theme="*-dark"]` finds nine and silently omits the house one.
+ *
+ * Each theme overrides the accent, up/down and surface tokens, so the
+ * chips genuinely change — border, score colour, and the flash on a
+ * scoring play all follow. If a theme only moved the background these
+ * clips would not be worth cutting together.
+ */
+export const DARK_THEMES = [
+  "scrollr-dark",
+  "catppuccin-dark",
+  "dracula-dark",
+  "everforest-dark",
+  "gruvbox-dark",
+  "nord-dark",
+  "one-dark",
+  "rose-pine-dark",
+  "solarized-dark",
+  "tokyo-night-dark",
+] as const;
+
+export type DarkTheme = (typeof DARK_THEMES)[number];

--- a/promo/src/styles.css
+++ b/promo/src/styles.css
@@ -14,6 +14,27 @@
  */
 @import "../../desktop/src/style.css";
 
+/*
+ * THE APP'S OWN @source LINES ARE `*.tsx` ONLY, AND THAT LOSES CLASSES.
+ *
+ * `chipColors.ts` is a .ts file, and it is where every chip's border,
+ * background and text classes are defined as strings. Tailwind never
+ * scanned it here, so `border-accent-purple/25` and
+ * `bg-accent-purple/[0.06]` were never generated — which does not fail
+ * loudly. The border silently fell back to Tailwind's default of
+ * `currentColor`, inheriting the light body foreground, and rendered as
+ * a hard white 1px line on every chip. The 6% fill simply never existed.
+ *
+ * In the app this does not bite, because Tailwind's automatic content
+ * detection walks the project from desktop/ and picks the .ts files up
+ * anyway. Here the detection root is promo/, so desktop/src is covered
+ * ONLY by those explicit .tsx globs.
+ *
+ * Scanning both extensions across the app's source fixes it at the
+ * root, rather than restyling the chip to hide it.
+ */
+@source "../../desktop/src/**/*.{ts,tsx}";
+
 @source "./**/*.tsx";
 
 

--- a/promo/src/styles.css
+++ b/promo/src/styles.css
@@ -1,0 +1,34 @@
+/*
+ * Pulls in the app's own stylesheet so the chips render with the real
+ * palette rather than a copy that drifts. Tailwind v4's `@source`
+ * directives inside it are relative to THAT file, so its
+ * `./components/**` scan still finds the chips correctly from here.
+ *
+ * The extra @source below adds this project's own files, which the
+ * app's stylesheet obviously doesn't know about.
+ *
+ * No web font import. The film that used to live here set its supers in
+ * Barlow Condensed; these compositions render only chips, which take
+ * their face from the app's own --font-mono. Fetching a font nothing
+ * uses just adds a network round trip to every render.
+ */
+@import "../../desktop/src/style.css";
+
+@source "./**/*.tsx";
+
+
+@source "./**/*.tsx";
+
+/*
+ * Video is not a webpage: it renders at a fixed size and gets scaled by
+ * the player, so the browser default of 16px root and the app's own
+ * responsive assumptions don't apply. Compositions set their own scale
+ * explicitly.
+ */
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}

--- a/promo/src/vite-env.d.ts
+++ b/promo/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+/**
+ * The desktop app is a Vite project and uses `import.meta.env` and
+ * `import.meta.glob`. Importing its components here drags those into the
+ * typecheck, and this project is bundled by Remotion's webpack, which has
+ * no Vite types.
+ *
+ * Declaring them is enough for tsc. Whether webpack can EXECUTE
+ * `import.meta.glob` is a separate question, and the answer is no — see
+ * remotion.config.ts for how that module is handled.
+ */
+interface ImportMeta {
+  env: Record<string, string | boolean | undefined>;
+  glob: (pattern: string, opts?: unknown) => Record<string, unknown>;
+}

--- a/promo/stubs/datawidget-registry.ts
+++ b/promo/stubs/datawidget-registry.ts
@@ -1,0 +1,27 @@
+/**
+ * Stand-in for desktop/src/datawidgets/registry.ts.
+ *
+ * That module discovers widget FeedTab components with
+ * `import.meta.glob`, which is a Vite build-time transform. Remotion
+ * bundles with webpack, where it is a plain property access on
+ * import.meta and fails at runtime with "{}.glob is not a function" —
+ * the whole bundle dies before a frame renders.
+ *
+ * Nothing in a ticker render needs it. It reaches the graph through
+ * marketplace.ts, and the only thing the ticker asks marketplace is
+ * `sourceForWidget`, which falls back to the tab name when the catalog
+ * has no entry. Returning nothing here takes exactly that fallback.
+ *
+ * If a composition ever renders a widget PAGE rather than ticker chips,
+ * this becomes wrong and the page will render empty. Build the registry
+ * eagerly from explicit imports at that point rather than widening this.
+ */
+import type { DataWidgetManifest } from "../../desktop/src/types";
+
+export function getDataWidget(_id: string): DataWidgetManifest | undefined {
+  return undefined;
+}
+
+export function getAllDataWidgets(): DataWidgetManifest[] {
+  return [];
+}

--- a/promo/stubs/tauri-store.ts
+++ b/promo/stubs/tauri-store.ts
@@ -1,0 +1,76 @@
+/**
+ * Stand-in for @tauri-apps/plugin-store.
+ *
+ * The chips don't touch persistent storage, but they import
+ * `shouldShowOnTicker` from preferences.ts, and preferences.ts imports
+ * lib/store.ts, which constructs a LazyStore at module scope. That
+ * import chain has to resolve for the bundle to build even though
+ * nothing in a render path ever calls it.
+ *
+ * Installing a Tauri package into a video project to satisfy an import
+ * that never runs would be worse, so remotion.config.ts aliases the
+ * module here instead.
+ *
+ * Every method throws rather than returning a plausible empty value. If
+ * a component ever DOES reach for storage during a render, that's a
+ * real bug — the composition would be silently rendering default
+ * preferences instead of the ones the shot intends — and a loud failure
+ * is how we find out.
+ */
+
+const unreachable = (method: string): never => {
+  throw new Error(
+    `[promo] LazyStore.${method}() was called during a render. ` +
+      `Compositions must pass preferences explicitly as props — see ` +
+      `promo/stubs/tauri-store.ts.`,
+  );
+};
+
+export class LazyStore {
+  constructor(_path: string) {
+    // Constructing is fine and expected: lib/store.ts does it at module
+    // scope. Only actual operations are a problem.
+  }
+
+  async get<T>(_key: string): Promise<T | null> {
+    return unreachable("get");
+  }
+  async set(_key: string, _value: unknown): Promise<void> {
+    return unreachable("set");
+  }
+  async entries<T>(): Promise<[string, T][]> {
+    return unreachable("entries");
+  }
+  async save(): Promise<void> {
+    return unreachable("save");
+  }
+  async delete(_key: string): Promise<boolean> {
+    return unreachable("delete");
+  }
+  /*
+    The SUBSCRIPTIONS do not throw, unlike everything above, and the
+    distinction is deliberate.
+   
+    Reading storage and getting a plausible empty value is dangerous —
+    the composition would render default preferences while looking like
+    it rendered the shot's. Subscribing to changes that will never come
+    is not: a render is one frame of a fixed timeline, nothing mutates
+    during it, and "you will never be notified" is the truthful answer.
+   
+    ScrollrTicker subscribes on mount (watchlist), so throwing here took
+    the whole ticker down.
+  */
+  async onChange<T>(
+    _cb: (key: string, value: T | null) => void,
+  ): Promise<UnlistenFn> {
+    return () => {};
+  }
+  async onKeyChange<T>(
+    _key: string,
+    _cb: (value: T | null) => void,
+  ): Promise<UnlistenFn> {
+    return () => {};
+  }
+}
+
+type UnlistenFn = () => void;

--- a/promo/stubs/widget-registry.ts
+++ b/promo/stubs/widget-registry.ts
@@ -1,0 +1,31 @@
+/**
+ * Stand-in for desktop/src/widgets/registry.ts.
+ *
+ * Same reason as stubs/datawidget-registry.ts: that module builds itself
+ * with `import.meta.glob`, a Vite build-time transform that webpack
+ * cannot execute — the bundle dies on load with "{}.glob is not a
+ * function" before a frame renders.
+ *
+ * ScrollrTicker takes exactly one thing from it, WIDGET_ORDER, and that
+ * is a plain literal rather than anything the glob produces. Copied
+ * verbatim; if the real one gains an entry this silently falls behind,
+ * so keep them together.
+ */
+import type { WidgetManifest } from "../../desktop/src/types";
+
+export const WIDGET_ORDER = [
+  "clock",
+  "timer",
+  "weather",
+  "sysmon",
+  "uptime",
+  "github",
+];
+
+export function getWidget(_id: string): WidgetManifest | undefined {
+  return undefined;
+}
+
+export function getAllWidgets(): WidgetManifest[] {
+  return [];
+}

--- a/promo/tsconfig.json
+++ b/promo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "paths": {
+      "@tauri-apps/plugin-store": ["./stubs/tauri-store.ts"]
+    }
+  },
+  "include": ["src", "stubs", "remotion.config.ts"]
+}

--- a/promo/variants/dynasty.json
+++ b/promo/variants/dynasty.json
@@ -4,14 +4,31 @@
   "opponentName": "Air Yards Only",
   "week": 12,
   "status": "final",
-  "myScore": 184.5,
+  "myScore": 176.1,
   "opponentScore": 151.0,
   "projection": 184.5,
-  "topScorer": { "name": "Allen", "team": "BUF", "position": "QB", "points": 36.9 },
-  "record": { "wins": 9, "losses": 2 },
+  "topScorer": {
+    "name": "Allen",
+    "team": "BUF",
+    "position": "QB",
+    "points": 36.9
+  },
+  "record": {
+    "wins": 9,
+    "losses": 2
+  },
   "rank": 1,
   "numTeams": 8,
-  "streak": { "type": "win", "value": 1 },
-  "countUpFrom": 170.2,
-  "scale": 2
+  "streak": {
+    "type": "win",
+    "value": 1
+  },
+  "scale": 2,
+  "scoreEvents": [
+    {
+      "at": 60,
+      "points": 8.4,
+      "kind": "big"
+    }
+  ]
 }

--- a/promo/variants/dynasty.json
+++ b/promo/variants/dynasty.json
@@ -1,0 +1,17 @@
+{
+  "leagueName": "Dynasty or Bust",
+  "teamName": "Regression Candidates",
+  "opponentName": "Air Yards Only",
+  "week": 12,
+  "status": "final",
+  "myScore": 184.5,
+  "opponentScore": 151.0,
+  "projection": 184.5,
+  "topScorer": { "name": "Allen", "team": "BUF", "position": "QB", "points": 36.9 },
+  "record": { "wins": 9, "losses": 2 },
+  "rank": 1,
+  "numTeams": 8,
+  "streak": { "type": "win", "value": 1 },
+  "countUpFrom": 170.2,
+  "scale": 2
+}


### PR DESCRIPTION
Ticker polish, cut as **v1.4.1**.

## What users get

**The rail stops jumping.** A player going 8.3 → 14.9 gains a character, which widened its chip and shoved every chip after it along the bar. Numeric segments now reserve their width in `ch` — exact here rather than approximate, because chips render in `font-mono` with `tabular-nums`, so one `ch` is one digit. Right-aligned, so a score grows leftward from a fixed decimal point and reads as counting rather than drifting.

**Scores flash when they actually change.** `.pts-flash` already existed but is a 6s ambient loop meaning "this player is live" — a heartbeat, not an event. `ChipFlash` fires once, on change, green up / red down.

**The spine keeps up.** It set its width inline, so it snapped to the new value in a single frame while the digits above it rolled for 1.8s — the bar finished before the number started.

## Two details worth knowing

The flash remounts an **overlay**, not the number. A CSS animation only replays on a fresh element, so something has to remount — and remounting the score would kill the digit roll mid-flight, which is the very thing the flash exists to draw attention to.

It also refuses to fire on mount, and on the first real value after a null. Every chip scrolling onto the rail has "changed" from nothing, and a player resolving out of a roster has *appeared* rather than scored; counting either would strobe the whole bar. Five tests hold that down, including that an unchanged score arriving on the 30s poll is not an event.

In `FollowedPlayerChip` the hook sits **above** the early return, because that component bails when the player isn't in any roster and a hook can't sit behind a conditional.

## Also in here

A `promo/` directory — a Remotion project that renders transparent ProRes overlays of the real chips for the marketing video. It imports `FantasyStatChip` and `FollowedPlayerChip` directly rather than recreating them, so the overlays can't drift from the product. **It does not ship**: nothing in CI builds or deploys it, and no workspace pulls it into the desktop build.

## Verification

- `tsc --noEmit` clean
- `vitest run` — 44 files, **543 tests passing**
- Version bumped in all four places that must agree: `package.json`, `tauri.conf.json`, `Cargo.toml`, and the `scrollr-desktop` entry in `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
