### PR TITLE
fix(web): download button shipped 1.0.18 — unauthenticated API call, and a guard that never saw CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -290,7 +290,8 @@ jobs:
               "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" \
               "SENTRY_ORG=$SENTRY_ORG" \
               "MOTION_PLUS_TOKEN=$MOTION_PLUS_TOKEN" \
-              "GITHUB_TOKEN=$GH_API_TOKEN"; do
+              "GITHUB_TOKEN=$GH_API_TOKEN" \
+              "CI=true"; do
               BUILD_ARGS="$BUILD_ARGS --build-arg $arg"
             done
           fi

--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -22,6 +22,13 @@ COPY myscrollr.com/ ./myscrollr.com/
 # during prebuild (shared CI runner IPs exhaust the anonymous 60/hr).
 # Builder-stage only; the final image is a separate stage.
 ARG GITHUB_TOKEN
+# Propagates the CI signal INTO the build. Without it every container
+# build looks like local dev to the prebuild scripts, so
+# fetch-latest-version.mjs took its offline fallback and shipped a
+# download button advertising 1.0.18 (2026-09-01). The script has a
+# guard that exits non-zero in CI precisely to stop that; the guard was
+# fine, it just never saw CI=true.
+ARG CI
 # Required: Motion+ registry token for scripts/ensure-motion-plus.mjs
 # (motion-plus is deliberately absent from package.json — this repo is
 # public and the install URL embeds the private token). Builder-stage

--- a/myscrollr.com/scripts/fetch-latest-version.mjs
+++ b/myscrollr.com/scripts/fetch-latest-version.mjs
@@ -48,10 +48,22 @@ const OUTPUT_PATH = new URL(
 const IS_CI = process.env.CI === 'true' || process.env.CI === '1'
 
 async function fetchLatestReleaseFromGitHub() {
+  // Authenticated when a token is available, exactly like its sibling
+  // fetch-releases.mjs. This script did not send the header and that is
+  // what shipped a fallback version to production on 2026-09-01: the
+  // anonymous limit is 60/hr per IP, GitHub Actions runners share IPs,
+  // and the website build lost the race and got a 403. The token was
+  // already being handed to the container (deploy.yml passes
+  // GITHUB_TOKEN=$GH_API_TOKEN, the Dockerfile declares the ARG) — this
+  // was the one consumer that never picked it up.
+  const headers = { 'User-Agent': 'myscrollr.com prebuild' }
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
   const res = await fetch(
     `https://api.github.com/repos/${REPO}/releases/latest`,
     {
-      headers: { 'User-Agent': 'myscrollr.com prebuild' },
+      headers,
       signal: AbortSignal.timeout(10_000),
     },
   )


### PR DESCRIPTION
The website currently advertises **v1.0.18** on its download button. Two latent faults lined up on the v1.4.1 rebuild.

## The API call was never authenticated

`fetch-latest-version.mjs` sent only a `User-Agent`, so it always used the anonymous GitHub limit — 60/hr per IP, and Actions runners share IPs. It got a 403.

Its sibling `fetch-releases.mjs` has read `GITHUB_TOKEN` and sent `Authorization: Bearer` all along, and the token was **already reaching the container**: `deploy.yml` passes `GITHUB_TOKEN=$GH_API_TOKEN`, the Dockerfile declares the `ARG`. This was just the one consumer that never picked it up.

## The guard could not fire

The script already refuses to ship a fallback in CI:

```js
if (IS_CI) { console.error('FATAL: … Refusing to ship a build that would advertise the fallback'); process.exit(1) }
```

But `IS_CI` reads `process.env.CI`, and **`CI` was never passed into the Docker build**. Inside the container every production build looked like a local dev machine, so it took the offline fallback and shipped it.

The guard was correct. It just never saw `CI=true`.

So the failure was silent by construction: the one script that could lose the race was the one that couldn't fail loudly.

## Fix

- `fetch-latest-version.mjs` sends the auth header when a token is present, mirroring `fetch-releases.mjs`
- `ARG CI` in the Dockerfile, declared before the build step (line 31 vs line 73)
- `deploy.yml` passes `CI=true`

A future rate-limit now **stops the deploy** instead of quietly downgrading the download button.

## Verification

With `CI=true`, the script resolves `1.4.1` from the API on both the authenticated and unauthenticated paths.

Not caused by the v1.4.1 desktop release, and that release is unaffected — installed apps poll `releases/latest/download/latest.json` directly and never consult the website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
