### PR TITLE
fix(test): skip the client drift-guards when the client trees are absent

### DIFF
--- a/api/cmd/gents/gents_test.go
+++ b/api/cmd/gents/gents_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"errors"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -21,6 +24,25 @@ func TestGeneratedTypesAreCurrent(t *testing.T) {
 	}
 
 	for _, out := range outputPaths() {
+		// Both clients live OUTSIDE the api module. `make shell svc=core-api`
+		// mounts only api/ — and AGENTS.md sends you there to compile-check
+		// without a host Go toolchain — so in that container the client trees
+		// genuinely are not on disk and there is nothing to compare against.
+		// Skip that case instead of failing: a guard that is red for everyone
+		// following the documented workflow is a guard people learn to ignore,
+		// which is the same argument normalizeEOL below already makes about
+		// Windows line endings.
+		//
+		// A missing FILE inside a directory that exists is still a failure —
+		// that is someone deleting a generated file, precisely what this
+		// guards. Only the whole tree being absent is a skip. CI checks out
+		// the entire repo and runs `go test -v`, so a skip there is visible
+		// (that is why -v is set, see 67a83cca).
+		if _, err := os.Stat(filepath.Dir(out)); errors.Is(err, fs.ErrNotExist) {
+			t.Skipf("%s does not exist — api-only checkout (e.g. the core-api "+
+				"dev container); nothing to compare against", filepath.Dir(out))
+		}
+
 		got, err := os.ReadFile(out)
 		if err != nil {
 			t.Fatalf("%s: %v (run `go -C api run ./cmd/gents`)", out, err)

--- a/api/internal/widgets/catalog_snapshot_test.go
+++ b/api/internal/widgets/catalog_snapshot_test.go
@@ -2,7 +2,9 @@ package widgets
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,6 +45,19 @@ func TestCatalogSnapshotMatchesServer(t *testing.T) {
 		}
 		t.Logf("regenerated %s (%d widgets, version %s)", path, len(catalogBody.Widgets), catalogBody.Version)
 		return
+	}
+
+	// desktop/ lives outside the api module, and `make shell svc=core-api`
+	// mounts only api/ (AGENTS.md points you there to compile-check without a
+	// host toolchain), so the tree is legitimately absent in that container.
+	// Skip rather than fail — but only when the whole directory is missing.
+	// A missing snapshot inside a present desktop/ is still a failure, which
+	// is the case this guard exists for. CI has the full checkout and runs
+	// `go test -v`, so a skip is visible there.
+	desktopSrc := filepath.Dir(path)
+	if _, err := os.Stat(desktopSrc); errors.Is(err, fs.ErrNotExist) {
+		t.Skipf("%s does not exist — api-only checkout (e.g. the core-api dev "+
+			"container); nothing to compare against", desktopSrc)
 	}
 
 	raw, err := os.ReadFile(path)


### PR DESCRIPTION
## The failure

`go test ./...` inside the core-api dev container failed two tests:

```
--- FAIL: TestGeneratedTypesAreCurrent      api/cmd/gents
--- FAIL: TestCatalogSnapshotMatchesServer  api/internal/widgets
```

## Why

Both compare against files that live **outside the api module**:

- `desktop/src/types/api.generated.ts`
- `myscrollr.com/src/types/api.generated.ts`
- `desktop/src/catalog.snapshot.json`

`docker/compose.yml` mounts only `api/` into the core-api container, and AGENTS.md points you there to compile-check without a host Go toolchain (*"To compile-check or test a specific service without a local toolchain, use its container: `make shell svc=core-api` then `go build ./...`"*). So the files genuinely are not on disk, and the tests reported that absence as a failure.

They were red for everyone following the documented workflow. That's the same argument `normalizeEOL` in `gents_test.go` already makes about Windows line endings:

> a guard that cries wolf on the developer's own machine is a guard that gets ignored

## The fix

Skip when the **containing directory** does not exist — the whole client tree is absent, so there is nothing to compare against.

**Not** when the file is missing. A deleted generated file inside a present tree is precisely what these guards exist to catch, and it still fails. Only "this checkout doesn't contain the clients at all" is a skip.

CI checks out the whole repo and runs `go test -v`, so a skip is visible there if it ever happens — that is why `-v` is set (67a83cca, *"ci: run go tests verbosely so skips are visible"*).

## Verification

A skip that swallows a real regression would be worse than the failure it replaces, so all four paths were checked — the three needing the client trees by mounting the full repo into a `golang:1.25-alpine` container:

| scenario | result |
|---|---|
| full repo, files current | **PASS** — runs, does not silently skip |
| full repo, files stale | **FAIL** — `is stale`, `snapshot version "0.0.0-stale" != server` |
| full repo, files deleted | **FAIL** — not skipped |
| api-only container | **SKIP** |

`go test ./...` in the core-api container now reports no failures at all, down from seven lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
