### PR TITLE
fix(dev): make seed leave the id sequences in step with the data

### DIFF
--- a/.github/workflows/dev-stack.yml
+++ b/.github/workflows/dev-stack.yml
@@ -120,6 +120,20 @@ jobs:
             exit 1
           fi
 
+      # The assertion above is a READ, and a read cannot see a broken write
+      # path. `make seed` COPYs rows carrying explicit ids; if it does not also
+      # advance the id sequences, every subsequent INSERT collides on the
+      # primary key — which broke the RSS ingester (the one service that polls
+      # without an API key) and every test that inserts a fixture row, while
+      # /public/feed kept serving the seeded rows perfectly (REL-154).
+      #
+      # So: seed, then write.
+      - name: Seeded database still accepts writes
+        run: |
+          set -euo pipefail
+          docker compose -f docker/compose.yml exec -T postgres             psql -U scrollr -d scrollr -v ON_ERROR_STOP=1             -c "INSERT INTO tracked_leagues (name, sport_api, api_host, league_id, category) VALUES ('__ci_write_probe__', 'football', 'localhost', 0, 'Test')"             -c "DELETE FROM tracked_leagues WHERE name = '__ci_write_probe__'"
+          echo "seeded database accepts inserts (id sequences are in step with the data)"
+
       # `make down` was broken once on its own (4047e5b0): a fresh checkout
       # could start the stack but not stop it.
       - name: make down

--- a/scripts/dev/seed.sh
+++ b/scripts/dev/seed.sh
@@ -172,6 +172,38 @@ UPDATE markets SET close_time = close_time
   WHERE close_time IS NOT NULL
     AND (SELECT max(close_time) FROM markets) IS NOT NULL;
 
+-- Every id sequence is left behind by the load itself. The file opens with
+-- TRUNCATE ... RESTART IDENTITY, which resets each sequence to 1, and then
+-- COPYs rows carrying EXPLICIT ids -- and COPY does not advance a sequence.
+-- So after a seed the data runs to (say) id 418088 while the sequence still
+-- hands out 1, and the next INSERT that relies on it collides on the primary
+-- key. That breaks the RSS ingester (the one service that polls with no API
+-- key) and any test that inserts a fixture row. Catch every seeded table up.
+DO \$\$
+DECLARE t text; seq text; mx bigint;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'tracked_symbols','tracked_leagues','tracked_markets','tracked_feeds',
+    'trades','games','standings','teams','markets','rss_items'
+  ] LOOP
+    -- Check the column exists FIRST. pg_get_serial_sequence RAISES on a
+    -- missing column rather than returning NULL, and one raise aborts the
+    -- whole DO block -- which silently left the tables listed after
+    -- tracked_feeds (games, trades, rss_items) still broken.
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = t AND column_name = 'id'
+    ) THEN
+      seq := pg_get_serial_sequence(t, 'id');
+      IF seq IS NOT NULL THEN
+        EXECUTE format('SELECT COALESCE(max(id), 0) FROM %I', t) INTO mx;
+        PERFORM setval(seq, GREATEST(mx, 1));
+      END IF;
+    END IF;
+  END LOOP;
+END
+\$\$;
+
 UPDATE games SET start_time = start_time
   + (now() + interval '3 hours' - (SELECT max(start_time) FROM games))
   WHERE start_time IS NOT NULL


### PR DESCRIPTION
Regression I introduced in #298. Found while running the sports crate's tests against a seeded local database.

## Symptom

```
cargo test --test cleanup
  duplicate key value violates unique constraint "tracked_leagues_pkey"
  Key (id)=(3) already exists.
```

## Cause

`seed.sh` opens with `TRUNCATE ... RESTART IDENTITY` — which resets every sequence to 1 — then `COPY`s rows carrying **explicit ids**. `COPY` does not advance a sequence. So after a seed:

| table | sequence at | max(id) |
|---|---|---|
| tracked_leagues | 2 | 22 |
| tracked_symbols | 1 | 499 |
| trades | 1 | 1,997 |
| games | 1 | 418,088 |
| rss_items | 1 | 3,719,562 |

Any INSERT that relies on a sequence collides until it catches up.

## Blast radius — wider than the test that found it

The **RSS ingester** is the one service that polls without an API key, so a seeded local stack could not ingest new articles. Every `upsert_*` path into a seeded table was exposed.

CI never saw it: `rust-tests` uses a clean Postgres service container with no seed data, which is why #298, #299 and #300 all passed green.

## Fix

Catch every seeded table's sequence up to `max(id)` after loading.

**The obvious version of that guard was wrong, and wrong in the quiet way.** `pg_get_serial_sequence` *raises* on a missing column rather than returning NULL, so `tracked_feeds` (no `id` column) aborted the whole `DO` block — leaving every table listed after it (`games`, `trades`, `rss_items`) still broken while the seed reported success. I only caught it because the abort also skipped the timestamp rebase and I checked the sequence table afterwards. Now it tests `information_schema` first.

## The CI job could not have caught this — so it does now

`dev-stack.yml` seeds and then asserts `/public/feed` serves rows. That's a **read**, and a read cannot see a broken write path: the seeded rows served perfectly for the entire time this bug was live.

Added a write to the job — insert a row into a seeded table, delete it again. That is the check that would have failed on the PR that caused this.

## Verification

- reproduced the collision on the old seed (`Key (id)=(3) already exists`)
- re-seeded; all **eight** sequences now equal `max(id)`
- the previously failing INSERT returns `id 23`
- `cargo test --test cleanup` passes **3/3** where it failed before
- full sports crate suite green; shellcheck clean
- ran the new CI step verbatim against the local stack

Fixes REL-154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
