### PR TITLE
fix(dev): anchor the seed timestamp rebase on the last write, not the last fixture

### DIFF
--- a/.github/workflows/dev-stack.yml
+++ b/.github/workflows/dev-stack.yml
@@ -134,6 +134,22 @@ jobs:
           docker compose -f docker/compose.yml exec -T postgres             psql -U scrollr -d scrollr -v ON_ERROR_STOP=1             -c "INSERT INTO tracked_leagues (name, sport_api, api_host, league_id, category) VALUES ('__ci_write_probe__', 'football', 'localhost', 0, 'Test')"             -c "DELETE FROM tracked_leagues WHERE name = '__ci_write_probe__'"
           echo "seeded database accepts inserts (id sequences are in step with the data)"
 
+      # Shape is not correctness. The /public/feed assertion above passed
+      # happily while every seeded game was dated four months in the past --
+      # 225KB of perfectly-formed, entirely stale data, and an app that
+      # rendered nothing (REL-155). The widgets filter on a date window, so
+      # assert the seed actually lands inside one.
+      - name: Seeded games are dated near today
+        run: |
+          set -euo pipefail
+          n="$(docker compose -f docker/compose.yml exec -T postgres             psql -U scrollr -d scrollr -At -c             "SELECT count(*) FROM games WHERE start_time BETWEEN now() - interval '7 days' AND now() + interval '7 days'")"
+          echo "games within the +/-7 day widget window: $n"
+          case "$n" in ''|*[!0-9]*) echo "::error::could not count games"; exit 1 ;; esac
+          if [ "$n" -lt 1 ]; then
+            echo "::error::seed loaded games but none fall near today — the timestamp rebase anchor is wrong, and the app will render an empty ticker."
+            exit 1
+          fi
+
       # `make down` was broken once on its own (4047e5b0): a fresh checkout
       # could start the stack but not stop it.
       - name: make down

--- a/scripts/dev/seed.sh
+++ b/scripts/dev/seed.sh
@@ -153,12 +153,37 @@ capture() {
 # trades, standings, teams and the tracked_* config tables carry no
 # time-relative read, so they are restored as-is.
 REBASE_SQL="
--- Slide the whole article window forward so its newest item lands ~1h ago,
--- preserving relative spacing rather than collapsing every item onto now().
-UPDATE rss_items SET published_at = published_at
-  + (now() - interval '1 hour' - (SELECT max(published_at) FROM rss_items))
+-- ONE delta for everything, taken from the freshest WRITE in the snapshot.
+--
+-- The first version of this anchored each table on the max of the column it
+-- was shifting -- for games, max(start_time). That is the wrong end of the
+-- data. A snapshot contains fixtures scheduled far beyond \"now\": the F1
+-- calendar runs months ahead, so pinning the LAST race to now+3h dragged every
+-- other league backwards with it and landed the entire MLB and MLS schedule in
+-- May, four months in the past. Zero games fell inside the +/-7 day window the
+-- widgets filter on, so a correctly working app rendered nothing.
+--
+-- max(updated_at) is when the ingester last wrote a row, which approximates
+-- the moment of capture. Shifting everything by (now - that) preserves each
+-- record's true relationship to \"now\": a game that was two days out when the
+-- snapshot was taken is two days out today, and a fixture scheduled months
+-- ahead stays months ahead.
+--
+-- updated_at itself is deliberately NOT shifted, so the anchor stays stable
+-- across the statements below. Nothing reads it for staleness -- the ingesters
+-- track freshness in memory, and the RSS janitor uses tracked_feeds, handled
+-- separately below.
+UPDATE games SET start_time = start_time + (now() - (SELECT max(updated_at) FROM games))
+  WHERE start_time IS NOT NULL
+    AND (SELECT max(updated_at) FROM games) IS NOT NULL;
+
+UPDATE rss_items SET published_at = published_at + (now() - (SELECT max(updated_at) FROM games))
   WHERE published_at IS NOT NULL
-    AND (SELECT max(published_at) FROM rss_items) IS NOT NULL;
+    AND (SELECT max(updated_at) FROM games) IS NOT NULL;
+
+UPDATE markets SET close_time = close_time + (now() - (SELECT max(updated_at) FROM games))
+  WHERE close_time IS NOT NULL
+    AND (SELECT max(updated_at) FROM games) IS NOT NULL;
 
 UPDATE tracked_feeds SET last_success_at = NULL,
                          created_at = now(),
@@ -166,48 +191,6 @@ UPDATE tracked_feeds SET last_success_at = NULL,
                          last_error = NULL,
                          last_error_at = NULL,
                          is_enabled = true;
-
-UPDATE markets SET close_time = close_time
-  + (now() + interval '7 days' - (SELECT max(close_time) FROM markets))
-  WHERE close_time IS NOT NULL
-    AND (SELECT max(close_time) FROM markets) IS NOT NULL;
-
--- Every id sequence is left behind by the load itself. The file opens with
--- TRUNCATE ... RESTART IDENTITY, which resets each sequence to 1, and then
--- COPYs rows carrying EXPLICIT ids -- and COPY does not advance a sequence.
--- So after a seed the data runs to (say) id 418088 while the sequence still
--- hands out 1, and the next INSERT that relies on it collides on the primary
--- key. That breaks the RSS ingester (the one service that polls with no API
--- key) and any test that inserts a fixture row. Catch every seeded table up.
-DO \$\$
-DECLARE t text; seq text; mx bigint;
-BEGIN
-  FOREACH t IN ARRAY ARRAY[
-    'tracked_symbols','tracked_leagues','tracked_markets','tracked_feeds',
-    'trades','games','standings','teams','markets','rss_items'
-  ] LOOP
-    -- Check the column exists FIRST. pg_get_serial_sequence RAISES on a
-    -- missing column rather than returning NULL, and one raise aborts the
-    -- whole DO block -- which silently left the tables listed after
-    -- tracked_feeds (games, trades, rss_items) still broken.
-    IF EXISTS (
-      SELECT 1 FROM information_schema.columns
-      WHERE table_schema = 'public' AND table_name = t AND column_name = 'id'
-    ) THEN
-      seq := pg_get_serial_sequence(t, 'id');
-      IF seq IS NOT NULL THEN
-        EXECUTE format('SELECT COALESCE(max(id), 0) FROM %I', t) INTO mx;
-        PERFORM setval(seq, GREATEST(mx, 1));
-      END IF;
-    END IF;
-  END LOOP;
-END
-\$\$;
-
-UPDATE games SET start_time = start_time
-  + (now() + interval '3 hours' - (SELECT max(start_time) FROM games))
-  WHERE start_time IS NOT NULL
-    AND (SELECT max(start_time) FROM games) IS NOT NULL;
 "
 
 load() {

--- a/scripts/dev/seed.sh
+++ b/scripts/dev/seed.sh
@@ -173,6 +173,38 @@ REBASE_SQL="
 -- across the statements below. Nothing reads it for staleness -- the ingesters
 -- track freshness in memory, and the RSS janitor uses tracked_feeds, handled
 -- separately below.
+-- Every id sequence is left behind by the load itself. The file opens with
+-- TRUNCATE ... RESTART IDENTITY, which resets each sequence to 1, and then
+-- COPYs rows carrying EXPLICIT ids -- and COPY does not advance a sequence.
+-- So after a seed the data runs to (say) id 418088 while the sequence still
+-- hands out 1, and the next INSERT that relies on it collides on the primary
+-- key. That breaks the RSS ingester (the one service that polls with no API
+-- key) and any test that inserts a fixture row. Catch every seeded table up.
+DO \$\$
+DECLARE t text; seq text; mx bigint;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'tracked_symbols','tracked_leagues','tracked_markets','tracked_feeds',
+    'trades','games','standings','teams','markets','rss_items'
+  ] LOOP
+    -- Check the column exists FIRST. pg_get_serial_sequence RAISES on a
+    -- missing column rather than returning NULL, and one raise aborts the
+    -- whole DO block -- which silently left the tables listed after
+    -- tracked_feeds (games, trades, rss_items) still broken.
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = t AND column_name = 'id'
+    ) THEN
+      seq := pg_get_serial_sequence(t, 'id');
+      IF seq IS NOT NULL THEN
+        EXECUTE format('SELECT COALESCE(max(id), 0) FROM %I', t) INTO mx;
+        PERFORM setval(seq, GREATEST(mx, 1));
+      END IF;
+    END IF;
+  END LOOP;
+END
+\$\$;
+
 UPDATE games SET start_time = start_time + (now() - (SELECT max(updated_at) FROM games))
   WHERE start_time IS NOT NULL
     AND (SELECT max(updated_at) FROM games) IS NOT NULL;


### PR DESCRIPTION
## Symptom

Reported as *"none of the widgets seem to be showing sports data"* on a freshly seeded stack.

The backend was fine — `/dashboard` returned 45 games, `/sports/public` returned 200 — but every one carried a nonsense date:

```json
{"state": "in", "start_time": "2026-05-11T09:24:20Z"}   // a LIVE game, four months ago
```

```
 league | earliest   | latest     | in ±7d window | total
--------+------------+------------+---------------+-------
 MLB    | 2026-05-05 | 2026-05-19 |             0 |   187
 MLS    | 2026-05-06 | 2026-05-17 |             0 |    31
```

Zero games fell inside the ±7-day window the widgets filter on, so a **correctly working app rendered nothing**.

## Cause

`seed.sh` rebased each table on the max of the column it was shifting — for `games`, `max(start_time)`:

```sql
UPDATE games SET start_time = start_time
  + (now() + interval '3 hours' - (SELECT max(start_time) FROM games));
```

That's the wrong end of the data. A snapshot contains fixtures scheduled far beyond "now" — **the Formula 1 calendar runs months ahead**. The furthest-out race sat ~3.5 months past the rest of the schedule, so pinning *it* to `now + 3h` dragged every other league backwards with it. F1's max was December; MLB's was May. One fixture, whole schedule wrong.

## Fix

Anchor on **`max(updated_at)`** — when the ingester last wrote a row, which approximates the moment of capture — and apply that single delta to every time column.

This preserves each record's true relationship to "now": a game two days out at capture is two days out today, and a fixture months ahead stays months ahead. `updated_at` is deliberately not shifted, so the anchor stays stable across the statements.

| | earliest | latest | in ±7d window | total |
|---|---|---|---|---|
| MLB | 2026-08-27 | 2026-09-10 | **180** | 187 |
| MLS | 2026-08-28 | 2026-09-08 | **31** | 31 |
| Formula 1 | 2026-05-02 | 2026-12-26 | 0 | 13 |

F1 correctly still spans its real season with nothing this week. MLB and MLS straddle today, including two live games dated this afternoon. Verified end to end: the running desktop app's dashboard cache repopulated with today's dates.

## The assertion that would have caught it

The existing gate checks `/public/feed` is non-empty. It was — 225 KB of perfectly-formed, entirely stale data. **Shape is not correctness.** CI now asserts at least one game falls inside the window the widgets actually query.

That's the third time today this pattern has bitten: a status check couldn't see empty content (#298), a read couldn't see a broken write (REL-154), and a shape check couldn't see wrong content (this one). Each fix added the assertion at the level the bug actually lived.

Fixes REL-155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
