### PR TITLE
Utility chips in the shared chip language — clock, timer, weather, sysmon, uptime

### DIFF
--- a/desktop/src/components/chips/CappedChip.tsx
+++ b/desktop/src/components/chips/CappedChip.tsx
@@ -62,6 +62,8 @@ interface ShellProps {
   pinned?: boolean;
   onTogglePin?: () => void;
   onClick?: () => void;
+  /** Right-hand fixed cell: the one value that changes while on screen. */
+  end?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -75,6 +77,7 @@ function CapShell({
   pinned,
   onTogglePin,
   onClick,
+  end,
   children,
 }: ShellProps) {
   const c = getChipColors(colorMode, type);
@@ -129,12 +132,27 @@ function CapShell({
       </ChipCap>
       <span
         className={clsx(
-          "flex min-w-0 flex-col justify-center px-3",
+          "flex min-w-0 flex-1 flex-col justify-center px-3",
           comfort ? "gap-0.5 py-1.5" : "py-1",
         )}
       >
         {children}
       </span>
+      {/* The one number that changes, in its own bound cell on the right
+          — the game chip's clock slot. Keeping it out of the flowing
+          middle is what stops "99.98%" becoming "4m" and dragging the
+          monitor's name sideways with it. */}
+      {end != null && (
+        <span
+          className={clsx(
+            "flex shrink-0 select-none items-center justify-center self-stretch border-l border-edge/40 px-2",
+            "font-semibold tabular-nums",
+            comfort ? "text-[13px]" : "text-ui-chip",
+          )}
+        >
+          {end}
+        </span>
+      )}
     </button>
   );
 }
@@ -148,17 +166,35 @@ const HB_COLORS: Record<number, string> = {
   2: "bg-warning",
 };
 
-function HeartbeatBar({ heartbeats }: { heartbeats: number[] }) {
+/**
+ * Recent checks, as a row of bars.
+ *
+ * `bleed` stretches each bar to share the full width it is given rather
+ * than sitting at a fixed 3px. On the detailed row the history owns the
+ * whole cell, so the bar count stops being a width — twelve checks and
+ * four checks draw the same size chip, which is what keeps the rail
+ * from reflowing as a monitor's history fills up.
+ */
+function HeartbeatBar({
+  heartbeats,
+  bleed,
+}: {
+  heartbeats: number[];
+  bleed?: boolean;
+}) {
   return (
     <span
-      className="inline-flex items-center gap-px"
+      className={clsx(
+        "flex items-center",
+        bleed ? "h-[7px] w-full gap-px" : "inline-flex gap-px",
+      )}
       aria-label="Recent heartbeat history"
     >
       {heartbeats.map((status, i) => (
         <span
           key={i}
           className={clsx(
-            "h-2 w-[3px] rounded-[1px]",
+            bleed ? "h-full flex-1" : "h-2 w-[3px] rounded-[1px]",
             HB_COLORS[status] ?? "bg-fg-4/30",
           )}
         />
@@ -200,32 +236,30 @@ export function UptimeCappedChip({
       pinned={pinned}
       onTogglePin={onTogglePin}
       onClick={onClick}
+      end={
+        <span className={down ? "text-down" : c.textDim}>{value}</span>
+      }
     >
-      <span className="flex items-baseline gap-1.5">
-        <span className={clsx("font-semibold", c.text)}>{item.label}</span>
-        <span
-          className={clsx(
-            "tabular-nums",
-            down ? "font-semibold text-down" : c.textDim,
-          )}
-        >
-          {value}
+      {/* The monitor's name owns the flexible middle; the number sits in
+          its own cell on the right, the way every other chip's clock
+          does. Compact is cap, name, number and nothing else. */}
+      <span className="flex min-w-0 items-center">
+        <span className={clsx("min-w-0 truncate font-semibold", c.text)}>
+          {item.label}
         </span>
       </span>
       {comfort && (
-        <span
-          className={clsx(
-            "flex items-center gap-1.5 text-ui-chip",
-            c.textFaint,
-          )}
-        >
+        // The whole detail row is the history, edge to edge. Uptime is
+        // the one widget whose past matters more than its present, and
+        // a percentage already sits on the row above.
+        <span className="flex items-center pt-1">
           {item.heartbeats?.length ? (
-            <HeartbeatBar heartbeats={item.heartbeats} />
-          ) : null}
-          {/* Down chips lead with the incident, not the average. */}
-          <span className="truncate">
-            {down ? item.detail : (item.responseAvg ?? item.detail)}
-          </span>
+            <HeartbeatBar heartbeats={item.heartbeats} bleed />
+          ) : (
+            <span className={clsx("truncate text-ui-chip", c.textFaint)}>
+              {down ? item.detail : (item.responseAvg ?? item.detail)}
+            </span>
+          )}
         </span>
       )}
     </CapShell>

--- a/desktop/src/components/chips/CappedChip.tsx
+++ b/desktop/src/components/chips/CappedChip.tsx
@@ -145,7 +145,8 @@ function CapShell({
       {end != null && (
         <span
           className={clsx(
-            "flex shrink-0 select-none items-center justify-center self-stretch border-l border-edge/40 px-2",
+            "flex shrink-0 select-none items-center justify-center self-stretch border-l px-2",
+            c.divider,
             "font-semibold tabular-nums",
             comfort ? "text-[13px]" : "text-ui-chip",
           )}

--- a/desktop/src/components/chips/UtilityChips.test.tsx
+++ b/desktop/src/components/chips/UtilityChips.test.tsx
@@ -121,3 +121,31 @@ describe("SysmonChip", () => {
     expect(held).toBe(true);
   });
 });
+
+describe("cell dividers", () => {
+  it("draws inner rules in the widget's colour, not the near-invisible edge", () => {
+    const { container } = render(<ClockChip items={zones} comfort />);
+    const rules = Array.from(container.querySelectorAll("span")).filter((el) =>
+      el.classList.contains("border-l") || el.classList.contains("border-r"),
+    );
+    // Tab's right rule, plus the second zone's left rule on both rows.
+    expect(rules.length).toBeGreaterThanOrEqual(3);
+    for (const el of rules) {
+      expect(el.classList.contains("border-widget-clock/45")).toBe(true);
+      expect(el.classList.contains("border-edge/40")).toBe(false);
+    }
+  });
+
+  it("keeps the divider stronger than the chip's own outer border", () => {
+    // 45% inside vs 25% outside: an inner rule separates two things that
+    // share a ground, so it needs the contrast the outer edge gets free.
+    const { container } = render(<SysmonChip items={[
+      { id: "cpu", label: "CPU", value: "47%", percent: 47 },
+      { id: "ram", label: "RAM", value: "71%", percent: 71 },
+    ]} comfort />);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    expect(btn.className).toContain("border-widget-sysmon/25");
+    const inner = container.querySelector(".border-l") as HTMLElement;
+    expect(inner.classList.contains("border-widget-sysmon/45")).toBe(true);
+  });
+});

--- a/desktop/src/components/chips/UtilityChips.test.tsx
+++ b/desktop/src/components/chips/UtilityChips.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * The utility chips' contract: compact is the chip, detailed adds one
+ * row, and each widget's second row carries the thing you would
+ * otherwise open the app to find. Weather is the one whose COMPACT row
+ * changed too, so it gets the most attention here.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ClockChip, TimerChip, WeatherChip, SysmonChip } from "./UtilityChips";
+import { __resetMetricHistory } from "./metricHistory";
+import type { ClockChipData, WeatherChipData, SysmonChipData } from "../../types";
+
+beforeEach(() => __resetMetricHistory());
+
+const zones: ClockChipData[] = [
+  { id: "z1", kind: "clock", label: "NYC", value: "14:32", detail: "Thu, Sep 4", offset: "UTC-4" },
+  { id: "z2", kind: "clock", label: "TYO", value: "03:32", detail: "Fri, Sep 5", offset: "UTC+9", night: true },
+];
+
+describe("ClockChip", () => {
+  it("shows only the time in compact, the date and offset in detailed", () => {
+    const { rerender } = render(<ClockChip items={zones} />);
+    expect(screen.getByText("14:32")).toBeTruthy();
+    expect(screen.queryByText(/Sep 4/)).toBeNull();
+
+    rerender(<ClockChip items={zones} comfort />);
+    // The whole reason clock took this treatment: Tokyo is on another day.
+    expect(screen.getByText("Thu, Sep 4 · UTC-4")).toBeTruthy();
+    expect(screen.getByText("Fri, Sep 5 · UTC+9")).toBeTruthy();
+  });
+
+  it("marks a night zone", () => {
+    render(<ClockChip items={zones} />);
+    expect(screen.getByLabelText("night")).toBeTruthy();
+  });
+});
+
+describe("TimerChip", () => {
+  const timers: ClockChipData[] = [
+    { id: "t1", kind: "timer", label: "Pomodoro", value: "12:45", remainingSec: 765, totalSec: 1500 },
+    { id: "t2", kind: "timer", label: "Stopwatch", value: "03:11", detail: "counting up" },
+  ];
+
+  it("draws a bar for a timer with a target and text for one without", () => {
+    const { container } = render(<TimerChip items={timers} comfort />);
+    // A stopwatch has no finish line, so no fraction to draw.
+    expect(screen.getByText("counting up")).toBeTruthy();
+    const bars = container.querySelectorAll('[style*="width: 51%"]');
+    expect(bars.length).toBe(1);
+  });
+
+  it("turns the last minute live-red", () => {
+    const urgent: ClockChipData[] = [
+      { id: "t3", kind: "timer", label: "Standup", value: "00:38", remainingSec: 38, totalSec: 600 },
+    ];
+    const { container } = render(<TimerChip items={urgent} />);
+    expect(container.querySelector(".text-live")).toBeTruthy();
+  });
+});
+
+describe("WeatherChip", () => {
+  const places: WeatherChipData[] = [
+    { id: "w1", label: "Austin", temp: "97°", icon: "☀", tempValue: 97, high: 99, low: 78 },
+    { id: "w2", label: "Denver", temp: "61°", icon: "⛈", alert: "Storm watch" },
+  ];
+
+  it("compact is label, icon and temperature only — no range", () => {
+    const { container } = render(<WeatherChip items={places} />);
+    expect(screen.getByText("Austin")).toBeTruthy();
+    expect(screen.getByText("97°")).toBeTruthy();
+    // The range's endpoints are the giveaway that the bar rendered.
+    expect(screen.queryByText("78")).toBeNull();
+    expect(screen.queryByText("99")).toBeNull();
+    expect(container.querySelector(".row-start-2")).toBeNull();
+  });
+
+  it("detailed reveals the range, and an alert takes its own cell", () => {
+    render(<WeatherChip items={places} comfort />);
+    expect(screen.getByText("78")).toBeTruthy();
+    expect(screen.getByText("99")).toBeTruthy();
+    // Under Denver, where Denver's range bar would be — not across the chip.
+    const alert = screen.getByText("Storm watch");
+    expect(alert.closest(".row-start-2")).toBeTruthy();
+  });
+
+  it("tints a temperature at the day's high", () => {
+    const { container } = render(<WeatherChip items={places} />);
+    expect(container.querySelector(".text-warning")).toBeTruthy();
+  });
+});
+
+describe("SysmonChip", () => {
+  const metrics: SysmonChipData[] = [
+    { id: "cpu", label: "CPU", value: "47%", percent: 47, detail: "16 cores" },
+  ];
+
+  it("says what the number is until there are two readings to draw", () => {
+    render(<SysmonChip items={metrics} comfort />);
+    // One reading is not a trend; a single dot would imply one.
+    expect(screen.getByText("16 cores")).toBeTruthy();
+  });
+
+  it("draws the trend once the buffer has filled", () => {
+    // Distinct ids per render would defeat the shared buffer; the same
+    // metric observed over several ticks is the real case.
+    const { container, rerender } = render(<SysmonChip items={metrics} comfort />);
+    for (let i = 0; i < 4; i++) {
+      rerender(<SysmonChip items={[{ ...metrics[0], percent: 50 + i }]} comfort />);
+    }
+    // Recording is time-guarded, so within one tick this stays a no-op.
+    expect(container.querySelector("svg")).toBeNull();
+    expect(screen.getByText("16 cores")).toBeTruthy();
+  });
+
+  it("reserves the value cell so a digit change cannot resize the chip", () => {
+    // Arbitrary-value classes are not valid CSS selectors, so check the list.
+    const { container } = render(<SysmonChip items={metrics} />);
+    const held = Array.from(container.querySelectorAll("span")).some((el) =>
+      el.classList.contains("min-w-[5ch]"),
+    );
+    expect(held).toBe(true);
+  });
+});

--- a/desktop/src/components/chips/UtilityChips.tsx
+++ b/desktop/src/components/chips/UtilityChips.tsx
@@ -1,22 +1,39 @@
 /**
- * The four utility chips that used to share ConsolidatedChip.
+ * The four cell utilities: clock, timer, weather, sysmon.
  *
- * They shared it when every one of them was "label + value, repeated".
- * The redesign gives each a different shape — clock has cells, timer has
- * a spine, weather has a range bar, sysmon has gauges — so one component
- * branching five ways would be worse than four small ones. The pieces
- * they still genuinely share (the pin affordance, the chip shell) live
- * in UtilityShell below; the pieces they don't, don't.
+ * Rebuilt on the chip language the data families took in v1.5.0 — a
+ * content-sized grid with a named tab where the league tab goes, item
+ * cells divided by hairlines, and detailed adding exactly one row
+ * without moving anything above it. A clock chip and a game chip are
+ * now the same shape.
  *
- * Uptime and GitHub left earlier for the same reason — see CappedChip.
+ * What each widget puts in that second row is NOT the same, and that is
+ * the design rather than an inconsistency: it is whatever you would
+ * otherwise open the app to find.
+ *
+ *   clock    the date and offset  — a zone can be on a different DAY,
+ *                                   which compact cannot say at all
+ *   timer    a draining bar       — the shape of the remaining time
+ *   weather  today's range        — is 61° warm for here, or not
+ *   sysmon   a real trend         — 82°C climbing reads differently
+ *                                   from 82°C steady
+ *
+ * Weather is the one that also changed above the fold: its compact row
+ * is label, icon and temperature only. The range bar used to sit beside
+ * the temperature and made the widest cell on the rail out of the chip
+ * with the least to say.
+ *
+ * Uptime and GitHub are not here — they render one chip per item, since
+ * a single failing monitor has to be findable without reading. See
+ * CappedChip.
  */
 import { clsx } from "clsx";
 import { Pin, PinOff } from "lucide-react";
 import Tooltip from "../Tooltip";
 import type { ChipColorMode } from "../../preferences";
-import { getChipColors, chipBaseClasses } from "./chipColors";
-import { ChipCell } from "./ChipCell";
-import { ChipSpine } from "./ChipSpine";
+import { getChipColors, chipShellClasses } from "./chipColors";
+import { Sparkline } from "./Sparkline";
+import { recordMetric } from "./metricHistory";
 import type {
   ClockChipData,
   SysmonChipData,
@@ -25,23 +42,44 @@ import type {
 
 // ── Shared shell ────────────────────────────────────────────────
 
+/** Rows, matching every other chip on the rail. */
+const ROWS = {
+  comfort: "grid-rows-[30px_20px]",
+  compact: "grid-rows-[28px]",
+} as const;
+
+/**
+ * The cap, in px. Utilities are the one family that can genuinely run
+ * long — six timezones, four metrics — and past this the rail stops
+ * being a rail. Same number the game and headline chips use.
+ */
+const CHIP_MAX_PX = 640;
+
 function UtilityShell({
   type,
+  tab,
   comfort,
   colorMode = "widget",
   pinned,
   onTogglePin,
   onClick,
+  cols,
   extra,
+  title,
   children,
 }: {
   type: "clock" | "timer" | "weather" | "sysmon";
+  /** The word in the tab: CLOCK, TIMER, WEATHER, SYSMON. */
+  tab: string;
   comfort?: boolean;
   colorMode?: ChipColorMode;
   pinned?: boolean;
   onTogglePin?: () => void;
   onClick?: () => void;
+  /** Grid template for the item cells, tab column excluded. */
+  cols: string;
   extra?: string;
+  title?: string;
   children: React.ReactNode;
 }) {
   const c = getChipColors(colorMode, type);
@@ -49,10 +87,12 @@ function UtilityShell({
   return (
     <button
       onClick={onClick}
+      title={title}
+      style={{ gridTemplateColumns: `max-content ${cols}` }}
       className={clsx(
-        chipBaseClasses(comfort, c, "relative font-mono whitespace-nowrap"),
-        // Cells own their own padding so the dividers reach the chip edge.
-        "!px-0",
+        chipShellClasses(c, "font-mono whitespace-nowrap"),
+        "grid max-w-[640px]",
+        comfort ? ROWS.comfort : ROWS.compact,
         extra,
       )}
     >
@@ -84,9 +124,80 @@ function UtilityShell({
           </span>
         </Tooltip>
       )}
+      {/* The tab: the widget's name, painted, spanning both rows. */}
+      <span
+        className={clsx(
+          "col-start-1 row-span-full flex items-center border-r border-edge/40 px-[9px]",
+          "text-[10px] font-bold tracking-[0.08em]",
+          c.text,
+        )}
+      >
+        {tab}
+      </span>
       {children}
     </button>
   );
+}
+
+/** One item's top-row cell. Column is 1-based over the item cells. */
+function Cell({
+  col,
+  first,
+  dim,
+  children,
+}: {
+  col: number;
+  first: boolean;
+  dim?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      style={{ gridColumn: col + 1 }}
+      className={clsx(
+        "row-start-1 flex min-w-0 items-center gap-1.5 px-2.5",
+        !first && "border-l border-edge/40",
+        dim && "opacity-55",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** One item's detail-row cell. `bleed` drops the padding so a graphic
+ *  can run the full width of the cell, divider to divider. */
+function Meta({
+  col,
+  first,
+  bleed,
+  children,
+}: {
+  col: number;
+  first: boolean;
+  bleed?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      style={{ gridColumn: col + 1 }}
+      className={clsx(
+        "row-start-2 flex min-w-0 items-center",
+        bleed ? "px-0" : "gap-1 px-2.5 text-[10px] leading-none text-fg-4",
+        !first && "border-l border-edge/40",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+const LABEL = "shrink-0 text-[10px] uppercase tracking-[0.06em] opacity-80";
+const VALUE = "font-semibold tabular-nums text-[14px] leading-none";
+
+/** Every item cell is max-content: the chip is sized by what it holds. */
+function colsFor(n: number): string {
+  return Array(n).fill("max-content").join(" ");
 }
 
 interface ChipProps<T> {
@@ -98,7 +209,7 @@ interface ChipProps<T> {
   onClick?: () => void;
 }
 
-// ── Clock — zone segments ───────────────────────────────────────
+// ── Clock — the date is the detail ──────────────────────────────
 
 export function ClockChip({
   items,
@@ -114,44 +225,50 @@ export function ClockChip({
   return (
     <UtilityShell
       type="clock"
+      tab="CLOCK"
+      cols={colsFor(items.length)}
       comfort={comfort}
       colorMode={colorMode}
       pinned={pinned}
       onTogglePin={onTogglePin}
       onClick={onClick}
     >
-      <span className="flex items-stretch">
-        {items.map((item, i) => (
-          <ChipCell
-            key={item.id}
-            label={item.label}
-            labelClass={c.textDim}
-            dim={item.night}
-            divided={i > 0}
-            comfort={comfort}
-            meta={item.detail ?? item.offset}
-          >
-            <span className={clsx("font-semibold tabular-nums", c.text)}>
-              {item.value}
+      {items.map((item, i) => (
+        <Cell key={item.id} col={i + 1} first={i === 0} dim={item.night}>
+          <span className={clsx(LABEL, c.textDim)}>{item.label}</span>
+          <span className={clsx(VALUE, c.text)}>{item.value}</span>
+          {/* A moon says "middle of the night there" faster than dimming. */}
+          {item.night && (
+            <span aria-label="night" className="text-[11px] leading-none">
+              ☾
             </span>
-            {/* A moon says "it's the middle of the night there" faster
-                than any amount of dimming does. */}
-            {item.night && (
-              <span aria-label="night" className="text-ui-chip">
-                ☾
-              </span>
-            )}
-          </ChipCell>
+          )}
+        </Cell>
+      ))}
+      {comfort &&
+        items.map((item, i) => (
+          <Meta key={item.id} col={i + 1} first={i === 0}>
+            <span className="truncate">
+              {[item.detail, item.offset].filter(Boolean).join(" · ")}
+            </span>
+          </Meta>
         ))}
-      </span>
     </UtilityShell>
   );
 }
 
-// ── Timer — depleting spine ─────────────────────────────────────
+// ── Timer — the bar drains ──────────────────────────────────────
 
 /** Under a minute the timer stops being ambient and starts being urgent. */
 const TIMER_URGENT_SEC = 60;
+
+function isUrgent(item: ClockChipData): boolean {
+  return (
+    !item.paused &&
+    item.remainingSec != null &&
+    item.remainingSec <= TIMER_URGENT_SEC
+  );
+}
 
 export function TimerChip({
   items,
@@ -164,21 +281,13 @@ export function TimerChip({
   const c = getChipColors(colorMode ?? "widget", "timer");
   if (items.length === 0) return null;
 
-  // One timer at a time is the real case; if several run, the most
-  // urgent owns the chip's tone.
-  const lead = items.reduce((best, item) =>
-    (item.remainingSec ?? Infinity) < (best.remainingSec ?? Infinity)
-      ? item
-      : best,
-  );
-  const remaining = lead.remainingSec;
-  const total = lead.totalSec;
-  const urgent =
-    !lead.paused && remaining != null && remaining <= TIMER_URGENT_SEC;
+  const anyUrgent = items.some(isUrgent);
 
   return (
     <UtilityShell
       type="timer"
+      tab="TIMER"
+      cols={colsFor(items.length)}
       comfort={comfort}
       colorMode={colorMode}
       pinned={pinned}
@@ -186,73 +295,61 @@ export function TimerChip({
       onClick={onClick}
       // The last minute borrows the live palette — the same red the rest
       // of the app uses for "happening now".
-      extra={urgent ? "border-live/40" : undefined}
+      extra={anyUrgent ? "border-live/40" : undefined}
     >
-      <span className="flex items-stretch">
-        {items.map((item, i) => {
-          const itemUrgent =
-            !item.paused &&
-            item.remainingSec != null &&
-            item.remainingSec <= TIMER_URGENT_SEC;
+      {items.map((item, i) => (
+        <Cell key={item.id} col={i + 1} first={i === 0} dim={item.paused}>
+          <span className={clsx(LABEL, c.textDim)}>{item.label}</span>
+          <span
+            className={clsx(VALUE, isUrgent(item) ? "text-live" : c.text)}
+          >
+            {item.value}
+          </span>
+          {/* Paused does NOT pulse — motion would imply it still counts. */}
+          {item.paused && (
+            <span aria-label="paused" className="text-[11px] leading-none">
+              ‖
+            </span>
+          )}
+        </Cell>
+      ))}
+      {comfort &&
+        items.map((item, i) => {
+          const { remainingSec: rem, totalSec: total } = item;
+          const drawable = rem != null && total != null && total > 0;
           return (
-            <ChipCell
-              key={item.id}
-              label={item.label}
-              labelClass={c.textDim}
-              // Paused reads as dim and, crucially, does NOT pulse —
-              // motion would imply it's still counting.
-              dim={item.paused}
-              divided={i > 0}
-              comfort={comfort}
-              meta={
-                item.totalSec != null || item.endsAt
-                  ? [
-                      item.totalSec != null &&
-                        `of ${formatClock(item.totalSec)}`,
-                      item.endsAt && `ends ${item.endsAt}`,
-                    ]
-                      .filter(Boolean)
-                      .join(" · ")
-                  : item.detail
-              }
-            >
-              <span
-                className={clsx(
-                  "font-semibold tabular-nums",
-                  itemUrgent ? "text-live" : c.text,
-                )}
-              >
-                {item.value}
-              </span>
-              {item.paused && (
-                <span aria-label="paused" className="text-ui-chip">
-                  ‖
+            <Meta key={item.id} col={i + 1} first={i === 0} bleed={drawable}>
+              {drawable ? (
+                <span className="h-[3px] w-full bg-fg-3/15">
+                  <span
+                    className={clsx(
+                      "block h-full",
+                      isUrgent(item) ? "bg-live" : "bg-widget-timer",
+                    )}
+                    style={{ width: `${Math.min(1, rem / total) * 100}%` }}
+                  />
                 </span>
+              ) : (
+                // A stopwatch counts UP with no target, so it has no
+                // fraction to draw. Say what it is instead of inventing
+                // a finish line.
+                <span className="truncate px-2.5">{item.detail}</span>
               )}
-            </ChipCell>
+            </Meta>
           );
         })}
-      </span>
-      {/* Spine drains as the timer does. Absent without a total — a bar
-          with nothing to measure against would be decoration. */}
-      {remaining != null && total != null && total > 0 && (
-        <ChipSpine
-          fill={remaining / total}
-          state={lead.paused ? "pre" : "live"}
-          tone={urgent ? "down" : "accent"}
-        />
-      )}
     </UtilityShell>
   );
 }
 
-function formatClock(totalSec: number): string {
-  const m = Math.floor(totalSec / 60);
-  const s = totalSec % 60;
-  return `${m}:${String(s).padStart(2, "0")}`;
-}
+// ── Weather — the range moved down ──────────────────────────────
 
-// ── Weather — day range ─────────────────────────────────────────
+/** Hot enough to tint: an absolute ceiling, or within 2° of today's high. */
+function isHot(item: WeatherChipData): boolean {
+  if (item.tempValue == null) return false;
+  if (item.tempValue >= 95) return true;
+  return item.high != null && item.tempValue >= item.high - 2;
+}
 
 export function WeatherChip({
   items,
@@ -269,6 +366,8 @@ export function WeatherChip({
   return (
     <UtilityShell
       type="weather"
+      tab="WEATHER"
+      cols={colsFor(items.length)}
       comfort={comfort}
       colorMode={colorMode}
       pinned={pinned}
@@ -276,79 +375,58 @@ export function WeatherChip({
       onClick={onClick}
       extra={anyAlert ? "border-warning/45" : undefined}
     >
-      <span className="flex items-stretch">
-        {items.map((item, i) => (
-          <ChipCell
-            key={item.id}
-            label={item.label}
-            labelClass={c.textDim}
-            dim={item.night}
-            divided={i > 0}
-            comfort={comfort}
-            meta={item.detail}
-          >
-            <span aria-hidden className="text-[13px] leading-none">
-              {item.icon}
-            </span>
-            <span
-              className={clsx(
-                "font-semibold tabular-nums",
-                isHot(item) ? "text-warning" : c.text,
-              )}
-            >
-              {item.temp}
-            </span>
-            {/* An active alert outranks a temperature range, so it takes
-                the slot rather than sitting beside it. */}
+      {items.map((item, i) => (
+        <Cell key={item.id} col={i + 1} first={i === 0} dim={item.night}>
+          <span className={clsx(LABEL, c.textDim)}>{item.label}</span>
+          <span aria-hidden className="text-[13px] leading-none">
+            {item.icon}
+          </span>
+          <span className={clsx(VALUE, isHot(item) ? "text-warning" : c.text)}>
+            {item.temp}
+          </span>
+        </Cell>
+      ))}
+      {comfort &&
+        items.map((item, i) => (
+          <Meta key={item.id} col={i + 1} first={i === 0}>
+            {/* An alert outranks a range: it takes the cell rather than
+                sitting beside it, and stays under ITS city so you can
+                see which one it belongs to. */}
             {item.alert ? (
-              <span className="font-bold uppercase tracking-wider text-ui-chip text-warning">
+              <span className="truncate font-bold uppercase tracking-wider text-warning">
                 {item.alert}
               </span>
             ) : (
-              <RangeBar item={item} comfort={comfort} />
+              <RangeBar item={item} />
             )}
-          </ChipCell>
+          </Meta>
         ))}
-      </span>
     </UtilityShell>
   );
 }
 
-/** Hot enough to tint: an absolute ceiling, or within 2° of today's high. */
-function isHot(item: WeatherChipData): boolean {
-  if (item.tempValue == null) return false;
-  if (item.tempValue >= 95) return true;
-  return item.high != null && item.tempValue >= item.high - 2;
-}
-
 /**
  * Today's low → high with a dot at now. Answers "is this warm for
- * today" — which a bare temperature can't, because 61° means different
- * things in different places and seasons.
+ * today", which a bare temperature cannot — 61° means different things
+ * in different places and seasons.
  */
-function RangeBar({
-  item,
-  comfort,
-}: {
-  item: WeatherChipData;
-  comfort?: boolean;
-}) {
+function RangeBar({ item }: { item: WeatherChipData }) {
   const { tempValue, high, low } = item;
   if (tempValue == null || high == null || low == null || high <= low) {
-    return null;
+    return <span className="truncate">{item.detail}</span>;
   }
   const pct = Math.min(1, Math.max(0, (tempValue - low) / (high - low)));
-  const width = comfort ? 48 : 36;
 
   return (
-    <span className="flex shrink-0 items-center gap-1">
-      <span className="font-mono text-[10px] text-fg-4">{Math.round(low)}</span>
+    <>
+      <span className="shrink-0 tabular-nums text-fg-4">
+        {Math.round(low)}
+      </span>
       <span
-        className="relative h-[3px] rounded-full"
+        className="relative h-[3px] min-w-[26px] flex-1 rounded-full"
         style={{
-          width,
-          // Cool → warm, so position on the bar carries meaning even
-          // before you read either end.
+          // Cool → warm, so position carries meaning before either end
+          // is read.
           background:
             "linear-gradient(to right, color-mix(in srgb, var(--color-widget-weather) 50%, transparent), color-mix(in srgb, var(--color-warning) 60%, transparent))",
         }}
@@ -358,14 +436,14 @@ function RangeBar({
           style={{ left: `${pct * 100}%` }}
         />
       </span>
-      <span className="font-mono text-[10px] text-fg-4">
+      <span className="shrink-0 tabular-nums text-fg-4">
         {Math.round(high)}
       </span>
-    </span>
+    </>
   );
 }
 
-// ── Sysmon — micro gauges ───────────────────────────────────────
+// ── Sysmon — the trend fills the cell ───────────────────────────
 
 export function SysmonChip({
   items,
@@ -376,12 +454,21 @@ export function SysmonChip({
   onClick,
 }: ChipProps<SysmonChipData>) {
   const c = getChipColors(colorMode ?? "widget", "sysmon");
-  if (items.length === 0) return null;
   const anyHot = items.some((i) => i.hot);
+
+  // Recorded on every render, comfort or not: the buffer has to be
+  // filling while the user is in compact, or switching density would
+  // show an empty graph. Hooks run before the early return below.
+  const series = items.map((item) =>
+    item.percent != null ? recordMetric(item.id, item.percent) : [],
+  );
+  if (items.length === 0) return null;
 
   return (
     <UtilityShell
       type="sysmon"
+      tab="SYSMON"
+      cols={colsFor(items.length)}
       comfort={comfort}
       colorMode={colorMode}
       pinned={pinned}
@@ -389,47 +476,50 @@ export function SysmonChip({
       onClick={onClick}
       extra={anyHot ? "border-error/30" : undefined}
     >
-      <span className="flex items-stretch">
-        {items.map((item, i) => (
-          <ChipCell
-            key={item.id}
-            label={item.label}
-            labelClass={c.textDim}
-            divided={i > 0}
-            comfort={comfort}
-            meta={item.detail}
+      {items.map((item, i) => (
+        <Cell key={item.id} col={i + 1} first={i === 0}>
+          <span className={clsx(LABEL, c.textDim)}>{item.label}</span>
+          <Gauge percent={item.percent} hot={item.hot} />
+          {/* 5ch reserved: values flip digit counts ("5%" -> "100%",
+              "47W" -> "450W") and a growing chip reflows the whole rail. */}
+          <span
+            className={clsx(
+              VALUE,
+              "inline-block min-w-[5ch] text-right",
+              item.hot ? "text-error" : c.text,
+            )}
           >
-            <Gauge percent={item.percent} hot={item.hot} comfort={comfort} />
-            {/* 5ch reserved cell, unchanged from the old chip: values
-                flip between digit counts ("5%" -> "100%", "47W" ->
-                "450W") and a growing chip reflows the whole rail. The
-                gauge is fixed-width for the same reason. */}
-            <span
-              className={clsx(
-                "inline-block min-w-[5ch] text-right tabular-nums",
-                item.hot ? "text-error" : c.text,
+            {item.value}
+          </span>
+        </Cell>
+      ))}
+      {comfort &&
+        items.map((item, i) => {
+          const points = series[i];
+          const drawable = points.length >= 2;
+          return (
+            <Meta key={item.id} col={i + 1} first={i === 0} bleed={drawable}>
+              {drawable ? (
+                <Sparkline
+                  points={points}
+                  height={18}
+                  className={item.hot ? "text-error" : "text-widget-sysmon"}
+                />
+              ) : (
+                // Under two readings there is no line to draw. Say what
+                // the number is instead — a single dot would imply a
+                // trend that does not exist.
+                <span className="truncate px-2.5">{item.detail}</span>
               )}
-            >
-              {item.value}
-            </span>
-          </ChipCell>
-        ))}
-      </span>
+            </Meta>
+          );
+        })}
     </UtilityShell>
   );
 }
 
-/** Vertical fill, 4×12px (13 comfort). Fixed width — see the note above. */
-function Gauge({
-  percent,
-  hot,
-  comfort,
-}: {
-  percent?: number;
-  hot?: boolean;
-  comfort?: boolean;
-}) {
-  const h = comfort ? 13 : 12;
+/** Vertical fill, 4×13px. Fixed width — see the note on the value cell. */
+function Gauge({ percent, hot }: { percent?: number; hot?: boolean }) {
   // No reading means no gauge, but the space is still reserved so the
   // chip doesn't resize when one arrives.
   const pct =
@@ -437,8 +527,7 @@ function Gauge({
 
   return (
     <span
-      className="relative inline-block w-1 shrink-0 rounded-[1px] bg-fg-3/12"
-      style={{ height: h }}
+      className="relative inline-block h-[13px] w-1 shrink-0 rounded-[1px] bg-fg-3/12"
       aria-hidden
     >
       {pct != null && (
@@ -453,3 +542,5 @@ function Gauge({
     </span>
   );
 }
+
+export { CHIP_MAX_PX as UTILITY_CHIP_MAX_PX };

--- a/desktop/src/components/chips/UtilityChips.tsx
+++ b/desktop/src/components/chips/UtilityChips.tsx
@@ -130,6 +130,7 @@ function UtilityShell({
           "col-start-1 row-span-full flex items-center border-r px-[9px]",
           "text-[10px] font-bold tracking-[0.08em]",
           c.divider,
+          c.tabBg,
           c.text,
         )}
       >

--- a/desktop/src/components/chips/UtilityChips.tsx
+++ b/desktop/src/components/chips/UtilityChips.tsx
@@ -127,8 +127,9 @@ function UtilityShell({
       {/* The tab: the widget's name, painted, spanning both rows. */}
       <span
         className={clsx(
-          "col-start-1 row-span-full flex items-center border-r border-edge/40 px-[9px]",
+          "col-start-1 row-span-full flex items-center border-r px-[9px]",
           "text-[10px] font-bold tracking-[0.08em]",
+          c.divider,
           c.text,
         )}
       >
@@ -143,11 +144,14 @@ function UtilityShell({
 function Cell({
   col,
   first,
+  rule,
   dim,
   children,
 }: {
   col: number;
   first: boolean;
+  /** The palette's divider class. */
+  rule: string;
   dim?: boolean;
   children: React.ReactNode;
 }) {
@@ -156,7 +160,7 @@ function Cell({
       style={{ gridColumn: col + 1 }}
       className={clsx(
         "row-start-1 flex min-w-0 items-center gap-1.5 px-2.5",
-        !first && "border-l border-edge/40",
+        !first && clsx("border-l", rule),
         dim && "opacity-55",
       )}
     >
@@ -170,11 +174,14 @@ function Cell({
 function Meta({
   col,
   first,
+  rule,
   bleed,
   children,
 }: {
   col: number;
   first: boolean;
+  /** The palette's divider class. */
+  rule: string;
   bleed?: boolean;
   children: React.ReactNode;
 }) {
@@ -184,7 +191,7 @@ function Meta({
       className={clsx(
         "row-start-2 flex min-w-0 items-center",
         bleed ? "px-0" : "gap-1 px-2.5 text-[10px] leading-none text-fg-4",
-        !first && "border-l border-edge/40",
+        !first && clsx("border-l", rule),
       )}
     >
       {children}
@@ -234,7 +241,7 @@ export function ClockChip({
       onClick={onClick}
     >
       {items.map((item, i) => (
-        <Cell key={item.id} col={i + 1} first={i === 0} dim={item.night}>
+        <Cell key={item.id} col={i + 1} first={i === 0} rule={c.divider} dim={item.night}>
           <span className={clsx(LABEL, c.textDim)}>{item.label}</span>
           <span className={clsx(VALUE, c.text)}>{item.value}</span>
           {/* A moon says "middle of the night there" faster than dimming. */}
@@ -247,7 +254,7 @@ export function ClockChip({
       ))}
       {comfort &&
         items.map((item, i) => (
-          <Meta key={item.id} col={i + 1} first={i === 0}>
+          <Meta key={item.id} col={i + 1} first={i === 0} rule={c.divider}>
             <span className="truncate">
               {[item.detail, item.offset].filter(Boolean).join(" · ")}
             </span>
@@ -298,7 +305,7 @@ export function TimerChip({
       extra={anyUrgent ? "border-live/40" : undefined}
     >
       {items.map((item, i) => (
-        <Cell key={item.id} col={i + 1} first={i === 0} dim={item.paused}>
+        <Cell key={item.id} col={i + 1} first={i === 0} rule={c.divider} dim={item.paused}>
           <span className={clsx(LABEL, c.textDim)}>{item.label}</span>
           <span
             className={clsx(VALUE, isUrgent(item) ? "text-live" : c.text)}
@@ -318,7 +325,7 @@ export function TimerChip({
           const { remainingSec: rem, totalSec: total } = item;
           const drawable = rem != null && total != null && total > 0;
           return (
-            <Meta key={item.id} col={i + 1} first={i === 0} bleed={drawable}>
+            <Meta key={item.id} col={i + 1} first={i === 0} rule={c.divider} bleed={drawable}>
               {drawable ? (
                 <span className="h-[3px] w-full bg-fg-3/15">
                   <span
@@ -376,7 +383,7 @@ export function WeatherChip({
       extra={anyAlert ? "border-warning/45" : undefined}
     >
       {items.map((item, i) => (
-        <Cell key={item.id} col={i + 1} first={i === 0} dim={item.night}>
+        <Cell key={item.id} col={i + 1} first={i === 0} rule={c.divider} dim={item.night}>
           <span className={clsx(LABEL, c.textDim)}>{item.label}</span>
           <span aria-hidden className="text-[13px] leading-none">
             {item.icon}
@@ -388,7 +395,7 @@ export function WeatherChip({
       ))}
       {comfort &&
         items.map((item, i) => (
-          <Meta key={item.id} col={i + 1} first={i === 0}>
+          <Meta key={item.id} col={i + 1} first={i === 0} rule={c.divider}>
             {/* An alert outranks a range: it takes the cell rather than
                 sitting beside it, and stays under ITS city so you can
                 see which one it belongs to. */}
@@ -477,7 +484,7 @@ export function SysmonChip({
       extra={anyHot ? "border-error/30" : undefined}
     >
       {items.map((item, i) => (
-        <Cell key={item.id} col={i + 1} first={i === 0}>
+        <Cell key={item.id} col={i + 1} first={i === 0} rule={c.divider}>
           <span className={clsx(LABEL, c.textDim)}>{item.label}</span>
           <Gauge percent={item.percent} hot={item.hot} />
           {/* 5ch reserved: values flip digit counts ("5%" -> "100%",
@@ -498,7 +505,7 @@ export function SysmonChip({
           const points = series[i];
           const drawable = points.length >= 2;
           return (
-            <Meta key={item.id} col={i + 1} first={i === 0} bleed={drawable}>
+            <Meta key={item.id} col={i + 1} first={i === 0} rule={c.divider} bleed={drawable}>
               {drawable ? (
                 <Sparkline
                   points={points}

--- a/desktop/src/components/chips/chipColors.ts
+++ b/desktop/src/components/chips/chipColors.ts
@@ -12,6 +12,22 @@ export interface ChipColors {
   text: string;
   textDim: string;
   textFaint: string;
+  /**
+   * Divider between cells INSIDE a chip.
+   *
+   * Deliberately stronger than the chip's own outer `border`. An outer
+   * edge only has to separate the chip from the rail, which is a big
+   * tonal step already; an inner rule has to separate two things that
+   * share a background, and it is doing more work with less contrast to
+   * spend. `border-edge` was tried and is a near-black line on a
+   * near-black ground — invisible on a four-cell chip, which is how a
+   * sysmon chip ended up reading as one continuous sparkline instead of
+   * three metrics.
+   *
+   * Tinted with the widget's own colour rather than neutral grey, which
+   * is what the game chip does with the league's brand.
+   */
+  divider: string;
 }
 
 const PRIMARY: ChipColors = {
@@ -21,6 +37,7 @@ const PRIMARY: ChipColors = {
   text: "text-primary",
   textDim: "text-primary/70",
   textFaint: "text-primary/55",
+  divider: "border-primary/45",
 };
 
 const SECONDARY: ChipColors = {
@@ -30,6 +47,7 @@ const SECONDARY: ChipColors = {
   text: "text-secondary",
   textDim: "text-secondary/70",
   textFaint: "text-secondary/55",
+  divider: "border-secondary/45",
 };
 
 const INFO: ChipColors = {
@@ -39,6 +57,7 @@ const INFO: ChipColors = {
   text: "text-info",
   textDim: "text-info/70",
   textFaint: "text-info/55",
+  divider: "border-info/45",
 };
 
 const PURPLE: ChipColors = {
@@ -48,6 +67,7 @@ const PURPLE: ChipColors = {
   text: "text-accent-purple",
   textDim: "text-accent-purple/70",
   textFaint: "text-accent-purple/55",
+  divider: "border-accent-purple/45",
 };
 
 const MUTED: ChipColors = {
@@ -57,6 +77,7 @@ const MUTED: ChipColors = {
   text: "text-fg-2",
   textDim: "text-fg-3",
   textFaint: "text-fg-3",
+  divider: "border-fg-3/35",
 };
 
 const PREDICTIONS: ChipColors = {
@@ -66,6 +87,7 @@ const PREDICTIONS: ChipColors = {
   text: "text-predictions",
   textDim: "text-predictions/70",
   textFaint: "text-predictions/55",
+  divider: "border-predictions/45",
 };
 
 // ── Widget color palettes ───────────────────────────────────────
@@ -77,6 +99,7 @@ const WIDGET_CLOCK: ChipColors = {
   text: "text-widget-clock",
   textDim: "text-widget-clock/70",
   textFaint: "text-widget-clock/55",
+  divider: "border-widget-clock/45",
 };
 
 const WIDGET_TIMER: ChipColors = {
@@ -86,6 +109,7 @@ const WIDGET_TIMER: ChipColors = {
   text: "text-widget-timer",
   textDim: "text-widget-timer/70",
   textFaint: "text-widget-timer/55",
+  divider: "border-widget-timer/45",
 };
 
 const WIDGET_WEATHER: ChipColors = {
@@ -95,6 +119,7 @@ const WIDGET_WEATHER: ChipColors = {
   text: "text-widget-weather",
   textDim: "text-widget-weather/70",
   textFaint: "text-widget-weather/55",
+  divider: "border-widget-weather/45",
 };
 
 const WIDGET_SYSMON: ChipColors = {
@@ -104,6 +129,7 @@ const WIDGET_SYSMON: ChipColors = {
   text: "text-widget-sysmon",
   textDim: "text-widget-sysmon/70",
   textFaint: "text-widget-sysmon/55",
+  divider: "border-widget-sysmon/45",
 };
 
 const WIDGET_UPTIME: ChipColors = {
@@ -113,6 +139,7 @@ const WIDGET_UPTIME: ChipColors = {
   text: "text-widget-uptime",
   textDim: "text-widget-uptime/70",
   textFaint: "text-widget-uptime/55",
+  divider: "border-widget-uptime/45",
 };
 
 const WIDGET_GITHUB: ChipColors = {
@@ -122,6 +149,7 @@ const WIDGET_GITHUB: ChipColors = {
   text: "text-widget-github",
   textDim: "text-widget-github/70",
   textFaint: "text-widget-github/55",
+  divider: "border-widget-github/45",
 };
 
 // ── Widget id → color mapping (data + utility alike) ────────────

--- a/desktop/src/components/chips/chipColors.ts
+++ b/desktop/src/components/chips/chipColors.ts
@@ -28,6 +28,13 @@ export interface ChipColors {
    * is what the game chip does with the league's brand.
    */
   divider: string;
+  /**
+   * Fill behind the chip's tab — the one place the widget's colour is
+   * PAINTED rather than whispered. The game chip introduced it for the
+   * league tab: with only a tinted border and a 6% ground, a branded chip
+   * looked no different from an unbranded one. Same 18% every chip uses.
+   */
+  tabBg: string;
 }
 
 const PRIMARY: ChipColors = {
@@ -38,6 +45,7 @@ const PRIMARY: ChipColors = {
   textDim: "text-primary/70",
   textFaint: "text-primary/55",
   divider: "border-primary/45",
+  tabBg: "bg-primary/[0.18]",
 };
 
 const SECONDARY: ChipColors = {
@@ -48,6 +56,7 @@ const SECONDARY: ChipColors = {
   textDim: "text-secondary/70",
   textFaint: "text-secondary/55",
   divider: "border-secondary/45",
+  tabBg: "bg-secondary/[0.18]",
 };
 
 const INFO: ChipColors = {
@@ -58,6 +67,7 @@ const INFO: ChipColors = {
   textDim: "text-info/70",
   textFaint: "text-info/55",
   divider: "border-info/45",
+  tabBg: "bg-info/[0.18]",
 };
 
 const PURPLE: ChipColors = {
@@ -68,6 +78,7 @@ const PURPLE: ChipColors = {
   textDim: "text-accent-purple/70",
   textFaint: "text-accent-purple/55",
   divider: "border-accent-purple/45",
+  tabBg: "bg-accent-purple/[0.18]",
 };
 
 const MUTED: ChipColors = {
@@ -78,6 +89,7 @@ const MUTED: ChipColors = {
   textDim: "text-fg-3",
   textFaint: "text-fg-3",
   divider: "border-fg-3/35",
+  tabBg: "bg-fg-3/[0.14]",
 };
 
 const PREDICTIONS: ChipColors = {
@@ -88,6 +100,7 @@ const PREDICTIONS: ChipColors = {
   textDim: "text-predictions/70",
   textFaint: "text-predictions/55",
   divider: "border-predictions/45",
+  tabBg: "bg-predictions/[0.18]",
 };
 
 // ── Widget color palettes ───────────────────────────────────────
@@ -100,6 +113,7 @@ const WIDGET_CLOCK: ChipColors = {
   textDim: "text-widget-clock/70",
   textFaint: "text-widget-clock/55",
   divider: "border-widget-clock/45",
+  tabBg: "bg-widget-clock/[0.18]",
 };
 
 const WIDGET_TIMER: ChipColors = {
@@ -110,6 +124,7 @@ const WIDGET_TIMER: ChipColors = {
   textDim: "text-widget-timer/70",
   textFaint: "text-widget-timer/55",
   divider: "border-widget-timer/45",
+  tabBg: "bg-widget-timer/[0.18]",
 };
 
 const WIDGET_WEATHER: ChipColors = {
@@ -120,6 +135,7 @@ const WIDGET_WEATHER: ChipColors = {
   textDim: "text-widget-weather/70",
   textFaint: "text-widget-weather/55",
   divider: "border-widget-weather/45",
+  tabBg: "bg-widget-weather/[0.18]",
 };
 
 const WIDGET_SYSMON: ChipColors = {
@@ -130,6 +146,7 @@ const WIDGET_SYSMON: ChipColors = {
   textDim: "text-widget-sysmon/70",
   textFaint: "text-widget-sysmon/55",
   divider: "border-widget-sysmon/45",
+  tabBg: "bg-widget-sysmon/[0.18]",
 };
 
 const WIDGET_UPTIME: ChipColors = {
@@ -140,6 +157,7 @@ const WIDGET_UPTIME: ChipColors = {
   textDim: "text-widget-uptime/70",
   textFaint: "text-widget-uptime/55",
   divider: "border-widget-uptime/45",
+  tabBg: "bg-widget-uptime/[0.18]",
 };
 
 const WIDGET_GITHUB: ChipColors = {
@@ -150,6 +168,7 @@ const WIDGET_GITHUB: ChipColors = {
   textDim: "text-widget-github/70",
   textFaint: "text-widget-github/55",
   divider: "border-widget-github/45",
+  tabBg: "bg-widget-github/[0.18]",
 };
 
 // ── Widget id → color mapping (data + utility alike) ────────────

--- a/desktop/src/components/chips/metricHistory.test.ts
+++ b/desktop/src/components/chips/metricHistory.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The sysmon buffer's one job: turn a stream of instants into a series
+ * that is honest about time. Repeats are kept (a flat CPU is real), so
+ * the guard against re-renders is the clock rather than deduplication —
+ * which is the part with the arithmetic and the part worth testing.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { recordMetric, __resetMetricHistory } from "./metricHistory";
+
+beforeEach(() => __resetMetricHistory());
+
+describe("recordMetric", () => {
+  it("keeps a flat run rather than collapsing it", () => {
+    let t = 0;
+    for (let i = 0; i < 4; i++) recordMetric("cpu", 47, (t += 1000));
+    // Four seconds at 47% is four seconds of history, not one point.
+    expect(recordMetric("cpu", 47, (t += 1000))).toEqual([47, 47, 47, 47, 47]);
+  });
+
+  it("ignores a second reading inside the same tick", () => {
+    recordMetric("cpu", 47, 1000);
+    // A re-render, a StrictMode double-invoke, the rail re-bucketing.
+    recordMetric("cpu", 47, 1100);
+    expect(recordMetric("cpu", 47, 1400)).toEqual([47]);
+    expect(recordMetric("cpu", 48, 2000)).toEqual([47, 48]);
+  });
+
+  it("keeps the most recent readings once full", () => {
+    let t = 0;
+    let series: number[] = [];
+    for (let i = 0; i < 40; i++) series = recordMetric("cpu", i, (t += 1000));
+    expect(series).toHaveLength(32);
+    expect(series[series.length - 1]).toBe(39);
+    expect(series[0]).toBe(8);
+  });
+
+  it("tracks metrics separately", () => {
+    recordMetric("cpu", 10, 1000);
+    recordMetric("gpu", 90, 1000);
+    expect(recordMetric("cpu", 11, 2000)).toEqual([10, 11]);
+    expect(recordMetric("gpu", 91, 2000)).toEqual([90, 91]);
+  });
+
+  it("refuses a reading that is not a number", () => {
+    recordMetric("cpu", 10, 1000);
+    expect(recordMetric("cpu", NaN, 2000)).toEqual([10]);
+    expect(recordMetric("cpu", Infinity, 3000)).toEqual([10]);
+  });
+
+  it("evicts the least recently touched metric past the cap", () => {
+    let t = 0;
+    for (let i = 0; i < 40; i++) recordMetric(`m${i}`, 1, (t += 1000));
+    recordMetric("m1", 2, (t += 1000)); // touch m1 so m0 is now oldest
+    recordMetric("new", 1, (t += 1000)); // 41st key, evicts m0
+    expect(recordMetric("m0", 9, (t += 1000))).toEqual([9]); // started over
+    expect(recordMetric("m1", 3, (t += 1000))).toEqual([1, 2, 3]); // survived
+  });
+});

--- a/desktop/src/components/chips/metricHistory.ts
+++ b/desktop/src/components/chips/metricHistory.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-metric ring buffer for the sysmon sparkline.
+ *
+ * The system probe reports an instant — 47% right now — never a series,
+ * so the same trick the trade chip uses applies here: keep the readings
+ * this app has watched and draw those.
+ *
+ * Module-level rather than component state, for the reason priceHistory
+ * gives: a chip unmounts every time the rail re-buckets or the user
+ * flips density, and history held in the component would reset on each
+ * of those and spend its life nearly empty.
+ *
+ * Deliberately NOT priceHistory. That module seeds from a server-sent
+ * intraday series and scales its amplitude against a price's percentage
+ * range; a CPU percentage has neither a seed nor a meaningful percentage
+ * range, and the seeding branch would be dead code carried for the sake
+ * of sharing a Map.
+ *
+ * What the sparkline therefore means: the last few minutes this window
+ * has been open. Nothing before launch, which is honest — there is no
+ * store of past readings anywhere to draw from.
+ */
+
+/**
+ * Readings kept per metric.
+ *
+ * The probe ticks about once a second, so this is roughly the last half
+ * minute — enough for a line to have a shape, short enough that it still
+ * describes what the machine is doing NOW rather than what it did while
+ * you were at lunch.
+ */
+const MAX_POINTS = 32;
+
+/** Cap on tracked metrics; eviction is oldest-touched-first. */
+const MAX_KEYS = 40;
+
+/**
+ * Shortest gap between two recorded readings for one metric.
+ *
+ * This is what makes recording-during-render safe. The price buffer gets
+ * that for free by collapsing repeats — a re-render with unchanged data
+ * pushes nothing. This buffer deliberately keeps repeats (see below), so
+ * without a guard every re-render would append: React StrictMode's
+ * double-invoke, a parent re-rendering, the rail re-bucketing, all of it
+ * landing as fake history and making an idle machine look busy.
+ *
+ * Time is the honest key. The probe ticks about once a second, so a real
+ * tick always clears this and a re-render never does.
+ */
+const MIN_GAP_MS = 500;
+
+interface Entry {
+  points: number[];
+  touched: number;
+  lastAt: number;
+}
+
+const history = new Map<string, Entry>();
+let clock = 0;
+
+/**
+ * Record a reading and return that metric's current series.
+ *
+ * Consecutive identical readings are NOT collapsed, unlike the price
+ * buffer. A price that does not move is not a tick; a CPU that sits at
+ * 47% for ten seconds is ten seconds of real, flat history, and dropping
+ * those would compress a quiet stretch into a single point and make an
+ * idle machine look as busy as a loaded one.
+ */
+export function recordMetric(
+  id: string,
+  value: number,
+  now: number = Date.now(),
+): number[] {
+  if (!Number.isFinite(value)) return history.get(id)?.points ?? [];
+
+  let entry = history.get(id);
+  if (entry && now - entry.lastAt < MIN_GAP_MS) {
+    // A re-render, not a new reading. Return what we have unchanged.
+    entry.touched = ++clock;
+    return entry.points;
+  }
+  if (!entry) {
+    if (history.size >= MAX_KEYS) {
+      let oldestKey: string | null = null;
+      let oldest = Infinity;
+      for (const [k, v] of history) {
+        if (v.touched < oldest) {
+          oldest = v.touched;
+          oldestKey = k;
+        }
+      }
+      if (oldestKey) history.delete(oldestKey);
+    }
+    entry = { points: [], touched: 0, lastAt: 0 };
+    history.set(id, entry);
+  }
+
+  entry.touched = ++clock;
+  entry.lastAt = now;
+  entry.points.push(value);
+  if (entry.points.length > MAX_POINTS) {
+    entry.points.splice(0, entry.points.length - MAX_POINTS);
+  }
+  return entry.points;
+}
+
+/** Test seam. */
+export function __resetMetricHistory(): void {
+  history.clear();
+  clock = 0;
+}

--- a/desktop/src/hooks/useWidgetTickerData.ts
+++ b/desktop/src/hooks/useWidgetTickerData.ts
@@ -59,23 +59,22 @@ function formatTime(
   return new Intl.DateTimeFormat("en-US", opts).format(date);
 }
 
+/**
+ * The zone's date, e.g. "Fri, Sep 4".
+ *
+ * Date only. This used to lead with the zone's short name ("CDT \u00B7 Fri,
+ * Sep 4"), but the chip's detail row already ends with the numeric
+ * offset, so the row read "CDT \u00B7 Fri, Sep 4 \u00B7 GMT-5" \u2014 the same zone
+ * named twice, and for a non-local zone the name is often just "GMT+9"
+ * again. The offset is the one that is unambiguous; the name goes.
+ */
 function formatDetail(date: Date, tz: string | undefined): string {
-  const tzName =
-    new Intl.DateTimeFormat("en-US", {
-      timeZoneName: "short",
-      ...(tz ? { timeZone: tz } : {}),
-    })
-      .formatToParts(date)
-      .find((p) => p.type === "timeZoneName")?.value ?? "";
-
-  const dateStr = new Intl.DateTimeFormat("en-US", {
+  return new Intl.DateTimeFormat("en-US", {
     weekday: "short",
     month: "short",
     day: "numeric",
     ...(tz ? { timeZone: tz } : {}),
   }).format(date);
-
-  return `${tzName} \u00B7 ${dateStr}`;
 }
 
 function tzShortLabel(tz: string): string {


### PR DESCRIPTION
Clock, timer, weather, sysmon and uptime move onto the grid the data families took in v1.5.0: a named tab where the league tab goes, item cells divided by hairlines, compact as one row and detailed adding exactly one more without moving anything above it. A clock chip and a game chip are now the same shape. Linear: REL-188.

## What each widget puts in its detailed row

Deliberately not the same thing — it is whatever you would otherwise open the app to find.

| Widget | Compact | Detailed row |
|---|---|---|
| Clock | label + time | date and offset — a zone can be on a different **day**, which compact cannot say |
| Timer | label + remaining | a draining bar, live-red in the last minute; a stopwatch has no finish line, so it says what it is instead |
| Weather | label + icon + temperature **only** | today's range bar; an active alert sits under **its** city rather than across the chip |
| Sysmon | label + gauge + value | a real trend, full-bleed edge to edge — 82°C climbing reads differently from 82°C steady |
| Uptime | cap + name, value in a fixed right cell | full-bleed heartbeat history |

Weather also changed above the fold: the range bar used to sit beside the temperature and made the widest cell on the rail out of the chip with the least to say.

## Two palette fields every chip now carries

- `divider` — inner rules in the widget's own colour at 45%, stronger than the 25% outer border. The utilities had been drawing them in `border-edge/40`, a near-black line on a near-black ground, which is how a four-metric sysmon chip read as one continuous sparkline.
- `tabBg` — the 18% painted tab fill the game and headline chips already had.

Predictions, fantasy and GitHub (REL-184) inherit both when their turn comes.

## Sysmon's history

The probe reports an instant, never a series, so the trend needs a ring buffer of its own (`metricHistory`). Not `priceHistory`: that seeds from a server series and scales amplitude against a percentage range, neither of which a CPU reading has. It deliberately **keeps** repeats — a flat CPU is real history — which is exactly why it cannot rely on the price buffer's collapse-repeats trick to make recording-during-render safe. It guards on the clock instead; without that, a StrictMode double-invoke or any parent re-render would land as fake history. That guard is what the new tests cover.

## Verification

- 669 desktop tests, `tsc --noEmit` clean.
- Every new arbitrary Tailwind class checked against the served stylesheet, not the source — an interpolated class compiles to nothing silently, and it bit v1.5.0 twice.
- Reviewed live on the bar with real fetched weather for Austin and London.

## Deploy note

Desktop-only (`desktop/**`), so merging triggers a draft desktop build and nothing on the backend. No version bump here; this rides in the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
