### PR TITLE
Rotate sports games through fixed ticker slots

### DIFF
--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -48,6 +48,7 @@ import { sourceForWidget } from "../marketplace";
 import { useCatalog } from "../hooks/useCatalog";
 import { TICKER_SOURCES } from "../datawidgets/tickerRegistry";
 import { stepItemIndex } from "./tickerStep";
+import { advanceCycles, visibleSlots } from "./tickerRotation";
 import { WIDGET_ORDER } from "../widgets/registry";
 
 // ── Types ────────────────────────────────────────────────────────
@@ -280,9 +281,14 @@ export default function ScrollrTicker({
   // subscribing, a server-added widget renders with no source and is skipped.
   const catalogVersion = useCatalog();
 
+  // Laps completed by each rotating slot, keyed by slot. Bumped by the
+  // rotation effect below when a slot has fully left the viewport; read by
+  // sources through ctx.cycles to decide what the slot shows this lap.
+  const [cycles, setCycles] = useState<Readonly<Record<string, number>>>({});
+
   const chips = useMemo(() => {
-    const wrap = (key: string, chip: React.ReactNode) => (
-      <div key={key} className="py-1">
+    const wrap = (key: string, chip: React.ReactNode, rotateSlot?: string) => (
+      <div key={key} className="py-1" data-rotate-slot={rotateSlot}>
         {chip}
       </div>
     );
@@ -345,9 +351,10 @@ export default function ScrollrTicker({
         chipColorMode,
         widgetDisplay,
         predictionsWatchlist,
+        cycles,
         onChipClick,
       })) {
-        bucket.push(wrap(chip.key, chip.node));
+        bucket.push(wrap(chip.key, chip.node, chip.rotateSlot));
       }
 
       // Only push a bucket that actually has chips in it.
@@ -374,11 +381,36 @@ export default function ScrollrTicker({
     widgetDisplay,
     predictionsWatchlist,
     catalogVersion,
+    cycles,
   ]);
 
   // ── Shared refs ─────────────────────────────────────────────────
   const containerRef = useRef<HTMLDivElement>(null);
   const isHoveredRef = useRef(false);
+
+  // ── Slot rotation: advance a slot once it has fully left the viewport ──
+  //
+  // motion-plus has no loop callback, so this polls. Four reads a second
+  // of a handful of rects is nothing next to the marquee's own per-frame
+  // transform, and the check is skipped entirely when no slot rotates.
+  // Flip mode paginates rather than scrolls, so nothing there is ever
+  // "off screen" in the sense that matters; it keeps its first page.
+  const wasVisibleRef = useRef<Set<string>>(new Set());
+  const hasRotatingSlots = useMemo(
+    () => chips.some((c) => (c as React.ReactElement<{ "data-rotate-slot"?: string }>).props?.["data-rotate-slot"]),
+    [chips],
+  );
+  useEffect(() => {
+    if (!hasRotatingSlots || effectiveScrollMode === "flip") return;
+    const id = window.setInterval(() => {
+      const container = containerRef.current;
+      if (!container) return;
+      const now = visibleSlots(container);
+      setCycles((prev) => advanceCycles(prev, wasVisibleRef.current, now));
+      wasVisibleRef.current = now;
+    }, 250);
+    return () => window.clearInterval(id);
+  }, [hasRotatingSlots, effectiveScrollMode]);
 
   // ── Step mode: external offset driven by async animate loop ──
   const offset = useMotionValue(0);

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -37,6 +37,12 @@ interface GameChipProps {
    * sports palette.
    */
   accent?: string;
+  /**
+   * The widest short names this chip will ever be asked to show, when it
+   * is a rotating slot. The name cells reserve their width so a swap
+   * between games never resizes the chip. Fixed chips leave it unset.
+   */
+  reserveNames?: { away: string; home: string };
   onClick?: () => void;
 }
 
@@ -72,6 +78,7 @@ const GameChip = memo(
     comfort,
     colorMode = "widget",
     accent,
+    reserveNames,
     onClick,
   }: GameChipProps) {
     const c = getChipColors(colorMode, "sports");
@@ -87,7 +94,9 @@ const GameChip = memo(
     const final_ = isFinal(game);
     const pre_ = isPre(game);
     const ppd = game.state === "postponed";
-    const flash = useScoreFlash(game.away_team_score, game.home_team_score);
+    // Keyed on the game: a rotating slot swapping games must not flash as
+    // if somebody scored.
+    const flash = useScoreFlash(game.away_team_score, game.home_team_score, game.id);
     const r = reservationFor(game.league);
 
     // At the cap the chip is pinned at CHIP_MAX_PX and the names truncate.
@@ -156,15 +165,29 @@ const GameChip = memo(
             short name only labels, and at 12px on a 30px row it read as a
             bullet. ESPN runs ~18px against 12px type for the same reason. */}
         <TeamLogo src={logo} alt={name} size="lg" />
-        <span
-          className={clsx(
-            // 14px against a 20px crest; 12px read as a caption under it.
-            "min-w-0 truncate text-left text-[14px] leading-none",
-            pre_ ? "font-medium text-fg" : leads ? "font-semibold text-fg" : "font-medium text-fg-2",
-          )}
-          title={name}
-        >
-          {teamShortName(game.league, name)}
+        {/* The name and, underneath it in the same grid cell, an invisible
+            copy of the widest name this slot will ever show. The cell is as
+            wide as the wider of the two, so a rotating slot swapping
+            "Rays" for "Diamondbacks" does not resize the chip and shove
+            the rail. Still min-w-0, so the cap can truncate both. Fixed
+            chips pass no reserve and the sizer is empty. */}
+        <span className="grid min-w-0 grid-cols-[minmax(0,1fr)]">
+          <span
+            className={clsx(
+              // 14px against a 20px crest; 12px read as a caption under it.
+              "col-start-1 row-start-1 min-w-0 truncate text-left text-[14px] leading-none",
+              pre_ ? "font-medium text-fg" : leads ? "font-semibold text-fg" : "font-medium text-fg-2",
+            )}
+            title={name}
+          >
+            {teamShortName(game.league, name)}
+          </span>
+          <span
+            aria-hidden
+            className="invisible col-start-1 row-start-1 h-0 min-w-0 overflow-hidden whitespace-nowrap text-[14px] font-semibold leading-none"
+          >
+            {reserveNames?.[side] ?? ""}
+          </span>
         </span>
         <span className="min-w-[6px] flex-1" />
         <span
@@ -342,6 +365,8 @@ const GameChip = memo(
     prev.comfort === next.comfort &&
     prev.colorMode === next.colorMode &&
     prev.onClick === next.onClick &&
+    prev.reserveNames?.away === next.reserveNames?.away &&
+    prev.reserveNames?.home === next.reserveNames?.home &&
     sameGame(prev.game, next.game),
 );
 

--- a/desktop/src/components/tickerRotation.test.ts
+++ b/desktop/src/components/tickerRotation.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The lap counter's arithmetic: a slot advances exactly once per
+ * visible->hidden transition, never while on screen, and never on a
+ * tick where nothing changed.
+ */
+import { describe, it, expect } from "vitest";
+import { advanceCycles } from "./tickerRotation";
+
+const S = (...xs: string[]) => new Set(xs);
+
+describe("advanceCycles", () => {
+  it("advances a slot that was visible and no longer is", () => {
+    expect(advanceCycles({}, S("a"), S())).toEqual({ a: 1 });
+  });
+
+  it("does not advance a slot while it stays visible", () => {
+    const c = { a: 3 };
+    expect(advanceCycles(c, S("a"), S("a"))).toBe(c);
+  });
+
+  it("does not advance a slot on the tick it becomes visible", () => {
+    // Entering is not a lap; leaving is.
+    const c = { a: 3 };
+    expect(advanceCycles(c, S(), S("a"))).toBe(c);
+  });
+
+  it("returns the same object when nothing changed, so state does not churn", () => {
+    const c = { a: 1, b: 2 };
+    expect(advanceCycles(c, S("a", "b"), S("a", "b"))).toBe(c);
+    expect(advanceCycles(c, S(), S())).toBe(c);
+  });
+
+  it("advances only the slots that left, independently", () => {
+    expect(advanceCycles({ a: 1, b: 1 }, S("a", "b"), S("b"))).toEqual({ a: 2, b: 1 });
+  });
+
+  it("counts a full lap as exactly one", () => {
+    let c: Readonly<Record<string, number>> = {};
+    // visible, visible, gone, gone, visible again, gone
+    const frames = [S("a"), S("a"), S(), S(), S("a"), S()];
+    for (let i = 1; i < frames.length; i++) c = advanceCycles(c, frames[i - 1], frames[i]);
+    expect(c).toEqual({ a: 2 });
+  });
+});

--- a/desktop/src/components/tickerRotation.ts
+++ b/desktop/src/components/tickerRotation.ts
@@ -1,0 +1,52 @@
+/**
+ * When a rotating slot may change what it shows.
+ *
+ * The rule: never while it is on screen. A marquee chip is read as it
+ * passes, and a swap mid-pass loses the reader the game they were
+ * looking at. So a slot's content advances once per LAP -- the moment
+ * it has fully left the viewport -- and the count of those moments is
+ * the slot's cycle number, which the source turns into "which game".
+ *
+ * motion-plus renders each item twice, an original (`.ticker-item`) and
+ * a clone (`.clone-item`) one track-length apart, so "off screen" means
+ * EVERY instance of the slot is outside the container. The track is
+ * always longer than the viewport, so there is always a stretch where
+ * that is true, and always exactly one visible->hidden transition per
+ * lap. It has no loop callback, hence the polling in ScrollrTicker; this
+ * module is the pure part of that, so the arithmetic is testable without
+ * a DOM.
+ */
+
+/** Which slots are visible right now, from the DOM. */
+export function visibleSlots(container: HTMLElement): Set<string> {
+  const box = container.getBoundingClientRect();
+  const seen = new Set<string>();
+  const nodes = container.querySelectorAll<HTMLElement>("[data-rotate-slot]");
+  for (const node of nodes) {
+    const slot = node.dataset.rotateSlot;
+    if (!slot || seen.has(slot)) continue;
+    const r = node.getBoundingClientRect();
+    // Any overlap counts; a chip half off the edge is still being read.
+    if (r.right > box.left && r.left < box.right) seen.add(slot);
+  }
+  return seen;
+}
+
+/**
+ * Advance the cycle of every slot that was visible last tick and is not
+ * now. Returns the same object when nothing changed, so callers can use
+ * it as a state setter without spurious re-renders.
+ */
+export function advanceCycles(
+  cycles: Readonly<Record<string, number>>,
+  wasVisible: ReadonlySet<string>,
+  nowVisible: ReadonlySet<string>,
+): Readonly<Record<string, number>> {
+  let next: Record<string, number> | null = null;
+  for (const slot of wasVisible) {
+    if (nowVisible.has(slot)) continue;
+    next ??= { ...cycles };
+    next[slot] = (next[slot] ?? 0) + 1;
+  }
+  return next ?? cycles;
+}

--- a/desktop/src/datawidgets/sports/FeedTab.tsx
+++ b/desktop/src/datawidgets/sports/FeedTab.tsx
@@ -13,7 +13,7 @@
  * and coarse `sports` rows can't exist post-migration-000014.
  */
 import { useState, useMemo, useCallback } from "react";
-import { Trophy, CalendarRange } from "lucide-react";
+import { Trophy, CalendarRange, Layers } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { sportsFullQueryOptions, sportsTeamsOptions } from "../../api/queries";
 import type { TeamInfo } from "../../api/queries";
@@ -292,6 +292,28 @@ function SportsBarControls({
           if (o) setDisplay({ daysBack: o.back, daysAhead: o.ahead });
         }}
       />
+      {/* How many non-favourite games hold a place on the ticker at once;
+          the rest rotate through those places one lap at a time. The
+          favourite is always pinned on top of this. */}
+      <SelectMenu
+        ariaLabel="Games on the ticker at once"
+        icon={Layers}
+        value={String(display.tickerSlots)}
+        options={slotOptions(display.tickerSlots)}
+        onChange={(v) => setDisplay({ tickerSlots: Number(v) })}
+      />
     </>
   );
+}
+
+const SLOT_OPTIONS = [2, 3, 4, 6, 8].map((n) => ({
+  value: String(n),
+  label: `${n} on the bar`,
+}));
+
+/** A stored value outside the menu gets its own row, as the window does. */
+function slotOptions(current: number) {
+  return SLOT_OPTIONS.some((o) => o.value === String(current))
+    ? SLOT_OPTIONS
+    : [...SLOT_OPTIONS, { value: String(current), label: `${current} on the bar` }];
 }

--- a/desktop/src/datawidgets/sports/ticker.tsx
+++ b/desktop/src/datawidgets/sports/ticker.tsx
@@ -3,7 +3,12 @@ import GameChip from "../../components/chips/GameChip";
 import { chipUrlForSports } from "../../utils/chipUrl";
 import type { TickerChip, TickerContext, TickerSource } from "../ticker";
 import { scopedRows } from "../ticker";
-import { selectSportsForTicker, getSportsDisplayConfig } from "./view";
+import {
+  selectSportsForTicker,
+  getSportsDisplayConfig,
+  arrangeTickerSlots,
+  TICKER_SLOTS_DEFAULT,
+} from "./view";
 import { catalogItemById } from "../../marketplace";
 
 /**
@@ -12,10 +17,18 @@ import { catalogItemById } from "../../marketplace";
  * Sports display prefs live server-side on the WIDGET row's config.display
  * (per-league toggles since the 000014 split), so the tab is passed through
  * to gate an NFL widget's chips by its own toggles.
+ *
+ * What the horizon admits is not what the rail shows. A favourite's game
+ * is always on; everything else shares a fixed number of rotating slots
+ * that cycle through the eligible pool one lap at a time. The slot keeps
+ * its key and its width while its game changes, so the rail never grows,
+ * shrinks or reflows as a slate fills up -- a busy MLB night is one chip
+ * per slot, not thirty chips.
  */
 export const sportsTickerSource: TickerSource = {
   chips(raw: unknown, ctx: TickerContext): TickerChip[] {
     const config = getSportsDisplayConfig(ctx.dashboard, ctx.tab);
+    const favorites = favoriteTeamsFor(ctx);
 
     const rows = scopedRows<Game>(raw, ctx);
     // Each league is its own widget and the catalog gives it a brand colour
@@ -23,14 +36,24 @@ export const sportsTickerSource: TickerSource = {
     // league the old single "sports channel" red; it now takes the widget's
     // own colour, as the catalog cards and Home ticker already do.
     const accent = catalogItemById(ctx.tab)?.hex;
-    return selectSportsForTicker(rows, config).map((game) => ({
-      key: `spo-${game.id}`,
+    const eligible = selectSportsForTicker(rows, config);
+    const slots = arrangeTickerSlots(
+      eligible,
+      favorites,
+      config.tickerSlots ?? TICKER_SLOTS_DEFAULT,
+      ctx.cycles ?? {},
+      `spo-${ctx.tab}`,
+    );
+    return slots.map(({ key, game, rotateSlot, reserveNames }) => ({
+      key,
+      rotateSlot,
       node: (
         <GameChip
           game={game}
           comfort={ctx.comfort}
           colorMode={ctx.chipColorMode}
           accent={accent}
+          reserveNames={reserveNames}
           onClick={() =>
             ctx.onChipClick?.("sports", game.id, chipUrlForSports(game))
           }
@@ -39,3 +62,14 @@ export const sportsTickerSource: TickerSource = {
     }));
   },
 };
+
+/** The widget's favourite team names, from its stored config. */
+function favoriteTeamsFor(ctx: TickerContext): ReadonlySet<string> {
+  const config = ctx.dashboard?.widgets?.find((c) => c.widget_type === ctx.tab)
+    ?.config as { favoriteTeams?: Record<string, { teamName?: string }> } | undefined;
+  const set = new Set<string>();
+  for (const ft of Object.values(config?.favoriteTeams ?? {})) {
+    if (ft?.teamName) set.add(ft.teamName);
+  }
+  return set;
+}

--- a/desktop/src/datawidgets/sports/view.test.ts
+++ b/desktop/src/datawidgets/sports/view.test.ts
@@ -399,3 +399,82 @@ describe("selectSportsForFeed", () => {
     expect(result.map((g) => g.id)).toEqual([4, 3, 2, 1]);
   });
 });
+
+// ── arrangeTickerSlots ──────────────────────────────────────────
+
+import { arrangeTickerSlots } from "./view";
+
+describe("arrangeTickerSlots", () => {
+  const g = (id: number, away: string, home: string, state = "pre") =>
+    mk({ id, state, away_team_name: away, home_team_name: home, league: "MLB" });
+  const pool = [
+    g(1, "Tampa Bay Rays", "Texas Rangers"),
+    g(2, "Arizona Diamondbacks", "Houston Astros"),
+    g(3, "Toronto Blue Jays", "Kansas City Royals"),
+    g(4, "New York Yankees", "San Diego Padres"),
+    g(5, "Chicago Cubs", "Miami Marlins"),
+  ];
+  const NONE = new Set<string>();
+
+  it("keys every game by id when the pool fits the slots", () => {
+    const out = arrangeTickerSlots(pool.slice(0, 3), NONE, 4, {}, "p");
+    expect(out.map((s) => s.key)).toEqual(["p-1", "p-2", "p-3"]);
+    expect(out.every((s) => !s.rotateSlot && !s.reserveNames)).toBe(true);
+  });
+
+  it("gives a bigger pool exactly `slots` rotating positions", () => {
+    const out = arrangeTickerSlots(pool, NONE, 2, {}, "p");
+    expect(out.map((s) => s.key)).toEqual(["p-slot-0", "p-slot-1"]);
+    expect(out.map((s) => s.game.id)).toEqual([1, 2]);
+  });
+
+  it("walks each slot through its own residue class as its laps advance", () => {
+    // slot 0 owns games 1,3,5; slot 1 owns 2,4. Independent counters.
+    const at = (c: Record<string, number>) =>
+      arrangeTickerSlots(pool, NONE, 2, c, "p").map((s) => s.game.id);
+    expect(at({ "p-slot-0": 1 })).toEqual([3, 2]);
+    expect(at({ "p-slot-0": 2, "p-slot-1": 1 })).toEqual([5, 4]);
+    expect(at({ "p-slot-0": 3, "p-slot-1": 2 })).toEqual([1, 2]); // wrapped
+  });
+
+  it("reserves the widest names a slot will actually show, not the league's", () => {
+    const [s0, s1] = arrangeTickerSlots(pool, NONE, 2, {}, "p");
+    // The reserve is what the chip RENDERS, and teamShortName leaves any
+    // name within its 20-character budget untouched -- so these are the
+    // widest full names in each slot's class, not abbreviations.
+    // slot 0: games 1, 3, 5
+    expect(s0.reserveNames).toEqual({ away: "Toronto Blue Jays", home: "Kansas City Royals" });
+    // slot 1: games 2, 4
+    expect(s1.reserveNames).toEqual({ away: "Arizona Diamondbacks", home: "San Diego Padres" });
+  });
+
+  it("pins a favourite's game outside the slot count", () => {
+    const favs = new Set(["Chicago Cubs"]);
+    const out = arrangeTickerSlots(pool, favs, 2, {}, "p");
+    expect(out.map((s) => s.key)).toEqual(["p-5", "p-slot-0", "p-slot-1"]);
+    // and the favourite never appears in a rotating slot's class
+    const rotating = arrangeTickerSlots(pool, favs, 2, { "p-slot-0": 9, "p-slot-1": 9 }, "p")
+      .filter((s) => s.rotateSlot)
+      .map((s) => s.game.id);
+    expect(rotating).not.toContain(5);
+  });
+
+  it("does not rotate when the favourites alone exceed the slots", () => {
+    const favs = new Set(["Tampa Bay Rays", "Arizona Diamondbacks", "Toronto Blue Jays"]);
+    const out = arrangeTickerSlots(pool.slice(0, 4), favs, 1, {}, "p");
+    // three pinned, one non-favourite fits in the single slot: no rotation
+    expect(out.map((s) => s.key)).toEqual(["p-1", "p-2", "p-3", "p-4"]);
+  });
+});
+
+describe("normalizeSportsDisplayConfig tickerSlots", () => {
+  it("defaults, rounds and clamps", async () => {
+    const { normalizeSportsDisplayConfig, TICKER_SLOTS_DEFAULT, TICKER_SLOTS_MAX } =
+      await import("./view");
+    expect(normalizeSportsDisplayConfig({}).tickerSlots).toBe(TICKER_SLOTS_DEFAULT);
+    expect(normalizeSportsDisplayConfig({ tickerSlots: 2.6 }).tickerSlots).toBe(3);
+    expect(normalizeSportsDisplayConfig({ tickerSlots: 0 }).tickerSlots).toBe(1);
+    expect(normalizeSportsDisplayConfig({ tickerSlots: 99 }).tickerSlots).toBe(TICKER_SLOTS_MAX);
+    expect(normalizeSportsDisplayConfig({ tickerSlots: "4" }).tickerSlots).toBe(TICKER_SLOTS_DEFAULT);
+  });
+});

--- a/desktop/src/datawidgets/sports/view.ts
+++ b/desktop/src/datawidgets/sports/view.ts
@@ -10,6 +10,7 @@
  */
 import type { Game } from "../../types";
 import { isLive, isCloseGame } from "../../utils/gameHelpers";
+import { teamShortName } from "../../utils/teamShortName";
 import { migrateVenue } from "../../preferences";
 
 // ── Display prefs shape (mirrors server-side widget config.display) ─
@@ -26,10 +27,31 @@ export interface SportsDisplayConfig {
    */
   daysBack?: number;
   daysAhead?: number;
+  /**
+   * Rotating ticker slots for games that are NOT a favourite's. The
+   * horizon decides what is eligible; this decides how many of those are
+   * on the rail at once, with the rest cycling through the same slots one
+   * lap at a time. Favourites are pinned on top of this number, never
+   * counted against it.
+   */
+  tickerSlots?: number;
 }
 
 /** Defaults: yesterday's finals through next week's slate. */
 export const SPORTS_WINDOW_DEFAULTS = { daysBack: 1, daysAhead: 7 } as const;
+
+/**
+ * Four non-favourite games at once.
+ *
+ * A full MLB day is ~30 eligible games; four slots means the whole slate
+ * comes round in about eight laps, and a league widget stops being able
+ * to bury the clock and the weather behind twenty-six chips in a row.
+ * Bounded so a misconfigured value cannot either empty the rail or
+ * recreate the flood.
+ */
+export const TICKER_SLOTS_DEFAULT = 4;
+export const TICKER_SLOTS_MIN = 1;
+export const TICKER_SLOTS_MAX = 12;
 
 /**
  * Hard ceiling looking BACK. cleanup_old_games (sports service) deletes
@@ -319,5 +341,85 @@ export function normalizeSportsDisplayConfig(
       legacyUpcoming === "off" ? 0 : SPORTS_WINDOW_DEFAULTS.daysAhead,
       SPORTS_WINDOW_MAX_DAYS_AHEAD,
     ),
+    tickerSlots:
+      typeof obj.tickerSlots === "number" && Number.isFinite(obj.tickerSlots)
+        ? Math.min(TICKER_SLOTS_MAX, Math.max(TICKER_SLOTS_MIN, Math.round(obj.tickerSlots)))
+        : TICKER_SLOTS_DEFAULT,
   };
+}
+
+// ── Pure: rotating slots for the ticker ──────────────────────────
+
+/** One position on the rail: a fixed game, or a slot cycling through several. */
+export interface TickerSlot {
+  /** Stable key. A rotating slot keeps its key while its game changes. */
+  key: string;
+  game: Game;
+  /** Set on rotating slots; the ticker counts this slot's laps under it. */
+  rotateSlot?: string;
+  /**
+   * The longest short names this slot will ever show, so the chip can
+   * reserve their width and a swap never resizes it. Absent on fixed
+   * games, whose names never change.
+   */
+  reserveNames?: { away: string; home: string };
+}
+
+/**
+ * Lay eligible games out as pinned games plus rotating slots.
+ *
+ * Favourites are pinned: every one of them is on the rail, keyed by the
+ * game, exempt from the count. Everything else goes into a pool in the
+ * display order (live and close first, then live, soonest upcoming,
+ * newest finals) and `slots` positions cycle through it.
+ *
+ * Each slot owns a residue class of the pool -- slot i shows pool[i],
+ * then pool[i + slots], then pool[i + 2·slots] -- advancing once per
+ * lap. No coordination between slots is needed for every game to come
+ * round, which matters because the slots leave the viewport at
+ * different moments and so have different cycle counts. The reservation
+ * is per class too: a slot reserves the widest names IT will show, not
+ * the widest in the league, so the whitespace cost is only what its own
+ * rotation actually needs.
+ *
+ * When the pool fits in the slots nothing rotates and the games are keyed
+ * by id like any fixed chip.
+ */
+export function arrangeTickerSlots(
+  eligible: Game[],
+  favoriteTeams: ReadonlySet<string>,
+  slots: number,
+  cycles: Readonly<Record<string, number>>,
+  keyPrefix: string,
+): TickerSlot[] {
+  const pinned: Game[] = [];
+  const pool: Game[] = [];
+  for (const g of eligible) {
+    const fav = favoriteTeams.has(g.home_team_name) || favoriteTeams.has(g.away_team_name);
+    (fav ? pinned : pool).push(g);
+  }
+  const forGame = (g: Game): TickerSlot => ({ key: `${keyPrefix}-${g.id}`, game: g });
+  if (pool.length <= slots) return [...pinned.map(forGame), ...pool.map(forGame)];
+
+  const k = Math.max(1, slots);
+  const rotating: TickerSlot[] = [];
+  for (let i = 0; i < k; i++) {
+    const cls = pool.filter((_, idx) => idx % k === i);
+    if (cls.length === 0) continue;
+    const slotKey = `${keyPrefix}-slot-${i}`;
+    const turn = cycles[slotKey] ?? 0;
+    const game = cls[turn % cls.length];
+    const widest = (pick: (g: Game) => string) =>
+      cls.map((g) => teamShortName(g.league, pick(g))).reduce((a, b) => (b.length > a.length ? b : a), "");
+    rotating.push({
+      key: slotKey,
+      game,
+      rotateSlot: slotKey,
+      reserveNames: {
+        away: widest((g) => g.away_team_name),
+        home: widest((g) => g.home_team_name),
+      },
+    });
+  }
+  return [...pinned.map(forGame), ...rotating];
 }

--- a/desktop/src/datawidgets/ticker.ts
+++ b/desktop/src/datawidgets/ticker.ts
@@ -23,6 +23,14 @@ import { scopeSourceData } from "../utils/widgetScope";
 export interface TickerChip {
   key: string;
   node: ReactNode;
+  /**
+   * Set when this chip is a rotating SLOT rather than a fixed item: the
+   * key stays, the content cycles. The ticker tags the wrapper with it
+   * and counts how many times the slot has left the viewport, and the
+   * source reads that count back out of `ctx.cycles` to decide what the
+   * slot shows this lap.
+   */
+  rotateSlot?: string;
 }
 
 /** Everything a source needs to build its chips. */
@@ -37,6 +45,13 @@ export interface TickerContext {
   widgetDisplay?: WidgetDisplayPrefs;
   /** Starred prediction markets, live across windows. */
   predictionsWatchlist: ReadonlySet<string>;
+  /**
+   * How many times each rotating slot has left the viewport, by slot key.
+   * A slot's content advances only when this changes, which is how a chip
+   * never swaps while someone is reading it. Absent from callers that do
+   * not scroll (the fantasy preview): nothing rotates there.
+   */
+  cycles?: Readonly<Record<string, number>>;
   onChipClick?: (
     widgetType: string,
     itemId: string | number,

--- a/desktop/src/hooks/useScoreFlash.ts
+++ b/desktop/src/hooks/useScoreFlash.ts
@@ -1,35 +1,43 @@
-/**
- * Shared hook for score-change flash animation.
- *
- * Detects when a game's score changes and returns `true` for 800ms,
- * allowing components to show a brief highlight flash. Skips the
- * flash on initial mount so it only fires on live updates.
- */
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
+/**
+ * Flash once when either score changes.
+ *
+ * `resetKey` identifies WHICH game the scores belong to. When it changes
+ * the baseline is replaced silently instead of compared: a rotating slot
+ * swapping from one game to another looks exactly like a score change
+ * to a naive comparison, and every rotation would flash green or red as
+ * if somebody had scored. Fixed items pass their id and never trip it.
+ */
 export function useScoreFlash(
   awayScore: number | string,
   homeScore: number | string,
+  resetKey?: string | number,
 ): boolean {
-  const prevRef = useRef({ away: awayScore, home: homeScore });
+  const prevRef = useRef({ away: awayScore, home: homeScore, key: resetKey });
   const [flash, setFlash] = useState(false);
   const initialRender = useRef(true);
 
   useEffect(() => {
     if (initialRender.current) {
       initialRender.current = false;
-      prevRef.current = { away: awayScore, home: homeScore };
+      prevRef.current = { away: awayScore, home: homeScore, key: resetKey };
       return;
     }
 
     const prev = prevRef.current;
+    if (prev.key !== resetKey) {
+      // A different game, not a different score.
+      prevRef.current = { away: awayScore, home: homeScore, key: resetKey };
+      return;
+    }
     if (prev.away !== awayScore || prev.home !== homeScore) {
       setFlash(true);
       const t = setTimeout(() => setFlash(false), 800);
-      prevRef.current = { away: awayScore, home: homeScore };
+      prevRef.current = { away: awayScore, home: homeScore, key: resetKey };
       return () => clearTimeout(t);
     }
-  }, [awayScore, homeScore]);
+  }, [awayScore, homeScore, resetKey]);
 
   return flash;
 }

--- a/desktop/src/hooks/useSportsConfig.ts
+++ b/desktop/src/hooks/useSportsConfig.ts
@@ -15,6 +15,7 @@ import { useShellData } from "../shell-context";
 import {
   normalizeSportsDisplayConfig,
   SPORTS_WINDOW_DEFAULTS,
+  TICKER_SLOTS_DEFAULT,
 } from "../datawidgets/sports/view";
 
 export interface FavoriteTeam {
@@ -26,6 +27,8 @@ export interface SportsDisplayPrefs {
   /** Day window (v1.1.3 Time Controls) — see SportsDisplayConfig. */
   daysBack: number;
   daysAhead: number;
+  /** Rotating ticker slots for non-favourite games — see SportsDisplayConfig. */
+  tickerSlots: number;
 }
 
 export interface SportsConfig {
@@ -37,6 +40,7 @@ export interface SportsConfig {
 const DEFAULT_DISPLAY: SportsDisplayPrefs = {
   daysBack: SPORTS_WINDOW_DEFAULTS.daysBack,
   daysAhead: SPORTS_WINDOW_DEFAULTS.daysAhead,
+  tickerSlots: TICKER_SLOTS_DEFAULT,
 };
 
 export function useSportsConfig(widgetType: string = "sports") {
@@ -59,6 +63,7 @@ export function useSportsConfig(widgetType: string = "sports") {
       display: {
         daysBack: normalizedDisplay.daysBack ?? DEFAULT_DISPLAY.daysBack,
         daysAhead: normalizedDisplay.daysAhead ?? DEFAULT_DISPLAY.daysAhead,
+        tickerSlots: normalizedDisplay.tickerSlots ?? DEFAULT_DISPLAY.tickerSlots,
       },
       favoriteTeams:
         typeof raw.favoriteTeams === "object" && raw.favoriteTeams !== null


### PR DESCRIPTION
The horizon admitted every eligible game — around thirty on an MLB day — and the rail's round-robin weave then buried every other widget behind twenty-six chips in a row. A cap that drops games was the obvious fix and the wrong one: everything eligible is worth seeing, just not all at once.

## What changes

A league widget now holds a fixed number of **slots** (default four, per-widget "N on the bar" in the sports bar next to the time window) and the eligible games rotate through them. The slot keeps its key and its width while its game changes, so the rail never grows, shrinks or reflows as a slate fills. **Favourites are pinned on top of the count**, never against it.

## What makes the rotation honest

- **A slot advances only once it has fully left the viewport** — every instance of it, since motion-plus renders an original and a clone one track-length apart. Never while someone is reading it. motion-plus has no loop callback, so `ScrollrTicker` polls a handful of rects four times a second; the arithmetic is pure and tested (`tickerRotation`).
- **Each slot owns a residue class of the pool** (slot *i* shows pool[i], pool[i+k], …), so slots that leave the screen at different moments need no coordination for every game to come round.
- **Each name cell reserves the widest name its slot will show**, via an invisible sizer stacked under the visible name. A swap from "Rays" to "Diamondbacks" cannot resize the chip. The reserve is what the chip *renders*, so a name inside the shortener's 20-character budget reserves its full length.
- **The score flash is keyed on the game.** A swap used to look exactly like somebody scoring.

## Verification

- 682 desktop tests, `tsc --noEmit` clean. New tests cover the lap arithmetic, the residue-class walk, the per-slot reservation, favourite pinning, and the config clamp.
- Measured on a harness mounting the real chip, real slot arrangement and real off-screen rule over four full laps: every slot's width identical to 0.1px through five games each, total rail width constant, and **zero swaps while a chip was on screen** out of sixteen. (Harness not committed; the embedded pane only paints frames on demand, so it drove the marquee with a timer rather than rAF.)
- Reviewed live on the bar with MLB (17 eligible), NCAA Football (50 eligible), Premier League and UFC alongside finance, news and the utilities.

## Cost to know about

A short matchup sharing a slot with a long one carries the long one's whitespace — bounded by the 640 cap and the shortener. And a full slate takes pool/slots laps to come round: fifty NCAA games through four slots is about thirteen laps.

## Deploy note

Desktop-only. No version bump; rides the next release cut with the utility chips (#305).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
