### PR TITLE
The ticker has one rule per source, and the user sets none of it

### DIFF
--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -47,6 +47,7 @@ import {
 import { sourceForWidget } from "../marketplace";
 import { useCatalog } from "../hooks/useCatalog";
 import { TICKER_SOURCES } from "../datawidgets/tickerRegistry";
+import { rotateSlots } from "../datawidgets/ticker";
 import { stepItemIndex } from "./tickerStep";
 import { advanceCycles, visibleSlots } from "./tickerRotation";
 import { WIDGET_ORDER } from "../widgets/registry";
@@ -177,9 +178,10 @@ function widgetChipsFor(
     onTogglePin?: (id: string) => void;
     onChipClick?: (type: string, id: string, url?: string) => void;
     pinned?: boolean;
+    cycles?: Readonly<Record<string, number>>;
   },
-): React.ReactNode[] {
-  const { comfort, chipColorMode, onTogglePin, onChipClick, pinned } = opts;
+): Array<{ key: string; node: React.ReactNode; rotateSlot?: string }> {
+  const { comfort, chipColorMode, onTogglePin, onChipClick, pinned, cycles } = opts;
 
   // The four cell/gauge/spine utilities each render as ONE chip holding
   // their items, unlike the capped pair which render one chip per item.
@@ -193,16 +195,27 @@ function widgetChipsFor(
       onTogglePin: onTogglePin ? () => onTogglePin(wt) : undefined,
       onClick: () => onChipClick?.(wt, wt),
     };
-    if (wt === "clock")
-      return [<ClockChip items={items as ClockChipData[]} {...shared} />];
-    if (wt === "timer")
-      return [<TimerChip items={items as ClockChipData[]} {...shared} />];
-    if (wt === "weather")
-      return [<WeatherChip items={items as WeatherChipData[]} {...shared} />];
-    return [<SysmonChip items={items as SysmonChipData[]} {...shared} />];
+    const node =
+      wt === "clock" ? <ClockChip items={items as ClockChipData[]} {...shared} />
+      : wt === "timer" ? <TimerChip items={items as ClockChipData[]} {...shared} />
+      : wt === "weather" ? <WeatherChip items={items as WeatherChipData[]} {...shared} />
+      : <SysmonChip items={items as SysmonChipData[]} {...shared} />;
+    return [{ key: `${wt}-chip`, node }];
   }
 
-  return items.map((item, i) => {
+  // One chip per monitor or repo, rotating through a fixed number of
+  // slots once there are more than that -- thirty monitors is still four
+  // chips, and a failing one still comes round. Fixed-width chips, so the
+  // slot needs no reservation.
+  const slots = rotateSlots(
+    items as Array<UptimeChipData | GitHubChipData>,
+    CAPPED_WIDGET_SLOTS,
+    cycles ?? {},
+    wt,
+    (item) => item.id,
+    () => undefined,
+  );
+  return slots.map(({ key, item, rotateSlot }, i) => {
     const shared = {
       comfort,
       colorMode: chipColorMode,
@@ -210,13 +223,18 @@ function widgetChipsFor(
       onTogglePin: i === 0 && onTogglePin ? () => onTogglePin(wt) : undefined,
       onClick: () => onChipClick?.(wt, item.id),
     };
-    return wt === "uptime" ? (
-      <UptimeCappedChip item={item as UptimeChipData} {...shared} />
-    ) : (
-      <GitHubCappedChip item={item as GitHubChipData} {...shared} />
-    );
+    const node =
+      wt === "uptime" ? (
+        <UptimeCappedChip item={item as UptimeChipData} {...shared} />
+      ) : (
+        <GitHubCappedChip item={item as GitHubChipData} {...shared} />
+      );
+    return { key, node, rotateSlot };
   });
 }
+
+/** Monitors or workflow runs on the rail at once. Not a setting. */
+const CAPPED_WIDGET_SLOTS = 4;
 
 /** Round-robin interleave across buckets:
  *  bucket0[0], bucket1[0], bucket2[0], bucket0[1], bucket1[1], ... */
@@ -321,9 +339,10 @@ export default function ScrollrTicker({
             chipColorMode,
             onTogglePin,
             onChipClick,
+            cycles,
           });
-          chipsForWidget.forEach((node, i) =>
-            bucket.push(wrap(`${wt}-chip-${i}`, node)),
+          chipsForWidget.forEach(({ key, node, rotateSlot }) =>
+            bucket.push(wrap(key, node, rotateSlot)),
           );
           buckets.push(bucket);
         }
@@ -558,7 +577,7 @@ export default function ScrollrTicker({
           onChipClick,
           pinned: true,
         });
-        pinnedChips.forEach((node, i) =>
+        pinnedChips.forEach(({ node }, i) =>
           target.push(<Fragment key={`pinned-${wt}-${i}`}>{node}</Fragment>),
         );
       }

--- a/desktop/src/components/chips/RssChip.tsx
+++ b/desktop/src/components/chips/RssChip.tsx
@@ -21,6 +21,12 @@ interface RssChipProps {
    * cap the number that explains why five are showing and not thirty.
    */
   feedCountToday?: number;
+  /**
+   * The longest headline this chip will ever be asked to show, when it is
+   * a rotating slot. Rendered as a second hidden sizer so the headline
+   * column holds its width across swaps. Fixed chips leave it unset.
+   */
+  reserveTitle?: string;
   onClick?: () => void;
 }
 
@@ -62,6 +68,7 @@ const RssChip = memo(
     colorMode = "widget",
     accent,
     feedCountToday,
+    reserveTitle,
     onClick,
   }: RssChipProps) {
     const c = getChipColors(colorMode, "rss");
@@ -140,6 +147,16 @@ const RssChip = memo(
             >
               {title}
             </span>
+            {/* A rotating slot also sizes to the longest headline it will
+                ever hold, so a swap cannot widen or narrow the chip. */}
+            {reserveTitle && reserveTitle !== title && (
+              <span
+                aria-hidden
+                className="invisible col-start-2 row-start-1 h-0 overflow-hidden whitespace-nowrap px-2.5 font-sans text-[13px] font-semibold"
+              >
+                {reserveTitle}
+              </span>
+            )}
             <span ref={cellRef} className="col-start-2 row-span-full flex min-w-0 items-center px-2.5">
               <span
                 data-testid="headline-block"
@@ -162,11 +179,21 @@ const RssChip = memo(
             </span>
           </>
         ) : (
-          <span className="col-start-2 row-start-1 flex min-w-0 items-center px-2.5">
-            <span className={clsx("min-w-0 truncate text-left font-sans text-[13px] font-semibold", stale ? "text-fg/55" : "text-fg")}>
-              {title}
+          <>
+            {reserveTitle && reserveTitle !== title && (
+              <span
+                aria-hidden
+                className="invisible col-start-2 row-start-1 h-0 overflow-hidden whitespace-nowrap px-2.5 font-sans text-[13px] font-semibold"
+              >
+                {reserveTitle}
+              </span>
+            )}
+            <span className="col-start-2 row-start-1 flex min-w-0 items-center px-2.5">
+              <span className={clsx("min-w-0 truncate text-left font-sans text-[13px] font-semibold", stale ? "text-fg/55" : "text-fg")}>
+                {title}
+              </span>
             </span>
-          </span>
+          </>
         )}
 
         <span
@@ -187,6 +214,7 @@ const RssChip = memo(
     prev.colorMode === next.colorMode &&
     prev.accent === next.accent &&
     prev.feedCountToday === next.feedCountToday &&
+    prev.reserveTitle === next.reserveTitle &&
     prev.onClick === next.onClick &&
     prev.item.guid === next.item.guid &&
     prev.item.feed_url === next.item.feed_url &&

--- a/desktop/src/datawidgets/finance/ticker.tsx
+++ b/desktop/src/datawidgets/finance/ticker.tsx
@@ -2,31 +2,44 @@ import type { Trade } from "../../types";
 import TradeChip from "../../components/chips/TradeChip";
 import { chipUrlForFinance } from "../../utils/chipUrl";
 import type { TickerChip, TickerContext, TickerSource } from "../ticker";
-import { scopedRows } from "../ticker";
-import { selectFinanceForTicker } from "./view";
+import { scopedRows, rotateSlots } from "../ticker";
+import { selectFinanceForTicker, TICKER_FINANCE_SLOTS } from "./view";
 
 /**
  * Finance ticker chips.
  *
- * Display prefs: `defaultSort` affects both feed and ticker (universal
- * sort).
+ * Independent of the feed page: the pool is the widget's watchlist in
+ * the order the user built it, rotating through a fixed number of slots.
+ * A list of three shows three; a list of thirty still shows four and
+ * every symbol comes round. The chip is fixed-width, so a slot needs no
+ * reservation to hold its size across swaps.
  */
 export const financeTickerSource: TickerSource = {
   chips(raw: unknown, ctx: TickerContext): TickerChip[] {
-    const prefs = ctx.widgetDisplay?.finance;
-    if (!prefs) return [];
-
     const rows = scopedRows<Trade>(raw, ctx);
-    return selectFinanceForTicker(rows, prefs).map((trade) => ({
-      key: `fin-${trade.symbol}`,
+    const config = ctx.dashboard?.widgets?.find((c) => c.widget_type === ctx.tab)?.config as
+      | { symbols?: unknown }
+      | undefined;
+    const watchlist = Array.isArray(config?.symbols)
+      ? config.symbols.filter((s): s is string => typeof s === "string")
+      : [];
+    const slots = rotateSlots(
+      selectFinanceForTicker(rows, watchlist),
+      TICKER_FINANCE_SLOTS,
+      ctx.cycles ?? {},
+      `fin-${ctx.tab}`,
+      (t) => t.symbol,
+      () => undefined,
+    );
+    return slots.map(({ key, item: trade, rotateSlot }) => ({
+      key,
+      rotateSlot,
       node: (
         <TradeChip
           trade={trade}
           comfort={ctx.comfort}
           colorMode={ctx.chipColorMode}
-          onClick={() =>
-            ctx.onChipClick?.("finance", trade.symbol, chipUrlForFinance(trade))
-          }
+          onClick={() => ctx.onChipClick?.("finance", trade.symbol, chipUrlForFinance(trade))}
         />
       ),
     }));

--- a/desktop/src/datawidgets/finance/view.test.ts
+++ b/desktop/src/datawidgets/finance/view.test.ts
@@ -255,38 +255,20 @@ describe("applyFinancePipeline", () => {
 // ── selectFinanceForTicker ──────────────────────────────────────
 
 describe("selectFinanceForTicker", () => {
-  it("applies defaultSort=alpha from prefs", () => {
-    const trades = [mk({ symbol: "C" }), mk({ symbol: "A" }), mk({ symbol: "B" })];
-    const result = selectFinanceForTicker(trades, { ...DEFAULT_PREFS, defaultSort: "alpha" });
-    expect(result.map((t) => t.symbol)).toEqual(["A", "B", "C"]);
+  it("orders by the watchlist as the user built it, not by any sort", () => {
+    const trades = [mk({ symbol: "C", price: 1 }), mk({ symbol: "A", price: 30 }), mk({ symbol: "B", price: 20 })];
+    expect(selectFinanceForTicker(trades, ["B", "C", "A"]).map((t) => t.symbol)).toEqual(["B", "C", "A"]);
   });
 
-  it("applies defaultSort=price from prefs", () => {
-    const trades = [
-      mk({ symbol: "A", price: 10 }),
-      mk({ symbol: "B", price: 30 }),
-      mk({ symbol: "C", price: 20 }),
-    ];
-    const result = selectFinanceForTicker(trades, { ...DEFAULT_PREFS, defaultSort: "price" });
-    expect(result.map((t) => t.symbol)).toEqual(["B", "C", "A"]);
+  it("drops nothing the watchlist names but the payload lacks, silently", () => {
+    const trades = [mk({ symbol: "A" })];
+    expect(selectFinanceForTicker(trades, ["Z", "A"]).map((t) => t.symbol)).toEqual(["A"]);
   });
 
-  it("applies defaultSort=change from prefs", () => {
-    const trades = [
-      mk({ symbol: "A", percentage_change: -2 }),
-      mk({ symbol: "B", percentage_change: 5 }),
-      mk({ symbol: "C", percentage_change: 1 }),
-    ];
-    const result = selectFinanceForTicker(trades, { ...DEFAULT_PREFS, defaultSort: "change" });
-    expect(result.map((t) => t.symbol)).toEqual(["B", "C", "A"]);
-  });
-
-  it("applies defaultSort=updated from prefs", () => {
-    const trades = [
-      mk({ symbol: "A", last_updated: "2026-01-01T00:00:00Z" }),
-      mk({ symbol: "B", last_updated: "2026-06-01T00:00:00Z" }),
-    ];
-    const result = selectFinanceForTicker(trades, { ...DEFAULT_PREFS, defaultSort: "updated" });
-    expect(result.map((t) => t.symbol)).toEqual(["B", "A"]);
+  it("trails unlisted rows alphabetically so a legacy widget still shows everything", () => {
+    const trades = [mk({ symbol: "Z" }), mk({ symbol: "M" }), mk({ symbol: "A" })];
+    expect(selectFinanceForTicker(trades, ["M"]).map((t) => t.symbol)).toEqual(["M", "A", "Z"]);
+    expect(selectFinanceForTicker(trades, []).map((t) => t.symbol)).toEqual(["A", "M", "Z"]);
   });
 });
+

--- a/desktop/src/datawidgets/finance/view.ts
+++ b/desktop/src/datawidgets/finance/view.ts
@@ -142,15 +142,27 @@ export function selectStockView(
 // ── Pure: selector for the ticker ────────────────────────────────
 
 /**
- * Baseline pipeline used by the ticker: applies the user's `defaultSort`
- * from Display prefs. Ticker does not expose interactive filters.
+ * Symbols on the rail at once. Beyond this the watchlist rotates through
+ * the same four positions one lap at a time, so a list of three and a
+ * list of thirty take the same width. Not a setting.
  */
-export function selectFinanceForTicker(
-  trades: Trade[],
-  prefs: FinanceDisplayPrefs,
-): Trade[] {
-  const sortKey: FinanceSortKey = prefs.defaultSort ?? "alpha";
-  return sortTrades(trades, sortKey);
+export const TICKER_FINANCE_SLOTS = 4;
+
+/**
+ * The ticker's pool: the widget's watchlist, in the order the user built
+ * it. Independent of the feed page -- its sort is about reading a list,
+ * and re-sorting a list must not rearrange the rail. A symbol the
+ * watchlist names but the payload lacks is simply absent; a payload row
+ * the watchlist does not name trails, alphabetically, so a legacy widget
+ * with no symbol list still shows everything.
+ */
+export function selectFinanceForTicker(trades: Trade[], watchlist: readonly string[]): Trade[] {
+  const rank = new Map(watchlist.map((s, i) => [s, i] as const));
+  const listed = trades
+    .filter((t) => rank.has(t.symbol))
+    .sort((a, b) => rank.get(a.symbol)! - rank.get(b.symbol)!);
+  const rest = sortTrades(trades.filter((t) => !rank.has(t.symbol)), "alpha");
+  return [...listed, ...rest];
 }
 
 // ── Pipeline for FeedTab ─────────────────────────────────────────

--- a/desktop/src/datawidgets/predictions/ticker.tsx
+++ b/desktop/src/datawidgets/predictions/ticker.tsx
@@ -1,36 +1,40 @@
 import type { Prediction } from "../../types";
 import PredictionChip from "../../components/chips/PredictionChip";
 import type { TickerChip, TickerContext, TickerSource } from "../ticker";
-import { scopedRows } from "../ticker";
-import { selectPredictionsForTicker } from "./view";
+import { scopedRows, rotateSlots } from "../ticker";
+import { selectPredictionsForTicker, TICKER_PREDICTIONS_SLOTS } from "./view";
 
 /**
  * Prediction-market ticker chips.
  *
- * Implied probability + ▲/▼ delta is the "heartbeat"; the universal
- * `defaultSort` (movers/volume/closing) governs ordering on both surfaces.
- * v1.1.4 scoping: starred markets only when the watchlist has any, otherwise
- * the selector falls back to the top rank-1 movers — never the whole
- * ingested universe.
+ * v1.1.4 scoping stays: starred markets only when the watchlist has any,
+ * otherwise the top rank-1 movers -- never the whole ingested universe.
+ * The feed page's sort no longer reaches the rail; the pool is ordered by
+ * one fixed rule and rotates through a fixed number of slots. The chip
+ * is fixed-width, so a slot needs no reservation.
  */
 export const predictionsTickerSource: TickerSource = {
   chips(raw: unknown, ctx: TickerContext): TickerChip[] {
-    const prefs = ctx.widgetDisplay?.predictions;
-    if (!prefs) return [];
-
     const rows = scopedRows<Prediction>(raw, ctx);
-    return selectPredictionsForTicker(rows, prefs, ctx.predictionsWatchlist).map(
-      (p) => ({
-        key: `pred-${p.id}`,
-        node: (
-          <PredictionChip
-            prediction={p}
-            comfort={ctx.comfort}
-            colorMode={ctx.chipColorMode}
-            onClick={() => ctx.onChipClick?.("predictions", p.id, p.link)}
-          />
-        ),
-      }),
+    const slots = rotateSlots(
+      selectPredictionsForTicker(rows, ctx.predictionsWatchlist),
+      TICKER_PREDICTIONS_SLOTS,
+      ctx.cycles ?? {},
+      `pred-${ctx.tab}`,
+      (p) => p.id,
+      () => undefined,
     );
+    return slots.map(({ key, item: p, rotateSlot }) => ({
+      key,
+      rotateSlot,
+      node: (
+        <PredictionChip
+          prediction={p}
+          comfort={ctx.comfort}
+          colorMode={ctx.chipColorMode}
+          onClick={() => ctx.onChipClick?.("predictions", p.id, p.link)}
+        />
+      ),
+    }));
   },
 };

--- a/desktop/src/datawidgets/predictions/view.test.ts
+++ b/desktop/src/datawidgets/predictions/view.test.ts
@@ -325,30 +325,13 @@ describe("groupEventsByCategory", () => {
 // ── selectPredictionsForTicker ──────────────────────────────────
 
 describe("selectPredictionsForTicker", () => {
-  it("applies defaultSort=movers from prefs", () => {
-    const items = [
-      mk({ id: "A", yes_price: 52, prev_yes_price: 50 }),
-      mk({ id: "B", yes_price: 30, prev_yes_price: 50 }),
-      mk({ id: "C", yes_price: 55, prev_yes_price: 50 }),
-    ];
-    const result = selectPredictionsForTicker(items, {
-      ...DEFAULT_PREFS,
-      defaultSort: "movers",
-    });
-    expect(result.map((p) => p.id)).toEqual(["B", "C", "A"]);
-  });
-
-  it("applies defaultSort=trending from prefs", () => {
+  it("orders the fallback rail by trailing volume, whatever the feed page's sort is", () => {
     const items = [
       mk({ id: "A", volume_24h: 10 }),
       mk({ id: "B", volume_24h: 30 }),
       mk({ id: "C", volume_24h: 20 }),
     ];
-    const result = selectPredictionsForTicker(items, {
-      ...DEFAULT_PREFS,
-      defaultSort: "trending",
-    });
-    expect(result.map((p) => p.id)).toEqual(["B", "C", "A"]);
+    expect(selectPredictionsForTicker(items).map((p) => p.id)).toEqual(["B", "C", "A"]);
   });
 
   it("excludes dropped and resolved markets from the fallback rail", () => {
@@ -357,36 +340,11 @@ describe("selectPredictionsForTicker", () => {
       mk({ id: "dead", volume_24h: 999, in_sweep: false }),
       mk({ id: "settled", volume_24h: 500, status: "finalized" }),
     ];
-    const result = selectPredictionsForTicker(items, {
-      ...DEFAULT_PREFS,
-      defaultSort: "trending",
-    });
-    expect(result.map((p) => p.id)).toEqual(["live"]);
+    expect(selectPredictionsForTicker(items).map((p) => p.id)).toEqual(["live"]);
   });
 
-  it("applies defaultSort=alpha from prefs", () => {
-    const items = [
-      mk({ id: "3", title: "C" }),
-      mk({ id: "1", title: "A" }),
-      mk({ id: "2", title: "B" }),
-    ];
-    const result = selectPredictionsForTicker(items, {
-      ...DEFAULT_PREFS,
-      defaultSort: "alpha",
-    });
-    expect(result.map((p) => p.title)).toEqual(["A", "B", "C"]);
-  });
-
-  it("applies defaultSort=closing from prefs", () => {
-    const items = [
-      mk({ id: "A", close_time: "2026-06-01T00:00:00Z" }),
-      mk({ id: "B", close_time: "2026-01-01T00:00:00Z" }),
-    ];
-    const result = selectPredictionsForTicker(items, {
-      ...DEFAULT_PREFS,
-      defaultSort: "closing",
-    });
-    expect(result.map((p) => p.id)).toEqual(["B", "A"]);
+  it("takes no preferences at all", () => {
+    expect(selectPredictionsForTicker.length).toBeLessThanOrEqual(2);
   });
 });
 
@@ -475,11 +433,7 @@ describe("selectPredictionsForTicker scoping", () => {
       mk({ id: "B", event_rank: 2, volume: 90 }),
       mk({ id: "C", event_rank: 1, volume: 80 }),
     ];
-    const out = selectPredictionsForTicker(
-      items,
-      { ...DEFAULT_PREFS, defaultSort: "trending" },
-      new Set(["B"]),
-    );
+    const out = selectPredictionsForTicker(items, new Set(["B"]));
     expect(out.map((p) => p.id)).toEqual(["B"]);
   });
 
@@ -489,10 +443,7 @@ describe("selectPredictionsForTicker scoping", () => {
       mk({ id: "done", in_sweep: false, status: "settled", result: "no" }),
       mk({ id: "live" }),
     ];
-    const out = selectPredictionsForTicker(
-      items,
-      { ...DEFAULT_PREFS, defaultSort: "trending" },
-      new Set(["gone", "done", "live"]),
+    const out = selectPredictionsForTicker(items, new Set(["gone", "done", "live"]),
     );
     expect(out.map((p) => p.id).sort()).toEqual(["done", "live"]);
   });
@@ -505,10 +456,7 @@ describe("selectPredictionsForTicker scoping", () => {
         volume: 1000 - i,
       }),
     );
-    const out = selectPredictionsForTicker(
-      items,
-      { ...DEFAULT_PREFS, defaultSort: "trending" },
-      new Set(),
+    const out = selectPredictionsForTicker(items, new Set(),
     );
     expect(out.length).toBe(TICKER_FALLBACK_LIMIT);
     expect(out.every((p) => (p.event_rank ?? 1) === 1)).toBe(true);
@@ -517,10 +465,7 @@ describe("selectPredictionsForTicker scoping", () => {
 
   it("treats missing event_rank as rank 1 (pre-backfill rows)", () => {
     const items = [mk({ id: "LEGACY", volume: 5 })];
-    const out = selectPredictionsForTicker(
-      items,
-      { ...DEFAULT_PREFS, defaultSort: "trending" },
-      new Set(),
+    const out = selectPredictionsForTicker(items, new Set(),
     );
     expect(out.map((p) => p.id)).toEqual(["LEGACY"]);
   });

--- a/desktop/src/datawidgets/predictions/view.ts
+++ b/desktop/src/datawidgets/predictions/view.ts
@@ -153,36 +153,35 @@ export function selectLens(
  */
 export const TICKER_FALLBACK_LIMIT = 15;
 
+/** Markets on the rail at once; the rest rotate through these. Not a setting. */
+export const TICKER_PREDICTIONS_SLOTS = 4;
+
 /**
- * Baseline pipeline used by the ticker (v1.1.4 scoping):
- *   - Watchlist non-empty → starred markets only (any event rank).
- *   - Otherwise → the top TICKER_FALLBACK_LIMIT rank-1 legs (one per
- *     event) by the user's `defaultSort`.
+ * The ticker's pool (v1.1.4 scoping, minus the prefs):
+ *   - Watchlist non-empty -> starred markets only (any event rank).
+ *   - Otherwise -> the top TICKER_FALLBACK_LIMIT rank-1 legs (one per event).
+ *
+ * Ordered by trailing volume as one fixed rule rather than the feed
+ * page's sort: the rail is independent of how the list is being read,
+ * and with rotation the order only decides which markets take the slots
+ * first -- every one still comes round.
  */
 export function selectPredictionsForTicker(
   items: Prediction[],
-  prefs: PredictionsDisplayPrefs,
   watchlist?: ReadonlySet<string>,
 ): Prediction[] {
-  const sortKey: PredictionsSortKey = prefs.defaultSort ?? "trending";
   if (watchlist && watchlist.size > 0) {
-    // Starred markets only. Dropped-but-unresolved stars are excluded —
+    // Starred markets only. Dropped-but-unresolved stars are excluded --
     // their frozen price scrolling by forever IS the stale-data bug.
     // Resolved stars stay (final odds are closure, and the resolved-today
     // payload window bounds how long they linger).
     return sortPredictions(
-      items.filter(
-        (p) =>
-          watchlist.has(p.ticker) &&
-          (p.in_sweep !== false || isResolved(p)),
-      ),
-      sortKey,
+      items.filter((p) => watchlist.has(p.ticker) && (p.in_sweep !== false || isResolved(p))),
+      "trending",
     );
   }
-  const primaries = items.filter(
-    (p) => isDisplayable(p) && (p.event_rank ?? 1) === 1,
-  );
-  return sortPredictions(primaries, sortKey).slice(0, TICKER_FALLBACK_LIMIT);
+  const primaries = items.filter((p) => isDisplayable(p) && (p.event_rank ?? 1) === 1);
+  return sortPredictions(primaries, "trending").slice(0, TICKER_FALLBACK_LIMIT);
 }
 
 // ── Pure: event grouping (v1.1.4 Kalshi-style cards) ─────────────

--- a/desktop/src/datawidgets/rss/FeedTab.tsx
+++ b/desktop/src/datawidgets/rss/FeedTab.tsx
@@ -473,7 +473,7 @@ function RssLimitInput({
         // The pill's own pr-2 is chevron room; a field has none.
         "pr-2.5",
       )}
-      title="How many articles to show, here and on the ticker"
+      title="How many articles to show in the feed"
     >
       <Hash
         size={12}

--- a/desktop/src/datawidgets/rss/ticker.tsx
+++ b/desktop/src/datawidgets/rss/ticker.tsx
@@ -3,42 +3,43 @@ import RssChip from "../../components/chips/RssChip";
 import { chipUrlForRss } from "../../utils/chipUrl";
 import type { TickerChip, TickerContext, TickerSource } from "../ticker";
 import { scopedRows } from "../ticker";
-import { selectRssForTicker, getRssDisplayPrefs } from "./view";
+import { selectRssForTicker, arrangeRssSlots } from "./view";
 import { catalogItemById } from "../../marketplace";
 
 /**
  * News/RSS ticker chips.
  *
- * Global Display prefs are merged with THIS widget's config.display override
- * (v1.1.3: the per-widget time window must gate ticker chips exactly like
- * the feed).
+ * Independent of the widget page. The feed's sort, filters, "Show N" and
+ * time window are about reading a list; the rail applies its own horizon
+ * and rotates whatever is eligible through a fixed number of slots. The
+ * user configures nothing here, and a wire that posts thirty articles in
+ * an hour is still three chips.
  */
 export const rssTickerSource: TickerSource = {
   chips(raw: unknown, ctx: TickerContext): TickerChip[] {
-    const prefs = ctx.widgetDisplay?.rss;
-    if (!prefs) return [];
-
-    const merged = getRssDisplayPrefs(prefs, ctx.dashboard, ctx.tab);
     const rows = scopedRows<RssItem>(raw, ctx);
     // The widget's catalog brand colour, as the sports chips take theirs.
     const accent = catalogItemById(ctx.tab)?.hex;
     // Items per feed in the last day, from everything the widget holds --
-    // not just what survives the ticker horizon, since the point is to say
-    // how much the horizon is hiding.
+    // not just what is eligible, since the point is to say how much the
+    // rail is holding back.
     const dayAgo = Date.now() - 86_400_000;
     const perFeed = new Map<string, number>();
     for (const r of rows) {
       const t = new Date(r.published_at ?? r.created_at).getTime();
       if (Number.isFinite(t) && t >= dayAgo) perFeed.set(r.feed_url, (perFeed.get(r.feed_url) ?? 0) + 1);
     }
-    return selectRssForTicker(rows, merged).map((item) => ({
-      key: `rss-${item.id}`,
+    const slots = arrangeRssSlots(selectRssForTicker(rows), ctx.cycles ?? {}, `rss-${ctx.tab}`);
+    return slots.map(({ key, item, rotateSlot, reserveTitle }) => ({
+      key,
+      rotateSlot,
       node: (
         <RssChip
           item={item}
           comfort={ctx.comfort}
           colorMode={ctx.chipColorMode}
           accent={accent}
+          reserveTitle={reserveTitle}
           feedCountToday={perFeed.get(item.feed_url)}
           onClick={() => ctx.onChipClick?.("rss", item.id, chipUrlForRss(item))}
         />

--- a/desktop/src/datawidgets/rss/view.test.ts
+++ b/desktop/src/datawidgets/rss/view.test.ts
@@ -6,8 +6,9 @@ import {
   distinctSourceCount,
   filterByArticleAge,
   TICKER_RSS_HOURS,
-  TICKER_RSS_PER_FEED,
   TICKER_RSS_FLOOR_HOURS,
+  TICKER_RSS_SLOTS,
+  arrangeRssSlots,
 } from "./view";
 import type { RssItem } from "../../types";
 import type { RssDisplayPrefs } from "../../preferences";
@@ -87,19 +88,6 @@ describe("filterByArticleAge", () => {
   it("keeps items with unparseable timestamps visible", () => {
     const weird = { ...mk(1, "a", "not-a-date"), created_at: "also-bad" };
     expect(filterByArticleAge([weird], 1, NOW)).toHaveLength(1);
-  });
-
-  it("applies inside the ticker selector via prefs", () => {
-    const items = [
-      mk(1, "a", hoursAgo(2)),
-      mk(2, "b", hoursAgo(24 * 5)),
-    ];
-    const result = selectRssForTicker(
-      items,
-      { ...DEFAULT_PREFS, maxArticleAgeDays: 2 },
-      NOW,
-    );
-    expect(result.map((i) => i.id)).toEqual([1]);
   });
 
   it("applies inside applyRssPipeline before per-source limiting", () => {
@@ -314,32 +302,6 @@ describe("applyRssPipeline", () => {
 
 // ── selectRssForTicker ──────────────────────────────────────────
 
-describe("selectRssForTicker", () => {
-  it("applies articlesPerSource from prefs", () => {
-    const items = [
-      mk(1, "a"),
-      mk(2, "a"),
-      mk(3, "a"),
-      mk(4, "b"),
-    ];
-    const result = selectRssForTicker(items, { ...DEFAULT_PREFS, articlesPerSource: 2 }, FIXTURE_NOW);
-    expect(result).toHaveLength(3);
-    expect(result.filter((i) => i.source_name === "a")).toHaveLength(2);
-  });
-
-  it("returns all items when articlesPerSource is 0", () => {
-    const items = [mk(1, "a"), mk(2, "a"), mk(3, "b")];
-    const result = selectRssForTicker(items, { ...DEFAULT_PREFS, articlesPerSource: 0 }, FIXTURE_NOW);
-    expect(result).toHaveLength(3);
-  });
-
-  it("preserves input (newest-first) order", () => {
-    const items = [mk(1, "a"), mk(2, "b"), mk(3, "a")];
-    const result = selectRssForTicker(items, { ...DEFAULT_PREFS, articlesPerSource: 10 }, FIXTURE_NOW);
-    expect(result.map((i) => i.id)).toEqual([1, 2, 3]);
-  });
-});
-
 // ── v1.1.1 smart removal: single-source payloads skip the cap ───
 
 describe("single-source smart removal (v1.1.1)", () => {
@@ -349,18 +311,6 @@ describe("single-source smart removal (v1.1.1)", () => {
     expect(distinctSourceCount([])).toBe(0);
     expect(distinctSourceCount([mk(1, "a"), mk(2, "a")])).toBe(1);
     expect(distinctSourceCount([mk(1, "a"), mk(2, "b"), mk(3, "a")])).toBe(2);
-  });
-
-  it("ticker: a single-outlet widget shows its whole feed despite a cap", () => {
-    const items = [mk(1, "bbc"), mk(2, "bbc"), mk(3, "bbc"), mk(4, "bbc")];
-    expect(selectRssForTicker(items, capped, FIXTURE_NOW)).toHaveLength(4);
-  });
-
-  it("ticker: multi-source payloads still balance per source", () => {
-    const items = [mk(1, "a"), mk(2, "a"), mk(3, "a"), mk(4, "b")];
-    const result = selectRssForTicker(items, capped, FIXTURE_NOW);
-    expect(result.filter((i) => i.source_name === "a")).toHaveLength(2);
-    expect(result.filter((i) => i.source_name === "b")).toHaveLength(1);
   });
 
   it("pipeline: single-source ignores the cap and reports nothing hidden", () => {
@@ -398,64 +348,82 @@ describe("selectRssForTicker horizon", () => {
   const ago = (h: number) => new Date(NOW_T - h * 3_600_000).toISOString();
   const feed = "https://sports.yahoo.com/rss/";
 
-  it("keeps only the newest few from the last few hours of a busy feed", () => {
-    const items = Array.from({ length: 40 }, (_, i) => mk(i + 1, "yahoo", ago(i * 0.25), feed)); // one every 15 min
-    const out = selectRssForTicker(items, DEFAULT_PREFS, NOW_T);
-    expect(out).toHaveLength(TICKER_RSS_PER_FEED);
-    expect(out.map((i) => i.id)).toEqual([1, 2, 3, 4, 5]); // the newest, in order
+  it("admits everything inside the window -- the slots do the limiting, not a cap", () => {
+    const items = Array.from({ length: 40 }, (_, i) => mk(i + 1, "yahoo", ago(i * 0.1), feed));
+    expect(selectRssForTicker(items, NOW_T)).toHaveLength(40);
   });
 
   it("drops what is older than the window", () => {
     const items = [mk(1, "a", ago(1), feed), mk(2, "a", ago(TICKER_RSS_HOURS + 1), feed)];
-    expect(selectRssForTicker(items, DEFAULT_PREFS, NOW_T).map((i) => i.id)).toEqual([1]);
+    expect(selectRssForTicker(items, NOW_T).map((i) => i.id)).toEqual([1]);
   });
 
   it("stands the newest item in for a quiet feed", () => {
     const items = [mk(1, "a", ago(30), feed), mk(2, "a", ago(50), feed)];
-    expect(selectRssForTicker(items, DEFAULT_PREFS, NOW_T).map((i) => i.id)).toEqual([1]);
+    expect(selectRssForTicker(items, NOW_T).map((i) => i.id)).toEqual([1]);
   });
 
   it("drops a dead feed rather than floor it: nothing older than 48h", () => {
     const items = [mk(1, "a", ago(TICKER_RSS_FLOOR_HOURS + 1), feed), mk(2, "a", ago(90), feed)];
-    expect(selectRssForTicker(items, DEFAULT_PREFS, NOW_T)).toEqual([]);
+    expect(selectRssForTicker(items, NOW_T)).toEqual([]);
   });
 
   it("floors an item with no readable date, having no reason to call it old", () => {
     const items = [{ ...mk(1, "a", "not-a-date", feed), created_at: "also-bad" }];
-    expect(selectRssForTicker(items, DEFAULT_PREFS, NOW_T).map((i) => i.id)).toEqual([1]);
+    expect(selectRssForTicker(items, NOW_T).map((i) => i.id)).toEqual([1]);
   });
 
-  it("takes the widget's own Show N as the per-feed cap", () => {
-    const items = Array.from({ length: 9 }, (_, i) => mk(i + 1, "a", ago(i * 0.25), feed));
-    const out = selectRssForTicker(items, { ...DEFAULT_PREFS, maxArticles: 2 }, NOW_T);
-    expect(out.map((i) => i.id)).toEqual([1, 2]);
-  });
-
-  it("falls back to the default cap when Show is set to All", () => {
-    const items = Array.from({ length: 9 }, (_, i) => mk(i + 1, "a", ago(i * 0.25), feed));
-    const out = selectRssForTicker(items, { ...DEFAULT_PREFS, maxArticles: 0 }, NOW_T);
-    expect(out).toHaveLength(TICKER_RSS_PER_FEED);
-  });
-
-  it("spends Show N per feed, so the loudest wire cannot take it all", () => {
+  it("interleaves feeds so one wire cannot own the front of the rotation", () => {
     const a = "https://a.example.com/feed", b = "https://b.example.com/feed";
     const items = [
       ...Array.from({ length: 6 }, (_, i) => mk(100 + i, "a", ago(i * 0.1), a)),
-      mk(1, "b", ago(2), b),
+      mk(1, "b", ago(0.05), b),
+      mk(2, "b", ago(2), b),
     ];
-    const out = selectRssForTicker(items, { ...DEFAULT_PREFS, maxArticles: 2, articlesPerSource: 0 }, NOW_T);
-    expect(out.filter((i) => i.feed_url === a)).toHaveLength(2);
-    expect(out.filter((i) => i.feed_url === b)).toHaveLength(1);
+    const out = selectRssForTicker(items, NOW_T).map((i) => i.id);
+    // a's newest (item 100, right now) beats b's (item 1, three minutes
+    // ago), so a leads; then the two feeds alternate, item for item,
+    // rather than a's six running first.
+    expect(out.slice(0, 4)).toEqual([100, 1, 101, 2]);
+    expect(out).toHaveLength(8);
   });
 
-  it("applies per feed, so one wire cannot crowd out another", () => {
-    const a = "https://a.example.com/feed", b = "https://b.example.com/feed";
-    const items = [
-      ...Array.from({ length: 10 }, (_, i) => mk(100 + i, "a", ago(i * 0.1), a)),
-      mk(1, "b", ago(2), b),
-    ];
-    const out = selectRssForTicker(items, { ...DEFAULT_PREFS, articlesPerSource: 0 }, NOW_T);
-    expect(out.filter((i) => i.feed_url === a)).toHaveLength(TICKER_RSS_PER_FEED);
-    expect(out.filter((i) => i.feed_url === b)).toHaveLength(1);
+  it("ignores the feed page's prefs entirely", () => {
+    // No prefs argument exists any more; the rail has one rule.
+    expect(selectRssForTicker.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("arrangeRssSlots", () => {
+  const NOW_T = new Date("2026-09-04T12:00:00Z").getTime();
+  const ago = (h: number) => new Date(NOW_T - h * 3_600_000).toISOString();
+  const feed = "https://www.theguardian.com/world/rss";
+  const titled = (id: number, title: string) => ({ ...mk(id, "g", ago(id * 0.2), feed), title });
+  const pool = [
+    titled(1, "Short one"),
+    titled(2, "A considerably longer headline about something"),
+    titled(3, "Mid-length headline here"),
+    titled(4, "Tiny"),
+    titled(5, "The longest headline of the whole set, by some distance"),
+  ];
+
+  it("keys by id and reserves nothing when the pool fits", () => {
+    const out = arrangeRssSlots(pool.slice(0, 3), {}, "r");
+    expect(out.map((s) => s.key)).toEqual(["r-1", "r-2", "r-3"]);
+    expect(out.every((s) => !s.rotateSlot && !s.reserveTitle)).toBe(true);
+  });
+
+  it("rotates a bigger pool through TICKER_RSS_SLOTS positions", () => {
+    const out = arrangeRssSlots(pool, {}, "r");
+    expect(out).toHaveLength(TICKER_RSS_SLOTS);
+    expect(out.map((s) => s.item.id)).toEqual([1, 2, 3]);
+    expect(arrangeRssSlots(pool, { "r-slot-0": 1 }, "r").map((s) => s.item.id)).toEqual([4, 2, 3]);
+  });
+
+  it("reserves the longest headline in each slot's own class", () => {
+    const [s0, s1, s2] = arrangeRssSlots(pool, {}, "r");
+    expect(s0.reserveTitle).toBe("Tiny".length > "Short one".length ? "Tiny" : "Short one"); // class: 1, 4
+    expect(s1.reserveTitle).toBe("The longest headline of the whole set, by some distance"); // class: 2, 5
+    expect(s2.reserveTitle).toBe("Mid-length headline here"); // class: 3
   });
 });

--- a/desktop/src/datawidgets/rss/view.ts
+++ b/desktop/src/datawidgets/rss/view.ts
@@ -11,6 +11,8 @@
  * sort order) to work on the feed but not the ticker prior to this module.
  */
 import type { RssItem } from "../../types";
+import { rotateSlots } from "../ticker";
+import { plainText } from "../../utils/rssText";
 import { migrateRssDisplay, type RssDisplayPrefs } from "../../preferences";
 
 export type RssSortOrder = "newest" | "oldest";
@@ -92,79 +94,77 @@ export function limitPerSource(items: RssItem[], limit: number): RssItem[] {
  * sort toggle). If those are added later, surface them as arguments here.
  */
 /**
- * The ticker's own horizon for headlines, applied on top of the widget's
- * prefs and never inherited by the widget page.
+ * The ticker's own horizon for headlines. Independent of the widget page:
+ * the feed's sort, source filters, "Show N" and time window are about
+ * reading a list, and none of them reach the rail. The rail has one rule
+ * and the user never configures it.
  *
- * A per-feed news widget put every article in its window on the rail, and
- * the default window is unlimited -- the per-source cap only ever applied
- * to multi-feed widgets. So a Yahoo Sports widget was 297 chips. On the
- * rail a feed now shows its newest TICKER_RSS_PER_FEED items from the last
- * TICKER_RSS_HOURS. A feed with nothing in that window still gets its
- * latest item, provided that item is itself under TICKER_RSS_FLOOR_HOURS
- * old: the floor keeps a QUIET feed represented, not a dead one. The
- * window and cap stop a wire from becoming the whole bar. Same shape the
- * sports ticker got.
+ * Eligible is everything from the last TICKER_RSS_HOURS. A feed with
+ * nothing in that window still gets its latest item, provided that item
+ * is under TICKER_RSS_FLOOR_HOURS old: the floor keeps a QUIET feed
+ * represented, not a dead one. What is eligible then rotates through
+ * TICKER_RSS_SLOTS fixed positions (arrangeRssSlots), so a wire that
+ * posts thirty articles in an hour is still three chips on the bar and
+ * every article still comes round.
  */
 export const TICKER_RSS_HOURS = 6;
-export const TICKER_RSS_PER_FEED = 5;
-/**
- * How stale the floor's one item may be.
- *
- * The floor exists so a quiet feed still has a presence on the rail, not so
- * a dead one does. Past two days an item is not news and the chip is just
- * occupying width; a feed that has said nothing since then says nothing.
- */
 export const TICKER_RSS_FLOOR_HOURS = 48;
+/**
+ * Three headlines on the rail at once. Headline chips are the widest on
+ * the bar (up to the 640 cap) and a news widget is usually one feed, so
+ * three is about the width a league's four game chips take.
+ */
+export const TICKER_RSS_SLOTS = 3;
 
-function onTicker(items: RssItem[], now: number, perFeedCap = TICKER_RSS_PER_FEED): RssItem[] {
-  // `items` arrive newest-first; keep that order within each feed.
+/**
+ * Everything eligible for the rail, newest first but interleaved by feed,
+ * so on a multi-feed widget one loud wire cannot own the front of every
+ * slot's rotation.
+ */
+export function selectRssForTicker(items: RssItem[], now: number = Date.now()): RssItem[] {
+  const sorted = sortRssItems(items, "newest");
   const cutoff = now - TICKER_RSS_HOURS * 3_600_000;
   const floorCutoff = now - TICKER_RSS_FLOOR_HOURS * 3_600_000;
   const perFeed = new Map<string, RssItem[]>();
   const newest = new Map<string, RssItem>();
-  for (const it of items) {
+  for (const it of sorted) {
     const t = new Date(it.published_at ?? it.created_at).getTime();
     // An undated item is treated as current rather than dropped: the feed
     // gave us no reason to think it is old.
     if (!newest.has(it.feed_url) && !(Number.isFinite(t) && t < floorCutoff)) newest.set(it.feed_url, it);
     if (Number.isFinite(t) && t < cutoff) continue;
-    const list = perFeed.get(it.feed_url) ?? [];
-    if (list.length < perFeedCap) list.push(it);
-    perFeed.set(it.feed_url, list);
+    perFeed.set(it.feed_url, [...(perFeed.get(it.feed_url) ?? []), it]);
   }
   for (const [feed, top] of newest) {
     if (!perFeed.has(feed)) perFeed.set(feed, [top]);
   }
-  const keep = new Set<RssItem>();
-  for (const list of perFeed.values()) for (const it of list) keep.add(it);
-  return items.filter((it) => keep.has(it));
+  // Interleave: feeds in order of their newest item, one item from each in turn.
+  const lists = [...perFeed.values()];
+  const out: RssItem[] = [];
+  for (let i = 0; lists.some((l) => i < l.length); i++) {
+    for (const l of lists) if (i < l.length) out.push(l[i]);
+  }
+  return out;
 }
 
-export function selectRssForTicker(
-  items: RssItem[],
-  prefs: RssDisplayPrefs,
-  now: number = Date.now(),
-): RssItem[] {
-  // Age window first (v1.1.3) so the per-source balancer only allocates
-  // slots among articles that are actually eligible to show.
-  const fresh = filterByArticleAge(items, prefs.maxArticleAgeDays ?? 0, now);
-  // The widget's own "Show N" is the cap when it is set. That control is
-  // the answer to "how many of these do I want to see", and the ticker
-  // ignoring it while the feed obeyed it was the surprise -- one widget,
-  // two different numbers. TICKER_RSS_PER_FEED is only the default for
-  // "All", where the rail still needs a bound the feed page does not.
-  //
-  // Per FEED, not per widget: on a multi-feed widget a shared total would
-  // let the loudest wire spend the whole allowance, which is the flood the
-  // horizon exists to stop.
-  const perFeedCap = prefs.maxArticles > 0 ? prefs.maxArticles : TICKER_RSS_PER_FEED;
-  const ordered = onTicker(sortRssItems(fresh, "newest"), now, perFeedCap);
-  // Single-outlet widgets (news_bbc, news_npr, ...) have exactly one
-  // source — a per-source cap there just hides articles for no reason
-  // (v1.1.1 "smart removal"). The balancer only makes sense when
-  // multiple feeds compete for space (Custom RSS, legacy News).
-  if (distinctSourceCount(ordered) <= 1) return ordered;
-  return limitPerSource(ordered, prefs.articlesPerSource);
+/** One rail position for headlines. */
+export interface RssSlot {
+  key: string;
+  item: RssItem;
+  rotateSlot?: string;
+  /** The longest headline this slot will show, so its width holds across swaps. */
+  reserveTitle?: string;
+}
+
+/** Eligible headlines laid out as TICKER_RSS_SLOTS rotating positions. */
+export function arrangeRssSlots(
+  eligible: RssItem[],
+  cycles: Readonly<Record<string, number>>,
+  keyPrefix: string,
+): RssSlot[] {
+  return rotateSlots(eligible, TICKER_RSS_SLOTS, cycles, keyPrefix, (it) => it.id, (cls) =>
+    cls.map((it) => plainText(it.title)).reduce((a, b) => (b.length > a.length ? b : a), ""),
+  ).map((r) => ({ key: r.key, item: r.item, rotateSlot: r.rotateSlot, reserveTitle: r.reserve }));
 }
 
 /** Number of distinct sources present in a payload. Widgets are already

--- a/desktop/src/datawidgets/sports/FeedTab.tsx
+++ b/desktop/src/datawidgets/sports/FeedTab.tsx
@@ -13,7 +13,7 @@
  * and coarse `sports` rows can't exist post-migration-000014.
  */
 import { useState, useMemo, useCallback } from "react";
-import { Trophy, CalendarRange, Layers } from "lucide-react";
+import { Trophy, CalendarRange } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { sportsFullQueryOptions, sportsTeamsOptions } from "../../api/queries";
 import type { TeamInfo } from "../../api/queries";
@@ -292,28 +292,7 @@ function SportsBarControls({
           if (o) setDisplay({ daysBack: o.back, daysAhead: o.ahead });
         }}
       />
-      {/* How many non-favourite games hold a place on the ticker at once;
-          the rest rotate through those places one lap at a time. The
-          favourite is always pinned on top of this. */}
-      <SelectMenu
-        ariaLabel="Games on the ticker at once"
-        icon={Layers}
-        value={String(display.tickerSlots)}
-        options={slotOptions(display.tickerSlots)}
-        onChange={(v) => setDisplay({ tickerSlots: Number(v) })}
-      />
     </>
   );
 }
 
-const SLOT_OPTIONS = [2, 3, 4, 6, 8].map((n) => ({
-  value: String(n),
-  label: `${n} on the bar`,
-}));
-
-/** A stored value outside the menu gets its own row, as the window does. */
-function slotOptions(current: number) {
-  return SLOT_OPTIONS.some((o) => o.value === String(current))
-    ? SLOT_OPTIONS
-    : [...SLOT_OPTIONS, { value: String(current), label: `${current} on the bar` }];
-}

--- a/desktop/src/datawidgets/sports/ticker.tsx
+++ b/desktop/src/datawidgets/sports/ticker.tsx
@@ -7,7 +7,7 @@ import {
   selectSportsForTicker,
   getSportsDisplayConfig,
   arrangeTickerSlots,
-  TICKER_SLOTS_DEFAULT,
+  TICKER_SLOTS,
 } from "./view";
 import { catalogItemById } from "../../marketplace";
 
@@ -40,7 +40,7 @@ export const sportsTickerSource: TickerSource = {
     const slots = arrangeTickerSlots(
       eligible,
       favorites,
-      config.tickerSlots ?? TICKER_SLOTS_DEFAULT,
+      TICKER_SLOTS,
       ctx.cycles ?? {},
       `spo-${ctx.tab}`,
     );

--- a/desktop/src/datawidgets/sports/view.test.ts
+++ b/desktop/src/datawidgets/sports/view.test.ts
@@ -466,15 +466,3 @@ describe("arrangeTickerSlots", () => {
     expect(out.map((s) => s.key)).toEqual(["p-1", "p-2", "p-3", "p-4"]);
   });
 });
-
-describe("normalizeSportsDisplayConfig tickerSlots", () => {
-  it("defaults, rounds and clamps", async () => {
-    const { normalizeSportsDisplayConfig, TICKER_SLOTS_DEFAULT, TICKER_SLOTS_MAX } =
-      await import("./view");
-    expect(normalizeSportsDisplayConfig({}).tickerSlots).toBe(TICKER_SLOTS_DEFAULT);
-    expect(normalizeSportsDisplayConfig({ tickerSlots: 2.6 }).tickerSlots).toBe(3);
-    expect(normalizeSportsDisplayConfig({ tickerSlots: 0 }).tickerSlots).toBe(1);
-    expect(normalizeSportsDisplayConfig({ tickerSlots: 99 }).tickerSlots).toBe(TICKER_SLOTS_MAX);
-    expect(normalizeSportsDisplayConfig({ tickerSlots: "4" }).tickerSlots).toBe(TICKER_SLOTS_DEFAULT);
-  });
-});

--- a/desktop/src/datawidgets/sports/view.ts
+++ b/desktop/src/datawidgets/sports/view.ts
@@ -11,6 +11,7 @@
 import type { Game } from "../../types";
 import { isLive, isCloseGame } from "../../utils/gameHelpers";
 import { teamShortName } from "../../utils/teamShortName";
+import { rotateSlots } from "../ticker";
 import { migrateVenue } from "../../preferences";
 
 // ── Display prefs shape (mirrors server-side widget config.display) ─
@@ -27,31 +28,22 @@ export interface SportsDisplayConfig {
    */
   daysBack?: number;
   daysAhead?: number;
-  /**
-   * Rotating ticker slots for games that are NOT a favourite's. The
-   * horizon decides what is eligible; this decides how many of those are
-   * on the rail at once, with the rest cycling through the same slots one
-   * lap at a time. Favourites are pinned on top of this number, never
-   * counted against it.
-   */
-  tickerSlots?: number;
 }
 
 /** Defaults: yesterday's finals through next week's slate. */
 export const SPORTS_WINDOW_DEFAULTS = { daysBack: 1, daysAhead: 7 } as const;
 
 /**
- * Four non-favourite games at once.
+ * Four non-favourite games on the rail at once; the rest rotate through
+ * those four one lap at a time. Favourites are pinned on top.
  *
- * A full MLB day is ~30 eligible games; four slots means the whole slate
- * comes round in about eight laps, and a league widget stops being able
- * to bury the clock and the weather behind twenty-six chips in a row.
- * Bounded so a misconfigured value cannot either empty the rail or
- * recreate the flood.
+ * Not a setting. A full MLB day is ~30 eligible games and four slots
+ * brings the slate round in about eight laps without a league widget
+ * burying the clock and the weather behind twenty-six chips in a row.
+ * The number is the chip's width and the sport's volume, which the user
+ * should not have to think about; the rail just works.
  */
-export const TICKER_SLOTS_DEFAULT = 4;
-export const TICKER_SLOTS_MIN = 1;
-export const TICKER_SLOTS_MAX = 12;
+export const TICKER_SLOTS = 4;
 
 /**
  * Hard ceiling looking BACK. cleanup_old_games (sports service) deletes
@@ -341,10 +333,6 @@ export function normalizeSportsDisplayConfig(
       legacyUpcoming === "off" ? 0 : SPORTS_WINDOW_DEFAULTS.daysAhead,
       SPORTS_WINDOW_MAX_DAYS_AHEAD,
     ),
-    tickerSlots:
-      typeof obj.tickerSlots === "number" && Number.isFinite(obj.tickerSlots)
-        ? Math.min(TICKER_SLOTS_MAX, Math.max(TICKER_SLOTS_MIN, Math.round(obj.tickerSlots)))
-        : TICKER_SLOTS_DEFAULT,
   };
 }
 
@@ -371,19 +359,8 @@ export interface TickerSlot {
  * Favourites are pinned: every one of them is on the rail, keyed by the
  * game, exempt from the count. Everything else goes into a pool in the
  * display order (live and close first, then live, soonest upcoming,
- * newest finals) and `slots` positions cycle through it.
- *
- * Each slot owns a residue class of the pool -- slot i shows pool[i],
- * then pool[i + slots], then pool[i + 2·slots] -- advancing once per
- * lap. No coordination between slots is needed for every game to come
- * round, which matters because the slots leave the viewport at
- * different moments and so have different cycle counts. The reservation
- * is per class too: a slot reserves the widest names IT will show, not
- * the widest in the league, so the whitespace cost is only what its own
- * rotation actually needs.
- *
- * When the pool fits in the slots nothing rotates and the games are keyed
- * by id like any fixed chip.
+ * newest finals) and rotateSlots cycles the slots through it. The
+ * reservation is the widest short names in each slot's own class.
  */
 export function arrangeTickerSlots(
   eligible: Game[],
@@ -398,28 +375,14 @@ export function arrangeTickerSlots(
     const fav = favoriteTeams.has(g.home_team_name) || favoriteTeams.has(g.away_team_name);
     (fav ? pinned : pool).push(g);
   }
-  const forGame = (g: Game): TickerSlot => ({ key: `${keyPrefix}-${g.id}`, game: g });
-  if (pool.length <= slots) return [...pinned.map(forGame), ...pool.map(forGame)];
-
-  const k = Math.max(1, slots);
-  const rotating: TickerSlot[] = [];
-  for (let i = 0; i < k; i++) {
-    const cls = pool.filter((_, idx) => idx % k === i);
-    if (cls.length === 0) continue;
-    const slotKey = `${keyPrefix}-slot-${i}`;
-    const turn = cycles[slotKey] ?? 0;
-    const game = cls[turn % cls.length];
-    const widest = (pick: (g: Game) => string) =>
-      cls.map((g) => teamShortName(g.league, pick(g))).reduce((a, b) => (b.length > a.length ? b : a), "");
-    rotating.push({
-      key: slotKey,
-      game,
-      rotateSlot: slotKey,
-      reserveNames: {
-        away: widest((g) => g.away_team_name),
-        home: widest((g) => g.home_team_name),
-      },
-    });
-  }
-  return [...pinned.map(forGame), ...rotating];
+  const widest = (cls: Game[], pick: (g: Game) => string) =>
+    cls.map((g) => teamShortName(g.league, pick(g))).reduce((a, b) => (b.length > a.length ? b : a), "");
+  const rotating = rotateSlots(pool, slots, cycles, keyPrefix, (g) => g.id, (cls) => ({
+    away: widest(cls, (g) => g.away_team_name),
+    home: widest(cls, (g) => g.home_team_name),
+  }));
+  return [
+    ...pinned.map((g) => ({ key: `${keyPrefix}-${g.id}`, game: g })),
+    ...rotating.map((r) => ({ key: r.key, game: r.item, rotateSlot: r.rotateSlot, reserveNames: r.reserve })),
+  ];
 }

--- a/desktop/src/datawidgets/ticker.test.ts
+++ b/desktop/src/datawidgets/ticker.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The one rotation every flooding source shares. Sports and news test
+ * their own reservations; this covers the arithmetic with none.
+ */
+import { describe, it, expect } from "vitest";
+import { rotateSlots } from "./ticker";
+
+const ids = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `s${i + 1}` }));
+const run = (n: number, slots: number, cycles: Record<string, number> = {}) =>
+  rotateSlots(ids(n), slots, cycles, "p", (x) => x.id, () => undefined);
+
+describe("rotateSlots", () => {
+  it("keys every item by id and rotates nothing when the pool fits", () => {
+    const out = run(3, 4);
+    expect(out.map((s) => s.key)).toEqual(["p-s1", "p-s2", "p-s3"]);
+    expect(out.every((s) => s.rotateSlot === undefined)).toBe(true);
+  });
+
+  it("rotates exactly at the boundary: slots + 1 items become slots positions", () => {
+    expect(run(4, 4)).toHaveLength(4);
+    const out = run(5, 4);
+    expect(out).toHaveLength(4);
+    expect(out.map((s) => s.rotateSlot)).toEqual(["p-slot-0", "p-slot-1", "p-slot-2", "p-slot-3"]);
+  });
+
+  it("walks each slot through its own residue class on its own count", () => {
+    const at = (c: Record<string, number>) => run(7, 3, c).map((s) => s.item.id);
+    expect(at({})).toEqual(["s1", "s2", "s3"]);
+    expect(at({ "p-slot-0": 1 })).toEqual(["s4", "s2", "s3"]);
+    expect(at({ "p-slot-0": 2, "p-slot-2": 1 })).toEqual(["s7", "s2", "s6"]);
+    expect(at({ "p-slot-0": 3 })).toEqual(["s1", "s2", "s3"]); // wrapped: class of 3
+  });
+
+  it("is what 'add to the watchlist and it rotates' means", () => {
+    // Three symbols: all shown. Add a fourth: shown. Add a fifth: rotation.
+    expect(run(3, 4).map((s) => s.item.id)).toEqual(["s1", "s2", "s3"]);
+    expect(run(4, 4).map((s) => s.item.id)).toEqual(["s1", "s2", "s3", "s4"]);
+    const five = run(5, 4);
+    expect(five.map((s) => s.item.id)).toEqual(["s1", "s2", "s3", "s4"]);
+    expect(run(5, 4, { "p-slot-0": 1 }).map((s) => s.item.id)).toEqual(["s5", "s2", "s3", "s4"]);
+  });
+
+  it("hands each slot's class to the reserve function", () => {
+    const seen: string[][] = [];
+    rotateSlots(ids(5), 2, {}, "p", (x) => x.id, (cls) => { seen.push(cls.map((x) => x.id)); return null; });
+    expect(seen).toEqual([["s1", "s3", "s5"], ["s2", "s4"]]);
+  });
+});

--- a/desktop/src/datawidgets/ticker.ts
+++ b/desktop/src/datawidgets/ticker.ts
@@ -70,6 +70,59 @@ export interface TickerSource {
   chips(raw: unknown, ctx: TickerContext): TickerChip[];
 }
 
+/** One rotating position on the rail. */
+export interface RotatingSlot<T, R> {
+  /** Stable key; the slot keeps it while its item changes. */
+  key: string;
+  item: T;
+  /** Present on slots that rotate; absent when the pool fit and nothing does. */
+  rotateSlot?: string;
+  /** What the chip must reserve so no item in this slot's class resizes it. */
+  reserve?: R;
+}
+
+/**
+ * Cycle a pool through a fixed number of slots, one step per lap.
+ *
+ * Shared by every source that can produce more chips than a bar should
+ * hold at once. The horizon decides what is eligible; this decides how
+ * many are on the rail, and the rest come round instead of being dropped.
+ * The user configures none of it -- the number is the source's own
+ * judgement of its chip width and its typical volume, and the rail just
+ * works.
+ *
+ * Each slot owns a residue class of the pool: slot i shows pool[i], then
+ * pool[i+k], then pool[i+2k], advancing when ITS cycle count does. Slots
+ * leave the viewport at different moments, so each has its own count and
+ * none of them need to agree for every item to come round. `reserve` is
+ * computed over the class, not the whole pool, so a slot only reserves
+ * the width it will actually use.
+ *
+ * When the pool fits, nothing rotates and every item is keyed by `id`.
+ */
+export function rotateSlots<T, R>(
+  pool: T[],
+  slots: number,
+  cycles: Readonly<Record<string, number>>,
+  keyPrefix: string,
+  id: (item: T) => string | number,
+  reserve: (cls: T[]) => R,
+): RotatingSlot<T, R>[] {
+  if (pool.length <= slots) {
+    return pool.map((item) => ({ key: `${keyPrefix}-${id(item)}`, item }));
+  }
+  const k = Math.max(1, slots);
+  const out: RotatingSlot<T, R>[] = [];
+  for (let i = 0; i < k; i++) {
+    const cls = pool.filter((_, idx) => idx % k === i);
+    if (cls.length === 0) continue;
+    const slotKey = `${keyPrefix}-slot-${i}`;
+    const turn = cycles[slotKey] ?? 0;
+    out.push({ key: slotKey, item: cls[turn % cls.length], rotateSlot: slotKey, reserve: reserve(cls) });
+  }
+  return out;
+}
+
 /**
  * Narrow a raw payload to this widget's own rows.
  *

--- a/desktop/src/datawidgets/tickerRegistry.test.ts
+++ b/desktop/src/datawidgets/tickerRegistry.test.ts
@@ -43,9 +43,11 @@ describe("finance chips", () => {
     { symbol: "MSFT", price: 410.5, direction: "down" as const },
   ];
 
-  it("builds one keyed chip per trade", () => {
+  it("builds one keyed chip per trade, keyed by widget and symbol", () => {
     const chips = TICKER_SOURCES["finance"]!.chips(trades, ctx());
-    expect(chips.map((c) => c.key)).toEqual(["fin-AAPL", "fin-MSFT"]);
+    // The widget id is in the key so two finance widgets sharing a symbol
+    // never collide, and a rotating slot's key survives a swap.
+    expect(chips.map((c) => c.key.replace(/^fin-.*-(?=[A-Z]+$)/, "fin-"))).toEqual(["fin-AAPL", "fin-MSFT"]);
     expect(chips[0].node).toBeTruthy();
   });
 
@@ -56,12 +58,12 @@ describe("finance chips", () => {
     expect(source.chips({ not: "an array" }, ctx())).toEqual([]);
   });
 
-  it("renders nothing when display prefs are missing", () => {
+  it("renders with no display prefs at all: the rail is independent of the feed page", () => {
     const chips = TICKER_SOURCES["finance"]!.chips(
       trades,
       ctx({ widgetDisplay: undefined }),
     );
-    expect(chips).toEqual([]);
+    expect(chips).toHaveLength(2);
   });
 });
 

--- a/desktop/src/hooks/useSportsConfig.ts
+++ b/desktop/src/hooks/useSportsConfig.ts
@@ -15,7 +15,6 @@ import { useShellData } from "../shell-context";
 import {
   normalizeSportsDisplayConfig,
   SPORTS_WINDOW_DEFAULTS,
-  TICKER_SLOTS_DEFAULT,
 } from "../datawidgets/sports/view";
 
 export interface FavoriteTeam {
@@ -27,8 +26,6 @@ export interface SportsDisplayPrefs {
   /** Day window (v1.1.3 Time Controls) — see SportsDisplayConfig. */
   daysBack: number;
   daysAhead: number;
-  /** Rotating ticker slots for non-favourite games — see SportsDisplayConfig. */
-  tickerSlots: number;
 }
 
 export interface SportsConfig {
@@ -40,7 +37,6 @@ export interface SportsConfig {
 const DEFAULT_DISPLAY: SportsDisplayPrefs = {
   daysBack: SPORTS_WINDOW_DEFAULTS.daysBack,
   daysAhead: SPORTS_WINDOW_DEFAULTS.daysAhead,
-  tickerSlots: TICKER_SLOTS_DEFAULT,
 };
 
 export function useSportsConfig(widgetType: string = "sports") {
@@ -63,7 +59,6 @@ export function useSportsConfig(widgetType: string = "sports") {
       display: {
         daysBack: normalizedDisplay.daysBack ?? DEFAULT_DISPLAY.daysBack,
         daysAhead: normalizedDisplay.daysAhead ?? DEFAULT_DISPLAY.daysAhead,
-        tickerSlots: normalizedDisplay.tickerSlots ?? DEFAULT_DISPLAY.tickerSlots,
       },
       favoriteTeams:
         typeof raw.favoriteTeams === "object" && raw.favoriteTeams !== null


### PR DESCRIPTION
Follows #306. The rail becomes independent of every widget page, every flooding source rotates through the same fixed slots, and the one ticker setting added earlier today is removed. Linear: REL-192.

## What changes

**News.** The rail no longer reads anything from the feed page — not the sort, not the source filters, not "Show N", not the time window. It applies its own horizon (last six hours; a quiet feed's latest item stands in if under two days old) and rotates everything eligible through three fixed slots. The per-feed cap is gone because the slots are the bound. On a multi-feed widget the pool is interleaved feed by feed so one loud wire cannot own the front of every slot's rotation. The feed page keeps its own "Show N" for reading the list; it just no longer touches the rail.

**Finance.** The pool is the watchlist in the order the user built it, through four slots. Three symbols show three; a fifth starts them rotating; the rail looks the same at three symbols as at thirty.

**Predictions.** The v1.1.4 scoping stays (stars, else the top movers), ordered by trailing volume as one fixed rule, through four slots.

**Uptime / GitHub.** One chip per item as before, rotating once there are more than four, so a failing monitor still comes round.

**Sports.** The "N on the bar" control and the `tickerSlots` setting behind it (added in #306) are removed. Four slots is a constant. Favourites are still pinned on top.

**Sort decoupling.** Finance and predictions took their rail order from the widget page's sort preference — the same feed-to-ticker leak removed from news. Re-sorting a list never rearranges the bar now.

## One implementation

`rotateSlots<T, R>()` in `datawidgets/ticker.ts` is the whole mechanism: a pool, a slot count, per-slot lap counts, and a reserve computed over each slot's residue class. Sports, news, finance, predictions and the capped utilities are five callers of it. Sports and news pass a reserve because their chips are content-sized; the other three are fixed-width and pass none. `RssChip` gains `reserveTitle` (a second hidden sizer) so a headline slot holds its width across swaps.

Pinned widgets never scroll, so nothing there is ever off screen and nothing rotates; the first slots' items hold.

## Verification

- 678 desktop tests, `tsc --noEmit` clean. New tests cover the generic rotation (boundary at slots+1, residue-class walk, the "add to the watchlist and it rotates" case), the news horizon without a cap, feed interleaving, per-slot headline reservation, and watchlist-order finance.
- Reviewed live on the bar with MLB, NCAA Football, Premier League, UFC, stocks, crypto, the Guardian, predictions and the utilities all enabled.

## Deploy note

Desktop-only. No version bump; rides the next release cut with #305 and #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
