### PR TITLE
docs: ticker chip rules, in two registers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,14 @@ Operational guide for AI coding agents working in this repository.
 
 MyScrollr aggregates financial market data, sports scores, RSS feeds, and Yahoo Fantasy Sports. Tauri desktop app (primary product), React marketing website, Go gateway API, and independent channel services. Infrastructure: PostgreSQL, Redis, Logto (auth), Sequin (CDC), Stripe (billing). Deployed on DigitalOcean Kubernetes (DOKS) with images stored in DigitalOcean Container Registry (DOCR). See `k8s/` for manifests and `.github/workflows/deploy.yml` for the build-and-deploy pipeline.
 
+## Ticker chips
+
+Before building or changing any chip on the ticker (`desktop/src/components/chips/`,
+any `desktop/src/datawidgets/*/ticker.tsx`), read **`docs/CHIP_SPEC.md`** in full and
+follow its build recipe (§12) and review checklist (§13). It is the exact contract:
+geometry, reservations, palette fields, the ticker's horizon/slot/rotation rules, and
+the traps. `docs/CHIP_DESIGN.md` is the short human version.
+
 ## Repository Layout
 
 Monorepo — each component is independently deployable with its own dependencies:

--- a/docs/CHIP_DESIGN.md
+++ b/docs/CHIP_DESIGN.md
@@ -1,284 +1,129 @@
-# Ticker chip design rules
+# How a chip works
 
-*The definitive list. Distilled from the v1.5.0 and v1.5.1 chip redesign (sports,
-finance, news, clock, timer, weather, sysmon, uptime, and the slot rotation), September
-2026. Every rule here was learned by getting it wrong first on the running bar. When a
-new chip is built, it follows this document; when a rule is broken deliberately, the
-reason is written next to the code.*
-
-Still to be rebuilt on these rules: predictions, fantasy, GitHub (REL-184).
+*The short version of the ticker chip rules. Read this first; the exact spec with every
+number, class and file is `docs/CHIP_SPEC.md`. If the two ever disagree, the spec wins.*
 
 ---
 
-## 1. The one rule
+## One rule above all
 
-**Compact is the chip. Detailed is compact plus exactly one row underneath. Nothing in the
-top row moves when the second row appears.**
+**Compact is the chip. Detailed is the same chip with one extra row underneath. Nothing
+on the top row moves.**
 
-Detailed literally shows more; compact shows less and takes less room. That is a real
-trade-off the user makes, not two different layouts. A user must recognise the same chip
-across both modes without re-reading it. The sports chip was rejected twice for breaking
-this before it was written down.
+That's it. If you remember one thing, remember this. A user should be able to switch
+density and recognise every chip instantly, because the only difference is a row of
+extra detail appearing beneath what was already there.
 
-- Top row: 30px in detailed, 28px in compact. Second row: 20px. These are the same on
-  every chip so the rail's rows line up across widgets.
-- The detailed row is never a restatement of the top row. It is **the thing you would
-  otherwise open the app to find** — see §5.
-- A chip that has nothing to add in detailed leaves the row empty rather than inventing
-  content. The utility chips' first detailed pass rendered a taller chip with an empty
-  row and was called "desperately" bad; the fix was real content, not decoration.
+## What a chip looks like
 
-## 2. The grammar
-
-Every chip is the same three-part sentence:
+Every chip is the same sentence, left to right:
 
 ```
-[ tab ] [ content cells … ] [ fixed right cell ]
+[ who ] [ what ] [ the number that changes ]
 ```
 
-- **The tab** names the source: league code, feed name, widget name, or a status cap. It
-  spans both rows. It is *painted* — 18% fill of the widget's colour, text in the colour
-  — because a tinted border and a 6% ground whisper, and a branded chip looked no
-  different from an unbranded one without one place the colour is actually seen.
-- **Content cells** own the flexible middle. They are `minmax(0, max-content)` tracks so
-  the cap can shrink them and their text truncates; plain `max-content` tracks cannot
-  shrink at all and the cap sliced off the *last* cell instead ("PPD" rendered as "PPI").
-- **The fixed right cell** holds the one value that changes while the chip is on screen:
-  the game clock, the article age, the monitor's uptime or outage. Keeping it out of the
-  flowing middle is what stops "99.98%" becoming "4m" and dragging the name sideways.
-- **Dividers** between cells are hairlines in the widget's own colour at **45%** —
-  deliberately stronger than the 25% outer border. An outer edge separates the chip from
-  the rail, which is already a big tonal step; an inner rule separates two things sharing
-  a ground, with far less contrast to spend. `border-edge/40` was a near-black line on a
-  near-black ground and made four sysmon metrics read as one continuous sparkline.
-- **Width cap: 640px.** Content-sized up to it, then names truncate. The widest real
-  sports pairing (two 20-character names, every reservation held) is ~575px; the cap
-  exists for the pathological case, not the worst ordinary one.
-- Every palette carries `bg / border / hoverBorder / text / textDim / textFaint / divider
-  / tabBg`. A new chip takes them from `getChipColors`; it does not invent its own.
+- **Who** is a small painted tab: the league, the feed, the widget. It's the one place
+  the chip's colour is actually filled in rather than hinted.
+- **What** is the middle, and it's the part that flexes: team names, a headline, the
+  clocks.
+- **The number that changes** sits in its own box on the right, with a line before it.
+  Game clock, article age, uptime. Boxing it in is what keeps the rest of the chip from
+  shuffling when it ticks.
 
-## 3. Nothing moves
+Cells are separated by thin lines in the chip's own colour, strong enough to see. Chips
+are as wide as their content, up to a limit, and then names get cut short.
 
-The ticker is the one surface where a value is *guaranteed* to change while it is being
-read. Width stability is therefore the first constraint, ahead of density and ahead of
-looks.
+## The bar must never jump
 
-- **Reserve every slot that can change while on screen.** Scores, clocks, deltas, prices,
-  points. A score going 8.3 → 14.9 gains a digit; without a reservation the chip widens
-  and shoves every chip after it along the rail.
-- **Reserve in `ch` for numbers**, which is exact because chips render mono with
-  `tabular-nums`: one `ch` is one digit. Right-align a reserved number — a number growing
-  leftward from a fixed decimal reads as counting; growing rightward reads as drifting.
-- **Reserve with a hidden sizer for proportional text.** A `ch` is only an approximation
-  in a sans face. The headline chip and the rotating name cells stack an invisible copy of
-  the widest string under the visible one in the same grid cell; the cell is as wide as
-  the wider of the two, and both stay `min-w-0` so the cap can still truncate.
-- **Size reservations from real data, per league, per class — never the theoretical
-  ceiling.** A team that breaks 1000 points has bigger problems than a reflow; padding
-  every chip for a case that never happens leaves a visible gap on every chip that does.
-  The sports chip's per-league table (`sportsChipLayout.ts`) was measured from the
-  catalog, and a rotating slot reserves the widest name *it* will show, not the widest in
-  the league.
-- **At the cap, release the reservations.** Once the chip is pinned at 640px nothing can
-  move it, so a reservation buys nothing there and the name gets the empty characters
-  back — the whole name before kickoff, one more character while the score is a digit.
-- **A slot that is sometimes empty still occupies its space.** The live dot is always in
-  the DOM, `invisible` when not live; a chip that gains a dot when the game starts was
-  9px wider live than pre.
-- **Responsive text size must not change width.** The clock scales from 11px to 16px by
-  string length, but the reservation is on the *outer* span at the base size, so the
-  scaled text never shifts the chip.
-- **Prove it by rendering the same fixture pre / live / final side by side.** If the three
-  are not pixel-identical in width, the chip is not done.
+A ticker is the one place where numbers are guaranteed to change while you're looking
+at them. So a chip reserves room for everything that can change before it changes: a
+score that will go from 9 to 10, a clock that will read "Q4 2:14", a name that will be
+swapped for a longer one. The reservation is sized from real data, not a guess, and only
+as big as that league or feed actually needs.
 
-## 4. Text
+The test is simple: put the same chip on screen before the game, during it, and after it.
+If the three aren't exactly the same width, it isn't finished.
 
-- **Mono for data, sans for prose.** Every chip is mono; the headline chip is the one
-  sans-serif thing on the rail, deliberately, because it is the one chip whose content
-  is a sentence.
-- **Sizes that earned their place:** team names 14px against a 20px crest (12px read as
-  a caption under it); scores 15px, a step above the name so the number leads; headline
-  13px semibold; detail rows 10px; tabs 10px bold with 0.08em tracking.
-- **Crests are 20px.** At 12px on a 30px row a crest read as a bullet. ESPN runs ~18px
-  against 12px type for the same reason.
-- **Text on a `<button>` needs `text-left`.** A button centres its text by UA default. A
-  single truncated line fills its width and hides it; a wrapped block centres whichever of
-  its two lines is shorter, which reads as a random indent and was mistaken for a
-  vertical-alignment bug.
-- **Short names are derived by rule, checked against the whole catalog.** Never hand
-  maintained. The rule set (`teamShortName.ts`) is proven over 2,022 real names with
-  duplicate-spelling tolerance; anything within the 20-character budget is left whole,
-  which means the *reservation* is what the chip renders, not an abbreviation.
-- **Tabs longer than twelve characters take their first word.** "The Hollywood Reporter"
-  is a 130px tab; "HOLLYWOOD" is not. "Science and Technology" → "SCI".
-- **Decode entities and strip tags** before measuring or rendering feed text. Feeds send
-  `&#39;` and `<p>`.
-- **Truncate responsively.** At the cap the name gets the score slot's space back, so a
-  chip with no score yet shows more of the name than one mid-game. Be generous: the
-  first version gave back one character and was told so.
+## What the second row is for
 
-## 5. What the detailed row is for
+The extra row answers the question you'd otherwise open the app for. It never repeats the
+top row.
 
-It carries what the user would otherwise open the app to find. It is never something
-derivable from the top row.
-
-| Chip | Compact (the chip) | Detailed adds |
+| Chip | The top row says | The second row adds |
 |---|---|---|
-| Sports | tab · crest + name + score ×2 · clock | league position, record, points per side |
-| Finance | symbol · price · change | intraday sparkline, day-range rail |
-| News | tab · headline · age | the rest of the headline, then the summary in the room left |
-| Clock | label · time (· moon) | date and offset — a zone can be on a different **day** |
-| Timer | label · remaining | a draining bar, live-red in the last minute |
-| Weather | label · icon · temperature | today's range bar; an alert sits under **its** city |
-| Sysmon | label · gauge · value | a real trend, full-bleed, edge to edge |
-| Uptime | cap · name · value | the heartbeat history, full-bleed |
+| Sports | who's playing, the score, the clock | where each team sits in the table |
+| Finance | symbol, price, change | the day's line and range |
+| News | the headline, how old it is | the rest of it, and the summary |
+| Clock | the time in each zone | the date — Tokyo may already be tomorrow |
+| Timer | time remaining | a bar draining down |
+| Weather | city, icon, temperature | today's low and high, or a storm warning |
+| Sysmon | the reading | a live trend line |
+| Uptime | the monitor and its status | its recent heartbeat history |
 
-- **A graphic on the detailed row runs full-bleed.** Divider to divider, no padding. A
-  fixed-width sparkline in a wider cell left a quarter of the cell empty and was the
-  first thing noticed.
-- **The headline's second row is one measured block.** Whether the title fit on one line
-  is *measured* (hidden sizer vs cell width), not counted — eighty characters can be
-  anywhere from 470px to 560px in a proportional face. If it fit, the summary takes line
-  two; if it wrapped, the summary continues after it in whatever room is left. The
-  summary never widens the chip.
-- **When there is nothing to say, say the one true thing.** A feed item with no summary
-  and a short title shows the feed's own volume today ("Dev.to · 34 today") — real, not
-  already on the chip, and the number that explains why five are showing and not thirty.
+If there's a graphic, it fills the whole cell edge to edge. If there's nothing worth
+saying, the row stays empty rather than getting filler.
 
-## 6. Colour
+## Colour
 
-- **The widget's colour is the chip's colour.** Sports chips take their league's catalog
-  brand; news takes the feed's; utilities take their widget token. The old single "sports
-  red" was retired because it was an outdated model, not a decision.
-- **Lift brand colours before tinting.** A navy tints invisibly on a dark surface.
-  `liftForTint` gates on *luminance* (below 60), raising HSL lightness to 0.6 and
-  saturation to 0.55 — gating on lightness alone turned F1's red into salmon.
-- **Red means live or urgent, and nothing else.** A close game brightens the league's
-  *own* colour (70% border, 14% fill, a glow mixed from the same accent). It used to turn
-  the chip live-red, which on a rail where colour means league read as the wrong league —
-  an MLS game wearing La Liga's paint. The muted and accent colour modes have no league
-  colour of their own, so red still says close there.
-- **Semantic borders never use the widget accent.** Alert (warning), down (red), urgent
-  (live) borders have to mean the same thing on every chip.
-- **Status caps are semantic, not branded.** UP / DOWN / MNT and ✓ / ✗ / ● carry their
-  own tones; only the failing state pulses.
-- **Colour modes:** `widget` (brand), `accent` (one shared palette), `muted` (grey). A chip
-  reads its palette from `getChipColors(mode, widget)` and never hardcodes a hue.
+- A chip wears its own colour: the league's, the feed's, the widget's. Dark brand colours
+  are lightened a little so they show on the dark bar.
+- **Red means "live" or "something's wrong", and nothing else.** A close game gets brighter
+  in its own colour; it doesn't turn red. A red monitor is down. A red timer is in its
+  last minute.
+- Dividers, tabs and text all come from one shared palette. A chip never picks its own hue.
 
-## 7. Motion
+## Movement
 
-- **Flash on a change of value, keyed on the *identity* of the thing.** The score flash
-  compares scores only while the game id is unchanged. A rotating slot swapping games
-  looked exactly like somebody scoring until the flash was keyed.
-- **Paused does not pulse.** Motion implies counting.
-- **Only the state that earns attention pulses**: live close games, a down monitor, an
-  in-progress run.
-- **A rotating slot never changes while on screen** (§8).
+- A score flashes once when it changes, and only when *that game's* score changes.
+- Things that are paused don't pulse. Only things that need your attention do: a close
+  live game, a down monitor, a build in progress.
 
-## 8. What is on the rail
+## What goes on the bar
 
-The rail is not the feed. It has one rule per source and the user configures none of it.
+The bar isn't the feed. It has one rule per kind of thing, and there are no settings for
+it. Nothing on the ticker can be misconfigured because nothing on it is configured.
 
-1. **A horizon decides what is eligible.** Stated as a rule, not a count, so it breathes:
-   sports keeps live games always, upcoming within 24h, finals within 18h of kickoff;
-   news keeps the last 6h; finance and predictions keep the watchlist.
-2. **A floor keeps a quiet source represented, not a dead one.** A league with nothing
-   near shows its next fixture if it is within 7 days; a quiet feed shows its latest item
-   if it is under 48h old. Past that, absence is the honest state.
-3. **Fixed slots decide how many are on the bar at once.** Sports 4, news 3, finance 4,
-   predictions 4, capped utilities 4. These are constants chosen from the chip's width
-   and the source's typical volume — a busy MLB night is four chips, not thirty — and
-   they are *not settings*. The one ticker control ever added ("N on the bar") was
-   removed the same day: nothing on the ticker is user-configured, so nothing on it can
-   be misconfigured.
-4. **Everything eligible rotates through the slots; nothing is dropped.** A cap that
-   drops games was the obvious fix and the wrong one — everything eligible is worth
-   seeing, just not all at once.
-5. **Favourites are pinned on top of the count**, never against it.
-6. **A slot advances only once every instance of it has left the viewport.** The marquee
-   renders an original and a clone one track-length apart; "off screen" means both.
-   Rotation is once per lap, so a chip never changes under the reader's eyes.
-7. **Each slot owns a residue class of the pool** (slot *i* shows pool[i], pool[i+k], …)
-   with its own lap count. Slots leave the screen at different moments and need no
-   coordination for every item to come round.
-8. **A slot reserves the widest content in its own class** (§3). A swap cannot resize
-   the chip, and the rail's total width never changes mid-scroll.
-9. **Multi-feed sources interleave** so one loud wire cannot own the front of every
-   slot's rotation.
-10. **The rail is independent of the widget page.** Sort, filter, "Show N" and time
-    window are about reading a list; re-sorting a list must never rearrange the bar.
-11. **Pinned widgets never scroll, so nothing there rotates.** The first slots' items
-    hold.
+1. **A time window decides what's eligible.** Live games always; games starting within a
+   day; results from the last eighteen hours; headlines from the last six hours; your
+   watchlist.
+2. **A quiet source still gets one chip** — its next fixture, its latest headline — as
+   long as that isn't stale. A dead source shows nothing.
+3. **Each kind of thing gets a fixed number of places.** Four games per league, three
+   headlines, four symbols. Those numbers are chosen once, from how wide the chip is and
+   how much that source produces.
+4. **Everything eligible takes turns.** Nothing is dropped. A busy baseball night is four
+   chips, and every game still comes round.
+5. **Your favourite team is always on**, on top of those four.
+6. **A chip only swaps its content while it's off screen.** Never under your eyes.
+7. **The bar doesn't care how you sorted the list.** Sorting and filtering are for reading
+   the widget page; they don't rearrange the ticker.
 
-The cost, stated so it is chosen: a short item sharing a slot with a long one carries the
-long one's whitespace, and a full slate takes pool ÷ slots laps to come round (fifty NCAA
-games through four slots is about thirteen).
+The honest cost: a short name sharing a place with a long one carries the long one's
+width, and a full slate takes a few laps to see. Fifty college games through four places
+is about thirteen laps.
 
-## 9. Data honesty
+## Keep it honest
 
-- **Design against real data.** Sports directions were drawn from 500 production games,
-  the name rules from 2,022 catalog names, the news chip from real feed items, the
-  prediction directions from 500 markets. When real data cannot exist locally (fantasy is
-  user data, utilities are device-local), the canvas says so at the top and the fixtures
-  are labelled representative.
-- **Measure the worst case, then design the cap.** The 91-character prediction leg and
-  the 139-character question, the 154-character Deadline headline, the two 20-character
-  team names — the cap and the truncation exist for these, and the mock shows them.
-- **A single point is not a trend.** A sparkline draws nothing below two readings; a lone
-  dot next to a number implies movement that does not exist. The sysmon buffer keeps
-  repeats (a flat CPU is real history) and guards on the *clock*, because a buffer that
-  keeps repeats cannot rely on collapse-repeats to make recording-during-render safe — a
-  StrictMode double-invoke would land as fake history.
-- **Never fabricate a value.** A missing reading reserves its space and shows nothing;
-  an empty score is blank, not "—"; a stopwatch with no target has no bar.
-- **The chip's own arithmetic is what the tests cover.** Reservation widths, residue-class
-  walks, lap counting, the fit measurement, the clock guard.
+- Design against real data. Real games, real feeds, real markets. When real data can't
+  exist locally (fantasy is personal, clocks are your machine), say so on the mock.
+- Find the longest name, the longest headline, the biggest score before deciding anything.
+- One reading is not a trend; a line needs two points. Nothing gets made up to fill a gap.
 
-## 10. Process
+## How we work
 
-- **Canvas first, then code.** Every chip family was drawn on the Claude Design canvas
-  with many real fixtures across states, in ten directions, compact first. The user
-  picks from options; prose does not get picked from.
-- **Show worst cases and why.** "Why are these boxes that size" was answered with a page
-  that rendered each reservation at its maximum.
-- **Verify on the running bar, then measure.** A design that has not been looked at on
-  the rail is not done. When something cannot be seen (the bar runs in Tauri), build a
-  harness that mounts the real chip and the real rule and logs the numbers — the rotation
-  was signed off on a run showing every slot's width identical to 0.1px across five games
-  and zero swaps while visible.
-- **Ship whole families.** Sports, finance and news went out together; the utilities
-  together; the rotation for every source together. A rail carrying two languages is the
-  thing this language exists to avoid.
+1. Draw it first, on the canvas, with lots of real examples, compact before detailed.
+2. Pick a direction, then build exactly that.
+3. Look at it on the running bar. If something can't be seen, measure it instead.
+4. Ship a whole family at once, so the bar never speaks two languages.
 
-## 11. Traps that cost a round each
+## Things we've already decided against
 
-- **An interpolated Tailwind class compiles to nothing, silently.** Tailwind reads source
-  text; `` `grid-cols-[..._${n}px]` `` produces no CSS and the element falls back to auto.
-  A test asserting the class *string* still passes. Write both branches literally, and
-  verify against the served stylesheet (`curl …/src/style.css?direct`), never the markup.
-- **`<button>` centres its text.** §4.
-- **Arbitrary-value classes are not valid CSS selectors in tests.** Check `classList`.
-- **The embedded browser pane only paints frames on demand.** `requestAnimationFrame`
-  never ticks between screenshots there, so anything rAF-driven (the marquee) looks
-  frozen; timers keep real time and layout reads are synchronous. Drive a harness with a
-  timer.
-- **HMR breaks on new module exports.** Restart the app after adding one.
-- **A near-invisible divider looks like a design choice.** It is not; check the contrast
-  arithmetic before accepting a "subtle" rule.
+Two different layouts for the two densities. Every chip the same width. Dots and spines as
+decoration. A dash where a score should be blank. A shared red for close games. The
+weather range squeezed into the compact row. Monitors packed into one chip as cells. A
+per-widget "how many on the bar" control. Naming a time zone twice. Dropping items instead
+of rotating them.
 
-## 12. Rejected, so they are not proposed again
+## Still to do
 
-- Two different layouts for compact and detailed.
-- Every chip the same fixed width (264px). Ragged rails were the complaint; content-sized
-  with reservations is the answer.
-- Five dots / spines as decoration on leagues that do not need them.
-- "—" for an empty score. Blank.
-- A shared red for close games. The league's own colour, brighter.
-- The range bar beside the temperature in compact. The widest cell on the rail on the
-  chip with the least to say.
-- Monitors as cells inside one chip. A single red block must be findable without
-  reading; cells make every monitor equally loud.
-- A per-widget ticker count control. Removed.
-- The zone name twice on a clock ("CDT · Fri, Sep 4 · GMT-5"). The offset is the
-  unambiguous one.
-- Dropping eligible items to make room. Rotate them.
+Predictions, fantasy and GitHub chips haven't been rebuilt on these rules yet (REL-184).

--- a/docs/CHIP_DESIGN.md
+++ b/docs/CHIP_DESIGN.md
@@ -1,0 +1,284 @@
+# Ticker chip design rules
+
+*The definitive list. Distilled from the v1.5.0 and v1.5.1 chip redesign (sports,
+finance, news, clock, timer, weather, sysmon, uptime, and the slot rotation), September
+2026. Every rule here was learned by getting it wrong first on the running bar. When a
+new chip is built, it follows this document; when a rule is broken deliberately, the
+reason is written next to the code.*
+
+Still to be rebuilt on these rules: predictions, fantasy, GitHub (REL-184).
+
+---
+
+## 1. The one rule
+
+**Compact is the chip. Detailed is compact plus exactly one row underneath. Nothing in the
+top row moves when the second row appears.**
+
+Detailed literally shows more; compact shows less and takes less room. That is a real
+trade-off the user makes, not two different layouts. A user must recognise the same chip
+across both modes without re-reading it. The sports chip was rejected twice for breaking
+this before it was written down.
+
+- Top row: 30px in detailed, 28px in compact. Second row: 20px. These are the same on
+  every chip so the rail's rows line up across widgets.
+- The detailed row is never a restatement of the top row. It is **the thing you would
+  otherwise open the app to find** — see §5.
+- A chip that has nothing to add in detailed leaves the row empty rather than inventing
+  content. The utility chips' first detailed pass rendered a taller chip with an empty
+  row and was called "desperately" bad; the fix was real content, not decoration.
+
+## 2. The grammar
+
+Every chip is the same three-part sentence:
+
+```
+[ tab ] [ content cells … ] [ fixed right cell ]
+```
+
+- **The tab** names the source: league code, feed name, widget name, or a status cap. It
+  spans both rows. It is *painted* — 18% fill of the widget's colour, text in the colour
+  — because a tinted border and a 6% ground whisper, and a branded chip looked no
+  different from an unbranded one without one place the colour is actually seen.
+- **Content cells** own the flexible middle. They are `minmax(0, max-content)` tracks so
+  the cap can shrink them and their text truncates; plain `max-content` tracks cannot
+  shrink at all and the cap sliced off the *last* cell instead ("PPD" rendered as "PPI").
+- **The fixed right cell** holds the one value that changes while the chip is on screen:
+  the game clock, the article age, the monitor's uptime or outage. Keeping it out of the
+  flowing middle is what stops "99.98%" becoming "4m" and dragging the name sideways.
+- **Dividers** between cells are hairlines in the widget's own colour at **45%** —
+  deliberately stronger than the 25% outer border. An outer edge separates the chip from
+  the rail, which is already a big tonal step; an inner rule separates two things sharing
+  a ground, with far less contrast to spend. `border-edge/40` was a near-black line on a
+  near-black ground and made four sysmon metrics read as one continuous sparkline.
+- **Width cap: 640px.** Content-sized up to it, then names truncate. The widest real
+  sports pairing (two 20-character names, every reservation held) is ~575px; the cap
+  exists for the pathological case, not the worst ordinary one.
+- Every palette carries `bg / border / hoverBorder / text / textDim / textFaint / divider
+  / tabBg`. A new chip takes them from `getChipColors`; it does not invent its own.
+
+## 3. Nothing moves
+
+The ticker is the one surface where a value is *guaranteed* to change while it is being
+read. Width stability is therefore the first constraint, ahead of density and ahead of
+looks.
+
+- **Reserve every slot that can change while on screen.** Scores, clocks, deltas, prices,
+  points. A score going 8.3 → 14.9 gains a digit; without a reservation the chip widens
+  and shoves every chip after it along the rail.
+- **Reserve in `ch` for numbers**, which is exact because chips render mono with
+  `tabular-nums`: one `ch` is one digit. Right-align a reserved number — a number growing
+  leftward from a fixed decimal reads as counting; growing rightward reads as drifting.
+- **Reserve with a hidden sizer for proportional text.** A `ch` is only an approximation
+  in a sans face. The headline chip and the rotating name cells stack an invisible copy of
+  the widest string under the visible one in the same grid cell; the cell is as wide as
+  the wider of the two, and both stay `min-w-0` so the cap can still truncate.
+- **Size reservations from real data, per league, per class — never the theoretical
+  ceiling.** A team that breaks 1000 points has bigger problems than a reflow; padding
+  every chip for a case that never happens leaves a visible gap on every chip that does.
+  The sports chip's per-league table (`sportsChipLayout.ts`) was measured from the
+  catalog, and a rotating slot reserves the widest name *it* will show, not the widest in
+  the league.
+- **At the cap, release the reservations.** Once the chip is pinned at 640px nothing can
+  move it, so a reservation buys nothing there and the name gets the empty characters
+  back — the whole name before kickoff, one more character while the score is a digit.
+- **A slot that is sometimes empty still occupies its space.** The live dot is always in
+  the DOM, `invisible` when not live; a chip that gains a dot when the game starts was
+  9px wider live than pre.
+- **Responsive text size must not change width.** The clock scales from 11px to 16px by
+  string length, but the reservation is on the *outer* span at the base size, so the
+  scaled text never shifts the chip.
+- **Prove it by rendering the same fixture pre / live / final side by side.** If the three
+  are not pixel-identical in width, the chip is not done.
+
+## 4. Text
+
+- **Mono for data, sans for prose.** Every chip is mono; the headline chip is the one
+  sans-serif thing on the rail, deliberately, because it is the one chip whose content
+  is a sentence.
+- **Sizes that earned their place:** team names 14px against a 20px crest (12px read as
+  a caption under it); scores 15px, a step above the name so the number leads; headline
+  13px semibold; detail rows 10px; tabs 10px bold with 0.08em tracking.
+- **Crests are 20px.** At 12px on a 30px row a crest read as a bullet. ESPN runs ~18px
+  against 12px type for the same reason.
+- **Text on a `<button>` needs `text-left`.** A button centres its text by UA default. A
+  single truncated line fills its width and hides it; a wrapped block centres whichever of
+  its two lines is shorter, which reads as a random indent and was mistaken for a
+  vertical-alignment bug.
+- **Short names are derived by rule, checked against the whole catalog.** Never hand
+  maintained. The rule set (`teamShortName.ts`) is proven over 2,022 real names with
+  duplicate-spelling tolerance; anything within the 20-character budget is left whole,
+  which means the *reservation* is what the chip renders, not an abbreviation.
+- **Tabs longer than twelve characters take their first word.** "The Hollywood Reporter"
+  is a 130px tab; "HOLLYWOOD" is not. "Science and Technology" → "SCI".
+- **Decode entities and strip tags** before measuring or rendering feed text. Feeds send
+  `&#39;` and `<p>`.
+- **Truncate responsively.** At the cap the name gets the score slot's space back, so a
+  chip with no score yet shows more of the name than one mid-game. Be generous: the
+  first version gave back one character and was told so.
+
+## 5. What the detailed row is for
+
+It carries what the user would otherwise open the app to find. It is never something
+derivable from the top row.
+
+| Chip | Compact (the chip) | Detailed adds |
+|---|---|---|
+| Sports | tab · crest + name + score ×2 · clock | league position, record, points per side |
+| Finance | symbol · price · change | intraday sparkline, day-range rail |
+| News | tab · headline · age | the rest of the headline, then the summary in the room left |
+| Clock | label · time (· moon) | date and offset — a zone can be on a different **day** |
+| Timer | label · remaining | a draining bar, live-red in the last minute |
+| Weather | label · icon · temperature | today's range bar; an alert sits under **its** city |
+| Sysmon | label · gauge · value | a real trend, full-bleed, edge to edge |
+| Uptime | cap · name · value | the heartbeat history, full-bleed |
+
+- **A graphic on the detailed row runs full-bleed.** Divider to divider, no padding. A
+  fixed-width sparkline in a wider cell left a quarter of the cell empty and was the
+  first thing noticed.
+- **The headline's second row is one measured block.** Whether the title fit on one line
+  is *measured* (hidden sizer vs cell width), not counted — eighty characters can be
+  anywhere from 470px to 560px in a proportional face. If it fit, the summary takes line
+  two; if it wrapped, the summary continues after it in whatever room is left. The
+  summary never widens the chip.
+- **When there is nothing to say, say the one true thing.** A feed item with no summary
+  and a short title shows the feed's own volume today ("Dev.to · 34 today") — real, not
+  already on the chip, and the number that explains why five are showing and not thirty.
+
+## 6. Colour
+
+- **The widget's colour is the chip's colour.** Sports chips take their league's catalog
+  brand; news takes the feed's; utilities take their widget token. The old single "sports
+  red" was retired because it was an outdated model, not a decision.
+- **Lift brand colours before tinting.** A navy tints invisibly on a dark surface.
+  `liftForTint` gates on *luminance* (below 60), raising HSL lightness to 0.6 and
+  saturation to 0.55 — gating on lightness alone turned F1's red into salmon.
+- **Red means live or urgent, and nothing else.** A close game brightens the league's
+  *own* colour (70% border, 14% fill, a glow mixed from the same accent). It used to turn
+  the chip live-red, which on a rail where colour means league read as the wrong league —
+  an MLS game wearing La Liga's paint. The muted and accent colour modes have no league
+  colour of their own, so red still says close there.
+- **Semantic borders never use the widget accent.** Alert (warning), down (red), urgent
+  (live) borders have to mean the same thing on every chip.
+- **Status caps are semantic, not branded.** UP / DOWN / MNT and ✓ / ✗ / ● carry their
+  own tones; only the failing state pulses.
+- **Colour modes:** `widget` (brand), `accent` (one shared palette), `muted` (grey). A chip
+  reads its palette from `getChipColors(mode, widget)` and never hardcodes a hue.
+
+## 7. Motion
+
+- **Flash on a change of value, keyed on the *identity* of the thing.** The score flash
+  compares scores only while the game id is unchanged. A rotating slot swapping games
+  looked exactly like somebody scoring until the flash was keyed.
+- **Paused does not pulse.** Motion implies counting.
+- **Only the state that earns attention pulses**: live close games, a down monitor, an
+  in-progress run.
+- **A rotating slot never changes while on screen** (§8).
+
+## 8. What is on the rail
+
+The rail is not the feed. It has one rule per source and the user configures none of it.
+
+1. **A horizon decides what is eligible.** Stated as a rule, not a count, so it breathes:
+   sports keeps live games always, upcoming within 24h, finals within 18h of kickoff;
+   news keeps the last 6h; finance and predictions keep the watchlist.
+2. **A floor keeps a quiet source represented, not a dead one.** A league with nothing
+   near shows its next fixture if it is within 7 days; a quiet feed shows its latest item
+   if it is under 48h old. Past that, absence is the honest state.
+3. **Fixed slots decide how many are on the bar at once.** Sports 4, news 3, finance 4,
+   predictions 4, capped utilities 4. These are constants chosen from the chip's width
+   and the source's typical volume — a busy MLB night is four chips, not thirty — and
+   they are *not settings*. The one ticker control ever added ("N on the bar") was
+   removed the same day: nothing on the ticker is user-configured, so nothing on it can
+   be misconfigured.
+4. **Everything eligible rotates through the slots; nothing is dropped.** A cap that
+   drops games was the obvious fix and the wrong one — everything eligible is worth
+   seeing, just not all at once.
+5. **Favourites are pinned on top of the count**, never against it.
+6. **A slot advances only once every instance of it has left the viewport.** The marquee
+   renders an original and a clone one track-length apart; "off screen" means both.
+   Rotation is once per lap, so a chip never changes under the reader's eyes.
+7. **Each slot owns a residue class of the pool** (slot *i* shows pool[i], pool[i+k], …)
+   with its own lap count. Slots leave the screen at different moments and need no
+   coordination for every item to come round.
+8. **A slot reserves the widest content in its own class** (§3). A swap cannot resize
+   the chip, and the rail's total width never changes mid-scroll.
+9. **Multi-feed sources interleave** so one loud wire cannot own the front of every
+   slot's rotation.
+10. **The rail is independent of the widget page.** Sort, filter, "Show N" and time
+    window are about reading a list; re-sorting a list must never rearrange the bar.
+11. **Pinned widgets never scroll, so nothing there rotates.** The first slots' items
+    hold.
+
+The cost, stated so it is chosen: a short item sharing a slot with a long one carries the
+long one's whitespace, and a full slate takes pool ÷ slots laps to come round (fifty NCAA
+games through four slots is about thirteen).
+
+## 9. Data honesty
+
+- **Design against real data.** Sports directions were drawn from 500 production games,
+  the name rules from 2,022 catalog names, the news chip from real feed items, the
+  prediction directions from 500 markets. When real data cannot exist locally (fantasy is
+  user data, utilities are device-local), the canvas says so at the top and the fixtures
+  are labelled representative.
+- **Measure the worst case, then design the cap.** The 91-character prediction leg and
+  the 139-character question, the 154-character Deadline headline, the two 20-character
+  team names — the cap and the truncation exist for these, and the mock shows them.
+- **A single point is not a trend.** A sparkline draws nothing below two readings; a lone
+  dot next to a number implies movement that does not exist. The sysmon buffer keeps
+  repeats (a flat CPU is real history) and guards on the *clock*, because a buffer that
+  keeps repeats cannot rely on collapse-repeats to make recording-during-render safe — a
+  StrictMode double-invoke would land as fake history.
+- **Never fabricate a value.** A missing reading reserves its space and shows nothing;
+  an empty score is blank, not "—"; a stopwatch with no target has no bar.
+- **The chip's own arithmetic is what the tests cover.** Reservation widths, residue-class
+  walks, lap counting, the fit measurement, the clock guard.
+
+## 10. Process
+
+- **Canvas first, then code.** Every chip family was drawn on the Claude Design canvas
+  with many real fixtures across states, in ten directions, compact first. The user
+  picks from options; prose does not get picked from.
+- **Show worst cases and why.** "Why are these boxes that size" was answered with a page
+  that rendered each reservation at its maximum.
+- **Verify on the running bar, then measure.** A design that has not been looked at on
+  the rail is not done. When something cannot be seen (the bar runs in Tauri), build a
+  harness that mounts the real chip and the real rule and logs the numbers — the rotation
+  was signed off on a run showing every slot's width identical to 0.1px across five games
+  and zero swaps while visible.
+- **Ship whole families.** Sports, finance and news went out together; the utilities
+  together; the rotation for every source together. A rail carrying two languages is the
+  thing this language exists to avoid.
+
+## 11. Traps that cost a round each
+
+- **An interpolated Tailwind class compiles to nothing, silently.** Tailwind reads source
+  text; `` `grid-cols-[..._${n}px]` `` produces no CSS and the element falls back to auto.
+  A test asserting the class *string* still passes. Write both branches literally, and
+  verify against the served stylesheet (`curl …/src/style.css?direct`), never the markup.
+- **`<button>` centres its text.** §4.
+- **Arbitrary-value classes are not valid CSS selectors in tests.** Check `classList`.
+- **The embedded browser pane only paints frames on demand.** `requestAnimationFrame`
+  never ticks between screenshots there, so anything rAF-driven (the marquee) looks
+  frozen; timers keep real time and layout reads are synchronous. Drive a harness with a
+  timer.
+- **HMR breaks on new module exports.** Restart the app after adding one.
+- **A near-invisible divider looks like a design choice.** It is not; check the contrast
+  arithmetic before accepting a "subtle" rule.
+
+## 12. Rejected, so they are not proposed again
+
+- Two different layouts for compact and detailed.
+- Every chip the same fixed width (264px). Ragged rails were the complaint; content-sized
+  with reservations is the answer.
+- Five dots / spines as decoration on leagues that do not need them.
+- "—" for an empty score. Blank.
+- A shared red for close games. The league's own colour, brighter.
+- The range bar beside the temperature in compact. The widest cell on the rail on the
+  chip with the least to say.
+- Monitors as cells inside one chip. A single red block must be findable without
+  reading; cells make every monitor equally loud.
+- A per-widget ticker count control. Removed.
+- The zone name twice on a clock ("CDT · Fri, Sep 4 · GMT-5"). The offset is the
+  unambiguous one.
+- Dropping eligible items to make room. Rotate them.

--- a/docs/CHIP_SPEC.md
+++ b/docs/CHIP_SPEC.md
@@ -1,0 +1,576 @@
+# Ticker chip specification (for AI agents)
+
+This is the complete, exact specification for building or changing a chip on the Scrollr
+ticker. It is written for a model: every number, class, file path, contract and test
+pattern is stated literally so nothing has to be inferred. The human summary is
+`docs/CHIP_DESIGN.md`. When the two disagree, this file wins, and the disagreement is a
+bug to fix in the other.
+
+Read all of it before touching `desktop/src/components/chips/` or any
+`desktop/src/datawidgets/*/ticker.tsx`. Then follow §12 (build recipe) and §13 (review
+checklist) literally.
+
+---
+
+## 0. Vocabulary
+
+| Term | Meaning |
+|---|---|
+| **chip** | One `<button>` on the ticker rail representing one item (game, symbol, headline, …) or one widget (clock, weather, …). |
+| **rail** | The scrolling marquee. `desktop/src/components/ScrollrTicker.tsx`, rendered by motion-plus `<Ticker>`. |
+| **compact** | The single-row density. `comfort === false`. Row height 28px. |
+| **detailed** | The two-row density. `comfort === true`. Rows 30px + 20px. Also called "comfort" in code. |
+| **tab** | The left cell naming the source: league code, feed name, widget name, or status cap. Spans both rows. |
+| **fixed right cell** | The rightmost cell holding the one value that changes on screen. Bordered on its left. |
+| **reservation** | Width held from first render for a value that will change, so the chip never resizes. |
+| **cap** | The chip's max width: `CHIP_MAX_PX = 640`, class `max-w-[640px]`. |
+| **slot** | One rail position that cycles through several items. Keeps its React key while its content changes. |
+| **pool** | Everything eligible for the rail from one source, in display order. |
+| **lap / cycle** | One complete trip of a slot off the right edge, across, and off the left. A slot's content advances once per lap. |
+| **horizon** | The per-source time rule deciding what is eligible. |
+| **floor** | The one item a quiet source still shows when nothing is inside its horizon. |
+| **palette** | The `ChipColors` object for a chip's colour mode and widget. |
+| **source** | A `TickerSource` in `desktop/src/datawidgets/<source>/ticker.tsx`, registered in `tickerRegistry.ts`. |
+
+---
+
+## 1. The invariants (never violate)
+
+1. **Compact is the chip. Detailed is compact plus exactly one 20px row underneath. Every element of the top row keeps its position, size and content across both densities.** Verify: render the same item with `comfort={false}` and `comfort={true}`; the top row must be pixel-identical.
+2. **A chip never changes width while on screen.** Every value that can change reserves its widest plausible width from first render (§4). Verify: render the same fixture in every state it can pass through (pre / live / final; no-score / one-digit / two-digit; short / long swap) side by side; widths must be identical.
+3. **The detailed row is never derivable from the top row.** It is what the user would otherwise open the app to find (§6).
+4. **Nothing on the ticker is user-configurable.** No per-widget or global setting decides what is on the rail or how many. Horizons, floors and slot counts are constants (§8).
+5. **The rail is independent of the widget page.** A source's `chips()` must not read any feed-page display preference (`defaultSort`, `articlesPerSource`, `maxArticles`, `maxArticleAgeDays`, filters). Verify: `selectXForTicker` takes no prefs argument.
+6. **Red means live or urgent, and nothing else.** Never use `live`, `down`, `error` or `warning` tokens for brand or emphasis.
+7. **Never fabricate a value.** Missing data reserves its space and renders empty. No "—" placeholders for scores. No single-point sparklines. No synthetic history.
+8. **Tailwind classes are literal strings in source.** Never build a class with a template literal or string concatenation (§11).
+
+---
+
+## 2. Files and contracts
+
+### 2.1 Shared modules
+
+| File | Exports you use | Purpose |
+|---|---|---|
+| `desktop/src/components/chips/chipColors.ts` | `getChipColors(mode, widget): ChipColors`, `chipShellClasses(colors, extra?)`, `chipBaseClasses(...)`, `stableNum(chars)`, `NUM_WIDTH` | Palettes and the shell. |
+| `desktop/src/components/chips/ChipCap.tsx` | `ChipCap`, `cappedChipClasses`, `CapTone` | Status cap for uptime/GitHub. |
+| `desktop/src/components/chips/Sparkline.tsx` | `Sparkline({points, height?, className?})` | viewBox 100×30, `preserveAspectRatio="none"`, `flex-1`, `stroke="currentColor"`. Draws nothing below 2 points. |
+| `desktop/src/components/chips/metricHistory.ts` | `recordMetric(id, value, now?)`, `__resetMetricHistory()` | Ring buffer for sysmon, 32 points, 500ms tick guard. |
+| `desktop/src/components/chips/priceHistory.ts` | `pushPrice(symbol, price, seed?)` | Ring buffer for trades, seeded from server series, collapses repeats. |
+| `desktop/src/components/TeamLogo.tsx` | `TeamLogo({src, alt, size})` | Sizes: `sm` 14px, `md` default, `lg` 20px. Chips use `lg`. |
+| `desktop/src/hooks/useLatchedCap.ts` | `useLatchedCap(ref, cap): boolean` | True once measured ≥ cap; latches. |
+| `desktop/src/hooks/useFitsOneLine.ts` | `useFitsOneLine(sizerRef, cellRef): boolean \| null` | `sizer.scrollWidth <= cell.clientWidth + 0.5`; re-measures after `document.fonts.ready`; latches. |
+| `desktop/src/hooks/useScoreFlash.ts` | `useScoreFlash(away, home, resetKey?): boolean` | 800ms flash on change; `resetKey` change resets silently. |
+| `desktop/src/utils/chipAccent.ts` | `liftForTint(hex): hex` | Luminance-gated tint lift (§7.2). |
+| `desktop/src/utils/sportsChipLayout.ts` | `reservationFor(league)`, `ordinal`, `recordText`, `metricText`, `ChipReservation` | Per-league reservation table (§4.3). |
+| `desktop/src/utils/teamShortName.ts` | `teamShortName(league, name)`, `SHORT_NAME_BUDGET = 20` | Deterministic short names (§5.4). |
+| `desktop/src/utils/rssText.ts` | `plainText(s)`, `decodeEntities(s)`, `sourceTab(name)` | Feed text hygiene (§5.5). |
+| `desktop/src/datawidgets/ticker.ts` | `TickerSource`, `TickerChip`, `TickerContext`, `scopedRows`, `rotateSlots`, `RotatingSlot` | The source contract and the rotation (§8). |
+| `desktop/src/datawidgets/tickerRegistry.ts` | `TICKER_SOURCES` | Register a new source here, one line. |
+| `desktop/src/components/tickerRotation.ts` | `visibleSlots(container)`, `advanceCycles(cycles, was, now)` | Off-screen detection (§8.5). |
+| `desktop/src/components/tickerStep.ts` | `stepItemIndex(step, count, direction)` | Step-mode measurement; do not touch. |
+
+### 2.2 The source contract
+
+```ts
+// desktop/src/datawidgets/ticker.ts
+export interface TickerChip {
+  key: string;            // stable; for a rotating slot this is the SLOT key
+  node: ReactNode;
+  rotateSlot?: string;    // set on rotating slots; equals key
+}
+export interface TickerContext {
+  tab: string;            // widget id, e.g. "sports_mlb"
+  source: string;         // "sports" | "finance" | "rss" | "predictions" | "fantasy"
+  dashboard: DashboardResponse | null;
+  comfort: boolean;
+  chipColorMode: ChipColorMode;   // "widget" | "accent" | "muted"
+  widgetDisplay?: WidgetDisplayPrefs;   // DO NOT read for ticker selection (§1.5)
+  predictionsWatchlist: ReadonlySet<string>;
+  cycles?: Readonly<Record<string, number>>;   // per-slot lap counts
+  onChipClick?: (widgetType: string, itemId: string | number, url?: string) => void;
+}
+export interface TickerSource { chips(raw: unknown, ctx: TickerContext): TickerChip[]; }
+export function scopedRows<T>(raw: unknown, ctx: TickerContext): T[];   // widget-scoped rows
+export function rotateSlots<T, R>(
+  pool: T[], slots: number, cycles: Readonly<Record<string, number>>,
+  keyPrefix: string, id: (item: T) => string | number, reserve: (cls: T[]) => R,
+): RotatingSlot<T, R>[];
+```
+
+A source reads widget *config* (symbols, favouriteTeams, feeds) from
+`ctx.dashboard.widgets.find(w => w.widget_type === ctx.tab).config`. It never reads
+`ctx.widgetDisplay` to decide what is on the rail.
+
+### 2.3 The palette
+
+```ts
+export interface ChipColors {
+  bg: string;          // "bg-<token>/[0.06]"
+  border: string;      // "border-<token>/25"
+  hoverBorder: string; // "hover:border-<token>/40"
+  text: string;        // "text-<token>"
+  textDim: string;     // "text-<token>/70"
+  textFaint: string;   // "text-<token>/55"
+  divider: string;     // "border-<token>/45"   — inner rules, stronger than the outer border
+  tabBg: string;       // "bg-<token>/[0.18]"   — the painted tab
+}
+getChipColors("widget", "clock")   // WIDGET_MAP[widget], PURPLE if unknown
+getChipColors("accent", any)       // PRIMARY (emerald)
+getChipColors("muted", any)        // MUTED (grey: divider border-fg-3/35, tabBg bg-fg-3/[0.14])
+```
+
+Widget → token: `finance→primary #34d399`, `sports→secondary #ff4757` (only when no brand
+accent), `rss→info #00d4ff`, `fantasy→accent-purple #a855f7`, `predictions→#1fc9a0`,
+`clock→#6366f1`, `timer→#f59e0b`, `weather→#0ea5e9`, `sysmon→#06b6d4`,
+`uptime→#10b981`, `github→#f97316`.
+
+Theme tokens (dark, `desktop/src/style.css`): surface `#141420`, edge `#282838`, fg
+`#e2e2ec`, fg-2 `#b7b7c6`, fg-3 `#9292a4`, fg-4 `#78788a`, up `#22c55e`, down
+`#ef4444`, live `#ff4757`, warning (amber), error `#ef4444`, info `#00d4ff`.
+
+---
+
+## 3. Geometry
+
+### 3.1 The shell
+
+Content-sized chips (sports, news, utilities) use `chipShellClasses(colors, extra)`,
+which yields `ticker-chip group rounded-sm border transition-colors cursor-pointer
+relative overflow-hidden shrink-0 {bg} {border} {hoverBorder} {extra}`. On top of it the
+chip adds:
+
+```
+grid max-w-[640px]
+grid-cols-[<tab> <cells…> <end>]        // literal string, see §3.2
+comfort ? "grid-rows-[30px_20px]" : "grid-rows-[28px]"
+```
+
+Fixed-width chips (finance, predictions, fantasy, uptime, GitHub) still use
+`chipBaseClasses(comfort, colors, extra)` = the 264px flex box (`w-[264px]`, comfort
+`h-[52px]`). They need no reservations and rotate without a reserve. Rebuilding them onto
+the grid is the open work (REL-184); when doing so, follow this spec.
+
+### 3.2 Column templates (literal)
+
+| Chip | `grid-template-columns` |
+|---|---|
+| Sports | `grid-cols-[max-content_minmax(0,max-content)_minmax(0,max-content)_max-content]` |
+| News | `grid-cols-[max-content_minmax(0,max-content)_46px]` |
+| Utilities (clock/timer/weather/sysmon) | inline style `gridTemplateColumns: "max-content " + "max-content ".repeat(n)` (allowed: it is a `style`, not a class) |
+
+Rules:
+- Tab column: `max-content`.
+- Content columns that hold text which must truncate: `minmax(0,max-content)`. **Never**
+  plain `max-content` for a truncating column — the grid cannot shrink and the cap slices
+  the last cell.
+- Fixed right cell: `max-content` sized by its reserved contents, or a literal px
+  (`46px` for the news age cell: "Sep 3" at 12px mono + padding).
+
+### 3.3 Rows
+
+- Compact: `grid-rows-[28px]`. Detailed: `grid-rows-[30px_20px]`.
+- Tab and fixed right cell: `row-span-full`.
+- Top-row cells: `row-start-1`. Detail-row cells: `row-start-2`.
+- Exception: a chip whose detail is a single two-line block (news) uses one
+  `row-span-full` cell containing the block, vertically centred (`items-center`).
+
+### 3.4 Cell padding
+
+- Team / item cells: `px-2.5` (10px). At the cap: `px-1.5` (6px), via the `capped` flag.
+- Tab: `px-[9px]`. Fixed right cell: `px-[9px]` (sports), `justify-center` with a literal
+  width (news), `px-2` (capped chips).
+- Full-bleed detail graphics: `px-0`.
+
+### 3.5 The tab
+
+```
+col-start-1 row-span-full flex items-center border-r px-[9px]
+text-[10px] font-bold tracking-[0.08em]
+{colors.divider}   // the border-r colour
+{colors.tabBg}     // 18% fill
+{colors.text}
+```
+For a brand-accented chip (sports/news in `widget` mode) the tab uses the CSS variable
+instead of the palette:
+```
+bg-[color-mix(in_srgb,var(--accent)_18%,transparent)]
+text-[var(--accent)]
+border colour: border-[color-mix(in_srgb,var(--accent)_22%,transparent)]  (close game: 40%)
+```
+with `style={{ "--accent": liftForTint(accent) }}` on the button.
+
+Tab text: league code (`leagueCode(game.league)`), `sourceTab(feed name)` (§5.5), or
+the widget name in caps (`CLOCK`, `TIMER`, `WEATHER`, `SYSMON`).
+
+### 3.6 Dividers
+
+Inner rules between cells: `border-l` + `colors.divider` (`border-<token>/45`), or for
+brand-accented chips the `rule` string above. The outer border stays at 25%. Never use
+`border-edge` or `border-edge/40` for an inner rule.
+
+### 3.7 The fixed right cell
+
+```
+col-start-N row-span-full flex items-center justify-center border-l {rule} px-[9px]
+```
+Contents reserve width (§4). Text scales to its length (§5.2) but the reservation lives
+on the **outer** span at the base size so scaling cannot move the chip.
+
+---
+
+## 4. Width stability (reservations)
+
+### 4.1 Rules
+
+1. Every value that can change while the chip is mounted reserves its widest plausible
+   width from first render. That includes values that are currently empty.
+2. Numbers in a mono face reserve in `ch` (`style={{ minWidth: \`${n}ch\` }}`, or
+   `stableNum(n)` which also sets `display:inline-block; text-align:right`). One `ch` is
+   exactly one digit under `font-mono tabular-nums`.
+3. Proportional text (a name, a headline) reserves with a **hidden sizer**: an
+   `aria-hidden` span containing the widest string, in the same grid cell / same column
+   as the visible text, `invisible … h-0 overflow-hidden whitespace-nowrap`, same font
+   classes as the visible text. Both visible and sizer are `min-w-0` so the cap can
+   truncate them.
+4. A slot that is sometimes empty still occupies its space: render the element always
+   and toggle `invisible`, never conditionally mount it. (The live dot: `h-1.5 w-1.5
+   rounded-full bg-live`, `invisible` when not live.)
+5. Sizes come from real data, per league / per rotation class — never a theoretical
+   maximum. Use the widest thing the source actually produces.
+6. At the cap (`useLatchedCap(ref, 640)` returned true), release the reservations
+   (`minWidth: undefined`) and tighten `cellPad` to `px-1.5`. The chip cannot move at the
+   cap, so the reservation only steals characters from the name.
+7. Responsive text size (§5.2) must never change width: reserve on the wrapper.
+
+### 4.2 Verification recipe
+
+Render the same item in every state it can pass through, side by side, and compare
+`getBoundingClientRect().width`. In jsdom you cannot measure; instead assert the
+reservation props/classes exist (`minWidth` style, sizer text). For real measurement use
+a harness (§10.3).
+
+### 4.3 The sports reservation table (`sportsChipLayout.ts`)
+
+```
+DEFAULT: score 2ch, status 7ch ("Q4 2:14"), rank 4ch ("10th"), record 8ch, metric 4ch ("−201"), draws false, metricKind "diff", unit "PD"
+SOCCER : score 2, status 7, rank 4, record 8, metric 3, draws true, metricKind "pts", unit "PTS"
+MLB    : rank 3, record 7, unit "RD"      NFL: rank 3, record 6
+NBA    : score 3, record 5                NHL: rank 3, record 7, metric 3, "pts", "PTS"
+NCAA Football: record 4                   NCAA Basketball: score 3, record 5
+AFL    : score 3, record 6
+La Liga / Premier League / Champions League / FIFA World Cup / MLS: SOCCER
+Formula 1: score 0, single: true   (one cell: grand prix over circuit, no score slot)
+```
+A new league gets a row here, measured from what it actually produces.
+
+### 4.4 Rotating-slot reservation
+
+`rotateSlots(..., reserve: (cls) => R)` computes `R` over the slot's residue class only.
+Sports: `{away: widest teamShortName, home: widest teamShortName}` → `GameChip
+reserveNames`. News: longest `plainText(title)` → `RssChip reserveTitle`. Fixed-width
+chips: `() => undefined`. The reserve must be **what the chip renders** (post-shortening,
+post-decoding), not the raw field.
+
+---
+
+## 5. Text
+
+### 5.1 Faces and sizes
+
+| Element | Classes |
+|---|---|
+| Chip default | `font-mono whitespace-nowrap` on the button |
+| Tab text | `text-[10px] font-bold tracking-[0.08em]` |
+| Team name | `font-sans`? **No** — sports names are mono: `text-[14px] leading-none`, `font-semibold text-fg` when leading, `font-medium text-fg-2` when behind, `font-medium text-fg` pre-game |
+| Score | `text-[15px] leading-none tabular-nums`, `font-bold text-fg` leading / `font-medium text-fg-2` |
+| Headline (news) | `font-sans text-[13px] font-semibold text-fg` (`text-fg/55` when stale >2h) |
+| Headline summary | `text-[11px] font-medium text-fg-3` |
+| Detail row text | `text-[10px] leading-none text-fg-3` / `text-fg-4` |
+| Utility label | `text-[10px] uppercase tracking-[0.06em] opacity-80` + `colors.textDim` |
+| Utility value | `font-semibold tabular-nums text-[14px] leading-none` + `colors.text` |
+| Age / clock cell | `font-mono font-semibold leading-none tracking-[0.04em] text-fg-2` + responsive size |
+
+Mono for every data chip. Sans (`font-sans`) only for the headline chip's prose.
+
+### 5.2 Responsive size for the fixed right cell
+
+Sports status: `len<=2 → text-[16px]`, `<=3 → 15px`, `<=4 → 13px`, `<=6 → 12px`, else
+`11px`. News age: `len<=3 → 15px`, `<=4 → 13px`, else `12px`. Reservation on the outer
+span at the base size (7ch sports; 46px news column).
+
+### 5.3 Alignment
+
+Every text cell inside a `<button>` that can wrap or truncate carries `text-left`. A
+button's UA default is `text-align: center`; a wrapped block centres its shorter line.
+
+### 5.4 Short names (`teamShortName(league, name)`)
+
+- Returns `name` unchanged when `name.length <= 20` (`SHORT_NAME_BUDGET`).
+- `KNOWN` map first (two-word nicknames, special cases).
+- `UFC`: drop leading given names → surname.
+- `Formula 1`: "Grand Prix"→"GP"; strip Autódromo/Circuit/International/Street; then drop
+  trailing words.
+- US pro (`MLB NBA NHL NFL MLS AFL`): strip club suffix; if still long, the **last word**
+  (the nickname).
+- Everything else (NCAA…): strip institutional words (`STRIP`), AP-style abbreviations
+  (`ABBREV`), keep a trailing "(KY)" qualifier, then drop trailing words.
+- Tested over `utils/__fixtures__/team-names.json` (2,022 names) with
+  `institutionKey` duplicate tolerance. Never hand-edit a name; add a rule or a `KNOWN`.
+
+### 5.5 Feed text (`rssText.ts`)
+
+- `plainText(s)`: strip tags, decode entities (`&#39;`, `&#x27;`, named map incl.
+  `rsquo`, `mdash`, `hellip`), collapse whitespace, trim. Apply before measuring and
+  before rendering.
+- `sourceTab(name)`: uppercase, drop leading "The"; if `> 12` chars, first word.
+  ("The Hollywood Reporter" → "HOLLYWOOD"; "PBS NewsHour" (12) unchanged.)
+
+### 5.6 Crests
+
+`<TeamLogo size="lg">` = 20px. Never smaller on a 30px row.
+
+---
+
+## 6. The detailed row
+
+The detail row content per chip (§6.1) is fixed by design. When adding a chip, the
+detailed row must be the single most useful thing the user would otherwise open the app
+to find, and must not restate the top row.
+
+### 6.1 Table
+
+| Chip | Detail row cells |
+|---|---|
+| Sports | per side: `ordinal(rank)` (`font-bold text-fg-2`, `minWidth rank ch`), `recordText` (`text-fg-3 tabular-nums`, `minWidth record ch`), `metricText` (+/− tone, `minWidth metric ch`) with unit |
+| Finance | `Sparkline` (intraday, seeded) + `DayRangeRail` |
+| News | one two-line block: title, then `<br>` + summary if title fit, else summary inline; `[display:-webkit-box] [-webkit-line-clamp:2] leading-[17px]`; block is `w-0 min-w-full` so it never widens the chip |
+| Clock | `[detail, offset].filter(Boolean).join(" · ")` → "Fri, Sep 4 · GMT-5" |
+| Timer | full-bleed bar: `h-[3px] w-full bg-fg-3/15` with inner `bg-widget-timer` (`bg-live` if urgent) at `remaining/total`; stopwatch (no total) shows `detail` text instead |
+| Weather | `RangeBar` (low · gradient bar with dot at `(t-low)/(high-low)` · high) or, if `alert`, the alert text `font-bold uppercase tracking-wider text-warning` **in that city's cell** |
+| Sysmon | `Sparkline` of `recordMetric(id, percent)` full-bleed, `text-widget-sysmon` / `text-error` when hot; below 2 points shows `detail` text |
+| Uptime | `HeartbeatBar bleed` (each bar `h-full flex-1`, tones by status code 1/0/2/3) |
+
+### 6.2 Rules
+
+- Detail graphics are full-bleed (`px-0`); text detail keeps `px-2.5`.
+- The news fit decision is **measured** (`useFitsOneLine`) never counted.
+- When there is no summary and the title fit, show `${source_name} · ${feedCountToday}
+  today` (feed volume over the last 24h from all rows the widget holds).
+- Sysmon must call `recordMetric` on every render including compact, so the buffer fills
+  before the user switches density.
+
+---
+
+## 7. Colour
+
+### 7.1 Modes
+
+`ctx.chipColorMode`: `"widget"` (brand / widget token), `"accent"` (PRIMARY for all),
+`"muted"` (grey for all). Brand accents (`accent` prop, a `#rrggbb` from
+`catalogItemById(ctx.tab)?.hex`) apply only in `widget` mode: `branded = colorMode ===
+"widget" && !!accent`.
+
+### 7.2 Brand tint
+
+`liftForTint(hex)`: if perceived luminance `0.299R+0.587G+0.114B >= 60` return unchanged;
+else HSL lightness `max(l, 0.6)`, saturation `max(s, 0.55)`. Applied once, as the
+`--accent` CSS variable on the button. All brand classes use
+`color-mix(in_srgb,var(--accent)_N%,transparent)` with N = 6 (bg), 25 (border), 40
+(hover), 18 (tab), 22 (rule), 40 (rule when close), 70 (close border), 14 (close bg),
+25 (close glow).
+
+### 7.3 Semantic colour
+
+| State | Classes |
+|---|---|
+| Live dot | `bg-live` |
+| Close game, branded | `border-[color-mix(in_srgb,var(--accent)_70%,transparent)] bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] shadow-[0_0_14px_color-mix(in_srgb,var(--accent)_25%,transparent)]` |
+| Close game, unbranded | `border-live/70 bg-live/[0.13] shadow-[0_0_14px_rgba(255,71,87,0.2)]` |
+| Final | `opacity-[0.82]` |
+| Score flash | `bg-live/20` |
+| Timer urgent (≤60s, not paused) | value `text-live`, chip `border-live/40`, bar `bg-live` |
+| Weather alert | chip `border-warning/45`, text `text-warning`; hot temp (≥95 or within 2° of high) `text-warning` |
+| Sysmon hot | chip `border-error/30`, value `text-error`, gauge/line `bg-error`/`text-error` |
+| Uptime down | chip `border-down/30`, value `text-down`, cap `down` pulses |
+| Stale news (>2h) | `border-edge/55`, title `text-fg/55`, tab `opacity-55` |
+| Night zone / paused timer | cell `opacity-55`, glyph `☾` / `‖` |
+
+Caps (`ChipCap` tones): `up bg-up/[0.16] border-up/30 text-up`, `down`, `info`,
+`warning`, `neutral bg-fg-3/[0.10] border-fg-3/30 text-fg-3`. Uptime: UP/DOWN/MNT/`···`.
+GitHub: ✓/✗/●/○. Only `down` and `in_progress` pulse (`data-motion="cap-pulse"`).
+
+---
+
+## 8. What is on the rail
+
+### 8.1 Per-source constants (not settings)
+
+| Source | Eligible (horizon) | Floor | Slots | Pool order | Reserve |
+|---|---|---|---|---|---|
+| Sports | live always; `pre` with `0 <= h <= 24`; `final` with `h >= -18` (from kickoff) | soonest `pre` within 7 days | `TICKER_SLOTS = 4` | `sortForDisplay`: live+close 100, live 80, pre 60 (soonest first), final 30 (newest first) | widest short names per class |
+| News | items within `TICKER_RSS_HOURS = 6` | newest per feed if within `TICKER_RSS_FLOOR_HOURS = 48`; undated counts as current | `TICKER_RSS_SLOTS = 3` | newest first, **interleaved by feed** (round-robin, feeds ordered by their newest item) | longest `plainText(title)` per class |
+| Finance | the widget's `symbols` | — | `TICKER_FINANCE_SLOTS = 4` | watchlist order; unlisted rows trail alphabetically | none |
+| Predictions | stars if any (drop `in_sweep===false` unless resolved); else top `TICKER_FALLBACK_LIMIT = 15` rank-1 by trailing volume | — | `TICKER_PREDICTIONS_SLOTS = 4` | `sortPredictions(..., "trending")` | none |
+| Uptime / GitHub | all items | — | `CAPPED_WIDGET_SLOTS = 4` (in `ScrollrTicker.tsx`) | item order | none |
+| Clock / Timer / Weather / Sysmon | all items in one chip | — | n/a | config order | n/a |
+| Fantasy | bounded by the fantasy ticker dial | — | n/a | as built | n/a |
+
+Sports favourites (`config.favoriteTeams[league].teamName` matching either team name)
+are **pinned**: every one is on the rail, keyed `spo-<tab>-<gameId>`, exempt from the
+slot count.
+
+### 8.2 `rotateSlots` semantics
+
+- If `pool.length <= slots`: return every item keyed `${prefix}-${id(item)}`, no
+  `rotateSlot`, no `reserve`.
+- Else for `i in 0..k-1`: class `cls = pool.filter((_, idx) => idx % k === i)`; slot key
+  `${prefix}-slot-${i}`; `turn = cycles[slotKey] ?? 0`; item `cls[turn % cls.length]`;
+  `reserve = reserve(cls)`.
+- Keys must be namespaced by widget: prefixes are `spo-${ctx.tab}`, `rss-${ctx.tab}`,
+  `fin-${ctx.tab}`, `pred-${ctx.tab}`, `uptime`, `github`.
+
+### 8.3 Ticker wiring (already done; do not duplicate)
+
+`ScrollrTicker` holds `cycles` state; `wrap(key, node, rotateSlot)` renders
+`<div key className="py-1" data-rotate-slot={rotateSlot}>`; passes `cycles` in `ctx` and
+to `widgetChipsFor`; an effect polls every 250ms (skipped in `flip` mode or when no slot
+exists): `setCycles(prev => advanceCycles(prev, wasVisibleRef.current, visibleSlots(container)))`.
+
+### 8.4 Off-screen rule
+
+`visibleSlots(container)`: for every `[data-rotate-slot]` descendant (originals **and**
+motion-plus clones, class `.ticker-item` / `.clone-item`), a slot is visible if any
+instance's rect overlaps the container's rect horizontally. `advanceCycles` increments a
+slot only on a visible→hidden transition and returns the same object when nothing
+changed.
+
+### 8.5 Pinned widgets
+
+`pinnedWidgets[tab]` render in a static zone via `widgetChipsFor(..., { pinned: true })`;
+they never scroll, so `cycles` stays `{}` there and the first `slots` items hold.
+
+### 8.6 Costs to state in any PR that adds rotation
+
+- A short item sharing a slot with a long one carries the long one's width.
+- Full coverage takes `ceil(pool/slots)` laps.
+
+---
+
+## 9. Motion
+
+- `useScoreFlash(away, home, game.id)`: flash 800ms on a score change **for the same
+  id**; an id change resets silently. Any chip that flashes on a changing value and can
+  rotate must key its flash on the item's identity.
+- `data-motion="cap-pulse"` only on `down` / `in_progress` caps. Paused timers do not
+  pulse. Nothing else animates on the chip; the marquee moves, the chip does not.
+- `transition-colors duration-700` on the sports shell for the flash fade.
+
+---
+
+## 10. Data and history
+
+### 10.1 Buffers
+
+- `pushPrice(symbol, price, seed)`: seeds from `trade.sparkline` once, collapses
+  consecutive identical prices, 32 points, 200 symbols LRU. Safe to call during render
+  **because** it collapses repeats.
+- `recordMetric(id, value, now)`: keeps repeats (flat history is real), so it is **not**
+  safe to call during render without its guard: a reading within `MIN_GAP_MS = 500` of
+  the previous one is ignored. 32 points, 40 keys LRU. Non-finite values ignored.
+- A sparkline needs ≥ 2 points; below that render the item's `detail` text.
+
+### 10.2 Fixtures
+
+- Design and test against production-shaped data: `make seed` loads
+  `scripts/dev/seed.sql.gz` (500 games, 500 trades, 500 markets, real feed items). Fantasy
+  and utility data are not in the seed (user / device data); fixtures for those are
+  representative and must be labelled so.
+- Measure the worst case before choosing a cap or reservation: query `max(length(…))`
+  on the real table.
+
+### 10.3 Measuring for real (harness)
+
+When a property cannot be seen (the bar runs in Tauri; the embedded browser pane cannot
+run the app shell), mount the real chip + real selector + real rule in a throwaway Vite
+entry (`desktop/<name>.html` + `desktop/src/dev/<name>.tsx`, both deleted afterwards),
+open it in the browser pane, and log `getBoundingClientRect().width` per state. Drive
+any marquee with `setInterval`, not `requestAnimationFrame` (the pane paints on demand;
+rAF does not tick between screenshots; timers and layout reads work). Never commit the
+harness.
+
+---
+
+## 11. Traps (each cost a review round)
+
+1. **Interpolated Tailwind classes.** `` `grid-cols-[..._${n}px]` `` produces no CSS.
+   Tailwind v4 scans source text for literal class strings. Write every branch literally
+   (`close ? "border-[…40%…]" : "border-[…22%…]"`). Verify with
+   `curl -s "http://localhost:5174/src/style.css?direct" | grep -c "<distinctive fragment>"`
+   while `npm run tauri:dev` is running. A test asserting the class string proves nothing.
+2. **`<button>` centres text.** Add `text-left` to text cells.
+3. **Arbitrary-value classes in tests.** `querySelector(".min-w-\\[5ch\\]")` is invalid;
+   use `el.classList.contains("min-w-[5ch]")`.
+4. **Recording history during render.** Only with a repeat-collapse or a time guard.
+5. **`max-content` truncating tracks.** Use `minmax(0,max-content)`.
+6. **Conditionally mounted slots** (dot, badge) change width. Mount always, toggle
+   `invisible`.
+7. **Flash on identity change.** Key the flash.
+8. **HMR on new exports** shows "Something went wrong": restart `npm run tauri:dev`.
+9. **jsdom has no layout.** Stub `HTMLElement.prototype.scrollWidth/clientWidth` via
+   `Object.defineProperty` for fit tests; `delete` them in `afterEach`.
+10. **Reading feed prefs in a ticker selector.** Forbidden (§1.5).
+
+---
+
+## 12. Build recipe for a new or rebuilt chip
+
+1. **Read** this file, `docs/CHIP_DESIGN.md`, `GameChip.tsx`, `RssChip.tsx`,
+   `UtilityChips.tsx`, and the source's `view.ts` / `ticker.tsx`.
+2. **Query the real data** for the widest values of every field the chip will show
+   (`docker exec scrollr-postgres psql … -c "SELECT max(length(col)) …"`). Record them.
+3. **Decide the grammar cells**: what is the tab, what are the content cells, what is the
+   one changing value for the fixed right cell, what is the detail row (must satisfy §6).
+4. **Draw it on the canvas first** (Claude Design), compact first, with ≥ 4 real fixtures
+   across every state, plus the worst cases from step 2, and ≥ 3 directions if the design
+   is not already settled. Get a pick before writing code.
+5. **Write the reservation plan**: for each changing value, `ch` or sizer, sized from
+   step 2. For rotation, decide the reserve function.
+6. **Implement** with `chipShellClasses` + grid, literal classes, `getChipColors`
+   palette fields (`divider`, `tabBg`), `useLatchedCap` if content-sized, `text-left`,
+   `TeamLogo size="lg"` if crests, always-mounted slots.
+7. **Wire the source**: `selectXForTicker(rows, …)` with no prefs; `rotateSlots(pool,
+   SLOTS_CONST, ctx.cycles ?? {}, \`x-${ctx.tab}\`, id, reserve)`; return `{key, node,
+   rotateSlot}`; register in `tickerRegistry.ts` if new.
+8. **Memo compare** must include every prop that changes rendering (`comfort`,
+   `colorMode`, `accent`, `reserve*`, `onClick`, item identity and displayed fields).
+9. **Tests** (vitest, `@testing-library/react`): compact hides the detail row; detailed
+   shows the specified content; reservations present (classList / style); flash keyed;
+   selector ignores prefs; rotation arrangement (keys, residue classes, reserve equals
+   what is rendered); horizon boundaries (`NOW` fixed, `ago(h)` helper).
+10. **Verify**: `npx tsc --noEmit`; `npx vitest run`; served-CSS grep for every new
+    arbitrary class; restart the app; look at the bar; if width stability matters, run
+    the harness (§10.3) and record widths per state.
+11. **Commit** with a message that states the rule being applied and any cost accepted.
+    Ship whole families together.
+
+---
+
+## 13. Review checklist (answer every line before approving)
+
+- [ ] Top row identical in compact and detailed (position, size, content).
+- [ ] Detail row is not derivable from the top row; matches §6 for its family.
+- [ ] Every changing value has a reservation; sizes cite real data.
+- [ ] Sometimes-empty elements are always mounted (`invisible`), never conditional.
+- [ ] Content columns are `minmax(0,max-content)`; cap `max-w-[640px]`; `useLatchedCap` releases at the cap.
+- [ ] Tab painted (`tabBg` or `--accent` 18%); dividers `divider` (45%) or `--accent` rule; never `border-edge`.
+- [ ] `text-left` on text cells; mono for data, sans only for prose.
+- [ ] Colours only via palette or `--accent`; red only for live/urgent; semantic borders never branded.
+- [ ] Flash keyed on identity; only earning states pulse.
+- [ ] Ticker selector reads no feed prefs; constants, not settings; rotation via `rotateSlots`; keys namespaced by `ctx.tab`.
+- [ ] Reserve for rotation equals what the chip renders.
+- [ ] No template-literal classes; served CSS checked for each new arbitrary class.
+- [ ] Tests cover the arithmetic (reservations, horizons, rotation, fit/flash guards).
+- [ ] Verified on the running bar; widths measured if anything can change.
+- [ ] Any accepted cost (whitespace, laps) written in the PR.


### PR DESCRIPTION
Docs only. Everything learned across the v1.5.0 and v1.5.1 chip redesigns, written down so the next chip follows it.

- **`docs/CHIP_SPEC.md`** — the exact contract for an AI agent building or changing a chip: vocabulary, invariants, every file and signature, literal grid templates and classes, the per-league reservation table, palette fields and tokens, the per-source horizon / floor / slot constants, `rotateSlots` semantics, the off-screen rule, buffer guards, the traps, a build recipe and a review checklist. Declared the winner on any disagreement.
- **`docs/CHIP_DESIGN.md`** — the short human version: one rule, the shape, why the bar never jumps, what row two is for, colour, movement, what goes on the bar, and what was already decided against.
- **`AGENTS.md`** — points every agent at the spec before it touches `desktop/src/components/chips/` or any `datawidgets/*/ticker.tsx`.

No code changes; no workflow is triggered by `docs/**` or `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
