### PR TITLE
docs: the feed page and the ticker are different products, and what the user controls

### DIFF
--- a/docs/CHIP_DESIGN.md
+++ b/docs/CHIP_DESIGN.md
@@ -78,6 +78,48 @@ saying, the row stays empty rather than getting filler.
 - Things that are paused don't pulse. Only things that need your attention do: a close
   live game, a down monitor, a build in progress.
 
+## The feed page and the ticker are two different things
+
+They show the same data and they are not the same product.
+
+**The feed page is for reading.** You open it on purpose, you sit with it, and you make it
+yours: sort it, filter it, cut it to today, show ten or show all. Every control there is a
+way of reading a list, and all of them are yours.
+
+**The ticker is for glancing.** It's on all day whether you're looking or not. It has one
+job: show you what's happening now, in a fixed amount of room, without ever needing
+you. So it has no controls of its own. It decides what's on it, how many, and in what
+order, from one rule per kind of thing, and then it rotates through everything eligible
+so you still see it all.
+
+The line between them is simple. **Anything about *reading* belongs to the feed page and
+never reaches the bar. Anything about *what's on the bar* isn't a setting at all.**
+
+That's why we did two things together: gave every source a fixed number of places on
+the bar, and made the chips rotate their contents rather than adding and removing chips.
+A user never has to answer "how many do I want on the ticker", and the bar never grows,
+shrinks or jumps. It just works.
+
+## What you control, and what you don't
+
+**You control your inputs.** Which widgets are on the ticker at all. Your watchlist, your
+starred markets, your favourite team, your feeds, your time zones, your cities, which
+system metrics matter to you, which monitors and repos to watch. These are *what you
+care about*, and they're yours everywhere.
+
+**You control how the bar looks and moves.** Compact or detailed. Speed, direction, gap,
+whether it pauses on hover. Continuous, step or flip. Grouped or woven. Colour mode. Pin a
+widget so it never scrolls. Where the bar sits.
+
+**You don't control selection.** How many of a widget's things are on the bar at once,
+which of them, in what order, how far back or ahead it looks, or how the rotation runs.
+Those are fixed per kind of thing, chosen once from real data, and they never appear as
+a setting. If a user could set them, a user could get them wrong.
+
+One leftover from before this rule: the fantasy widget still has an Essential / Standard
+/ Everything dial for its ticker. It's a selection control, and it will be reconciled
+when fantasy is rebuilt (REL-184). Followed players stay, since that's an input.
+
 ## What goes on the bar
 
 The bar isn't the feed. It has one rule per kind of thing, and there are no settings for

--- a/docs/CHIP_SPEC.md
+++ b/docs/CHIP_SPEC.md
@@ -405,6 +405,70 @@ GitHub: ✓/✗/●/○. Only `down` and `in_progress` pulse (`data-motion="cap-
 
 ## 8. What is on the rail
 
+### 8.0 The feed page and the ticker are different products
+
+They render the same `dashboard.data`, through different selectors, for different jobs.
+
+| | Feed page (widget page) | Ticker (rail) |
+|---|---|---|
+| Job | Reading a list the user opened on purpose | Glancing at what is happening now, unattended, all day |
+| Selector | `applyXPipeline` / `selectXForFeed` — takes prefs | `selectXForTicker` — takes **no** prefs |
+| Amount shown | Whatever the user asks for (all, or "Show N") | A fixed number of slots per source; the rest rotate |
+| Order | The user's sort | One fixed rule per source |
+| Time window | The user's window (`daysBack/daysAhead`, `maxArticleAgeDays`) | The source's horizon constant |
+| Filters | Source / category / lens filters | None |
+| User settings | All of the above are theirs | **None** for selection; presentation only (§8.0.1) |
+
+The rule that follows from the table, stated so it can be enforced in review:
+
+> **Anything about *reading* belongs to the feed page and must not reach the rail.
+> Anything about *what is on the rail* is a constant, not a setting.**
+
+Concretely, a ticker source or selector must not read `widgetDisplay.<source>.defaultSort`,
+`articlesPerSource`, `maxArticles`, `maxArticleAgeDays`, `feedSort`, or any feed filter
+state. It may read widget **config** (the user's inputs — see §8.0.1) and `ctx.cycles`.
+
+The design that makes "no settings" workable is the pair introduced together: **fixed
+slots per source** (§8.1) and **rotation inside the same chips** (§8.2). Together they
+remove both questions a setting would otherwise have to answer — "how many?" and "which
+ones?" — and they keep the rail's chip count and width constant, so the bar never grows,
+shrinks or jumps as a slate fills.
+
+#### 8.0.1 The control inventory
+
+**The user controls their inputs** (widget config; read by ticker sources as data):
+
+| Widget | Inputs the user owns |
+|---|---|
+| All | Which widgets are on the ticker (`widgetsOnTicker`); pinned widgets |
+| Finance | `config.symbols` (the watchlist, in the user's order) |
+| Predictions | starred markets (`predictionsWatchlist`) |
+| Sports | `config.favoriteTeams[league]` |
+| News | `config.feeds` (custom RSS) |
+| Clock | `localTime`, `showTimezones`, `excludedTimezones`, zones |
+| Timer | `activeTimer`, pomodoro durations |
+| Weather | saved cities, `excludedCities` |
+| Sysmon | `cpu`, `memory`, `gpu`, `gpuPower` toggles |
+| Uptime | `url`, `excludedMonitors` |
+| GitHub | `repos`, `excludedRepos` |
+
+**The user controls presentation** (`TickerPrefs`): `showTicker`, `tickerSpeed`,
+`pauseOnHover`, `hoverSpeed`, `tickerGap`, `tickerMode` (compact / detailed),
+`mixMode` (grouped / weave), `chipColors` (widget / accent / muted), `tickerDirection`,
+`scrollMode` (continuous / step / flip), `stepPause`, `tickerPosition`,
+`hideOnFullscreen`, `showWidgetGlyphIcons`, pinning.
+
+**The user does not control selection.** Never add a setting for: how many chips a
+widget contributes; which eligible items appear; their order; the horizon or floor;
+rotation cadence or slot count. The one such control ever added (sports "N on the
+bar", 2026-09-04) was removed the same day.
+
+**Documented exception, to be reconciled:** fantasy's `tickerMode` dial (essential /
+standard / everything) plus its per-item venue prefs are selection controls that
+predate this rule. When fantasy is rebuilt (REL-184), the dial becomes the fixed
+`standard` rule and the per-item venue toggles go; followed players remain, since they
+are an input.
+
 ### 8.1 Per-source constants (not settings)
 
 | Source | Eligible (horizon) | Floor | Slots | Pool order | Reserve |


### PR DESCRIPTION
Docs only. Adds the philosophy that the chip rules were missing.

**The split.** The feed page is for reading a list the user opened on purpose; every control there — sort, filter, window, "Show N" — is theirs. The ticker is for glancing, unattended, all day; it has no controls of its own. The rule, stated so it can be enforced in review: anything about *reading* belongs to the feed page and never reaches the rail; anything about *what is on the rail* is a constant, not a setting.

**The control inventory** (both docs; the spec has it down to field names): inputs the user owns (watchlist, stars, favourite team, feeds, zones, cities, metric toggles, monitors, repos, which widgets are on the ticker), presentation the user owns (density, speed, direction, gap, hover, scroll mode, mix, colour mode, pinning, position), and the selection controls that must never exist (count, which items, order, horizon, floor, rotation).

**The pair that makes "no settings" work** is named: fixed slots per source and rotation inside the same chips, introduced together, because together they remove both questions a setting would otherwise have to answer.

**One leftover recorded rather than hidden:** the fantasy ticker's Essential / Standard / Everything dial is a selection control that predates the rule. Decision written down for REL-184: the dial becomes the fixed Standard rule; followed players stay, since they are an input.

The rich, illustrated version of the human doc lives as the "Scrollr Chip Rules" artifact; the markdown stays text.

No workflow is triggered by `docs/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
