### PR TITLE
feat(desktop): list monitors, place the ticker on a named monitor, per-window AppBar state [REL-199]

### DIFF
--- a/desktop/src-tauri/src/commands/appbar_win.rs
+++ b/desktop/src-tauri/src/commands/appbar_win.rs
@@ -10,6 +10,7 @@
 //!   unregister()   -> ABM_REMOVE
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
 use windows_sys::Win32::Foundation::{HWND, RECT};
 use windows_sys::Win32::UI::Shell::{
     SHAppBarMessage, ABE_BOTTOM, ABE_TOP, ABM_ACTIVATE, ABM_NEW, ABM_QUERYPOS, ABM_REMOVE,
@@ -22,8 +23,14 @@ use windows_sys::Win32::UI::WindowsAndMessaging::WM_USER;
 /// to register us.
 const APPBAR_CALLBACK_MSG: u32 = WM_USER + 1;
 
-/// Tracks AppBar registration. Prevents double-register/unregister.
-static REGISTERED: AtomicBool = AtomicBool::new(false);
+/// HWNDs currently registered as AppBars — one per ticker window, so
+/// several tickers (one per monitor) can each reserve their edge.
+/// Prevents double-register/unregister per window.
+static REGISTERED: Mutex<Vec<isize>> = Mutex::new(Vec::new());
+
+fn registered() -> MutexGuard<'static, Vec<isize>> {
+    REGISTERED.lock().unwrap_or_else(|p| p.into_inner())
+}
 
 /// Whether to hide the ticker when a fullscreen app appears.
 /// Default: true (taskbar-like behavior). When false, ticker stays
@@ -49,10 +56,10 @@ fn hwnd_of(window: &tauri::Window) -> Result<HWND, String> {
 
 /// Register the ticker as a Shell AppBar. Idempotent.
 pub fn register(window: &tauri::Window) -> Result<(), String> {
-    if REGISTERED.load(Ordering::Relaxed) {
+    let hwnd = hwnd_of(window)?;
+    if registered().contains(&(hwnd as isize)) {
         return Ok(());
     }
-    let hwnd = hwnd_of(window)?;
 
     let mut data: APPBARDATA = unsafe { std::mem::zeroed() };
     data.cbSize = std::mem::size_of::<APPBARDATA>() as u32;
@@ -63,7 +70,7 @@ pub fn register(window: &tauri::Window) -> Result<(), String> {
     if result == 0 {
         return Err("SHAppBarMessage(ABM_NEW) failed".into());
     }
-    REGISTERED.store(true, Ordering::Relaxed);
+    registered().push(hwnd as isize);
     log::info!("[AppBar] registered, hwnd={hwnd:?}");
 
     // Install the style-stripping subclass FIRST so subsequent style
@@ -74,29 +81,30 @@ pub fn register(window: &tauri::Window) -> Result<(), String> {
     Ok(())
 }
 
-/// Unregister the AppBar. Idempotent.
+/// Unregister this window's AppBar. Idempotent.
 pub fn unregister(window: &tauri::Window) -> Result<(), String> {
-    if !REGISTERED.load(Ordering::Relaxed) {
-        return Ok(());
-    }
     let hwnd = hwnd_of(window)?;
-
-    let mut data: APPBARDATA = unsafe { std::mem::zeroed() };
-    data.cbSize = std::mem::size_of::<APPBARDATA>() as u32;
-    data.hWnd = hwnd;
-
-    unsafe {
-        SHAppBarMessage(ABM_REMOVE, &mut data);
-        // Force the shell to reflow now that our slot is gone. Without
-        // this, maximized windows can be slow to reclaim the space.
-        let mut wpc_data: APPBARDATA = std::mem::zeroed();
-        wpc_data.cbSize = std::mem::size_of::<APPBARDATA>() as u32;
-        wpc_data.hWnd = hwnd;
-        SHAppBarMessage(ABM_WINDOWPOSCHANGED, &mut wpc_data);
+    let was_registered = {
+        let mut reg = registered();
+        let before = reg.len();
+        reg.retain(|&h| h != hwnd as isize);
+        reg.len() != before
+    };
+    if was_registered {
+        remove(hwnd);
+        log::info!("[AppBar] unregistered hwnd={hwnd:?}");
     }
-    REGISTERED.store(false, Ordering::Relaxed);
-    log::info!("[AppBar] unregistered");
     Ok(())
+}
+
+/// ABM_REMOVE every registered AppBar. Called on exit: the shell keeps
+/// the work area shrunk until logoff if a registration outlives us.
+pub fn unregister_all() {
+    let all = std::mem::take(&mut *registered());
+    for h in &all {
+        remove(*h as HWND);
+    }
+    log::info!("[AppBar] unregistered all ({})", all.len());
 }
 
 /// Defensive unregister called during app startup BEFORE any
@@ -107,18 +115,23 @@ pub fn unregister(window: &tauri::Window) -> Result<(), String> {
 /// Scrollr process registered the same HWND and never called
 /// ABM_REMOVE, the work area stays shrunk until logoff or
 /// explorer.exe restart. This call is a harmless no-op if there's
-/// no stale entry.
-///
-/// We bypass the REGISTERED atomic (which is false at startup) and
-/// don't update it — the next register() call will set it cleanly.
+/// no stale entry. It bypasses REGISTERED (empty at startup).
 pub fn force_unregister_stale(window: &tauri::Window) -> Result<(), String> {
-    let hwnd = hwnd_of(window)?;
+    remove(hwnd_of(window)?);
+    log::info!("[AppBar] force_unregister_stale (defensive startup cleanup)");
+    Ok(())
+}
+
+/// ABM_REMOVE plus a reflow nudge: without ABM_WINDOWPOSCHANGED,
+/// maximized windows can be slow to reclaim the space.
+fn remove(hwnd: HWND) {
     let mut data: APPBARDATA = unsafe { std::mem::zeroed() };
     data.cbSize = std::mem::size_of::<APPBARDATA>() as u32;
     data.hWnd = hwnd;
-    unsafe { SHAppBarMessage(ABM_REMOVE, &mut data) };
-    log::info!("[AppBar] force_unregister_stale (defensive startup cleanup)");
-    Ok(())
+    unsafe {
+        SHAppBarMessage(ABM_REMOVE, &mut data);
+        SHAppBarMessage(ABM_WINDOWPOSCHANGED, &mut data);
+    }
 }
 
 /// Set the AppBar position. Caller must register() first.
@@ -131,10 +144,10 @@ pub fn set_position(
     physical_width: i32,
     physical_height: i32,
 ) -> Result<(), String> {
-    if !REGISTERED.load(Ordering::Relaxed) {
+    let hwnd = hwnd_of(window)?;
+    if !registered().contains(&(hwnd as isize)) {
         return Err("AppBar not registered — call register() first".into());
     }
-    let hwnd = hwnd_of(window)?;
     let edge = match position {
         "top" => ABE_TOP,
         "bottom" => ABE_BOTTOM,

--- a/desktop/src-tauri/src/commands/diagnostics.rs
+++ b/desktop/src-tauri/src/commands/diagnostics.rs
@@ -69,13 +69,71 @@ struct SystemInfo {
     hostname_hash: String,
 }
 
-#[derive(Serialize)]
+/// One attached monitor in LOGICAL (DPI-scaled) coordinates — the same
+/// space `position_ticker` computes in. `name` is the OS identifier
+/// (`\\.\DISPLAY1` on Windows; `monitor-<index>` when the platform has
+/// none) and is what `position_ticker` accepts.
+#[derive(Serialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-struct MonitorInfo {
-    name: Option<String>,
-    width: u32,
-    height: u32,
-    scale_factor: f64,
+pub struct MonitorInfo {
+    pub name: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub scale_factor: f64,
+    pub is_primary: bool,
+}
+
+impl MonitorInfo {
+    pub fn from_monitor(m: &tauri::Monitor, is_primary: bool) -> Self {
+        let scale = m.scale_factor();
+        Self {
+            name: m.name().cloned().unwrap_or_default(),
+            x: m.position().x as f64 / scale,
+            y: m.position().y as f64 / scale,
+            width: m.size().width as f64 / scale,
+            height: m.size().height as f64 / scale,
+            scale_factor: scale,
+            is_primary,
+        }
+    }
+}
+
+/// Every attached monitor, primary flagged. Empty if the platform
+/// cannot enumerate (callers fall back to the window's own monitor).
+pub fn monitors(app: &AppHandle) -> Vec<MonitorInfo> {
+    let primary = app.primary_monitor().ok().flatten();
+    let is_primary = |m: &tauri::Monitor| {
+        primary
+            .as_ref()
+            .is_some_and(|p| p.position() == m.position() && p.size() == m.size())
+    };
+    app.available_monitors()
+        .map(|list| {
+            list.iter()
+                .enumerate()
+                .map(|(i, m)| {
+                    let mut info = MonitorInfo::from_monitor(m, is_primary(m));
+                    if info.name.is_empty() {
+                        info.name = format!("monitor-{i}");
+                    }
+                    info
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The monitor called `name`, else the primary, else the first.
+/// `None` only when there are no monitors at all. Never errors: a
+/// stale name from prefs (monitor unplugged) lands on the primary.
+pub fn pick_monitor<'a>(monitors: &'a [MonitorInfo], name: &str) -> Option<&'a MonitorInfo> {
+    monitors
+        .iter()
+        .find(|m| m.name == name)
+        .or_else(|| monitors.iter().find(|m| m.is_primary))
+        .or_else(|| monitors.first())
 }
 
 #[derive(Serialize)]
@@ -262,27 +320,10 @@ pub async fn collect_diagnostics(app: AppHandle) -> Result<DiagnosticReport, Str
     drop(static_info);
 
     // Environment
-    let monitors: Vec<MonitorInfo> = app
-        .available_monitors()
-        .map(|list| {
-            list.into_iter()
-                .map(|m| {
-                    let size = m.size();
-                    MonitorInfo {
-                        name: m.name().map(String::from),
-                        width: size.width,
-                        height: size.height,
-                        scale_factor: m.scale_factor(),
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
     let environment = EnvironmentInfo {
         desktop_environment: get_desktop_environment(),
         session_type: get_session_type(),
-        monitors,
+        monitors: monitors(&app),
     };
 
     // Window state
@@ -337,4 +378,33 @@ pub async fn collect_diagnostics(app: AppHandle) -> Result<DiagnosticReport, Str
         runtime,
         logs,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mon(name: &str, is_primary: bool) -> MonitorInfo {
+        MonitorInfo {
+            name: name.into(),
+            x: 0.0,
+            y: 0.0,
+            width: 1920.0,
+            height: 1080.0,
+            scale_factor: 1.0,
+            is_primary,
+        }
+    }
+
+    #[test]
+    fn pick_monitor_prefers_name_then_primary_then_first() {
+        let list = [mon(r"\.\DISPLAY2", false), mon(r"\.\DISPLAY1", true)];
+        assert_eq!(pick_monitor(&list, r"\.\DISPLAY2"), Some(&list[0]));
+        assert_eq!(pick_monitor(&list, "unplugged"), Some(&list[1]));
+
+        let no_primary = [mon("a", false), mon("b", false)];
+        assert_eq!(pick_monitor(&no_primary, "unplugged"), Some(&no_primary[0]));
+
+        assert_eq!(pick_monitor(&[], "a"), None);
+    }
 }

--- a/desktop/src-tauri/src/commands/window.rs
+++ b/desktop/src-tauri/src/commands/window.rs
@@ -1,8 +1,20 @@
+use crate::commands::diagnostics::{monitors, pick_monitor, MonitorInfo};
 use crate::compositor::{self, Compositor};
 use tauri::Manager;
 
+/// Every attached monitor in logical coordinates, primary flagged.
+/// The `name` values are what `position_ticker`'s `monitor` takes.
+#[tauri::command]
+pub fn list_monitors(app: tauri::AppHandle) -> Vec<MonitorInfo> {
+    monitors(&app)
+}
+
 /// Snap the ticker window to a screen edge and stretch it to full monitor width.
 /// Sets x = monitor left edge, width = monitor width, y = top or bottom edge.
+///
+/// `monitor` names the target screen (see `list_monitors`). An unknown
+/// name lands on the primary; omitted keeps the window on the monitor
+/// it is currently on.
 ///
 /// Wayland compositors ignore GTK's `set_position()` and may ignore `set_size()`.
 /// We detect the compositor and use native IPC:
@@ -15,6 +27,7 @@ pub fn position_ticker(
     window: tauri::Window,
     position: String,
     height: Option<f64>,
+    monitor: Option<String>,
 ) -> Result<(), String> {
     // Validate inputs
     if position != "top" && position != "bottom" {
@@ -26,16 +39,21 @@ pub fn position_ticker(
         }
     }
 
-    let monitor = window
-        .current_monitor()
-        .map_err(|e| format!("monitor query failed: {e}"))?
+    let current = || {
+        let m = window.current_monitor().ok().flatten()?;
+        Some(MonitorInfo::from_monitor(&m, false))
+    };
+    let target = monitor
+        .as_deref()
+        .and_then(|name| pick_monitor(&monitors(window.app_handle()), name).cloned())
+        .or_else(current)
         .ok_or("no monitor found")?;
 
-    let scale = monitor.scale_factor();
-    let screen_width = monitor.size().width as f64 / scale;
-    let screen_height = monitor.size().height as f64 / scale;
-    let monitor_x = monitor.position().x as f64 / scale;
-    let monitor_y = monitor.position().y as f64 / scale;
+    let scale = target.scale_factor;
+    let screen_width = target.width;
+    let screen_height = target.height;
+    let monitor_x = target.x;
+    let monitor_y = target.y;
 
     // Use explicit height if provided; otherwise read from window.
     // On Wayland, a preceding set_size() may not have propagated yet,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -49,7 +49,7 @@ fn init_sentry() -> sentry::ClientInitGuard {
                         if let Some(filename) = frame.filename.as_mut() {
                             if !home.is_empty() {
                                 let s: String = filename.to_string();
-                                *filename = s.replace(&home, "~").into();
+                                *filename = s.replace(&home, "~");
                             }
                         }
                     }
@@ -152,6 +152,7 @@ pub fn run() {
         })))
         .invoke_handler(tauri::generate_handler![
             commands::window::position_ticker,
+            commands::window::list_monitors,
             commands::window::pin_window,
             commands::window::set_hide_on_fullscreen,
             commands::window::set_ticker_visible,
@@ -273,18 +274,16 @@ pub fn run() {
                 }
             }
         }
-        // Windows AppBar cleanup. MUST call ABM_REMOVE before the
-        // process exits or the work area stays shrunk until logout
-        // or explorer restart.
+        // Windows AppBar cleanup. MUST call ABM_REMOVE on every
+        // registered ticker before the process exits or the work area
+        // stays shrunk until logout or explorer restart.
         #[cfg(target_os = "windows")]
         {
             if matches!(
                 &event,
                 tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
             ) {
-                if let Some(ticker) = app_handle.get_webview_window("ticker") {
-                    let _ = crate::commands::appbar_win::unregister(&ticker.as_ref().window());
-                }
+                crate::commands::appbar_win::unregister_all();
             }
         }
 


### PR DESCRIPTION
Part 1/3 of monitor management for the ticker ([REL-199](https://linear.app/relentnet/issue/REL-199)). Rust only; no user-visible change on its own. Parts 2 (prefs + UI, REL-200) and 3 (hotplug, REL-201) build on it.

## What

- **`list_monitors` command** (`commands/window.rs`). Per attached monitor: `name`, logical `x`/`y`/`width`/`height`, `scaleFactor`, `isPrimary` (primary matched by position+size). The diagnostics `MonitorInfo` is extended (logical coordinates, `isPrimary`, `name` synthesised as `monitor-<index>` when the platform has none) rather than adding a second struct; `collect_diagnostics` uses the same `monitors()` helper. Fields are flat rather than nested `position`/`size` objects, matching the existing struct.
- **`position_ticker(position, height, monitor?)`**. A named monitor is resolved from `available_monitors()`; an unknown or stale name lands on the **primary**, never an error. Omitted keeps today's `current_monitor()` path, so the existing JS call sites are untouched. Everything downstream (compositor shims, AppBar, GTK fallback) already takes per-monitor logical coordinates, so nothing else in the function changed.
- **`pick_monitor`** pure helper: name → primary → first, `None` only for an empty list. Unit-tested. (Signature is `(&[MonitorInfo], &str) -> Option<&MonitorInfo>`; the "omitted = current monitor" rule lives at the call site so the helper stays pure.)
- **Windows AppBar per window** (`appbar_win.rs`). The process-wide `REGISTERED: AtomicBool` becomes a `Mutex<Vec<isize>>` of registered HWNDs, so `register`/`unregister`/`set_position` work for N ticker windows. `unregister_all()` runs on `ExitRequested`/`Exit` in `lib.rs` instead of unregistering only the `"ticker"` label. `HIDE_ON_FULLSCREEN` stays global (it is a preference). The subclass install was already per-HWND.
- No capability entries were needed: monitor enumeration happens in Rust, not via the JS window API.

## Verification

- `cargo test --lib`: 20 passed (includes the new `pick_monitor_prefers_name_then_primary_then_first`).
- `cargo clippy --lib --tests`: clean on every touched file. The one remaining warning is pre-existing in `gpu_win.rs` (not touched). A pre-existing `useless_conversion` in `lib.rs` was fixed since that file is in the diff.
- Dev app on this box, which turned out to have **two** 3440x1440 monitors (`\.\DISPLAY2` primary at x=0, `\.\DISPLAY1` at x=-3440), so the non-primary path was exercised for real, not only the fallback:
  - `invoke("list_monitors")` from both windows returns both monitors with the primary flagged.
  - `position_ticker({position:"top", height:64, monitor:"\.\DISPLAY1"})` → ticker at x=-3440, y=0, 3440x64, visible. AppBar log: `set_position edge=1 rect=(-3440,0)-(0,64)`. Captured with `capture-window.ps1`: full-width bar rendering on DISPLAY1.
  - `monitor:"unplugged"` → x=0 (primary), 3440x64.
  - `monitor` omitted, `position:"bottom"` → stays on the current monitor, y=1328.
  - Hide → show cycle re-registers the same HWND through the new list; on `quit_app` the log shows `[AppBar] unregistered all`.
- Observed but out of scope: setting `showTicker` from the main window via the dev bus flipped back to `false` on its own a few seconds later once during the session (pre-existing pref sync; `position_ticker` does not touch prefs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
