### PR TITLE
feat(desktop): monitor hotplug — tickers follow screens plugged/unplugged live [REL-201]

### DIFF
--- a/desktop/src-tauri/src/commands/appbar_win.rs
+++ b/desktop/src-tauri/src/commands/appbar_win.rs
@@ -416,7 +416,7 @@ use windows_sys::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
 use windows_sys::Win32::UI::Shell::{
     DefSubclassProc, SetWindowSubclass,
 };
-use windows_sys::Win32::UI::WindowsAndMessaging::WM_STYLECHANGING;
+use windows_sys::Win32::UI::WindowsAndMessaging::{WM_DISPLAYCHANGE, WM_STYLECHANGING};
 
 const SUBCLASS_ID: usize = 0xA9B_0001;
 
@@ -458,6 +458,13 @@ unsafe extern "system" fn appbar_subclass_proc(
     // with the window class's background brush (white).
     if msg == WM_NCCALCSIZE && wparam != 0 {
         return 0;
+    }
+
+    // A monitor came, went, or moved (Win+P, a cable, a resolution
+    // change). Every top-level window gets this broadcast, so each
+    // ticker re-checks; `check_monitors` emits once per real change.
+    if msg == WM_DISPLAYCHANGE {
+        crate::commands::window::check_monitors();
     }
 
     // AppBar callback: Windows notifies us of system events that affect

--- a/desktop/src-tauri/src/commands/diagnostics.rs
+++ b/desktop/src-tauri/src/commands/diagnostics.rs
@@ -141,7 +141,12 @@ pub fn pick_monitor<'a>(monitors: &'a [MonitorInfo], name: &str) -> Option<&'a M
 struct EnvironmentInfo {
     desktop_environment: Option<String>,
     session_type: String,
+    /// Attached right now.
     monitors: Vec<MonitorInfo>,
+    /// `window.tickerMonitors` from prefs: the screens the user chose,
+    /// attached or not. Compare with `monitors` to spot an unplugged
+    /// choice; empty means "the primary".
+    chosen_monitors: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -161,8 +166,19 @@ struct WindowState {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+struct TickerWindowState {
+    #[serde(flatten)]
+    window: WindowState,
+    /// The monitor `sync_ticker_windows` assigned this window.
+    monitor: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct WindowsState {
-    ticker: Option<WindowState>,
+    /// Every live ticker window (`ticker`, `ticker-2`, …), one per
+    /// chosen-and-attached monitor.
+    tickers: Vec<TickerWindowState>,
     main: Option<WindowState>,
 }
 
@@ -204,6 +220,39 @@ fn get_window_state(app: &AppHandle, label: &str) -> Option<WindowState> {
         maximized,
         minimized,
     })
+}
+
+fn ticker_windows(app: &AppHandle) -> Vec<TickerWindowState> {
+    let assigned = crate::commands::window::ticker_monitor_map();
+    let mut labels: Vec<String> = app
+        .webview_windows()
+        .into_keys()
+        .filter(|l| crate::commands::window::is_ticker_label(l))
+        .collect();
+    labels.sort();
+    labels
+        .iter()
+        .filter_map(|label| {
+            Some(TickerWindowState {
+                window: get_window_state(app, label)?,
+                monitor: assigned.iter().find(|(l, _)| l == label).map(|(_, m)| m.clone()),
+            })
+        })
+        .collect()
+}
+
+/// `window.tickerMonitors` as saved by the JS side (lib/store.ts keeps
+/// prefs under `scrollr:settings` in `scrollr.json`).
+fn chosen_monitors(app: &AppHandle) -> Vec<String> {
+    use tauri_plugin_store::StoreExt;
+    app.store("scrollr.json")
+        .ok()
+        .and_then(|s| s.get("scrollr:settings"))
+        .and_then(|v| v.pointer("/window/tickerMonitors")?.as_array().cloned())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect()
 }
 
 fn get_session_type() -> String {
@@ -324,11 +373,12 @@ pub async fn collect_diagnostics(app: AppHandle) -> Result<DiagnosticReport, Str
         desktop_environment: get_desktop_environment(),
         session_type: get_session_type(),
         monitors: monitors(&app),
+        chosen_monitors: chosen_monitors(&app),
     };
 
     // Window state
     let windows = WindowsState {
-        ticker: get_window_state(&app, "ticker"),
+        tickers: ticker_windows(&app),
         main: get_window_state(&app, "main"),
     };
 

--- a/desktop/src-tauri/src/commands/window.rs
+++ b/desktop/src-tauri/src/commands/window.rs
@@ -1,6 +1,6 @@
 use crate::commands::diagnostics::{monitors, pick_monitor, MonitorInfo};
 use crate::compositor::{self, Compositor};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use tauri::{Emitter, Manager};
 
 /// Every attached monitor in logical coordinates, primary flagged.
@@ -37,6 +37,64 @@ fn monitor_for_label(label: &str) -> Option<String> {
         .find(|(l, _)| l == label)
         .map(|(_, m)| m.clone())
 }
+
+/// A copy of the `label → monitor name` map (for diagnostics).
+pub fn ticker_monitor_map() -> Vec<(String, String)> {
+    ticker_monitors().clone()
+}
+
+// ── Monitor hotplug ──────────────────────────────────────────────
+//
+// Tauri has no monitor-changed event. `check_monitors` compares the
+// attached set with the last one seen and emits `monitors-changed` to
+// every window when it differs; the main window answers by re-running
+// `sync_ticker_windows` against the unchanged pref (routes/__root.tsx),
+// Settings › Window by re-listing. Two things drive it: a 5 s poll
+// (every platform) and WM_DISPLAYCHANGE in the ticker's AppBar
+// subclass (Windows, instant). Both funnel through the same last-seen
+// state, so the burst of WM_DISPLAYCHANGE a Win+P switch produces
+// emits once per real change, not once per message.
+
+static APP: OnceLock<tauri::AppHandle> = OnceLock::new();
+static LAST_MONITORS: Mutex<Option<Vec<MonitorInfo>>> = Mutex::new(None);
+
+/// Records `now`; true when it differs from the previous set. The first
+/// observation only records — launch is not a hotplug.
+fn monitors_changed(last: &mut Option<Vec<MonitorInfo>>, now: Vec<MonitorInfo>) -> bool {
+    let changed = last.as_ref().is_some_and(|l| *l != now);
+    *last = Some(now);
+    changed
+}
+
+/// Re-enumerate and emit `monitors-changed` if the set moved. Safe from
+/// any thread, including the ticker's window proc.
+pub fn check_monitors() {
+    let Some(app) = APP.get() else { return };
+    let now = monitors(app);
+    let changed = monitors_changed(&mut LAST_MONITORS.lock().unwrap_or_else(|p| p.into_inner()), now);
+    if changed {
+        log::info!("[ticker] monitor set changed");
+        let _ = app.emit("monitors-changed", ());
+    }
+}
+
+/// Record the launch-time set and start the poll. Once, from setup.
+pub fn watch_monitors(app: &tauri::AppHandle) {
+    if APP.set(app.clone()).is_err() {
+        return;
+    }
+    check_monitors();
+    std::thread::spawn(|| loop {
+        std::thread::sleep(std::time::Duration::from_secs(5));
+        check_monitors();
+    });
+}
+
+/// Serialises `sync_ticker_windows`: hotplug can fire it twice in quick
+/// succession, and two syncs building the same `ticker-N` at once is a
+/// duplicate-label error. The later caller enumerates after the earlier
+/// one finished, so the final set is the current one.
+static SYNC: Mutex<()> = Mutex::new(());
 
 pub fn is_ticker_label(label: &str) -> bool {
     label == "ticker" || label.starts_with("ticker-")
@@ -87,6 +145,7 @@ pub fn prepare_ticker(win: &tauri::WebviewWindow) {
 /// building a window from there deadlocks on Windows (Tauri docs).
 #[tauri::command]
 pub async fn sync_ticker_windows(app: tauri::AppHandle, monitors: Vec<String>) -> Result<Vec<String>, String> {
+    let _serial = SYNC.lock().unwrap_or_else(|p| p.into_inner());
     let wanted = choose_monitors(&monitors, &crate::commands::diagnostics::monitors(&app));
     *ticker_monitors() = wanted
         .iter()
@@ -103,10 +162,23 @@ pub async fn sync_ticker_windows(app: tauri::AppHandle, monitors: Vec<String>) -
         .cloned()
         .ok_or("no ticker window in tauri.conf.json")?;
 
-    let mut live = Vec::new();
-    for i in 0..wanted.len().max(1) {
-        let label = ticker_label(i);
-        if app.get_webview_window(&label).is_some() {
+    let live: Vec<String> = (0..wanted.len().max(1)).map(ticker_label).collect();
+
+    // Surplus first: a window whose monitor vanished has been shoved
+    // onto a surviving screen by the OS, AppBar reservation and all,
+    // and a survivor re-querying its edge while that reservation
+    // stands gets pushed down by one bar height.
+    for (label, win) in app.webview_windows() {
+        if is_ticker_label(&label) && !live.contains(&label) {
+            #[cfg(target_os = "windows")]
+            let _ = crate::commands::appbar_win::unregister(&win.as_ref().window());
+            let _ = win.destroy();
+            log::info!("[ticker] destroyed {label}");
+        }
+    }
+
+    for (i, label) in live.iter().enumerate() {
+        if app.get_webview_window(label).is_some() {
             let _ = app.emit_to(label.as_str(), "ticker-reposition", ());
         } else {
             let mut cfg = template.clone();
@@ -117,16 +189,6 @@ pub async fn sync_ticker_windows(app: tauri::AppHandle, monitors: Vec<String>) -
                 .map_err(|e| format!("create {label} failed: {e}"))?;
             prepare_ticker(&win);
             log::info!("[ticker] created {label} for {:?}", wanted.get(i));
-        }
-        live.push(label);
-    }
-
-    for (label, win) in app.webview_windows() {
-        if is_ticker_label(&label) && !live.contains(&label) {
-            #[cfg(target_os = "windows")]
-            let _ = crate::commands::appbar_win::unregister(&win.as_ref().window());
-            let _ = win.destroy();
-            log::info!("[ticker] destroyed {label}");
         }
     }
     Ok(live)
@@ -162,12 +224,23 @@ pub fn position_ticker(
         }
     }
 
+    // A ticker the last sync dropped from its map is on its way out:
+    // its own JS can still fire this between the sync's AppBar
+    // unregister and the destroy, and registering then leaves the
+    // shell reserving an edge for a dead HWND until logoff. (The map
+    // is only empty before the first sync, when `ticker` positions
+    // itself at launch.)
+    let assigned = monitor_for_label(window.label());
+    if is_ticker_label(window.label()) && assigned.is_none() && !ticker_monitors().is_empty() {
+        return Err(format!("{} is being removed", window.label()));
+    }
+
     let current = || {
         let m = window.current_monitor().ok().flatten()?;
         Some(MonitorInfo::from_monitor(&m, false))
     };
     let target = monitor
-        .or_else(|| monitor_for_label(window.label()))
+        .or(assigned)
         .as_deref()
         .and_then(|name| pick_monitor(&monitors(window.app_handle()), name).cloned())
         .or_else(current)
@@ -347,5 +420,20 @@ mod tests {
         assert_eq!(choose_monitors(&["gone".to_string()], &attached), vec![r"\.\DISPLAY2".to_string()]);
         // nothing enumerable: no mapping, caller still keeps one window
         assert!(choose_monitors(&two, &[]).is_empty());
+    }
+
+    #[test]
+    fn monitors_changed_ignores_first_observation_and_repeats() {
+        let two = vec![mon(r"\.\DISPLAY1", false), mon(r"\.\DISPLAY2", true)];
+        let one = vec![mon(r"\.\DISPLAY2", true)];
+        let mut last = None;
+        assert!(!monitors_changed(&mut last, two.clone()), "launch is not a hotplug");
+        assert!(!monitors_changed(&mut last, two.clone()), "same set, no event");
+        assert!(monitors_changed(&mut last, one.clone()), "unplugged");
+        assert!(monitors_changed(&mut last, two), "plugged back in");
+        // primary moving counts too: the fallback screen follows it
+        let mut moved = one.clone();
+        moved[0].is_primary = false;
+        assert!(monitors_changed(&mut Some(one), moved));
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -205,6 +205,9 @@ pub fn run() {
             } else {
                 log::error!("Failed to create ticker window — continuing without it");
             }
+            // Monitor hotplug: poll + WM_DISPLAYCHANGE → `monitors-changed`,
+            // which the main window answers with `sync_ticker_windows`.
+            commands::window::watch_monitors(app.handle());
 
             // ── App window: strip native chrome on Linux/Windows ─
             // macOS keeps decorations on purpose: tauri.conf.json sets

--- a/desktop/src/components/settings/pages/WindowStartupPage.tsx
+++ b/desktop/src/components/settings/pages/WindowStartupPage.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { StartupPrefs, WindowPrefs } from "../../../preferences";
+import { useTauriListener } from "../../../hooks/useTauriListener";
 import { RowList, SettingsGroup, ToggleRow } from "../SettingsControls";
 import { Row } from "./Row";
 
@@ -84,9 +85,12 @@ function MonitorsGroup({
   onChange: (names: string[]) => void;
 }) {
   const [monitors, setMonitors] = useState<MonitorInfo[]>([]);
+  const refresh = () => invoke<MonitorInfo[]>("list_monitors").then(setMonitors).catch(() => {});
   useEffect(() => {
-    invoke<MonitorInfo[]>("list_monitors").then(setMonitors).catch(() => {});
-  }, []);
+    void refresh();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  // Plugged / unplugged while the page is open: re-list on Rust's event.
+  useTauriListener("monitors-changed", refresh);
   if (monitors.length === 0) return null;
 
   const primary = monitors.find((m) => m.isPrimary) ?? monitors[0];

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -105,6 +105,13 @@ import {
 import { onStoreChange, setStore, removeStore } from "../lib/store";
 import { invoke } from "@tauri-apps/api/core";
 
+/** One ticker window per chosen-and-attached monitor; Rust resolves an
+ *  empty list, or a list with nothing attached, to the primary. */
+const syncTickerWindows = (monitors: string[]) =>
+  invoke("sync_ticker_windows", { monitors }).catch((err) =>
+    console.error("[Scrollr] sync_ticker_windows failed:", err),
+  );
+
 // ── Route context ────────────────────────────────────────────────
 
 interface RouterContext {
@@ -503,11 +510,15 @@ function RootLayout() {
   // resolves an empty list to the primary monitor.
   const tickerMonitorsKey = prefs.window.tickerMonitors.join("\n");
   useEffect(() => {
-    invoke("sync_ticker_windows", { monitors: prefs.window.tickerMonitors }).catch((err) =>
-      console.error("[Scrollr] sync_ticker_windows failed:", err),
-    );
+    syncTickerWindows(prefs.window.tickerMonitors);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tickerMonitorsKey]);
+  // A monitor came or went (Rust polls, and Windows gets WM_DISPLAYCHANGE):
+  // the pref is unchanged but which of its screens are attached is not.
+  // Same owner, same call — Rust drops the vanished screen's window,
+  // gives a returning one its bar back, and falls back to the primary
+  // when none of the chosen screens is present.
+  useTauriListener("monitors-changed", () => syncTickerWindows(prefs.window.tickerMonitors));
 
   useEffect(() => {
     isAutostartEnabled().then(setAutostartOn).catch(() => {});


### PR DESCRIPTION
Part 3/3 of monitor management (REL-201). Builds on REL-199 (#315) and REL-200 (#316).

## What

Tauri has no monitor-changed event, so the app notices display changes itself and keeps the ticker windows matching the pref without a restart.

**Detect** — two sources, one funnel:
- A 5s poll of `available_monitors()` (cross-platform baseline).
- `WM_DISPLAYCHANGE` in the ticker's existing AppBar subclass proc (Windows, instant).
- Both call `check_monitors`, which compares a fingerprint (names + positions + sizes) against the last-seen set and emits `monitors-changed` once per real change — a Win+P burst collapses to a single event.

**React** — the MAIN window (unchanged owner) re-runs `sync_ticker_windows` against the same pref:
- A chosen monitor that vanished → its window is destroyed.
- No chosen monitor present → the ticker falls back to the **primary** and never disappears.
- A returning monitor → its bar comes back.
- Survivors reposition via the existing `ticker-reposition` path.

**Settings › Window** re-lists monitors on the same event while open.

**Diagnostics** now report every ticker window with its assigned monitor, plus chosen-vs-present monitor names, so a support ticket shows the mismatch.

## Notable implementation points

- `sync_ticker_windows` is serialised with a mutex: hotplug can fire it twice in quick succession, and two syncs building the same `ticker-N` at once would be a duplicate-label error.
- Surplus windows are destroyed **before** survivors reposition.
- `position_ticker` refuses a ticker already dropped from the label→monitor map, so a late in-flight call can't leave an orphan AppBar reservation on a dead HWND.

## Verify

Live on two 3440×1440 monitors (DISPLAY1/DISPLAY2), driving topology with `SetDisplayConfig` (the Win+P API):
- **Extend** → one bar per screen.
- **Duplicate / PC-screen-only** → drops to a single bar on the survivor, AppBar reservation follows (work area top stays reserved), no orphan window.
- **Back to Extend** → the second bar returns.
- **Only-secondary chosen, secondary removed** → falls back to the primary, stays visible; diagnostics shows chosen=DISPLAY2 vs present=DISPLAY1.
- `capture-window.ps1 -Title "Scrollr Ticker"` still matches the primary's exact-title bar, not "Scrollr Ticker 2".

`cargo test --lib` (23), `tsc --noEmit`, and `vitest` (675) all green. Before/after captures shared with the reviewer.

## Known follow-up

**REL-202** (filed): a second same-edge bar can sit one bar-height off its screen edge — Win32 AppBar `ABM_QUERYPOS` stacks same-edge bars across the virtual desktop rather than per monitor. Pre-existing since REL-200 (reproduces on a plain position toggle, no hotplug), cosmetic (the reservation itself is correct). Fix needs per-monitor `rcWork` math; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)