### PR TITLE
fix(desktop): Monitors map draws physical rects; Display N labels, Identify, click-to-toggle [REL-203]

### DIFF
--- a/desktop/identify.html
+++ b/desktop/identify.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Scrollr Display</title>
+    <!--
+      The "Identify" tile: one small always-on-top window per monitor
+      showing that screen's number (Settings › Monitors). Opened and
+      closed by `identify_monitors` in src-tauri/src/commands/window.rs,
+      which also fills in #n — the page has no script of its own, so it
+      needs nothing from the CSP.
+    -->
+    <style>
+      html, body {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #141420;
+        color: #fff;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        user-select: none;
+        cursor: default;
+      }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        border: 3px solid #6c8cff;
+      }
+      #n { font-size: 120px; font-weight: 600; line-height: 1; }
+    </style>
+  </head>
+  <body>
+    <div id="n"></div>
+  </body>
+</html>

--- a/desktop/src-tauri/src/commands/diagnostics.rs
+++ b/desktop/src-tauri/src/commands/diagnostics.rs
@@ -69,10 +69,17 @@ struct SystemInfo {
     hostname_hash: String,
 }
 
-/// One attached monitor in LOGICAL (DPI-scaled) coordinates — the same
-/// space `position_ticker` computes in. `name` is the OS identifier
-/// (`\\.\DISPLAY1` on Windows; `monitor-<index>` when the platform has
-/// none) and is what `position_ticker` accepts.
+/// One attached monitor. `name` is the OS identifier (`\\.\DISPLAY1` on
+/// Windows; `monitor-<index>` when the platform has none) and is what
+/// `position_ticker` accepts.
+///
+/// Two coordinate sets on purpose. `physical_*` is the OS's one shared
+/// plane (the Display-settings arrangement): only there do rects of
+/// mixed-DPI monitors sit side by side, which is what a map or a
+/// window placement needs. `x/y/width/height` divide each monitor by
+/// ITS OWN scale — right for sizing content on that screen, wrong for
+/// comparing screens (a 3840 px screen at 300 % reads as 1280 wide and
+/// "overlaps" its 100 % neighbour, REL-203).
 #[derive(Serialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MonitorInfo {
@@ -83,19 +90,36 @@ pub struct MonitorInfo {
     pub height: f64,
     pub scale_factor: f64,
     pub is_primary: bool,
+    pub physical_x: i32,
+    pub physical_y: i32,
+    pub physical_width: u32,
+    pub physical_height: u32,
 }
 
 impl MonitorInfo {
     pub fn from_monitor(m: &tauri::Monitor, is_primary: bool) -> Self {
-        let scale = m.scale_factor();
+        Self::new(
+            m.name().cloned().unwrap_or_default(),
+            (m.position().x, m.position().y),
+            (m.size().width, m.size().height),
+            m.scale_factor(),
+            is_primary,
+        )
+    }
+
+    pub fn new(name: String, (px, py): (i32, i32), (pw, ph): (u32, u32), scale: f64, is_primary: bool) -> Self {
         Self {
-            name: m.name().cloned().unwrap_or_default(),
-            x: m.position().x as f64 / scale,
-            y: m.position().y as f64 / scale,
-            width: m.size().width as f64 / scale,
-            height: m.size().height as f64 / scale,
+            name,
+            x: px as f64 / scale,
+            y: py as f64 / scale,
+            width: pw as f64 / scale,
+            height: ph as f64 / scale,
             scale_factor: scale,
             is_primary,
+            physical_x: px,
+            physical_y: py,
+            physical_width: pw,
+            physical_height: ph,
         }
     }
 }
@@ -435,15 +459,15 @@ mod tests {
     use super::*;
 
     fn mon(name: &str, is_primary: bool) -> MonitorInfo {
-        MonitorInfo {
-            name: name.into(),
-            x: 0.0,
-            y: 0.0,
-            width: 1920.0,
-            height: 1080.0,
-            scale_factor: 1.0,
-            is_primary,
-        }
+        MonitorInfo::new(name.into(), (0, 0), (1920, 1080), 1.0, is_primary)
+    }
+
+    #[test]
+    fn logical_rect_is_physical_over_own_scale() {
+        // Brandon's DISPLAY3: 3840×2160 at 300 %, right of a 3440 primary.
+        let m = MonitorInfo::new("d3".into(), (3440, 0), (3840, 2160), 3.0, false);
+        assert_eq!((m.physical_x, m.physical_width, m.physical_height), (3440, 3840, 2160));
+        assert_eq!((m.x, m.width, m.height), (3440.0 / 3.0, 1280.0, 720.0));
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/window.rs
+++ b/desktop/src-tauri/src/commands/window.rs
@@ -3,7 +3,7 @@ use crate::compositor::{self, Compositor};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tauri::{Emitter, Manager};
 
-/// Every attached monitor in logical coordinates, primary flagged.
+/// Every attached monitor, logical and physical rects, primary flagged.
 /// The `name` values are what `position_ticker`'s `monitor` takes.
 #[tauri::command]
 pub fn list_monitors(app: tauri::AppHandle) -> Vec<MonitorInfo> {
@@ -292,12 +292,23 @@ pub fn position_ticker(
             {
                 use crate::commands::appbar_win;
                 appbar_win::register(&window)?;
-                let phys_x = (monitor_x * scale).round() as i32;
-                let phys_y = (new_y * scale).round() as i32;
-                let phys_w = (screen_width * scale).round() as i32;
+                // The monitor's own physical rect, not logical × scale:
+                // on a 300 % screen the logical x is a third and would
+                // round-trip inexactly (REL-203). Only the bar height
+                // is ours to scale.
                 let phys_h = (win_height * scale).round() as i32;
+                let phys_y = if position == "top" {
+                    target.physical_y
+                } else {
+                    target.physical_y + target.physical_height as i32 - phys_h
+                };
                 return appbar_win::set_position(
-                    &window, &position, phys_x, phys_y, phys_w, phys_h,
+                    &window,
+                    &position,
+                    target.physical_x,
+                    phys_y,
+                    target.physical_width as i32,
+                    phys_h,
                 );
             }
 
@@ -311,6 +322,79 @@ pub fn position_ticker(
             }
         }
     }
+}
+
+// ── Identify: flash each screen's number on it ───────────────────
+//
+// Settings › Monitors numbers the screens in `list_monitors` order;
+// this shows that number on each one for a moment (Windows' own
+// "Identify" button) so the user can tell which switch is which
+// without a ticker being on it. One tiny always-on-top window per
+// monitor, `identify-N`, destroyed after `IDENTIFY_MS`.
+
+const IDENTIFY_MS: u64 = 1500;
+/// Tile side in logical px — scaled by the screen's own factor so it
+/// looks the same size on every screen.
+const IDENTIFY_SIZE: f64 = 220.0;
+
+/// `(x, y, w, h)` of the tile, centred on `m`, in physical pixels.
+fn identify_tile(m: &MonitorInfo) -> (i32, i32, i32, i32) {
+    let side = (IDENTIFY_SIZE * m.scale_factor).round() as i32;
+    (
+        m.physical_x + (m.physical_width as i32 - side) / 2,
+        m.physical_y + (m.physical_height as i32 - side) / 2,
+        side,
+        side,
+    )
+}
+
+/// `async` for the same reason as `sync_ticker_windows`: window
+/// creation from the main thread deadlocks on Windows.
+#[tauri::command]
+pub async fn identify_monitors(app: tauri::AppHandle) -> Result<(), String> {
+    if app.get_webview_window("identify-1").is_some() {
+        return Ok(()); // already flashing
+    }
+    let list = monitors(&app);
+    for (i, m) in list.iter().enumerate() {
+        let n = i + 1;
+        let (x, y, w, h) = identify_tile(m);
+        let win = tauri::WebviewWindowBuilder::new(
+            &app,
+            format!("identify-{n}"),
+            tauri::WebviewUrl::App("identify.html".into()),
+        )
+        // The page has no script of its own (CSP); this runs before
+        // it and fills in the number.
+        .initialization_script(format!(
+            "document.addEventListener('DOMContentLoaded',()=>{{document.getElementById('n').textContent='{n}'}})"
+        ))
+        .title(format!("Scrollr Display {n}"))
+        .decorations(false)
+        .always_on_top(true)
+        .skip_taskbar(true)
+        .resizable(false)
+        .focused(false)
+        .visible(false)
+        .build()
+        .map_err(|e| format!("identify-{n}: {e}"))?;
+        let _ = win.set_background_color(Some(tauri::webview::Color(20, 20, 32, 255)));
+        // Physical, after build: the builder's logical position would
+        // be resolved against the wrong scale on a mixed-DPI desktop.
+        let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
+        let _ = win.set_size(tauri::PhysicalSize::new(w as u32, h as u32));
+        let _ = win.show();
+    }
+    let count = list.len();
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(IDENTIFY_MS));
+        for n in 1..=count {
+            if let Some(w) = app.get_webview_window(&format!("identify-{n}")) {
+                let _ = w.destroy();
+            }
+        }
+    });
+    Ok(())
 }
 
 // ── Pin (always-on-top) via compositor IPC ───────────────────────
@@ -386,15 +470,17 @@ mod tests {
     use super::*;
 
     fn mon(name: &str, is_primary: bool) -> MonitorInfo {
-        MonitorInfo {
-            name: name.into(),
-            x: 0.0,
-            y: 0.0,
-            width: 3440.0,
-            height: 1440.0,
-            scale_factor: 1.0,
-            is_primary,
-        }
+        MonitorInfo::new(name.into(), (0, 0), (3440, 1440), 1.0, is_primary)
+    }
+
+    #[test]
+    fn identify_tile_is_centred_in_physical_pixels() {
+        // 300 % screen right of the primary: the tile is 3× bigger and
+        // sits at that screen's physical centre, not at 1/3 of it.
+        let d3 = MonitorInfo::new("d3".into(), (3440, 0), (3840, 2160), 3.0, false);
+        assert_eq!(identify_tile(&d3), (3440 + 1920 - 330, 1080 - 330, 660, 660));
+        let d2 = MonitorInfo::new("d2".into(), (-3440, 0), (3440, 1440), 1.0, false);
+        assert_eq!(identify_tile(&d2), (-3440 + 1720 - 110, 720 - 110, 220, 220));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -154,6 +154,7 @@ pub fn run() {
             commands::window::position_ticker,
             commands::window::list_monitors,
             commands::window::sync_ticker_windows,
+            commands::window::identify_monitors,
             commands::window::pin_window,
             commands::window::set_hide_on_fullscreen,
             commands::window::set_ticker_visible,

--- a/desktop/src/components/settings/MonitorMap.test.tsx
+++ b/desktop/src/components/settings/MonitorMap.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { MonitorMap, monitorLabel, type MonitorInfo } from "./MonitorMap";
+
+// Brandon's desk as `list_monitors` reports it (REL-203): two 3440×1440
+// at 100 % and a 3840×2160 at 300 % to the right. Logically DISPLAY3 is
+// 1280 wide at x≈1147 — inside DISPLAY1.
+const mon = (
+  name: string,
+  [px, py, pw, ph]: [number, number, number, number],
+  scale: number,
+  isPrimary = false,
+): MonitorInfo => ({
+  name,
+  x: px / scale,
+  y: py / scale,
+  width: pw / scale,
+  height: ph / scale,
+  scaleFactor: scale,
+  isPrimary,
+  physicalX: px,
+  physicalY: py,
+  physicalWidth: pw,
+  physicalHeight: ph,
+});
+const DESK = [
+  mon("\\\\.\\DISPLAY1", [0, 0, 3440, 1440], 1, true),
+  mon("\\\\.\\DISPLAY2", [-3440, 0, 3440, 1440], 1),
+  mon("\\\\.\\DISPLAY3", [3440, 0, 3840, 2160], 3),
+];
+
+// Names hold backslashes, so index the <g>s rather than select by attribute.
+const groupAt = (el: HTMLElement, i: number) => el.querySelectorAll("g[data-monitor]")[i];
+const rectOf = (el: HTMLElement, i: number) => {
+  const r = groupAt(el, i).querySelector("rect")!;
+  const n = (a: string) => Number(r.getAttribute(a));
+  return { x: n("x"), y: n("y"), w: n("width"), h: n("height") };
+};
+
+describe("MonitorMap", () => {
+  it("draws physical rects, so mixed-DPI screens sit side by side without overlap", () => {
+    const { container } = render(<MonitorMap monitors={DESK} on={new Set()} />);
+    const rects = DESK.map((_, i) => rectOf(container, i));
+    expect(rects[2]).toEqual({ x: 3440, y: 0, w: 3840, h: 2160 });
+    for (const a of rects) {
+      for (const b of rects) {
+        if (a === b) continue;
+        const overlap = a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+        expect(overlap).toBe(false);
+      }
+    }
+    // 2 | 1 | 3 left to right, top-aligned
+    expect(rects.map((r) => r.x).sort((p, q) => p - q)).toEqual([-3440, 0, 3440]);
+    expect(rects.every((r) => r.y === 0)).toBe(true);
+  });
+
+  it("numbers screens in list order, matching Identify and the row labels", () => {
+    const { container } = render(<MonitorMap monitors={DESK} on={new Set()} />);
+    const texts = Array.from(container.querySelectorAll("text")).map((t) => t.textContent);
+    expect(texts).toEqual(["1", "2", "3"]);
+    expect(monitorLabel(2, DESK[2])).toBe("Display 3 · 3840 × 2160");
+  });
+
+  it("click toggles a screen, except the last one on", () => {
+    const onToggle = vi.fn();
+    const on = new Set([DESK[0].name]);
+    const { container } = render(<MonitorMap monitors={DESK} on={on} onToggle={onToggle} />);
+    fireEvent.click(groupAt(container, 2));
+    expect(onToggle).toHaveBeenCalledWith(DESK[2].name, true);
+    fireEvent.click(groupAt(container, 0));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/components/settings/MonitorMap.tsx
+++ b/desktop/src/components/settings/MonitorMap.tsx
@@ -1,0 +1,176 @@
+/**
+ * Monitors: the map, the per-screen switches, and the Identify button.
+ *
+ * Shared by Settings pages (Window & startup today, the Ticker page
+ * next — REL-204), so nothing here knows which page it is on.
+ *
+ * The map draws PHYSICAL rects: that is the one plane where mixed-DPI
+ * screens sit side by side the way Windows' Display settings shows
+ * them. Logical rects divide each screen by its own scale, so a 4K
+ * screen at 300 % came out a third the size, overlapping its
+ * neighbour (REL-203).
+ *
+ * Screens are numbered in `list_monitors` order, and "Identify" flashes
+ * that number on each screen so the user can match switch to glass.
+ */
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTauriListener } from "../../hooks/useTauriListener";
+import { RowList, SettingsButton, SettingsGroup, ToggleRow } from "./SettingsControls";
+import { Row } from "./pages/Row";
+
+/** One `list_monitors` entry. `x/y/width/height` are logical (that
+ *  screen's own scale); `physical*` are the OS's shared plane. */
+export interface MonitorInfo {
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scaleFactor: number;
+  isPrimary: boolean;
+  physicalX: number;
+  physicalY: number;
+  physicalWidth: number;
+  physicalHeight: number;
+}
+
+/** "Display 3 · 3840 × 2160" — what Windows calls it, at its real size. */
+export const monitorLabel = (i: number, m: MonitorInfo) =>
+  `Display ${i + 1} · ${m.physicalWidth} × ${m.physicalHeight}`;
+
+/** The attached monitors, re-listed when one is plugged or unplugged. */
+export function useMonitors(): MonitorInfo[] {
+  const [monitors, setMonitors] = useState<MonitorInfo[]>([]);
+  const refresh = () => invoke<MonitorInfo[]>("list_monitors").then(setMonitors).catch(() => {});
+  useEffect(() => {
+    void refresh();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useTauriListener("monitors-changed", refresh);
+  return monitors;
+}
+
+export function MonitorMap({
+  monitors,
+  on,
+  onToggle,
+}: {
+  monitors: MonitorInfo[];
+  on: Set<string>;
+  /** Click on a screen. Absent = display only. */
+  onToggle?: (name: string, checked: boolean) => void;
+}) {
+  const minX = Math.min(...monitors.map((m) => m.physicalX));
+  const minY = Math.min(...monitors.map((m) => m.physicalY));
+  const maxX = Math.max(...monitors.map((m) => m.physicalX + m.physicalWidth));
+  const maxY = Math.max(...monitors.map((m) => m.physicalY + m.physicalHeight));
+  const pad = (maxX - minX) * 0.02;
+  return (
+    // The switches below are the accessible control; the rects are the
+    // pointer shortcut, so the SVG stays one labelled image.
+    <svg
+      role="img"
+      aria-label="Monitor layout"
+      viewBox={`${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`}
+      className="mx-auto block h-24 w-full"
+    >
+      {monitors.map((m, i) => {
+        const checked = on.has(m.name);
+        // The last screen on stays on (same rule as its switch).
+        const locked = checked && on.size === 1;
+        return (
+          <g
+            key={m.name}
+            data-monitor={m.name}
+            onClick={onToggle && !locked ? () => onToggle(m.name, !checked) : undefined}
+            className={onToggle && !locked ? "cursor-pointer" : undefined}
+          >
+            <rect
+              x={m.physicalX}
+              y={m.physicalY}
+              width={m.physicalWidth}
+              height={m.physicalHeight}
+              rx={m.physicalWidth * 0.015}
+              vectorEffect="non-scaling-stroke"
+              strokeWidth={1.5}
+              className={checked ? "fill-accent/25 stroke-accent" : "fill-base-250/50 stroke-edge"}
+            />
+            <text
+              x={m.physicalX + m.physicalWidth / 2}
+              y={m.physicalY + m.physicalHeight / 2}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fontSize={m.physicalHeight * 0.35}
+              className={checked ? "fill-fg font-medium" : "fill-fg-4"}
+            >
+              {i + 1}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+/**
+ * The whole Monitors group. `chosen` is `window.tickerMonitors` (names;
+ * empty means primary, so a fresh install shows the primary switched
+ * on with nothing saved). The main window turns the pref into windows
+ * (routes/__root.tsx).
+ */
+export function MonitorsGroup({
+  chosen,
+  onChange,
+}: {
+  chosen: string[];
+  onChange: (names: string[]) => void;
+}) {
+  const monitors = useMonitors();
+  if (monitors.length === 0) return null;
+
+  const primary = monitors.find((m) => m.isPrimary) ?? monitors[0];
+  const on = new Set(chosen.filter((n) => monitors.some((m) => m.name === n)));
+  if (on.size === 0) on.add(primary.name);
+
+  // Save in detection order so the first ticker window's screen is
+  // stable no matter which switch was flipped last.
+  const toggle = (name: string, checked: boolean) =>
+    onChange(
+      monitors
+        .filter((m) => (m.name === name ? checked : on.has(m.name)))
+        .map((m) => m.name),
+    );
+
+  return (
+    <SettingsGroup
+      label="Monitors"
+      action={
+        <SettingsButton onClick={() => void invoke("identify_monitors").catch(() => {})}>
+          Identify
+        </SettingsButton>
+      }
+    >
+      <Row id="tickerMonitors">
+        <div className="border-b border-edge/60 px-4 py-3">
+          <MonitorMap monitors={monitors} on={on} onToggle={toggle} />
+        </div>
+        <RowList>
+          {monitors.map((m, i) => {
+            const locked = on.size === 1 && on.has(m.name);
+            return (
+              <ToggleRow
+                key={m.name}
+                label={monitorLabel(i, m)}
+                badge={m.isPrimary ? "Primary" : undefined}
+                checked={on.has(m.name)}
+                disabled={locked}
+                title={locked ? "Keep at least one" : undefined}
+                onChange={(v) => toggle(m.name, v)}
+              />
+            );
+          })}
+        </RowList>
+      </Row>
+    </SettingsGroup>
+  );
+}

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -241,6 +241,8 @@ interface ToggleRowProps {
   onChange: (checked: boolean) => void;
   /** Shown but inert, e.g. the last monitor that cannot be turned off. */
   disabled?: boolean;
+  /** Native tooltip — the place to say WHY a row is disabled. */
+  title?: string;
 }
 
 export function ToggleRow({
@@ -250,6 +252,7 @@ export function ToggleRow({
   checked,
   onChange,
   disabled = false,
+  title,
 }: ToggleRowProps) {
   return (
     <button
@@ -257,6 +260,7 @@ export function ToggleRow({
       role="switch"
       aria-checked={checked}
       disabled={disabled}
+      title={title}
       onClick={() => onChange(!checked)}
       className={clsx(
         ROW_BASE,

--- a/desktop/src/components/settings/pages/WindowStartupPage.tsx
+++ b/desktop/src/components/settings/pages/WindowStartupPage.tsx
@@ -6,129 +6,13 @@
  * "what happens when Scrollr launches" switches together. The Updates
  * page points at this row instead of duplicating it.
  *
- * Monitors: one switch per detected screen plus a map drawn from the
- * real positions. The pref stores monitor names; empty means primary,
- * so a fresh install shows the primary switched on with nothing saved.
- * The main window turns the pref into windows (routes/__root.tsx).
+ * Monitors (map, switches, Identify) come from ../MonitorMap so the
+ * Ticker page can host the same group (REL-204).
  */
-import { useEffect, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import type { StartupPrefs, WindowPrefs } from "../../../preferences";
-import { useTauriListener } from "../../../hooks/useTauriListener";
+import { MonitorsGroup } from "../MonitorMap";
 import { RowList, SettingsGroup, ToggleRow } from "../SettingsControls";
 import { Row } from "./Row";
-
-/** Shape of one `list_monitors` entry (logical coordinates). */
-interface MonitorInfo {
-  name: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  scaleFactor: number;
-  isPrimary: boolean;
-}
-
-/** `\\.\DISPLAY2` → `DISPLAY2`; other platforms' names pass through. */
-const displayName = (name: string) => name.replace(/^\\\\\.\\/, "");
-
-function MonitorMap({ monitors, on }: { monitors: MonitorInfo[]; on: Set<string> }) {
-  const minX = Math.min(...monitors.map((m) => m.x));
-  const minY = Math.min(...monitors.map((m) => m.y));
-  const maxX = Math.max(...monitors.map((m) => m.x + m.width));
-  const maxY = Math.max(...monitors.map((m) => m.y + m.height));
-  const pad = (maxX - minX) * 0.02;
-  return (
-    <svg
-      role="img"
-      aria-label="Monitor layout"
-      viewBox={`${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`}
-      className="mx-auto block h-24 w-full"
-    >
-      {monitors.map((m) => (
-        <g key={m.name}>
-          <rect
-            x={m.x}
-            y={m.y}
-            width={m.width}
-            height={m.height}
-            rx={m.width * 0.015}
-            vectorEffect="non-scaling-stroke"
-            strokeWidth={1.5}
-            className={
-              on.has(m.name)
-                ? "fill-accent/25 stroke-accent"
-                : "fill-base-250/50 stroke-edge"
-            }
-          />
-          <text
-            x={m.x + m.width / 2}
-            y={m.y + m.height / 2}
-            textAnchor="middle"
-            dominantBaseline="middle"
-            fontSize={m.height * 0.16}
-            className={on.has(m.name) ? "fill-fg font-medium" : "fill-fg-4"}
-          >
-            {displayName(m.name)}
-          </text>
-        </g>
-      ))}
-    </svg>
-  );
-}
-
-function MonitorsGroup({
-  chosen,
-  onChange,
-}: {
-  chosen: string[];
-  onChange: (names: string[]) => void;
-}) {
-  const [monitors, setMonitors] = useState<MonitorInfo[]>([]);
-  const refresh = () => invoke<MonitorInfo[]>("list_monitors").then(setMonitors).catch(() => {});
-  useEffect(() => {
-    void refresh();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-  // Plugged / unplugged while the page is open: re-list on Rust's event.
-  useTauriListener("monitors-changed", refresh);
-  if (monitors.length === 0) return null;
-
-  const primary = monitors.find((m) => m.isPrimary) ?? monitors[0];
-  const on = new Set(chosen.filter((n) => monitors.some((m) => m.name === n)));
-  if (on.size === 0) on.add(primary.name);
-
-  // Save in detection order so the first ticker window's screen is
-  // stable no matter which switch was flipped last.
-  const toggle = (name: string, checked: boolean) =>
-    onChange(
-      monitors
-        .filter((m) => (m.name === name ? checked : on.has(m.name)))
-        .map((m) => m.name),
-    );
-
-  return (
-    <SettingsGroup label="Monitors">
-      <Row id="tickerMonitors">
-        <div className="border-b border-edge/60 px-4 py-3">
-          <MonitorMap monitors={monitors} on={on} />
-        </div>
-        <RowList>
-          {monitors.map((m) => (
-            <ToggleRow
-              key={m.name}
-              label={displayName(m.name)}
-              badge={m.isPrimary ? "Primary" : undefined}
-              description={`${Math.round(m.width * m.scaleFactor)} × ${Math.round(m.height * m.scaleFactor)}`}
-              checked={on.has(m.name)}
-              disabled={on.size === 1 && on.has(m.name)}
-              onChange={(v) => toggle(m.name, v)}
-            />
-          ))}
-        </RowList>
-      </Row>
-    </SettingsGroup>
-  );
-}
 
 interface WindowStartupPageProps {
   window_: WindowPrefs;

--- a/desktop/src/components/settings/settingsSearchIndex.test.ts
+++ b/desktop/src/components/settings/settingsSearchIndex.test.ts
@@ -17,7 +17,8 @@ import { SETTINGS_PAGES, isSettingsPage } from "./pages";
 // globals — reaching for node builtins here type-checks fine under
 // vitest (Vite resolves them at runtime) but fails `tsc --noEmit`, which
 // is the second half of `npm run build` and therefore the release build.
-const PAGE_SOURCES = import.meta.glob("./pages/*.tsx", {
+// Groups shared between pages (MonitorMap.tsx) sit one level up.
+const PAGE_SOURCES = import.meta.glob(["./pages/*.tsx", "./*.tsx"], {
   query: "?raw",
   import: "default",
   eager: true,

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -59,7 +59,8 @@ export default defineConfig({
     watch: { ignored: ["**/src-tauri/target/**"] },
   },
 
-  // Multi-page build: ticker (index.html) + app window (app.html)
+  // Multi-page build: ticker (index.html) + app window (app.html) +
+  // the Identify tile (identify.html, no JS of its own)
   build: {
     outDir: "dist",
     emptyOutDir: true,
@@ -71,6 +72,7 @@ export default defineConfig({
       input: {
         main: resolve(projectRoot, "index.html"),
         app: resolve(projectRoot, "app.html"),
+        identify: resolve(projectRoot, "identify.html"),
       },
     },
   },

--- a/scripts/dev/capture-window.ps1
+++ b/scripts/dev/capture-window.ps1
@@ -35,11 +35,16 @@ public static class Win {
   [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
   [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr dc, uint flags);
   [DllImport("user32.dll")] public static extern bool SetProcessDPIAware();
+  [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr ctx);
   [DllImport("dwmapi.dll")] public static extern int DwmGetWindowAttribute(IntPtr h, int a, out RECT r, int size);
   [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
 }
 "@
-[void][Win]::SetProcessDPIAware()
+# Per-monitor-v2, not system-DPI: with mixed scaling (a 300 % screen next
+# to 100 % ones) a system-aware process sees other screens' windows
+# virtualised to a third of their size and PrintWindow paints them at
+# that DPI, leaving the rest of the bitmap blank. Falls back on old Windows.
+if (-not [Win]::SetProcessDpiAwarenessContext([IntPtr]::op_Explicit(-4))) { [void][Win]::SetProcessDPIAware() }
 
 $pids = @(Get-Process -Name $Process -ErrorAction SilentlyContinue | ForEach-Object { [uint32]$_.Id })
 if ($pids.Count -eq 0) { throw "no process named $Process is running" }


### PR DESCRIPTION
Fixes [REL-203](https://linear.app/relentnet/issue/REL-203). Follows REL-199…202 (#315–#318) and the settings audit (#319); REL-204 moves the Monitors group onto the Ticker page next.

## What

**`list_monitors` returns both coordinate sets.** `MonitorInfo` (`desktop/src-tauri/src/commands/diagnostics.rs`) gains `physicalX/Y/Width/Height`. The logical fields stay (each monitor divided by its own scale — right for sizing content *on* that screen, wrong for comparing screens). `MonitorInfo::new` builds both from the physical rect + scale; the test helpers use it.

**The map draws physical rects.** `MonitorMap.tsx` (new, `desktop/src/components/settings/`) holds `MonitorMap`, `useMonitors()`, `monitorLabel()` and the whole `MonitorsGroup`; `WindowStartupPage.tsx` just renders the group. Rects are the OS's shared plane, so the arrangement matches Windows' Display settings: **2 | 1 | 3**, top-aligned, 3 visibly larger, no overlap.

**Settings › Monitors**
- Rows: **Display N · W × H** (N = `list_monitors` order, physical size), Primary badge kept.
- The last switch on is disabled with a native tooltip **"Keep at least one"** (`ToggleRow` gains `title`).
- Clicking a rectangle toggles that screen (same last-one-stays rule).
- **Identify** (group action): `identify_monitors` opens one tiny always-on-top window per monitor showing its number, centred in **physical** pixels (a logical builder position resolves against the wrong scale on mixed DPI), and destroys them after 1.5 s. The page is `desktop/identify.html` — no script of its own, the number is filled in by an initialization script, so nothing new for the CSP. Added to the Vite multi-page inputs.

**`position_ticker` on Windows** places the AppBar from `target.physical_*` instead of `logical × scale`. The old path happened to round-trip exactly here (1146.67 × 3 = 3440.0) but is fragile; only the bar height is scaled now.

**`scripts/dev/capture-window.ps1`** is per-monitor-DPI-aware (v2). System-DPI awareness saw Ticker 3 as `1280x64` and PrintWindow painted it at that DPI into a 3840×192 bitmap (two-thirds white). Falls back to `SetProcessDPIAware` on old Windows.

## Tests

- `cargo test --lib` (31): new `logical_rect_is_physical_over_own_scale` (DISPLAY3: physical 3440/3840/2160 ↔ logical 1146.67/1280/720) and `identify_tile_is_centred_in_physical_pixels` (300 % tile is 660 px at (5030, 750); 100 % tile 220 px).
- `vitest` (678): new `MonitorMap.test.tsx` with the real three-monitor fixture — physical rects, no pairwise overlap, 2|1|3 order, labels 1/2/3 + `Display 3 · 3840 × 2160`, click toggles except the last one on. `settingsSearchIndex.test.ts` now also reads `settings/*.tsx` (the shared group moved out of `pages/`).
- `tsc --noEmit` clean. `cargo clippy -D warnings`: nothing from this change; the one remaining lint (`missing_const_for_thread_local` in `gpu_win.rs`) predates it and CI does not run clippy.

## Verified live (Brandon's box)

Two 3440×1440 @ 100 % (`\.\DISPLAY2` at x=−3440, `\.\DISPLAY1` primary at 0) + `\.\DISPLAY3` 3840×2160 @ **300 %** at x=3440 (physical), all plugged in. `list_monitors` now reports DISPLAY3 as `x 1146.67 w 1280 h 720 scale 3` **and** `physicalX 3440 physicalWidth 3840 physicalHeight 2160`.

| | |
|---|---|
| **Before** (main's page, same build) — DISPLAY3 drawn at a third, inside DISPLAY1 | ![before](https://github.com/doughknee/myscrollr/blob/captures/rel-203/settings-before.png?raw=true) |
| **After**, all three on — 2 \| 1 \| 3, no overlap, Display N rows, Identify button | ![after](https://github.com/doughknee/myscrollr/blob/captures/rel-203/settings-after-3on.png?raw=true) |
| **Ticker 3** on the 300 % screen: window `3840x192 @ 3440,0` (per-monitor-aware list), webview `innerWidth 1280 × 64, devicePixelRatio 3` — flush, full width | ![ticker3](https://github.com/doughknee/myscrollr/blob/captures/rel-203/ticker3-after.png?raw=true) |
| **Identify** tile (Display 2); tiles listed at `@ 1610,610` / `@ -1830,610` / `696x681 @ 5030,750` and gone afterwards | ![identify](https://github.com/doughknee/myscrollr/blob/captures/rel-203/identify-2.png?raw=true) |

Toggling DISPLAY3 on went through the real pref path (`savePrefs` from a ticker window → main's `sync_ticker_windows` → `ticker-3` created and positioned). Pref put back to the original two afterwards.

Captures live on the orphan branch `captures/rel-203`, not in the app tree.

Not done: nothing from the issue. Linear could not be updated from this session (connector not authorised) — see the session recap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
