### PR TITLE
feat(desktop): drop the fantasy "Advanced — ticker items" toggles and the dead prefs behind them [REL-208]

### DIFF
--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -31,7 +31,6 @@ import type {
   WidgetPinConfig,
   WidgetDisplayPrefs,
 } from "../preferences";
-import { shouldShowOnTicker } from "../preferences";
 import type { LeagueResponse as FantasyLeague } from "../datawidgets/fantasy/types";
 import { GitHubCappedChip, UptimeCappedChip } from "./chips/CappedChip";
 import {

--- a/desktop/src/components/chips/FantasyStatChip.test.tsx
+++ b/desktop/src/components/chips/FantasyStatChip.test.tsx
@@ -1,10 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import FantasyStatChip from "./FantasyStatChip";
-import { DEFAULT_WIDGET_DISPLAY } from "../../preferences";
 import type { LeagueResponse } from "../../datawidgets/fantasy/types";
-
-const prefs = DEFAULT_WIDGET_DISPLAY.fantasy;
 
 function league(): LeagueResponse {
   return {
@@ -64,7 +61,7 @@ describe("FantasyStatChip score rolling", () => {
    */
   it("renders the score as one plain string by default", () => {
     const { container } = render(
-      <FantasyStatChip league={league()} prefs={prefs} />,
+      <FantasyStatChip league={league()} />,
     );
     expect(screen.getByText("149.9–151.7")).toBeTruthy();
     // No roller mounted, so no digit columns in the markup.
@@ -79,7 +76,7 @@ describe("FantasyStatChip score rolling", () => {
    */
   it("rolls the digits when opted in without losing the accessible score", () => {
     const { container } = render(
-      <FantasyStatChip league={league()} prefs={prefs} rollScore />,
+      <FantasyStatChip league={league()} rollScore />,
     );
     expect(container.textContent).toContain("0123456789");
     expect(screen.getByText("149.9–151.7")).toBeTruthy();

--- a/desktop/src/components/chips/FantasyStatChip.tsx
+++ b/desktop/src/components/chips/FantasyStatChip.tsx
@@ -2,8 +2,7 @@ import { clsx } from "clsx";
 import { motion } from "motion/react";
 import { AnimateNumber } from "motion-plus/react";
 import type { ReactNode } from "react";
-import type { ChipColorMode, FantasyDisplayPrefs } from "../../preferences";
-import { shouldShowOnTicker } from "../../preferences";
+import type { ChipColorMode } from "../../preferences";
 import type { LeagueResponse } from "../../datawidgets/fantasy/types";
 import {
   SPORT_EMOJI,
@@ -30,7 +29,6 @@ import { ChipFlash, useChangeFlash } from "./ChipFlash";
 
 interface FantasyStatChipProps {
   league: LeagueResponse;
-  prefs: FantasyDisplayPrefs;
   comfort?: boolean;
   colorMode?: ChipColorMode;
   onClick?: () => void;
@@ -68,46 +66,25 @@ interface StatSegment {
 }
 
 /**
- * Compact fantasy ticker chip that renders the ENABLED subset of the
- * per-league items gated by the user's per-item `Venue` prefs.
+ * Compact fantasy ticker chip: one per league, a fixed set of segments
+ * (docs/CHIP_SPEC.md §8 — nothing on the rail is user-selected).
  *
- * This chip replaces the older `FantasyChip` for ticker use. It keeps
- * the same visual footprint (single row when `comfort=false`, two rows
- * when true) but composes the contents from whichever items the user
- * has routed to the ticker.
+ * Single row when `comfort=false`, two rows when true. The segments:
+ *   Matchup-derived:  "Wk 5" · LIVE / FINAL / PRE · "89.5–76.2" ·
+ *                     "Proj 95.2" · "62%"
+ *   Standings-derived: "6-3" · "3rd/10" · "W3"
+ *   Roster-derived:    "2 IR" · "★ LeBron 42.3"
  *
- * Each segment is opt-in:
- *   Matchup-derived:
- *   - `matchupScore` — "My Team 89.5 — 76.2 Opp"
- *   - `matchupStatus` — LIVE / FINAL / PRE badge
- *   - `week` — "Wk 5"
- *   - `projectedPoints` — "Proj 95.2"
- *   - `winProbability` — "62%"
- *   Standings-derived:
- *   - `record` — "6-3"
- *   - `standingsPosition` — "3rd / 10"
- *   - `streak` — "W3"
- *   Roster-derived:
- *   - `injuryCount` — "2 IR"
- *   - `topScorer` — "★ LeBron 42.3"
+ * Each renders only when its data exists for this league (standings
+ * skip pre-season; the top scorer skips an all-zero roster), so a
+ * league with nothing yet collapses to a name-only chip.
  *
- * Segments render only when their data is available for this league
- * (e.g. `standingsPosition` skips pre-season; `topScorer` skips rosters
- * with all-zero points). A league with ZERO ticker-enabled items
- * collapses to a name-only chip so the user still sees something
- * meaningful per-league.
- *
- * The 4 "Player stats" venues (`topThreeScorers`, `worstStarter`,
- * `benchOpportunity`, `injuryDetail`) used to render here as inline
- * segments. They are now emitted as standalone chips on the rail by
- * `ScrollrTicker`'s fantasy bucket builder, using `FollowedPlayerChip`
- * with an `accent` prop. This keeps the league chip focused on
- * matchup-level context while letting per-player stats stand on their
- * own where they're easier to scan.
+ * Per-player items (top scorers, worst starter, bench top, injury
+ * report) are standalone chips emitted by the fantasy ticker source
+ * with `FollowedPlayerChip` + an `accent`, not segments here.
  */
 export default function FantasyStatChip({
   league,
-  prefs,
   comfort,
   colorMode = "widget",
   onClick,
@@ -145,79 +122,63 @@ export default function FantasyStatChip({
     if (myPts > oppPts) scoreTone = "up";
     else if (myPts < oppPts) scoreTone = "down";
 
-    if (shouldShowOnTicker(prefs.week)) {
-      primarySegments.push({ key: "week", text: `Wk ${ctx.matchup.week}` });
-    }
+    primarySegments.push({ key: "week", text: `Wk ${ctx.matchup.week}` });
 
-    if (shouldShowOnTicker(prefs.matchupStatus)) {
-      if (live)
-        primarySegments.push({ key: "status", text: "LIVE", tone: "live" });
-      else if (final) primarySegments.push({ key: "status", text: "FINAL" });
-      else if (ctx.matchup.status === "preevent")
-        primarySegments.push({ key: "status", text: "PRE" });
-    }
+    if (live)
+      primarySegments.push({ key: "status", text: "LIVE", tone: "live" });
+    else if (final) primarySegments.push({ key: "status", text: "FINAL" });
+    else if (ctx.matchup.status === "preevent")
+      primarySegments.push({ key: "status", text: "PRE" });
 
-    if (shouldShowOnTicker(prefs.matchupScore)) {
-      const scoreText = `${fmtPlayerPoints(myPts)}–${fmtPlayerPoints(oppPts)}`;
-      primarySegments.push({
-        key: "score",
-        text: scoreText,
-        tone: scoreTone,
-        // Both sides plus the separator. Reserved as one block so the
-        // dash never walks left as a score crosses into three figures.
-        width: NUM_WIDTH.teamScore * 2 + 1,
-        node: rollScore ? (
-          <RollingScore myPts={myPts} oppPts={oppPts} label={scoreText} />
-        ) : undefined,
-      });
-    }
+    const scoreText = `${fmtPlayerPoints(myPts)}–${fmtPlayerPoints(oppPts)}`;
+    primarySegments.push({
+      key: "score",
+      text: scoreText,
+      tone: scoreTone,
+      // Both sides plus the separator. Reserved as one block so the
+      // dash never walks left as a score crosses into three figures.
+      width: NUM_WIDTH.teamScore * 2 + 1,
+      node: rollScore ? (
+        <RollingScore myPts={myPts} oppPts={oppPts} label={scoreText} />
+      ) : undefined,
+    });
 
-    if (
-      shouldShowOnTicker(prefs.projectedPoints) &&
-      typeof ctx.user.projected_points === "number"
-    ) {
+    if (typeof ctx.user.projected_points === "number") {
       primarySegments.push({
         key: "proj",
         text: `Proj ${ctx.user.projected_points.toFixed(1)}`,
       });
     }
 
-    if (shouldShowOnTicker(prefs.winProbability)) {
-      const wp = estimateWinProbability(ctx.matchup, league.team_key);
-      if (wp !== null) {
-        primarySegments.push({
-          key: "wp",
-          text: `${Math.round(wp * 100)}%`,
-          tone: wp >= 0.5 ? "up" : "down",
-          // 65% -> 100% gains a digit, and a win probability crossing
-          // three figures is exactly the moment the rail must hold
-          // still rather than nudge every chip along.
-          width: NUM_WIDTH.percent,
-        });
-      }
+    const wp = estimateWinProbability(ctx.matchup, league.team_key);
+    if (wp !== null) {
+      primarySegments.push({
+        key: "wp",
+        text: `${Math.round(wp * 100)}%`,
+        tone: wp >= 0.5 ? "up" : "down",
+        // 65% -> 100% gains a digit, and a win probability crossing
+        // three figures is exactly the moment the rail must hold
+        // still rather than nudge every chip along.
+        width: NUM_WIDTH.percent,
+      });
     }
   }
 
   // ── Standings-derived (secondary row) ───────────────────────
   if (standing) {
-    if (shouldShowOnTicker(prefs.record)) {
-      const { wins, losses, ties } = standing;
-      const record =
-        ties > 0 ? `${wins}-${losses}-${ties}` : `${wins}-${losses}`;
-      secondarySegments.push({ key: "record", text: record });
-    }
+    const { wins, losses, ties } = standing;
+    const record =
+      ties > 0 ? `${wins}-${losses}-${ties}` : `${wins}-${losses}`;
+    secondarySegments.push({ key: "record", text: record });
 
-    if (
-      shouldShowOnTicker(prefs.standingsPosition) &&
-      typeof standing.rank === "number"
-    ) {
+    if (typeof standing.rank === "number") {
       secondarySegments.push({
         key: "rank",
         text: `${ordinal(standing.rank)}/${league.data.num_teams ?? "?"}`,
       });
     }
 
-    if (shouldShowOnTicker(prefs.streak) && standing.streak_value > 0) {
+    if (standing.streak_value > 0) {
       secondarySegments.push({
         key: "streak",
         text: streakLabel(standing.streak_type, standing.streak_value),
@@ -230,32 +191,23 @@ export default function FantasyStatChip({
 
   // ── Roster-derived (secondary row) ──────────────────────────
   if (roster) {
-    if (shouldShowOnTicker(prefs.injuryCount)) {
-      const injuries = countInjuries(roster);
-      if (injuries > 0) {
-        secondarySegments.push({
-          key: "inj",
-          text: `${injuries} IR`,
-          tone: "down",
-        });
-      }
+    const injuries = countInjuries(roster);
+    if (injuries > 0) {
+      secondarySegments.push({
+        key: "inj",
+        text: `${injuries} IR`,
+        tone: "down",
+      });
     }
 
-    if (shouldShowOnTicker(prefs.topScorer)) {
-      const top = findTopScorer(roster.data.players);
-      if (top) {
-        secondarySegments.push({
-          key: "top",
-          text: `★ ${top.name.last} ${top.player_points!.toFixed(1)}`,
-          tone: "up",
-        });
-      }
+    const top = findTopScorer(roster.data.players);
+    if (top) {
+      secondarySegments.push({
+        key: "top",
+        text: `★ ${top.name.last} ${top.player_points!.toFixed(1)}`,
+        tone: "up",
+      });
     }
-
-    // The four "Player stats" venues (topThreeScorers, worstStarter,
-    // benchOpportunity, injuryDetail) USED to render here as inline
-    // segments. They are now emitted as standalone chips on the rail
-    // by ScrollrTicker — see the fantasy bucket builder there.
   }
 
   // In compact mode (single-line ticker), pour everything into a

--- a/desktop/src/datawidgets/fantasy/ConnectedView.test.tsx
+++ b/desktop/src/datawidgets/fantasy/ConnectedView.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConnectedView } from "./ConnectedView";
+import { loadPrefs } from "../../preferences";
+import type { LeagueResponse } from "./types";
+
+vi.mock("../../lib/store", () => ({
+  getStore: vi.fn((_key: string, fallback: unknown) => fallback),
+  setStore: vi.fn(),
+}));
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
+vi.mock("../../shell-context", () => ({
+  useShell: () => ({ prefs: loadPrefs(), onPrefsChange: vi.fn() }),
+}));
+
+function league(): LeagueResponse {
+  return {
+    league_key: "449.l.1",
+    name: "Test League",
+    game_code: "nfl",
+    season: "2025",
+    team_key: "449.l.1.t.4",
+    team_name: "Mine",
+    data: { num_teams: 8, is_finished: false, current_week: 12, scoring_type: "head" },
+    standings: null,
+    matchups: [],
+    rosters: null,
+  } as LeagueResponse;
+}
+
+describe("ConnectedView ticker section", () => {
+  it("offers the one dial and no per-item toggles (REL-208)", () => {
+    render(
+      <ConnectedView
+        leagues={[league()]}
+        yahooConnected
+        hex="#6366f1"
+        noLeaguesFound={false}
+        onStartDiscovery={vi.fn()}
+        onDisconnect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("What shows on the ticker")).toBeTruthy();
+    for (const label of ["Essential", "Standard", "Everything"]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+    // The preview is the real ticker source's output: one league chip.
+    expect(screen.getByText(/^1 chip ·/)).toBeTruthy();
+
+    expect(screen.queryByText(/Advanced/)).toBeNull();
+    for (const gone of [
+      "Matchup score",
+      "Win probability",
+      "Projected points",
+      "Top 3 scorers",
+      "Worst starter",
+      "Injury report",
+    ]) {
+      expect(screen.queryByText(gone)).toBeNull();
+    }
+  });
+});

--- a/desktop/src/datawidgets/fantasy/ConnectedView.tsx
+++ b/desktop/src/datawidgets/fantasy/ConnectedView.tsx
@@ -19,10 +19,7 @@ import {
   DisplayRow,
   ActionRow,
   SegmentedRow,
-  ToggleRow,
-  Badge,
 } from "../../components/settings/SettingsControls";
-import { shouldShowOnTicker } from "../../preferences";
 import type { FantasyDisplayPrefs, FantasyTickerMode } from "../../preferences";
 import { fantasyTickerSource } from "./ticker";
 import type { TickerContext } from "../ticker";
@@ -279,7 +276,6 @@ function TickerSection({
   onPatch: (patch: Partial<FantasyDisplayPrefs>) => void;
 }) {
   const mode = prefs.tickerMode ?? "everything";
-  const everything = mode === "everything";
 
   const chips = useMemo(
     () =>
@@ -365,39 +361,6 @@ function TickerSection({
             : "None yet"
         }
       />
-
-      {/* Advanced — only meaningful in Everything, and disabled rather
-          than hidden so the dial's consequence is visible. */}
-      <div
-        className={clsx(
-          "transition-none",
-          !everything && "pointer-events-none opacity-45",
-        )}
-        aria-hidden={!everything}
-      >
-        <div className="px-3 pb-1 pt-3">
-          <div className="flex items-center gap-2">
-            <span className="font-mono text-[11px] uppercase tracking-wider text-fg-3">
-              Advanced — ticker items
-            </span>
-            <Badge>Everything only</Badge>
-          </div>
-          <p className="mt-1 text-[11px] text-fg-4">
-            The feed always shows everything — these only control what joins the
-            ticker.
-          </p>
-        </div>
-        {ADVANCED_ITEMS.map(({ key, label }) => (
-          <ToggleRow
-            key={key}
-            label={label}
-            checked={shouldShowOnTicker(prefs[key])}
-            // Toggles, not Off/Feed/Ticker segments: feed content is
-            // never gated, so OFF means "feed only", never "gone".
-            onChange={(on) => onPatch({ [key]: on ? "both" : "feed" })}
-          />
-        ))}
-      </div>
     </Section>
   );
 }
@@ -405,29 +368,8 @@ function TickerSection({
 const MODE_CAPTION: Record<FantasyTickerMode, string> = {
   essential: "one per league",
   standard: "+ live moments",
-  everything: "everything, always",
+  everything: "+ top scorers, worst starter, bench, injuries",
 };
-
-/** The venue prefs the Advanced block exposes, in the handoff's order. */
-const ADVANCED_ITEMS: Array<{
-  key: keyof FantasyDisplayPrefs & VenueKey;
-  label: string;
-}> = [
-  { key: "matchupScore", label: "Matchup score" },
-  { key: "winProbability", label: "Win probability" },
-  { key: "projectedPoints", label: "Projected points" },
-  { key: "topThreeScorers", label: "Top 3 scorers" },
-  { key: "worstStarter", label: "Worst starter" },
-  { key: "injuryDetail", label: "Injury report" },
-];
-
-type VenueKey =
-  | "matchupScore"
-  | "winProbability"
-  | "projectedPoints"
-  | "topThreeScorers"
-  | "worstStarter"
-  | "injuryDetail";
 
 function playerName(leagues: LeagueResponse[], playerKey: string): string {
   for (const l of leagues) {

--- a/desktop/src/datawidgets/fantasy/ticker.test.tsx
+++ b/desktop/src/datawidgets/fantasy/ticker.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { fantasyTickerSource } from "./ticker";
+import type { TickerContext } from "../ticker";
+import type { LeagueResponse, RosterPlayer } from "./types";
+import { DEFAULT_WIDGET_DISPLAY } from "../../preferences";
+import type { FantasyTickerMode } from "../../preferences";
+
+// The dial's three positions are FIXED sets (docs/CHIP_SPEC.md §8);
+// there is no per-item pref underneath. This pins what each one emits.
+
+function player(
+  key: string,
+  overrides: Partial<RosterPlayer>,
+): RosterPlayer {
+  return {
+    player_key: key,
+    name: { full: `P ${key}`, first: "P", last: key },
+    editorial_team_abbr: "KC",
+    display_position: "RB",
+    selected_position: "RB",
+    image_url: "",
+    status: null,
+    status_full: null,
+    injury_note: null,
+    player_points: 10,
+    ...overrides,
+  } as RosterPlayer;
+}
+
+function league(): LeagueResponse {
+  return {
+    league_key: "449.l.1",
+    name: "Test League",
+    game_code: "nfl",
+    season: "2025",
+    team_key: "449.l.1.t.4",
+    team_name: "Mine",
+    data: { num_teams: 8, is_finished: false, current_week: 12, scoring_type: "head" },
+    standings: null,
+    matchups: [],
+    rosters: [
+      {
+        team_key: "449.l.1.t.4",
+        data: {
+          team_key: "449.l.1.t.4",
+          team_name: "Mine",
+          players: [
+            player("qb", { selected_position: "QB", player_points: 30, game_state: "Q3 8:42" }),
+            player("rb", { player_points: 20 }),
+            player("wr", { selected_position: "WR", player_points: 5, status: "OUT" }),
+            player("bn", { selected_position: "BN", player_points: 18 }),
+          ],
+        },
+      },
+    ],
+  } as LeagueResponse;
+}
+
+function chipKeys(tickerMode: FantasyTickerMode): string[] {
+  const ctx = {
+    widgetDisplay: {
+      fantasy: { ...DEFAULT_WIDGET_DISPLAY.fantasy, tickerMode },
+    },
+    comfort: false,
+    chipColorMode: "widget",
+  } as unknown as TickerContext;
+  return fantasyTickerSource.chips({ leagues: [league()] }, ctx).map((c) => c.key);
+}
+
+describe("fantasy ticker dial", () => {
+  it("essential: the league chip only", () => {
+    expect(chipKeys("essential")).toEqual(["fan-449.l.1"]);
+  });
+
+  it("standard: + the player in play (a first-seen injury is not news)", () => {
+    expect(chipKeys("standard")).toEqual(["fan-449.l.1", "fan-449.l.1-live-qb"]);
+  });
+
+  it("everything: + starters 2-3, worst starter, bench top, injury report", () => {
+    expect(chipKeys("everything")).toEqual([
+      "fan-449.l.1",
+      "fan-449.l.1-live-qb",
+      "fan-449.l.1-top-rb",
+      "fan-449.l.1-top-wr",
+      "fan-449.l.1-worst-wr",
+      "fan-449.l.1-bench-bn",
+      "fan-449.l.1-inj-wr",
+    ]);
+  });
+});

--- a/desktop/src/datawidgets/fantasy/ticker.tsx
+++ b/desktop/src/datawidgets/fantasy/ticker.tsx
@@ -1,4 +1,3 @@
-import { shouldShowOnTicker } from "../../preferences";
 import FantasyStatChip from "../../components/chips/FantasyStatChip";
 import FollowedPlayerChip from "../../components/chips/FollowedPlayerChip";
 import { buildYahooLeagueUrl, buildYahooPlayerUrl } from "../../utils/chipUrl";
@@ -35,10 +34,12 @@ export const fantasyTickerSource: TickerSource = {
     const prefs = ctx.widgetDisplay?.fantasy;
     if (!prefs) return [];
 
-    // The simplicity dial. `essential` and `standard` are presets
-    // computed here and DELIBERATELY ignore the per-item venue prefs —
-    // the prefs stay untouched underneath, so moving the dial back to
-    // `everything` restores exactly what the user had configured.
+    // The simplicity dial. Each position is a fixed set, built right
+    // here — there is no per-item control underneath it (REL-208;
+    // docs/CHIP_SPEC.md §8: nothing on the rail is user-selected).
+    //   essential  — the league chip only
+    //   standard   — + moment chips (in play, breaking injury)
+    //   everything — + top scorers, worst starter, bench top, injury report
     const mode = prefs.tickerMode ?? "everything";
     const everything = mode === "everything";
     const moments = mode === "standard" || everything;
@@ -137,7 +138,6 @@ export const fantasyTickerSource: TickerSource = {
         node: (
           <FantasyStatChip
             league={league}
-            prefs={prefs}
             comfort={ctx.comfort}
             colorMode={ctx.chipColorMode}
             // The ticker window has no #app-shell stilling rule, so the
@@ -185,36 +185,25 @@ export const fantasyTickerSource: TickerSource = {
         }
       }
 
-      // ── Per-item venues (everything only) ──
+      // ── Player chips (everything only) ──
       if (!everything) continue;
 
-      if (shouldShowOnTicker(prefs.topThreeScorers)) {
-        const top3 = findTopN(players, 3, { startersOnly: true });
-        // Skip top1 when topScorer is also enabled — it is already on the
-        // league chip as "★ Mahomes 32" and would duplicate.
-        const startIdx =
-          shouldShowOnTicker(prefs.topScorer) && top3.length > 0 ? 1 : 0;
-        for (let i = startIdx; i < top3.length; i++) {
-          chips.push(playerChip("top", top3[i].player_key, "top"));
-        }
+      // Top starters 2 and 3: the top scorer is already on the league
+      // chip as "★ Mahomes 32" and would duplicate.
+      for (const p of findTopN(players, 3, { startersOnly: true }).slice(1)) {
+        chips.push(playerChip("top", p.player_key, "top"));
       }
 
-      if (shouldShowOnTicker(prefs.worstStarter)) {
-        const worst = findWorstStarter(players);
-        if (worst) chips.push(playerChip("worst", worst.player_key, "worst"));
+      const worst = findWorstStarter(players);
+      if (worst) chips.push(playerChip("worst", worst.player_key, "worst"));
+
+      const topBench = findTopBench(players);
+      if (topBench) {
+        chips.push(playerChip("bench", topBench.player_key, "bench"));
       }
 
-      if (shouldShowOnTicker(prefs.benchOpportunity)) {
-        const topBench = findTopBench(players);
-        if (topBench) {
-          chips.push(playerChip("bench", topBench.player_key, "bench"));
-        }
-      }
-
-      if (shouldShowOnTicker(prefs.injuryDetail)) {
-        for (const p of findInjuredPlayers(players)) {
-          chips.push(playerChip("inj", p.player_key, "injury"));
-        }
+      for (const p of findInjuredPlayers(players)) {
+        chips.push(playerChip("inj", p.player_key, "injury"));
       }
     }
 

--- a/desktop/src/datawidgets/fantasy/view.test.ts
+++ b/desktop/src/datawidgets/fantasy/view.test.ts
@@ -64,30 +64,8 @@ function league(opts: LeagueOpts): LeagueResponse {
 }
 
 const DEFAULT_PREFS: FantasyDisplayPrefs = {
-  // These tests predate the simplicity dial and assert per-item venue
-  // behaviour, which only `everything` honours.
   tickerMode: "everything",
-  matchupScore: "both",
-  winProbability: "both",
-  matchupStatus: "both",
-  projectedPoints: "both",
-  week: "both",
-  record: "both",
-  standingsPosition: "both",
-  streak: "both",
-  injuryCount: "both",
-  topScorer: "both",
-  // Phase 1 player-stats fields. Match production defaults so any
-  // selectFantasyForTicker test using DEFAULT_PREFS exercises the
-  // anyItemOnTicker check the same way as a real install.
-  topThreeScorers: "both",
-  worstStarter: "both",
-  benchOpportunity: "both",
-  injuryDetail: "both",
   followedPlayerKeys: [],
-  showStandings: true,
-  showMatchups: true,
-  defaultSort: "name",
   defaultSubTab: "overview",
   primaryLeagueKey: null,
   enabledLeagueKeys: [],
@@ -204,98 +182,11 @@ describe("rankFantasyLeagues", () => {
 // ── selectFantasyForTicker ──────────────────────────────────────
 
 describe("selectFantasyForTicker", () => {
-  it("returns [] when every per-item venue toggle is off", () => {
+  it("returns every enabled league — there is no per-item gate (REL-208)", () => {
     const leagues = [league({ key: "a" })];
-    const allOff: FantasyDisplayPrefs = {
-      ...DEFAULT_PREFS,
-      matchupScore: "off",
-      winProbability: "off",
-      matchupStatus: "off",
-      projectedPoints: "off",
-      week: "off",
-      record: "off",
-      standingsPosition: "off",
-      streak: "off",
-      injuryCount: "off",
-      topScorer: "off",
-      // Phase 1 player-stats — must also be off, otherwise the
-      // selector should still return leagues.
-      topThreeScorers: "off",
-      worstStarter: "off",
-      benchOpportunity: "off",
-      injuryDetail: "off",
-    };
-    expect(selectFantasyForTicker(leagues, allOff)).toEqual([]);
-  });
-
-  it("returns [] when every per-item venue toggle is feed-only (nothing routes to ticker)", () => {
-    const leagues = [league({ key: "a" })];
-    const allFeed: FantasyDisplayPrefs = {
-      ...DEFAULT_PREFS,
-      matchupScore: "feed",
-      winProbability: "feed",
-      matchupStatus: "feed",
-      projectedPoints: "feed",
-      week: "feed",
-      record: "feed",
-      standingsPosition: "feed",
-      streak: "feed",
-      injuryCount: "feed",
-      topScorer: "feed",
-      topThreeScorers: "feed",
-      worstStarter: "feed",
-      benchOpportunity: "feed",
-      injuryDetail: "feed",
-    };
-    expect(selectFantasyForTicker(leagues, allFeed)).toEqual([]);
-  });
-
-  it("returns the leagues when at least one item is routed to the ticker", () => {
-    const leagues = [league({ key: "a" })];
-    const onlyScoreOnTicker: FantasyDisplayPrefs = {
-      ...DEFAULT_PREFS,
-      matchupScore: "ticker",
-      winProbability: "off",
-      matchupStatus: "off",
-      projectedPoints: "off",
-      week: "off",
-      record: "off",
-      standingsPosition: "off",
-      streak: "off",
-      injuryCount: "off",
-      topScorer: "off",
-      topThreeScorers: "off",
-      worstStarter: "off",
-      benchOpportunity: "off",
-      injuryDetail: "off",
-    };
-    expect(selectFantasyForTicker(leagues, onlyScoreOnTicker)).toHaveLength(1);
-  });
-
-  it("renders leagues when ONLY a player-stats segment is on the ticker", () => {
-    // Phase 1 player-stats are part of the OR-gate. If a user disabled
-    // every "old" item but turned on, e.g. injuryDetail for the ticker,
-    // their league chip must still render.
-    const leagues = [league({ key: "a" })];
-    const onlyInjuryDetailOnTicker: FantasyDisplayPrefs = {
-      ...DEFAULT_PREFS,
-      matchupScore: "off",
-      winProbability: "off",
-      matchupStatus: "off",
-      projectedPoints: "off",
-      week: "off",
-      record: "off",
-      standingsPosition: "off",
-      streak: "off",
-      injuryCount: "off",
-      topScorer: "off",
-      topThreeScorers: "off",
-      worstStarter: "off",
-      benchOpportunity: "off",
-      injuryDetail: "ticker",
-    };
+    expect(selectFantasyForTicker(leagues, DEFAULT_PREFS)).toHaveLength(1);
     expect(
-      selectFantasyForTicker(leagues, onlyInjuryDetailOnTicker),
+      selectFantasyForTicker(leagues, { ...DEFAULT_PREFS, tickerMode: "essential" }),
     ).toHaveLength(1);
   });
 

--- a/desktop/src/datawidgets/fantasy/view.ts
+++ b/desktop/src/datawidgets/fantasy/view.ts
@@ -91,42 +91,16 @@ export function rankFantasyLeagues(
 
 // ── Selector for the ticker ─────────────────────────────────────
 
-import { shouldShowOnTicker } from "../../preferences";
-
 /**
  * Baseline pipeline used by the ticker: applies `enabledLeagueKeys`
  * filter, promotes `primaryLeagueKey` to the front, sorts remaining
- * by engagement.
- *
- * Returns `[]` when NONE of the per-item venue toggles are set to
- * "both" or "ticker" — no point rendering a chip with no content. The
- * per-item filtering (which fields actually render) happens downstream
- * in `FantasyStatChip` / `ScrollrTicker`.
+ * by engagement. Those two are the user's INPUTS (which leagues, which
+ * one leads); what each league chip shows is fixed (docs/CHIP_SPEC.md §8).
  */
 export function selectFantasyForTicker(
   leagues: LeagueResponse[],
   prefs: FantasyDisplayPrefs,
 ): LeagueResponse[] {
-  const anyItemOnTicker =
-    shouldShowOnTicker(prefs.matchupScore) ||
-    shouldShowOnTicker(prefs.winProbability) ||
-    shouldShowOnTicker(prefs.matchupStatus) ||
-    shouldShowOnTicker(prefs.projectedPoints) ||
-    shouldShowOnTicker(prefs.week) ||
-    shouldShowOnTicker(prefs.record) ||
-    shouldShowOnTicker(prefs.standingsPosition) ||
-    shouldShowOnTicker(prefs.streak) ||
-    shouldShowOnTicker(prefs.injuryCount) ||
-    shouldShowOnTicker(prefs.topScorer) ||
-    // Phase 1 player-stats segments — same OR-gate semantics: if any
-    // of these is on the ticker, the league chip should render so
-    // FantasyStatChip can compose the enabled segments.
-    shouldShowOnTicker(prefs.topThreeScorers) ||
-    shouldShowOnTicker(prefs.worstStarter) ||
-    shouldShowOnTicker(prefs.benchOpportunity) ||
-    shouldShowOnTicker(prefs.injuryDetail);
-  if (!anyItemOnTicker) return [];
-
   const visible = filterEnabledLeagues(leagues, prefs.enabledLeagueKeys);
   if (visible.length === 0) return [];
   const primary = resolvePrimaryLeague(visible, prefs.primaryLeagueKey);

--- a/desktop/src/datawidgets/rss/FeedTab.tsx
+++ b/desktop/src/datawidgets/rss/FeedTab.tsx
@@ -40,7 +40,6 @@ import { useSetToggle, latestTimestamp } from "../feedHooks";
 import {
   applyRssPipeline,
   type RssSortOrder,
-  distinctSourceCount,
   getRssDisplayPrefs,
 } from "./view";
 import type {
@@ -202,8 +201,6 @@ function RssFeedTab({ mode, feedContext, widgetId }: FeedTabProps) {
   const [sortOrder, setSortOrder] = useState<SortOrder>(
     () => dp.feedSort ?? "newest",
   );
-  const [showAll, setShowAll] = useState(false);
-
   // Per-source article counts — menu rows carry the numbers now.
   const sourceCounts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -231,7 +228,6 @@ function RssFeedTab({ mode, feedContext, widgetId }: FeedTabProps) {
   const pickSort = useCallback(
     (next: SortOrder) => {
       setSortOrder(next);
-      setShowAll(false);
       persistDisplay({ ...displayOverride, feedSort: next });
     },
     [displayOverride, persistDisplay],
@@ -264,29 +260,17 @@ function RssFeedTab({ mode, feedContext, widgetId }: FeedTabProps) {
   );
 
   // ── Data pipeline ────────────────────────────────────────────
-  // Delegates to the shared `applyRssPipeline` selector so the feed page
-  // and the ticker apply the same filter/sort/limit logic.
-  const { visibleItems, totalHidden } = useMemo(
+  const visibleItems = useMemo(
     () =>
       applyRssPipeline(rssItems, {
         selectedSources,
         selectedCategories,
         categoryMap,
         sortOrder,
-        articlesPerSource: dp.articlesPerSource,
         maxArticles: dp.maxArticles,
         maxArticleAgeDays: dp.maxArticleAgeDays,
-        showAll,
       }),
-    [rssItems, selectedSources, selectedCategories, sortOrder, dp.articlesPerSource, dp.maxArticles, dp.maxArticleAgeDays, categoryMap, showAll],
-  );
-
-  // Single-outlet widgets have exactly one source; the per-source
-  // limit UI only exists for multi-feed widgets (Custom RSS, legacy
-  // News) — see v1.1.1 smart removal.
-  const multiSource = useMemo(
-    () => distinctSourceCount(rssItems) > 1,
-    [rssItems],
+    [rssItems, selectedSources, selectedCategories, sortOrder, dp.maxArticles, dp.maxArticleAgeDays, categoryMap],
   );
 
   const showEmpty = rssItems.length === 0;
@@ -416,33 +400,6 @@ function RssFeedTab({ mode, feedContext, widgetId }: FeedTabProps) {
                   now={now}
                 />
               ))}
-            </div>
-          )}
-
-          {/* Per-source limit — list FOOTER content, not chrome (the old
-              info bands above the list are gone). Multi-source only:
-              single-outlet widgets have no per-source concept. */}
-          {multiSource && totalHidden > 0 && !showAll && (
-            <div className="flex items-center justify-center gap-3 px-3 py-3">
-              <button
-                onClick={() => setShowAll(true)}
-                className="px-4 py-1.5 rounded-md text-xs font-medium text-accent bg-accent/10 hover:bg-accent/20  cursor-pointer"
-              >
-                Show all
-              </button>
-              <span className="text-xs text-fg-3 tabular-nums font-mono">
-                {totalHidden} hidden · {dp.articlesPerSource} per source
-              </span>
-            </div>
-          )}
-          {multiSource && showAll && totalHidden === 0 && dp.articlesPerSource > 0 && (
-            <div className="flex items-center justify-center px-3 py-3">
-              <button
-                onClick={() => setShowAll(false)}
-                className="px-4 py-1.5 rounded-md text-xs font-medium text-accent bg-accent/10 hover:bg-accent/20  cursor-pointer"
-              >
-                Limit to {dp.articlesPerSource} per source
-              </button>
             </div>
           )}
           </>

--- a/desktop/src/datawidgets/rss/view.test.ts
+++ b/desktop/src/datawidgets/rss/view.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
-  limitPerSource,
   applyRssPipeline,
   selectRssForTicker,
-  distinctSourceCount,
   filterByArticleAge,
   TICKER_RSS_HOURS,
   TICKER_RSS_FLOOR_HOURS,
@@ -11,7 +9,6 @@ import {
   arrangeRssSlots,
 } from "./view";
 import type { RssItem } from "../../types";
-import type { RssDisplayPrefs } from "../../preferences";
 
 // ── Fixtures ────────────────────────────────────────────────────
 
@@ -39,13 +36,6 @@ function mk(
 // now applies a freshness horizon, so tests of its OTHER rules must ask
 // about a moment when the fixtures are fresh.
 const FIXTURE_NOW = new Date("2026-01-01T01:00:00Z").getTime();
-
-const DEFAULT_PREFS: RssDisplayPrefs = {
-  feedSort: "newest",
-  articlesPerSource: 4,
-  maxArticles: 0,
-  maxArticleAgeDays: 0,
-};
 
 // ── filterByArticleAge (v1.1.3 Time Controls) ───────────────────
 
@@ -90,7 +80,7 @@ describe("filterByArticleAge", () => {
     expect(filterByArticleAge([weird], 1, NOW)).toHaveLength(1);
   });
 
-  it("applies inside applyRssPipeline before per-source limiting", () => {
+  it("applies inside applyRssPipeline before the total cap", () => {
     const items = [
       mk(1, "a", hoursAgo(1)),
       mk(2, "a", hoursAgo(24 * 9)), // stale — must not consume a slot
@@ -99,58 +89,11 @@ describe("filterByArticleAge", () => {
     const result = applyRssPipeline(items, {
       categoryMap: new Map(),
       sortOrder: "newest",
-      articlesPerSource: 1,
+      maxArticles: 2,
       maxArticleAgeDays: 2,
       now: NOW,
     });
-    expect(result.visibleItems.map((i) => i.id)).toEqual([1, 3]);
-    expect(result.totalHidden).toBe(0);
-  });
-});
-
-// ── limitPerSource ──────────────────────────────────────────────
-
-describe("limitPerSource", () => {
-  it("returns all items when limit is 0", () => {
-    const items = [mk(1, "a"), mk(2, "a"), mk(3, "b")];
-    const result = limitPerSource(items, 0);
-    expect(result).toHaveLength(3);
-    // returns same reference when limit is zero
-    expect(result).toBe(items);
-  });
-
-  it("returns all items when limit is negative", () => {
-    const items = [mk(1, "a"), mk(2, "a")];
-    expect(limitPerSource(items, -1)).toBe(items);
-  });
-
-  it("caps items per source at the given limit", () => {
-    const items = [mk(1, "a"), mk(2, "a"), mk(3, "a"), mk(4, "b"), mk(5, "b")];
-    const result = limitPerSource(items, 2);
-    expect(result).toHaveLength(4);
-    expect(result.filter((i) => i.source_name === "a")).toHaveLength(2);
-    expect(result.filter((i) => i.source_name === "b")).toHaveLength(2);
-  });
-
-  it("keeps the first N items per source in input order", () => {
-    const items = [mk(1, "a"), mk(2, "a"), mk(3, "a")];
-    const result = limitPerSource(items, 2);
-    expect(result.map((i) => i.id)).toEqual([1, 2]);
-  });
-
-  it("preserves interleaved input order", () => {
-    const items = [mk(1, "a"), mk(2, "b"), mk(3, "a"), mk(4, "b"), mk(5, "a")];
-    const result = limitPerSource(items, 2);
-    expect(result.map((i) => i.id)).toEqual([1, 2, 3, 4]);
-  });
-
-  it("handles a single-source dataset", () => {
-    const items = [mk(1, "a"), mk(2, "a"), mk(3, "a"), mk(4, "a")];
-    expect(limitPerSource(items, 2).map((i) => i.id)).toEqual([1, 2]);
-  });
-
-  it("handles an empty input", () => {
-    expect(limitPerSource([], 5)).toEqual([]);
+    expect(result.map((i) => i.id)).toEqual([1, 3]);
   });
 });
 
@@ -178,9 +121,8 @@ describe("applyRssPipeline", () => {
       selectedSources: new Set(["a"]),
       categoryMap,
       sortOrder: "newest",
-      articlesPerSource: 0,
     });
-    expect(result.visibleItems.map((i) => i.source_name)).toEqual(["a", "a"]);
+    expect(result.map((i) => i.source_name)).toEqual(["a", "a"]);
   });
 
   it("ignores selectedSources when empty", () => {
@@ -188,9 +130,8 @@ describe("applyRssPipeline", () => {
       selectedSources: new Set(),
       categoryMap,
       sortOrder: "newest",
-      articlesPerSource: 0,
     });
-    expect(result.visibleItems).toHaveLength(5);
+    expect(result).toHaveLength(5);
   });
 
   it("filters by selectedCategories when non-empty", () => {
@@ -198,10 +139,9 @@ describe("applyRssPipeline", () => {
       selectedCategories: new Set(["tech"]),
       categoryMap,
       sortOrder: "newest",
-      articlesPerSource: 0,
     });
     // tech = feeds a + c, so ids 1, 2, 5
-    expect(result.visibleItems.map((i) => i.id).sort()).toEqual([1, 2, 5]);
+    expect(result.map((i) => i.id).sort()).toEqual([1, 2, 5]);
   });
 
   it("drops items whose feed is not in the category map under a category filter", () => {
@@ -213,9 +153,8 @@ describe("applyRssPipeline", () => {
       selectedCategories: new Set(["tech"]),
       categoryMap,
       sortOrder: "newest",
-      articlesPerSource: 0,
     });
-    expect(result.visibleItems.map((i) => i.id)).toEqual([1]);
+    expect(result.map((i) => i.id)).toEqual([1]);
   });
 
   it("leaves input order untouched when sortOrder=newest", () => {
@@ -224,43 +163,17 @@ describe("applyRssPipeline", () => {
     const result = applyRssPipeline(items, {
       categoryMap,
       sortOrder: "newest",
-      articlesPerSource: 0,
     });
-    expect(result.visibleItems.map((i) => i.id)).toEqual([1, 2, 3, 4, 5]);
+    expect(result.map((i) => i.id)).toEqual([1, 2, 3, 4, 5]);
   });
 
   it("sorts oldest-first by published_at when sortOrder=oldest", () => {
     const result = applyRssPipeline(makeItems(), {
       categoryMap,
       sortOrder: "oldest",
-      articlesPerSource: 0,
     });
     // ids by date ascending: 4 (2026-01-01), 2 (2026-01-15), 1 (2026-02-01), 5 (2026-02-15), 3 (2026-03-01)
-    expect(result.visibleItems.map((i) => i.id)).toEqual([4, 2, 1, 5, 3]);
-  });
-
-  it("applies per-source limit and reports overflow counts", () => {
-    const result = applyRssPipeline(makeItems(), {
-      categoryMap,
-      sortOrder: "newest",
-      articlesPerSource: 1,
-    });
-    expect(result.visibleItems).toHaveLength(3); // one per source
-    expect(result.overflowCounts.get("a")).toBe(1);
-    expect(result.overflowCounts.get("b")).toBe(1);
-    expect(result.overflowCounts.get("c")).toBeUndefined();
-    expect(result.totalHidden).toBe(2);
-  });
-
-  it("bypasses per-source limit when showAll=true", () => {
-    const result = applyRssPipeline(makeItems(), {
-      categoryMap,
-      sortOrder: "newest",
-      articlesPerSource: 1,
-      showAll: true,
-    });
-    expect(result.visibleItems).toHaveLength(5);
-    expect(result.totalHidden).toBe(0);
+    expect(result.map((i) => i.id)).toEqual([4, 2, 1, 5, 3]);
   });
 
   it("falls back to created_at when published_at is null (oldest sort)", () => {
@@ -273,9 +186,8 @@ describe("applyRssPipeline", () => {
     const result = applyRssPipeline(items, {
       categoryMap,
       sortOrder: "oldest",
-      articlesPerSource: 0,
     });
-    expect(result.visibleItems.map((i) => i.id)).toEqual([1, 2]);
+    expect(result.map((i) => i.id)).toEqual([1, 2]);
   });
 
   it("applies a finite total cap after filters and ordering", () => {
@@ -283,60 +195,20 @@ describe("applyRssPipeline", () => {
       selectedCategories: new Set(["tech"]),
       categoryMap,
       sortOrder: "oldest",
-      articlesPerSource: 0,
       maxArticles: 2,
     });
-    expect(result.visibleItems.map((i) => i.id)).toEqual([2, 1]);
+    expect(result.map((i) => i.id)).toEqual([2, 1]);
   });
 
   it("shows all eligible articles when the total cap is unlimited", () => {
     const result = applyRssPipeline(makeItems(), {
       categoryMap,
       sortOrder: "newest",
-      articlesPerSource: 0,
       maxArticles: 0,
     });
-    expect(result.visibleItems).toHaveLength(5);
+    expect(result).toHaveLength(5);
   });
 });
-
-// ── selectRssForTicker ──────────────────────────────────────────
-
-// ── v1.1.1 smart removal: single-source payloads skip the cap ───
-
-describe("single-source smart removal (v1.1.1)", () => {
-  const capped: RssDisplayPrefs = { ...DEFAULT_PREFS, articlesPerSource: 2 };
-
-  it("distinctSourceCount counts unique sources", () => {
-    expect(distinctSourceCount([])).toBe(0);
-    expect(distinctSourceCount([mk(1, "a"), mk(2, "a")])).toBe(1);
-    expect(distinctSourceCount([mk(1, "a"), mk(2, "b"), mk(3, "a")])).toBe(2);
-  });
-
-  it("pipeline: single-source ignores the cap and reports nothing hidden", () => {
-    const items = [mk(1, "bbc"), mk(2, "bbc"), mk(3, "bbc")];
-    const { visibleItems, totalHidden } = applyRssPipeline(items, {
-      categoryMap: new Map(),
-      sortOrder: "newest",
-      articlesPerSource: 2,
-    });
-    expect(visibleItems).toHaveLength(3);
-    expect(totalHidden).toBe(0);
-  });
-
-  it("pipeline: multi-source still caps and reports overflow", () => {
-    const items = [mk(1, "a"), mk(2, "a"), mk(3, "a"), mk(4, "b")];
-    const { visibleItems, totalHidden, overflowCounts } = applyRssPipeline(items, {
-      categoryMap: new Map(),
-      sortOrder: "newest",
-      articlesPerSource: 2,
-    });
-    expect(visibleItems).toHaveLength(3);
-    expect(totalHidden).toBe(1);
-    expect(overflowCounts.get("a")).toBe(1);
-  });
-});
-
 
 // ── Ticker horizon ──────────────────────────────────────────────
 //

--- a/desktop/src/datawidgets/rss/view.ts
+++ b/desktop/src/datawidgets/rss/view.ts
@@ -63,36 +63,8 @@ export function filterByArticleAge(
   });
 }
 
-// ── Pure: per-source limit ───────────────────────────────────────
-
-/**
- * Cap the number of items shown per source. `limit === 0` means "no limit".
- * Keeps the first N items encountered per source, in the order given
- * (so pair this with a sort step that establishes the desired ordering).
- */
-export function limitPerSource(items: RssItem[], limit: number): RssItem[] {
-  if (limit <= 0) return items;
-  const counts = new Map<string, number>();
-  const result: RssItem[] = [];
-  for (const item of items) {
-    const count = counts.get(item.source_name) ?? 0;
-    if (count < limit) {
-      result.push(item);
-      counts.set(item.source_name, count + 1);
-    }
-  }
-  return result;
-}
-
 // ── Pure: selector for the ticker ────────────────────────────────
 
-/**
- * Baseline pipeline used by the ticker: applies per-source limit (from Display
- * prefs) and ensures the default "newest-first" ordering.
- *
- * The ticker doesn't expose interactive filters (source/category selection,
- * sort toggle). If those are added later, surface them as arguments here.
- */
 /**
  * The ticker's own horizon for headlines. Independent of the widget page:
  * the feed's sort, source filters, "Show N" and time window are about
@@ -167,15 +139,6 @@ export function arrangeRssSlots(
   ).map((r) => ({ key: r.key, item: r.item, rotateSlot: r.rotateSlot, reserveTitle: r.reserve }));
 }
 
-/** Number of distinct sources present in a payload. Widgets are already
- *  scoped per widget upstream, so this is "how many feeds does THIS
- *  widget aggregate" — 1 for outlet widgets, N for Custom RSS. */
-export function distinctSourceCount(items: RssItem[]): number {
-  const sources = new Set<string>();
-  for (const item of items) sources.add(item.source_name);
-  return sources.size;
-}
-
 // ── Helper: per-widget display prefs (global + config.display) ──
 
 import type { DashboardResponse } from "../../types";
@@ -223,48 +186,35 @@ export interface RssPipelineOptions {
   categoryMap: Map<string, string>;
   /** Current sort order. */
   sortOrder: RssSortOrder;
-  /** Per-source limit (from Display prefs). 0 = no limit. */
-  articlesPerSource: number;
   /** Total feed limit after filtering and sorting. 0 = no limit. */
   maxArticles?: number;
   /** Article-age window in days (v1.1.3). 0 = no filter. */
   maxArticleAgeDays?: number;
   /** Injectable clock for tests; defaults to Date.now(). */
   now?: number;
-  /** Feed-page interactive toggle that disables the per-source limit. */
-  showAll?: boolean;
-}
-
-export interface RssPipelineResult {
-  visibleItems: RssItem[];
-  /** Map of source_name → hidden count (only populated when limit > 0). */
-  overflowCounts: Map<string, number>;
-  /** Total items hidden by the per-source limit. */
-  totalHidden: number;
 }
 
 /**
- * Full interactive pipeline used by the feed page. Applies source + category
- * filters, sort, and per-source limit with per-source expansion support.
+ * Full interactive pipeline used by the feed page: age window, source +
+ * category filters, sort, total cap. (The per-source cap and its
+ * "Show all" toggle went in REL-208 — nothing ever set the pref.)
  */
 export function applyRssPipeline(
   items: RssItem[],
   opts: RssPipelineOptions,
-): RssPipelineResult {
+): RssItem[] {
   const {
     selectedSources,
     selectedCategories,
     categoryMap,
     sortOrder,
-    articlesPerSource,
     maxArticles = 0,
     maxArticleAgeDays = 0,
     now = Date.now(),
-    showAll,
   } = opts;
 
-  // Age window first (v1.1.3) — everything downstream (filters, limit,
-  // overflow counts) should only ever see eligible articles.
+  // Age window first (v1.1.3) — everything downstream should only ever
+  // see eligible articles.
   let filtered = filterByArticleAge(items, maxArticleAgeDays, now);
 
   if (selectedSources && selectedSources.size > 0) {
@@ -279,42 +229,5 @@ export function applyRssPipeline(
   }
 
   const sorted = sortRssItems(filtered, sortOrder);
-
-  const overflow = new Map<string, number>();
-  // Per-source limiting only means anything when several sources are
-  // competing — single-outlet widgets show their whole feed (v1.1.1).
-  const multiSource = distinctSourceCount(items) > 1;
-
-  if (multiSource && articlesPerSource > 0 && !showAll) {
-    const sourceCounts = new Map<string, number>();
-    const limited: RssItem[] = [];
-
-    for (const item of sorted) {
-      const count = sourceCounts.get(item.source_name) ?? 0;
-      if (count < articlesPerSource) {
-        limited.push(item);
-      }
-      sourceCounts.set(item.source_name, count + 1);
-    }
-
-    let hidden = 0;
-    for (const [source, total] of sourceCounts) {
-      if (total > articlesPerSource) {
-        overflow.set(source, total - articlesPerSource);
-        hidden += total - articlesPerSource;
-      }
-    }
-
-    return {
-      visibleItems: maxArticles > 0 ? limited.slice(0, maxArticles) : limited,
-      overflowCounts: overflow,
-      totalHidden: hidden,
-    };
-  }
-
-  return {
-    visibleItems: maxArticles > 0 ? sorted.slice(0, maxArticles) : sorted,
-    overflowCounts: overflow,
-    totalHidden: 0,
-  };
+  return maxArticles > 0 ? sorted.slice(0, maxArticles) : sorted;
 }

--- a/desktop/src/hooks/useWidgetConfig.ts
+++ b/desktop/src/hooks/useWidgetConfig.ts
@@ -9,7 +9,7 @@ import { savePrefs } from "../preferences";
 import type { AppPreferences, WidgetPrefs } from "../preferences";
 
 /** Subset of WidgetPrefs that are per-widget config objects (not arrays). */
-type WidgetConfigKey = "clock" | "timer" | "weather" | "sysmon" | "uptime" | "github";
+type WidgetConfigKey = "timer" | "sysmon" | "uptime" | "github";
 
 /** The config object for a given widget key. */
 type WidgetConfig<K extends WidgetConfigKey> = WidgetPrefs[K];

--- a/desktop/src/hooks/useWidgetTickerData.test.ts
+++ b/desktop/src/hooks/useWidgetTickerData.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
-import { LS_CLOCK_FORMAT, LS_TIMER_STATE } from "../constants";
+import { LS_CLOCK_FORMAT, LS_CLOCK_TIMEZONES, LS_TIMER_STATE } from "../constants";
 import { useWidgetTickerData } from "./useWidgetTickerData";
 import type { WidgetPrefs } from "../preferences";
 
@@ -20,15 +20,7 @@ function makeWidgetPrefs(widgetsOnTicker: string[]): WidgetPrefs {
     sidebarOrder: [],
     widgetsOnTicker,
     pinnedWidgets: {},
-    clock: {
-      ticker: {
-        localTime: false,
-        showTimezones: false,
-        excludedTimezones: [],
-      },
-    },
     timer: {
-      ticker: { activeTimer: true },
       pomodoro: {
         workMins: 25,
         shortBreakMins: 5,
@@ -36,7 +28,6 @@ function makeWidgetPrefs(widgetsOnTicker: string[]): WidgetPrefs {
         longBreakEvery: 4,
       },
     },
-    weather: { ticker: { excludedCities: [] } },
     sysmon: {
       refreshInterval: 2,
       tempUnit: "celsius",
@@ -50,23 +41,10 @@ function makeWidgetPrefs(widgetsOnTicker: string[]): WidgetPrefs {
     uptime: {
       url: "",
       pollInterval: 60,
-      ticker: { excludedMonitors: [] },
     },
     github: {
       repos: [],
       pollInterval: 120,
-      ticker: { excludedRepos: [] },
-    },
-  };
-}
-
-function makeTimerPrefs(activeTimer: boolean): WidgetPrefs {
-  const prefs = makeWidgetPrefs(["timer"]);
-  return {
-    ...prefs,
-    timer: {
-      ...prefs.timer,
-      ticker: { activeTimer },
     },
   };
 }
@@ -91,7 +69,7 @@ describe("useWidgetTickerData", () => {
     const { result } = renderHook(() => useWidgetTickerData(prefs));
 
     await waitFor(() => {
-      expect(result.current.clock).toEqual([]);
+      expect(result.current.clock.map((c) => c.id)).toEqual(["clock-local"]);
       expect(result.current.timer).toEqual([
         {
           id: "timer",
@@ -111,20 +89,20 @@ describe("useWidgetTickerData", () => {
     });
   });
 
-  it("suppresses timer chips when the timer ticker setting is disabled", async () => {
-    storeValues.set(LS_TIMER_STATE, {
-      mode: "stopwatch",
-      startedAt: null,
-      bankedMs: 65_000,
-      targetSecs: 0,
-      completedSessions: 0,
-    });
+  // If you track it, it's on the ticker (docs/CHIP_SPEC.md §8): every
+  // saved world clock becomes a chip, with no per-zone exclusion pref.
+  it("puts local time and every tracked timezone on the ticker", async () => {
+    storeValues.set(LS_CLOCK_TIMEZONES, ["Asia/Tokyo", "Europe/London"]);
 
-    const prefs = makeTimerPrefs(false);
+    const prefs = makeWidgetPrefs(["clock"]);
     const { result } = renderHook(() => useWidgetTickerData(prefs));
 
     await waitFor(() => {
-      expect(result.current.timer).toEqual([]);
+      expect(result.current.clock.map((c) => c.id)).toEqual([
+        "clock-local",
+        "clock-Asia/Tokyo",
+        "clock-Europe/London",
+      ]);
     });
   });
 

--- a/desktop/src/hooks/useWidgetTickerData.ts
+++ b/desktop/src/hooks/useWidgetTickerData.ts
@@ -204,48 +204,41 @@ export function useWidgetTickerData(
   // ── Build clock chips ─────────────────────────────────────────
   const buildClockChips = useCallback((): ClockChipData[] => {
     if (!enabledWidgets.has("clock")) return [];
-    const cfg = widgetPrefs.clock;
     const chips: ClockChipData[] = [];
     const now = new Date();
     const format = getStore<string>(LS_CLOCK_FORMAT, "12h");
 
-    // Local time
-    if (cfg.ticker.localTime) {
+    // Local time, then every tracked world clock: if you track it, it's
+    // on the ticker (docs/CHIP_SPEC.md §8 — no per-item selection).
+    chips.push({
+      id: "clock-local",
+      kind: "clock",
+      label: "Local",
+      value: formatTime(now, undefined, format),
+      detail: formatDetail(now, undefined),
+      night: isNightIn(now, undefined),
+      offset: utcOffsetLabel(now, undefined),
+    });
+
+    const tzs = getStore<string[]>(LS_CLOCK_TIMEZONES, []);
+    for (const tz of Array.isArray(tzs) ? tzs : []) {
       chips.push({
-        id: "clock-local",
+        id: `clock-${tz}`,
         kind: "clock",
-        label: "Local",
-        value: formatTime(now, undefined, format),
-        detail: formatDetail(now, undefined),
-        night: isNightIn(now, undefined),
-        offset: utcOffsetLabel(now, undefined),
+        label: tzShortLabel(tz),
+        value: formatTime(now, tz, format),
+        detail: formatDetail(now, tz),
+        night: isNightIn(now, tz),
+        offset: utcOffsetLabel(now, tz),
       });
     }
 
-    // Configured timezones (gated by showTimezones, then filtered by excludedTimezones)
-    if (cfg.ticker.showTimezones) {
-      const tzs = getStore<string[]>(LS_CLOCK_TIMEZONES, []);
-      for (const tz of Array.isArray(tzs) ? tzs : []) {
-        if (cfg.ticker.excludedTimezones.includes(tz)) continue;
-        chips.push({
-          id: `clock-${tz}`,
-          kind: "clock",
-          label: tzShortLabel(tz),
-          value: formatTime(now, tz, format),
-          detail: formatDetail(now, tz),
-          night: isNightIn(now, tz),
-          offset: utcOffsetLabel(now, tz),
-        });
-      }
-    }
-
     return chips;
-  }, [widgetPrefs.clock, enabledWidgets]);
+  }, [enabledWidgets]);
 
   // ── Build timer chips ─────────────────────────────────────────
   const buildTimerChips = useCallback((): ClockChipData[] => {
     if (!enabledWidgets.has("timer")) return [];
-    if (!widgetPrefs.timer.ticker.activeTimer) return [];
 
     const state = getStore<TimerState | null>(LS_TIMER_STATE, null);
     if (!state) return [];
@@ -260,7 +253,6 @@ export function useWidgetTickerData(
   // ── Build weather chips ───────────────────────────────────────
   const buildWeatherChips = useCallback((): WeatherChipData[] => {
     if (!enabledWidgets.has("weather")) return [];
-    const cfg = widgetPrefs.weather;
     const chips: WeatherChipData[] = [];
     const unit = getStore<string>(LS_WEATHER_UNIT, "fahrenheit");
 
@@ -268,8 +260,6 @@ export function useWidgetTickerData(
 
     for (const city of Array.isArray(cities) ? cities : []) {
       const name = city.location.name;
-      if (cfg.ticker.excludedCities.includes(name)) continue;
-
       const w = city.weather;
       const temp =
         w?.temperature != null
@@ -306,7 +296,7 @@ export function useWidgetTickerData(
     }
 
     return chips;
-  }, [widgetPrefs.weather, enabledWidgets]);
+  }, [enabledWidgets]);
 
   // ── Build sysmon chips ────────────────────────────────────────
   const buildSysmonChips = useCallback((): SysmonChipData[] => {
@@ -404,12 +394,9 @@ export function useWidgetTickerData(
     const monitors = loadMonitors();
     if (monitors.length === 0) return [];
 
-    const cfg = widgetPrefs.uptime;
     const chips: UptimeChipData[] = [];
 
     for (const mon of monitors) {
-      if (cfg.ticker.excludedMonitors.includes(mon.id)) continue;
-
       const uptimeStr =
         mon.uptimePercent != null
           ? `${mon.uptimePercent.toFixed(mon.uptimePercent === 100 ? 0 : 1)}%`
@@ -442,7 +429,7 @@ export function useWidgetTickerData(
     }
 
     return chips;
-  }, [widgetPrefs.uptime, enabledWidgets]);
+  }, [enabledWidgets]);
 
   // ── Build github chips ────────────────────────────────────────
   const buildGithubChips = useCallback((): GitHubChipData[] => {
@@ -450,13 +437,10 @@ export function useWidgetTickerData(
     const repos = loadRepoData();
     if (repos.length === 0) return [];
 
-    const cfg = widgetPrefs.github;
     const chips: GitHubChipData[] = [];
 
     for (const repo of repos) {
       const key = repoKey(repo);
-      if (cfg.ticker.excludedRepos.includes(key)) continue;
-
       const repoLabel = truncate(repo.repo, 20);
       const workflow = repo.workflowName ?? "CI";
 
@@ -491,7 +475,7 @@ export function useWidgetTickerData(
     }
 
     return chips;
-  }, [widgetPrefs.github, enabledWidgets]);
+  }, [enabledWidgets]);
 
   // ── Polling intervals ─────────────────────────────────────────
 

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -1,22 +1,17 @@
 /**
- * Tests for the Display-page venue-toggle migration helpers.
+ * Tests for the prefs migration helpers.
  *
  * These lock in the contract that lets us upgrade user prefs in place:
- *  - legacy boolean `true`  becomes `"both"` (visible everywhere — preserves
- *    the old behaviour where a true boolean meant "show this")
- *  - legacy boolean `false` becomes `"off"`  (hidden everywhere — preserves
- *    the old behaviour where a false boolean meant "hide this")
- *  - legacy `tickerShowMatchup` and `showInjuryCount` booleans on Fantasy
- *    fold into their new venue-aware replacements without losing the user's
- *    prior on/off choice
- *  - unknown / corrupt values fall back to `"both"` so loadPrefs never
+ *  - legacy booleans coerce to a well-formed `Venue` (sports still folds
+ *    `showUpcoming` / `showFinal` this way)
+ *  - retired fields are DROPPED, not carried: loadPrefs builds the object
+ *    that gets saved back, so anything it doesn't spread falls off disk
+ *  - unknown / corrupt values fall back to defaults so loadPrefs never
  *    throws or produces a bad shape
  */
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   migrateVenue,
-  shouldShowOnFeed,
-  shouldShowOnTicker,
   migrateFinanceDisplay,
   migrateRssDisplay,
   migratePredictionsDisplay,
@@ -57,11 +52,15 @@ it("reconciles sidebar ordering across widget types", () => {
   ).toEqual(["clock", "finance", "sports", "github"]);
 });
 
-interface LegacyClockTimerWidgetPrefs extends Omit<Partial<WidgetPrefs>, "clock"> {
+// The pre-split combined clock/timer widget's stored shape, plus the
+// per-widget `ticker` sub-configs that REL-208 removed from the type.
+interface LegacyClockTimerWidgetPrefs extends Omit<Partial<WidgetPrefs>, "timer"> {
   clock?: {
-    ticker?: Partial<WidgetPrefs["clock"]["ticker"]> & {
-      activeTimer?: boolean;
-    };
+    ticker?: Record<string, unknown> & { activeTimer?: boolean };
+    pomodoro?: Partial<WidgetPrefs["timer"]["pomodoro"]>;
+  };
+  timer?: {
+    ticker?: { activeTimer?: boolean };
     pomodoro?: Partial<WidgetPrefs["timer"]["pomodoro"]>;
   };
 }
@@ -91,20 +90,6 @@ describe("migrateVenue", () => {
     expect(migrateVenue(42)).toBe("both");
     expect(migrateVenue(null)).toBe("both");
     expect(migrateVenue(undefined)).toBe("both");
-  });
-});
-
-describe("shouldShowOnFeed / shouldShowOnTicker", () => {
-  it("routes each venue to the correct surface", () => {
-    expect(shouldShowOnFeed("off")).toBe(false);
-    expect(shouldShowOnFeed("feed")).toBe(true);
-    expect(shouldShowOnFeed("both")).toBe(true);
-    expect(shouldShowOnFeed("ticker")).toBe(false);
-
-    expect(shouldShowOnTicker("off")).toBe(false);
-    expect(shouldShowOnTicker("feed")).toBe(false);
-    expect(shouldShowOnTicker("both")).toBe(true);
-    expect(shouldShowOnTicker("ticker")).toBe(true);
   });
 });
 
@@ -153,34 +138,17 @@ describe("migrateFinanceDisplay", () => {
 });
 
 describe("migrateRssDisplay", () => {
-  it("preserves articlesPerSource and ignores unknown stored keys", () => {
+  it("drops the retired per-source cap and unknown stored keys (REL-208)", () => {
     const legacy = {
       showDescription: true,
       showSource: false,
       articlesPerSource: 3,
+      feedSort: "oldest",
     } as unknown as Parameters<typeof migrateRssDisplay>[0];
 
-    expect(migrateRssDisplay(legacy).articlesPerSource).toBe(3);
-  });
-
-  it("falls back to default for non-number articlesPerSource", () => {
-    const migrated = migrateRssDisplay({
-      articlesPerSource: "lots",
-    } as unknown as Parameters<typeof migrateRssDisplay>[0]);
-    expect(migrated.articlesPerSource).toBe(0);
-  });
-
-  it("migrates the old untouched default (4) to All (0) — v1.1.1", () => {
-    // 4 was the pre-widget-era default and never appeared in the picker
-    // (1/3/5/10), so a stored 4 is not a user's choice.
-    const migrated = migrateRssDisplay({ articlesPerSource: 4 });
-    expect(migrated.articlesPerSource).toBe(0);
-  });
-
-  it("keeps deliberately chosen per-source caps (picker values)", () => {
-    for (const chosen of [1, 3, 5, 10]) {
-      expect(migrateRssDisplay({ articlesPerSource: chosen }).articlesPerSource).toBe(chosen);
-    }
+    const migrated = migrateRssDisplay(legacy);
+    expect(migrated.feedSort).toBe("oldest");
+    expect("articlesPerSource" in migrated).toBe(false);
   });
 
   it("keeps positive total article caps and maps invalid values to All", () => {
@@ -214,125 +182,49 @@ describe("migratePredictionsDisplay", () => {
 });
 
 describe("migrateFantasyDisplay", () => {
-  it("folds legacy tickerShowMatchup=true into matchupScore='both'", () => {
-    const legacy = { tickerShowMatchup: true } as unknown as Parameters<
-      typeof migrateFantasyDisplay
-    >[0];
-    const migrated = migrateFantasyDisplay(legacy);
-    expect(migrated.matchupScore).toBe("both");
-  });
-
-  it("folds legacy tickerShowMatchup=false into matchupScore='feed'", () => {
-    // Rationale: user explicitly hid the matchup from the ticker but had no
-    // way to hide it from the feed under the old model. Keep it visible in
-    // the feed after migration so no feed-page content disappears silently.
-    const legacy = { tickerShowMatchup: false } as unknown as Parameters<
-      typeof migrateFantasyDisplay
-    >[0];
-    const migrated = migrateFantasyDisplay(legacy);
-    expect(migrated.matchupScore).toBe("feed");
-  });
-
-  it("folds legacy showInjuryCount boolean into injuryCount venue", () => {
-    expect(
-      migrateFantasyDisplay({ showInjuryCount: true } as unknown as Parameters<
-        typeof migrateFantasyDisplay
-      >[0]).injuryCount,
-    ).toBe("both");
-    expect(
-      migrateFantasyDisplay({ showInjuryCount: false } as unknown as Parameters<
-        typeof migrateFantasyDisplay
-      >[0]).injuryCount,
-    ).toBe("off");
-  });
-
-  it("preserves feed-layout booleans (showStandings, showMatchups)", () => {
+  it("preserves the user's inputs", () => {
     const migrated = migrateFantasyDisplay({
-      showStandings: false,
-      showMatchups: true,
-    });
-    expect(migrated.showStandings).toBe(false);
-    expect(migrated.showMatchups).toBe(true);
-  });
-
-  it("preserves non-venue scalar fields", () => {
-    const migrated = migrateFantasyDisplay({
+      tickerMode: "essential",
       defaultSubTab: "matchup",
-      defaultSort: "record",
       enabledLeagueKeys: ["nfl.l.12345"],
       primaryLeagueKey: "nfl.l.12345",
+      followedPlayerKeys: ["449.p.1", 7, null] as unknown as string[],
     });
 
+    expect(migrated.tickerMode).toBe("essential");
     expect(migrated.defaultSubTab).toBe("matchup");
-    expect(migrated.defaultSort).toBe("record");
     expect(migrated.enabledLeagueKeys).toEqual(["nfl.l.12345"]);
     expect(migrated.primaryLeagueKey).toBe("nfl.l.12345");
+    expect(migrated.followedPlayerKeys).toEqual(["449.p.1"]);
   });
 
-  it("new-shape venue fields survive migration unchanged", () => {
-    const current = {
-      matchupScore: "ticker",
-      winProbability: "feed",
-      matchupStatus: "off",
-      projectedPoints: "both",
-      week: "ticker",
-      record: "feed",
-      standingsPosition: "both",
-      streak: "off",
-      injuryCount: "feed",
-      topScorer: "ticker",
-    } as Parameters<typeof migrateFantasyDisplay>[0];
-    const migrated = migrateFantasyDisplay(current);
-    expect(migrated.matchupScore).toBe("ticker");
-    expect(migrated.winProbability).toBe("feed");
-    expect(migrated.matchupStatus).toBe("off");
-    expect(migrated.projectedPoints).toBe("both");
-    expect(migrated.streak).toBe("off");
-    expect(migrated.topScorer).toBe("ticker");
+  it("resolves a pre-dial prefs file to 'everything' (the ticker it already had)", () => {
+    expect(migrateFantasyDisplay({}).tickerMode).toBe("everything");
+    expect(
+      migrateFantasyDisplay({ tickerMode: "loud" } as unknown as Parameters<
+        typeof migrateFantasyDisplay
+      >[0]).tickerMode,
+    ).toBe("everything");
   });
 
-  it("legacy tickerShowMatchup is dropped from the returned object", () => {
-    const migrated = migrateFantasyDisplay({
-      tickerShowMatchup: true,
-    } as unknown as Parameters<typeof migrateFantasyDisplay>[0]);
-    // @ts-expect-error — legacy key shouldn't exist on the migrated shape
-    expect(migrated.tickerShowMatchup).toBeUndefined();
-  });
-
-  it("new-shape value wins over legacy boolean when both are present", () => {
-    // A user whose prefs file was partially migrated (new key set, old key
-    // still present) should not regress to the legacy value.
+  it("drops the retired venue prefs, legacy booleans and feed-layout fields (REL-208)", () => {
     const migrated = migrateFantasyDisplay({
       tickerShowMatchup: false,
+      showInjuryCount: true,
       matchupScore: "ticker",
+      injuryDetail: "off",
+      showStandings: false,
+      showMatchups: true,
+      defaultSort: "record",
     } as unknown as Parameters<typeof migrateFantasyDisplay>[0]);
-    expect(migrated.matchupScore).toBe("ticker");
-  });
 
-  it("Phase 1 player-stats fields default to 'both' for upgrading users", () => {
-    // A user upgrading from a build that predates these fields will have
-    // no key for them in their prefs file. migrateVenue's unknown-input
-    // fallback returns "both" — fields appear visible-everywhere by
-    // default, matching what users have been asking for ("when can we
-    // see player stats on the ticker?").
-    const migrated = migrateFantasyDisplay({});
-    expect(migrated.topThreeScorers).toBe("both");
-    expect(migrated.worstStarter).toBe("both");
-    expect(migrated.benchOpportunity).toBe("both");
-    expect(migrated.injuryDetail).toBe("both");
-  });
-
-  it("Phase 1 player-stats fields preserve user choices on subsequent loads", () => {
-    const migrated = migrateFantasyDisplay({
-      topThreeScorers: "ticker",
-      worstStarter: "feed",
-      benchOpportunity: "off",
-      injuryDetail: "both",
-    });
-    expect(migrated.topThreeScorers).toBe("ticker");
-    expect(migrated.worstStarter).toBe("feed");
-    expect(migrated.benchOpportunity).toBe("off");
-    expect(migrated.injuryDetail).toBe("both");
+    expect(Object.keys(migrated).sort()).toEqual([
+      "defaultSubTab",
+      "enabledLeagueKeys",
+      "followedPlayerKeys",
+      "primaryLeagueKey",
+      "tickerMode",
+    ]);
   });
 });
 
@@ -472,18 +364,10 @@ describe("widget timer preference migration", () => {
       },
     }));
 
-    // 2026-07-17 unification: stored per-item ticker values are ignored —
-    // tracked content always reaches the ticker.
-    expect(prefs.clock).toMatchObject({
-      ticker: {
-        localTime: true,
-        showTimezones: true,
-        excludedTimezones: [],
-      },
-    });
-    expect("activeTimer" in prefs.clock.ticker).toBe(false);
+    // REL-208: the clock block and every per-item ticker value are
+    // dropped — tracked content always reaches the ticker.
+    expect("clock" in prefs).toBe(false);
     expect(prefs.timer).toEqual({
-      ticker: { activeTimer: true },
       pomodoro: {
         workMins: 50,
         shortBreakMins: 10,
@@ -518,7 +402,6 @@ describe("widget timer preference migration", () => {
     }));
 
     expect(prefs.timer).toEqual({
-      ticker: { activeTimer: true },
       pomodoro: {
         workMins: 20,
         shortBreakMins: 4,
@@ -597,9 +480,6 @@ describe("widget timer preference migration", () => {
 
     expect(prefs.enabledWidgets).toEqual(["clock", "timer"]);
     expect(prefs.widgetsOnTicker).toEqual(["clock"]);
-    // 2026-07-17 unification: a running timer always reaches the ticker;
-    // the stored activeTimer:false is deliberately ignored.
-    expect(prefs.timer.ticker.activeTimer).toBe(true);
   });
 
   it("does not auto-add timer visibility when current timer prefs exist", () => {
@@ -622,7 +502,6 @@ describe("widget timer preference migration", () => {
 
     expect(prefs.enabledWidgets).toEqual(["clock"]);
     expect(prefs.widgetsOnTicker).toEqual(["clock"]);
-    expect(prefs.timer.ticker.activeTimer).toBe(true);
   });
 
   it("does not auto-enable timer for current timer prefs", () => {
@@ -686,6 +565,31 @@ describe("widget timer preference migration", () => {
     });
 
     expect(loadPrefs().widgets.widgetsOnTicker).toEqual(["clock", "timer"]);
+  });
+});
+
+describe("dead prefs are shed on load (REL-208)", () => {
+  it("drops the taskbar block and the per-widget ticker sub-configs", () => {
+    storeValues.set("scrollr:settings", {
+      taskbar: { showWidgetGlyphIcons: false, taskbarHeight: "compact" },
+      widgets: {
+        enabledWidgets: ["clock", "weather", "uptime"],
+        widgetsOnTicker: ["clock"],
+        clock: { ticker: { localTime: false, excludedTimezones: ["UTC"] } },
+        weather: { ticker: { excludedCities: ["Oslo"] } },
+        uptime: { url: "https://status.example", pollInterval: 30, ticker: { excludedMonitors: [1] } },
+        github: { repos: [], pollInterval: 90, ticker: { excludedRepos: ["a/b"] } },
+      },
+    });
+
+    const prefs = loadPrefs();
+    expect("taskbar" in prefs).toBe(false);
+    expect("clock" in prefs.widgets).toBe(false);
+    expect("weather" in prefs.widgets).toBe(false);
+    expect(prefs.widgets.uptime).toEqual({ url: "https://status.example", pollInterval: 30 });
+    expect(prefs.widgets.github).toEqual({ repos: [], pollInterval: 90 });
+    // Sysmon's stat toggles are real content selection and stay.
+    expect(prefs.widgets.sysmon.ticker).toEqual({ cpu: true, memory: true, gpu: true, gpuPower: true });
   });
 });
 

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -65,7 +65,6 @@ export function isThemeFamily(value: unknown): value is ThemeFamily {
 export function isThemeMode(value: unknown): value is ThemeMode {
   return value === "light" || value === "dark" || value === "system";
 }
-type TaskbarHeight = "compact" | "default" | "comfortable";
 export type TickerGap = "tight" | "normal" | "spacious";
 export type TickerMode = "compact" | "comfort";
 export type MixMode = "grouped" | "weave";
@@ -163,31 +162,13 @@ export interface WindowPrefs {
   tickerMonitors: string[];
 }
 
-interface TaskbarPrefs {
-  showWidgetGlyphIcons: boolean;
-  showConnectionIndicator: boolean;
-  showCanvasToggle: boolean;
-  taskbarHeight: TaskbarHeight;
-  pinnedActions: string[];
-}
-
 // ── Per-widget config types ─────────────────────────────────────
-
-export interface ClockTickerConfig {
-  localTime: boolean;
-  /** Whether to show world clocks on the ticker at all (default false). */
-  showTimezones: boolean;
-  /** Timezone IANA IDs excluded from the ticker (empty = all configured TZs shown). */
-  excludedTimezones: string[];
-}
-
-export interface ClockWidgetConfig {
-  ticker: ClockTickerConfig;
-}
-
-export interface TimerTickerConfig {
-  activeTimer: boolean;
-}
+//
+// Only what the user can actually set lives here. The per-widget
+// `ticker.excluded*` lists and the clock/timer on-off gates were
+// force-reset to their defaults on every load from 2026-07-17 until
+// REL-208 removed them: tracked content always reaches the ticker, so
+// the readers in useWidgetTickerData no longer consult a pref at all.
 
 export interface TimerPomodoroConfig {
   workMins: number;
@@ -197,17 +178,7 @@ export interface TimerPomodoroConfig {
 }
 
 export interface TimerWidgetConfig {
-  ticker: TimerTickerConfig;
   pomodoro: TimerPomodoroConfig;
-}
-
-export interface WeatherTickerConfig {
-  /** City display names excluded from the ticker (empty = all configured cities shown). */
-  excludedCities: string[];
-}
-
-export interface WeatherWidgetConfig {
-  ticker: WeatherTickerConfig;
 }
 
 export type TempUnit = "celsius" | "fahrenheit";
@@ -225,22 +196,11 @@ export interface SysmonWidgetConfig {
   ticker: SysmonTickerConfig;
 }
 
-export interface UptimeTickerConfig {
-  /** Monitor IDs excluded from the ticker (empty = all configured monitors shown). */
-  excludedMonitors: number[];
-}
-
 export interface UptimeWidgetConfig {
   /** The user's Uptime Kuma public status page URL. Empty = not configured. */
   url: string;
   /** Poll interval in seconds (default 60). */
   pollInterval: number;
-  ticker: UptimeTickerConfig;
-}
-
-export interface GitHubTickerConfig {
-  /** Repo keys ("owner/repo") excluded from the ticker. */
-  excludedRepos: string[];
 }
 
 export interface GitHubWidgetConfig {
@@ -248,7 +208,6 @@ export interface GitHubWidgetConfig {
   repos: Array<{ owner: string; repo: string }>;
   /** Poll interval in seconds (default 120). */
   pollInterval: number;
-  ticker: GitHubTickerConfig;
 }
 
 export interface WidgetPinConfig {
@@ -265,9 +224,7 @@ export interface WidgetPrefs {
   /** Per-widget pin state: removes the chip from the scrolling ticker and
    *  places it as a static element on the chosen side. Keyed by widget ID. */
   pinnedWidgets: Record<string, WidgetPinConfig>;
-  clock: ClockWidgetConfig;
   timer: TimerWidgetConfig;
-  weather: WeatherWidgetConfig;
   sysmon: SysmonWidgetConfig;
   uptime: UptimeWidgetConfig;
   github: GitHubWidgetConfig;
@@ -285,33 +242,21 @@ export interface WidgetPrefs {
  *   both    — shown in both places (default for migrated `true` booleans)
  *   ticker  — shown on the always-on-top ticker only; hidden from the feed
  *
- * There is no longer a UI for switching these: the `VenueRow` segmented
- * control lived on the Configure pages, which v1.1.9 retired. The values
- * still drive rendering — `shouldShowOnTicker` / `shouldShowOnFeed` are read
- * by the ticker and the chips — they just come from stored prefs and the
- * per-widget defaults now, not from a settings screen.
+ * Nothing reads a Venue any more: the last per-item toggles (fantasy's
+ * Advanced block) went in REL-208, and the ticker shows a fixed set per
+ * source (docs/CHIP_SPEC.md §8). The type survives only so the sports
+ * migration can coerce the legacy `showUpcoming` / `showFinal` booleans.
  */
 export type Venue = "off" | "feed" | "both" | "ticker";
 
 /**
- * Fantasy ticker simplicity dial. Three positions instead of ~10
- * per-item venue toggles; see FantasyDisplayPrefs.tickerMode.
+ * Fantasy ticker simplicity dial; see FantasyDisplayPrefs.tickerMode.
  *
  * Named for the widget because `TickerMode` is already taken by the
  * ticker's density setting (compact | comfort) — a genuinely different
  * axis that happens to want the same word.
  */
 export type FantasyTickerMode = "essential" | "standard" | "everything";
-
-/** True when the venue indicates the setting should render on the ticker. */
-export function shouldShowOnTicker(venue: Venue): boolean {
-  return venue === "both" || venue === "ticker";
-}
-
-/** True when the venue indicates the setting should render on the feed page. */
-export function shouldShowOnFeed(venue: Venue): boolean {
-  return venue === "both" || venue === "feed";
-}
 
 /**
  * Coerce a saved value (boolean from the pre-v1.0.2 era, or any other
@@ -363,7 +308,6 @@ export interface RssDisplayPrefs {
    *  persists per widget via the config.display override; this is the
    *  global fallback. */
   feedSort: "newest" | "oldest";
-  articlesPerSource: number; // 0 = all (the default since v1.1.1); 1/3/5/10 legacy per-source caps
   /** Maximum eligible articles shown in the feed. 0 = all. */
   maxArticles: number;
   /** v1.1.3 Time Controls: hide articles older than N days (published_at,
@@ -375,44 +319,6 @@ export interface RssDisplayPrefs {
 export type FantasySubTab = "overview" | "matchup" | "standings" | "roster";
 
 export interface FantasyDisplayPrefs {
-  // ── Per-item venue controls (visibility) ──
-  /** Live matchup score: "My Team 89.5 — 76.2 Opponent". */
-  matchupScore: Venue;
-  /** "62% win" — uses estimateWinProbability. */
-  winProbability: Venue;
-  /** LIVE / FINAL / PRE badge on the matchup summary. */
-  matchupStatus: Venue;
-  /** "Proj 95.2" on the user's team this week. */
-  projectedPoints: Venue;
-  /** "Week 5" label. */
-  week: Venue;
-  /** Season record "6-3-1". */
-  record: Venue;
-  /** "3rd of 10" standings position. */
-  standingsPosition: Venue;
-  /** Streak badge ("W3" / "L2"). */
-  streak: Venue;
-  /** Injury count on the user's roster ("2 injured"). */
-  injuryCount: Venue;
-  /** Top scorer on the user's active roster this week ("LeBron 42.3"). */
-  topScorer: Venue;
-
-  // ── Player-stats segments (Phase 1, 2026-04-25) ──
-  /** Top three active starters by current points
-   *  ("Mahomes 32 · Hill 18 · CMC 14"). One combined segment, not three. */
-  topThreeScorers: Venue;
-  /** Lowest-scoring active starter ("Worst: Andrews 0.0"). Surfaces
-   *  sit/start regret. Skipped silently when there are no starters. */
-  worstStarter: Venue;
-  /** Highest-scoring bench player ("Bench top: Pacheco 18.0"). Hidden
-   *  when no bench player has any points yet — avoids a meaningless
-   *  "Bench top: someone 0.0" cluttering the chip pre-kickoff. */
-  benchOpportunity: Venue;
-  /** Names + statuses for injured players on the roster
-   *  ("🚨 Saquon OUT, Mixon DTD"). Capped at 3 names; spillover shown
-   *  as "+N more". Complementary to `injuryCount` — both can be on. */
-  injuryDetail: Venue;
-
   // ── Followed players (Phase 2, 2026-04-25) ──
   /**
    * Yahoo player_keys the user wants surfaced as their own dedicated
@@ -431,30 +337,20 @@ export interface FantasyDisplayPrefs {
 
   // ── Ticker simplicity dial (2026-08) ──
   /**
-   * How much of the fantasy story reaches the ticker.
+   * How much of the fantasy story reaches the ticker. Each position is
+   * a fixed set built in ticker.tsx — there is no per-item control
+   * underneath it any more (REL-208; docs/CHIP_SPEC.md §8).
    *
    *   essential  — one smart chip per league, nothing else
    *   standard   — + live moment chips (in-play, breaking injury).
    *                THE DEFAULT for fresh installs.
-   *   everything — every per-item venue pref above is honoured, and the
-   *                Advanced block in the Account panel unlocks
-   *
-   * A preset LAYER over the venue prefs, not a replacement: essential
-   * and standard are computed at chip-build time in ticker.tsx and
-   * ignore the per-item values, which stay untouched underneath. Moving
-   * the dial back to Everything restores exactly what the user had.
+   *   everything — + top scorers, worst starter, bench top, injury report
    *
    * Followed players are deliberately outside the dial — an explicit
    * opt-in shouldn't be silently dropped by a simplicity setting.
    */
   tickerMode: FantasyTickerMode;
 
-  // ── Feed-structural settings (not venue-toggled) ──
-  /** Render the standings section inside the Fantasy feed view. */
-  showStandings: boolean;
-  /** Render the matchups section inside the Fantasy feed view. */
-  showMatchups: boolean;
-  defaultSort: "name" | "season" | "record" | "matchup";
   /** Which sub-tab the Feed view opens on. Defaults to overview when in 2+ leagues, matchup otherwise. */
   defaultSubTab: FantasySubTab;
   /** The user-preferred "primary" league key shown as the hero in Overview/Matchup tabs. */
@@ -483,7 +379,6 @@ export interface AppPreferences {
   startup: StartupPrefs;
   privacy: PrivacyPrefs;
   window: WindowPrefs;
-  taskbar: TaskbarPrefs;
   widgets: WidgetPrefs;
   widgetDisplay: WidgetDisplayPrefs;
   /**
@@ -541,31 +436,6 @@ const DEFAULT_WINDOW: WindowPrefs = {
   tickerMonitors: [],
 };
 
-const DEFAULT_TASKBAR: TaskbarPrefs = {
-  showWidgetGlyphIcons: true,
-  showConnectionIndicator: true,
-  showCanvasToggle: true,
-  taskbarHeight: "default",
-  pinnedActions: ["showTicker", "width", "pinned"],
-};
-
-// 2026-07-17 settings-model unification: per-item ticker exclusions and
-// the on/off ticker gates left the UI — "if you track it, it's on the
-// ticker". These defaults are FORCED at migration (stored values are
-// ignored); the fields survive so the ticker-data readers stay
-// untouched (empty exclusion lists filter nothing). Sysmon is the one
-// exception: its stat toggles remain user-editable content selection.
-export const DEFAULT_CLOCK_TICKER: ClockTickerConfig = {
-  localTime: true,
-  // true since the unification — tracked world clocks appear.
-  showTimezones: true,
-  excludedTimezones: [],
-};
-
-export const DEFAULT_TIMER_TICKER: TimerTickerConfig = {
-  activeTimer: true,
-};
-
 export const DEFAULT_TIMER_POMODORO: TimerPomodoroConfig = {
   workMins: 25,
   shortBreakMins: 5,
@@ -573,26 +443,15 @@ export const DEFAULT_TIMER_POMODORO: TimerPomodoroConfig = {
   longBreakEvery: 4,
 };
 
-export const DEFAULT_WEATHER_TICKER: WeatherTickerConfig = {
-  excludedCities: [],
-};
-
-// All-on since the unification: the stat toggles are content selection
-// now and gate BOTH the feed cards and the ticker chips, so defaults
-// must match what the feed always showed (everything the hardware has).
+// All-on since the 2026-07-17 unification: the stat toggles are content
+// selection and gate BOTH the feed cards and the ticker chips, so
+// defaults must match what the feed always showed (everything the
+// hardware has). Sysmon is the one widget that kept a ticker sub-config.
 export const DEFAULT_SYSMON_TICKER: SysmonTickerConfig = {
   cpu: true,
   memory: true,
   gpu: true,
   gpuPower: true,
-};
-
-export const DEFAULT_UPTIME_TICKER: UptimeTickerConfig = {
-  excludedMonitors: [],
-};
-
-export const DEFAULT_GITHUB_TICKER: GitHubTickerConfig = {
-  excludedRepos: [],
 };
 
 export const DEFAULT_WIDGET_DISPLAY: WidgetDisplayPrefs = {
@@ -601,7 +460,6 @@ export const DEFAULT_WIDGET_DISPLAY: WidgetDisplayPrefs = {
   },
   rss: {
     feedSort: "newest",
-    articlesPerSource: 0,
     maxArticles: 0,
     maxArticleAgeDays: 0,
   },
@@ -609,26 +467,6 @@ export const DEFAULT_WIDGET_DISPLAY: WidgetDisplayPrefs = {
     defaultSort: "trending",
   },
   fantasy: {
-    matchupScore: "both",
-    winProbability: "both",
-    matchupStatus: "both",
-    projectedPoints: "both",
-    week: "both",
-    record: "both",
-    standingsPosition: "both",
-    streak: "both",
-    injuryCount: "both",
-    topScorer: "both",
-    // Phase 1 player-stats: all default to "both" — users have been
-    // explicitly asking for these, so make them visible on the ticker
-    // out of the box. Users who find the chip too dense can flip
-    // individual ones to "feed" or "off" via Display tab. The
-    // migration helper also defaults these to "both" via its
-    // unknown-input fallback, so existing users see them post-upgrade.
-    topThreeScorers: "both",
-    worstStarter: "both",
-    benchOpportunity: "both",
-    injuryDetail: "both",
     followedPlayerKeys: [],
     // Standard, not Essential: the smart league chip tells you a league
     // is live but not WHO is doing it, and the player mid-game is the
@@ -639,9 +477,6 @@ export const DEFAULT_WIDGET_DISPLAY: WidgetDisplayPrefs = {
     // Existing users keep their configured ticker regardless — see
     // migrateFantasyDisplay.
     tickerMode: "standard",
-    showStandings: true,
-    showMatchups: true,
-    defaultSort: "name",
     defaultSubTab: "overview",
     primaryLeagueKey: null,
     enabledLeagueKeys: [],
@@ -658,15 +493,8 @@ const DEFAULT_WIDGETS: WidgetPrefs = {
   sidebarOrder: [],
   widgetsOnTicker: ["clock"],
   pinnedWidgets: {},
-  clock: {
-    ticker: { ...DEFAULT_CLOCK_TICKER },
-  },
   timer: {
-    ticker: { ...DEFAULT_TIMER_TICKER },
     pomodoro: { ...DEFAULT_TIMER_POMODORO },
-  },
-  weather: {
-    ticker: { ...DEFAULT_WEATHER_TICKER },
   },
   sysmon: {
     refreshInterval: 2,
@@ -676,12 +504,10 @@ const DEFAULT_WIDGETS: WidgetPrefs = {
   uptime: {
     url: "",
     pollInterval: 60,
-    ticker: { ...DEFAULT_UPTIME_TICKER },
   },
   github: {
     repos: [],
     pollInterval: 120,
-    ticker: { ...DEFAULT_GITHUB_TICKER },
   },
 };
 
@@ -691,7 +517,6 @@ const DEFAULT_PREFS: AppPreferences = {
   startup: DEFAULT_STARTUP,
   privacy: DEFAULT_PRIVACY,
   window: DEFAULT_WINDOW,
-  taskbar: DEFAULT_TASKBAR,
   widgets: DEFAULT_WIDGETS,
   widgetDisplay: DEFAULT_WIDGET_DISPLAY,
   tipsShown: [],
@@ -714,17 +539,7 @@ function migrateV1(saved: Record<string, unknown>): Partial<AppPreferences> {
     result.startup = { ...DEFAULT_STARTUP };
   }
 
-  // Old "taskbar" → taskbar (add pinnedActions)
-  const taskbar = saved.taskbar as Record<string, unknown> | undefined;
-  if (taskbar) {
-    result.taskbar = {
-      ...DEFAULT_TASKBAR,
-      ...taskbar,
-      // v1 had no pinnedActions; default to the standard set
-      pinnedActions:
-        (taskbar.pinnedActions as string[]) ?? DEFAULT_TASKBAR.pinnedActions,
-    };
-  }
+  // v1's "taskbar" block is dropped: nothing ever read it (REL-208).
 
   // "ticker" stays the same shape
   if (saved.ticker) {
@@ -776,8 +591,10 @@ function shouldAddLegacyTimerToTicker(
 ): boolean {
   if (!saved) return false;
   if (saved.timer != null && typeof saved.timer === "object") return false;
+  // `clock` is no longer on WidgetPrefs (REL-208); this reads the raw
+  // pre-split blob, where the timer lived under the clock widget.
   const clockTicker = (
-    saved.clock as unknown as
+    (saved as Record<string, unknown>).clock as
       { ticker?: { activeTimer?: unknown } } | null | undefined
   )?.ticker;
   if (clockTicker?.activeTimer === false) return false;
@@ -801,9 +618,9 @@ export function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
       ? (v as Record<string, unknown>)
       : undefined;
 
-  const clk = obj(saved.clock);
+  // Pre-split blobs kept the pomodoro config under `clock`.
+  const clk = obj((saved as Record<string, unknown>).clock);
   const tmr = obj(saved.timer);
-  const wth = obj(saved.weather);
   const sys = obj(saved.sysmon);
   const upt = obj(saved.uptime);
   const ghb = obj(saved.github);
@@ -836,24 +653,16 @@ export function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
       !Array.isArray(saved.pinnedWidgets)
         ? (saved.pinnedWidgets as Record<string, WidgetPinConfig>)
         : {},
-    // 2026-07-17 unification reset: clock/timer/weather/uptime/github
-    // ticker configs are forced to defaults — the exclusion/on-off UIs
-    // are gone and tracked content always reaches the ticker. Stored
-    // values are deliberately ignored (idempotent, zero-write; same
-    // idiom as the display-venue reset).
-    clock: {
-      ticker: { ...DEFAULT_CLOCK_TICKER },
-    },
+    // Stored clock/weather blocks and the per-widget `ticker` sub-configs
+    // (other than sysmon's) are dropped here: the fields were force-reset
+    // on every load since 2026-07-17 and REL-208 removed them outright.
+    // Not spreading them is what sheds them from disk on the next save.
     timer: {
-      ticker: { ...DEFAULT_TIMER_TICKER },
       pomodoro: {
         ...DEFAULT_TIMER_POMODORO,
         ...obj(clk?.pomodoro),
         ...obj(tmr?.pomodoro),
       },
-    },
-    weather: {
-      ticker: { ...DEFAULT_WEATHER_TICKER },
     },
     sysmon: {
       refreshInterval:
@@ -869,7 +678,6 @@ export function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
         typeof upt?.pollInterval === "number"
           ? upt.pollInterval
           : DEFAULT_WIDGETS.uptime.pollInterval,
-      ticker: { ...DEFAULT_UPTIME_TICKER },
     },
     github: {
       repos: Array.isArray(ghb?.repos)
@@ -885,7 +693,6 @@ export function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
         typeof ghb?.pollInterval === "number"
           ? ghb.pollInterval
           : DEFAULT_WIDGETS.github.pollInterval,
-      ticker: { ...DEFAULT_GITHUB_TICKER },
     },
   };
 }
@@ -958,14 +765,8 @@ export function migrateRssDisplay(
       ["newest", "oldest"],
       DEFAULT_WIDGET_DISPLAY.rss.feedSort,
     ),
-    // One-shot migration (v1.1.1): 4 was the pre-widget-era DEFAULT and
-    // never appeared in the picker (1/3/5/10), so a stored 4 is an
-    // untouched default, not a user's choice — map it to 0 (all).
-    // Deliberately chosen values (1/3/5/10) survive.
-    articlesPerSource:
-      typeof raw.articlesPerSource === "number" && raw.articlesPerSource !== 4
-        ? raw.articlesPerSource
-        : DEFAULT_WIDGET_DISPLAY.rss.articlesPerSource,
+    // A stored `articlesPerSource` (the retired per-source cap, REL-208)
+    // is not carried: the feed shows every eligible article per source.
     maxArticles:
       typeof raw.maxArticles === "number" &&
       Number.isFinite(raw.maxArticles) &&
@@ -991,33 +792,16 @@ export function migrateFantasyDisplay(
 ): FantasyDisplayPrefs {
   const raw = (saved ?? {}) as Record<string, unknown>;
 
-  // tickerShowMatchup (pre-v1.0.2 boolean) folds into matchupScore:
-  //   true  → "both" (score visible everywhere)
-  //   false → "feed" (hide from ticker; keep in feed cards)
-  // If the user already has a `matchupScore` Venue stored, use it.
-  const legacyTickerMatchup = raw.tickerShowMatchup;
-  const explicitMatchupScore = raw.matchupScore;
-  const matchupScore: Venue = explicitMatchupScore
-    ? migrateVenue(explicitMatchupScore)
-    : legacyTickerMatchup === false
-      ? "feed"
-      : "both";
-
-  // showInjuryCount (pre-v1.0.2 boolean) folds into injuryCount.
-  const legacyInjuryCount = raw.showInjuryCount;
-  const explicitInjuryCount = raw.injuryCount;
-  const injuryCount: Venue = explicitInjuryCount
-    ? migrateVenue(explicitInjuryCount)
-    : legacyInjuryCount === false
-      ? "off"
-      : "both";
-
-  // The dial is new. Defaulting everyone to "essential" would silently
-  // strip segments an existing user had deliberately switched on, so a
-  // prefs file that predates the dial resolves to "everything" — the
-  // mode whose behaviour IS the old behaviour (every per-item venue
-  // pref honoured). Only genuinely fresh installs, which never reach
-  // this function, get the calm default.
+  // A prefs file that predates the dial resolves to "everything": every
+  // per-item venue pref defaulted to "both" back then, so that is the
+  // ticker those users already had. Only genuinely fresh installs, which
+  // never reach this function, get the calm default.
+  //
+  // The 14 venue prefs, the two legacy booleans they were folded from
+  // (`tickerShowMatchup`, `showInjuryCount`), and the never-read
+  // `showStandings` / `showMatchups` / `defaultSort` are not carried
+  // (REL-208) — the object built here is what gets saved back, so they
+  // fall off on the next write.
   const tickerMode: FantasyTickerMode = isFantasyTickerMode(raw.tickerMode)
     ? raw.tickerMode
     : "everything";
@@ -1025,26 +809,6 @@ export function migrateFantasyDisplay(
   return {
     ...DEFAULT_WIDGET_DISPLAY.fantasy,
     tickerMode,
-    matchupScore,
-    winProbability: migrateVenue(raw.winProbability),
-    matchupStatus: migrateVenue(raw.matchupStatus),
-    projectedPoints: migrateVenue(raw.projectedPoints),
-    week: migrateVenue(raw.week),
-    record: migrateVenue(raw.record),
-    standingsPosition: migrateVenue(raw.standingsPosition),
-    streak: migrateVenue(raw.streak),
-    injuryCount,
-    topScorer: migrateVenue(raw.topScorer),
-    // Phase 1 player-stats fields. New fields default to "both" via
-    // migrateVenue's fallback for unknown inputs, so existing prefs
-    // files (which won't have these keys) get the new segments
-    // visible by default. The DEFAULT_WIDGET_DISPLAY values above
-    // are what fresh installs and `handleReset` produce; this
-    // migration is what existing users see post-upgrade.
-    topThreeScorers: migrateVenue(raw.topThreeScorers),
-    worstStarter: migrateVenue(raw.worstStarter),
-    benchOpportunity: migrateVenue(raw.benchOpportunity),
-    injuryDetail: migrateVenue(raw.injuryDetail),
     // Followed players is just a string array — no enum migration.
     // Filter to strings defensively in case the persisted shape is
     // garbled (older prefs files with no key get [] from the default).
@@ -1053,19 +817,6 @@ export function migrateFantasyDisplay(
           (k): k is string => typeof k === "string",
         )
       : DEFAULT_WIDGET_DISPLAY.fantasy.followedPlayerKeys,
-    showStandings:
-      typeof raw.showStandings === "boolean"
-        ? raw.showStandings
-        : DEFAULT_WIDGET_DISPLAY.fantasy.showStandings,
-    showMatchups:
-      typeof raw.showMatchups === "boolean"
-        ? raw.showMatchups
-        : DEFAULT_WIDGET_DISPLAY.fantasy.showMatchups,
-    defaultSort: oneOf(
-      raw.defaultSort,
-      ["name", "season", "record", "matchup"],
-      DEFAULT_WIDGET_DISPLAY.fantasy.defaultSort,
-    ),
     defaultSubTab: oneOf(
       raw.defaultSubTab,
       ["overview", "matchup", "standings", "roster"],
@@ -1183,7 +934,8 @@ export function loadPrefs(): AppPreferences {
           ? savedWindow.tickerMonitors.filter((m): m is string => typeof m === "string")
           : [],
       },
-      taskbar: { ...DEFAULT_TASKBAR, ...source.taskbar },
+      // No `taskbar`: the block was migrated, defaulted and reset for
+      // years without a reader. Not carrying it here sheds it on save.
       widgets: mergeWidgetPrefs(
         source.widgets as Partial<WidgetPrefs> | undefined,
       ),
@@ -1254,7 +1006,6 @@ export function resetAll(): AppPreferences {
     startup: { ...DEFAULT_STARTUP },
     privacy: { ...DEFAULT_PRIVACY },
     window: { ...DEFAULT_WINDOW },
-    taskbar: { ...DEFAULT_TASKBAR },
     widgets: { ...DEFAULT_WIDGETS },
     widgetDisplay: { ...DEFAULT_WIDGET_DISPLAY },
     // Reset clears tipsShown — the user explicitly asked for a clean
@@ -1325,12 +1076,6 @@ export function migrateAppearanceTheme(
 }
 
 // ── Derived values ──────────────────────────────────────────────
-
-export const TASKBAR_HEIGHTS: Record<TaskbarHeight, number> = {
-  compact: 28,
-  default: 36,
-  comfortable: 44,
-};
 
 export const TICKER_GAPS: Record<TickerGap, number> = {
   tight: 8,

--- a/docs/CHIP_SPEC.md
+++ b/docs/CHIP_SPEC.md
@@ -464,10 +464,11 @@ rotation cadence or slot count. The one such control ever added (sports "N on th
 bar", 2026-09-04) was removed the same day.
 
 **Documented exception, to be reconciled:** fantasy's `tickerMode` dial (essential /
-standard / everything) plus its per-item venue prefs are selection controls that
-predate this rule. When fantasy is rebuilt (REL-184), the dial becomes the fixed
-`standard` rule and the per-item venue toggles go; followed players remain, since they
-are an input.
+standard / everything) is a selection control that predates this rule. Its per-item
+venue toggles and the 14 venue prefs behind them went in REL-208 (2026-09-06); each
+dial position is now a fixed set built in the fantasy ticker source. When fantasy is
+rebuilt (REL-184), the dial becomes the fixed `standard` rule; followed players remain,
+since they are an input.
 
 ### 8.1 Per-source constants (not settings)
 


### PR DESCRIPTION
## Settings 6/7 — REL-208

Enforces `docs/CHIP_SPEC.md` §8: the feed is user-controlled reading, the ticker is glancing, and nothing on the rail is user-selected. Audit: `docs/SETTINGS_AUDIT.md` §9 (fantasy) and §10.

### Fantasy
- **Deleted the "Advanced — ticker items" block** (Matchup score, Win probability, Projected points, Top 3 scorers, Worst starter, Injury report) from `ConnectedView.tsx`. The page keeps the one dial (Essential / Standard / Everything) and the live preview.
- **Each dial position is now a fixed set built in `fantasy/ticker.tsx`**: essential = league chip; standard = + moment chips (in play, breaking injury); everything = + starters 2–3, worst starter, bench top, injury report.
- `FantasyStatChip` renders every segment its data supports; it no longer takes `prefs`. `selectFantasyForTicker` lost its "any venue on ticker" gate and only applies the user's inputs (enabled leagues, primary league).

### Dead prefs deleted (`preferences.ts`, with defaults / migration / reset plumbing)
- The whole `taskbar.*` block and `TASKBAR_HEIGHTS` — never read.
- The 14 fantasy venue prefs, `showStandings` / `showMatchups` / `defaultSort`, and the two legacy booleans they were folded from.
- `widgetDisplay.rss.articlesPerSource` — plus the per-source cap branch, the `showAll` toggle and the "N hidden · N per source / Limit to N per source" feed footer that only it drove, and the `limitPerSource` / `distinctSourceCount` helpers left with no callers.
- The per-widget `ticker.excluded*` lists and the clock / timer gates that `mergeWidgetPrefs` force-reset on every load. `useWidgetTickerData` now just puts every tracked item on the rail. The `clock` and `weather` widget config blocks are gone entirely (nothing was left in them); sysmon's stat toggles stay, they are real content selection.
- `shouldShowOnTicker` / `shouldShowOnFeed` go with their last readers. `Venue` + `migrateVenue` stay for the sports migration.

`loadPrefs` / the `migrate*` helpers simply don't spread the retired fields, so they fall off disk on the next save. The pre-dial fallback to `everything` stays (that was the ticker those users already had).

### Verification
- `tsc --noEmit` clean; `vitest run` 63 files / 660 tests green, rebased on current main (after REL-209 #320 and REL-203 #321, which also touched `preferences.ts`).
- New `fantasy/ticker.test.tsx` pins the chip set of each dial position; new `ConnectedView.test.tsx` renders the connected page and asserts the dial is there and none of the six toggles are.
- Chip-per-mode check against `fixtures/serve-fantasy-demo.mjs --emit` (3 demo leagues): essential 3 chips, standard 8, everything 23.
- **Not done in a browser:** the app-window entry calls `getCurrentWindow()` at module scope, so `app.html` throws in a plain browser pane (no Tauri globals), and the connected fantasy page also needs a signed-in Yahoo account. The page render is covered by the vitest render above instead; the desktop app was not started (another session owns :5174).

### Docs
`docs/CHIP_SPEC.md` §8.0.1 "documented exception" updated: the venue toggles are gone; only the dial remains until REL-184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
