### PR TITLE
feat(desktop): Ticker settings page rebuilt — On · Where · Look · Motion · Behaviour [REL-204]

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -27,7 +27,6 @@ import {
   savePref,
   loadPrefs,
   savePrefs,
-  TICKER_GAPS,
   TICKER_HEIGHTS,
   toggleWidgetPin,
   } from "./preferences";
@@ -789,14 +788,11 @@ export default function App() {
                 onTogglePin={handleTogglePin}
                 pinnedWidgets={prefs.widgets.pinnedWidgets}
                 speed={prefs.ticker.tickerSpeed}
-                gap={TICKER_GAPS[prefs.ticker.tickerGap]}
-                pauseOnHover={prefs.ticker.pauseOnHover}
-                hoverSpeed={prefs.ticker.hoverSpeed}
+                onHover={prefs.ticker.onHover}
                 mixMode={prefs.ticker.mixMode}
                 chipColorMode={prefs.ticker.chipColors}
                 widgetDisplay={prefs.widgetDisplay}
                 comfort={prefs.ticker.tickerMode === "comfort"}
-                direction={prefs.ticker.tickerDirection}
                 scrollMode={prefs.ticker.scrollMode}
                 stepPause={prefs.ticker.stepPause}
                 showSourcelessCTA={showSourcelessCTA}

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -9,7 +9,7 @@ import {
 import clsx from "clsx";
 import { ChevronDown, Plus, Settings2 } from "lucide-react";
 import { Ticker } from "motion-plus/react";
-import { useMotionValue, animate, AnimatePresence, motion } from "motion/react";
+import { useMotionValue, animate } from "motion/react";
 import type {
   DashboardResponse,
   Trade,
@@ -24,9 +24,9 @@ import type {
   SysmonChipData,
 } from "../types";
 import type {
+  HoverBehavior,
   MixMode,
   ChipColorMode,
-  TickerDirection,
   ScrollMode,
   WidgetPinConfig,
   WidgetDisplayPrefs,
@@ -75,10 +75,9 @@ interface ScrollrTickerProps {
   speed?: number;
   /** Gap between chips in px (default 8) */
   gap?: number;
-  /** Whether hovering slows the ticker (default true) */
-  pauseOnHover?: boolean;
-  /** Speed multiplier on hover, 0 = full pause (default 0.3) */
-  hoverSpeed?: number;
+  /** Continuous: keep / slow to 30 % / stop under the mouse.
+   *  Page: keep advancing, or hold the page (slow and pause alike). */
+  onHover?: HoverBehavior;
   /** Show 2-row comfort chips with extra detail */
   comfort?: boolean;
   /** How items from different widgets are ordered */
@@ -87,11 +86,9 @@ interface ScrollrTickerProps {
   chipColorMode?: ChipColorMode;
   /** Per-widget display preferences (controls what data chips show) */
   widgetDisplay?: WidgetDisplayPrefs;
-  /** Scroll direction: left (default) or right */
-  direction?: TickerDirection;
-  /** Scroll mode: continuous, step, or flip */
+  /** Scroll mode: continuous or step (Page) */
   scrollMode?: ScrollMode;
-  /** Seconds to pause between transitions in step/flip modes (default 2) */
+  /** Seconds each page stays put in step mode (default 5) */
   stepPause?: number;
   /**
    * When true, this row should render the "no sources installed yet"
@@ -260,13 +257,11 @@ export default function ScrollrTicker({
   pinnedWidgets = {},
   speed = 25,
   gap = 8,
-  pauseOnHover = true,
-  hoverSpeed = 0.3,
+  onHover = "slow",
   mixMode = "grouped",
   chipColorMode = "widget",
   widgetDisplay,
   comfort = false,
-  direction = "left",
   scrollMode = "continuous",
   stepPause = 5,
   showSourcelessCTA = false,
@@ -276,7 +271,9 @@ export default function ScrollrTicker({
   onOpenWidget,
 }: ScrollrTickerProps) {
   const effectiveScrollMode: ScrollMode = scrollMode;
-  const effectiveDirection: TickerDirection = direction;
+  // Direction left the settings 2026-09-06 (REL-204): tickers go left.
+  const effectiveDirection = "left" as const;
+  const holdOnHover = onHover !== "keep";
   const effectiveSpeed: number = speed;
   const effectiveMixMode: MixMode = mixMode;
 
@@ -411,15 +408,13 @@ export default function ScrollrTicker({
   // motion-plus has no loop callback, so this polls. Four reads a second
   // of a handful of rects is nothing next to the marquee's own per-frame
   // transform, and the check is skipped entirely when no slot rotates.
-  // Flip mode paginates rather than scrolls, so nothing there is ever
-  // "off screen" in the sense that matters; it keeps its first page.
   const wasVisibleRef = useRef<Set<string>>(new Set());
   const hasRotatingSlots = useMemo(
     () => chips.some((c) => (c as React.ReactElement<{ "data-rotate-slot"?: string }>).props?.["data-rotate-slot"]),
     [chips],
   );
   useEffect(() => {
-    if (!hasRotatingSlots || effectiveScrollMode === "flip") return;
+    if (!hasRotatingSlots) return;
     const id = window.setInterval(() => {
       const container = containerRef.current;
       if (!container) return;
@@ -479,8 +474,8 @@ export default function ScrollrTicker({
       await sleep(500);
 
       while (!cancelled && stepLoopRef.current) {
-        // Skip advancing while hovered and pauseOnHover is enabled
-        if (pauseOnHover && isHoveredRef.current) {
+        // Hold the page while hovered unless the user chose Keep moving
+        if (holdOnHover && isHoveredRef.current) {
           await sleep(100);
           continue;
         }
@@ -514,45 +509,13 @@ export default function ScrollrTicker({
     effectiveScrollMode,
     effectiveDirection,
     stepPause,
-    pauseOnHover,
+    holdOnHover,
     effectiveSpeed,
     chips.length,
     measureStepSize,
     offset,
     transitionDuration,
   ]);
-
-  // ── Flip mode: paginated vertical slide ───────────────────────
-  const [flipPage, setFlipPage] = useState(0);
-
-  // Estimate how many chips fit visually, then rotate the array
-  const visibleCount = useMemo(() => {
-    const containerWidth = containerRef.current?.clientWidth ?? 1200;
-    const avgChipWidth = comfort ? 180 : 120;
-    return Math.max(1, Math.floor(containerWidth / (avgChipWidth + gap)));
-  }, [comfort, gap, chips.length]); // re-estimate when chip count changes
-
-  const flipChips = useMemo(() => {
-    if (chips.length === 0) return [];
-    const shift = (flipPage * visibleCount) % chips.length;
-    return [...chips.slice(shift), ...chips.slice(0, shift)];
-  }, [chips, flipPage, visibleCount]);
-
-  // Flip timer: cycle pages on stepPause interval.
-  // Also resets flipPage when chips change (chips.length in deps triggers
-  // cleanup → fresh start) avoiding a separate effect with ordering concerns.
-  useEffect(() => {
-    if (effectiveScrollMode !== "flip" || chips.length === 0) return;
-
-    setFlipPage(0);
-
-    const timer = setInterval(() => {
-      if (pauseOnHover && isHoveredRef.current) return;
-      setFlipPage((p) => p + 1);
-    }, stepPause * 1000);
-
-    return () => clearInterval(timer);
-  }, [effectiveScrollMode, stepPause, pauseOnHover, chips.length]);
 
   // ── Build pinned chip arrays (rendered inside this row) ─────────
   //
@@ -734,44 +697,6 @@ export default function ScrollrTicker({
       </div>
     ) : null;
 
-  // ── Flip mode: AnimatePresence with vertical slide ────────────
-  if (effectiveScrollMode === "flip") {
-    return (
-      <div
-        ref={containerRef}
-        className={containerClass}
-        onMouseEnter={() => {
-          isHoveredRef.current = true;
-        }}
-        onMouseLeave={() => {
-          isHoveredRef.current = false;
-        }}
-      >
-        {accentLine}
-        {pinnedZone("left", pinnedLeft)}
-        <div className="ticker-scroll-wrapper">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={flipPage}
-              initial={{ y: "100%", opacity: 0 }}
-              animate={{ y: 0, opacity: 1 }}
-              exit={{ y: "-100%", opacity: 0 }}
-              transition={{
-                duration: transitionDuration,
-                ease: [0.25, 0.1, 0.25, 1],
-              }}
-              className="flex items-center h-full"
-              style={{ gap }}
-            >
-              {flipChips}
-            </motion.div>
-          </AnimatePresence>
-        </div>
-        {pinnedZone("right", pinnedRight)}
-      </div>
-    );
-  }
-
   // ── Continuous / Step mode: motion-plus Ticker ────────────────
   const velocity =
     effectiveDirection === "left" ? effectiveSpeed : -effectiveSpeed;
@@ -795,7 +720,7 @@ export default function ScrollrTicker({
           items={chips}
           velocity={isStepMode ? 0 : velocity}
           offset={isStepMode ? offset : undefined}
-          hoverFactor={isStepMode ? 1 : pauseOnHover ? hoverSpeed : 1}
+          hoverFactor={isStepMode ? 1 : HOVER_FACTOR[onHover]}
           gap={gap}
           fade={hasPinnedLeft || hasPinnedRight ? 20 : 40}
         />
@@ -807,14 +732,16 @@ export default function ScrollrTicker({
 
 // ── Helpers (module-level) ───────────────────────────────────────
 
+/** Continuous-mode speed multiplier under the mouse; 0 stops the marquee. */
+const HOVER_FACTOR: Record<HoverBehavior, number> = { keep: 1, slow: 0.3, pause: 0 };
+
 /** Promise-based sleep helper. */
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** Map speed slider (5–150) to transition duration for step/flip modes.
- *  speed 5 → ~1.2s (crawl), speed 25 → ~0.9s (default),
- *  speed 60 → ~0.55s, speed 150 → ~0.15s (blazing). */
+/** Map speed (px/s) to the step transition duration in Page mode.
+ *  Slow 20 → ~1.1s, Normal 40 → ~0.95s, Fast 80 → ~0.66s. */
 function speedToTransitionDuration(speed: number): number {
   return Math.max(0.15, 1.2 - (speed - 5) * 0.0072);
 }

--- a/desktop/src/components/WindowControls.tsx
+++ b/desktop/src/components/WindowControls.tsx
@@ -8,9 +8,11 @@ import { useState, useEffect } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import Tooltip from "./Tooltip";
 
-export const IS_MACOS =
+const UA_PLATFORM =
   (navigator as { userAgentData?: { platform?: string } }).userAgentData
-    ?.platform === "macOS" || /Mac/.test(navigator.platform);
+    ?.platform ?? navigator.platform;
+export const IS_MACOS = /Mac/.test(UA_PLATFORM);
+export const IS_WINDOWS = /Win/.test(UA_PLATFORM);
 
 const appWindow = getCurrentWindow();
 

--- a/desktop/src/components/settings/MonitorMap.tsx
+++ b/desktop/src/components/settings/MonitorMap.tsx
@@ -1,8 +1,8 @@
 /**
  * Monitors: the map, the per-screen switches, and the Identify button.
  *
- * Shared by Settings pages (Window & startup today, the Ticker page
- * next — REL-204), so nothing here knows which page it is on.
+ * Rendered by the Ticker page under "Where" (REL-204); the page owns
+ * the group, this owns the rows and the Identify button.
  *
  * The map draws PHYSICAL rects: that is the one plane where mixed-DPI
  * screens sit side by side the way Windows' Display settings shows
@@ -16,7 +16,7 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useTauriListener } from "../../hooks/useTauriListener";
-import { RowList, SettingsButton, SettingsGroup, ToggleRow } from "./SettingsControls";
+import { RowList, SettingsButton, ToggleRow } from "./SettingsControls";
 import { Row } from "./pages/Row";
 
 /** One `list_monitors` entry. `x/y/width/height` are logical (that
@@ -112,13 +112,22 @@ export function MonitorMap({
   );
 }
 
+/** Flashes each screen's number on it, so switch matches glass. */
+export function IdentifyButton() {
+  return (
+    <SettingsButton onClick={() => void invoke("identify_monitors").catch(() => {})}>
+      Identify
+    </SettingsButton>
+  );
+}
+
 /**
- * The whole Monitors group. `chosen` is `window.tickerMonitors` (names;
- * empty means primary, so a fresh install shows the primary switched
- * on with nothing saved). The main window turns the pref into windows
- * (routes/__root.tsx).
+ * The map plus one switch per screen. `chosen` is `window.tickerMonitors`
+ * (names; empty means primary, so a fresh install shows the primary
+ * switched on with nothing saved). The main window turns the pref into
+ * windows (routes/__root.tsx). Renders nothing until the list arrives.
  */
-export function MonitorsGroup({
+export function MonitorsRows({
   chosen,
   onChange,
 }: {
@@ -142,18 +151,11 @@ export function MonitorsGroup({
     );
 
   return (
-    <SettingsGroup
-      label="Monitors"
-      action={
-        <SettingsButton onClick={() => void invoke("identify_monitors").catch(() => {})}>
-          Identify
-        </SettingsButton>
-      }
-    >
-      <Row id="tickerMonitors">
-        <div className="border-b border-edge/60 px-4 py-3">
-          <MonitorMap monitors={monitors} on={on} onToggle={toggle} />
-        </div>
+    <Row id="tickerMonitors">
+      <div className="border-b border-edge/60 px-4 py-3">
+        <MonitorMap monitors={monitors} on={on} onToggle={toggle} />
+      </div>
+      <div className="border-b border-edge/60">
         <RowList>
           {monitors.map((m, i) => {
             const locked = on.size === 1 && on.has(m.name);
@@ -170,7 +172,7 @@ export function MonitorsGroup({
             );
           })}
         </RowList>
-      </Row>
-    </SettingsGroup>
+      </div>
+    </Row>
   );
 }

--- a/desktop/src/components/settings/SettingsControls.tsx
+++ b/desktop/src/components/settings/SettingsControls.tsx
@@ -555,7 +555,7 @@ export function ResetButton({
 //
 // Wraps each child after the first in a hairline divider, so callers can
 // list rows without threading separator props through every one. Rows
-// that conditionally render (Direction, Hover speed, Time per page) drop
+// that conditionally render (Time per page, Hide when fullscreen) drop
 // out cleanly because `false`/`null` children are filtered first.
 
 export function RowList({ children }: { children: React.ReactNode }) {
@@ -565,7 +565,7 @@ export function RowList({ children }: { children: React.ReactNode }) {
     <>
       {visible.map((row, i) => (
         // Keyed by the row's own id where it has one, not by position.
-        // Conditional rows (Direction, Time per page, Hover speed) shift
+        // Conditional rows (Time per page, Hide when fullscreen) shift
         // every index below them as they appear and disappear, so an
         // index key hands one setting's mounted instance to a different
         // setting — the sliding pill and any transient state ride along

--- a/desktop/src/components/settings/SettingsSurface.tsx
+++ b/desktop/src/components/settings/SettingsSurface.tsx
@@ -41,7 +41,7 @@ import PageHeader from "./pages/PageHeader";
 import AppearancePage from "./pages/AppearancePage";
 import WindowStartupPage from "./pages/WindowStartupPage";
 import ShortcutsPage from "./pages/ShortcutsPage";
-import TickerPage, { useTickerReset } from "./pages/TickerPage";
+import TickerPage, { RESET_TICKER_LABEL, useTickerReset } from "./pages/TickerPage";
 import ProfilePlanPage from "./pages/ProfilePlanPage";
 import DataPrivacyPage from "./pages/DataPrivacyPage";
 import UpdatesPage from "./pages/UpdatesPage";
@@ -169,7 +169,7 @@ export default function SettingsSurface({
                   action={
                     page === "ticker" ? (
                       <SettingsButton onClick={resetTicker}>
-                        Reset ticker settings
+                        {RESET_TICKER_LABEL}
                       </SettingsButton>
                     ) : undefined
                   }
@@ -187,10 +187,6 @@ export default function SettingsSurface({
 
               {page === "window" && (
                 <WindowStartupPage
-                  window_={prefs.window}
-                  onWindowChange={(window_) =>
-                    onPrefsChange({ ...prefs, window: window_ })
-                  }
                   startup={prefs.startup}
                   onStartupChange={(startup) =>
                     onPrefsChange({ ...prefs, startup })

--- a/desktop/src/components/settings/pages.ts
+++ b/desktop/src/components/settings/pages.ts
@@ -74,7 +74,7 @@ export const SETTINGS_PAGE_META: Record<SettingsPage, SettingsPageMeta> = {
     id: "ticker",
     label: "Ticker",
     title: "Ticker",
-    subtitle: "How the pinned ticker strip moves and looks.",
+    subtitle: "The bar: whether it's on, where it lives, how it looks, moves and behaves.",
     icon: RadioTower,
   },
   profile: {

--- a/desktop/src/components/settings/pages/TickerPage.tsx
+++ b/desktop/src/components/settings/pages/TickerPage.tsx
@@ -1,53 +1,50 @@
 /**
- * Ticker.
+ * Ticker — the bar, in the order a person thinks about it:
+ * is it on → where → what it looks like → how it moves → how it behaves
+ * (docs/SETTINGS_AUDIT.md §1, §3; REL-204).
  *
- * Every conditional here mirrors what ScrollrTicker actually reads, so
- * the page never offers a control that does nothing:
- *   - Direction is meaningless in Rotate (pages swap, they don't travel).
- *   - Time per page only exists for the two timed modes (:335, :363).
- *   - Hover speed is only consulted in continuous scroll; Page and
- *     Rotate halt outright on hover instead (:316, :372), so the toggle's
- *     description changes rather than the toggle disappearing.
+ * Every number on this page is a preset, never a slider. The prefs stay
+ * numbers (`tickerSpeed`, `stepPause`, `tickerScale`) so the bar reads
+ * them unchanged; `loadPrefs` snaps anything off the list.
+ *
+ * Time per page only exists in Page mode, so it only renders there.
+ * Hide-when-fullscreen only does anything on Windows, so it only
+ * renders there.
  *
  * Screen edge writes `window.tickerPosition`; App.tsx's pref subscriber
  * owns the reposition side effect, so this only has to set the pref.
  */
 import { useCallback } from "react";
-import { resetCategory } from "../../../preferences";
+import {
+  resetTickerPage,
+  SCALE_PRESETS,
+  STEP_PAUSES,
+  TICKER_SPEEDS,
+} from "../../../preferences";
 import type {
   AppPreferences,
   ChipColorMode,
+  HoverBehavior,
   MixMode,
   ScrollMode,
-  TickerDirection,
-  TickerGap,
   TickerPosition,
   TickerPrefs,
+  WindowPrefs,
 } from "../../../preferences";
 import { useUndoableAction } from "../../../hooks/useUndoableAction";
+import { IS_WINDOWS } from "../../WindowControls";
+import { IdentifyButton, MonitorsRows } from "../MonitorMap";
 import {
   RowList,
   SegmentedRow,
   SettingsGroup,
-  SliderRow,
   ToggleRow,
 } from "../SettingsControls";
 import { Row } from "./Row";
 
-const SCROLL_MODE_OPTIONS: { value: ScrollMode; label: string }[] = [
-  { value: "continuous", label: "Continuous" },
-  { value: "step", label: "Page" },
-  { value: "flip", label: "Rotate" },
-];
-
-const DIRECTION_OPTIONS: { value: TickerDirection; label: string }[] = [
-  { value: "left", label: "← Left" },
-  { value: "right", label: "Right →" },
-];
-
-const MIX_OPTIONS: { value: MixMode; label: string }[] = [
-  { value: "grouped", label: "By source" },
-  { value: "weave", label: "Mixed" },
+const POSITION_OPTIONS: { value: TickerPosition; label: string }[] = [
+  { value: "top", label: "Top" },
+  { value: "bottom", label: "Bottom" },
 ];
 
 const DETAIL_LEVEL_OPTIONS: { value: "compact" | "comfort"; label: string }[] = [
@@ -55,11 +52,10 @@ const DETAIL_LEVEL_OPTIONS: { value: "compact" | "comfort"; label: string }[] = 
   { value: "comfort", label: "Detailed" },
 ];
 
-const SPACING_OPTIONS: { value: TickerGap; label: string }[] = [
-  { value: "tight", label: "Tight" },
-  { value: "normal", label: "Normal" },
-  { value: "spacious", label: "Wide" },
-];
+const SIZE_OPTIONS = SCALE_PRESETS.map((v) => ({
+  value: String(v),
+  label: `${v}%`,
+}));
 
 const CHIP_COLOR_OPTIONS: { value: ChipColorMode; label: string }[] = [
   { value: "widget", label: "Widget" },
@@ -67,9 +63,31 @@ const CHIP_COLOR_OPTIONS: { value: ChipColorMode; label: string }[] = [
   { value: "muted", label: "Subtle" },
 ];
 
-const POSITION_OPTIONS: { value: TickerPosition; label: string }[] = [
-  { value: "top", label: "Top" },
-  { value: "bottom", label: "Bottom" },
+const SCROLL_MODE_OPTIONS: { value: ScrollMode; label: string }[] = [
+  { value: "continuous", label: "Continuous" },
+  { value: "step", label: "Page" },
+];
+
+const SPEED_OPTIONS = [
+  { value: String(TICKER_SPEEDS.slow), label: "Slow" },
+  { value: String(TICKER_SPEEDS.normal), label: "Normal" },
+  { value: String(TICKER_SPEEDS.fast), label: "Fast" },
+];
+
+const HOVER_OPTIONS: { value: HoverBehavior; label: string }[] = [
+  { value: "keep", label: "Keep moving" },
+  { value: "slow", label: "Slow down" },
+  { value: "pause", label: "Pause" },
+];
+
+const STEP_PAUSE_OPTIONS = STEP_PAUSES.map((v) => ({
+  value: String(v),
+  label: `${v} s`,
+}));
+
+const MIX_OPTIONS: { value: MixMode; label: string }[] = [
+  { value: "grouped", label: "By source" },
+  { value: "weave", label: "Mixed" },
 ];
 
 interface TickerPageProps {
@@ -78,51 +96,85 @@ interface TickerPageProps {
 }
 
 export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
-  const { ticker } = prefs;
-
-  const hoverSpeedApplies =
-    ticker.scrollMode === "continuous" && ticker.pauseOnHover;
-  const stepPauseApplies =
-    ticker.scrollMode === "step" || ticker.scrollMode === "flip";
+  const { ticker, window: window_ } = prefs;
+  const paged = ticker.scrollMode === "step";
 
   const setTicker = useCallback(
-    <K extends keyof TickerPrefs>(key: K, value: TickerPrefs[K]) => {
-      onPrefsChange({ ...prefs, ticker: { ...ticker, [key]: value } });
-    },
+    <K extends keyof TickerPrefs>(key: K, value: TickerPrefs[K]) =>
+      onPrefsChange({ ...prefs, ticker: { ...ticker, [key]: value } }),
     [prefs, ticker, onPrefsChange],
+  );
+  const setWindow = useCallback(
+    <K extends keyof WindowPrefs>(key: K, value: WindowPrefs[K]) =>
+      onPrefsChange({ ...prefs, window: { ...window_, [key]: value } }),
+    [prefs, window_, onPrefsChange],
   );
 
   return (
     <>
-      <SettingsGroup label="Behavior">
+      <SettingsGroup label="On">
         <RowList>
-          <Row id="scrollMode">
-            <SegmentedRow
-              label="Scroll mode"
-              description="How chips advance: continuous scroll, page through, or rotate."
-              value={ticker.scrollMode}
-              options={SCROLL_MODE_OPTIONS}
-              onChange={(v) => setTicker("scrollMode", v)}
+          <Row id="showTicker">
+            <ToggleRow
+              label="Show the ticker"
+              description="The bar on your screen. Ctrl+T, the tray and the ticker's right-click menu do the same."
+              checked={ticker.showTicker}
+              onChange={(v) => setTicker("showTicker", v)}
             />
           </Row>
-          {ticker.scrollMode !== "flip" && (
-            <Row id="direction">
-              <SegmentedRow
-                label="Direction"
-                description="Which way the ticker moves."
-                value={ticker.tickerDirection}
-                options={DIRECTION_OPTIONS}
-                onChange={(v) => setTicker("tickerDirection", v)}
-              />
-            </Row>
-          )}
-          <Row id="itemOrder">
+        </RowList>
+      </SettingsGroup>
+
+      <SettingsGroup label="Where" action={<IdentifyButton />}>
+        <MonitorsRows
+          chosen={window_.tickerMonitors}
+          onChange={(v) => setWindow("tickerMonitors", v)}
+        />
+        <RowList>
+          <Row id="screenEdge">
             <SegmentedRow
-              label="Item order"
-              description="Group items by source or weave them together."
-              value={ticker.mixMode}
-              options={MIX_OPTIONS}
-              onChange={(v) => setTicker("mixMode", v)}
+              label="Screen edge"
+              description="Which edge of the screen the ticker sits on."
+              value={window_.tickerPosition}
+              options={POSITION_OPTIONS}
+              onChange={(v) => setWindow("tickerPosition", v)}
+            />
+          </Row>
+        </RowList>
+      </SettingsGroup>
+
+      <SettingsGroup label="Look">
+        <RowList>
+          <Row id="detailLevel">
+            <SegmentedRow
+              label="Detail level"
+              description="One line per chip, or a detail row under each."
+              value={ticker.tickerMode}
+              options={DETAIL_LEVEL_OPTIONS}
+              onChange={(v) => setTicker("tickerMode", v)}
+            />
+          </Row>
+          <Row id="tickerScale">
+            <SegmentedRow
+              label="Size"
+              description="Resize the bar. The app window has its own size."
+              value={String(prefs.appearance.tickerScale)}
+              options={SIZE_OPTIONS}
+              onChange={(v) =>
+                onPrefsChange({
+                  ...prefs,
+                  appearance: { ...prefs.appearance, tickerScale: Number(v) },
+                })
+              }
+            />
+          </Row>
+          <Row id="chipColors">
+            <SegmentedRow
+              label="Chip colors"
+              description="Each widget's own color, the theme accent, or subtle grays."
+              value={ticker.chipColors}
+              options={CHIP_COLOR_OPTIONS}
+              onChange={(v) => setTicker("chipColors", v)}
             />
           </Row>
         </RowList>
@@ -130,123 +182,82 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
 
       <SettingsGroup label="Motion">
         <RowList>
+          <Row id="scrollMode">
+            <SegmentedRow
+              label="Scroll mode"
+              description="Scroll without stopping, or show a page at a time."
+              value={ticker.scrollMode}
+              options={SCROLL_MODE_OPTIONS}
+              onChange={(v) => setTicker("scrollMode", v)}
+            />
+          </Row>
           <Row id="speed">
-            <SliderRow
+            <SegmentedRow
               label="Speed"
-              description="How fast the ticker scrolls."
-              value={ticker.tickerSpeed}
-              min={5}
-              max={150}
-              step={1}
-              displayValue={`${ticker.tickerSpeed}`}
-              onChange={(v) => setTicker("tickerSpeed", v)}
-            />
-          </Row>
-          {stepPauseApplies && (
-            <Row id="stepPause">
-              <SliderRow
-                label="Time per page"
-                description="How long each page stays put before the ticker advances."
-                value={ticker.stepPause}
-                min={1}
-                max={10}
-                step={1}
-                displayValue={`${ticker.stepPause}s`}
-                onChange={(v) => setTicker("stepPause", v)}
-              />
-            </Row>
-          )}
-          <Row id="pauseOnHover">
-            <ToggleRow
-              label="Slow down on hover"
               description={
-                ticker.scrollMode === "continuous"
-                  ? "Ease off while you hover so chips are easier to read."
-                  : "Hold the current page while you hover so it doesn't advance out from under you."
+                paged
+                  ? "How quickly each page slides in."
+                  : "How fast the chips travel."
               }
-              checked={ticker.pauseOnHover}
-              onChange={(v) => setTicker("pauseOnHover", v)}
+              value={String(ticker.tickerSpeed)}
+              options={SPEED_OPTIONS}
+              onChange={(v) => setTicker("tickerSpeed", Number(v))}
             />
           </Row>
-          {hoverSpeedApplies && (
-            <Row id="hoverSpeed">
-              <SliderRow
-                label="Hover speed"
-                description="How far it slows while hovered. At 0% the ticker stops completely."
-                value={Math.round(ticker.hoverSpeed * 100)}
-                min={0}
-                max={100}
-                step={5}
-                displayValue={
-                  ticker.hoverSpeed === 0
-                    ? "Stop"
-                    : `${Math.round(ticker.hoverSpeed * 100)}%`
-                }
-                onChange={(v) => setTicker("hoverSpeed", v / 100)}
+          <Row id="onHover">
+            <SegmentedRow
+              label="On hover"
+              description={
+                paged
+                  ? "Whether the page holds still while your mouse is over it."
+                  : "What the bar does while your mouse is over it."
+              }
+              value={ticker.onHover}
+              options={HOVER_OPTIONS}
+              onChange={(v) => setTicker("onHover", v)}
+            />
+          </Row>
+          {paged && (
+            <Row id="stepPause">
+              <SegmentedRow
+                label="Time per page"
+                description="How long each page stays before the next one."
+                value={String(ticker.stepPause)}
+                options={STEP_PAUSE_OPTIONS}
+                onChange={(v) => setTicker("stepPause", Number(v))}
               />
             </Row>
           )}
         </RowList>
       </SettingsGroup>
 
-      <SettingsGroup label="Display">
+      <SettingsGroup label="Behaviour">
         <RowList>
-          <Row id="screenEdge">
-            <SegmentedRow
-              label="Screen edge"
-              description="Which edge of the screen the ticker sits on."
-              value={prefs.window.tickerPosition}
-              options={POSITION_OPTIONS}
-              onChange={(v) =>
-                onPrefsChange({
-                  ...prefs,
-                  window: { ...prefs.window, tickerPosition: v },
-                })
-              }
+          <Row id="alwaysOnTop">
+            <ToggleRow
+              label="Stay above other windows"
+              description="Keep the ticker visible over whatever else is open."
+              checked={window_.pinned}
+              onChange={(v) => setWindow("pinned", v)}
             />
           </Row>
-          <Row id="detailLevel">
+          {IS_WINDOWS && (
+            <Row id="hideFullscreen">
+              <ToggleRow
+                label="Hide when an app goes fullscreen"
+                description="Get out of the way of games, videos and presentations."
+                checked={window_.hideOnFullscreen}
+                onChange={(v) => setWindow("hideOnFullscreen", v)}
+              />
+            </Row>
+          )}
+          <Row id="itemOrder">
             <SegmentedRow
-              label="Detail level"
-              description="Single line vs. detail row under each chip."
-              value={ticker.tickerMode}
-              options={DETAIL_LEVEL_OPTIONS}
-              onChange={(v) => setTicker("tickerMode", v)}
-            />
-          </Row>
-          <Row id="spacing">
-            <SegmentedRow
-              label="Spacing"
-              description="Gap between chips."
-              value={ticker.tickerGap}
-              options={SPACING_OPTIONS}
-              onChange={(v) => setTicker("tickerGap", v as TickerGap)}
-            />
-          </Row>
-          <Row id="chipColors">
-            <SegmentedRow
-              label="Chip colors"
-              description="Source colors, accent theme, or subtle grayscale."
-              value={ticker.chipColors}
-              options={CHIP_COLOR_OPTIONS}
-              onChange={(v) => setTicker("chipColors", v)}
-            />
-          </Row>
-          <Row id="tickerScale">
-            <SliderRow
-              label="Scale"
-              description="Resize the ticker window. Independent from the main app scale."
-              value={prefs.appearance.tickerScale}
-              min={75}
-              max={150}
-              step={5}
-              displayValue={`${prefs.appearance.tickerScale}%`}
-              onChange={(v) =>
-                onPrefsChange({
-                  ...prefs,
-                  appearance: { ...prefs.appearance, tickerScale: v },
-                })
-              }
+              label="Item order"
+              description="Keep each widget's items together, or mix them."
+              value={ticker.mixMode}
+              options={MIX_OPTIONS}
+              onChange={(v) => setTicker("mixMode", v)}
             />
           </Row>
         </RowList>
@@ -259,17 +270,20 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
  * Reset handler for the page header button. Exposed separately so the
  * surface can render the button in the title row while the undo toast
  * still snapshots through the same `useUndoableAction` contract.
+ * Button, toast and undo share the one name.
  */
+export const RESET_TICKER_LABEL = "Reset ticker settings";
+
 export function useTickerReset() {
   const undoable = useUndoableAction();
   return useCallback(
     () =>
       undoable(
         {
-          label: "Reset ticker style",
-          description: "Restored all ticker style defaults.",
+          label: RESET_TICKER_LABEL,
+          description: "Every setting on the Ticker page is back to its default.",
         },
-        (current) => resetCategory(current, "ticker"),
+        resetTickerPage,
       ),
     [undoable],
   );

--- a/desktop/src/components/settings/pages/WindowStartupPage.tsx
+++ b/desktop/src/components/settings/pages/WindowStartupPage.tsx
@@ -1,22 +1,16 @@
 /**
- * Window & startup.
+ * Window & startup — what happens when Scrollr launches.
  *
- * "Check for updates on startup" lives here rather than on Updates:
- * it is a startup behavior, and grouping it with autostart puts the two
- * "what happens when Scrollr launches" switches together. The Updates
- * page points at this row instead of duplicating it.
- *
- * Monitors (map, switches, Identify) come from ../MonitorMap so the
- * Ticker page can host the same group (REL-204).
+ * Everything about the bar itself (stay above other windows, hide on
+ * fullscreen, monitors) moved to the Ticker page with REL-204; this
+ * page is the computer's side of things. "Check for updates on startup"
+ * lives here rather than on Updates because it is a startup behavior.
  */
-import type { StartupPrefs, WindowPrefs } from "../../../preferences";
-import { MonitorsGroup } from "../MonitorMap";
+import type { StartupPrefs } from "../../../preferences";
 import { RowList, SettingsGroup, ToggleRow } from "../SettingsControls";
 import { Row } from "./Row";
 
 interface WindowStartupPageProps {
-  window_: WindowPrefs;
-  onWindowChange: (prefs: WindowPrefs) => void;
   startup: StartupPrefs;
   onStartupChange: (prefs: StartupPrefs) => void;
   autostartEnabled: boolean;
@@ -24,68 +18,33 @@ interface WindowStartupPageProps {
 }
 
 export default function WindowStartupPage({
-  window_,
-  onWindowChange,
   startup,
   onStartupChange,
   autostartEnabled,
   onAutostartChange,
 }: WindowStartupPageProps) {
   return (
-    <>
-      <SettingsGroup label="Window">
-        <RowList>
-          <Row id="alwaysOnTop">
-            <ToggleRow
-              label="Always on top"
-              description="Keep the ticker above all other windows"
-              checked={window_.pinned}
-              onChange={(v) => onWindowChange({ ...window_, pinned: v })}
-            />
-          </Row>
-          <Row id="hideFullscreen">
-            <ToggleRow
-              label="Hide when an app goes fullscreen"
-              badge="Windows"
-              description="Hides the ticker when YouTube, games, or other apps enter fullscreen so they aren't visually clipped."
-              checked={window_.hideOnFullscreen}
-              onChange={(v) =>
-                onWindowChange({ ...window_, hideOnFullscreen: v })
-              }
-            />
-          </Row>
-        </RowList>
-      </SettingsGroup>
-
-      <MonitorsGroup
-        chosen={window_.tickerMonitors}
-        onChange={(tickerMonitors) =>
-          onWindowChange({ ...window_, tickerMonitors })
-        }
-      />
-
-      <SettingsGroup label="Startup">
-        <RowList>
-          <Row id="autostart">
-            <ToggleRow
-              label="Launch on system startup"
-              description="Automatically open Scrollr when you start your computer"
-              checked={autostartEnabled}
-              onChange={onAutostartChange}
-            />
-          </Row>
-          <Row id="autoCheck">
-            <ToggleRow
-              label="Check for updates on startup"
-              description="Notify me when a new version is available shortly after launch"
-              checked={startup.autoCheckUpdates}
-              onChange={(v) =>
-                onStartupChange({ ...startup, autoCheckUpdates: v })
-              }
-            />
-          </Row>
-        </RowList>
-      </SettingsGroup>
-    </>
+    <SettingsGroup label="Startup">
+      <RowList>
+        <Row id="autostart">
+          <ToggleRow
+            label="Launch on system startup"
+            description="Automatically open Scrollr when you start your computer"
+            checked={autostartEnabled}
+            onChange={onAutostartChange}
+          />
+        </Row>
+        <Row id="autoCheck">
+          <ToggleRow
+            label="Check for updates on startup"
+            description="Notify me when a new version is available shortly after launch"
+            checked={startup.autoCheckUpdates}
+            onChange={(v) =>
+              onStartupChange({ ...startup, autoCheckUpdates: v })
+            }
+          />
+        </Row>
+      </RowList>
+    </SettingsGroup>
   );
 }

--- a/desktop/src/components/settings/searchIndex.ts
+++ b/desktop/src/components/settings/searchIndex.ts
@@ -3,8 +3,8 @@
  *
  * A static, hand-maintained list of every jumpable row. It is not
  * derived from the rendered pages on purpose: rows appear and disappear
- * with preference state (Direction hides on Rotate, Hover speed only on
- * continuous scroll), and a search that could only find the settings you
+ * with preference state (Time per page only in Page mode, Hide when
+ * fullscreen only on Windows), and a search that could only find the settings you
  * had already configured your way into would be worse than useless.
  * Everything is findable; following a result may land you on a row that
  * is currently conditional-hidden, which is the honest outcome — the
@@ -66,31 +66,6 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   // ── Window & startup ──────────────────────────────────────────
   {
     page: "window",
-    rowId: "tickerMonitors",
-    label: "Monitors",
-    description: "Choose which screens show the ticker",
-    keywords: "display screen second dual multi monitor",
-  },
-  {
-    page: "window",
-    rowId: "alwaysOnTop",
-    label: "Always on top",
-    description: "Keep the ticker above all other windows",
-    keywords: "pin float",
-  },
-  {
-    // The prototype's index still carried "— Windows only" here even
-    // though the redesign moves that caveat out of the description and
-    // into a badge chip. Kept as a keyword so searching "windows" still
-    // finds it, without the result card contradicting the row.
-    page: "window",
-    rowId: "hideFullscreen",
-    label: "Hide when an app goes fullscreen",
-    description: "Hides the ticker during fullscreen apps",
-    keywords: "youtube games movie windows only",
-  },
-  {
-    page: "window",
     rowId: "autostart",
     label: "Launch on system startup",
     description: "Open Scrollr when you start your computer",
@@ -113,57 +88,20 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
     keywords: "hotkey keys cmd ctrl",
   },
 
-  // ── Ticker ────────────────────────────────────────────────────
+  // ── Ticker (page order: On · Where · Look · Motion · Behaviour) ──
   {
     page: "ticker",
-    rowId: "scrollMode",
-    label: "Scroll mode",
-    description: "Continuous scroll, page through, or rotate",
-    keywords: "continuous page rotate flip step",
+    rowId: "showTicker",
+    label: "Show the ticker",
+    description: "The bar on your screen",
+    keywords: "enable disable on off hide toggle visible",
   },
   {
     page: "ticker",
-    rowId: "direction",
-    label: "Direction",
-    description: "Which way the ticker moves",
-    keywords: "left right",
-  },
-  {
-    page: "ticker",
-    rowId: "itemOrder",
-    label: "Item order",
-    description: "Group items by source or weave them together",
-    keywords: "mix grouped weave",
-  },
-  {
-    page: "ticker",
-    rowId: "speed",
-    label: "Speed",
-    description: "How fast the ticker scrolls",
-    keywords: "fast slow velocity",
-  },
-  {
-    // Absent from the prototype (both the page and its index) but
-    // required by the handoff spec, and backed by a live pref.
-    page: "ticker",
-    rowId: "stepPause",
-    label: "Time per page",
-    description: "How long each page stays put before the ticker advances",
-    keywords: "dwell pause step rotate interval",
-  },
-  {
-    page: "ticker",
-    rowId: "pauseOnHover",
-    label: "Slow down on hover",
-    description: "Ease off while you hover so chips are easier to read",
-    keywords: "pause mouse",
-  },
-  {
-    page: "ticker",
-    rowId: "hoverSpeed",
-    label: "Hover speed",
-    description: "How far it slows while hovered",
-    keywords: "pause stop",
+    rowId: "tickerMonitors",
+    label: "Monitors",
+    description: "Which screens show the ticker",
+    keywords: "display screen second dual multi monitor identify",
   },
   {
     page: "ticker",
@@ -176,29 +114,75 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
     page: "ticker",
     rowId: "detailLevel",
     label: "Detail level",
-    description: "Single line vs. detail row under each chip",
+    description: "One line per chip, or a detail row under each",
     keywords: "compact detailed comfort",
   },
   {
     page: "ticker",
-    rowId: "spacing",
-    label: "Spacing",
-    description: "Gap between chips",
-    keywords: "tight wide gap density",
+    rowId: "tickerScale",
+    label: "Size",
+    description: "Resize the bar",
+    keywords: "scale zoom bigger smaller",
   },
   {
     page: "ticker",
     rowId: "chipColors",
     label: "Chip colors",
-    description: "Source colors, accent theme, or subtle grayscale",
-    keywords: "color widget subtle",
+    description: "Each widget's own color, the theme accent, or subtle grays",
+    keywords: "color widget subtle theme",
   },
   {
     page: "ticker",
-    rowId: "tickerScale",
-    label: "Scale",
-    description: "Resize the ticker window",
-    keywords: "size zoom",
+    rowId: "scrollMode",
+    label: "Scroll mode",
+    description: "Scroll without stopping, or show a page at a time",
+    keywords: "continuous page step rotate",
+  },
+  {
+    page: "ticker",
+    rowId: "speed",
+    label: "Speed",
+    description: "How fast the chips travel",
+    keywords: "fast slow normal velocity",
+  },
+  {
+    page: "ticker",
+    rowId: "onHover",
+    label: "On hover",
+    description: "What the bar does while your mouse is over it",
+    keywords: "pause stop slow down keep moving mouse hover",
+  },
+  {
+    // Only rendered in Page mode; following the result in Continuous
+    // mode lands on the Motion group, which is the honest outcome.
+    page: "ticker",
+    rowId: "stepPause",
+    label: "Time per page",
+    description: "How long each page stays before the next one",
+    keywords: "dwell pause step interval seconds",
+  },
+  {
+    page: "ticker",
+    rowId: "alwaysOnTop",
+    label: "Stay above other windows",
+    description: "Keep the ticker visible over whatever else is open",
+    keywords: "pin float always on top",
+  },
+  {
+    // Windows-only row; "windows" stays a keyword so the platform name
+    // finds it.
+    page: "ticker",
+    rowId: "hideFullscreen",
+    label: "Hide when an app goes fullscreen",
+    description: "Get out of the way of games, videos and presentations",
+    keywords: "youtube games movie windows only",
+  },
+  {
+    page: "ticker",
+    rowId: "itemOrder",
+    label: "Item order",
+    description: "Keep each widget's items together, or mix them",
+    keywords: "mix grouped weave by source",
   },
 
   // ── Profile & plan ────────────────────────────────────────────

--- a/desktop/src/components/settings/settingsSearchIndex.test.ts
+++ b/desktop/src/components/settings/settingsSearchIndex.test.ts
@@ -72,8 +72,8 @@ describe("searchSettings", () => {
   });
 
   it("matches on label", () => {
-    const hits = searchSettings("hover speed");
-    expect(hits.map((h) => h.rowId)).toContain("hoverSpeed");
+    const hits = searchSettings("on hover");
+    expect(hits.map((h) => h.rowId)).toContain("onHover");
   });
 
   it("matches on description", () => {
@@ -92,11 +92,32 @@ describe("searchSettings", () => {
     expect(searchSettings("CATPPUCCIN").map((h) => h.rowId)).toEqual(["theme"]);
   });
 
-  /** The behaviour the design reference shows: "speed" → 2 ticker rows. */
+  /** Hover speed folded into On hover (REL-204): "speed" → one ticker row. */
   it("reproduces the reference query", () => {
     const hits = searchSettings("speed");
-    expect(hits.map((h) => h.label)).toEqual(["Speed", "Hover speed"]);
+    expect(hits.map((h) => h.label)).toEqual(["Speed"]);
     expect(hits.every((h) => h.page === "ticker")).toBe(true);
+  });
+
+  /** The Ticker page's rows, in page order, are all findable (REL-204). */
+  it("indexes every Ticker page row in page order", () => {
+    expect(
+      SETTINGS_SEARCH_INDEX.filter((e) => e.page === "ticker").map((e) => e.rowId),
+    ).toEqual([
+      "showTicker",
+      "tickerMonitors",
+      "screenEdge",
+      "detailLevel",
+      "tickerScale",
+      "chipColors",
+      "scrollMode",
+      "speed",
+      "onHover",
+      "stepPause",
+      "alwaysOnTop",
+      "hideFullscreen",
+      "itemOrder",
+    ]);
   });
 
   /**

--- a/desktop/src/components/support/support-content.ts
+++ b/desktop/src/components/support/support-content.ts
@@ -113,7 +113,7 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
     ],
     steps: [
       "Press Ctrl+T (Cmd+T on macOS) to toggle ticker visibility.",
-      "Or go to Customize > Ticker and turn on \"Enable ticker\".",
+      "Or go to Settings > Ticker and turn on \"Show the ticker\".",
       "Or click the Ticker toggle in the title bar (next to the Pin button).",
       "Or right-click the system tray icon and choose \"Toggle Ticker\".",
     ],

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -24,6 +24,9 @@ import {
   mergeWidgetPrefs,
   reconcileSidebarOrder,
   loadPrefs,
+  migrateTicker,
+  resetTickerPage,
+  TICKER_SPEEDS,
   resetAll,
 } from "./preferences";
 import type { AppPreferences, WidgetPrefs } from "./preferences";
@@ -638,5 +641,73 @@ describe("privacy.sendCrashReports (REL-209)", () => {
     });
     expect(resetAll().privacy.sendCrashReports).toBe(true);
     expect(loadPrefs().privacy.sendCrashReports).toBe(true);
+  });
+});
+
+describe("migrateTicker (REL-204: presets + one hover row)", () => {
+  it("folds pauseOnHover + hoverSpeed into onHover", () => {
+    expect(migrateTicker({ pauseOnHover: false, hoverSpeed: 0.3 }).onHover).toBe("keep");
+    expect(migrateTicker({ pauseOnHover: true, hoverSpeed: 0 }).onHover).toBe("pause");
+    expect(migrateTicker({ pauseOnHover: true, hoverSpeed: 0.3 }).onHover).toBe("slow");
+    expect(migrateTicker({}).onHover).toBe("slow");
+    expect(migrateTicker({ onHover: "pause", pauseOnHover: false }).onHover).toBe("pause");
+  });
+
+  it("folds Rotate into Page and keeps the other modes", () => {
+    expect(migrateTicker({ scrollMode: "flip" }).scrollMode).toBe("step");
+    expect(migrateTicker({ scrollMode: "step" }).scrollMode).toBe("step");
+    expect(migrateTicker({ scrollMode: "continuous" }).scrollMode).toBe("continuous");
+    expect(migrateTicker({ scrollMode: "sideways" }).scrollMode).toBe("continuous");
+  });
+
+  it("snaps old slider values to the nearest preset", () => {
+    expect(migrateTicker({ tickerSpeed: 25 }).tickerSpeed).toBe(TICKER_SPEEDS.slow);
+    expect(migrateTicker({ tickerSpeed: 55 }).tickerSpeed).toBe(TICKER_SPEEDS.normal);
+    expect(migrateTicker({ tickerSpeed: 150 }).tickerSpeed).toBe(TICKER_SPEEDS.fast);
+    expect(migrateTicker({ tickerSpeed: "fast" }).tickerSpeed).toBe(TICKER_SPEEDS.normal);
+    expect(migrateTicker({ stepPause: 1 }).stepPause).toBe(3);
+    expect(migrateTicker({ stepPause: 10 }).stepPause).toBe(8);
+    expect(migrateTicker({ stepPause: 6 }).stepPause).toBe(5);
+  });
+
+  it("drops Spacing, Direction and the legacy hover pair from the saved shape", () => {
+    const out = migrateTicker({
+      tickerGap: "spacious",
+      tickerDirection: "right",
+      pauseOnHover: true,
+      hoverSpeed: 0.5,
+      tickerMode: "compact",
+    });
+    expect(out).not.toHaveProperty("tickerGap");
+    expect(out).not.toHaveProperty("tickerDirection");
+    expect(out).not.toHaveProperty("pauseOnHover");
+    expect(out).not.toHaveProperty("hoverSpeed");
+    expect(out.tickerMode).toBe("compact");
+  });
+
+  it("runs on load, and Size snaps to the App-size presets too", () => {
+    storeValues.set("scrollr:settings", {
+      appearance: { tickerScale: 150 },
+      ticker: { scrollMode: "flip", pauseOnHover: true, hoverSpeed: 0, tickerSpeed: 5 },
+    });
+    const p = loadPrefs();
+    expect(p.ticker).toMatchObject({ scrollMode: "step", onHover: "pause", tickerSpeed: 20 });
+    expect(p.appearance.tickerScale).toBe(130);
+  });
+});
+
+describe("resetTickerPage (REL-204)", () => {
+  it("resets everything the Ticker page shows and nothing else", () => {
+    const before = loadPrefs();
+    const changed: AppPreferences = {
+      ...before,
+      ticker: { ...before.ticker, scrollMode: "step", onHover: "pause", tickerSpeed: 80 },
+      window: { ...before.window, pinned: false, tickerPosition: "bottom", tickerMonitors: ["X"] },
+      appearance: { ...before.appearance, tickerScale: 130, uiScale: 115, themeFamily: "nord" },
+    };
+    const after = resetTickerPage(changed);
+    expect(after.ticker).toEqual(before.ticker);
+    expect(after.window).toEqual(before.window);
+    expect(after.appearance).toEqual({ ...changed.appearance, tickerScale: 100 });
   });
 });

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -65,12 +65,14 @@ export function isThemeFamily(value: unknown): value is ThemeFamily {
 export function isThemeMode(value: unknown): value is ThemeMode {
   return value === "light" || value === "dark" || value === "system";
 }
-export type TickerGap = "tight" | "normal" | "spacious";
 export type TickerMode = "compact" | "comfort";
 export type MixMode = "grouped" | "weave";
 export type ChipColorMode = "widget" | "accent" | "muted";
-export type TickerDirection = "left" | "right";
-export type ScrollMode = "continuous" | "step" | "flip";
+/** "step" = Page. Rotate ("flip") folded into it 2026-09-06 (REL-204). */
+export type ScrollMode = "continuous" | "step";
+/** What the bar does under the mouse. Continuous: keep / slow to 30 % /
+ *  stop. Page: keep advancing / hold the page (slow and pause alike). */
+export type HoverBehavior = "keep" | "slow" | "pause";
 export type PinSide = "left" | "right";
 
 export type FontWeight = "normal" | "medium" | "bold";
@@ -102,16 +104,33 @@ export interface AppearancePrefs {
 
 export interface TickerPrefs {
   showTicker: boolean;
+  /** px/s; one of TICKER_SPEEDS (Slow / Normal / Fast on the page). */
   tickerSpeed: number;
-  pauseOnHover: boolean;
-  hoverSpeed: number;
-  tickerGap: TickerGap;
+  onHover: HoverBehavior;
   tickerMode: TickerMode;
   mixMode: MixMode;
   chipColors: ChipColorMode;
-  tickerDirection: TickerDirection;
   scrollMode: ScrollMode;
-  stepPause: number; // seconds between transitions (1–10)
+  /** Seconds each page stays put; one of STEP_PAUSES (Page mode only). */
+  stepPause: number;
+}
+
+// The Ticker page offers presets, never raw numbers (SETTINGS_AUDIT §3).
+// The prefs stay numbers so nothing downstream changes; a value off the
+// list (an old slider position) is snapped to the nearest preset on load.
+export const TICKER_SPEEDS = { slow: 20, normal: 40, fast: 80 } as const;
+export const STEP_PAUSES = [3, 5, 8] as const;
+export const SCALE_PRESETS = [85, 100, 115, 130] as const;
+
+export function snapToPreset(
+  value: unknown,
+  presets: readonly number[],
+  fallback: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return presets.reduce((best, p) =>
+    Math.abs(p - value) < Math.abs(best - value) ? p : best,
+  );
 }
 
 export interface StartupPrefs {
@@ -409,14 +428,11 @@ const DEFAULT_APPEARANCE: AppearancePrefs = {
 
 const DEFAULT_TICKER: TickerPrefs = {
   showTicker: true,
-  tickerSpeed: 40,
-  pauseOnHover: true,
-  hoverSpeed: 0.3,
-  tickerGap: "tight",
+  tickerSpeed: TICKER_SPEEDS.normal,
+  onHover: "slow",
   tickerMode: "comfort",
   mixMode: "weave",
   chipColors: "widget",
-  tickerDirection: "left",
   scrollMode: "continuous",
   stepPause: 5,
 };
@@ -886,7 +902,11 @@ export function loadPrefs(): AppPreferences {
     const mergedAppearance: AppearancePrefs = {
       ...DEFAULT_APPEARANCE,
       ...appearanceRest,
-      tickerScale: savedTickerScale,
+      tickerScale: snapToPreset(
+        savedTickerScale,
+        SCALE_PRESETS,
+        DEFAULT_APPEARANCE.tickerScale,
+      ),
       themeFamily,
       themeMode,
     };
@@ -918,7 +938,7 @@ export function loadPrefs(): AppPreferences {
     };
     const merged: AppPreferences = {
       appearance: mergedAppearance,
-      ticker: { ...DEFAULT_TICKER, ...source.ticker },
+      ticker: migrateTicker(source.ticker),
       startup: { ...DEFAULT_STARTUP, ...savedStartup },
       // Absent on every pre-REL-209 install → on. Only a literal
       // `false` turns reporting off; anything else is the default.
@@ -981,6 +1001,61 @@ export function loadPrefs(): AppPreferences {
   }
 }
 
+/**
+ * REL-204 (2026-09-06): the Ticker page went from sliders and switches to
+ * presets and one hover row. Retired keys are dropped, not carried:
+ *  - `pauseOnHover` + `hoverSpeed` → `onHover`
+ *    (false → keep; true + 0 → pause; true otherwise → slow)
+ *  - scrollMode "flip" (Rotate) → "step" (Page)
+ *  - `tickerGap` (Spacing) and `tickerDirection` (Direction) → gone
+ *  - `tickerSpeed` / `stepPause` snap to the nearest preset
+ */
+export function migrateTicker(raw: unknown): TickerPrefs {
+  const saved = (raw && typeof raw === "object" ? raw : {}) as Omit<
+    Partial<TickerPrefs>,
+    "scrollMode"
+  > & {
+    pauseOnHover?: unknown;
+    hoverSpeed?: unknown;
+    tickerGap?: unknown;
+    tickerDirection?: unknown;
+    scrollMode?: unknown;
+  };
+  const {
+    pauseOnHover,
+    hoverSpeed,
+    tickerGap: _gap,
+    tickerDirection: _direction,
+    scrollMode,
+    onHover,
+    ...rest
+  } = saved;
+  void _gap;
+  void _direction;
+  const isHover = (v: unknown): v is HoverBehavior =>
+    v === "keep" || v === "slow" || v === "pause";
+  const migratedHover: HoverBehavior = isHover(onHover)
+    ? onHover
+    : pauseOnHover === false
+      ? "keep"
+      : pauseOnHover === true && hoverSpeed === 0
+        ? "pause"
+        : DEFAULT_TICKER.onHover;
+  return {
+    ...DEFAULT_TICKER,
+    ...rest,
+    onHover: migratedHover,
+    scrollMode:
+      scrollMode === "step" || scrollMode === "flip" ? "step" : "continuous",
+    tickerSpeed: snapToPreset(
+      rest.tickerSpeed,
+      Object.values(TICKER_SPEEDS),
+      DEFAULT_TICKER.tickerSpeed,
+    ),
+    stepPause: snapToPreset(rest.stepPause, STEP_PAUSES, DEFAULT_TICKER.stepPause),
+  };
+}
+
 export function savePrefs(prefs: AppPreferences): void {
   setStore(PREFIX, prefs);
 }
@@ -996,6 +1071,23 @@ export function resetCategory<K extends keyof AppPreferences>(
       ? { ...def }
       : def;
   return { ...prefs, [category]: value };
+}
+
+/**
+ * Everything the Ticker page shows: `ticker.*`, the whole `window.*`
+ * block (edge, monitors, stay-above, hide-on-fullscreen) and the bar's
+ * own scale. The button, toast and undo all say "Reset ticker settings".
+ */
+export function resetTickerPage(prefs: AppPreferences): AppPreferences {
+  return {
+    ...prefs,
+    ticker: { ...DEFAULT_TICKER },
+    window: { ...DEFAULT_WINDOW },
+    appearance: {
+      ...prefs.appearance,
+      tickerScale: DEFAULT_APPEARANCE.tickerScale,
+    },
+  };
 }
 
 /** Reset everything to defaults. */
@@ -1076,12 +1168,6 @@ export function migrateAppearanceTheme(
 }
 
 // ── Derived values ──────────────────────────────────────────────
-
-export const TICKER_GAPS: Record<TickerGap, number> = {
-  tight: 8,
-  normal: 12,
-  spacious: 20,
-};
 
 export const TICKER_HEIGHTS: Record<TickerMode, number> = {
   compact: 44,

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -796,7 +796,7 @@ function RootLayout() {
   }, []);
 
   // ── TopBar ticker-toggle handler ─────────────────────────────
-  // Same pref as Customize → Ticker "Enable ticker" — one source of
+  // Same pref as Settings → Ticker "Show the ticker" — one source of
   // truth for the always-visible chrome control.
   const handleTickerToggle = useCallback(() => {
     persistPrefs({


### PR DESCRIPTION
Settings 2/7 — the Ticker page now owns the bar as a whole, in the order a person thinks about it (docs/SETTINGS_AUDIT.md §1, §3). Builds on REL-203's map and REL-208's pref cleanup (rebased on #322).

## Page

| Before | After | After (Page mode) |
|---|---|---|
| ![before](https://github.com/doughknee/myscrollr/blob/captures/rel-204/before-ticker-page.png?raw=true) | ![after](https://github.com/doughknee/myscrollr/blob/captures/rel-204/after-ticker-page.png?raw=true) | ![paged](https://github.com/doughknee/myscrollr/blob/captures/rel-204/after-ticker-page-paged.png?raw=true) |

- **On** — new *Show the ticker* switch on `ticker.showTicker`. Pill, Ctrl+T, tray and right-click unchanged.
- **Where** — Monitors (REL-203's map, rows and Identify, moved off Window & startup) + Screen edge.
- **Look** — Detail level · **Size** = the App-size presets 85/100/115/130 % on `appearance.tickerScale` (slider gone; stored values off the list snap on load) · Chip colors. **Spacing folded** (one gap, tight).
- **Motion** — Scroll mode Continuous / Page (**Rotate folded into Page**; I could not read the REL-204 Linear thread from this session, so this follows the audit's default — say the word and it comes back) · **Speed** Slow / Normal / Fast = 20 / 40 / 80 px/s on `ticker.tickerSpeed` · **On hover** Keep moving / Slow down / Pause on the new `ticker.onHover` · **Time per page** 3 / 5 / 8 s, Page mode only. **Direction folded.**
- **Behaviour** — *Stay above other windows* and *Hide when an app goes fullscreen* moved here (the latter renders only on Windows) · Item order.
- **Reset ticker settings** resets every pref on the page (`ticker.*`, `window.*`, `appearance.tickerScale`); button, toast and undo share the name.

Window & startup is left with only its Startup rows ([after](https://github.com/doughknee/myscrollr/blob/captures/rel-204/after-window-page.png?raw=true), [before](https://github.com/doughknee/myscrollr/blob/captures/rel-204/before-window-page.png?raw=true)); renaming that page is REL-205's call.

## Prefs

`migrateTicker` (with tests): `pauseOnHover` + `hoverSpeed` → `onHover` (false → keep; true + 0 → pause; else slow); `flip` → `step`; `tickerGap` and `tickerDirection` dropped; `tickerSpeed` / `stepPause` / `tickerScale` snap to the nearest preset. `TICKER_GAPS` gone. ScrollrTicker loses the Rotate branch, direction and the hover pair. Search index matches the rendered rows (test pins the page order). Stored value names are untouched — that is REL-207.

## Verified on the real bar (dev bus + PrintWindow)

Every control changed the ticker window:

| Control | Result |
|---|---|
| Detail level | [compact](https://github.com/doughknee/myscrollr/blob/captures/rel-204/bar-detail-compact.png?raw=true) 44 px · [detailed](https://github.com/doughknee/myscrollr/blob/captures/rel-204/bar-detail-detailed.png?raw=true) 64 px |
| Size | [85 %](https://github.com/doughknee/myscrollr/blob/captures/rel-204/bar-size-85.png?raw=true) 54 px · 100 % 64 px · [115 %](https://github.com/doughknee/myscrollr/blob/captures/rel-204/bar-size-115.png?raw=true) 74 px · [130 %](https://github.com/doughknee/myscrollr/blob/captures/rel-204/bar-size-130.png?raw=true) 83 px |
| Speed | measured 20.0 / 40.1 / 80.2 px/s. Slow reads easily (a chip takes ~10 s to cross); Fast is brisk but a chip is still on screen for ~2.5 s — not too fast |
| On hover, Continuous | 40 → 40 (Keep) · 12 (Slow, 30 %) · 0 (Pause) px/s while hovered, 40 again after |
| Scroll mode Page | [bar](https://github.com/doughknee/myscrollr/blob/captures/rel-204/bar-page-mode.png?raw=true); step period 4.0 s at the 3 s preset (3 s rest + 0.95 s slide), one step in 9 s at 8 s |
| On hover, Page | Slow down: 0 px moved in 6 s hovered · Keep moving: 668 px |
| Screen edge | y = 0 → y = 1328 ([bottom](https://github.com/doughknee/myscrollr/blob/captures/rel-204/bar-edge-bottom.png?raw=true)) |
| Monitors | switching Display 2 off destroys "Scrollr Ticker 2"; on again re-creates it |
| Stay above | isAlwaysOnTop true → false → true |
| Show the ticker | isVisible true → false → true |
| Reset | button/toast/undo all "Reset ticker settings"; reset returned every page pref to default, Undo put them all back |

Hover was driven with synthetic pointer events over the marquee (computer-use is not available on Scrollr), everything else through the real prefs and windows. `tsc --noEmit` clean, vitest 667/667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
