### PR TITLE
design: catalog redesign handoff (Hub → Directory)

### DIFF
--- a/design_handoff_catalog/Catalog Final.dc.html
+++ b/design_handoff_catalog/Catalog Final.dc.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<meta name="design_doc_mode" content="canvas">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+body{margin:0;background:#0b0b12;font-family:"Plus Jakarta Sans",system-ui,sans-serif;-webkit-font-smoothing:antialiased;color:#e2e2ec}
+*{box-sizing:border-box}
+a{color:#34d399}a:hover{color:#6ee7b7}
+</style>
+</helmet>
+<section style="padding:48px;display:flex;flex-direction:column;gap:40px">
+  <div style="display:flex;flex-direction:column;gap:8px;max-width:960px">
+    <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#9292a4">Scrollr · Catalog · Reference</div>
+    <h1 style="margin:0;font-size:26px;line-height:32px;font-weight:700;letter-spacing:-0.01em">Hub → Directory catalog</h1>
+    <p style="margin:0;font-size:13.5px;line-height:21px;color:#9292a4">One route, two views. The <strong style="color:#e2e2ec;font-weight:600">hub</strong> is where you arrive: a search hero, one tile per kind, what's new, what's yours. A tile or a query drops into the <strong style="color:#e2e2ec;font-weight:600">directory</strong>: a kind rail on the left, grouped rows on the right. Every frame below is the same live prototype — click and type in it. Source: <a href="Catalog G - Hub Directory.dc.html">Catalog G - Hub Directory.dc.html</a>.</p>
+  </div>
+
+  <div style="display:flex;flex-wrap:wrap;gap:48px 40px;align-items:flex-start">
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="display:flex;align-items:baseline;gap:10px;max-width:1144px"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:600;color:#34d399;background:rgba(52,211,153,.15);border-radius:6px;padding:2px 8px">01</span><span style="font-size:14px;font-weight:700">Hub</span><span style="font-size:12.5px;color:#9292a4">Landing. Search hero with example chips, kind tiles (count, logos, “n new”, “n added”), New this month, In your ticker.</span></div>
+      <dc-import name="Catalog G - Hub Directory" view="hub" hint-size="1144px,787px"></dc-import>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="display:flex;align-items:baseline;gap:10px;max-width:1144px"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:600;color:#34d399;background:rgba(52,211,153,.15);border-radius:6px;padding:2px 8px">02</span><span style="font-size:14px;font-weight:700">Directory · Sports</span><span style="font-size:12.5px;color:#9292a4">After a tile click. Rail shows every kind with counts; rows are grouped (Football, Soccer…) with group pills as anchors. “Overview” returns to the hub.</span></div>
+      <dc-import name="Catalog G - Hub Directory" view="dir" cat="sports" hint-size="1144px,787px"></dc-import>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="display:flex;align-items:baseline;gap:10px;max-width:1144px"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:600;color:#34d399;background:rgba(52,211,153,.15);border-radius:6px;padding:2px 8px">03</span><span style="font-size:14px;font-weight:700">Search · hit</span><span style="font-size:12.5px;color:#9292a4">“soccer” from anywhere lands in the directory as results grouped by kind. Aliases (bitcoin → Crypto, epl → Premier League) are part of the match.</span></div>
+      <dc-import name="Catalog G - Hub Directory" view="dir" cat="all" query="soccer" hint-size="1144px,787px"></dc-import>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="display:flex;align-items:baseline;gap:10px;max-width:1144px"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:600;color:#34d399;background:rgba(52,211,153,.15);border-radius:6px;padding:2px 8px">04</span><span style="font-size:14px;font-weight:700">Search · miss</span><span style="font-size:12.5px;color:#9292a4">“Eredivisie” has no widget. The card counts the request and promises a nudge when it ships; the closest group (Soccer) fills the page instead of an empty state.</span></div>
+      <dc-import name="Catalog G - Hub Directory" view="dir" cat="all" query="Eredivisie" hint-size="1144px,787px"></dc-import>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="display:flex;align-items:baseline;gap:10px;max-width:1144px"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:600;color:#34d399;background:rgba(52,211,153,.15);border-radius:6px;padding:2px 8px">05</span><span style="font-size:14px;font-weight:700">Free tier · at cap</span><span style="font-size:12.5px;color:#9292a4">6 of 6 slots. Slot count rides the sidebar chip and the rail; the Upgrade pill sits on the In-your-ticker line; + still opens the panel with the upgrade path.</span></div>
+      <dc-import name="Catalog G - Hub Directory" view="hub" tier="free" hint-size="1144px,787px"></dc-import>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <div style="display:flex;align-items:baseline;gap:10px;max-width:1144px"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:600;color:#34d399;background:rgba(52,211,153,.15);border-radius:6px;padding:2px 8px">06</span><span style="font-size:14px;font-weight:700">Directory · All widgets</span><span style="font-size:12.5px;color:#9292a4">The long view for people who want to scroll everything: one titled block per kind, grouped inside. Rail stays put for jumping.</span></div>
+      <dc-import name="Catalog G - Hub Directory" view="dir" cat="all" hint-size="1144px,787px"></dc-import>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px;max-width:2328px;margin-top:8px">
+    <div style="border-radius:12px;border:1px solid #282838;background:#141420;padding:20px 22px;display:flex;flex-direction:column;gap:10px">
+      <h2 style="margin:0;font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#9292a4">Behavior rules</h2>
+      <ul style="margin:0;padding-left:16px;font-size:12.5px;line-height:19px;color:#b7b7c6;display:flex;flex-direction:column;gap:6px">
+        <li>Hub is the default landing. Directory is a sub-state of the same route (<code style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#9292a4">?kind=sports</code>, <code style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#9292a4">?q=…</code>) so Back and deep links work.</li>
+        <li>Typing anywhere switches to directory results grouped by kind; clearing the field returns to the last kind, not the hub.</li>
+        <li>Picking a kind in the rail clears the query (same rule as today's segmented tabs).</li>
+        <li>+ adds in place; ✓ removes on click with a toast undo. Row body still opens the existing slide-over panel.</li>
+        <li>Zero matches → request card + closest group. Request is one click, counted server-side, and subscribes the user to a “shipped” notification.</li>
+        <li>At slot cap, + opens the panel with the upgrade path (unchanged); the cap reads on the sidebar chip, the rail, and the hub line.</li>
+      </ul>
+    </div>
+    <div style="border-radius:12px;border:1px solid #282838;background:#141420;padding:20px 22px;display:flex;flex-direction:column;gap:10px">
+      <h2 style="margin:0;font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#9292a4">Growth rules</h2>
+      <ul style="margin:0;padding-left:16px;font-size:12.5px;line-height:19px;color:#b7b7c6;display:flex;flex-direction:column;gap:6px">
+        <li>A new kind is a new hub tile and a new rail item — server-only, no client release (same contract as today).</li>
+        <li>Kinds with more than ~8 widgets must carry groups (Soccer, Motorsport, Business, Dev…). Under that, the group header is hidden.</li>
+        <li>Group pills in the directory header become jump anchors once a kind passes ~24 rows; add an A–Z sort past ~60.</li>
+        <li>Hub tiles show 5 logos + “+n”; the “n new” tag uses <code style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#9292a4">added_at</code> within 30 days.</li>
+        <li>“New this month” caps at 4; overflow goes to a “See all new” link into the directory sorted by date.</li>
+        <li>The rail scrolls independently; at 12+ kinds it still fits without collapsing.</li>
+      </ul>
+    </div>
+    <div style="border-radius:12px;border:1px solid #282838;background:#141420;padding:20px 22px;display:flex;flex-direction:column;gap:10px">
+      <h2 style="margin:0;font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#9292a4">Catalog schema additions</h2>
+      <ul style="margin:0;padding-left:16px;font-size:12.5px;line-height:19px;color:#b7b7c6;display:flex;flex-direction:column;gap:6px">
+        <li><code style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#e2e2ec">group</code> — sub-shelf label inside a category (“Soccer”). Optional; missing → ungrouped.</li>
+        <li><code style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#e2e2ec">keywords[]</code> — search aliases (“bitcoin btc eth”). Included in the match haystack with name, description, group, category.</li>
+        <li><code style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#e2e2ec">added_at</code> — drives “new” tags and the New this month strip.</li>
+        <li><code style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#e2e2ec">POST /catalog/requests</code> — { query, user } ; returns count. Powers the miss card and the roadmap.</li>
+        <li>Category order stays server-defined; the hub grid is 4-across so 7–8 kinds fill two rows with the “Something else?” tile last.</li>
+      </ul>
+      <div style="margin-top:6px;padding-top:10px;border-top:1px solid #282838;font-size:12px;line-height:18px;color:#78788a">Reused as-is: TopBar, Sidebar, WidgetBar chassis, Segmented, CatalogCard compact row anatomy, WidgetPanel, SlotPills, tokens and type scale.</div>
+    </div>
+  </div>
+</section>
+</x-dc>
+</body>
+</html>

--- a/design_handoff_catalog/Catalog G - Hub Directory.dc.html
+++ b/design_handoff_catalog/Catalog G - Hub Directory.dc.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+body{margin:0;background:#0b0b12;font-family:"Plus Jakarta Sans",system-ui,sans-serif;-webkit-font-smoothing:antialiased;color:#e2e2ec}
+*{box-sizing:border-box}
+a{color:#34d399}a:hover{color:#6ee7b7}
+button,input{font-family:inherit}
+input::placeholder{color:#78788a}
+::-webkit-scrollbar{width:8px}::-webkit-scrollbar-thumb{background:#303040;border-radius:4px}::-webkit-scrollbar-track{background:transparent}
+</style>
+</helmet>
+<div style="width:1144px;height:787px;display:flex;flex-direction:column;background:#1c1c2a;color:#e2e2ec;overflow:hidden;border:1px solid #2b2b3a;border-radius:8px;font-size:13px;line-height:20px">
+  <div style="display:flex;align-items:center;height:38px;flex-shrink:0;padding:0 12px;gap:8px;user-select:none">
+    <div style="display:flex;height:28px;align-items:center;gap:8px;padding:0 6px">
+      <svg viewBox="0 0 639 639" style="width:20px;height:20px;flex-shrink:0"><g transform="translate(0,639) scale(0.1,-0.1)" fill="#34d399"><path d="M4870 6321 c-100 -32 -157 -70 -215 -140 l-29 -36 41 37 c329 291 807 -68 501 -375 -132 -132 -60 -130 -1750 -66 -1538 57 -1544 57 -1792 9 -1687 -328 -1763 -2552 -101 -2980 253 -65 227 -64 1750 -65 1531 0 1427 4 1568 -66 371 -184 376 -666 9 -858 -160 -83 43 -75 -2157 -81 -2131 -6 -2047 -4 -2225 -61 -234 -74 -312 -243 -250 -539 54 -254 193 -701 256 -821 145 -275 578 -316 759 -72 l28 38 -39 -36 c-279 -257 -732 -25 -564 289 84 158 228 208 560 195 354 -13 3176 -93 3313 -93 895 0 1529 475 1690 1264 188 928 -386 1701 -1383 1862 -108 18 -198 19 -1510 19 l-1395 0 -78 22 c-556 158 -528 849 38 968 60 12 287 15 1525 15 1678 0 1780 4 1990 72 190 61 284 172 283 333 -2 156 -215 857 -302 991 -105 164 -326 238 -521 175z"></path></g><circle cx="492" cy="39" r="20" fill="#e2e2ec" opacity="0.6"></circle><circle cx="97" cy="599" r="20" fill="#e2e2ec" opacity="0.6"></circle></svg>
+      <span style="font-size:13px;font-weight:600;letter-spacing:-0.01em">Scrollr</span>
+    </div>
+    <div style="width:1px;height:20px;background:rgba(40,40,56,.4);margin:0 4px;flex-shrink:0"></div>
+    <div style="display:flex;width:28px;height:28px;align-items:center;justify-content:center;border-radius:6px;color:#9292a4"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"></rect><path d="M9 3v18"></path><path d="m16 15-3-3 3-3"></path></svg></div>
+    <div style="width:1px;height:20px;background:rgba(40,40,56,.4);margin:0 4px;flex-shrink:0"></div>
+    <div style="display:flex;align-items:center;gap:2px;flex-shrink:0">
+      <div style="display:flex;width:28px;height:28px;align-items:center;justify-content:center;border-radius:6px;color:#b7b7c6;cursor:pointer" onClick="{{ goHub }}"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"></path><path d="M19 12H5"></path></svg></div>
+      <div style="display:flex;width:28px;height:28px;align-items:center;justify-content:center;border-radius:6px;color:rgba(120,120,138,.4)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg></div>
+    </div>
+    <div style="width:1px;height:20px;background:rgba(40,40,56,.4);margin:0 4px;flex-shrink:0"></div>
+    <div style="display:flex;align-items:center;gap:6px;min-width:0;flex:1;font-size:12px;line-height:18px">
+      <span style="font-weight:600;color:#e2e2ec;cursor:pointer" onClick="{{ goHub }}">Catalog</span>
+      <sc-if value="{{ isDir }}" hint-placeholder-val="{{ false }}"><span style="color:#78788a">/</span><span style="color:#9292a4">{{ crumb }}</span></sc-if>
+    </div>
+    <div style="display:flex;align-items:center;gap:4px;flex-shrink:0">
+      <div style="display:flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:6px;background:rgba(52,211,153,.15);color:#34d399;font-size:11px;line-height:16px;font-weight:500"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4.9 16.1C1 12.2 1 5.8 4.9 1.9"></path><path d="M7.8 4.7a6.14 6.14 0 0 0-.8 7.5"></path><circle cx="12" cy="9" r="2"></circle><path d="M16.2 4.8c2 2 2.26 5.11.8 7.47"></path><path d="M19.1 1.9a9.96 9.96 0 0 1 0 14.1"></path><path d="M9.5 18h5"></path><path d="m8 22 4-11 4 11"></path></svg><span>Ticker</span></div>
+    </div>
+    <div style="display:flex;align-self:stretch;margin-left:4px;margin-right:-12px;color:#9292a4">
+      <div style="display:flex;width:44px;align-items:center;justify-content:center"><svg width="10" height="1" viewBox="0 0 10 1"><rect fill="currentColor" width="10" height="1" rx="0.5"></rect></svg></div>
+      <div style="display:flex;width:44px;align-items:center;justify-content:center"><svg width="10" height="10" viewBox="0 0 10 10" fill="none"><rect x="1" y="1" width="8" height="8" rx="1" stroke="currentColor" stroke-width="1.2"></rect></svg></div>
+      <div style="display:flex;width:44px;align-items:center;justify-content:center"><svg width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"></path></svg></div>
+    </div>
+  </div>
+  <div style="display:flex;flex:1;min-height:0;overflow:hidden;padding:0 6px 6px 0">
+    <aside style="width:200px;flex-shrink:0;display:flex;flex-direction:column;height:100%;overflow:hidden;user-select:none">
+      <nav style="padding:8px;display:flex;flex-direction:column;gap:2px;flex-shrink:0">
+        <div style="display:flex;align-items:center;gap:10px;padding:6px 10px;border-radius:8px;font-weight:500;color:#9292a4"><span style="display:flex;width:20px;height:20px;align-items:center;justify-content:center;flex-shrink:0"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"></path><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path></svg></span><span>Home</span></div>
+        <div style="display:flex;align-items:center;gap:10px;padding:6px 10px;border-radius:8px;font-weight:500;color:#9292a4"><span style="display:flex;width:20px;height:20px;align-items:center;justify-content:center;flex-shrink:0"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="21" x2="14" y1="4" y2="4"></line><line x1="10" x2="3" y1="4" y2="4"></line><line x1="21" x2="12" y1="12" y2="12"></line><line x1="8" x2="3" y1="12" y2="12"></line><line x1="21" x2="16" y1="20" y2="20"></line><line x1="12" x2="3" y1="20" y2="20"></line><line x1="14" x2="14" y1="2" y2="6"></line><line x1="8" x2="8" y1="10" y2="14"></line><line x1="16" x2="16" y1="18" y2="22"></line></svg></span><span>Settings</span></div>
+        <div style="display:flex;align-items:center;gap:10px;padding:6px 10px;border-radius:8px;font-weight:500;color:#34d399;background:rgba(52,211,153,.15);cursor:pointer" onClick="{{ goHub }}"><span style="display:flex;width:20px;height:20px;align-items:center;justify-content:center;flex-shrink:0"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg></span><span>{{ addLabel }}</span><sc-if value="{{ isFree }}" hint-placeholder-val="{{ false }}"><span style="margin-left:auto;font-size:12px;color:#78788a">{{ railSlots }}</span></sc-if></div>
+      </nav>
+      <nav style="padding:8px;display:flex;flex-direction:column;gap:2px;flex:1;min-height:0;overflow-y:auto">
+        <h2 style="padding:0 10px;margin:0 0 4px;font-size:11px;line-height:16px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:#9292a4">Widgets</h2>
+        <sc-for list="{{ sidebarList }}" as="s" hint-placeholder-count="13">
+          <div style="display:flex;align-items:center;gap:10px;padding:6px 10px;border-radius:8px;font-weight:500;color:#9292a4;min-width:0">
+            <span style="display:flex;width:20px;height:20px;align-items:center;justify-content:center;flex-shrink:0">
+              <sc-if value="{{ s.hasLogo }}" hint-placeholder-val="{{ true }}"><img src="{{ s.logoUrl }}" alt="" style="width:16px;height:16px;border-radius:4px;object-fit:contain;background:{{ s.logoBg }};padding:{{ s.logoPad }}"></sc-if>
+              <sc-if value="{{ s.noLogo }}" hint-placeholder-val="{{ false }}"><span style="display:flex;width:16px;height:16px;align-items:center;justify-content:center;border-radius:4px;color:#fff;background:{{ s.tileBg }}"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="{{ s.iconPath }}"></path></svg></span></sc-if>
+            </span>
+            <span style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.name }}</span>
+          </div>
+        </sc-for>
+      </nav>
+      <div style="padding:8px;display:flex;align-items:center;gap:4px;flex-shrink:0">
+        <div style="flex:1;display:flex;align-items:center;gap:8px;padding:4px 6px;border-radius:8px;min-width:0">
+          <span style="position:relative;display:flex;width:28px;height:28px;align-items:center;justify-content:center;border-radius:50%;background:rgba(52,211,153,.15);color:#34d399;font-size:11px;font-weight:600;flex-shrink:0">D<span style="position:absolute;bottom:-2px;right:-2px;display:flex;width:14px;height:14px;align-items:center;justify-content:center;border-radius:50%;border:1px solid #141420;background:#141420;color:#22c55e"><svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"></path></svg></span></span>
+          <span style="display:flex;flex-direction:column;min-width:0;line-height:1.25"><span style="font-size:13px;font-weight:500;color:#b7b7c6">doni</span><span style="font-size:12px;color:#78788a">Super User</span></span>
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-left:auto;color:#78788a;flex-shrink:0"><path d="m6 9 6 6 6-6"></path></svg>
+        </div>
+      </div>
+    </aside>
+    <main style="flex:1;display:flex;flex-direction:column;min-width:0;overflow:hidden;position:relative;background:#141420;border-radius:12px;border:1px solid rgba(40,40,56,.5)">
+
+      <sc-if value="{{ isHub }}" hint-placeholder-val="{{ true }}">
+        <div style="flex:1;min-height:0;overflow-y:auto;scrollbar-gutter:stable;padding:0 20px 20px">
+          <div style="max-width:880px;margin:0 auto;padding:44px 0 28px">
+            <h1 style="margin:0 0 14px;text-align:center;font-size:22px;line-height:28px;font-weight:700;letter-spacing:-0.01em;color:#e2e2ec">What do you want on your ticker?</h1>
+            <div style="position:relative;max-width:640px;margin:0 auto 10px">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position:absolute;left:14px;top:50%;transform:translateY(-50%);color:#78788a;pointer-events:none"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg>
+              <input type="search" value="{{ query }}" onChange="{{ onSearch }}" placeholder="Search {{ total }} widgets — a league, a publication, a tool" style="width:100%;height:44px;border-radius:10px;border:1px solid rgba(52,211,153,.35);background:#20202b;padding:0 14px 0 40px;font-size:14px;color:#e2e2ec;outline:none;box-shadow:0 0 0 3px rgba(52,211,153,.08)">
+            </div>
+            <div style="display:flex;align-items:center;justify-content:center;gap:6px;flex-wrap:wrap;margin-bottom:32px;font-size:12px;line-height:18px;color:#78788a">
+              <span>Try</span>
+              <sc-for list="{{ tries }}" as="t" hint-placeholder-count="6"><span onClick="{{ t.go }}" style="border-radius:999px;border:1px solid rgba(40,40,56,.8);padding:2px 10px;color:#9292a4;white-space:nowrap;cursor:pointer" style-hover="border-color:#303040;color:#b7b7c6">{{ t.label }}</span></sc-for>
+            </div>
+            <h2 style="margin:0 0 10px;font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:16px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:#9292a4">Browse by kind</h2>
+            <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px;margin-bottom:26px">
+              <sc-for list="{{ hubs }}" as="h" hint-placeholder-count="7">
+                <div onClick="{{ h.go }}" style="position:relative;overflow:hidden;display:flex;flex-direction:column;gap:10px;border-radius:12px;border:1px solid rgba(40,40,56,.55);background:#20202b;padding:12px 12px 10px;min-height:104px;cursor:pointer" style-hover="border-color:#303040">
+                  <div style="position:absolute;inset:0;pointer-events:none;background:linear-gradient(to bottom, {{ h.wash }}, transparent 60%)"></div>
+                  <div style="position:relative;display:flex;align-items:flex-start;gap:8px">
+                    <div style="min-width:0;flex:1">
+                      <div style="font-size:14px;line-height:20px;font-weight:700;color:#e2e2ec">{{ h.label }}</div>
+                      <div style="font-size:11.5px;line-height:16px;color:#9292a4">{{ h.blurb }}</div>
+                    </div>
+                    <span style="border-radius:999px;background:rgba(23,23,38,.9);padding:1px 7px;font-size:11px;line-height:16px;font-weight:600;color:#9292a4;flex-shrink:0">{{ h.count }}</span>
+                  </div>
+                  <div style="position:relative;display:flex;align-items:center;gap:5px;margin-top:auto">
+                    <sc-for list="{{ h.logos }}" as="w" hint-placeholder-count="5">
+                      <sc-if value="{{ w.hasLogo }}" hint-placeholder-val="{{ true }}"><img src="{{ w.logoUrl }}" alt="" style="width:22px;height:22px;border-radius:5px;object-fit:contain;background:{{ w.logoBg }};padding:{{ w.logoPad }}"></sc-if>
+                      <sc-if value="{{ w.noLogo }}" hint-placeholder-val="{{ false }}"><span style="display:flex;width:22px;height:22px;align-items:center;justify-content:center;border-radius:5px;color:#fff;background:{{ w.tileBg }}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="{{ w.iconPath }}"></path></svg></span></sc-if>
+                    </sc-for>
+                    <span style="font-size:11px;line-height:16px;color:#78788a;margin-left:2px">{{ h.more }}</span>
+                    <span style="margin-left:auto;display:flex;gap:6px;font-size:11px;line-height:16px;white-space:nowrap"><span style="color:#a855f7;font-weight:500">{{ h.newLabel }}</span><span style="color:#34d399;font-weight:500">{{ h.addedLabel }}</span></span>
+                  </div>
+                </div>
+              </sc-for>
+              <div style="display:flex;flex-direction:column;justify-content:center;gap:3px;border-radius:12px;border:1px dashed rgba(40,40,56,.8);padding:12px;min-height:104px">
+                <div style="font-size:13px;line-height:18px;font-weight:600;color:#e2e2ec">Something else?</div>
+                <div style="font-size:11.5px;line-height:16px;color:#78788a">Paste any RSS feed, or tell us what's missing.</div>
+                <div style="display:flex;gap:6px;margin-top:6px;flex-wrap:wrap"><span style="border-radius:7px;border:1px solid rgba(40,40,56,.8);padding:3px 9px;font-size:11px;line-height:16px;font-weight:500;color:#9292a4;white-space:nowrap">Custom RSS</span><span style="border-radius:7px;border:1px solid rgba(40,40,56,.8);padding:3px 9px;font-size:11px;line-height:16px;font-weight:500;color:#9292a4;white-space:nowrap">Request</span></div>
+              </div>
+            </div>
+            <h2 style="margin:0 0 8px;font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:16px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:#9292a4">New this month</h2>
+            <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px;margin-bottom:26px">
+              <sc-for list="{{ fresh }}" as="w" hint-placeholder-count="4">
+                <div style="position:relative;display:flex;align-items:center;gap:10px;overflow:hidden;border-radius:10px;border:1px solid rgba(40,40,56,.55);background:#20202b;padding:7px 10px">
+                  <div style="position:absolute;inset:0;pointer-events:none;background:linear-gradient(to right, {{ w.wash }}, transparent 70%)"></div>
+                  <div style="position:relative;display:flex;width:100%;align-items:center;gap:10px">
+                    <sc-if value="{{ w.hasLogo }}" hint-placeholder-val="{{ true }}"><img src="{{ w.logoUrl }}" alt="" style="width:28px;height:28px;border-radius:7px;object-fit:contain;flex-shrink:0;background:{{ w.logoBg }};padding:{{ w.logoPad }}"></sc-if>
+                    <sc-if value="{{ w.noLogo }}" hint-placeholder-val="{{ false }}"><span style="display:flex;width:28px;height:28px;flex-shrink:0;align-items:center;justify-content:center;border-radius:7px;color:#fff;background:{{ w.tileBg }}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="{{ w.iconPath }}"></path></svg></span></sc-if>
+                    <span style="min-width:0;flex:1;display:flex;flex-direction:column;line-height:15px"><span style="font-size:12.5px;font-weight:600;color:#e2e2ec;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ w.name }}</span><span style="font-size:11px;color:#78788a">{{ w.categoryLabel }} · {{ w.group }}</span></span>
+                    <sc-if value="{{ w.added }}" hint-placeholder-val="{{ false }}"><span onClick="{{ w.toggle }}" style="display:flex;width:24px;height:24px;flex-shrink:0;align-items:center;justify-content:center;border-radius:6px;background:rgba(52,211,153,.14);color:#34d399;cursor:pointer"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></span></sc-if>
+                    <sc-if value="{{ w.notAdded }}" hint-placeholder-val="{{ true }}"><span onClick="{{ w.toggle }}" style="display:flex;width:24px;height:24px;flex-shrink:0;align-items:center;justify-content:center;border-radius:6px;border:1px solid rgba(40,40,56,.7);color:#34d399;cursor:pointer"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg></span></sc-if>
+                  </div>
+                </div>
+              </sc-for>
+            </div>
+            <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+              <h2 style="margin:0;font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:16px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:#9292a4">In your ticker</h2>
+              <span style="margin-left:auto;font-size:11px;line-height:16px;color:#78788a">{{ slotLabel }}</span>
+              <sc-if value="{{ capped }}" hint-placeholder-val="{{ false }}"><span style="border-radius:8px;background:rgba(251,191,36,.15);color:#fbbf24;padding:3px 10px;font-size:11px;line-height:16px;font-weight:600">Upgrade for unlimited</span></sc-if>
+            </div>
+            <div style="display:flex;flex-wrap:wrap;gap:6px">
+              <sc-for list="{{ your }}" as="w" hint-placeholder-count="13">
+                <div style="display:flex;align-items:center;gap:7px;border-radius:8px;border:1px solid rgba(40,40,56,.55);background:#20202b;padding:5px 9px 5px 6px">
+                  <sc-if value="{{ w.hasLogo }}" hint-placeholder-val="{{ true }}"><img src="{{ w.logoUrl }}" alt="" style="width:16px;height:16px;border-radius:4px;object-fit:contain;background:{{ w.logoBg }};padding:{{ w.logoPad }}"></sc-if>
+                  <sc-if value="{{ w.noLogo }}" hint-placeholder-val="{{ false }}"><span style="display:flex;width:16px;height:16px;align-items:center;justify-content:center;border-radius:4px;color:#fff;background:{{ w.tileBg }}"><svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="{{ w.iconPath }}"></path></svg></span></sc-if>
+                  <span style="font-size:12px;line-height:18px;font-weight:500;color:#e2e2ec;white-space:nowrap">{{ w.name }}</span>
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+                </div>
+              </sc-for>
+            </div>
+          </div>
+        </div>
+      </sc-if>
+
+      <sc-if value="{{ isDir }}" hint-placeholder-val="{{ false }}">
+        <div style="padding:8px 12px;border-bottom:1px solid rgba(40,40,56,.3);flex-shrink:0">
+          <div style="display:flex;flex-wrap:wrap;align-items:center;gap:8px;min-height:30px">
+            <div style="position:relative;width:300px">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position:absolute;left:10px;top:50%;transform:translateY(-50%);color:#78788a;pointer-events:none"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg>
+              <input type="search" value="{{ query }}" onChange="{{ onSearch }}" placeholder="Search {{ total }} widgets" style="width:100%;border-radius:7px;border:1px solid rgba(40,40,56,.8);background:#20202b;padding:6px 10px 6px 28px;font-size:12px;line-height:18px;color:#e2e2ec;outline:none">
+            </div>
+            <sc-if value="{{ hasQuery }}" hint-placeholder-val="{{ false }}"><span style="font-size:12px;line-height:18px;color:#78788a">{{ resultSummary }}</span></sc-if>
+            <sc-if value="{{ capped }}" hint-placeholder-val="{{ false }}"><span style="display:flex;align-items:center;gap:6px;font-size:11px;line-height:16px;color:#fbbf24;background:rgba(251,191,36,.12);border-radius:8px;padding:4px 10px;font-weight:600;white-space:nowrap">All 6 slots used · remove one to swap, or upgrade</span></sc-if>
+            <div style="margin-left:auto;display:flex;flex-shrink:0;align-items:center;gap:2px;border-radius:8px;border:1px solid rgba(40,40,56,.3);background:rgba(23,23,38,.6);padding:2px;font-size:12px;line-height:18px;font-weight:500;color:#9292a4;white-space:nowrap">
+              <span style="padding:2px 10px;border-radius:6px;background:rgba(52,211,153,.15);color:#34d399;font-weight:600">By kind</span><span style="padding:2px 10px">A–Z</span><span style="padding:2px 10px">Popular</span>
+            </div>
+          </div>
+        </div>
+        <div style="display:flex;flex:1;min-height:0">
+          <nav style="width:184px;flex-shrink:0;border-right:1px solid rgba(40,40,56,.4);padding:10px 8px;display:flex;flex-direction:column;gap:2px;overflow-y:auto">
+            <div onClick="{{ goHub }}" style="display:flex;align-items:center;gap:8px;padding:6px 10px;border-radius:8px;font-size:12.5px;font-weight:500;color:#9292a4;cursor:pointer" style-hover="background:#1c1c2a"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"></path><path d="M19 12H5"></path></svg><span>Overview</span></div>
+            <div style="height:1px;background:rgba(40,40,56,.5);margin:6px 10px"></div>
+            <div style="display:flex;align-items:center;gap:8px;padding:6px 10px;border-radius:8px;font-size:12.5px;font-weight:500;color:#e2e2ec">
+              <span style="display:flex;width:16px;height:16px;align-items:center;justify-content:center;border-radius:4px;background:rgba(52,211,153,.15);color:#34d399"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></span>
+              <span style="flex:1">Your ticker</span><span style="font-size:11px;color:#78788a">{{ railSlots }}</span>
+            </div>
+            <div style="height:1px;background:rgba(40,40,56,.5);margin:6px 10px"></div>
+            <sc-for list="{{ rail }}" as="c" hint-placeholder-count="8">
+              <div onClick="{{ c.go }}" style="display:flex;align-items:center;gap:8px;padding:6px 10px;border-radius:8px;font-size:12.5px;font-weight:500;cursor:pointer;color:{{ c.fg }};background:{{ c.bg }}"><span style="flex:1">{{ c.label }}</span><span style="font-size:11px;color:{{ c.countFg }}">{{ c.count }}</span></div>
+            </sc-for>
+            <div style="margin-top:auto;padding:10px 10px 4px;font-size:11px;line-height:16px;color:#78788a">Don't see it? <a href="#" style="color:#9292a4;text-decoration:underline;text-decoration-color:rgba(146,146,164,.4)">Request a widget</a></div>
+          </nav>
+          <div style="flex:1;min-width:0;overflow-y:auto;scrollbar-gutter:stable;padding:16px 20px 28px">
+
+            <sc-if value="{{ isMiss }}" hint-placeholder-val="{{ false }}">
+              <section style="display:flex;align-items:center;gap:16px;border-radius:12px;border:1px solid rgba(40,40,56,.6);background:rgba(23,23,38,.6);padding:14px 16px;margin-bottom:22px">
+                <div style="min-width:0;flex:1">
+                  <div style="font-size:14px;line-height:20px;font-weight:700;color:#e2e2ec">No “{{ missName }}” widget yet</div>
+                  <div style="font-size:12px;line-height:18px;color:#9292a4;margin-top:2px">Requests are counted and the most-asked ones ship first — we'll tell you when it lands. Below are the closest things we do have.</div>
+                </div>
+                <span style="flex-shrink:0;display:flex;align-items:center;gap:6px;border-radius:8px;background:#34d399;color:#0b1a14;padding:7px 12px;font-size:12px;line-height:18px;font-weight:600;white-space:nowrap"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg>Request {{ missName }}</span>
+                <span style="flex-shrink:0;border-radius:8px;border:1px solid rgba(40,40,56,.9);padding:7px 12px;font-size:12px;line-height:18px;font-weight:500;color:#9292a4;white-space:nowrap">Use a custom RSS feed</span>
+              </section>
+            </sc-if>
+
+            <sc-for list="{{ blocks }}" as="b" hint-placeholder-count="1">
+              <div style="margin-bottom:22px">
+                <div style="display:flex;align-items:baseline;gap:10px;margin-bottom:12px;flex-wrap:wrap">
+                  <h1 style="margin:0;font-size:16px;line-height:22px;font-weight:700;color:#e2e2ec">{{ b.title }}</h1>
+                  <span style="font-size:12px;color:#78788a;white-space:nowrap">{{ b.sub }}</span>
+                  <div style="margin-left:auto;display:flex;gap:6px;flex-wrap:wrap;justify-content:flex-end;font-size:11px;line-height:16px;color:#9292a4">
+                    <sc-for list="{{ b.pills }}" as="g" hint-placeholder-count="4"><span style="padding:2px 8px;border-radius:999px;border:1px solid rgba(40,40,56,.7);white-space:nowrap">{{ g.key }}</span></sc-for>
+                  </div>
+                </div>
+                <sc-for list="{{ b.groups }}" as="g" hint-placeholder-count="4">
+                  <section style="margin-bottom:16px">
+                    <sc-if value="{{ g.showHead }}" hint-placeholder-val="{{ true }}">
+                      <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;padding:0 10px">
+                        <h2 style="margin:0;font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:16px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:#9292a4;white-space:nowrap">{{ g.key }}</h2>
+                        <span style="font-size:11px;line-height:16px;color:#78788a">{{ g.count }}</span>
+                        <div style="flex:1;height:1px;background:rgba(40,40,56,.5)"></div>
+                      </div>
+                    </sc-if>
+                    <div style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px 12px">
+                      <sc-for list="{{ g.items }}" as="w" hint-placeholder-count="4">
+                        <div style="display:flex;align-items:center;gap:10px;padding:6px 10px;border-radius:8px;min-width:0" style-hover="background:#1c1c2a">
+                          <sc-if value="{{ w.hasLogo }}" hint-placeholder-val="{{ true }}"><img src="{{ w.logoUrl }}" alt="" style="width:26px;height:26px;border-radius:6px;object-fit:contain;flex-shrink:0;background:{{ w.logoBg }};padding:{{ w.logoPad }}"></sc-if>
+                          <sc-if value="{{ w.noLogo }}" hint-placeholder-val="{{ false }}"><span style="display:flex;width:26px;height:26px;flex-shrink:0;align-items:center;justify-content:center;border-radius:6px;color:#fff;background:{{ w.tileBg }}"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="{{ w.iconPath }}"></path></svg></span></sc-if>
+                          <div style="min-width:0;flex:1;display:flex;flex-direction:column;line-height:16px">
+                            <span style="font-size:12.5px;font-weight:600;color:#e2e2ec;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ w.name }}</span>
+                            <span style="font-size:11px;color:#78788a;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ w.description }}</span>
+                          </div>
+                          <sc-if value="{{ w.added }}" hint-placeholder-val="{{ false }}"><span onClick="{{ w.toggle }}" style="display:flex;width:24px;height:24px;flex-shrink:0;align-items:center;justify-content:center;border-radius:6px;background:rgba(52,211,153,.14);color:#34d399;cursor:pointer"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></span></sc-if>
+                          <sc-if value="{{ w.notAdded }}" hint-placeholder-val="{{ true }}"><span onClick="{{ w.toggle }}" style="display:flex;width:24px;height:24px;flex-shrink:0;align-items:center;justify-content:center;border-radius:6px;border:1px solid rgba(40,40,56,.7);color:#34d399;cursor:pointer" style-hover="border-color:rgba(52,211,153,.5);background:rgba(52,211,153,.1)"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg></span></sc-if>
+                        </div>
+                      </sc-for>
+                    </div>
+                  </section>
+                </sc-for>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+      </sc-if>
+    </main>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1160,&quot;height&quot;:800},&quot;view&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;hub&quot;,&quot;dir&quot;],&quot;default&quot;:&quot;hub&quot;,&quot;tsType&quot;:&quot;'hub' | 'dir'&quot;,&quot;section&quot;:&quot;Start state&quot;},&quot;cat&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;all&quot;,&quot;sports&quot;,&quot;finance&quot;,&quot;news&quot;,&quot;fantasy&quot;,&quot;predictions&quot;,&quot;utility&quot;,&quot;gaming&quot;],&quot;default&quot;:&quot;all&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Start state&quot;},&quot;query&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Start state&quot;},&quot;tier&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;unlimited&quot;,&quot;free&quot;],&quot;default&quot;:&quot;unlimited&quot;,&quot;tsType&quot;:&quot;'unlimited' | 'free'&quot;,&quot;section&quot;:&quot;Account&quot;}}">
+class Component extends DCLogic {
+  state = { d: null, view: null, cat: null, query: null, added: null };
+  componentDidMount() { import("./catalog-data.js").then((d) => this.setState({ d, added: [...d.ADDED] })); }
+  renderVals() {
+    const d = this.state.d;
+    if (!d) return {};
+    const view = this.state.view ?? this.props.view ?? "hub";
+    const cat = this.state.cat ?? this.props.cat ?? "all";
+    const query = this.state.query ?? this.props.query ?? "";
+    const free = (this.props.tier ?? "unlimited") === "free";
+    const CAP = 6;
+    const FREE_ADDED = ["finance_stocks", "sports_mlb", "sports_ncaaf", "news_guardian", "clock", "weather"];
+    const added = free && !this.state.added_touched ? FREE_ADDED : this.state.added;
+    const NEW = ["sports_bundesliga", "news_reuters", "vercel", "twitch"];
+    const capped = free && added.length >= CAP;
+    const all = [...d.WIDGETS, ...d.FUTURE].map((w) => ({
+      ...d.decorate(w, added), notAdded: !added.includes(w.id), isNew: NEW.includes(w.id),
+      toggle: (e) => { e.stopPropagation(); this.setState((s) => { const cur = free && !s.added_touched ? FREE_ADDED : s.added; if (!cur.includes(w.id) && free && cur.length >= CAP) return {}; return { added_touched: true, added: cur.includes(w.id) ? cur.filter((x) => x !== w.id) : [...cur, w.id] }; }); },
+    }));
+    const find = (id) => all.find((i) => i.id === id);
+    const cats = d.FUTURE_CATEGORIES;
+    const label = (id) => (cats.find((c) => c.id === id) || { label: "All widgets" }).label;
+    const order = ["Football", "Basketball", "Baseball", "Hockey", "Soccer", "Motorsport", "Combat", "Golf & Tennis", "Cricket & Rugby", "Markets", "Calendar", "World", "Business", "Tech & Science", "Sports & Culture", "Social", "Desk", "Dev"];
+    const grp = (list) => d.groupBy(list, "group").sort((a, b) => order.indexOf(a.key) - order.indexOf(b.key)).map((g) => ({ ...g, showHead: true }));
+    const go = (patch) => () => this.setState(patch);
+    const blurbs = { sports: "Live scores from the leagues you follow", finance: "Quotes, watchlists and calendars", news: "Headlines from publications and feeds", fantasy: "Your leagues, matchups and standings", predictions: "Live odds from prediction markets", utility: "Clocks, weather, dev status and more", gaming: "Streams, esports and store watch" };
+    const hubWash = { sports: "#0b427a", finance: "#16a34a", news: "#b80000", fantasy: "#6001d2", predictions: "#1fc9a0", utility: "#6366f1", gaming: "#9146ff" };
+
+    // Blocks: one titled section per category in view.
+    const q = query.trim().toLowerCase();
+    // Aliases: what people type that the name/description doesn't contain. Would be a server-side `keywords` field.
+    const aliases = { finance_crypto: "bitcoin btc eth ethereum solana coins", finance_stocks: "shares etf s&p nasdaq dow tickers", predictions: "odds prediction market bets", news_hackernews: "hn ycombinator tech startups", sports_ncaaf: "college football cfb", sports_ncaab: "college basketball march madness", sports_f1: "formula 1 formula one grand prix", sports_ufc: "mma fights", sports_premierleague: "epl english soccer football", sports_laliga: "spanish soccer", sports_mls: "american soccer", sports_championsleague: "ucl uefa europe", weather: "forecast temperature rain", sysmon: "cpu gpu ram memory", github: "actions ci pull requests", timer: "pomodoro stopwatch countdown", clock: "time timezone world clock" };
+    let blocks = [], isMiss = false, missName = "", resultSummary = "";
+    if (q) {
+      const hits = all.filter((w) => `${w.name} ${w.description} ${w.group} ${w.categoryLabel} ${aliases[w.id] || ""}`.toLowerCase().includes(q));
+      if (hits.length) {
+        resultSummary = `${hits.length} match${hits.length === 1 ? "" : "es"}`;
+        blocks = cats.filter((c) => hits.some((w) => w.category === c.id)).map((c) => {
+          const list = hits.filter((w) => w.category === c.id);
+          return { title: c.label, sub: `${list.length} match${list.length === 1 ? "" : "es"}`, pills: [], groups: [{ key: "", count: list.length, items: list, showHead: false }] };
+        });
+      } else {
+        isMiss = true;
+        missName = query.trim().replace(/\b\w/g, (m) => m.toUpperCase());
+        resultSummary = "0 exact matches";
+        const hints = [["liga", "Soccer"], ["serie", "Soccer"], ["eredivisie", "Soccer"], ["league", "Soccer"], ["fc", "Soccer"], ["cup", "Soccer"], ["ball", "Basketball"], ["hockey", "Hockey"], ["race", "Motorsport"], ["gp", "Motorsport"], ["fight", "Combat"], ["tennis", "Golf & Tennis"], ["golf", "Golf & Tennis"], ["cricket", "Cricket & Rugby"], ["rugby", "Cricket & Rugby"], ["news", "World"], ["times", "World"], ["post", "World"], ["journal", "Business"], ["tech", "Tech & Science"], ["coin", "Markets"], ["stock", "Markets"], ["etf", "Markets"], ["ci", "Dev"], ["deploy", "Dev"], ["twitch", "Gaming"], ["game", "Gaming"]];
+        const hit = hints.find(([k]) => q.includes(k));
+        const group = hit ? hit[1] : (cat !== "all" ? null : "Soccer");
+        const list = group ? all.filter((w) => w.group === group) : all.filter((w) => w.category === cat);
+        blocks = [{ title: "Closest matches", sub: group || label(cat), pills: [], groups: [{ key: "", count: list.length, items: list, showHead: false }] }];
+      }
+    } else if (cat === "all") {
+      blocks = cats.map((c) => { const list = all.filter((w) => w.category === c.id); const groups = grp(list); return { title: c.label, sub: `${list.length} · ${list.filter((w) => w.added).length} in your ticker`, pills: groups.length > 1 ? groups : [], groups }; });
+    } else {
+      const list = all.filter((w) => w.category === cat); const groups = grp(list);
+      blocks = [{ title: label(cat), sub: `${list.length} widgets · ${list.filter((w) => w.added).length} in your ticker`, pills: groups.length > 1 ? groups : [], groups }];
+    }
+
+    return {
+      isHub: view === "hub", isDir: view === "dir", hasQuery: Boolean(q), isMiss, missName, resultSummary,
+      query, crumb: q ? `Search “${query.trim()}”` : label(cat),
+      total: all.length, yourCount: added.length,
+      slotLabel: free ? `${added.length} of ${CAP} slots used` : `${added.length} added · unlimited slots`,
+      railSlots: free ? `${added.length}/${CAP}` : String(added.length),
+      capped, isFree: free,
+      fresh: NEW.map(find),
+      sidebarList: free ? FREE_ADDED.map(find) : d.SIDEBAR.map(find),
+      addLabel: capped ? "Get more slots" : "Add widget",
+      sidebar: d.SIDEBAR.map(find),
+      your: all.filter((w) => w.added),
+      goHub: go({ view: "hub", query: "" }),
+      onSearch: (e) => this.setState({ query: e.target.value, view: "dir" }),
+      tries: ["NFL", "Bitcoin", "Weather", "Hacker News", "Kalshi", "Eredivisie"].map((t) => ({ label: t, go: go({ view: "dir", cat: "all", query: t }) })),
+      hubs: cats.map((c) => { const list = all.filter((w) => w.category === c.id); const n = list.filter((w) => w.added).length; const nw = list.filter((w) => w.isNew).length; return { ...c, count: list.length, blurb: blurbs[c.id], wash: hubWash[c.id] + "26", logos: list.slice(0, 5), more: list.length > 5 ? `+${list.length - 5}` : "", addedLabel: n ? `${n} added` : "", newLabel: nw ? `${nw} new` : "", go: go({ view: "dir", cat: c.id, query: "" }) }; }),
+      rail: [{ id: "all", label: "All widgets" }, ...cats].map((c) => { const active = !q && c.id === cat; const count = c.id === "all" ? all.length : all.filter((w) => w.category === c.id).length; return { ...c, count, fg: active ? "#34d399" : "#9292a4", bg: active ? "rgba(52,211,153,.12)" : "transparent", countFg: active ? "rgba(52,211,153,.7)" : "#78788a", go: go({ cat: c.id, query: "" }) }; }),
+      blocks,
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/design_handoff_catalog/README.md
+++ b/design_handoff_catalog/README.md
@@ -1,0 +1,37 @@
+# Catalog redesign — design handoff
+
+Source: Claude Design project `cf74b16c-25bd-4dd9-a27c-a66a40f7a8a2`
+("Catalog Final.dc.html"), pulled 2026-09-06. Brandon designed it; this folder
+is the versioned copy the implementation is built from. Ships in v1.6.0
+after the settings pass (REL-203…209).
+
+| File | What it is |
+|---|---|
+| `Catalog Final.dc.html` | The reference sheet: six frames of the same prototype (hub, directory, search hit, search miss, free tier at cap, all widgets) plus the **Behavior rules**, **Growth rules** and **Catalog schema additions** cards. Read the three cards first — they are the spec. |
+| `Catalog G - Hub Directory.dc.html` | The live prototype the frames import. The `<x-dc>` template is the markup; the `<script data-dc-script>` block is the state machine (hub/dir views, search, aliases, miss card, free-tier cap, rail). |
+| `catalog-data.js` | The data the prototype runs on: today's catalog (mirrors `desktop/src/catalog.snapshot.json`) plus a `FUTURE` list of plausible additions used to prove the layout at ~90 widgets, the `group` sub-shelf per widget, and the helpers (`decorate`, `groupBy`, `readableTextOn`). |
+
+`support.js` is the Claude Design runtime (generated, ~70 KB) the `.dc.html`
+files load to render standalone; open the project on claude.ai/design to
+click through the live prototype, or read the two `.dc.html` files.
+
+## The design in one paragraph
+
+One route, two views. The **hub** is where you arrive: a search hero with
+example chips, one tile per kind (count, five logos, "n new", "n added"),
+"New this month", and "In your ticker". A tile click or a typed query drops
+into the **directory**: a kind rail on the left (with counts and an
+"Overview" link back), grouped rows on the right (Football, Soccer, Business…)
+with group pills as jump anchors. Zero matches shows a request card and the
+closest group instead of an empty state. At the free-tier cap the slot count
+rides the sidebar chip, the rail and the hub line.
+
+## What the app does not have yet (from the schema card)
+
+- `group` per widget (sub-shelf inside a category); missing → ungrouped.
+- `keywords[]` search aliases ("bitcoin btc eth"), part of the match haystack.
+- `added_at` for "new" tags and the New-this-month strip (30-day window).
+- `POST /catalog/requests { query }` → count; powers the miss card.
+
+Reused as-is per the design: TopBar, Sidebar, WidgetBar chassis, Segmented,
+CatalogCard compact row anatomy, WidgetPanel, SlotPills, tokens, type scale.

--- a/design_handoff_catalog/catalog-data.js
+++ b/design_handoff_catalog/catalog-data.js
@@ -1,0 +1,165 @@
+// Catalog data — mirrors desktop/src/catalog.snapshot.json (hidden rss_custom omitted).
+// iconPath = lucide glyph the renderer registers for the source (used when no logo_url).
+const I = {
+  trendingUp: "M22 7l-8.5 8.5-5-5L2 17M16 7h6v6",
+  trophy: "M6 9H4.5a2.5 2.5 0 0 1 0-5H6M18 9h1.5a2.5 2.5 0 0 0 0-5H18M4 22h16M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22M18 2H6v7a6 6 0 0 0 12 0V2Z",
+  rss: "M4 11a9 9 0 0 1 9 9M4 4a16 16 0 0 1 16 16M5 18.5a.5.5 0 1 0 0 1a.5.5 0 1 0 0-1",
+  swords: "M14.5 17.5L3 6V3h3l11.5 11.5M13 19l6-6M16 16l4 4M19 21l2-2M14.5 6.5L18 3h3v3l-3.5 3.5M5 14l4 4M7 17l-3 3M3 19l2 2",
+  clock: "M12 2a10 10 0 1 0 0 20a10 10 0 1 0 0-20M12 6v6l4 2",
+  timer: "M10 2h4M12 14v-4M4 13a8 8 0 0 1 8-7 8 8 0 1 1-5.3 14L4 17.6M9 17H4v5",
+  cloudSun: "M12 2v2M4.93 4.93l1.41 1.41M20 12h2M19.07 4.93l-1.41 1.41M15.947 12.65a4 4 0 0 0-5.925-4.128M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z",
+  activity: "M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2",
+  heartPulse: "M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7ZM3.22 12H9.5l.5-1 2 4.5 2-7 1.5 3.5h5.27",
+  github: "M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4M9 18c-4.51 2-5-2-7-2",
+};
+const H = (d) => `https://icon.horse/icon/${d}`;
+
+// group = sub-shelf within a category (used by the explorations; the app has no such field yet).
+export const WIDGETS = [
+  { id: "finance_stocks", name: "Stocks", description: "Live stock & ETF prices with a watchlist you control.", category: "finance", group: "Markets", hex: "#16a34a", iconPath: I.trendingUp },
+  { id: "finance_crypto", name: "Crypto", description: "Live crypto prices with a watchlist you control.", category: "finance", group: "Markets", hex: "#f7931a", iconPath: I.trendingUp },
+  { id: "sports_nfl", name: "NFL", description: "Live NFL scores and game states.", category: "sports", group: "Football", hex: "#013369", logoUrl: H("nfl.com"), iconPath: I.trophy },
+  { id: "sports_nba", name: "NBA", description: "Live NBA scores and game states.", category: "sports", group: "Basketball", hex: "#c9082a", logoUrl: H("nba.com"), iconPath: I.trophy },
+  { id: "sports_nhl", name: "NHL", description: "Live NHL scores and game states.", category: "sports", group: "Hockey", hex: "#111827", logoUrl: H("nhl.com"), iconPath: I.trophy },
+  { id: "sports_mlb", name: "MLB", description: "Live MLB scores and game states.", category: "sports", group: "Baseball", hex: "#002d72", logoUrl: H("mlb.com"), iconPath: I.trophy },
+  { id: "sports_f1", name: "F1", description: "Formula 1 race weekends and results.", category: "sports", group: "Motorsport", hex: "#e10600", logoUrl: H("formula1.com"), iconPath: I.trophy },
+  { id: "sports_worldcup", name: "World Cup", description: "FIFA World Cup fixtures and scores.", category: "sports", group: "Soccer", hex: "#2e7d46", logoUrl: H("fifa.com"), iconPath: I.trophy },
+  { id: "sports_ncaaf", name: "NCAA Football", description: "Live college football scores across the FBS.", category: "sports", group: "Football", hex: "#0b427a", logoUrl: H("ncaa.com"), iconPath: I.trophy },
+  { id: "sports_ncaab", name: "NCAA Basketball", description: "Live college basketball scores and the road to March.", category: "sports", group: "Basketball", hex: "#d2691e", logoUrl: H("ncaa.com"), iconPath: I.trophy },
+  { id: "sports_premierleague", name: "Premier League", description: "Live scores from England's Premier League.", category: "sports", group: "Soccer", hex: "#37003c", logoUrl: H("premierleague.com"), iconPath: I.trophy },
+  { id: "sports_laliga", name: "La Liga", description: "Live scores from Spain's La Liga.", category: "sports", group: "Soccer", hex: "#e2001a", logoUrl: H("laliga.com"), iconPath: I.trophy },
+  { id: "sports_mls", name: "MLS", description: "Live Major League Soccer scores.", category: "sports", group: "Soccer", hex: "#001838", logoUrl: H("mlssoccer.com"), iconPath: I.trophy },
+  { id: "sports_championsleague", name: "Champions League", description: "Live UEFA Champions League scores.", category: "sports", group: "Soccer", hex: "#0e1e5b", logoUrl: H("uefa.com"), iconPath: I.trophy },
+  { id: "sports_ufc", name: "UFC", description: "UFC fight cards and results.", category: "sports", group: "Combat", hex: "#d20a0a", iconPath: I.trophy },
+  { id: "sports_afl", name: "AFL", description: "Live Australian Football League scores.", category: "sports", group: "Football", hex: "#003da5", logoUrl: H("afl.com.au"), iconPath: I.trophy },
+  { id: "news_bbc", name: "BBC News", description: "World, UK and breaking news from the BBC.", category: "news", group: "World", hex: "#b80000", logoUrl: H("bbc.com"), iconPath: I.rss },
+  { id: "news_npr", name: "NPR", description: "US and world news, analysis and reporting from NPR.", category: "news", group: "World", hex: "#4667de", logoUrl: H("npr.org"), iconPath: I.rss },
+  { id: "news_guardian", name: "The Guardian", description: "Independent world news, opinion and reporting.", category: "news", group: "World", hex: "#052962", logoUrl: H("theguardian.com"), iconPath: I.rss },
+  { id: "news_aljazeera", name: "Al Jazeera", description: "Breaking news from the Middle East and around the world.", category: "news", group: "World", hex: "#e8a33d", logoUrl: H("aljazeera.com"), iconPath: I.rss },
+  { id: "news_propublica", name: "ProPublica", description: "Investigative journalism in the public interest.", category: "news", group: "World", hex: "#c8102e", logoUrl: H("propublica.org"), iconPath: I.rss },
+  { id: "news_bloomberg", name: "Bloomberg", description: "Global markets, finance and business news.", category: "news", group: "Business", hex: "#1a1a2e", logoUrl: H("bloomberg.com"), iconPath: I.rss },
+  { id: "news_cnbc", name: "CNBC", description: "Markets, business and finance headlines.", category: "news", group: "Business", hex: "#005594", logoUrl: H("cnbc.com"), iconPath: I.rss },
+  { id: "news_nasa", name: "NASA", description: "Space, science and mission news from NASA.", category: "news", group: "Tech & Science", hex: "#0b3d91", logoUrl: H("nasa.gov"), iconPath: I.rss },
+  { id: "news_hackernews", name: "Hacker News", description: "Top stories from the Hacker News front page.", category: "news", group: "Tech & Science", hex: "#ff6600", logoUrl: H("news.ycombinator.com"), iconPath: I.rss },
+  { id: "news_theverge", name: "The Verge", description: "Technology, science, art and culture.", category: "news", group: "Tech & Science", hex: "#5200ff", logoUrl: H("theverge.com"), iconPath: I.rss },
+  { id: "news_drudge", name: "Drudge Report", description: "The Drudge Report's headline links, as they post.", category: "news", group: "World", hex: "#4b5563", logoUrl: H("drudgereport.com"), logoLight: true, iconPath: I.rss },
+  { id: "fantasy_yahoo", name: "Yahoo Fantasy", description: "Your Yahoo Fantasy leagues, matchups, and standings.", category: "fantasy", group: "Fantasy", hex: "#6001d2", logoUrl: H("yahoo.com"), iconPath: I.swords },
+  { id: "predictions", name: "Kalshi", description: "Live odds from the Kalshi prediction market.", category: "predictions", group: "Predictions", hex: "#1fc9a0", iconPath: I.trendingUp },
+  { id: "clock", name: "Clock", description: "Local time and world clocks", category: "utility", group: "Desk", hex: "#6366f1", iconPath: I.clock },
+  { id: "timer", name: "Timer", description: "Pomodoro, countdown, and stopwatch tools", category: "utility", group: "Desk", hex: "#f59e0b", iconPath: I.timer },
+  { id: "weather", name: "Weather", description: "Current conditions for your locations", category: "utility", group: "Desk", hex: "#0ea5e9", iconPath: I.cloudSun },
+  { id: "sysmon", name: "System Monitor", description: "Live CPU, memory, and GPU stats", category: "utility", group: "Dev", hex: "#06b6d4", iconPath: I.activity },
+  { id: "uptime", name: "Uptime", description: "Monitor status from Uptime Kuma", category: "utility", group: "Dev", hex: "#10b981", logoUrl: H("uptime.kuma.pet"), iconPath: I.heartPulse },
+  { id: "github", name: "GitHub", description: "CI/Actions status for your repos", category: "utility", group: "Dev", hex: "#f97316", logoUrl: H("github.com"), iconPath: I.github },
+];
+
+// Plausible next-year additions, for mockups that need to prove scale (~250 target).
+export const FUTURE = [
+  { id: "sports_bundesliga", name: "Bundesliga", description: "Live scores from Germany's Bundesliga.", category: "sports", group: "Soccer", hex: "#d3010c", logoUrl: H("bundesliga.com"), iconPath: I.trophy },
+  { id: "sports_seriea", name: "Serie A", description: "Live scores from Italy's Serie A.", category: "sports", group: "Soccer", hex: "#024494", logoUrl: H("legaseriea.it"), iconPath: I.trophy },
+  { id: "sports_ligue1", name: "Ligue 1", description: "Live scores from France's Ligue 1.", category: "sports", group: "Soccer", hex: "#091c3e", logoUrl: H("ligue1.com"), iconPath: I.trophy },
+  { id: "sports_wnba", name: "WNBA", description: "Live WNBA scores and game states.", category: "sports", group: "Basketball", hex: "#fa4d00", logoUrl: H("wnba.com"), iconPath: I.trophy },
+  { id: "sports_euroleague", name: "EuroLeague", description: "Live EuroLeague basketball scores.", category: "sports", group: "Basketball", hex: "#f47a20", logoUrl: H("euroleaguebasketball.net"), iconPath: I.trophy },
+  { id: "sports_pga", name: "PGA Tour", description: "Leaderboards from every tour stop.", category: "sports", group: "Golf & Tennis", hex: "#003a70", logoUrl: H("pgatour.com"), iconPath: I.trophy },
+  { id: "sports_atp", name: "ATP Tour", description: "Live men's tennis scores and draws.", category: "sports", group: "Golf & Tennis", hex: "#1a3c8c", logoUrl: H("atptour.com"), iconPath: I.trophy },
+  { id: "sports_wta", name: "WTA", description: "Live women's tennis scores and draws.", category: "sports", group: "Golf & Tennis", hex: "#7b1fa2", logoUrl: H("wtatennis.com"), iconPath: I.trophy },
+  { id: "sports_nascar", name: "NASCAR", description: "Race weekends, results and standings.", category: "sports", group: "Motorsport", hex: "#ffd659", logoUrl: H("nascar.com"), iconPath: I.trophy },
+  { id: "sports_indycar", name: "IndyCar", description: "IndyCar race weekends and results.", category: "sports", group: "Motorsport", hex: "#c8102e", logoUrl: H("indycar.com"), iconPath: I.trophy },
+  { id: "sports_motogp", name: "MotoGP", description: "MotoGP race weekends and results.", category: "sports", group: "Motorsport", hex: "#cc0000", logoUrl: H("motogp.com"), iconPath: I.trophy },
+  { id: "sports_ipl", name: "IPL", description: "Live Indian Premier League cricket scores.", category: "sports", group: "Cricket & Rugby", hex: "#19398a", logoUrl: H("iplt20.com"), iconPath: I.trophy },
+  { id: "sports_sixnations", name: "Six Nations", description: "Live Six Nations rugby scores.", category: "sports", group: "Cricket & Rugby", hex: "#0a2240", logoUrl: H("sixnationsrugby.com"), iconPath: I.trophy },
+  { id: "sports_nrl", name: "NRL", description: "Live National Rugby League scores.", category: "sports", group: "Cricket & Rugby", hex: "#00a651", logoUrl: H("nrl.com"), iconPath: I.trophy },
+  { id: "sports_boxing", name: "Boxing", description: "Major fight cards and results.", category: "sports", group: "Combat", hex: "#8b0000", iconPath: I.trophy },
+  { id: "sports_pfl", name: "PFL", description: "Professional Fighters League cards and results.", category: "sports", group: "Combat", hex: "#e4002b", logoUrl: H("pflmma.com"), iconPath: I.trophy },
+  { id: "sports_ncaabase", name: "NCAA Baseball", description: "Live college baseball scores.", category: "sports", group: "Baseball", hex: "#0b427a", logoUrl: H("ncaa.com"), iconPath: I.trophy },
+  { id: "sports_npb", name: "NPB", description: "Live Nippon Professional Baseball scores.", category: "sports", group: "Baseball", hex: "#c8102e", iconPath: I.trophy },
+  { id: "sports_khl", name: "KHL", description: "Live Kontinental Hockey League scores.", category: "sports", group: "Hockey", hex: "#1c3f95", iconPath: I.trophy },
+  { id: "sports_cfl", name: "CFL", description: "Live Canadian Football League scores.", category: "sports", group: "Football", hex: "#c8102e", logoUrl: H("cfl.ca"), iconPath: I.trophy },
+  { id: "news_reuters", name: "Reuters", description: "Wire headlines from Reuters.", category: "news", group: "World", hex: "#ff8000", logoUrl: H("reuters.com"), iconPath: I.rss },
+  { id: "news_ap", name: "AP News", description: "Associated Press top stories.", category: "news", group: "World", hex: "#ff322e", logoUrl: H("apnews.com"), iconPath: I.rss },
+  { id: "news_ft", name: "Financial Times", description: "Markets and business from the FT.", category: "news", group: "Business", hex: "#fff1e5", logoUrl: H("ft.com"), logoLight: true, iconPath: I.rss },
+  { id: "news_wsj", name: "WSJ", description: "Wall Street Journal headlines.", category: "news", group: "Business", hex: "#0274b6", logoUrl: H("wsj.com"), iconPath: I.rss },
+  { id: "news_arstechnica", name: "Ars Technica", description: "Technology, science and policy.", category: "news", group: "Tech & Science", hex: "#ff4e00", logoUrl: H("arstechnica.com"), iconPath: I.rss },
+  { id: "news_techcrunch", name: "TechCrunch", description: "Startups and technology news.", category: "news", group: "Tech & Science", hex: "#0a9e01", logoUrl: H("techcrunch.com"), iconPath: I.rss },
+  { id: "news_nature", name: "Nature", description: "Research highlights from Nature.", category: "news", group: "Tech & Science", hex: "#0b3f6d", logoUrl: H("nature.com"), iconPath: I.rss },
+  { id: "news_espn", name: "ESPN", description: "Top sports headlines from ESPN.", category: "news", group: "Sports & Culture", hex: "#d00", logoUrl: H("espn.com"), iconPath: I.rss },
+  { id: "news_athletic", name: "The Athletic", description: "In-depth sports journalism.", category: "news", group: "Sports & Culture", hex: "#000", logoUrl: H("theathletic.com"), iconPath: I.rss },
+  { id: "news_variety", name: "Variety", description: "Entertainment industry news.", category: "news", group: "Sports & Culture", hex: "#000", logoUrl: H("variety.com"), iconPath: I.rss },
+  { id: "news_polygon", name: "Polygon", description: "Games, entertainment and culture.", category: "news", group: "Sports & Culture", hex: "#e30a54", logoUrl: H("polygon.com"), iconPath: I.rss },
+  { id: "news_reddit", name: "Reddit", description: "Top posts from any subreddit.", category: "news", group: "Social", hex: "#ff4500", logoUrl: H("reddit.com"), iconPath: I.rss },
+  { id: "news_bluesky", name: "Bluesky", description: "Posts from a feed or account you follow.", category: "news", group: "Social", hex: "#0085ff", logoUrl: H("bsky.app"), iconPath: I.rss },
+  { id: "news_substack", name: "Substack", description: "New posts from newsletters you read.", category: "news", group: "Social", hex: "#ff6719", logoUrl: H("substack.com"), iconPath: I.rss },
+  { id: "news_youtube", name: "YouTube", description: "New uploads from channels you follow.", category: "news", group: "Social", hex: "#ff0000", logoUrl: H("youtube.com"), iconPath: I.rss },
+  { id: "finance_forex", name: "Forex", description: "Live currency pairs with a watchlist you control.", category: "finance", group: "Markets", hex: "#0ea5e9", iconPath: I.trendingUp },
+  { id: "finance_commodities", name: "Commodities", description: "Gold, oil, gas and more, live.", category: "finance", group: "Markets", hex: "#ca8a04", iconPath: I.trendingUp },
+  { id: "finance_indices", name: "Indices", description: "S&P 500, Nasdaq, Dow, FTSE and more.", category: "finance", group: "Markets", hex: "#7c3aed", iconPath: I.trendingUp },
+  { id: "finance_earnings", name: "Earnings", description: "This week's earnings calendar.", category: "finance", group: "Calendar", hex: "#0d9488", iconPath: I.trendingUp },
+  { id: "finance_econ", name: "Econ Calendar", description: "CPI, jobs, Fed decisions and more.", category: "finance", group: "Calendar", hex: "#475569", iconPath: I.trendingUp },
+  { id: "fantasy_espn", name: "ESPN Fantasy", description: "Your ESPN Fantasy leagues and matchups.", category: "fantasy", group: "Fantasy", hex: "#d00", logoUrl: H("espn.com"), iconPath: I.swords },
+  { id: "fantasy_sleeper", name: "Sleeper", description: "Your Sleeper leagues and matchups.", category: "fantasy", group: "Fantasy", hex: "#1a1b2e", logoUrl: H("sleeper.com"), iconPath: I.swords },
+  { id: "predictions_polymarket", name: "Polymarket", description: "Live odds from Polymarket.", category: "predictions", group: "Predictions", hex: "#2d5bff", logoUrl: H("polymarket.com"), iconPath: I.trendingUp },
+  { id: "calendar", name: "Calendar", description: "Your next events from Google or Outlook", category: "utility", group: "Desk", hex: "#2563eb", iconPath: I.clock },
+  { id: "pomodoro_team", name: "Focus", description: "Shared focus sessions with your team", category: "utility", group: "Desk", hex: "#db2777", iconPath: I.timer },
+  { id: "countdown", name: "Countdown", description: "Days until dates that matter", category: "utility", group: "Desk", hex: "#9333ea", iconPath: I.timer },
+  { id: "aqi", name: "Air Quality", description: "AQI and pollen for your locations", category: "utility", group: "Desk", hex: "#65a30d", iconPath: I.cloudSun },
+  { id: "transit", name: "Transit", description: "Next departures from your stops", category: "utility", group: "Desk", hex: "#0891b2", iconPath: I.clock },
+  { id: "vercel", name: "Vercel", description: "Deployment status for your projects", category: "utility", group: "Dev", hex: "#000", logoUrl: H("vercel.com"), iconPath: I.activity },
+  { id: "gitlab", name: "GitLab", description: "Pipeline status for your projects", category: "utility", group: "Dev", hex: "#fc6d26", logoUrl: H("gitlab.com"), iconPath: I.github },
+  { id: "sentry", name: "Sentry", description: "New issues in your projects", category: "utility", group: "Dev", hex: "#362d59", logoUrl: H("sentry.io"), iconPath: I.activity },
+  { id: "statuspage", name: "Statuspage", description: "Status of the services you depend on", category: "utility", group: "Dev", hex: "#3b82f6", iconPath: I.heartPulse },
+  { id: "docker", name: "Docker", description: "Running containers on this machine", category: "utility", group: "Dev", hex: "#2496ed", logoUrl: H("docker.com"), iconPath: I.activity },
+  { id: "twitch", name: "Twitch", description: "Who's live among the channels you follow", category: "gaming", group: "Gaming", hex: "#9146ff", logoUrl: H("twitch.tv"), iconPath: I.rss },
+  { id: "steam", name: "Steam", description: "Friends online and sales you're watching", category: "gaming", group: "Gaming", hex: "#1b2838", logoUrl: H("steampowered.com"), iconPath: I.rss },
+  { id: "esports_lol", name: "LoL Esports", description: "Live League of Legends match scores", category: "gaming", group: "Gaming", hex: "#c89b3c", logoUrl: H("lolesports.com"), iconPath: I.trophy },
+  { id: "esports_cs", name: "CS2 Esports", description: "Live Counter-Strike match scores", category: "gaming", group: "Gaming", hex: "#f5a623", iconPath: I.trophy },
+];
+
+export const CATEGORIES = [
+  { id: "sports", label: "Sports" },
+  { id: "finance", label: "Finance" },
+  { id: "news", label: "News" },
+  { id: "fantasy", label: "Fantasy" },
+  { id: "predictions", label: "Predictions" },
+  { id: "utility", label: "Utilities" },
+];
+export const FUTURE_CATEGORIES = [...CATEGORIES, { id: "gaming", label: "Gaming" }];
+
+export const ADDED = ["finance_stocks", "finance_crypto", "sports_mlb", "sports_ncaaf", "sports_premierleague", "sports_ufc", "news_guardian", "news_drudge", "clock", "timer", "weather", "sysmon", "uptime"];
+// Sidebar shows utilities first (local registry order), then data widgets in canonical order.
+export const SIDEBAR = ["timer", "clock", "weather", "sysmon", "uptime", "finance_stocks", "sports_ncaaf", "sports_mlb", "finance_crypto", "sports_premierleague", "sports_ufc", "news_guardian", "news_drudge"];
+
+export const SPOTLIGHT = [
+  { id: "finance_stocks", tagline: "Instant quotes" },
+  { id: "predictions", tagline: "Read the room" },
+  { id: "clock", tagline: "Always on time" },
+];
+
+export const byId = (id) => [...WIDGETS, ...FUTURE].find((w) => w.id === id);
+export const decorate = (w, added = ADDED) => ({
+  ...w,
+  added: added.includes(w.id),
+  wash: `${w.hex}26`,
+  tileBg: `linear-gradient(135deg, ${w.hex} 0%, ${w.hex}b8 100%)`,
+  heroBg: `linear-gradient(135deg, ${w.hex} 0%, ${w.hex}d8 100%)`,
+  hasLogo: Boolean(w.logoUrl),
+  noLogo: !w.logoUrl,
+  logoBg: w.logoLight ? "#ffffff" : "transparent",
+  logoPad: w.logoLight ? "2px" : "0",
+  textOn: readableTextOn(w.hex),
+  categoryLabel: (FUTURE_CATEGORIES.find((c) => c.id === w.category) || {}).label || "Utilities",
+});
+export function readableTextOn(hex) {
+  const h = hex.replace("#", "");
+  if (h.length < 6) return "#ffffff";
+  const r = parseInt(h.slice(0, 2), 16), g = parseInt(h.slice(2, 4), 16), b = parseInt(h.slice(4, 6), 16);
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.62 ? "#111827" : "#ffffff";
+}
+export function groupBy(items, key) {
+  const out = [];
+  for (const it of items) {
+    let g = out.find((x) => x.key === it[key]);
+    if (!g) out.push((g = { key: it[key], items: [] }));
+    g.items.push(it);
+  }
+  return out.map((g) => ({ ...g, count: g.items.length }));
+}

--- a/design_handoff_catalog/support.js
+++ b/design_handoff_catalog/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();


### PR DESCRIPTION
Versioned copy of Brandon's Claude Design catalog redesign (project cf74b16c…), pulled 2026-09-06: reference sheet, live prototype, data, runtime, README. No code. Implementation tracked in REL-214 (server) and REL-215 (desktop), shipping in v1.6.0 after the settings pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)