### PR TITLE
feat(catalog): group, keywords, added_at on WidgetDef; POST /catalog/requests [REL-214]

### DIFF
--- a/api/cmd/gents/main.go
+++ b/api/cmd/gents/main.go
@@ -54,6 +54,7 @@ var roots = []struct{ pkg, name string }{
 	{"internal/platform", "CheckoutReturnResponse"},
 	{"internal/platform", "WidgetDef"},
 	{"internal/widgets", "CatalogResponse"},
+	{"internal/widgets", "CatalogRequestResponse"},
 	{"internal/widgets", "TierLimitsResponse"},
 	{"internal/widgets", "WidgetLimits"},
 	{"internal/accounts", "OverviewResponse"},

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -211,6 +211,9 @@ func (s *Server) setupRoutes() {
 	s.App.Get("/channels", s.listChannels)
 	// The widget catalog — the single authority clients render from.
 	s.App.Get("/catalog", widgets.HandleGetCatalog)
+	// "Request it" from the catalog's zero-match card: one row per user
+	// and query, count across users. Authenticated; IP-rate-limited.
+	s.App.Post("/catalog/requests", platform.LogtoAuth, widgets.HandleCatalogRequest)
 	s.App.Get("/tier-limits", widgets.HandleGetTierLimits)
 	s.App.Get("/app/min-version", HandleGetMinDesktopVersion)
 	s.App.Get("/", s.landingPage)

--- a/api/internal/accounts/user_deletion.go
+++ b/api/internal/accounts/user_deletion.go
@@ -470,6 +470,13 @@ func PurgeUserAccount(ctx context.Context, logtoSub string) error {
 		return fmt.Errorf("read stripe_customers: %w", err)
 	}
 
+	// Catalog requests ("tell me when X ships") are keyed on the user.
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM catalog_requests WHERE logto_sub = $1`, logtoSub,
+	); err != nil {
+		return fmt.Errorf("delete catalog_requests: %w", err)
+	}
+
 	// Preferences (must come after anything that might reference them).
 	if _, err := tx.Exec(ctx,
 		`DELETE FROM user_preferences WHERE logto_sub = $1`, logtoSub,

--- a/api/internal/platform/widgets.go
+++ b/api/internal/platform/widgets.go
@@ -71,7 +71,31 @@ type WidgetDef struct {
 	// against slots. For turning something off "for now" without stranding
 	// the people who already have it.
 	Hidden bool `json:"hidden,omitempty"`
+
+	// Group is the sub-shelf inside a category the directory files this
+	// under ("Football", "Soccer", "Business", "Dev"). Optional: a widget
+	// without one lists ungrouped. Categories past ~8 entries should carry
+	// groups (design_handoff_catalog, "Growth rules").
+	Group string `json:"group,omitempty"`
+
+	// Keywords are search aliases that never appear on screen but join the
+	// match haystack with name, description, group and category — so
+	// "btc" finds Crypto and "epl" finds the Premier League.
+	Keywords []string `json:"keywords,omitempty"`
+
+	// AddedAt is the ISO date (YYYY-MM-DD) the entry shipped, driving the
+	// "new" tag and the New-this-month strip (30-day window). Dates are the
+	// release that carried the entry; widgets older than the catalog itself
+	// carry the catalog's own launch (v1.1.0). Day precision is best-effort.
+	AddedAt string `json:"added_at,omitempty"`
 }
+
+// Release dates for AddedAt — the desktop tag that carried the entry.
+const (
+	addedV110  = "2026-07-02" // v1.1.0: the catalog itself; every widget that predates it
+	addedV1110 = "2026-07-21" // v1.1.10: the sports and news expansion
+	addedV152  = "2026-09-05" // v1.5.2
+)
 
 // Shared usage recipes — most widgets in a family follow the same steps, so
 // they are named once and reused. A per-widget Usage overrides these.
@@ -98,7 +122,9 @@ var catalog = []WidgetDef{
 	// ── Finance — the finance source split by asset class ──────────────
 	{
 		ID: "finance_stocks", Name: "Stocks", Category: "finance", Source: "finance",
-		Color: "#16a34a",
+		Group: "Markets", AddedAt: addedV110,
+		Keywords:      []string{"shares", "etf", "s&p", "nasdaq", "dow", "tickers"},
+		Color:         "#16a34a",
 		Description:   "Live stock & ETF prices with a watchlist you control.",
 		DefaultConfig: map[string]any{"symbols": []string{}, "asset_class": "stock"},
 		About:         "Real-time stock and ETF prices for the tickers you follow. Your watchlist streams live as the market moves — no brokerage app open, no tab to babysit.",
@@ -110,7 +136,9 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "finance_crypto", Name: "Crypto", Category: "finance", Source: "finance",
-		Color: "#f7931a",
+		Group: "Markets", AddedAt: addedV110,
+		Keywords:      []string{"bitcoin", "btc", "eth", "ethereum", "solana", "coins"},
+		Color:         "#f7931a",
 		Description:   "Live crypto prices with a watchlist you control.",
 		DefaultConfig: map[string]any{"symbols": []string{}, "asset_class": "crypto"},
 		About:         "Live crypto prices for the coins you track, streamed around the clock. From BTC and ETH to the long tail, your picks update the moment the market does.",
@@ -124,35 +152,45 @@ var catalog = []WidgetDef{
 	// ── Sports — one widget per league ─────────────────────────────────
 	{
 		ID: "sports_nfl", Name: "NFL", Category: "sports", Source: "sports",
-		Color: "#013369", LogoURL: "https://icon.horse/icon/nfl.com",
+		Group: "Football", AddedAt: addedV110,
+		Keywords: []string{"football"},
+		Color:    "#013369", LogoURL: "https://icon.horse/icon/nfl.com",
 		Description:   "Live NFL scores and game states.",
 		DefaultConfig: map[string]any{"leagues": []string{"NFL"}}, Usage: usageTeamSport,
 		About: "Live NFL scores, quarters, and game clock for every matchup on the slate. Follow the whole week or zero in on your team.",
 	},
 	{
 		ID: "sports_nba", Name: "NBA", Category: "sports", Source: "sports",
-		Color: "#c9082a", LogoURL: "https://icon.horse/icon/nba.com",
+		Group: "Basketball", AddedAt: addedV110,
+		Keywords: []string{"basketball"},
+		Color:    "#c9082a", LogoURL: "https://icon.horse/icon/nba.com",
 		Description:   "Live NBA scores and game states.",
 		DefaultConfig: map[string]any{"leagues": []string{"NBA"}}, Usage: usageTeamSport,
 		About: "Live NBA scores and game state across the association — every quarter, every buzzer-beater, as it happens.",
 	},
 	{
 		ID: "sports_nhl", Name: "NHL", Category: "sports", Source: "sports",
-		Color: "#111827", LogoURL: "https://icon.horse/icon/nhl.com",
+		Group: "Hockey", AddedAt: addedV110,
+		Keywords: []string{"hockey"},
+		Color:    "#111827", LogoURL: "https://icon.horse/icon/nhl.com",
 		Description:   "Live NHL scores and game states.",
 		DefaultConfig: map[string]any{"leagues": []string{"NHL"}}, Usage: usageTeamSport,
 		About: "Live NHL scores and period-by-period game state for every game on the ice.",
 	},
 	{
 		ID: "sports_mlb", Name: "MLB", Category: "sports", Source: "sports",
-		Color: "#002d72", LogoURL: "https://icon.horse/icon/mlb.com",
+		Group: "Baseball", AddedAt: addedV110,
+		Keywords: []string{"baseball"},
+		Color:    "#002d72", LogoURL: "https://icon.horse/icon/mlb.com",
 		Description:   "Live MLB scores and game states.",
 		DefaultConfig: map[string]any{"leagues": []string{"MLB"}}, Usage: usageTeamSport,
 		About: "Live MLB scores, innings, and game state across the league, all season long.",
 	},
 	{
 		ID: "sports_f1", Name: "F1", Category: "sports", Source: "sports",
-		Color: "#e10600", LogoURL: "https://icon.horse/icon/formula1.com",
+		Group: "Motorsport", AddedAt: addedV110,
+		Keywords: []string{"formula 1", "formula one", "grand prix"},
+		Color:    "#e10600", LogoURL: "https://icon.horse/icon/formula1.com",
 		Description:   "Formula 1 race weekends and results.",
 		DefaultConfig: map[string]any{"leagues": []string{"Formula 1"}},
 		About:         "Formula 1 race weekends — practice, qualifying, and the Grand Prix result the moment the checkered flag drops.",
@@ -164,7 +202,9 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "sports_worldcup", Name: "World Cup", Category: "sports", Source: "sports",
-		Color: "#2e7d46", LogoURL: "https://icon.horse/icon/fifa.com",
+		Group: "Soccer", AddedAt: addedV110,
+		Keywords: []string{"fifa", "soccer", "football"},
+		Color:    "#2e7d46", LogoURL: "https://icon.horse/icon/fifa.com",
 		Description:   "FIFA World Cup fixtures and scores.",
 		DefaultConfig: map[string]any{"leagues": []string{"FIFA World Cup"}},
 		About:         "Every FIFA World Cup fixture and live score, through the group stage and into the knockouts.",
@@ -176,42 +216,54 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "sports_ncaaf", Name: "NCAA Football", Category: "sports", Source: "sports",
-		Color: "#0b427a", LogoURL: "https://icon.horse/icon/ncaa.com",
+		Group: "Football", AddedAt: addedV1110,
+		Keywords: []string{"college football", "cfb"},
+		Color:    "#0b427a", LogoURL: "https://icon.horse/icon/ncaa.com",
 		Description:   "Live college football scores across the FBS.",
 		DefaultConfig: map[string]any{"leagues": []string{"NCAA Football"}}, Usage: usageTeamSport,
 		About: "Live college football scores across the FBS — Saturday slates, rivalry week, and bowl season.",
 	},
 	{
 		ID: "sports_ncaab", Name: "NCAA Basketball", Category: "sports", Source: "sports",
-		Color: "#d2691e", LogoURL: "https://icon.horse/icon/ncaa.com",
+		Group: "Basketball", AddedAt: addedV1110,
+		Keywords: []string{"college basketball", "march madness"},
+		Color:    "#d2691e", LogoURL: "https://icon.horse/icon/ncaa.com",
 		Description:   "Live college basketball scores and the road to March.",
 		DefaultConfig: map[string]any{"leagues": []string{"NCAA Basketball"}}, Usage: usageTeamSport,
 		About: "Live college basketball scores through conference play and all the way into March Madness.",
 	},
 	{
 		ID: "sports_premierleague", Name: "Premier League", Category: "sports", Source: "sports",
-		Color: "#37003c", LogoURL: "https://icon.horse/icon/premierleague.com",
+		Group: "Soccer", AddedAt: addedV1110,
+		Keywords: []string{"epl", "english", "soccer", "football"},
+		Color:    "#37003c", LogoURL: "https://icon.horse/icon/premierleague.com",
 		Description:   "Live scores from England's Premier League.",
 		DefaultConfig: map[string]any{"leagues": []string{"Premier League"}}, Usage: usageTeamSport,
 		About: "Live scores from England's Premier League — all 20 clubs, every matchweek.",
 	},
 	{
 		ID: "sports_laliga", Name: "La Liga", Category: "sports", Source: "sports",
-		Color: "#e2001a", LogoURL: "https://icon.horse/icon/laliga.com",
+		Group: "Soccer", AddedAt: addedV1110,
+		Keywords: []string{"spanish", "soccer"},
+		Color:    "#e2001a", LogoURL: "https://icon.horse/icon/laliga.com",
 		Description:   "Live scores from Spain's La Liga.",
 		DefaultConfig: map[string]any{"leagues": []string{"La Liga"}}, Usage: usageTeamSport,
 		About: "Live scores from Spain's La Liga, from the title race to the relegation scrap.",
 	},
 	{
 		ID: "sports_mls", Name: "MLS", Category: "sports", Source: "sports",
-		Color: "#001838", LogoURL: "https://icon.horse/icon/mlssoccer.com",
+		Group: "Soccer", AddedAt: addedV1110,
+		Keywords: []string{"american", "soccer"},
+		Color:    "#001838", LogoURL: "https://icon.horse/icon/mlssoccer.com",
 		Description:   "Live Major League Soccer scores.",
 		DefaultConfig: map[string]any{"leagues": []string{"MLS"}}, Usage: usageTeamSport,
 		About: "Live Major League Soccer scores across the Eastern and Western conferences.",
 	},
 	{
 		ID: "sports_championsleague", Name: "Champions League", Category: "sports", Source: "sports",
-		Color: "#0e1e5b", LogoURL: "https://icon.horse/icon/uefa.com",
+		Group: "Soccer", AddedAt: addedV1110,
+		Keywords: []string{"ucl", "uefa", "europe"},
+		Color:    "#0e1e5b", LogoURL: "https://icon.horse/icon/uefa.com",
 		Description:   "Live UEFA Champions League scores.",
 		DefaultConfig: map[string]any{"leagues": []string{"Champions League"}}, Usage: usageTeamSport,
 		About: "Live UEFA Champions League scores through the league phase and into the knockout rounds.",
@@ -220,7 +272,9 @@ var catalog = []WidgetDef{
 		// icon.horse returns a blank image for ufc.com, so this is pinned to
 		// DuckDuckGo's icon CDN, which serves the real opaque wordmark.
 		ID: "sports_ufc", Name: "UFC", Category: "sports", Source: "sports",
-		Color: "#d20a0a", LogoLight: true,
+		Group: "Combat", AddedAt: addedV1110,
+		Keywords: []string{"mma", "fights"},
+		Color:    "#d20a0a", LogoLight: true,
 		LogoURL:       "https://icons.duckduckgo.com/ip3/ufc.com.ico",
 		Description:   "UFC fight cards and results.",
 		DefaultConfig: map[string]any{"leagues": []string{"UFC"}},
@@ -233,7 +287,9 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "sports_afl", Name: "AFL", Category: "sports", Source: "sports",
-		Color: "#003da5", LogoURL: "https://icon.horse/icon/afl.com.au",
+		Group: "Football", AddedAt: addedV1110,
+		Keywords: []string{"aussie rules", "australian football"},
+		Color:    "#003da5", LogoURL: "https://icon.horse/icon/afl.com.au",
 		Description:   "Live Australian Football League scores.",
 		DefaultConfig: map[string]any{"leagues": []string{"AFL"}}, Usage: usageTeamSport,
 		About: "Live Australian Football League scores across the home-and-away season and finals.",
@@ -242,6 +298,7 @@ var catalog = []WidgetDef{
 	// ── News — curated feeds, each its own widget over the rss source ───
 	{
 		ID: "news_bbc", Name: "BBC News", Category: "news", Source: "rss",
+		Group: "World", AddedAt: addedV110,
 		Color: "#b80000", LogoURL: "https://icon.horse/icon/bbc.com",
 		Description: "World, UK and breaking news from the BBC.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -252,6 +309,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_npr", Name: "NPR", Category: "news", Source: "rss",
+		Group: "World", AddedAt: addedV1110,
 		Color: "#4667de", LogoURL: "https://icon.horse/icon/npr.org",
 		Description: "US and world news, analysis and reporting from NPR.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -262,6 +320,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_guardian", Name: "The Guardian", Category: "news", Source: "rss",
+		Group: "World", AddedAt: addedV1110,
 		Color: "#052962", LogoURL: "https://icon.horse/icon/theguardian.com",
 		Description: "Independent world news, opinion and reporting.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -272,6 +331,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_aljazeera", Name: "Al Jazeera", Category: "news", Source: "rss",
+		Group: "World", AddedAt: addedV1110,
 		Color: "#e8a33d", LogoURL: "https://icon.horse/icon/aljazeera.com",
 		Description: "Breaking news from the Middle East and around the world.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -282,6 +342,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_propublica", Name: "ProPublica", Category: "news", Source: "rss",
+		Group: "World", AddedAt: addedV1110,
 		Color: "#c8102e", LogoURL: "https://icon.horse/icon/propublica.org",
 		Description: "Investigative journalism in the public interest.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -292,6 +353,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_bloomberg", Name: "Bloomberg", Category: "news", Source: "rss",
+		Group: "Business", AddedAt: addedV1110,
 		Color: "#1a1a2e", LogoURL: "https://icon.horse/icon/bloomberg.com",
 		Description: "Global markets, finance and business news.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -302,6 +364,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_cnbc", Name: "CNBC", Category: "news", Source: "rss",
+		Group: "Business", AddedAt: addedV1110,
 		Color: "#005594", LogoURL: "https://icon.horse/icon/cnbc.com",
 		Description: "Markets, business and finance headlines.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -312,6 +375,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_nasa", Name: "NASA", Category: "news", Source: "rss",
+		Group: "Tech & Science", AddedAt: addedV1110,
 		Color: "#0b3d91", LogoURL: "https://icon.horse/icon/nasa.gov",
 		Description: "Space, science and mission news from NASA.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -322,7 +386,9 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_hackernews", Name: "Hacker News", Category: "news", Source: "rss",
-		Color: "#ff6600", LogoURL: "https://icon.horse/icon/news.ycombinator.com",
+		Group: "Tech & Science", AddedAt: addedV110,
+		Keywords: []string{"hn", "ycombinator", "tech", "startups"},
+		Color:    "#ff6600", LogoURL: "https://icon.horse/icon/news.ycombinator.com",
 		Description: "Top stories from the Hacker News front page.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
 			{"name": "Hacker News", "url": "https://hnrss.org/frontpage"},
@@ -332,6 +398,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_theverge", Name: "The Verge", Category: "news", Source: "rss",
+		Group: "Tech & Science", AddedAt: addedV1110,
 		Color: "#5200ff", LogoURL: "https://icon.horse/icon/theverge.com",
 		Description: "Technology, science, art and culture.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -342,6 +409,7 @@ var catalog = []WidgetDef{
 	},
 	{
 		ID: "news_drudge", Name: "Drudge Report", Category: "news", Source: "rss",
+		Group: "World", AddedAt: addedV152,
 		Color: "#4b5563", LogoURL: "https://icon.horse/icon/drudgereport.com", LogoLight: true,
 		Description: "The Drudge Report's headline links, as they post.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{
@@ -354,7 +422,8 @@ var catalog = []WidgetDef{
 		// Off the add grid for now (2026-09-05) -- the feeds view and its
 		// flood behaviour need another pass. Anyone who already has it keeps it.
 		ID: "rss_custom", Name: "Custom RSS", Category: "news", Source: "rss", Hidden: true,
-		Color: "#ee802f",
+		AddedAt:       addedV110,
+		Color:         "#ee802f",
 		Description:   "Follow any RSS or Atom feed by pasting its URL.",
 		DefaultConfig: map[string]any{"feeds": []map[string]string{}},
 		About:         "Bring your own feeds. Paste any RSS or Atom URL and Scrollr streams its latest items alongside everything else.",
@@ -369,7 +438,9 @@ var catalog = []WidgetDef{
 	{
 		// The tier gate was retired in v1.1.2 — the slot is the only lever.
 		ID: "fantasy_yahoo", Name: "Yahoo Fantasy", Category: "fantasy", Source: "fantasy",
-		Color: "#6001d2", LogoURL: "https://icon.horse/icon/yahoo.com",
+		Group: "Fantasy", AddedAt: addedV110,
+		Keywords: []string{"fantasy football", "league"},
+		Color:    "#6001d2", LogoURL: "https://icon.horse/icon/yahoo.com",
 		Description: "Your Yahoo Fantasy leagues, matchups, and standings.",
 		About:       "Your Yahoo Fantasy leagues in the ticker — live scoring, matchups, and standings without ever opening the app.",
 		Usage: []string{
@@ -381,7 +452,9 @@ var catalog = []WidgetDef{
 	{
 		// icon.horse returns a blank image for kalshi.com; pinned like UFC.
 		ID: "predictions", Name: "Kalshi", Category: "predictions", Source: "predictions",
-		Color: "#1fc9a0",
+		Group: "Predictions", AddedAt: addedV110,
+		Keywords:    []string{"odds", "prediction market", "bets"},
+		Color:       "#1fc9a0",
 		LogoURL:     "https://icons.duckduckgo.com/ip3/kalshi.com.ico",
 		Description: "Live odds from the Kalshi prediction market.",
 		About:       "Live odds from Kalshi, the regulated US prediction market — a real-time read on elections, economic prints, and the events in the news.",
@@ -395,27 +468,39 @@ var catalog = []WidgetDef{
 	// ── Utilities — local-only, no data source, but still cost a slot ───
 	{
 		ID: "clock", Name: "Clock", Category: "utility", Color: "#6366f1",
+		Group: "Desk", AddedAt: addedV110,
+		Keywords:    []string{"time", "timezone", "world clock"},
 		Description: "Local time and world clocks",
 	},
 	{
 		ID: "timer", Name: "Timer", Category: "utility", Color: "#f59e0b",
+		Group: "Desk", AddedAt: addedV110,
+		Keywords:    []string{"pomodoro", "stopwatch", "countdown"},
 		Description: "Pomodoro, countdown, and stopwatch tools",
 	},
 	{
 		ID: "weather", Name: "Weather", Category: "utility", Color: "#0ea5e9",
+		Group: "Desk", AddedAt: addedV110,
+		Keywords:    []string{"forecast", "temperature", "rain"},
 		Description: "Current conditions for your locations",
 	},
 	{
 		ID: "sysmon", Name: "System Monitor", Category: "utility", Color: "#06b6d4",
+		Group: "Dev", AddedAt: addedV110,
+		Keywords:    []string{"cpu", "gpu", "ram", "memory"},
 		Description: "Live CPU, memory, and GPU stats",
 	},
 	{
 		ID: "uptime", Name: "Uptime", Category: "utility", Color: "#10b981",
+		Group: "Dev", AddedAt: addedV110,
+		Keywords:    []string{"kuma", "status", "monitor"},
 		Description: "Monitor status from Uptime Kuma",
 		LogoURL:     "https://icon.horse/icon/uptime.kuma.pet",
 	},
 	{
 		ID: "github", Name: "GitHub", Category: "utility", Color: "#f97316",
+		Group: "Dev", AddedAt: addedV110,
+		Keywords:    []string{"actions", "ci", "pull requests"},
 		Description: "CI/Actions status for your repos",
 		LogoURL:     "https://icon.horse/icon/github.com",
 	},

--- a/api/internal/platform/widgets_test.go
+++ b/api/internal/platform/widgets_test.go
@@ -1,6 +1,9 @@
 package platform
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // The catalog is the single authority clients render from (VISION §4.2), so
 // a malformed entry is a client-wide bug. Check the invariants the client
@@ -44,6 +47,12 @@ func TestCatalogIsWellFormed(t *testing.T) {
 
 		if !IsKnownWidgetType(w.ID) {
 			t.Errorf("catalog %q: not accepted by IsKnownWidgetType", w.ID)
+		}
+
+		// AddedAt drives the "new" tag: a missing or malformed date is a
+		// widget that can never be new, or a client-side parse error.
+		if _, err := time.Parse("2006-01-02", w.AddedAt); err != nil {
+			t.Errorf("catalog %q: AddedAt %q is not a YYYY-MM-DD date", w.ID, w.AddedAt)
 		}
 	}
 }

--- a/api/internal/widgets/catalog_requests.go
+++ b/api/internal/widgets/catalog_requests.go
@@ -1,0 +1,85 @@
+package widgets
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// maxCatalogRequestQuery bounds what one "request it" click can store. The
+// query is whatever was in the search box; nothing sensible is longer.
+const maxCatalogRequestQuery = 200
+
+// CatalogRequestResponse is the payload of POST /catalog/requests.
+type CatalogRequestResponse struct {
+	// Query is the normalised form that was stored (lower-cased, trimmed,
+	// inner whitespace collapsed) — the key the count is grouped on.
+	Query string `json:"query"`
+	// Count is how many distinct users have asked for this query, including
+	// the caller.
+	Count int `json:"count"`
+}
+
+// HandleCatalogRequest records that the signed-in user searched the catalog
+// for something it does not have. One row per (user, query): asking twice
+// changes nothing, so the count is people, not clicks.
+//
+// Authenticated because the count is per user and the row is the hook for
+// a later "tell me when it ships"; the miss card only shows to people who
+// are signed in and browsing the catalog anyway.
+func HandleCatalogRequest(c *fiber.Ctx) error {
+	userID := platform.GetUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
+			Status: "unauthorized",
+			Error:  "Authentication required",
+		})
+	}
+
+	var req struct {
+		Query string `json:"query"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "Invalid request body",
+		})
+	}
+	query := strings.ToLower(strings.Join(strings.Fields(req.Query), " "))
+	if query == "" || len(query) > maxCatalogRequestQuery {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "query is required",
+		})
+	}
+
+	// Background, like every other handler here: the pool is the timeout.
+	ctx := context.Background()
+	if _, err := platform.DBPool.Exec(ctx, `
+		INSERT INTO catalog_requests (logto_sub, query) VALUES ($1, $2)
+		ON CONFLICT (logto_sub, query) DO NOTHING
+	`, userID, query); err != nil {
+		log.Printf("[Catalog] record request %q: %v", query, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "Failed to record request",
+		})
+	}
+
+	var count int
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT count(*) FROM catalog_requests WHERE query = $1`, query,
+	).Scan(&count); err != nil {
+		log.Printf("[Catalog] count requests %q: %v", query, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "Failed to count requests",
+		})
+	}
+
+	return c.JSON(CatalogRequestResponse{Query: query, Count: count})
+}

--- a/api/internal/widgets/catalog_requests_test.go
+++ b/api/internal/widgets/catalog_requests_test.go
@@ -1,0 +1,111 @@
+package widgets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// requestsApp mounts the handler behind a stand-in for LogtoAuth that
+// seeds user_id from a header, so a test can speak as any user without a
+// real JWT. An absent header is an unauthenticated request.
+func requestsApp() *fiber.App {
+	app := fiber.New()
+	app.Post("/catalog/requests", func(c *fiber.Ctx) error {
+		if u := c.Get("X-Test-User"); u != "" {
+			c.Locals("user_id", u)
+		}
+		return HandleCatalogRequest(c)
+	})
+	return app
+}
+
+func postRequest(t *testing.T, app *fiber.App, user, body string) (int, CatalogRequestResponse) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/catalog/requests", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if user != "" {
+		req.Header.Set("X-Test-User", user)
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	var out CatalogRequestResponse
+	if resp.StatusCode == http.StatusOK {
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+	}
+	return resp.StatusCode, out
+}
+
+func TestCatalogRequestRejectsUnauthenticated(t *testing.T) {
+	status, _ := postRequest(t, requestsApp(), "", `{"query":"bundesliga"}`)
+	if status != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", status)
+	}
+}
+
+// Validation runs before the database is touched, so these hold in unit
+// mode too.
+func TestCatalogRequestRejectsEmptyQuery(t *testing.T) {
+	app := requestsApp()
+	for _, body := range []string{`{}`, `{"query":""}`, `{"query":"   "}`, `not json`,
+		fmt.Sprintf(`{"query":%q}`, strings.Repeat("x", maxCatalogRequestQuery+1))} {
+		if status, _ := postRequest(t, app, "user-a", body); status != http.StatusBadRequest {
+			t.Errorf("body %.30q: status = %d, want 400", body, status)
+		}
+	}
+}
+
+// One user counts once however they spell or repeat it; a second user
+// makes it two. This is what the miss card shows back.
+func TestCatalogRequestCountsUsersNotClicks(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	stamp := time.Now().UnixNano()
+	userA := fmt.Sprintf("test-catreq-a-%d", stamp)
+	userB := fmt.Sprintf("test-catreq-b-%d", stamp)
+	query := fmt.Sprintf("bundesliga %d", stamp)
+	t.Cleanup(func() {
+		_, _ = platform.DBPool.Exec(context.Background(),
+			`DELETE FROM catalog_requests WHERE query = $1`, query)
+	})
+
+	app := requestsApp()
+	steps := []struct {
+		user, body string
+		want       int
+	}{
+		{userA, fmt.Sprintf(`{"query":"  %s "}`, strings.ToUpper(query)), 1},
+		{userA, fmt.Sprintf(`{"query":"%s"}`, query), 1},
+		{userA, fmt.Sprintf(`{"query":"Bundesliga   %d"}`, stamp), 1},
+		{userB, fmt.Sprintf(`{"query":"%s"}`, query), 2},
+		{userA, fmt.Sprintf(`{"query":"%s"}`, query), 2},
+	}
+	for i, s := range steps {
+		status, out := postRequest(t, app, s.user, s.body)
+		if status != http.StatusOK {
+			t.Fatalf("step %d: status = %d, want 200", i, status)
+		}
+		if out.Query != query {
+			t.Errorf("step %d: stored query %q, want normalised %q", i, out.Query, query)
+		}
+		if out.Count != s.want {
+			t.Errorf("step %d (%s): count = %d, want %d", i, s.user, out.Count, s.want)
+		}
+	}
+}

--- a/api/internal/widgets/catalog_test.go
+++ b/api/internal/widgets/catalog_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
@@ -66,6 +67,25 @@ func TestHandleGetCatalogServesFullCatalog(t *testing.T) {
 	}
 	if !kalshi {
 		t.Error("predictions/Kalshi missing from the served catalog")
+	}
+
+	// The directory's shelf, search aliases and "new" tag all ride these
+	// three fields (REL-214); a lost tag here is a flat, unsearchable catalog.
+	var epl bool
+	for _, w := range body.Widgets {
+		if w.ID != "sports_premierleague" {
+			continue
+		}
+		epl = true
+		if w.Group != "Soccer" || w.AddedAt == "" {
+			t.Errorf("premier league lost group/added_at over the wire: %+v", w)
+		}
+		if !slices.Contains(w.Keywords, "epl") {
+			t.Errorf("premier league keywords = %v, want to include %q", w.Keywords, "epl")
+		}
+	}
+	if !epl {
+		t.Error("sports_premierleague missing from the served catalog")
 	}
 
 	// Order must survive JSON encoding — the client renders in array order.

--- a/api/internal/widgets/main_test.go
+++ b/api/internal/widgets/main_test.go
@@ -1,0 +1,14 @@
+package widgets
+
+import (
+	"os"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// TestMain switches this package into integration mode when
+// TEST_DATABASE_URL is set. See testsupport.Main for what that entails.
+func TestMain(m *testing.M) {
+	os.Exit(testsupport.Main(m))
+}

--- a/api/migrations/000009_catalog_requests.down.sql
+++ b/api/migrations/000009_catalog_requests.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE catalog_requests;

--- a/api/migrations/000009_catalog_requests.up.sql
+++ b/api/migrations/000009_catalog_requests.up.sql
@@ -1,0 +1,22 @@
+-- Catalog requests — what people searched for and did not find.
+--
+-- The catalog's zero-match state offers a one-click "request it" card
+-- (design_handoff_catalog, "Behavior rules"). Each click lands here, keyed
+-- on the user and the normalised query (lower-cased, trimmed) so one person
+-- counts once however many times they ask; the count across users is what
+-- the card shows back and what the roadmap reads.
+--
+-- There is no admin endpoint yet: `SELECT query, count(*) FROM
+-- catalog_requests GROUP BY 1 ORDER BY 2 DESC` is the roadmap for now. The
+-- row keeps the user and created_at so "notify me when it ships" can be
+-- built on it later without a second table.
+
+CREATE TABLE catalog_requests (
+    logto_sub  text NOT NULL,
+    query      text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (logto_sub, query)
+);
+
+-- The read path is "how many people asked for this query".
+CREATE INDEX catalog_requests_query_idx ON catalog_requests (query);

--- a/desktop/src/catalog.snapshot.json
+++ b/desktop/src/catalog.snapshot.json
@@ -1,5 +1,5 @@
 {
-    "version": "6e70d60047f305a3",
+    "version": "c703724dd8854d88",
     "widgets": [
         {
             "id": "finance_stocks",
@@ -19,7 +19,17 @@
                 "Quotes stream in real time during market hours.",
                 "Pin it to keep your watchlist always visible."
             ],
-            "order": 0
+            "order": 0,
+            "group": "Markets",
+            "keywords": [
+                "shares",
+                "etf",
+                "s\u0026p",
+                "nasdaq",
+                "dow",
+                "tickers"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "finance_crypto",
@@ -39,7 +49,17 @@
                 "Prices stream 24/7 — crypto never closes.",
                 "Pin it so every big move catches your eye."
             ],
-            "order": 1
+            "order": 1,
+            "group": "Markets",
+            "keywords": [
+                "bitcoin",
+                "btc",
+                "eth",
+                "ethereum",
+                "solana",
+                "coins"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "sports_nfl",
@@ -61,7 +81,12 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 2
+            "order": 2,
+            "group": "Football",
+            "keywords": [
+                "football"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "sports_nba",
@@ -83,7 +108,12 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 3
+            "order": 3,
+            "group": "Basketball",
+            "keywords": [
+                "basketball"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "sports_nhl",
@@ -105,7 +135,12 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 4
+            "order": 4,
+            "group": "Hockey",
+            "keywords": [
+                "hockey"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "sports_mlb",
@@ -127,7 +162,12 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 5
+            "order": 5,
+            "group": "Baseball",
+            "keywords": [
+                "baseball"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "sports_f1",
@@ -149,7 +189,14 @@
                 "See the podium the second the race ends.",
                 "Pin it during a Grand Prix to follow every session."
             ],
-            "order": 6
+            "order": 6,
+            "group": "Motorsport",
+            "keywords": [
+                "formula 1",
+                "formula one",
+                "grand prix"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "sports_worldcup",
@@ -171,7 +218,14 @@
                 "Every fixture on the calendar, updated automatically.",
                 "Pin it during the tournament so you never miss a goal."
             ],
-            "order": 7
+            "order": 7,
+            "group": "Soccer",
+            "keywords": [
+                "fifa",
+                "soccer",
+                "football"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "sports_ncaaf",
@@ -193,7 +247,13 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 8
+            "order": 8,
+            "group": "Football",
+            "keywords": [
+                "college football",
+                "cfb"
+            ],
+            "added_at": "2026-07-21"
         },
         {
             "id": "sports_ncaab",
@@ -215,7 +275,13 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 9
+            "order": 9,
+            "group": "Basketball",
+            "keywords": [
+                "college basketball",
+                "march madness"
+            ],
+            "added_at": "2026-07-21"
         },
         {
             "id": "sports_premierleague",
@@ -237,7 +303,15 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 10
+            "order": 10,
+            "group": "Soccer",
+            "keywords": [
+                "epl",
+                "english",
+                "soccer",
+                "football"
+            ],
+            "added_at": "2026-07-21"
         },
         {
             "id": "sports_laliga",
@@ -259,7 +333,13 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 11
+            "order": 11,
+            "group": "Soccer",
+            "keywords": [
+                "spanish",
+                "soccer"
+            ],
+            "added_at": "2026-07-21"
         },
         {
             "id": "sports_mls",
@@ -281,7 +361,13 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 12
+            "order": 12,
+            "group": "Soccer",
+            "keywords": [
+                "american",
+                "soccer"
+            ],
+            "added_at": "2026-07-21"
         },
         {
             "id": "sports_championsleague",
@@ -303,7 +389,14 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 13
+            "order": 13,
+            "group": "Soccer",
+            "keywords": [
+                "ucl",
+                "uefa",
+                "europe"
+            ],
+            "added_at": "2026-07-21"
         },
         {
             "id": "sports_ufc",
@@ -326,7 +419,13 @@
                 "Follow the main card and prelims in one place.",
                 "Pin it during an event to catch every finish."
             ],
-            "order": 14
+            "order": 14,
+            "group": "Combat",
+            "keywords": [
+                "mma",
+                "fights"
+            ],
+            "added_at": "2026-07-21"
         },
         {
             "id": "sports_afl",
@@ -348,7 +447,13 @@
                 "Set a favorite team from the top bar to keep it front and center.",
                 "Pin it on game days so scores stay on screen."
             ],
-            "order": 15
+            "order": 15,
+            "group": "Football",
+            "keywords": [
+                "aussie rules",
+                "australian football"
+            ],
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_bbc",
@@ -373,7 +478,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 16
+            "order": 16,
+            "group": "World",
+            "added_at": "2026-07-02"
         },
         {
             "id": "news_npr",
@@ -398,7 +505,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 17
+            "order": 17,
+            "group": "World",
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_guardian",
@@ -423,7 +532,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 18
+            "order": 18,
+            "group": "World",
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_aljazeera",
@@ -448,7 +559,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 19
+            "order": 19,
+            "group": "World",
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_propublica",
@@ -473,7 +586,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 20
+            "order": 20,
+            "group": "World",
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_bloomberg",
@@ -498,7 +613,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 21
+            "order": 21,
+            "group": "Business",
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_cnbc",
@@ -523,7 +640,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 22
+            "order": 22,
+            "group": "Business",
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_nasa",
@@ -548,7 +667,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 23
+            "order": 23,
+            "group": "Tech \u0026 Science",
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_hackernews",
@@ -573,7 +694,15 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 24
+            "order": 24,
+            "group": "Tech \u0026 Science",
+            "keywords": [
+                "hn",
+                "ycombinator",
+                "tech",
+                "startups"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "news_theverge",
@@ -598,7 +727,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 25
+            "order": 25,
+            "group": "Tech \u0026 Science",
+            "added_at": "2026-07-21"
         },
         {
             "id": "news_drudge",
@@ -624,7 +755,9 @@
                 "Open any headline from the feed to read the full story.",
                 "Pin it to keep the latest news in view."
             ],
-            "order": 26
+            "order": 26,
+            "group": "World",
+            "added_at": "2026-09-05"
         },
         {
             "id": "rss_custom",
@@ -644,7 +777,8 @@
                 "Perfect for niche blogs, newsletters, or subreddits with a feed."
             ],
             "order": 27,
-            "hidden": true
+            "hidden": true,
+            "added_at": "2026-07-02"
         },
         {
             "id": "fantasy_yahoo",
@@ -661,7 +795,13 @@
                 "Leagues, matchups, and standings sync automatically.",
                 "Live scoring updates while your players are on the field."
             ],
-            "order": 28
+            "order": 28,
+            "group": "Fantasy",
+            "keywords": [
+                "fantasy football",
+                "league"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "predictions",
@@ -678,7 +818,14 @@
                 "Follow the events and questions you care about.",
                 "Display-only — Scrollr shows the market, it never places a trade."
             ],
-            "order": 29
+            "order": 29,
+            "group": "Predictions",
+            "keywords": [
+                "odds",
+                "prediction market",
+                "bets"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "clock",
@@ -687,7 +834,14 @@
             "category": "utility",
             "color": "#6366f1",
             "required_tier": "free",
-            "order": 30
+            "order": 30,
+            "group": "Desk",
+            "keywords": [
+                "time",
+                "timezone",
+                "world clock"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "timer",
@@ -696,7 +850,14 @@
             "category": "utility",
             "color": "#f59e0b",
             "required_tier": "free",
-            "order": 31
+            "order": 31,
+            "group": "Desk",
+            "keywords": [
+                "pomodoro",
+                "stopwatch",
+                "countdown"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "weather",
@@ -705,7 +866,14 @@
             "category": "utility",
             "color": "#0ea5e9",
             "required_tier": "free",
-            "order": 32
+            "order": 32,
+            "group": "Desk",
+            "keywords": [
+                "forecast",
+                "temperature",
+                "rain"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "sysmon",
@@ -714,7 +882,15 @@
             "category": "utility",
             "color": "#06b6d4",
             "required_tier": "free",
-            "order": 33
+            "order": 33,
+            "group": "Dev",
+            "keywords": [
+                "cpu",
+                "gpu",
+                "ram",
+                "memory"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "uptime",
@@ -724,7 +900,14 @@
             "color": "#10b981",
             "logo_url": "https://icon.horse/icon/uptime.kuma.pet",
             "required_tier": "free",
-            "order": 34
+            "order": 34,
+            "group": "Dev",
+            "keywords": [
+                "kuma",
+                "status",
+                "monitor"
+            ],
+            "added_at": "2026-07-02"
         },
         {
             "id": "github",
@@ -734,7 +917,14 @@
             "color": "#f97316",
             "logo_url": "https://icon.horse/icon/github.com",
             "required_tier": "free",
-            "order": 35
+            "order": 35,
+            "group": "Dev",
+            "keywords": [
+                "actions",
+                "ci",
+                "pull requests"
+            ],
+            "added_at": "2026-07-02"
         }
     ]
 }

--- a/desktop/src/types/api.generated.ts
+++ b/desktop/src/types/api.generated.ts
@@ -14,6 +14,11 @@
 //
 // A test fails the build if this file is stale.
 
+export interface CatalogRequestResponse {
+  query: string;
+  count: number;
+}
+
 export interface CatalogResponse {
   version: string;
   widgets: WidgetDef[];
@@ -189,6 +194,9 @@ export interface WidgetDef {
   usage?: string[];
   order: number;
   hidden?: boolean;
+  group?: string;
+  keywords?: string[];
+  added_at?: string;
 }
 
 export interface WidgetLimits {

--- a/myscrollr.com/src/types/api.generated.ts
+++ b/myscrollr.com/src/types/api.generated.ts
@@ -14,6 +14,11 @@
 //
 // A test fails the build if this file is stale.
 
+export interface CatalogRequestResponse {
+  query: string;
+  count: number;
+}
+
 export interface CatalogResponse {
   version: string;
   widgets: WidgetDef[];
@@ -189,6 +194,9 @@ export interface WidgetDef {
   usage?: string[];
   order: number;
   hidden?: boolean;
+  group?: string;
+  keywords?: string[];
+  added_at?: string;
 }
 
 export interface WidgetLimits {


### PR DESCRIPTION
## Summary

Server half of the catalog redesign (design_handoff_catalog/, the "Catalog schema additions" card). The desktop page is REL-215.

- **`WidgetDef.Group`** — sub-shelf inside a category (Football, Soccer, Business, Dev…), per the handoff's `catalog-data.js`. Optional; missing lists ungrouped.
- **`WidgetDef.Keywords`** — search aliases from the prototype's `aliases` map plus the obvious sport per league. Never shown; part of the match haystack.
- **`WidgetDef.AddedAt`** — `YYYY-MM-DD` the entry shipped, taken from the desktop tag that carried it (v1.1.0 = 2026-07-02 for the launch set, v1.1.10 = 2026-07-21 for the sports/news expansion, v1.5.2 = 2026-09-05 for Drudge). Widgets older than the catalog itself carry the catalog's launch date; documented on the field.
- **`POST /catalog/requests { query }`** — authenticated. Upserts into the new `catalog_requests` table keyed on `(logto_sub, normalised query)` so one user counts once; returns `{ query, count }` with the count across users. Added to the GDPR purge cascade.
- **Migration `000009_catalog_requests`** — additive only (CREATE TABLE + index).
- Generated TS types (desktop + site) and the desktop catalog snapshot regenerated.

### Not in this PR (by design)
- **No admin list endpoint.** The roadmap read is `SELECT query, count(*) FROM catalog_requests GROUP BY 1 ORDER BY 2 DESC` for now.
- **"Notify when shipped"** is deferred; the row keeps `logto_sub` + `query` + `created_at` so it can be built without a second table.

## Verification
- `go vet ./...` and `go test ./...` green in Docker with `TEST_DATABASE_URL` pointing at the dev-stack Postgres (the requests test runs for real: user A ×3 spellings → 1, user B → 2, user A again → 2).
- Booted this branch's core beside the dev stack on the compose network: migrations applied, `GET /catalog` serves `group` / `keywords` / `added_at` (e.g. Premier League → `Soccer`, `["epl","english","soccer","football"]`, `2026-07-21`), version matches the regenerated snapshot, `POST /catalog/requests` without a token → 401.
- Could not exercise the authenticated POST against the dev stack: there is no local Logto and the desktop app (the only token source on this box) is owned by another session. The cross-user semantics are covered by the DB-backed Go test instead.
- `go run ./cmd/gents -check` clean.

Merging deploys core to production via the deploy workflow; the smoke test guards it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
