### PR TITLE
feat(desktop): settings copy and consistency sweep [REL-207]

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -193,7 +193,7 @@ pub fn run() {
             commands::window::quit_app,
             commands::system_info::get_system_info,
             commands::diagnostics::collect_diagnostics,
-            tray::sync_tray_pin,
+            tray::sync_tray_ticker,
             set_crash_reports,
         ])
         .on_window_event(|window, event| {

--- a/desktop/src-tauri/src/tray.rs
+++ b/desktop/src-tauri/src/tray.rs
@@ -6,18 +6,19 @@ use tauri::{
     Emitter, Manager, Wry,
 };
 
-/// State slot for the "Pin on Top" tray menu item. The frontend owns
-/// `prefs.window.pinned` as the source of truth, so this holds a handle
-/// we can update via `sync_tray_pin` whenever the frontend state flips.
-pub struct PinTrayItem(pub Mutex<Option<CheckMenuItem<Wry>>>);
+/// State slot for the "Show ticker" tray item. The frontend owns
+/// `prefs.ticker.showTicker` as the source of truth, so this holds a
+/// handle it updates via `sync_tray_ticker` whenever the pref flips.
+pub struct ShowTickerItem(pub Mutex<Option<CheckMenuItem<Wry>>>);
 
 /// Build the system tray with menu items and event handlers.
 pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let open = MenuItemBuilder::with_id("open", "Open Scrollr").build(app)?;
     let sep1 = PredefinedMenuItem::separator(app)?;
-    let toggle_ticker = MenuItemBuilder::with_id("toggle_ticker", "Toggle Ticker").build(app)?;
-    let pin_on_top = CheckMenuItemBuilder::with_id("pin_on_top", "Always on Top")
-        .checked(false)
+    // Same words as the settings row and the ticker's right-click menu.
+    // Built checked (the pref's default); JS settles it at launch.
+    let show_ticker = CheckMenuItemBuilder::with_id("show_ticker", "Show ticker")
+        .checked(true)
         .build(app)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
     let report_bug = MenuItemBuilder::with_id("report_bug", "Report a Bug").build(app)?;
@@ -27,8 +28,7 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .items(&[
             &open,
             &sep1,
-            &toggle_ticker,
-            &pin_on_top,
+            &show_ticker,
             &sep2,
             &report_bug,
             &sep3,
@@ -36,9 +36,9 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         ])
         .build()?;
 
-    // Park the CheckMenuItem in app state so the `sync_tray_pin` command
-    // can update its checkmark when the frontend flips prefs.window.pinned.
-    app.manage(PinTrayItem(Mutex::new(Some(pin_on_top.clone()))));
+    // Park the CheckMenuItem in app state so `sync_tray_ticker` can settle
+    // its checkmark when the frontend flips prefs.ticker.showTicker.
+    app.manage(ShowTickerItem(Mutex::new(Some(show_ticker.clone()))));
 
     // Monochrome icon for the system tray. On macOS, icon_as_template(true)
     // tells the OS to tint it white/black to match the menu bar appearance.
@@ -57,17 +57,12 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     let _ = w.set_focus();
                 }
             }
-            "toggle_ticker" => {
+            "show_ticker" => {
                 // JS owns prefs.ticker.showTicker — emit and let it toggle.
+                // Don't mutate the CheckMenuItem here: the OS already
+                // flipped it visually and JS's `sync_tray_ticker` echo is
+                // authoritative.
                 let _ = app.emit("toggle-ticker", ());
-            }
-            "pin_on_top" => {
-                // Same pattern as toggle_ticker. The frontend listener
-                // flips prefs.window.pinned, invokes pin_window, then calls
-                // sync_tray_pin to settle our checkmark. Don't mutate the
-                // CheckMenuItem here — the OS already toggled it visually
-                // and JS's echo is authoritative.
-                let _ = app.emit("toggle-pin", ());
             }
             "report_bug" => {
                 if let Some(main) = app.get_webview_window("main") {
@@ -100,14 +95,14 @@ pub fn setup(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Update the "Pin on Top" tray checkmark to match the given state.
-/// Called from JS whenever `prefs.window.pinned` changes, so the tray
-/// menu and the right-click menu stay visually consistent.
+/// Update the "Show ticker" tray checkmark to match the given state.
+/// Called from JS whenever `prefs.ticker.showTicker` changes, so the
+/// tray, the right-click menu and the settings row all agree.
 #[tauri::command]
-pub fn sync_tray_pin(state: tauri::State<'_, PinTrayItem>, pinned: bool) {
+pub fn sync_tray_ticker(state: tauri::State<'_, ShowTickerItem>, shown: bool) {
     if let Ok(slot) = state.0.lock() {
         if let Some(item) = slot.as_ref() {
-            let _ = item.set_checked(pinned);
+            let _ = item.set_checked(shown);
         }
     }
 }

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -167,14 +167,6 @@ export default function App() {
   const widgetsRef = useRef(widgets);
   widgetsRef.current = widgets;
 
-  // Pin (always-on-top) state
-  const [pinned, setPinned] = useState(() => loadPref("feedPinned", true));
-
-  // Ticker position state (top/bottom of screen)
-  const [tickerPosition, setTickerPosition] = useState<TickerPosition>(() =>
-    loadPref("tickerPosition", "top"),
-  );
-
   // The ticker window has no hover chrome. Every action lives in the
   // right-click menu and the system tray; the hover toolbar that used to
   // sit on the right edge was the thing users found rather than the menu,
@@ -315,11 +307,7 @@ export default function App() {
 
       // Side effects: pin toggle
       if (next.window.pinned !== prev.window.pinned) {
-        setPinned(next.window.pinned);
-        savePref("feedPinned", next.window.pinned);
         invoke("pin_window", { pinned: next.window.pinned }).catch(() => {});
-        // Keep the tray's "Pin on Top" checkmark in sync with the pref.
-        invoke("sync_tray_pin", { pinned: next.window.pinned }).catch(() => {});
       }
 
       // Side effects: hide-on-fullscreen toggle (Windows AppBar)
@@ -331,8 +319,6 @@ export default function App() {
 
       // Side effects: ticker position
       if (next.window.tickerPosition !== prev.window.tickerPosition) {
-        setTickerPosition(next.window.tickerPosition);
-        savePref("tickerPosition", next.window.tickerPosition);
         invoke("position_ticker", { position: next.window.tickerPosition, height: tickerHeight(next) }).catch(() => {});
       }
 
@@ -363,15 +349,14 @@ export default function App() {
     const tickerH = prefs.ticker.showTicker ? tickerHeight(prefs) : 0;
     if (tickerH > 0) {
       // position_ticker sets size + position atomically via compositor
-      invoke("position_ticker", { position: tickerPosition, height: tickerH })
+      invoke("position_ticker", {
+        position: prefs.window.tickerPosition,
+        height: tickerH,
+      })
         .then(() => getCurrentWindow().show())
         .catch(() => {});
     }
-    invoke("pin_window", { pinned }).catch(() => {});
-    // Initial state sync for the system-tray "Pin on Top" checkmark.
-    // The tray is built with checked=false by default; mirror the stored
-    // pref so the checkmark is accurate on app launch.
-    invoke("sync_tray_pin", { pinned }).catch(() => {});
+    invoke("pin_window", { pinned: prefs.window.pinned }).catch(() => {});
     // Initial sync for the Windows AppBar hide-on-fullscreen behavior.
     invoke("set_hide_on_fullscreen", {
       value: prefs.window.hideOnFullscreen,
@@ -388,14 +373,28 @@ export default function App() {
   useEffect(() => {
     const tickerH = prefs.ticker.showTicker ? tickerHeight(prefs) : 0;
     if (tickerH > 0) {
-      invoke("position_ticker", { position: tickerPosition, height: tickerH }).catch(() => {});
+      invoke("position_ticker", {
+        position: prefs.window.tickerPosition,
+        height: tickerH,
+      }).catch(() => {});
     }
   }, [
     prefs.ticker.tickerMode,
     prefs.appearance.tickerScale,
     prefs.ticker.showTicker,
-    tickerPosition,
+    prefs.window.tickerPosition,
   ]);
+
+  // The tray's "Show ticker" checkmark mirrors the pref. Every window
+  // that flips it (Ctrl+T in the main window, the settings row, the
+  // tray, the right-click menu) ends up here through the store, so
+  // this is the one place the tray is told — including at launch,
+  // where the tray is built checked and the pref may say otherwise.
+  useEffect(() => {
+    invoke("sync_tray_ticker", { shown: prefs.ticker.showTicker }).catch(
+      () => {},
+    );
+  }, [prefs.ticker.showTicker]);
 
   // ── Show/hide ticker window based on visibility ────────────────
   //
@@ -521,9 +520,8 @@ export default function App() {
   // ── Ticker position toggle ─────────────────────────────────────
 
   const handleTogglePosition = useCallback(() => {
-    const next: TickerPosition = tickerPosition === "top" ? "bottom" : "top";
-    setTickerPosition(next);
-    savePref("tickerPosition", next);
+    const next: TickerPosition =
+      prefsRef.current.window.tickerPosition === "top" ? "bottom" : "top";
     const updated = {
       ...prefsRef.current,
       window: { ...prefsRef.current.window, tickerPosition: next },
@@ -531,7 +529,7 @@ export default function App() {
     setPrefs(updated);
     savePrefs(updated);
     invoke("position_ticker", { position: next, height: tickerHeight(updated) }).catch(() => {});
-  }, [tickerPosition]);
+  }, []);
 
   // ── Toggle ticker visibility ─────────────────────────────────
 
@@ -545,7 +543,7 @@ export default function App() {
     savePrefs(updated);
   }, []);
 
-  // ── System tray "Show/Hide Ticker" → toggle via prefs ──────────
+  // ── System tray "Show ticker" → toggle via prefs ───────────────
   useTauriListener("toggle-ticker", () => handleToggleTicker());
 
   // ── Monitor set changed → re-place this window ──────────────────
@@ -561,8 +559,6 @@ export default function App() {
 
   const handleToggleWindowPin = useCallback(() => {
     const next = !prefsRef.current.window.pinned;
-    setPinned(next);
-    savePref("feedPinned", next);
     const updated = {
       ...prefsRef.current,
       window: { ...prefsRef.current.window, pinned: next },
@@ -570,14 +566,7 @@ export default function App() {
     setPrefs(updated);
     savePrefs(updated);
     invoke("pin_window", { pinned: next }).catch(() => {});
-    // Mirror the new state back into the system-tray "Pin on Top"
-    // CheckMenuItem so its checkmark stays in sync with the right-click
-    // menu. Harmless if the tray command is unavailable (e.g. dev mode).
-    invoke("sync_tray_pin", { pinned: next }).catch(() => {});
   }, []);
-
-  // ── System tray "Pin on Top" → same handler as the right-click menu ──
-  useTauriListener("toggle-pin", () => handleToggleWindowPin());
 
   // ── Right-click → native context menu ──────────────────────────
 
@@ -677,16 +666,12 @@ export default function App() {
         }),
       );
 
-      // Customize Ticker — opens main app to ticker settings
+      // Customize Ticker — the Ticker page of Settings, not the default
+      // (Appearance) page it used to land on.
       items.push(
         await MenuItem.new({
           text: "Customize Ticker",
-          action: () => {
-            invoke("show_app_window").catch(() => {});
-            // /ticker merged into /customize (its default tab); the
-            // redirect shim that used to cover this is gone.
-            setStore("scrollr:navigate", "/customize");
-          },
+          action: () => navigateMainWindow("/customize?page=ticker"),
         }),
       );
 
@@ -716,11 +701,13 @@ export default function App() {
 
       items.push(await PredefinedMenuItem.new({ item: "Separator" }));
 
-      // Hide Ticker — action verb, not a checkbox
+      // Same words and shape as the tray and the settings row: a checked
+      // "Show ticker". Unchecking it hides the bar; the tray brings it back.
       items.push(
-        await MenuItem.new({
-          text: "Hide Ticker",
-          action: () => handleToggleTicker(true),
+        await CheckMenuItem.new({
+          text: "Show ticker",
+          checked: prefsRef.current.ticker.showTicker,
+          action: () => handleToggleTicker(),
         }),
       );
 
@@ -739,7 +726,7 @@ export default function App() {
     }
     document.addEventListener("contextmenu", onContextMenu);
     return () => document.removeEventListener("contextmenu", onContextMenu);
-  }, [toggleOnTicker, handleTogglePosition]);
+  }, [toggleOnTicker, handleTogglePosition, navigateMainWindow]);
 
   // ── Merge widget + widget tabs ──────────────────────────────
   const activeTabs = useMemo(
@@ -792,7 +779,7 @@ export default function App() {
                 mixMode={prefs.ticker.mixMode}
                 chipColorMode={prefs.ticker.chipColors}
                 widgetDisplay={prefs.widgetDisplay}
-                comfort={prefs.ticker.tickerMode === "comfort"}
+                comfort={prefs.ticker.tickerMode === "detailed"}
                 scrollMode={prefs.ticker.scrollMode}
                 stepPause={prefs.ticker.stepPause}
                 showSourcelessCTA={showSourcelessCTA}

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -380,7 +380,7 @@ export default function ScrollrTicker({
     // Combine based on mix mode. Row filtering is handled upstream now,
     // so no round-robin distribution here.
     const allItems: React.ReactNode[] =
-      effectiveMixMode === "weave" ? weave(buckets) : buckets.flat();
+      effectiveMixMode === "mixed" ? weave(buckets) : buckets.flat();
 
     return allItems;
   }, [
@@ -456,7 +456,7 @@ export default function ScrollrTicker({
   // Reset step offset when entering step mode or when direction changes,
   // so the ticker doesn't start from a stale accumulated position.
   useEffect(() => {
-    if (effectiveScrollMode === "step") {
+    if (effectiveScrollMode === "page") {
       offset.set(0);
       stepCountRef.current = 0;
     }
@@ -464,7 +464,7 @@ export default function ScrollrTicker({
 
   // Step loop: animate offset by one item width, pause, repeat
   useEffect(() => {
-    if (effectiveScrollMode !== "step" || chips.length === 0) return;
+    if (effectiveScrollMode !== "page" || chips.length === 0) return;
 
     stepLoopRef.current = true;
     let cancelled = false;
@@ -700,7 +700,7 @@ export default function ScrollrTicker({
   // ── Continuous / Step mode: motion-plus Ticker ────────────────
   const velocity =
     effectiveDirection === "left" ? effectiveSpeed : -effectiveSpeed;
-  const isStepMode = effectiveScrollMode === "step";
+  const isStepMode = effectiveScrollMode === "page";
 
   return (
     <div

--- a/desktop/src/components/chips/GameChip.test.tsx
+++ b/desktop/src/components/chips/GameChip.test.tsx
@@ -135,7 +135,7 @@ describe("GameChip", () => {
     expect(btn.style.getPropertyValue("--accent")).toBe("#e10600");
     expect(btn.className).toContain("var(--accent)");
     // The other two colour modes are shared palettes and ignore the brand.
-    rerender(<GameChip game={game()} accent="#e10600" colorMode="muted" />);
+    rerender(<GameChip game={game()} accent="#e10600" colorMode="subtle" />);
     expect((container.querySelector("button") as HTMLButtonElement).style.getPropertyValue("--accent")).toBe("");
   });
 
@@ -148,7 +148,7 @@ describe("GameChip", () => {
     expect(btn.className).not.toContain("border-live/70");
     expect(btn.className).not.toContain("bg-live/[0.13]");
     // Unbranded modes have no colour of their own, so red still says close.
-    const { container: muted } = render(<GameChip game={tight} colorMode="muted" />);
+    const { container: muted } = render(<GameChip game={tight} colorMode="subtle" />);
     expect((muted.querySelector("button") as HTMLButtonElement).className).toContain("border-live/70");
   });
 

--- a/desktop/src/components/chips/GameChip.tsx
+++ b/desktop/src/components/chips/GameChip.tsx
@@ -32,7 +32,7 @@ interface GameChipProps {
   colorMode?: ChipColorMode;
   /**
    * The league widget's catalog brand colour (#rrggbb). Used only in the
-   * "widget" colour mode; "accent" and "muted" keep their shared palettes.
+   * "widget" colour mode; "theme" and "subtle" keep their shared palettes.
    * Absent (no catalog yet, or a coarse legacy row) falls back to the
    * sports palette.
    */

--- a/desktop/src/components/chips/RssChip.test.tsx
+++ b/desktop/src/components/chips/RssChip.test.tsx
@@ -89,7 +89,7 @@ describe("RssChip", () => {
     const { container, rerender } = render(<RssChip item={item()} accent="#052962" />);
     const btn = () => container.querySelector("button") as HTMLButtonElement;
     expect(btn().style.getPropertyValue("--accent")).not.toBe("");
-    rerender(<RssChip item={item()} accent="#052962" colorMode="muted" />);
+    rerender(<RssChip item={item()} accent="#052962" colorMode="subtle" />);
     expect(btn().style.getPropertyValue("--accent")).toBe("");
   });
 });

--- a/desktop/src/components/chips/chipColors.ts
+++ b/desktop/src/components/chips/chipColors.ts
@@ -192,8 +192,8 @@ const WIDGET_MAP: Record<string, ChipColors> = {
 // ── Resolver ────────────────────────────────────────────────────
 
 export function getChipColors(mode: ChipColorMode, widget: string): ChipColors {
-  if (mode === "accent") return PRIMARY;
-  if (mode === "muted") return MUTED;
+  if (mode === "theme") return PRIMARY;
+  if (mode === "subtle") return MUTED;
   return WIDGET_MAP[widget] ?? PURPLE;
 }
 

--- a/desktop/src/components/settings/SettingsSurface.tsx
+++ b/desktop/src/components/settings/SettingsSurface.tsx
@@ -66,7 +66,10 @@ export default function SettingsSurface({
   const resetTicker = useTickerReset();
 
   const searching = query.trim().length > 0;
-  const results = useMemo(() => searchSettings(query), [query]);
+  const results = useMemo(
+    () => searchSettings(query, shell.authenticated),
+    [query, shell.authenticated],
+  );
   const meta = SETTINGS_PAGE_META[page] ?? SETTINGS_PAGE_META[DEFAULT_SETTINGS_PAGE];
 
   const goTo = useCallback(

--- a/desktop/src/components/settings/pages/AppearancePage.tsx
+++ b/desktop/src/components/settings/pages/AppearancePage.tsx
@@ -29,6 +29,9 @@ import {
   ToggleRow,
 } from "../SettingsControls";
 import { Row } from "./Row";
+import { SETTINGS_ROWS } from "../rows";
+
+const R = SETTINGS_ROWS.appearance;
 
 const THEME_MODE_OPTIONS: { value: ThemeMode; label: string }[] = [
   { value: "light", label: "Light" },
@@ -82,13 +85,15 @@ export default function AppearancePage({
         <RowList>
           <Row id="theme">
             <div className="px-4 py-3">
-              <div className="text-ui-body font-medium text-fg">Theme</div>
+              <div className="text-ui-body font-medium text-fg">
+                {R.theme.label}
+              </div>
               <div className="mt-0.5 text-ui-meta text-fg-3">
-                Pick a color palette
+                {R.theme.description}
               </div>
               <div
                 role="radiogroup"
-                aria-label="Theme"
+                aria-label={R.theme.label}
                 className="mt-3 grid grid-cols-5 gap-2"
               >
                 {THEME_FAMILIES.map((family) => {
@@ -136,8 +141,8 @@ export default function AppearancePage({
           </Row>
           <Row id="colorMode">
             <SegmentedRow
-              label="Color mode"
-              description="Light, dark, or follow the system"
+              label={R.colorMode.label}
+              description={R.colorMode.description}
               value={appearance.themeMode}
               options={THEME_MODE_OPTIONS}
               onChange={(v) => set("themeMode", v)}
@@ -145,8 +150,8 @@ export default function AppearancePage({
           </Row>
           <Row id="appSize">
             <SegmentedRow
-              label="App size"
-              description="Resize the main app window. The ticker has its own scale."
+              label={R.appSize.label}
+              description={R.appSize.description}
               value={String(appearance.uiScale)}
               options={APP_SCALE_OPTIONS}
               onChange={(v) => set("uiScale", Number(v))}
@@ -159,8 +164,8 @@ export default function AppearancePage({
         <RowList>
           <Row id="fontWeight">
             <SegmentedRow
-              label="Font weight"
-              description="Increase text thickness for readability"
+              label={R.fontWeight.label}
+              description={R.fontWeight.description}
               value={appearance.fontWeight}
               options={FONT_WEIGHT_OPTIONS}
               onChange={(v) =>
@@ -170,8 +175,8 @@ export default function AppearancePage({
           </Row>
           <Row id="highContrast">
             <ToggleRow
-              label="High contrast text"
-              description="Brighten muted text for easier reading"
+              label={R.highContrast.label}
+              description={R.highContrast.description}
               checked={appearance.highContrast}
               onChange={(v) => set("highContrast", v)}
             />
@@ -183,8 +188,8 @@ export default function AppearancePage({
         <RowList>
           <Row id="temperature">
             <SegmentedRow
-              label="Temperature"
-              description="Used by Weather and System monitor"
+              label={R.temperature.label}
+              description={R.temperature.description}
               value={appearance.units.temperature}
               options={TEMPERATURE_OPTIONS}
               onChange={(v) => setUnit("temperature", v)}
@@ -192,8 +197,8 @@ export default function AppearancePage({
           </Row>
           <Row id="timeFormat">
             <SegmentedRow
-              label="Time"
-              description="Used by Clock and the ticker"
+              label={R.timeFormat.label}
+              description={R.timeFormat.description}
               value={appearance.units.timeFormat}
               options={TIME_FORMAT_OPTIONS}
               onChange={(v) => setUnit("timeFormat", v)}

--- a/desktop/src/components/settings/pages/DataPrivacyPage.tsx
+++ b/desktop/src/components/settings/pages/DataPrivacyPage.tsx
@@ -12,6 +12,9 @@ import { exportUserData } from "../../../api/client";
 import { ActionRow, RowList, SettingsGroup, ToggleRow } from "../SettingsControls";
 import ConfirmDialog from "../../ConfirmDialog";
 import { Row } from "./Row";
+import { SETTINGS_ROWS } from "../rows";
+
+const R = SETTINGS_ROWS.data;
 import type { PrivacyPrefs } from "../../../preferences";
 
 interface DataPrivacyPageProps {
@@ -59,8 +62,8 @@ export default function DataPrivacyPage({
           <RowList>
             <Row id="export">
               <ActionRow
-                label="Export your data"
-                description="Download your sources, preferences, and account metadata as JSON."
+                label={R.export.label}
+                description={R.export.description}
                 action={exportState === "loading" ? "Exporting…" : "Export"}
                 tone="accent"
                 muted={exportState === "loading"}
@@ -75,8 +78,8 @@ export default function DataPrivacyPage({
         <RowList>
           <Row id="crashReports">
             <ToggleRow
-              label="Send crash reports"
-              description="When something breaks, send the error, stack trace, app version and OS to Sentry. Never your account, IP address or file paths."
+              label={R.crashReports.label}
+              description={R.crashReports.description}
               checked={privacy.sendCrashReports}
               onChange={(v) =>
                 onPrivacyChange({ ...privacy, sendCrashReports: v })
@@ -90,8 +93,8 @@ export default function DataPrivacyPage({
         <RowList>
           <Row id="resetAll">
             <ActionRow
-              label="Reset all settings"
-              description="Clear every local preference. Your account, billing, and server data are untouched."
+              label={R.resetAll.label}
+              description={R.resetAll.description}
               action="Reset…"
               tone="error"
               onClick={() => setConfirmResetAll(true)}
@@ -103,7 +106,7 @@ export default function DataPrivacyPage({
       <ConfirmDialog
         open={confirmResetAll}
         title="Reset all settings?"
-        description="This will set everything back to the original settings. Your account and saved content won't change."
+        description="Every setting goes back to its default, Launch at login is turned off, and your local widgets are removed. Your account and saved content won't change."
         confirmLabel="Reset everything"
         destructive
         onConfirm={() => {

--- a/desktop/src/components/settings/pages/ProfilePlanPage.tsx
+++ b/desktop/src/components/settings/pages/ProfilePlanPage.tsx
@@ -37,6 +37,9 @@ import {
 import ProfileField from "../ProfileField";
 import ConfirmDialog from "../../ConfirmDialog";
 import { Row } from "./Row";
+import { SETTINGS_ROWS } from "../rows";
+
+const R = SETTINGS_ROWS.profile;
 
 // ── Status helpers (unchanged semantics) ────────────────────────
 
@@ -93,6 +96,8 @@ export default function ProfilePlanPage({
     "idle",
   );
   const [confirmSignOut, setConfirmSignOut] = useState(false);
+  // The email is the account's identity, so the inline edit asks first.
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const slots = useSlotUsage();
@@ -215,10 +220,10 @@ export default function ProfilePlanPage({
     return (
       <SettingsGroup>
         <RowList>
-          <Row id="signedIn">
+          <Row id="signIn">
             <ActionRow
-              label="Sign in to Scrollr"
-              description="Signing in syncs your subscription, profile, and source preferences across devices and unlocks billing management."
+              label={R.signIn.label}
+              description={R.signIn.description}
               action="Sign in"
               tone="accent"
               onClick={onLogin}
@@ -237,8 +242,11 @@ export default function ProfilePlanPage({
   return (
     <>
       {/* ── Identity card ──────────────────────────────────── */}
+      {/* Two search targets, one card: "Signed in as" and "Plan" both
+          land here (flashRow matches data-row tokens). The plan anchor
+          used to sit on the 20px badge, so "plan" focused a chip. */}
       <div
-        data-row="signedIn"
+        data-row="signedIn plan"
         className={`${CARD_SURFACE} flex items-center gap-3.5 p-4`}
       >
         <span
@@ -261,7 +269,6 @@ export default function ProfilePlanPage({
           )}
         </div>
         <span
-          data-row="plan"
           className="shrink-0 rounded-full bg-accent/12 px-3 py-1 text-ui-chip font-bold tracking-wide text-accent uppercase"
         >
           {TIER_LABELS[displayTier]} · {slots.used} widget
@@ -274,7 +281,7 @@ export default function ProfilePlanPage({
         <RowList>
           <Row id="displayName">
             <ProfileField
-              label="Display name"
+              label={R.displayName.label}
               value={overview?.identity.name ?? ""}
               placeholder="Add a display name"
               onSave={(next) => handleProfileSave({ name: next }, "Display name")}
@@ -282,17 +289,17 @@ export default function ProfilePlanPage({
           </Row>
           <Row id="email">
             <ProfileField
-              label="Email"
+              label={R.email.label}
               type="email"
               value={overview?.identity.email ?? ""}
               placeholder="you@example.com"
-              onSave={(next) => handleProfileSave({ email: next }, "Email")}
+              onSave={async (next) => setPendingEmail(next)}
             />
           </Row>
           <Row id="password">
             <ActionRow
-              label="Password"
-              description="We'll email you a reset link."
+              label={R.password.label}
+              description={R.password.description}
               action={passwordResetLabel}
               muted={resetState !== "idle"}
               onClick={() => {
@@ -418,8 +425,8 @@ export default function ProfilePlanPage({
         <RowList>
           <Row id="signOut">
             <ActionRow
-              label="Sign out"
-              description="Sign out of this device. Local preferences stay intact."
+              label={R.signOut.label}
+              description={R.signOut.description}
               action="Sign out"
               tone="error"
               onClick={() => setConfirmSignOut(true)}
@@ -427,6 +434,25 @@ export default function ProfilePlanPage({
           </Row>
         </RowList>
       </SettingsGroup>
+
+      <ConfirmDialog
+        open={pendingEmail !== null}
+        title="Change your account email?"
+        description={`Sign-in and billing emails will go to ${pendingEmail ?? ""} from now on.`}
+        confirmLabel="Change email"
+        onConfirm={() => {
+          const next = pendingEmail;
+          setPendingEmail(null);
+          if (next) {
+            handleProfileSave({ email: next }, "Email").catch((err) =>
+              toast.error(
+                err instanceof Error ? err.message : "Failed to update email",
+              ),
+            );
+          }
+        }}
+        onCancel={() => setPendingEmail(null)}
+      />
 
       <ConfirmDialog
         open={confirmSignOut}

--- a/desktop/src/components/settings/pages/ShortcutsPage.tsx
+++ b/desktop/src/components/settings/pages/ShortcutsPage.tsx
@@ -11,8 +11,8 @@ import { Row } from "./Row";
 const SHORTCUTS: { keys: string[]; label: string }[] = [
   { keys: ["⌘/Ctrl", ","], label: "Open Settings" },
   { keys: ["⌘/Ctrl", "F"], label: "Search settings" },
-  { keys: ["⌘/Ctrl", "T"], label: "Toggle ticker visibility" },
-  { keys: ["⌘/Ctrl", "Shift", "T"], label: "Cycle theme (light → dark → auto)" },
+  { keys: ["⌘/Ctrl", "T"], label: "Show/hide the ticker" },
+  { keys: ["⌘/Ctrl", "Shift", "T"], label: "Cycle color mode (light → dark → auto)" },
   { keys: ["Esc"], label: "Back / close current view" },
 ];
 

--- a/desktop/src/components/settings/pages/StartupPage.tsx
+++ b/desktop/src/components/settings/pages/StartupPage.tsx
@@ -13,6 +13,9 @@
 import type { StartupPrefs } from "../../../preferences";
 import { RowList, SettingsGroup, ToggleRow } from "../SettingsControls";
 import { Row } from "./Row";
+import { SETTINGS_ROWS } from "../rows";
+
+const R = SETTINGS_ROWS.startup;
 
 interface StartupPageProps {
   startup: StartupPrefs;
@@ -32,16 +35,16 @@ export default function StartupPage({
       <RowList>
         <Row id="autostart">
           <ToggleRow
-            label="Launch at login"
-            description="Open Scrollr when you sign in to your computer"
+            label={R.autostart.label}
+            description={R.autostart.description}
             checked={autostartEnabled}
             onChange={onAutostartChange}
           />
         </Row>
         <Row id="startInBackground">
           <ToggleRow
-            label="Start in the background"
-            description="Show only the ticker. Open the Scrollr window from the tray when you want it."
+            label={R.startInBackground.label}
+            description={R.startInBackground.description}
             checked={startup.startInBackground}
             onChange={(v) =>
               onStartupChange({ ...startup, startInBackground: v })

--- a/desktop/src/components/settings/pages/TickerPage.tsx
+++ b/desktop/src/components/settings/pages/TickerPage.tsx
@@ -27,6 +27,7 @@ import type {
   HoverBehavior,
   MixMode,
   ScrollMode,
+  TickerMode,
   TickerPosition,
   TickerPrefs,
   WindowPrefs,
@@ -41,15 +42,18 @@ import {
   ToggleRow,
 } from "../SettingsControls";
 import { Row } from "./Row";
+import { SETTINGS_ROWS } from "../rows";
+
+const R = SETTINGS_ROWS.ticker;
 
 const POSITION_OPTIONS: { value: TickerPosition; label: string }[] = [
   { value: "top", label: "Top" },
   { value: "bottom", label: "Bottom" },
 ];
 
-const DETAIL_LEVEL_OPTIONS: { value: "compact" | "comfort"; label: string }[] = [
+const DETAIL_LEVEL_OPTIONS: { value: TickerMode; label: string }[] = [
   { value: "compact", label: "Compact" },
-  { value: "comfort", label: "Detailed" },
+  { value: "detailed", label: "Detailed" },
 ];
 
 const SIZE_OPTIONS = SCALE_PRESETS.map((v) => ({
@@ -59,13 +63,13 @@ const SIZE_OPTIONS = SCALE_PRESETS.map((v) => ({
 
 const CHIP_COLOR_OPTIONS: { value: ChipColorMode; label: string }[] = [
   { value: "widget", label: "Widget" },
-  { value: "accent", label: "Theme" },
-  { value: "muted", label: "Subtle" },
+  { value: "theme", label: "Theme" },
+  { value: "subtle", label: "Subtle" },
 ];
 
 const SCROLL_MODE_OPTIONS: { value: ScrollMode; label: string }[] = [
   { value: "continuous", label: "Continuous" },
-  { value: "step", label: "Page" },
+  { value: "page", label: "Page" },
 ];
 
 const SPEED_OPTIONS = [
@@ -87,7 +91,7 @@ const STEP_PAUSE_OPTIONS = STEP_PAUSES.map((v) => ({
 
 const MIX_OPTIONS: { value: MixMode; label: string }[] = [
   { value: "grouped", label: "By source" },
-  { value: "weave", label: "Mixed" },
+  { value: "mixed", label: "Mixed" },
 ];
 
 interface TickerPageProps {
@@ -97,7 +101,7 @@ interface TickerPageProps {
 
 export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
   const { ticker, window: window_ } = prefs;
-  const paged = ticker.scrollMode === "step";
+  const paged = ticker.scrollMode === "page";
 
   const setTicker = useCallback(
     <K extends keyof TickerPrefs>(key: K, value: TickerPrefs[K]) =>
@@ -116,8 +120,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
         <RowList>
           <Row id="showTicker">
             <ToggleRow
-              label="Show the ticker"
-              description="The bar on your screen. Ctrl+T, the tray and the ticker's right-click menu do the same."
+              label={R.showTicker.label}
+              description={R.showTicker.description}
               checked={ticker.showTicker}
               onChange={(v) => setTicker("showTicker", v)}
             />
@@ -133,8 +137,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
         <RowList>
           <Row id="screenEdge">
             <SegmentedRow
-              label="Screen edge"
-              description="Which edge of the screen the ticker sits on."
+              label={R.screenEdge.label}
+              description={R.screenEdge.description}
               value={window_.tickerPosition}
               options={POSITION_OPTIONS}
               onChange={(v) => setWindow("tickerPosition", v)}
@@ -147,8 +151,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
         <RowList>
           <Row id="detailLevel">
             <SegmentedRow
-              label="Detail level"
-              description="One line per chip, or a detail row under each."
+              label={R.detailLevel.label}
+              description={R.detailLevel.description}
               value={ticker.tickerMode}
               options={DETAIL_LEVEL_OPTIONS}
               onChange={(v) => setTicker("tickerMode", v)}
@@ -156,8 +160,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
           </Row>
           <Row id="tickerScale">
             <SegmentedRow
-              label="Size"
-              description="Resize the bar. The app window has its own size."
+              label={R.tickerScale.label}
+              description={R.tickerScale.description}
               value={String(prefs.appearance.tickerScale)}
               options={SIZE_OPTIONS}
               onChange={(v) =>
@@ -170,8 +174,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
           </Row>
           <Row id="chipColors">
             <SegmentedRow
-              label="Chip colors"
-              description="Each widget's own color, the theme accent, or subtle grays."
+              label={R.chipColors.label}
+              description={R.chipColors.description}
               value={ticker.chipColors}
               options={CHIP_COLOR_OPTIONS}
               onChange={(v) => setTicker("chipColors", v)}
@@ -184,8 +188,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
         <RowList>
           <Row id="scrollMode">
             <SegmentedRow
-              label="Scroll mode"
-              description="Scroll without stopping, or show a page at a time."
+              label={R.scrollMode.label}
+              description={R.scrollMode.description}
               value={ticker.scrollMode}
               options={SCROLL_MODE_OPTIONS}
               onChange={(v) => setTicker("scrollMode", v)}
@@ -193,11 +197,9 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
           </Row>
           <Row id="speed">
             <SegmentedRow
-              label="Speed"
+              label={R.speed.label}
               description={
-                paged
-                  ? "How quickly each page slides in."
-                  : "How fast the chips travel."
+                paged ? "How quickly each page slides in." : R.speed.description
               }
               value={String(ticker.tickerSpeed)}
               options={SPEED_OPTIONS}
@@ -206,11 +208,11 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
           </Row>
           <Row id="onHover">
             <SegmentedRow
-              label="On hover"
+              label={R.onHover.label}
               description={
                 paged
                   ? "Whether the page holds still while your mouse is over it."
-                  : "What the bar does while your mouse is over it."
+                  : R.onHover.description
               }
               value={ticker.onHover}
               options={HOVER_OPTIONS}
@@ -220,8 +222,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
           {paged && (
             <Row id="stepPause">
               <SegmentedRow
-                label="Time per page"
-                description="How long each page stays before the next one."
+                label={R.stepPause.label}
+                description={R.stepPause.description}
                 value={String(ticker.stepPause)}
                 options={STEP_PAUSE_OPTIONS}
                 onChange={(v) => setTicker("stepPause", Number(v))}
@@ -235,8 +237,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
         <RowList>
           <Row id="alwaysOnTop">
             <ToggleRow
-              label="Stay above other windows"
-              description="Keep the ticker visible over whatever else is open."
+              label={R.alwaysOnTop.label}
+              description={R.alwaysOnTop.description}
               checked={window_.pinned}
               onChange={(v) => setWindow("pinned", v)}
             />
@@ -244,8 +246,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
           {IS_WINDOWS && (
             <Row id="hideFullscreen">
               <ToggleRow
-                label="Hide when an app goes fullscreen"
-                description="Get out of the way of games, videos and presentations."
+                label={R.hideFullscreen.label}
+                description={R.hideFullscreen.description}
                 checked={window_.hideOnFullscreen}
                 onChange={(v) => setWindow("hideOnFullscreen", v)}
               />
@@ -253,8 +255,8 @@ export default function TickerPage({ prefs, onPrefsChange }: TickerPageProps) {
           )}
           <Row id="itemOrder">
             <SegmentedRow
-              label="Item order"
-              description="Keep each widget's items together, or mix them."
+              label={R.itemOrder.label}
+              description={R.itemOrder.description}
               value={ticker.mixMode}
               options={MIX_OPTIONS}
               onChange={(v) => setTicker("mixMode", v)}

--- a/desktop/src/components/settings/pages/UpdatesPage.tsx
+++ b/desktop/src/components/settings/pages/UpdatesPage.tsx
@@ -27,6 +27,9 @@ import { RowList, SettingsButton, SettingsGroup } from "../SettingsControls";
 import ReleaseNotes from "../ReleaseNotes";
 import PageHeader from "./PageHeader";
 import { Row } from "./Row";
+import { SETTINGS_ROWS } from "../rows";
+
+const R = SETTINGS_ROWS.updates;
 
 type UpdateStatus =
   | { step: "idle" }
@@ -224,13 +227,13 @@ function UpdateRow({
         <div className={row}>
           <div className="flex min-w-0 flex-col gap-0.5">
             <span className="text-ui-body font-medium text-fg">
-              Check for new versions
+              {R.checkNow.label}
             </span>
             <span className="text-ui-meta text-fg-4">
-              Scrollr also checks each time it launches.
+              {R.checkNow.description}
             </span>
           </div>
-          <SettingsButton onClick={onCheck}>Check for updates</SettingsButton>
+          <SettingsButton onClick={onCheck}>Check now</SettingsButton>
         </div>
       );
 

--- a/desktop/src/components/settings/rows.ts
+++ b/desktop/src/components/settings/rows.ts
@@ -1,0 +1,252 @@
+/**
+ * Every settings row's copy, keyed by page and row id.
+ *
+ * This is the one place a row's label and description live. The pages
+ * render from it and the search index is generated from it, so what
+ * search shows is what the page says — the index cannot drift from the
+ * rows the way the hand-maintained list did (docs/SETTINGS_AUDIT.md §6).
+ *
+ * `settingsSearchIndex.test.ts` reads the page sources and fails when a
+ * rendered `<Row id>` / `data-row` has no entry here, and vice versa.
+ *
+ * Rows that only exist with or without an account carry `when`; rows
+ * that appear and disappear with preference state (Time per page,
+ * Hide when fullscreen) do not — everything is findable, and following
+ * a result may land you on a row that is currently hidden, which is the
+ * honest outcome.
+ *
+ * Some pages override the description at render time (Speed and On
+ * hover read differently in Page mode, the widget-slot row shows live
+ * counts). The entry here is the resting copy search shows.
+ */
+import type { SettingsPage } from "./pages";
+
+export interface RowCopy {
+  label: string;
+  description: string;
+  /** Extra search terms that do not appear in the visible copy. */
+  keywords?: string;
+  /** Only rendered (and only searchable) in this account state. */
+  when?: "signedIn" | "signedOut";
+}
+
+export const SETTINGS_ROWS = {
+  appearance: {
+    theme: {
+      label: "Theme",
+      description: "Pick a color palette",
+      keywords:
+        "palette colors scrollr catppuccin dracula tokyo night nord gruvbox solarized rose pine one everforest",
+    },
+    colorMode: {
+      label: "Color mode",
+      description: "Light, dark, or follow the system",
+      keywords: "dark mode light auto",
+    },
+    appSize: {
+      label: "App size",
+      description: "Resize the main app window. The ticker has its own size.",
+      keywords: "zoom scale ui display",
+    },
+    fontWeight: {
+      label: "Font weight",
+      description: "Increase text thickness for readability",
+      keywords: "bold text",
+    },
+    highContrast: {
+      label: "High contrast text",
+      description: "Brighten muted text for easier reading",
+      keywords: "accessibility a11y readability",
+    },
+    temperature: {
+      label: "Temperature",
+      description: "Used by Weather and System monitor",
+      keywords: "units fahrenheit celsius degrees °F °C sysmon",
+    },
+    timeFormat: {
+      label: "Time",
+      description: "Used by Clock and the ticker",
+      keywords: "units format 12h 24h 12-hour 24-hour hour clock am pm",
+    },
+  },
+
+  startup: {
+    autostart: {
+      label: "Launch at login",
+      description: "Open Scrollr when you sign in to your computer",
+      keywords: "boot startup system autostart start automatically",
+    },
+    startInBackground: {
+      label: "Start in the background",
+      description:
+        "Show only the ticker. Open the Scrollr window from the tray when you want it.",
+      keywords: "hidden minimized tray ticker only main window launch",
+    },
+  },
+
+  shortcuts: {
+    shortcuts: {
+      label: "Keyboard shortcuts",
+      description:
+        "Open Settings, show or hide the ticker, cycle the color mode, and more",
+      keywords: "hotkey keys cmd ctrl toggle theme",
+    },
+  },
+
+  // Page order: On · Where · Look · Motion · Behaviour (REL-204).
+  ticker: {
+    showTicker: {
+      label: "Show the ticker",
+      description:
+        "The bar on your screen. Ctrl+T, the tray and the ticker's right-click menu do the same.",
+      keywords: "enable disable on off hide toggle visible",
+    },
+    tickerMonitors: {
+      label: "Monitors",
+      description: "Which screens show the ticker",
+      keywords: "display screen second dual multi monitor identify",
+    },
+    screenEdge: {
+      label: "Screen edge",
+      description: "Which edge of the screen the ticker sits on.",
+      keywords: "top bottom position",
+    },
+    detailLevel: {
+      label: "Detail level",
+      description: "One line per chip, or a detail row under each.",
+      keywords: "compact detailed density rows height",
+    },
+    tickerScale: {
+      label: "Size",
+      description: "Resize the bar. The app window has its own size.",
+      keywords: "zoom scale ticker",
+    },
+    chipColors: {
+      label: "Chip colors",
+      description: "Each widget's own color, the theme accent, or subtle grays.",
+      keywords: "widget theme subtle muted accent",
+    },
+    scrollMode: {
+      label: "Scroll mode",
+      description: "Scroll without stopping, or show a page at a time.",
+      keywords: "continuous page step",
+    },
+    speed: {
+      label: "Speed",
+      description: "How fast the chips travel.",
+      keywords: "slow normal fast",
+    },
+    onHover: {
+      label: "On hover",
+      description: "What the bar does while your mouse is over it.",
+      keywords: "pause slow down keep moving mouse",
+    },
+    stepPause: {
+      label: "Time per page",
+      description: "How long each page stays before the next one.",
+      keywords: "seconds dwell",
+    },
+    alwaysOnTop: {
+      label: "Stay above other windows",
+      description: "Keep the ticker visible over whatever else is open.",
+      keywords: "always on top pin topmost",
+    },
+    hideFullscreen: {
+      label: "Hide when an app goes fullscreen",
+      description: "Get out of the way of games, videos and presentations.",
+      keywords: "youtube games movie windows only",
+    },
+    itemOrder: {
+      label: "Item order",
+      description: "Keep each widget's items together, or mix them.",
+      keywords: "mix grouped mixed by source",
+    },
+  },
+
+  profile: {
+    signIn: {
+      label: "Sign in to Scrollr",
+      description:
+        "Signing in syncs your subscription, profile, and source preferences across devices and unlocks billing management.",
+      keywords: "account login log in",
+      when: "signedOut",
+    },
+    signedIn: {
+      label: "Signed in as",
+      description: "The account this device is signed in to",
+      keywords: "account identity user who signin sign in",
+      when: "signedIn",
+    },
+    plan: {
+      label: "Plan",
+      description: "Your plan and how many widgets it includes",
+      keywords: "billing subscription upgrade uplink tier",
+      when: "signedIn",
+    },
+    displayName: {
+      label: "Display name",
+      description: "The name shown on your profile",
+      keywords: "name profile",
+      when: "signedIn",
+    },
+    email: {
+      label: "Email",
+      description: "The address on your account",
+      keywords: "mail address",
+      when: "signedIn",
+    },
+    password: {
+      label: "Password",
+      description: "We'll email you a reset link.",
+      keywords: "security reset",
+      when: "signedIn",
+    },
+    slots: {
+      label: "Widget slots",
+      description: "Open the Catalog to add, remove, or swap widgets.",
+      keywords: "manage widgets catalog plan",
+      when: "signedIn",
+    },
+    signOut: {
+      label: "Sign out",
+      description: "Sign out of this device. Local preferences stay intact.",
+      keywords: "logout log out",
+      when: "signedIn",
+    },
+  },
+
+  data: {
+    export: {
+      label: "Export your data",
+      description:
+        "Download your sources, preferences, and account metadata as a .zip file.",
+      keywords: "download backup gdpr json",
+      when: "signedIn",
+    },
+    crashReports: {
+      label: "Send crash reports",
+      description:
+        "When something breaks, send the error, stack trace, app version and OS to Sentry. Never your account, IP address or file paths.",
+      keywords: "sentry telemetry privacy error diagnostics",
+    },
+    resetAll: {
+      label: "Reset all settings",
+      description:
+        "Put every setting back to its default and remove your local widgets. Your account, billing, and server data are untouched.",
+      keywords: "defaults factory danger clear",
+    },
+  },
+
+  updates: {
+    checkNow: {
+      label: "Check for updates",
+      description: "Scrollr also checks each time it launches.",
+      keywords: "version upgrade new",
+    },
+    releaseHistory: {
+      label: "Release history",
+      description: "What shipped in every version",
+      keywords: "changelog whats new notes",
+    },
+  },
+} as const satisfies Record<SettingsPage, Record<string, RowCopy>>;

--- a/desktop/src/components/settings/searchIndex.ts
+++ b/desktop/src/components/settings/searchIndex.ts
@@ -1,304 +1,47 @@
 /**
- * The settings search index.
+ * The settings search index — generated from the row copy in rows.ts,
+ * so a search result always shows the words the page shows.
  *
- * A static, hand-maintained list of every jumpable row. It is not
- * derived from the rendered pages on purpose: rows appear and disappear
- * with preference state (Time per page only in Page mode, Hide when
- * fullscreen only on Windows), and a search that could only find the settings you
- * had already configured your way into would be worse than useless.
- * Everything is findable; following a result may land you on a row that
- * is currently conditional-hidden, which is the honest outcome — the
- * page still tells you why it is not there.
- *
- * Keep in sync by hand when rows are added. `settingsSearchIndex.test.ts`
- * guards the parts that can be checked mechanically.
+ * Rows that come and go with preference state (Time per page only in
+ * Page mode, Hide when fullscreen only on Windows) stay in the index:
+ * a search that could only find the settings you had already configured
+ * your way into would be worse than useless. Rows that only exist with
+ * or without an account are the exception — `when` filters them, so a
+ * signed-out user searching "email" is not sent to a sign-in card.
  */
 import type { SettingsPage } from "./pages";
+import { SETTINGS_ROWS, type RowCopy } from "./rows";
 
-export interface SettingsSearchEntry {
+export interface SettingsSearchEntry extends RowCopy {
   page: SettingsPage;
   /** Matches the row's `data-row` attribute, for the jump-flash. */
   rowId: string;
-  label: string;
-  description: string;
-  /** Extra search terms that do not appear in the visible copy. */
-  keywords: string;
 }
 
-export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
-  // ── Appearance ────────────────────────────────────────────────
-  {
-    page: "appearance",
-    rowId: "theme",
-    label: "Theme",
-    description: "Pick a color palette",
-    keywords:
-      "palette colors scrollr catppuccin dracula tokyo night nord gruvbox solarized rose pine one everforest",
-  },
-  {
-    page: "appearance",
-    rowId: "colorMode",
-    label: "Color mode",
-    description: "Light, dark, or follow the system",
-    keywords: "dark mode light auto",
-  },
-  {
-    page: "appearance",
-    rowId: "appSize",
-    label: "App size",
-    description: "Resize the main app window. The ticker has its own scale.",
-    keywords: "zoom scale ui display size",
-  },
-  {
-    page: "appearance",
-    rowId: "fontWeight",
-    label: "Font weight",
-    description: "Increase text thickness for readability",
-    keywords: "bold text",
-  },
-  {
-    page: "appearance",
-    rowId: "highContrast",
-    label: "High contrast text",
-    description: "Brighten muted text for easier reading",
-    keywords: "accessibility a11y readability",
-  },
-  {
-    page: "appearance",
-    rowId: "temperature",
-    label: "Temperature",
-    description: "Used by Weather and System monitor",
-    keywords: "units fahrenheit celsius degrees °F °C sysmon",
-  },
-  {
-    page: "appearance",
-    rowId: "timeFormat",
-    label: "Time",
-    description: "Used by Clock and the ticker",
-    keywords: "units format 12h 24h 12-hour 24-hour hour clock am pm",
-  },
-
-  // ── Startup ───────────────────────────────────────────────────
-  {
-    page: "startup",
-    rowId: "autostart",
-    label: "Launch at login",
-    description: "Open Scrollr when you sign in to your computer",
-    keywords: "boot startup system autostart start automatically",
-  },
-  {
-    page: "startup",
-    rowId: "startInBackground",
-    label: "Start in the background",
-    description: "Show only the ticker; open the window from the tray",
-    keywords: "hidden minimized tray ticker only main window launch",
-  },
-
-  // ── Shortcuts ─────────────────────────────────────────────────
-  {
-    page: "shortcuts",
-    rowId: "shortcuts",
-    label: "Keyboard shortcuts",
-    description: "Open Settings, toggle ticker, cycle theme, and more",
-    keywords: "hotkey keys cmd ctrl",
-  },
-
-  // ── Ticker (page order: On · Where · Look · Motion · Behaviour) ──
-  {
-    page: "ticker",
-    rowId: "showTicker",
-    label: "Show the ticker",
-    description: "The bar on your screen",
-    keywords: "enable disable on off hide toggle visible",
-  },
-  {
-    page: "ticker",
-    rowId: "tickerMonitors",
-    label: "Monitors",
-    description: "Which screens show the ticker",
-    keywords: "display screen second dual multi monitor identify",
-  },
-  {
-    page: "ticker",
-    rowId: "screenEdge",
-    label: "Screen edge",
-    description: "Which edge of the screen the ticker sits on",
-    keywords: "top bottom position",
-  },
-  {
-    page: "ticker",
-    rowId: "detailLevel",
-    label: "Detail level",
-    description: "One line per chip, or a detail row under each",
-    keywords: "compact detailed comfort",
-  },
-  {
-    page: "ticker",
-    rowId: "tickerScale",
-    label: "Size",
-    description: "Resize the bar",
-    keywords: "scale zoom bigger smaller",
-  },
-  {
-    page: "ticker",
-    rowId: "chipColors",
-    label: "Chip colors",
-    description: "Each widget's own color, the theme accent, or subtle grays",
-    keywords: "color widget subtle theme",
-  },
-  {
-    page: "ticker",
-    rowId: "scrollMode",
-    label: "Scroll mode",
-    description: "Scroll without stopping, or show a page at a time",
-    keywords: "continuous page step rotate",
-  },
-  {
-    page: "ticker",
-    rowId: "speed",
-    label: "Speed",
-    description: "How fast the chips travel",
-    keywords: "fast slow normal velocity",
-  },
-  {
-    page: "ticker",
-    rowId: "onHover",
-    label: "On hover",
-    description: "What the bar does while your mouse is over it",
-    keywords: "pause stop slow down keep moving mouse hover",
-  },
-  {
-    // Only rendered in Page mode; following the result in Continuous
-    // mode lands on the Motion group, which is the honest outcome.
-    page: "ticker",
-    rowId: "stepPause",
-    label: "Time per page",
-    description: "How long each page stays before the next one",
-    keywords: "dwell pause step interval seconds",
-  },
-  {
-    page: "ticker",
-    rowId: "alwaysOnTop",
-    label: "Stay above other windows",
-    description: "Keep the ticker visible over whatever else is open",
-    keywords: "pin float always on top",
-  },
-  {
-    // Windows-only row; "windows" stays a keyword so the platform name
-    // finds it.
-    page: "ticker",
-    rowId: "hideFullscreen",
-    label: "Hide when an app goes fullscreen",
-    description: "Get out of the way of games, videos and presentations",
-    keywords: "youtube games movie windows only",
-  },
-  {
-    page: "ticker",
-    rowId: "itemOrder",
-    label: "Item order",
-    description: "Keep each widget's items together, or mix them",
-    keywords: "mix grouped weave by source",
-  },
-
-  // ── Profile & plan ────────────────────────────────────────────
-  {
-    page: "profile",
-    rowId: "displayName",
-    label: "Display name",
-    description: "The name shown on your profile",
-    keywords: "name profile",
-  },
-  {
-    page: "profile",
-    rowId: "email",
-    label: "Email",
-    description: "The address on your account",
-    keywords: "mail address",
-  },
-  {
-    page: "profile",
-    rowId: "password",
-    label: "Password",
-    description: "We'll email you a reset link",
-    keywords: "security reset",
-  },
-  {
-    page: "profile",
-    rowId: "slots",
-    label: "Manage widgets",
-    description: "Add, remove, and swap widgets in the Catalog",
-    keywords: "slots catalog plan",
-  },
-  {
-    // Both of these have data-row targets in the prototype's DOM but no
-    // index entries, so they could never actually be jumped to.
-    page: "profile",
-    rowId: "signedIn",
-    label: "Signed in as",
-    description: "The account this device is signed in to",
-    keywords: "account identity user who signin sign in",
-  },
-  {
-    page: "profile",
-    rowId: "plan",
-    label: "Plan",
-    description: "Your subscription and what it includes",
-    keywords: "billing subscription upgrade uplink tier",
-  },
-  {
-    page: "profile",
-    rowId: "signOut",
-    label: "Sign out",
-    description: "Sign out of this device",
-    keywords: "logout log out",
-  },
-
-  // ── Data & privacy ────────────────────────────────────────────
-  {
-    page: "data",
-    rowId: "export",
-    label: "Export your data",
-    description: "Download sources, preferences, and metadata as JSON",
-    keywords: "download backup gdpr",
-  },
-  {
-    page: "data",
-    rowId: "crashReports",
-    label: "Send crash reports",
-    description: "Send errors and stack traces to Sentry",
-    keywords: "sentry telemetry privacy error diagnostics",
-  },
-  {
-    page: "data",
-    rowId: "resetAll",
-    label: "Reset all settings",
-    description: "Clear every local preference",
-    keywords: "defaults factory danger",
-  },
-
-  // ── Updates ───────────────────────────────────────────────────
-  {
-    page: "updates",
-    rowId: "checkNow",
-    label: "Check for updates",
-    description: "See if a new version is available",
-    keywords: "version upgrade",
-  },
-  {
-    page: "updates",
-    rowId: "releaseHistory",
-    label: "Release history",
-    description: "What shipped in every version",
-    keywords: "changelog whats new notes",
-  },
-];
+export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = (
+  Object.keys(SETTINGS_ROWS) as SettingsPage[]
+).flatMap((page) =>
+  Object.entries<RowCopy>(SETTINGS_ROWS[page]).map(([rowId, copy]) => ({
+    page,
+    rowId,
+    ...copy,
+  })),
+);
 
 /** Case-insensitive substring match over label + description + keywords. */
-export function searchSettings(query: string): SettingsSearchEntry[] {
+export function searchSettings(
+  query: string,
+  authenticated: boolean,
+): SettingsSearchEntry[] {
   const q = query.trim().toLowerCase();
   if (!q) return [];
-  return SETTINGS_SEARCH_INDEX.filter((e) =>
-    `${e.label} ${e.description} ${e.keywords}`.toLowerCase().includes(q),
+  const state = authenticated ? "signedIn" : "signedOut";
+  return SETTINGS_SEARCH_INDEX.filter(
+    (e) =>
+      (!e.when || e.when === state) &&
+      `${e.label} ${e.description} ${e.keywords ?? ""}`
+        .toLowerCase()
+        .includes(q),
   );
 }
 
@@ -311,8 +54,10 @@ export function searchSettings(query: string): SettingsSearchEntry[] {
  * early return. Scrolls the row into view either way — the scroll is
  * the functional half, the flash is only decoration.
  */
+// `~=` because one element can be the target of several ids
+// (`data-row="signedIn plan"` on the identity card).
 export function flashRow(rowId: string): void {
-  const el = document.querySelector<HTMLElement>(`[data-row="${rowId}"]`);
+  const el = document.querySelector<HTMLElement>(`[data-row~="${rowId}"]`);
   if (!el) return;
 
   const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;

--- a/desktop/src/components/settings/settingsSearchIndex.test.ts
+++ b/desktop/src/components/settings/settingsSearchIndex.test.ts
@@ -1,15 +1,13 @@
 /**
- * The search index is hand-maintained, so the thing most likely to go
- * wrong is drift: a row gets added, renamed, or moved and the index
- * silently stops matching it. These tests pin the parts that can be
- * checked mechanically — including reading the page sources to confirm
- * every indexed rowId still corresponds to a real `data-row` target.
+ * The search index is generated from rows.ts, and the pages render
+ * their copy from the same file — so the thing left to guard is that
+ * the two sets of row ids agree. These tests read the page sources and
+ * fail in both directions: a rendered `<Row id>` / `data-row` with no
+ * entry (unsearchable), and an entry with no rendered target (a jump
+ * that silently no-ops).
  */
 import { describe, expect, it } from "vitest";
-import {
-  SETTINGS_SEARCH_INDEX,
-  searchSettings,
-} from "./searchIndex";
+import { SETTINGS_SEARCH_INDEX, searchSettings } from "./searchIndex";
 import { SETTINGS_PAGES, isSettingsPage, resolveSettingsPage } from "./pages";
 
 // Page sources as raw strings, via Vite rather than node:fs. This file
@@ -24,15 +22,20 @@ const PAGE_SOURCES = import.meta.glob(["./pages/*.tsx", "./*.tsx"], {
   eager: true,
 }) as Record<string, string>;
 
-/** Every `<Row id="…">` and `data-row="…"` across the settings surface. */
+/** Every `<Row id="…">` and `data-row="…"` token across the settings surface. */
 function renderedRowIds(): Set<string> {
   const ids = new Set<string>();
   for (const src of Object.values(PAGE_SOURCES)) {
     for (const m of src.matchAll(/<Row\s+id="([^"]+)"/g)) ids.add(m[1]);
-    for (const m of src.matchAll(/data-row="([^"]+)"/g)) ids.add(m[1]);
+    // One element can carry several ids (`data-row="signedIn plan"`).
+    for (const m of src.matchAll(/data-row="([^"]+)"/g)) {
+      for (const id of m[1].split(/\s+/)) ids.add(id);
+    }
   }
   return ids;
 }
+
+const indexedIds = () => new Set(SETTINGS_SEARCH_INDEX.map((e) => e.rowId));
 
 describe("settings search index", () => {
   it("only references real pages", () => {
@@ -44,7 +47,7 @@ describe("settings search index", () => {
   });
 
   it("has no duplicate rowIds", () => {
-    const seen = SETTINGS_SEARCH_INDEX.map((e) => `${e.page}:${e.rowId}`);
+    const seen = SETTINGS_SEARCH_INDEX.map((e) => e.rowId);
     expect(new Set(seen).size).toBe(seen.length);
   });
 
@@ -57,44 +60,73 @@ describe("settings search index", () => {
     expect(missing).toEqual([]);
   });
 
+  /** The other direction: a row on a page that search cannot reach. */
+  it("every rendered row is indexed", () => {
+    const indexed = indexedIds();
+    const unsearchable = [...renderedRowIds()].filter((id) => !indexed.has(id));
+    expect(unsearchable).toEqual([]);
+  });
+
+  /** Searching a row's own label — the words on the page — finds it. */
+  it("every rendered row is found by its label", () => {
+    for (const entry of SETTINGS_SEARCH_INDEX) {
+      const hits = searchSettings(entry.label, entry.when !== "signedOut");
+      expect(
+        hits.map((h) => h.rowId),
+        `"${entry.label}" → ${entry.rowId}`,
+      ).toContain(entry.rowId);
+    }
+  });
+
   it("covers every page that has jumpable rows", () => {
     const indexed = new Set(SETTINGS_SEARCH_INDEX.map((e) => e.page));
     for (const page of SETTINGS_PAGES) {
       expect(indexed.has(page), `no search entries for "${page}"`).toBe(true);
     }
   });
+
+  /** The row that used to be indexed as a sort control is not a row. */
+  it("does not index the release-history sort control", () => {
+    expect(indexedIds().has("releaseSort")).toBe(false);
+  });
 });
 
 describe("searchSettings", () => {
   it("returns nothing for an empty or whitespace query", () => {
-    expect(searchSettings("")).toEqual([]);
-    expect(searchSettings("   ")).toEqual([]);
+    expect(searchSettings("", true)).toEqual([]);
+    expect(searchSettings("   ", true)).toEqual([]);
   });
 
   it("matches on label", () => {
-    const hits = searchSettings("on hover");
+    const hits = searchSettings("on hover", true);
     expect(hits.map((h) => h.rowId)).toContain("onHover");
   });
 
   it("matches on description", () => {
-    const hits = searchSettings("brighten muted text");
+    const hits = searchSettings("brighten muted text", true);
     expect(hits.map((h) => h.rowId)).toEqual(["highContrast"]);
   });
 
   /** Keywords are the whole point — they catch words not in the copy. */
   it("matches on keywords that appear nowhere in the visible text", () => {
-    expect(searchSettings("gdpr").map((h) => h.rowId)).toEqual(["export"]);
-    expect(searchSettings("a11y").map((h) => h.rowId)).toEqual(["highContrast"]);
-    expect(searchSettings("hotkey").map((h) => h.rowId)).toEqual(["shortcuts"]);
+    expect(searchSettings("gdpr", true).map((h) => h.rowId)).toEqual(["export"]);
+    expect(searchSettings("a11y", true).map((h) => h.rowId)).toEqual([
+      "highContrast",
+    ]);
+    expect(searchSettings("hotkey", true).map((h) => h.rowId)).toEqual([
+      "shortcuts",
+    ]);
   });
 
   it("is case-insensitive", () => {
-    expect(searchSettings("CATPPUCCIN").map((h) => h.rowId)).toEqual(["theme"]);
+    expect(searchSettings("CATPPUCCIN", true).map((h) => h.rowId)).toEqual([
+      "theme",
+    ]);
   });
 
   /** Hover speed folded into On hover (REL-204): "speed" → one ticker row. */
   it("reproduces the reference query", () => {
-    const hits = searchSettings("speed");
+    const hits = searchSettings("speed", true);
     expect(hits.map((h) => h.label)).toEqual(["Speed"]);
     expect(hits.every((h) => h.page === "ticker")).toBe(true);
   });
@@ -126,9 +158,28 @@ describe("searchSettings", () => {
    * list keeps it findable.
    */
   it("still finds the Windows-only toggle by platform name", () => {
-    expect(searchSettings("windows").map((h) => h.rowId)).toContain(
+    expect(searchSettings("windows", true).map((h) => h.rowId)).toContain(
       "hideFullscreen",
     );
+  });
+
+  /** Account rows only exist in one sign-in state, and so do their results. */
+  it("hides account rows that are not on the page in this sign-in state", () => {
+    expect(searchSettings("signed in as", false)).toEqual([]);
+    expect(searchSettings("email", false).map((h) => h.rowId)).toEqual([]);
+    expect(searchSettings("sign in to scrollr", true)).toEqual([]);
+    expect(searchSettings("sign in to scrollr", false).map((h) => h.rowId)).toEqual([
+      "signIn",
+    ]);
+    expect(searchSettings("export", false)).toEqual([]);
+    expect(searchSettings("export", true).map((h) => h.rowId)).toEqual(["export"]);
+  });
+
+  /** Updates: the page label and the search label are the same words. */
+  it("finds the update check by the label the page shows", () => {
+    expect(searchSettings("check for updates", true).map((h) => h.rowId)).toEqual([
+      "checkNow",
+    ]);
   });
 });
 

--- a/desktop/src/components/support/support-content.ts
+++ b/desktop/src/components/support/support-content.ts
@@ -112,10 +112,10 @@ export const TROUBLESHOOTING_ARTICLES: TroubleshootingArticle[] = [
       "Only the main window shows",
     ],
     steps: [
-      "Press Ctrl+T (Cmd+T on macOS) to toggle ticker visibility.",
+      "Press Ctrl+T (Cmd+T on macOS) to show or hide the ticker.",
       "Or go to Settings > Ticker and turn on \"Show the ticker\".",
       "Or click the Ticker toggle in the title bar (next to the Pin button).",
-      "Or right-click the system tray icon and choose \"Toggle Ticker\".",
+      "Or right-click the system tray icon and check \"Show ticker\".",
     ],
   },
   {

--- a/desktop/src/datawidgets/tickerRegistry.test.ts
+++ b/desktop/src/datawidgets/tickerRegistry.test.ts
@@ -16,7 +16,7 @@ function ctx(over: Partial<TickerContext> = {}): TickerContext {
     source: "finance",
     dashboard: null,
     comfort: false,
-    chipColorMode: "accent",
+    chipColorMode: "theme",
     widgetDisplay: DEFAULT_WIDGET_DISPLAY,
     predictionsWatchlist: new Set<string>(),
     ...over,

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -695,8 +695,8 @@ describe("migrateTicker (REL-204: presets + one hover row)", () => {
   });
 
   it("folds Rotate into Page and keeps the other modes", () => {
-    expect(migrateTicker({ scrollMode: "flip" }).scrollMode).toBe("step");
-    expect(migrateTicker({ scrollMode: "step" }).scrollMode).toBe("step");
+    expect(migrateTicker({ scrollMode: "flip" }).scrollMode).toBe("page");
+    expect(migrateTicker({ scrollMode: "step" }).scrollMode).toBe("page");
     expect(migrateTicker({ scrollMode: "continuous" }).scrollMode).toBe("continuous");
     expect(migrateTicker({ scrollMode: "sideways" }).scrollMode).toBe("continuous");
   });
@@ -732,7 +732,7 @@ describe("migrateTicker (REL-204: presets + one hover row)", () => {
       ticker: { scrollMode: "flip", pauseOnHover: true, hoverSpeed: 0, tickerSpeed: 5 },
     });
     const p = loadPrefs();
-    expect(p.ticker).toMatchObject({ scrollMode: "step", onHover: "pause", tickerSpeed: 20 });
+    expect(p.ticker).toMatchObject({ scrollMode: "page", onHover: "pause", tickerSpeed: 20 });
     expect(p.appearance.tickerScale).toBe(130);
   });
 });
@@ -742,7 +742,7 @@ describe("resetTickerPage (REL-204)", () => {
     const before = loadPrefs();
     const changed: AppPreferences = {
       ...before,
-      ticker: { ...before.ticker, scrollMode: "step", onHover: "pause", tickerSpeed: 80 },
+      ticker: { ...before.ticker, scrollMode: "page", onHover: "pause", tickerSpeed: 80 },
       window: { ...before.window, pinned: false, tickerPosition: "bottom", tickerMonitors: ["X"] },
       appearance: { ...before.appearance, tickerScale: 130, uiScale: 115, themeFamily: "nord" },
     };
@@ -825,5 +825,65 @@ describe("appearance.units migration (REL-205)", () => {
     const before = storeValues.get("scrollr:settings");
     expect(loadPrefs().appearance.units.temperature).toBe("celsius");
     expect(storeValues.get("scrollr:settings")).toBe(before);
+  });
+});
+
+describe("ticker values renamed to match their labels (REL-207)", () => {
+  it("maps every old spelling forward", () => {
+    const out = migrateTicker({
+      tickerMode: "comfort",
+      mixMode: "weave",
+      chipColors: "accent",
+      scrollMode: "step",
+    });
+    expect(out).toMatchObject({
+      tickerMode: "detailed",
+      mixMode: "mixed",
+      chipColors: "theme",
+      scrollMode: "page",
+    });
+    expect(migrateTicker({ chipColors: "muted" }).chipColors).toBe("subtle");
+    expect(migrateTicker({ scrollMode: "flip" }).scrollMode).toBe("page");
+  });
+
+  it("keeps the new spellings and defaults anything unknown", () => {
+    const out = migrateTicker({
+      tickerMode: "compact",
+      mixMode: "grouped",
+      chipColors: "subtle",
+      scrollMode: "page",
+    });
+    expect(out).toMatchObject({
+      tickerMode: "compact",
+      mixMode: "grouped",
+      chipColors: "subtle",
+      scrollMode: "page",
+    });
+    expect(migrateTicker({ tickerMode: "huge", chipColors: 3 })).toMatchObject({
+      tickerMode: "detailed",
+      chipColors: "widget",
+    });
+  });
+
+  it("sheds the ticker window's mirror keys on load", () => {
+    storeValues.set("scrollr:feedPinned", false);
+    storeValues.set("scrollr:tickerPosition", "bottom");
+    storeValues.set("scrollr:settings", {
+      appearance: {},
+      window: { pinned: false, tickerPosition: "bottom" },
+    });
+    const prefs = loadPrefs();
+    expect(prefs.window).toMatchObject({ pinned: false, tickerPosition: "bottom" });
+    expect(storeValues.has("scrollr:feedPinned")).toBe(false);
+    expect(storeValues.has("scrollr:tickerPosition")).toBe(false);
+  });
+
+  it("no longer reads or writes the widget-bar unit keys REL-205 folded", () => {
+    storeValues.set("scrollr:settings", {
+      appearance: { units: { temperature: "celsius", timeFormat: "24h" } },
+    });
+    loadPrefs();
+    expect(storeValues.has("scrollr:widget:weather:unit")).toBe(false);
+    expect(storeValues.has("scrollr:widget:clock:format")).toBe(false);
   });
 });

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -66,11 +66,14 @@ export function isThemeFamily(value: unknown): value is ThemeFamily {
 export function isThemeMode(value: unknown): value is ThemeMode {
   return value === "light" || value === "dark" || value === "system";
 }
-export type TickerMode = "compact" | "comfort";
-export type MixMode = "grouped" | "weave";
-export type ChipColorMode = "widget" | "accent" | "muted";
-/** "step" = Page. Rotate ("flip") folded into it 2026-09-06 (REL-204). */
-export type ScrollMode = "continuous" | "step";
+// Stored values match their labels on the Ticker page (REL-207). The
+// old spellings — comfort, weave, accent/muted, step/flip — are mapped
+// forward in `migrateTicker`.
+export type TickerMode = "compact" | "detailed";
+export type MixMode = "grouped" | "mixed";
+export type ChipColorMode = "widget" | "theme" | "subtle";
+/** Rotate ("flip") folded into Page 2026-09-06 (REL-204). */
+export type ScrollMode = "continuous" | "page";
 /** What the bar does under the mouse. Continuous: keep / slow to 30 % /
  *  stop. Page: keep advancing / hold the page (slow and pause alike). */
 export type HoverBehavior = "keep" | "slow" | "pause";
@@ -313,7 +316,7 @@ export type Venue = "off" | "feed" | "both" | "ticker";
  * Fantasy ticker simplicity dial; see FantasyDisplayPrefs.tickerMode.
  *
  * Named for the widget because `TickerMode` is already taken by the
- * ticker's density setting (compact | comfort) — a genuinely different
+ * ticker's density setting (compact | detailed) — a genuinely different
  * axis that happens to want the same word.
  */
 export type FantasyTickerMode = "essential" | "standard" | "everything";
@@ -472,8 +475,8 @@ const DEFAULT_TICKER: TickerPrefs = {
   showTicker: true,
   tickerSpeed: TICKER_SPEEDS.normal,
   onHover: "slow",
-  tickerMode: "comfort",
-  mixMode: "weave",
+  tickerMode: "detailed",
+  mixMode: "mixed",
   chipColors: "widget",
   scrollMode: "continuous",
   stepPause: 5,
@@ -579,6 +582,8 @@ const DEFAULT_PREFS: AppPreferences = {
 // ── Storage helpers ─────────────────────────────────────────────
 
 const PREFIX = "scrollr:settings";
+/** Pre-REL-207 per-window mirrors of `window.pinned` / `window.tickerPosition`. */
+const LEGACY_MIRROR_KEYS = ["scrollr:feedPinned", "scrollr:tickerPosition"];
 
 /** Migrate v1 prefs (general/taskbar/ticker/window) to v2 shape. */
 function migrateV1(saved: Record<string, unknown>): Partial<AppPreferences> {
@@ -1041,6 +1046,12 @@ export function loadPrefs(): AppPreferences {
       removeStore(LS_WEATHER_UNIT);
       removeStore(LS_CLOCK_FORMAT);
     }
+    // The ticker window used to mirror `window.pinned` and
+    // `window.tickerPosition` into their own keys and read those first
+    // (REL-207). It reads the prefs now; shed the mirrors once.
+    for (const key of LEGACY_MIRROR_KEYS) {
+      if (getStore<unknown>(key, undefined) !== undefined) removeStore(key);
+    }
 
     return merged;
   } catch {
@@ -1053,20 +1064,29 @@ export function loadPrefs(): AppPreferences {
  * presets and one hover row. Retired keys are dropped, not carried:
  *  - `pauseOnHover` + `hoverSpeed` → `onHover`
  *    (false → keep; true + 0 → pause; true otherwise → slow)
- *  - scrollMode "flip" (Rotate) → "step" (Page)
  *  - `tickerGap` (Spacing) and `tickerDirection` (Direction) → gone
  *  - `tickerSpeed` / `stepPause` snap to the nearest preset
+ *
+ * REL-207: stored values renamed to match their labels. Anything
+ * unrecognised falls back to the default:
+ *  - tickerMode  comfort → detailed
+ *  - mixMode     weave → mixed
+ *  - chipColors  accent → theme, muted → subtle
+ *  - scrollMode  step → page, and flip (Rotate, REL-204) → page
  */
 export function migrateTicker(raw: unknown): TickerPrefs {
   const saved = (raw && typeof raw === "object" ? raw : {}) as Omit<
     Partial<TickerPrefs>,
-    "scrollMode"
+    "scrollMode" | "tickerMode" | "mixMode" | "chipColors"
   > & {
     pauseOnHover?: unknown;
     hoverSpeed?: unknown;
     tickerGap?: unknown;
     tickerDirection?: unknown;
     scrollMode?: unknown;
+    tickerMode?: unknown;
+    mixMode?: unknown;
+    chipColors?: unknown;
   };
   const {
     pauseOnHover,
@@ -1074,6 +1094,9 @@ export function migrateTicker(raw: unknown): TickerPrefs {
     tickerGap: _gap,
     tickerDirection: _direction,
     scrollMode,
+    tickerMode,
+    mixMode,
+    chipColors,
     onHover,
     ...rest
   } = saved;
@@ -1092,8 +1115,18 @@ export function migrateTicker(raw: unknown): TickerPrefs {
     ...DEFAULT_TICKER,
     ...rest,
     onHover: migratedHover,
+    tickerMode: tickerMode === "compact" ? "compact" : "detailed",
+    mixMode: mixMode === "grouped" ? "grouped" : "mixed",
+    chipColors:
+      chipColors === "theme" || chipColors === "accent"
+        ? "theme"
+        : chipColors === "subtle" || chipColors === "muted"
+          ? "subtle"
+          : "widget",
     scrollMode:
-      scrollMode === "step" || scrollMode === "flip" ? "step" : "continuous",
+      scrollMode === "page" || scrollMode === "step" || scrollMode === "flip"
+        ? "page"
+        : "continuous",
     tickerSpeed: snapToPreset(
       rest.tickerSpeed,
       Object.values(TICKER_SPEEDS),
@@ -1218,7 +1251,7 @@ export function migrateAppearanceTheme(
 
 export const TICKER_HEIGHTS: Record<TickerMode, number> = {
   compact: 44,
-  comfort: 64,
+  detailed: 64,
 };
 
 // ── Ticker layout helpers ───────────────────────────────────────

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -494,10 +494,12 @@ function RootLayout() {
     const unsub1 = onStoreChange<AppPreferences>("scrollr:settings", (val) => {
       if (val) setPrefs(val);
     });
-    // Cross-window navigation requests (e.g. ticker context menu → "Customize Ticker")
+    // Cross-window navigation requests (e.g. ticker context menu →
+    // "Customize Ticker"). `href`, not `to`: the path may carry a query
+    // ("/customize?page=ticker") and the route's validateSearch reads it.
     const unsub2 = onStoreChange<string>("scrollr:navigate", (path) => {
       if (path) {
-        navigate({ to: path });
+        navigate({ href: path });
         // Clear the key so it can be triggered again
         removeStore("scrollr:navigate");
       }
@@ -740,12 +742,13 @@ function RootLayout() {
       // Ctrl+Shift+T → cycle color mode (theme family stays put)
       if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "T") {
         e.preventDefault();
+        // light → dark → auto, as the Shortcuts page says.
         const cycle: Record<string, "light" | "dark" | "system"> = {
-          dark: "light",
-          light: "system",
-          system: "dark",
+          light: "dark",
+          dark: "system",
+          system: "light",
         };
-        const nextMode = cycle[prefs.appearance.themeMode] ?? "dark";
+        const nextMode = cycle[prefs.appearance.themeMode] ?? "light";
         const next = {
           ...prefs,
           appearance: {

--- a/docs/CHIP_SPEC.md
+++ b/docs/CHIP_SPEC.md
@@ -453,10 +453,10 @@ shrinks or jumps as a slate fills.
 | GitHub | `repos`, `excludedRepos` |
 
 **The user controls presentation** (`TickerPrefs`): `showTicker`, `tickerSpeed`,
-`pauseOnHover`, `hoverSpeed`, `tickerGap`, `tickerMode` (compact / detailed),
-`mixMode` (grouped / weave), `chipColors` (widget / accent / muted), `tickerDirection`,
-`scrollMode` (continuous / step / flip), `stepPause`, `tickerPosition`,
-`hideOnFullscreen`, `showWidgetGlyphIcons`, pinning.
+`onHover` (keep / slow / pause), `tickerMode` (compact / detailed),
+`mixMode` (grouped / mixed), `chipColors` (widget / theme / subtle),
+`scrollMode` (continuous / page), `stepPause`, `tickerPosition`,
+`hideOnFullscreen`, pinning.
 
 **The user does not control selection.** Never add a setting for: how many chips a
 widget contributes; which eligible items appear; their order; the horizon or floor;

--- a/myscrollr.com/scripts/capture-ticker.mjs
+++ b/myscrollr.com/scripts/capture-ticker.mjs
@@ -45,7 +45,7 @@ const BUS = process.env.SCROLLR_DEV_URL ?? "http://localhost:5174";
 
 // What the site lays each row out for (TickerShowcase.tsx ASPECT_*).
 const ASPECT = { compact: 2930 / 80, detailed: 2930 / 124 };
-const MODE = { compact: "compact", detailed: "comfort" };
+const MODE = { compact: "compact", detailed: "detailed" };
 // Which server-backed widgets belong on the bar for each channel shot.
 const CHANNELS = {
   sports: (id) => id.startsWith("sports_"),


### PR DESCRIPTION
Settings 5/7 (REL-207): the final copy sweep now that REL-203/204/205/206/208/209 are in. Reasoning in `docs/SETTINGS_AUDIT.md` §5–§9.

## What changed
- **Search index generated from the rows.** `components/settings/rows.ts` holds every row's label/description/keywords; the pages render from it and `searchIndex.ts` is derived from it, so search cannot drift from the page. The test reads the page sources and fails in both directions (unindexed rendered row / entry with no target) and checks every row is found by its own label. Account-only rows carry `when`, so a signed-out search does not land on the sign-in card.
- **Stored values renamed to match labels**: `comfort→detailed`, `weave→mixed`, `accent→theme`, `muted→subtle`, `step→page` (and any leftover `flip→page`) in `migrateTicker`; unknown values fall back to the default. Proven live: the dev store's `comfort`/`weave` came up as `detailed`/`mixed`.
- **Tray**: "Toggle Ticker" → checked **Show ticker** synced from the pref via `sync_tray_ticker` (replaces `sync_tray_pin`); the third "Always on Top" copy is gone. Open / Report a Bug / Quit unchanged.
- **Right-click menu**: "Customize Ticker" opens `/customize?page=ticker` (the cross-window navigate key now goes through `navigate({ href })` so the query survives); "Hide Ticker" is the same checked **Show ticker** as the tray.
- **Legacy mirror keys** `scrollr:feedPinned` / `scrollr:tickerPosition` deleted; the ticker window reads `window.pinned` / `window.tickerPosition` from the real prefs, and `loadPrefs` sheds the old keys once.
- **Data & privacy**: Export says `.zip`; Reset all says local widgets are removed and Launch at login is turned off (REL-206 made that true). Test asserts the REL-205 ad-hoc unit keys stay gone.
- **Profile**: confirm dialog before changing the account email; `plan` anchor moved from the badge to the card (`data-row="signedIn plan"`, `flashRow` matches tokens); "Signed in as" is only indexed when signed in.
- **Updates**: row label is "Check for updates" on the page and in search (button is "Check now"); subtitle "Scrollr also checks each time it launches." kept, it is true since REL-206.
- **Shortcuts**: "Show/hide the ticker"; the Ctrl+Shift+T cycle now really goes light → dark → auto (code fixed, not the copy).
- Support article, `docs/CHIP_SPEC.md` and the website capture script updated to the new words/values.

## Verified
- `tsc --noEmit`, `vitest run` (63 files / 687 tests), `cargo test --lib` (32) green.
- Real app via the dev bus: every indexed row on every page found by its label and the jump landed on a real `data-row` (only `stepPause` absent in continuous mode, as designed); `sync_tray_ticker` registered and callable; "Customize Ticker" path lands on `/customize?page=ticker` with h1 "Ticker".
- Flipped °F/°C and 12h/24h on the running bar: Weather 96°F/71°F ↔ 35°C/21°C, Clock 3:35 PM ↔ 15:35 (captures below). Sysmon's chip shows CPU/RAM/GPU % only, so no unit to flip.

| °F / 12h | °C / 24h |
|---|---|
| Weather `96°F` `71°F`, Clock `3:35 PM` | Weather `35°C` `21°C`, Clock `15:35` |

Not verified by eye: the native tray and context menus themselves (no sanctioned way to capture a native menu); wording checked in code.

Noticed, not fixed here: after a search jump, segmented rows (radiogroups) do not keep focus while toggle/action rows do — pre-existing `flashRow` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
