### PR TITLE
feat(desktop): Catalog Hub → Directory — one route, two views [REL-215]

### DIFF
--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -105,6 +105,21 @@ export async function fetchCatalog(): Promise<import("../types").CatalogPayload>
   return request<import("../types").CatalogPayload>("/catalog");
 }
 
+/**
+ * POST /catalog/requests — "I looked for X and it isn't here". One row per
+ * (user, query) server-side, so the count that comes back is people, not
+ * clicks. Authenticated: the row is the hook for a later "it shipped" note.
+ */
+export async function requestCatalogWidget(
+  query: string,
+): Promise<import("../types/api.generated").CatalogRequestResponse> {
+  return authFetch("/catalog/requests", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+}
+
 // ── Health ──────────────────────────────────────────────────────
 
 /** Core's own view of its dependencies (public — no auth). Generated. */

--- a/desktop/src/components/layout/PageLayout.tsx
+++ b/desktop/src/components/layout/PageLayout.tsx
@@ -141,8 +141,8 @@ export default function PageLayout({
         <div className="flex-1 min-h-0 flex flex-col">
           <div
             className={clsx(
-              "mx-auto px-5 pt-5 pb-0 w-full flex-1 min-h-0 flex flex-col",
-              widthClass,
+              "w-full flex-1 min-h-0 flex flex-col",
+              !noContentPadding && clsx("mx-auto px-5 pt-5 pb-0", widthClass),
             )}
           >
             {children}

--- a/desktop/src/components/marketplace/CatalogCard.tsx
+++ b/desktop/src/components/marketplace/CatalogCard.tsx
@@ -16,11 +16,14 @@ import { CATEGORY_LABELS } from "../../marketplace";
 //   compact — sports. League descriptions are boilerplate ("Live NFL
 //             scores…"), so a shelf of 14 rich cards is 14 restatements
 //             of the same sentence. Logo + name + add button, 4-across.
+//   row     — the directory (Hub → Directory redesign). Compact anatomy
+//             plus a one-line description, no card chrome: a hover wash
+//             on a 2-across list, so ~90 widgets still read as a list.
 
 interface CatalogCardProps {
   item: CatalogItem;
   added: boolean;
-  variant?: "rich" | "compact";
+  variant?: "rich" | "compact" | "row";
   /** Open the detail panel. The card body is the hit target. */
   onOpen: (item: CatalogItem) => void;
   /**
@@ -29,11 +32,16 @@ interface CatalogCardProps {
    * panel instead, where the upgrade path is explained.
    */
   onAdd?: (item: CatalogItem) => void;
+  /**
+   * Make the ✓ a remove button. Directory rows take it (the design's
+   * "✓ removes with a toast undo"); the older shelves leave it a badge.
+   */
+  onRemove?: (item: CatalogItem) => void;
 }
 
 // ── Logo tile ───────────────────────────────────────────────────
 
-function LogoTile({
+export function LogoTile({
   item,
   size,
   radius,
@@ -87,11 +95,29 @@ function AddControl({
   item,
   added,
   onAdd,
+  onRemove,
 }: {
   item: CatalogItem;
   added: boolean;
   onAdd?: (item: CatalogItem) => void;
+  onRemove?: (item: CatalogItem) => void;
 }) {
+  if (added && onRemove) {
+    return (
+      <button
+        type="button"
+        aria-label={`Remove ${item.name}`}
+        title="Remove from your ticker"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove(item);
+        }}
+        className="flex size-[26px] shrink-0 cursor-pointer items-center justify-center rounded-[7px] bg-accent/14 text-accent hover:bg-warn/20 hover:text-warn"
+      >
+        <Check size={13} strokeWidth={3} />
+      </button>
+    );
+  }
   if (added) {
     return (
       <span
@@ -129,6 +155,7 @@ export default function CatalogCard({
   variant = "rich",
   onOpen,
   onAdd,
+  onRemove,
 }: CatalogCardProps) {
   const shared = {
     role: "button" as const,
@@ -142,6 +169,26 @@ export default function CatalogCard({
       }
     },
   };
+
+  if (variant === "row") {
+    return (
+      <div
+        {...shared}
+        className="group/card flex min-w-0 cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-1.5 hover:bg-base-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+      >
+        <LogoTile item={item} size={26} radius="rounded-md" />
+        <span className="flex min-w-0 flex-1 flex-col leading-4">
+          <span className="truncate text-[12.5px] font-semibold text-fg">
+            {item.name}
+          </span>
+          <span className="truncate text-ui-chip text-fg-4">
+            {item.description}
+          </span>
+        </span>
+        <AddControl item={item} added={added} onAdd={onAdd} onRemove={onRemove} />
+      </div>
+    );
+  }
 
   if (variant === "compact") {
     return (

--- a/desktop/src/components/marketplace/CatalogDirectory.tsx
+++ b/desktop/src/components/marketplace/CatalogDirectory.tsx
@@ -1,0 +1,467 @@
+/**
+ * CatalogDirectory — the catalog's browsing view (frames 02–04, 06).
+ *
+ * A kind rail on the left, one titled block per kind on the right with
+ * rows shelved by `group`. A query searches every kind and shows hits
+ * grouped by kind; zero hits shows a request card and the closest group
+ * we do have instead of an empty state.
+ */
+import { useEffect, useState } from "react";
+import { ArrowLeft, Check, Plus, Search } from "lucide-react";
+import { toast } from "sonner";
+import clsx from "clsx";
+
+import { CATEGORY_LABELS } from "../../marketplace";
+import type { CatalogItem, WidgetCategory } from "../../marketplace";
+import { requestCatalogWidget } from "../../api/client";
+import { WidgetBar } from "../widget-bar/Bar";
+import { Segmented } from "../widget-bar/Segmented";
+import EmptySection from "../layout/EmptySection";
+import CatalogCard from "./CatalogCard";
+import type { CatalogViewShared } from "./CatalogHub";
+import {
+  CATEGORY_ORDER,
+  byName,
+  byNewest,
+  closestGroup,
+  groupByShelf,
+  matchesQuery,
+  missName,
+  showGroupHeaders,
+} from "./catalogSearch";
+import type { CatalogKind, CatalogSort, Shelf } from "./catalogSearch";
+
+interface CatalogDirectoryProps extends CatalogViewShared {
+  kind: CatalogKind;
+  query: string;
+  sort?: CatalogSort;
+  authenticated: boolean;
+  onLogin: () => void;
+  onQueryChange: (q: string) => void;
+  onKindChange: (kind: CatalogKind) => void;
+  onSortChange: (sort: CatalogSort | undefined) => void;
+  onOverview: () => void;
+}
+
+interface Block {
+  key: string;
+  title: string;
+  sub: string;
+  showHeads: boolean;
+  shelves: Shelf<CatalogItem>[];
+}
+
+const kindLabel = (kind: CatalogKind) =>
+  kind === "all" ? "All widgets" : CATEGORY_LABELS[kind];
+
+const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "es"}`;
+
+const anchorId = (block: string, group: string) =>
+  `catalog-${block}-${group.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+
+// ── Blocks ──────────────────────────────────────────────────────
+
+function kindBlock(
+  cat: WidgetCategory,
+  list: CatalogItem[],
+  addedIds: Set<string>,
+  sort: CatalogSort | undefined,
+): Block {
+  const added = list.filter((i) => addedIds.has(i.id)).length;
+  const sub = `${list.length} widget${list.length === 1 ? "" : "s"} · ${added} in your ticker`;
+  if (sort === "az") {
+    return { key: cat, title: CATEGORY_LABELS[cat], sub, showHeads: false, shelves: [{ key: "", items: byName(list) }] };
+  }
+  const shelves = groupByShelf(list);
+  return {
+    key: cat,
+    title: CATEGORY_LABELS[cat],
+    sub,
+    showHeads: showGroupHeaders(list.length, shelves.length),
+    shelves,
+  };
+}
+
+export function buildBlocks(
+  items: CatalogItem[],
+  kind: CatalogKind,
+  query: string,
+  sort: CatalogSort | undefined,
+  addedIds: Set<string>,
+): { blocks: Block[]; miss: boolean; summary: string; closest?: string } {
+  if (query.trim()) {
+    const hits = items.filter((i) => matchesQuery(i, query));
+    if (hits.length > 0) {
+      const blocks = CATEGORY_ORDER.map((cat) => {
+        const list = hits.filter((i) => i.category === cat);
+        return {
+          key: cat,
+          title: CATEGORY_LABELS[cat],
+          sub: plural(list.length, "match"),
+          showHeads: false,
+          shelves: [{ key: "", items: sort === "az" ? byName(list) : list }],
+        };
+      }).filter((b) => b.shelves[0].items.length > 0);
+      return { blocks, miss: false, summary: plural(hits.length, "match") };
+    }
+    // A miss: the closest group by hint, else the kind being browsed.
+    const group = closestGroup(query);
+    const list = group
+      ? items.filter((i) => i.group === group)
+      : kind === "all"
+        ? []
+        : items.filter((i) => i.category === kind);
+    const blocks: Block[] = list.length
+      ? [{
+          key: "closest",
+          title: "Closest matches",
+          sub: group ?? kindLabel(kind),
+          showHeads: false,
+          shelves: [{ key: "", items: list }],
+        }]
+      : [];
+    return { blocks, miss: true, summary: "0 exact matches", closest: group };
+  }
+
+  if (sort === "new") {
+    return {
+      blocks: [{
+        key: "new",
+        title: "Newest first",
+        sub: `${items.length} widgets`,
+        showHeads: false,
+        shelves: [{ key: "", items: byNewest(items) }],
+      }],
+      miss: false,
+      summary: "",
+    };
+  }
+
+  const cats = kind === "all" ? CATEGORY_ORDER : [kind];
+  const blocks = cats
+    .map((cat) => kindBlock(cat, items.filter((i) => i.category === cat), addedIds, sort))
+    .filter((b) => b.shelves.some((s) => s.items.length > 0));
+  return { blocks, miss: false, summary: "" };
+}
+
+// ── Miss card ───────────────────────────────────────────────────
+
+function MissCard({
+  query,
+  authenticated,
+  onLogin,
+  onCustomRss,
+}: {
+  query: string;
+  authenticated: boolean;
+  onLogin: () => void;
+  onCustomRss?: () => void;
+}) {
+  const name = missName(query);
+  const [state, setState] = useState<
+    { status: "idle" } | { status: "sending" } | { status: "done"; count: number }
+  >({ status: "idle" });
+
+  const request = async () => {
+    if (!authenticated) {
+      onLogin();
+      return;
+    }
+    setState({ status: "sending" });
+    try {
+      const { count } = await requestCatalogWidget(query);
+      setState({ status: "done", count });
+    } catch {
+      setState({ status: "idle" });
+      toast.error(`Couldn't send the request for ${name}`);
+    }
+  };
+
+  return (
+    <section className="mb-5 flex items-center gap-4 rounded-xl border border-edge/60 bg-base-150/60 px-4 py-3.5">
+      <div className="min-w-0 flex-1">
+        <div className="text-[14px] leading-5 font-bold text-fg">
+          No “{name}” widget yet
+        </div>
+        <div className="mt-0.5 text-ui-meta text-fg-3">
+          Requests are counted and the most-asked ones ship first — we'll tell
+          you when it lands. Below are the closest things we do have.
+        </div>
+      </div>
+      {state.status === "done" ? (
+        <span className="flex shrink-0 items-center gap-1.5 rounded-lg bg-accent/15 px-3 py-[7px] text-ui-meta font-semibold whitespace-nowrap text-accent">
+          <Check size={13} strokeWidth={2.5} />
+          Requested ·{" "}
+          {state.count === 1
+            ? "you're the first to ask"
+            : `${state.count} people have asked`}
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={() => void request()}
+          disabled={state.status === "sending"}
+          className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-accent px-3 py-[7px] text-ui-meta font-semibold whitespace-nowrap text-[#0b1a14] hover:bg-accent/90 disabled:opacity-60"
+        >
+          <Plus size={13} strokeWidth={2.5} />
+          {authenticated ? `Request ${name}` : "Sign in to request"}
+        </button>
+      )}
+      {onCustomRss && (
+        <button
+          type="button"
+          onClick={onCustomRss}
+          className="shrink-0 cursor-pointer rounded-lg border border-edge px-3 py-[7px] text-ui-meta font-medium whitespace-nowrap text-fg-3 hover:border-edge-2 hover:text-fg"
+        >
+          Use a custom RSS feed
+        </button>
+      )}
+    </section>
+  );
+}
+
+// ── Component ───────────────────────────────────────────────────
+
+type SortTab = "kind" | CatalogSort;
+
+export default function CatalogDirectory({
+  items,
+  addedIds,
+  slots,
+  capped,
+  onOpen,
+  onAdd,
+  onRemove,
+  onUpgrade,
+  onCustomRss,
+  onRequestWidget,
+  kind,
+  query,
+  sort,
+  authenticated,
+  onLogin,
+  onQueryChange,
+  onKindChange,
+  onSortChange,
+  onOverview,
+}: CatalogDirectoryProps) {
+  // The field is its own source of truth while you type; the URL catches
+  // up a tick later, and a rail click (which clears the query) resets it.
+  const [draft, setDraft] = useState(query);
+  useEffect(() => setDraft(query), [query]);
+
+  const { blocks, miss, summary, closest } = buildBlocks(items, kind, query, sort, addedIds);
+
+  const rail = (["all", ...CATEGORY_ORDER] as CatalogKind[])
+    .map((k) => ({
+      kind: k,
+      count: k === "all" ? items.length : items.filter((i) => i.category === k).length,
+    }))
+    .filter((r) => r.count > 0);
+
+  const row = (item: CatalogItem) => {
+    const added = addedIds.has(item.id);
+    return (
+      <CatalogCard
+        key={item.id}
+        item={item}
+        added={added}
+        variant="row"
+        onOpen={onOpen}
+        onAdd={added ? undefined : onAdd}
+        onRemove={onRemove}
+      />
+    );
+  };
+
+  return (
+    <>
+      <WidgetBar>
+        <div className="relative w-[300px]">
+          <Search
+            size={13}
+            aria-hidden
+            className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-fg-4"
+          />
+          <input
+            type="search"
+            value={draft}
+            autoFocus={query !== ""}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              onQueryChange(e.target.value);
+            }}
+            aria-label="Search widgets"
+            placeholder={`Search ${items.length} widgets`}
+            autoComplete="off"
+            className="w-full rounded-[7px] border border-edge/80 bg-surface-raised py-1.5 pr-2.5 pl-7 text-ui-meta text-fg placeholder:text-fg-4 focus:border-accent/50 focus:outline-none"
+          />
+        </div>
+        {summary && <span className="text-ui-meta text-fg-4">{summary}</span>}
+        {capped && (
+          <button
+            type="button"
+            onClick={onUpgrade}
+            className="cursor-pointer rounded-lg bg-warn/12 px-2.5 py-1 text-ui-chip font-semibold whitespace-nowrap text-warn hover:bg-warn/20"
+          >
+            All {slots.max} slots used · remove one to swap, or upgrade
+          </button>
+        )}
+        <div className="ml-auto">
+          <Segmented<SortTab>
+            ariaLabel="Sort"
+            layoutGroupId="catalog-sort"
+            value={sort ?? "kind"}
+            onChange={(v) => onSortChange(v === "kind" ? undefined : v)}
+            options={[
+              { value: "kind", label: "By kind" },
+              { value: "az", label: "A–Z" },
+              { value: "popular", label: "Popular" },
+            ]}
+          />
+        </div>
+      </WidgetBar>
+
+      <div className="flex min-h-0 flex-1">
+        {/* ── Rail ─────────────────────────────────────────────── */}
+        <nav
+          aria-label="Kinds"
+          className="flex w-[184px] shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-edge/40 px-2 py-2.5 scrollbar-thin"
+        >
+          <button
+            type="button"
+            onClick={onOverview}
+            className="flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-[12.5px] font-medium text-fg-3 hover:bg-base-150 hover:text-fg-2"
+          >
+            <ArrowLeft size={13} />
+            Overview
+          </button>
+          <div className="mx-2.5 my-1.5 h-px bg-edge/50" />
+          <div className="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-[12.5px] font-medium text-fg">
+            <span className="flex size-4 items-center justify-center rounded bg-accent/15 text-accent">
+              <Check size={10} strokeWidth={3} />
+            </span>
+            <span className="flex-1">Your ticker</span>
+            <span className={clsx("text-ui-chip", capped ? "text-warn" : "text-fg-4")}>
+              {slots.finite ? `${slots.used}/${slots.max}` : slots.used}
+            </span>
+          </div>
+          <div className="mx-2.5 my-1.5 h-px bg-edge/50" />
+          {rail.map((r) => {
+            const active = !query && r.kind === kind;
+            return (
+              <button
+                key={r.kind}
+                type="button"
+                onClick={() => onKindChange(r.kind)}
+                aria-current={active ? "page" : undefined}
+                className={clsx(
+                  "flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-[12.5px] font-medium",
+                  active
+                    ? "bg-accent/12 text-accent"
+                    : "text-fg-3 hover:bg-base-150 hover:text-fg-2",
+                )}
+              >
+                <span className="flex-1">{kindLabel(r.kind)}</span>
+                <span className={clsx("text-ui-chip", active ? "text-accent/70" : "text-fg-4")}>
+                  {r.count}
+                </span>
+              </button>
+            );
+          })}
+          <div className="mt-auto px-2.5 pt-2.5 pb-1 text-ui-chip text-fg-4">
+            Don't see it?{" "}
+            <button
+              type="button"
+              onClick={onRequestWidget}
+              className="cursor-pointer text-fg-3 underline decoration-fg-4/40 hover:text-fg"
+            >
+              Request a widget
+            </button>
+          </div>
+        </nav>
+
+        {/* ── Blocks ───────────────────────────────────────────── */}
+        <div className="min-w-0 flex-1 overflow-y-auto px-5 pt-4 pb-7 scrollbar-thin [scrollbar-gutter:stable]">
+          {sort === "popular" && (
+            <p className="mb-4 text-ui-meta text-fg-4">
+              Popularity isn't tracked yet — this is the catalog's own order.
+            </p>
+          )}
+          {miss && (
+            <MissCard
+              key={query}
+              query={query}
+              authenticated={authenticated}
+              onLogin={onLogin}
+              onCustomRss={onCustomRss}
+            />
+          )}
+          {blocks.length === 0 && !miss && (
+            <EmptySection
+              icon={Search}
+              title="Nothing here"
+              description="Pick another kind from the rail."
+            />
+          )}
+          {blocks.map((block) => (
+            <div key={block.key} className="mb-5">
+              <div className="mb-3 flex flex-wrap items-baseline gap-2.5">
+                <h1 className="text-[16px] leading-[22px] font-bold text-fg">
+                  {block.title}
+                </h1>
+                <span className="text-ui-meta whitespace-nowrap text-fg-4">
+                  {block.sub}
+                </span>
+                {block.showHeads && (
+                  <div className="ml-auto flex flex-wrap justify-end gap-1.5">
+                    {block.shelves.map((s) => (
+                      <a
+                        key={s.key}
+                        href={`#${anchorId(block.key, s.key)}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          document
+                            .getElementById(anchorId(block.key, s.key))
+                            ?.scrollIntoView({ block: "start", behavior: "smooth" });
+                        }}
+                        className="rounded-full border border-edge/70 px-2 py-0.5 text-ui-chip whitespace-nowrap text-fg-3 hover:border-edge-2 hover:text-fg"
+                      >
+                        {s.key || "Other"}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+              {block.shelves.map((shelf) => (
+                <section
+                  key={shelf.key || "ungrouped"}
+                  id={anchorId(block.key, shelf.key)}
+                  className="mb-4 scroll-mt-4"
+                >
+                  {block.showHeads && (
+                    <div className="mb-1.5 flex items-center gap-2 px-2.5">
+                      <h2 className="font-mono text-ui-section whitespace-nowrap text-fg-3">
+                        {shelf.key || "Other"}
+                      </h2>
+                      <span className="text-ui-chip text-fg-4">{shelf.items.length}</span>
+                      <div className="h-px flex-1 bg-edge/50" />
+                    </div>
+                  )}
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
+                    {shelf.items.map(row)}
+                  </div>
+                </section>
+              ))}
+            </div>
+          ))}
+          {miss && closest === undefined && blocks.length === 0 && (
+            <p className="text-ui-meta text-fg-4">
+              Try a league, a publication or a tool — or pick a kind from the rail.
+            </p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/desktop/src/components/marketplace/CatalogHub.tsx
+++ b/desktop/src/components/marketplace/CatalogHub.tsx
@@ -1,0 +1,291 @@
+/**
+ * CatalogHub — the catalog's landing view (frame 01 / 05 of the design).
+ *
+ * A search hero with example chips, one tile per kind, "New this month",
+ * and "In your ticker" with the slot line. Everything here is a door into
+ * the directory; nothing is a list you scroll.
+ */
+import { Check, Search } from "lucide-react";
+
+import { CATEGORY_LABELS } from "../../marketplace";
+import type { CatalogItem, WidgetCategory } from "../../marketplace";
+import type { SlotUsage } from "../SlotMeter";
+import CatalogCard, { LogoTile } from "./CatalogCard";
+import { CATEGORY_ORDER, byNewest, isNew } from "./catalogSearch";
+import type { CatalogKind } from "./catalogSearch";
+
+export interface CatalogViewShared {
+  /** Every visible catalog item, in canonical order. */
+  items: CatalogItem[];
+  addedIds: Set<string>;
+  slots: SlotUsage;
+  capped: boolean;
+  onOpen: (item: CatalogItem) => void;
+  onAdd: (item: CatalogItem) => void;
+  onRemove: (item: CatalogItem) => void;
+  onUpgrade: () => void;
+  /** Opens the hidden Custom RSS entry's panel; absent if the catalog lacks it. */
+  onCustomRss?: () => void;
+  onRequestWidget: () => void;
+}
+
+interface CatalogHubProps extends CatalogViewShared {
+  onSearch: (q: string) => void;
+  onKind: (kind: CatalogKind) => void;
+  onSeeAllNew: () => void;
+}
+
+/** What people look for; the last one is a deliberate miss so the
+ *  request path is one click from the front door. */
+const TRIES = ["NFL", "Bitcoin", "Weather", "Hacker News", "Kalshi", "Eredivisie"];
+
+const BLURBS: Record<WidgetCategory, string> = {
+  sports: "Live scores from the leagues you follow",
+  finance: "Quotes, watchlists and calendars",
+  news: "Headlines from publications and feeds",
+  fantasy: "Your leagues, matchups and standings",
+  predictions: "Live odds from prediction markets",
+  utility: "Clocks, weather, dev status and more",
+};
+
+const NEW_CAP = 4;
+const TILE_LOGOS = 5;
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h2 className="font-mono text-ui-section text-fg-3">{children}</h2>;
+}
+
+export function slotLine(slots: SlotUsage): string {
+  return slots.finite
+    ? `${slots.used} of ${slots.max} slots used`
+    : `${slots.used} added · unlimited slots`;
+}
+
+export default function CatalogHub({
+  items,
+  addedIds,
+  slots,
+  capped,
+  onOpen,
+  onAdd,
+  onRemove,
+  onUpgrade,
+  onCustomRss,
+  onRequestWidget,
+  onSearch,
+  onKind,
+  onSeeAllNew,
+}: CatalogHubProps) {
+  const now = new Date();
+  const fresh = byNewest(items.filter((i) => isNew(i.addedAt, now)));
+  const yours = items.filter((i) => addedIds.has(i.id));
+
+  const tiles = CATEGORY_ORDER.map((cat) => {
+    const list = items.filter((i) => i.category === cat);
+    return {
+      cat,
+      list,
+      added: list.filter((i) => addedIds.has(i.id)).length,
+      fresh: list.filter((i) => isNew(i.addedAt, now)).length,
+    };
+  }).filter((t) => t.list.length > 0);
+
+  return (
+    <div className="mx-auto w-full max-w-[880px] pt-9 pb-7">
+      {/* ── Hero ───────────────────────────────────────────────── */}
+      <h1 className="mb-3.5 text-center text-[22px] leading-7 font-bold tracking-tight text-fg">
+        What do you want on your ticker?
+      </h1>
+      <div className="relative mx-auto mb-2.5 max-w-[640px]">
+        <Search
+          size={16}
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 left-3.5 -translate-y-1/2 text-fg-4"
+        />
+        <input
+          type="search"
+          defaultValue=""
+          onChange={(e) => onSearch(e.target.value)}
+          aria-label="Search widgets"
+          placeholder={`Search ${items.length} widgets — a league, a publication, a tool`}
+          autoComplete="off"
+          className="h-11 w-full rounded-[10px] border border-accent/35 bg-surface-raised pr-3.5 pl-10 text-[14px] text-fg shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-accent)_8%,transparent)] placeholder:text-fg-4 focus:border-accent/60 focus:outline-none"
+        />
+      </div>
+      <div className="mb-8 flex flex-wrap items-center justify-center gap-1.5 text-ui-meta text-fg-4">
+        <span>Try</span>
+        {TRIES.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => onSearch(t)}
+            className="cursor-pointer rounded-full border border-edge/80 px-2.5 py-0.5 whitespace-nowrap text-fg-3 hover:border-edge-2 hover:text-fg-2"
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Browse by kind ─────────────────────────────────────── */}
+      <div className="mb-2.5">
+        <SectionTitle>Browse by kind</SectionTitle>
+      </div>
+      <div className="mb-6 grid grid-cols-4 gap-2.5">
+        {tiles.map(({ cat, list, added, fresh: freshCount }) => (
+          <button
+            key={cat}
+            type="button"
+            onClick={() => onKind(cat)}
+            aria-label={`${CATEGORY_LABELS[cat]}, ${list.length} widgets`}
+            className="relative flex min-h-[104px] cursor-pointer flex-col gap-2.5 overflow-hidden rounded-xl border border-edge/55 bg-surface-raised px-3 pt-3 pb-2.5 text-left hover:border-edge-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+          >
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0"
+              style={{
+                background: `linear-gradient(to bottom, ${list[0].hex}26, transparent 60%)`,
+              }}
+            />
+            <div className="relative flex items-start gap-2">
+              <div className="min-w-0 flex-1">
+                <div className="text-[14px] leading-5 font-bold text-fg">
+                  {CATEGORY_LABELS[cat]}
+                </div>
+                <div className="text-[11.5px] leading-4 text-fg-3">
+                  {BLURBS[cat]}
+                </div>
+              </div>
+              <span className="shrink-0 rounded-full bg-base-150/90 px-1.5 text-ui-chip font-semibold text-fg-3">
+                {list.length}
+              </span>
+            </div>
+            {/* Wraps: five logos, "+n" and two labels don't all fit a
+                212px tile, and a clipped "1 add" is worse than a third
+                line (the grid row grows for every tile). */}
+            <div className="relative mt-auto flex flex-wrap items-center gap-x-[5px] gap-y-1">
+              {list.slice(0, TILE_LOGOS).map((i) => (
+                <LogoTile key={i.id} item={i} size={22} radius="rounded-[5px]" />
+              ))}
+              {list.length > TILE_LOGOS && (
+                <span className="ml-0.5 text-ui-chip text-fg-4">
+                  +{list.length - TILE_LOGOS}
+                </span>
+              )}
+              <span className="ml-auto flex gap-1.5 text-ui-chip font-medium whitespace-nowrap">
+                {freshCount > 0 && (
+                  <span className="text-accent-purple">{freshCount} new</span>
+                )}
+                {added > 0 && <span className="text-accent">{added} added</span>}
+              </span>
+            </div>
+          </button>
+        ))}
+        <div className="flex min-h-[104px] flex-col justify-center gap-[3px] rounded-xl border border-dashed border-edge/80 p-3">
+          <div className="text-ui-body font-semibold text-fg">Something else?</div>
+          <div className="text-[11.5px] leading-4 text-fg-4">
+            Paste any RSS feed, or tell us what's missing.
+          </div>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {onCustomRss && (
+              <button
+                type="button"
+                onClick={onCustomRss}
+                className="cursor-pointer rounded-[7px] border border-edge/80 px-2 py-[3px] text-ui-chip font-medium whitespace-nowrap text-fg-3 hover:border-edge-2 hover:text-fg"
+              >
+                Custom RSS
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onRequestWidget}
+              className="cursor-pointer rounded-[7px] border border-edge/80 px-2 py-[3px] text-ui-chip font-medium whitespace-nowrap text-fg-3 hover:border-edge-2 hover:text-fg"
+            >
+              Request
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* ── New this month ─────────────────────────────────────── */}
+      {fresh.length > 0 && (
+        <>
+          <div className="mb-2 flex items-center gap-2">
+            <SectionTitle>New this month</SectionTitle>
+            {fresh.length > NEW_CAP && (
+              <button
+                type="button"
+                onClick={onSeeAllNew}
+                className="ml-auto cursor-pointer text-ui-chip text-fg-3 underline decoration-fg-4/40 hover:text-fg"
+              >
+                See all new
+              </button>
+            )}
+          </div>
+          <div className="mb-6 grid grid-cols-4 gap-2">
+            {fresh.slice(0, NEW_CAP).map((item) => (
+              <div
+                key={item.id}
+                className="relative overflow-hidden rounded-[10px] border border-edge/55 bg-surface-raised"
+              >
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute inset-0"
+                  style={{
+                    background: `linear-gradient(to right, ${item.hex}26, transparent 70%)`,
+                  }}
+                />
+                <div className="relative">
+                  <CatalogCard
+                    item={item}
+                    added={addedIds.has(item.id)}
+                    variant="row"
+                    onOpen={onOpen}
+                    onAdd={addedIds.has(item.id) ? undefined : onAdd}
+                    onRemove={onRemove}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* ── In your ticker ─────────────────────────────────────── */}
+      <div className="mb-2 flex items-center gap-2">
+        <SectionTitle>In your ticker</SectionTitle>
+        <span className="ml-auto text-ui-chip text-fg-4">{slotLine(slots)}</span>
+        {capped && (
+          <button
+            type="button"
+            onClick={onUpgrade}
+            className="cursor-pointer rounded-lg bg-warn/15 px-2.5 py-[3px] text-ui-chip font-semibold text-warn hover:bg-warn/25"
+          >
+            Upgrade for unlimited
+          </button>
+        )}
+      </div>
+      {yours.length === 0 ? (
+        <p className="text-ui-meta text-fg-4">
+          Nothing yet — pick a kind above, or search for something.
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {yours.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onOpen(item)}
+              className="flex cursor-pointer items-center gap-[7px] rounded-lg border border-edge/55 bg-surface-raised py-[5px] pr-2 pl-1.5 hover:border-edge-2"
+            >
+              <LogoTile item={item} size={16} radius="rounded" />
+              <span className="text-ui-meta font-medium whitespace-nowrap text-fg">
+                {item.name}
+              </span>
+              <Check size={11} strokeWidth={3} className="text-accent" />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/marketplace/CatalogPage.test.tsx
+++ b/desktop/src/components/marketplace/CatalogPage.test.tsx
@@ -2,7 +2,9 @@
  * Catalog route — hub ↔ directory over the URL, against the bundled
  * snapshot catalog (REL-215). The real `Route` is mounted under a test
  * root that stands in for RootLayout's providers, so search-param
- * handling is the production code, not a re-statement of it.
+ * handling is the production code, not a re-statement of it. Lives here
+ * rather than in routes/ because the router plugin treats every file
+ * there as a route.
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
@@ -15,21 +17,21 @@ import {
 } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { Route } from "./catalog";
-import { buildBlocks } from "../components/marketplace/CatalogDirectory";
-import { getCatalogItems } from "../marketplace";
-import { ShellContext, ShellDataContext } from "../shell-context";
-import type { ShellState } from "../shell-context";
-import { loadPrefs } from "../preferences";
-import type { SubscriptionTier } from "../auth";
-import type { DataWidgetRow } from "../api/client";
+import { Route } from "../../routes/catalog";
+import { buildBlocks } from "./CatalogDirectory";
+import { getCatalogItems } from "../../marketplace";
+import { ShellContext, ShellDataContext } from "../../shell-context";
+import type { ShellState } from "../../shell-context";
+import { loadPrefs } from "../../preferences";
+import type { SubscriptionTier } from "../../auth";
+import type { DataWidgetRow } from "../../api/client";
 
 vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
 vi.mock("@tauri-apps/plugin-http", () => ({
   fetch: vi.fn(() => Promise.reject(new Error("no tauri in tests"))),
 }));
-vi.mock("../api/client", async (importOriginal) => {
-  const mod = await importOriginal<typeof import("../api/client")>();
+vi.mock("../../api/client", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../../api/client")>();
   return {
     ...mod,
     requestCatalogWidget: vi.fn(async (query: string) => ({ query, count: 3 })),

--- a/desktop/src/components/marketplace/catalogSearch.test.ts
+++ b/desktop/src/components/marketplace/catalogSearch.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  byNewest,
+  closestGroup,
+  groupByShelf,
+  haystack,
+  isNew,
+  matchesQuery,
+  missName,
+  showGroupHeaders,
+} from "./catalogSearch";
+import { getCatalogItems } from "../../marketplace";
+
+const items = getCatalogItems().filter((i) => !i.hidden);
+const byId = (id: string) => items.find((i) => i.id === id)!;
+
+describe("haystack", () => {
+  it("is name + description + group + category label + keywords", () => {
+    const h = haystack(byId("finance_crypto"));
+    expect(h).toContain("crypto"); // name
+    expect(h).toContain("watchlist"); // description
+    expect(h).toContain("markets"); // group
+    expect(h).toContain("finance"); // category label
+    expect(h).toContain("btc"); // keyword
+  });
+
+  it("matches aliases people actually type", () => {
+    expect(matchesQuery(byId("finance_crypto"), "Bitcoin")).toBe(true);
+    expect(matchesQuery(byId("sports_premierleague"), "soccer")).toBe(true);
+    expect(matchesQuery(byId("sports_nfl"), "soccer")).toBe(false);
+    // Empty and whitespace-only queries match everything.
+    expect(matchesQuery(byId("sports_nfl"), "   ")).toBe(true);
+  });
+
+  it("finds nothing for a league we don't carry", () => {
+    expect(items.some((i) => matchesQuery(i, "Eredivisie"))).toBe(false);
+  });
+});
+
+describe("grouping", () => {
+  it("shelves a kind by group in first-appearance order", () => {
+    const sports = items.filter((i) => i.category === "sports");
+    const shelves = groupByShelf(sports);
+    expect(shelves[0].key).toBe("Football"); // NFL leads the catalog
+    expect(shelves.find((s) => s.key === "Soccer")!.items.length).toBeGreaterThan(1);
+    expect(shelves.flatMap((s) => s.items)).toHaveLength(sports.length);
+  });
+
+  it("puts ungrouped items under an empty key", () => {
+    const shelves = groupByShelf([{ group: "A" }, {}, { group: "A" }]);
+    expect(shelves.map((s) => [s.key, s.items.length])).toEqual([
+      ["A", 2],
+      ["", 1],
+    ]);
+  });
+
+  it("hides group headers under ~8 widgets or with one group", () => {
+    expect(showGroupHeaders(16, 6)).toBe(true);
+    expect(showGroupHeaders(5, 3)).toBe(false);
+    expect(showGroupHeaders(20, 1)).toBe(false);
+  });
+});
+
+describe("closest group on a miss", () => {
+  it("maps league-shaped queries to Soccer", () => {
+    expect(closestGroup("Eredivisie")).toBe("Soccer");
+    expect(closestGroup("Serie A")).toBe("Soccer");
+    expect(closestGroup("Bundesliga")).toBe("Soccer");
+  });
+
+  it("maps other fragments to their nearest group, first hit wins", () => {
+    expect(closestGroup("dogecoin")).toBe("Markets");
+    expect(closestGroup("Washington Post")).toBe("World");
+    expect(closestGroup("gitlab ci")).toBe("Dev");
+    expect(closestGroup("zzz")).toBeUndefined();
+  });
+
+  it("title-cases the miss name", () => {
+    expect(missName("  serie a ")).toBe("Serie A");
+  });
+});
+
+describe("new within 30 days", () => {
+  const now = new Date("2026-09-06T12:00:00Z");
+
+  it("counts a recent date and not an old or missing one", () => {
+    expect(isNew("2026-09-05", now)).toBe(true);
+    expect(isNew("2026-08-10", now)).toBe(true);
+    expect(isNew("2026-07-21", now)).toBe(false);
+    expect(isNew(undefined, now)).toBe(false);
+    expect(isNew("not a date", now)).toBe(false);
+    // A date in the future is not "new", it's a typo.
+    expect(isNew("2027-01-01", now)).toBe(false);
+  });
+
+  it("sorts newest first with undated last", () => {
+    const sorted = byNewest([
+      { id: "a", addedAt: "2026-07-02" },
+      { id: "b" },
+      { id: "c", addedAt: "2026-09-05" },
+    ]);
+    expect(sorted.map((i) => i.id)).toEqual(["c", "a", "b"]);
+  });
+});

--- a/desktop/src/components/marketplace/catalogSearch.ts
+++ b/desktop/src/components/marketplace/catalogSearch.ts
@@ -1,0 +1,164 @@
+/**
+ * Catalog search + shelving — the pure half of the Hub → Directory page.
+ *
+ * Everything here is a function of the catalog and a string, so the route
+ * can stay a thin state machine over the URL. The rules come from the
+ * design's Behavior / Growth cards (design_handoff_catalog/README.md).
+ */
+import { CATEGORY_LABELS } from "../../marketplace";
+import type { CatalogItem, WidgetCategory } from "../../marketplace";
+
+// ── Kinds ───────────────────────────────────────────────────────
+
+export type CatalogKind = "all" | WidgetCategory;
+export type CatalogSort = "az" | "popular" | "new";
+
+/** Hub tile / rail order. Server-defined in spirit; the labels map is the
+ *  client's ceiling on kinds it can name, so the order lives beside it. */
+export const CATEGORY_ORDER: WidgetCategory[] = [
+  "sports",
+  "finance",
+  "news",
+  "fantasy",
+  "predictions",
+  "utility",
+];
+
+/** `?kind=` from the URL: a known category, else "all". */
+export function kindFromSearch(kind: string | undefined): CatalogKind {
+  return kind && kind in CATEGORY_LABELS ? (kind as WidgetCategory) : "all";
+}
+
+type Searchable = Pick<
+  CatalogItem,
+  "name" | "description" | "category" | "group" | "keywords"
+>;
+
+/** Everything a query is matched against, lower-cased. */
+export function haystack(item: Searchable): string {
+  return [
+    item.name,
+    item.description,
+    item.group ?? "",
+    CATEGORY_LABELS[item.category],
+    ...(item.keywords ?? []),
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+/** Normalise what was typed: trim, collapse whitespace, lower-case. */
+export function normalizeQuery(q: string): string {
+  return q.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+export function matchesQuery(item: Searchable, q: string): boolean {
+  const needle = normalizeQuery(q);
+  return needle === "" || haystack(item).includes(needle);
+}
+
+// ── Groups ──────────────────────────────────────────────────────
+
+/** A kind with fewer widgets than this shows no group headers. */
+export const GROUP_HEADER_MIN = 8;
+/** Past this many rows the group pills become jump anchors. */
+export const PILL_ANCHOR_MIN = 24;
+
+export interface Shelf<T> {
+  /** Group label; "" for ungrouped items. */
+  key: string;
+  items: T[];
+}
+
+/**
+ * Split a kind's widgets into its groups, in first-appearance order — the
+ * server's canonical order decides which group leads, so a new group is a
+ * server-only change like everything else in the catalog.
+ */
+export function groupByShelf<T extends { group?: string }>(items: T[]): Shelf<T>[] {
+  const out: Shelf<T>[] = [];
+  for (const item of items) {
+    const key = item.group ?? "";
+    let shelf = out.find((s) => s.key === key);
+    if (!shelf) out.push((shelf = { key, items: [] }));
+    shelf.items.push(item);
+  }
+  return out;
+}
+
+/** Group headers earn their place only once a kind is big enough to need
+ *  them and actually has more than one group. */
+export function showGroupHeaders(total: number, groups: number): boolean {
+  return total >= GROUP_HEADER_MIN && groups > 1;
+}
+
+// ── Miss → closest group ────────────────────────────────────────
+
+/**
+ * What people type when the catalog has nothing: a league name, a paper,
+ * a coin. Each hint maps a fragment of the query to the group we do have
+ * that is nearest to it. Order matters — first hit wins.
+ */
+const CLOSEST_GROUP_HINTS: [fragment: string, group: string][] = [
+  ["liga", "Soccer"],
+  ["serie", "Soccer"],
+  ["eredivisie", "Soccer"],
+  ["league", "Soccer"],
+  ["fc", "Soccer"],
+  ["cup", "Soccer"],
+  ["ball", "Basketball"],
+  ["hockey", "Hockey"],
+  ["race", "Motorsport"],
+  ["gp", "Motorsport"],
+  ["fight", "Combat"],
+  ["tennis", "Golf & Tennis"],
+  ["golf", "Golf & Tennis"],
+  ["cricket", "Cricket & Rugby"],
+  ["rugby", "Cricket & Rugby"],
+  ["news", "World"],
+  ["times", "World"],
+  ["post", "World"],
+  ["journal", "Business"],
+  ["tech", "Tech & Science"],
+  ["coin", "Markets"],
+  ["stock", "Markets"],
+  ["etf", "Markets"],
+  ["ci", "Dev"],
+  ["deploy", "Dev"],
+  ["twitch", "Gaming"],
+  ["game", "Gaming"],
+];
+
+/** The group a missed query is closest to, or undefined when no hint fits. */
+export function closestGroup(q: string): string | undefined {
+  const needle = normalizeQuery(q);
+  return CLOSEST_GROUP_HINTS.find(([fragment]) => needle.includes(fragment))?.[1];
+}
+
+/** Title-case the query for the miss card: "eredivisie" → "Eredivisie". */
+export function missName(q: string): string {
+  return q.trim().replace(/\b\w/g, (m) => m.toUpperCase());
+}
+
+// ── New ─────────────────────────────────────────────────────────
+
+const NEW_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Joined the catalog within the last 30 days. */
+export function isNew(addedAt: string | undefined, now: Date = new Date()): boolean {
+  if (!addedAt) return false;
+  const t = Date.parse(addedAt);
+  if (Number.isNaN(t)) return false;
+  const age = now.getTime() - t;
+  return age >= 0 && age <= NEW_WINDOW_MS;
+}
+
+/** Newest first; undated items sort last, ties keep catalog order. */
+export function byNewest<T extends { addedAt?: string }>(items: T[]): T[] {
+  const stamp = (i: T) => (i.addedAt ? Date.parse(i.addedAt) || 0 : 0);
+  return [...items].sort((a, b) => stamp(b) - stamp(a));
+}
+
+export function byName<T extends { name: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/desktop/src/hooks/useRemoveWidget.ts
+++ b/desktop/src/hooks/useRemoveWidget.ts
@@ -3,13 +3,14 @@
  * per-widget info page and the sidebar context menu (v1.1.2) so the two
  * surfaces can't drift:
  *   - DATA widget → DELETE /users/me/widgets/{type}, dashboard refetch,
- *     success toast. The slot frees immediately.
+ *     success toast with Undo (re-creates the row with the config it had,
+ *     so a mis-click doesn't lose a watchlist). The slot frees immediately.
  *   - UTILITY widget → disabled via the undoable prefs path (settings
  *     preserved, Undo in the toast).
  *
  * Errors are surfaced as toasts here — callers never need a catch.
  */
-import { useCallback } from "react";
+import { useCallback, useContext } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -18,6 +19,8 @@ import type { WidgetId } from "../api/client";
 import { queryKeys } from "../api/queries";
 import type { CatalogItem } from "../marketplace";
 import { disableWidget } from "../preferences";
+import { ShellContext } from "../shell-context";
+import type { DashboardResponse } from "../types";
 import { useUndoableAction } from "./useUndoableAction";
 import type { UndoShellPlumbing } from "./useUndoableAction";
 
@@ -30,6 +33,8 @@ export function useRemoveWidget(
 ): (item: CatalogItem) => Promise<void> {
   const queryClient = useQueryClient();
   const undoable = useUndoableAction(shell);
+  const ctx = useContext(ShellContext);
+  const prefs = (shell ?? ctx)?.prefs;
 
   return useCallback(
     async (item: CatalogItem) => {
@@ -39,11 +44,34 @@ export function useRemoveWidget(
       // catalog refresh landing between render and click would answer about a
       // different catalog than the one that produced this item.
       if (item.source) {
+        // The row's config, captured before the delete so Undo can put
+        // back the same watchlist / feeds rather than the catalog default.
+        const row = queryClient
+          .getQueryData<DashboardResponse>(queryKeys.dashboard)
+          ?.widgets?.find((w) => w.widget_type === item.id);
         try {
           await dataWidgetsApi.delete(item.id);
           queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
           toast.success(`${item.name} removed`, {
             description: "Its slot is free for another widget.",
+            action: {
+              label: "Undo",
+              onClick: () => {
+                dataWidgetsApi
+                  .create(
+                    item.id,
+                    row?.config ?? item.addConfig ?? {},
+                    prefs?.widgets.enabledWidgets.length,
+                  )
+                  .then(() => {
+                    queryClient.invalidateQueries({
+                      queryKey: queryKeys.dashboard,
+                    });
+                    toast.success(`${item.name} restored`);
+                  })
+                  .catch(() => toast.error(`Couldn't restore ${item.name}`));
+              },
+            },
           });
         } catch (err) {
           console.error("[Scrollr] Remove failed:", err);
@@ -60,6 +88,6 @@ export function useRemoveWidget(
         );
       }
     },
-    [queryClient, undoable],
+    [queryClient, undoable, prefs],
   );
 }

--- a/desktop/src/marketplace.ts
+++ b/desktop/src/marketplace.ts
@@ -153,6 +153,12 @@ export interface CatalogItem {
   addConfig?: Record<string, unknown>;
   info: SourceInfo;
   requiredTier: SubscriptionTier;
+  /** Sub-shelf inside a category ("Soccer"). Missing → ungrouped. */
+  group?: string;
+  /** Search aliases the name and description don't contain ("btc"). */
+  keywords?: string[];
+  /** ISO date the widget joined the catalog; drives "new". */
+  addedAt?: string;
 }
 
 /** The source widget id for a data-widget id, or undefined for a utility /
@@ -286,6 +292,9 @@ function buildItem(w: CatalogWidget): CatalogItem | null {
       usage: w.usage ?? renderer.info.usage,
     },
     requiredTier: w.required_tier as SubscriptionTier,
+    group: w.group,
+    keywords: w.keywords,
+    addedAt: w.added_at,
   };
 }
 

--- a/desktop/src/routes/catalog.test.tsx
+++ b/desktop/src/routes/catalog.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Catalog route — hub ↔ directory over the URL, against the bundled
+ * snapshot catalog (REL-215). The real `Route` is mounted under a test
+ * root that stands in for RootLayout's providers, so search-param
+ * handling is the production code, not a re-statement of it.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { Route } from "./catalog";
+import { buildBlocks } from "../components/marketplace/CatalogDirectory";
+import { getCatalogItems } from "../marketplace";
+import { ShellContext, ShellDataContext } from "../shell-context";
+import type { ShellState } from "../shell-context";
+import { loadPrefs } from "../preferences";
+import type { SubscriptionTier } from "../auth";
+import type { DataWidgetRow } from "../api/client";
+
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: vi.fn(() => Promise.reject(new Error("no tauri in tests"))),
+}));
+vi.mock("../api/client", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../api/client")>();
+  return {
+    ...mod,
+    requestCatalogWidget: vi.fn(async (query: string) => ({ query, count: 3 })),
+  };
+});
+
+const row = (widget_type: string): DataWidgetRow => ({
+  id: 1,
+  widget_type,
+  enabled: true,
+  ticker_enabled: true,
+  config: {},
+  created_at: "2026-09-01T00:00:00Z",
+  updated_at: "2026-09-01T00:00:00Z",
+});
+
+function mount(
+  path: string,
+  opts: { tier?: SubscriptionTier; widgets?: string[]; authenticated?: boolean } = {},
+) {
+  // Defaults enable a few utilities; the slot maths below wants a clean sheet.
+  const base = loadPrefs();
+  const prefs = {
+    ...base,
+    widgets: { ...base.widgets, enabledWidgets: [], widgetsOnTicker: [] },
+  };
+  const shell: ShellState = {
+    prefs,
+    onPrefsChange: vi.fn(),
+    authenticated: opts.authenticated ?? true,
+    tier: opts.tier ?? "super_user",
+    subscriptionInfo: null,
+    onLogin: vi.fn(),
+    onLogout: vi.fn(),
+    autostartEnabled: false,
+    onAutostartChange: vi.fn(),
+    appVersion: "test",
+    allDataWidgetManifests: [],
+    allWidgets: [],
+  };
+  const widgets = (opts.widgets ?? []).map(row);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const rootRoute = createRootRoute({
+    component: () => (
+      <QueryClientProvider client={queryClient}>
+        <ShellContext.Provider value={shell}>
+          <ShellDataContext.Provider value={{ widgets, dashboard: undefined }}>
+            <Outlet />
+          </ShellDataContext.Provider>
+        </ShellContext.Provider>
+      </QueryClientProvider>
+    ),
+  });
+  // Same wiring the generated route tree does for the file route.
+  const catalog = Route.update({
+    id: "/catalog",
+    path: "/catalog",
+    getParentRoute: () => rootRoute,
+  } as never);
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([catalog]),
+    history: createMemoryHistory({ initialEntries: [path] }),
+  });
+  render(<RouterProvider router={router} />);
+  return { router, shell };
+}
+
+// jsdom has no IntersectionObserver (the WidgetBar's pinned-shadow
+// sentinel) and no Element.scrollTo (PageLayout's scroll reset).
+class NoopObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.stubGlobal("IntersectionObserver", NoopObserver);
+  Element.prototype.scrollTo = () => {};
+});
+
+describe("hub", () => {
+  it("lands on the hub with one tile per kind and the slot line", async () => {
+    mount("/catalog", { tier: "free", widgets: ["sports_nfl"] });
+    expect(
+      await screen.findByRole("heading", { name: "What do you want on your ticker?" }),
+    ).toBeInTheDocument();
+    // Sports tile carries its count and the added count.
+    const sports = screen.getByRole("button", { name: /^Sports, \d+ widgets$/ });
+    expect(within(sports).getByText("1 added")).toBeInTheDocument();
+    expect(screen.getByText("Something else?")).toBeInTheDocument();
+    expect(screen.getByText("1 of 3 slots used")).toBeInTheDocument();
+    // In your ticker lists the added widget (the Try chip is the other one).
+    expect(screen.getAllByRole("button", { name: "NFL" })).toHaveLength(2);
+  });
+
+  it("flags the free-tier cap on the hub line", async () => {
+    mount("/catalog", {
+      tier: "free",
+      widgets: ["sports_nfl", "sports_nba", "finance_stocks"],
+    });
+    expect(await screen.findByText("3 of 3 slots used")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upgrade for unlimited" })).toBeInTheDocument();
+  });
+
+  it("a tile opens that kind's directory with the query cleared", async () => {
+    const { router } = mount("/catalog");
+    fireEvent.click(await screen.findByRole("button", { name: /^Sports, \d+ widgets$/ }));
+    await waitFor(() => expect(router.state.location.search).toEqual({ kind: "sports" }));
+    expect(await screen.findByRole("heading", { level: 1, name: "Sports" })).toBeInTheDocument();
+  });
+
+  it("typing in the hero drops into search results", async () => {
+    const { router } = mount("/catalog");
+    fireEvent.change(await screen.findByLabelText("Search widgets"), {
+      target: { value: "soccer" },
+    });
+    await waitFor(() => expect(router.state.location.search).toEqual({ q: "soccer" }));
+  });
+});
+
+describe("directory", () => {
+  it("shows a kind with group headers and the rail", async () => {
+    mount("/catalog?kind=sports");
+    expect(await screen.findByRole("heading", { level: 1, name: "Sports" })).toBeInTheDocument();
+    // Sports has enough widgets for group headers.
+    expect(screen.getByRole("heading", { level: 2, name: "Soccer" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Football" })).toBeInTheDocument();
+    const rail = screen.getByRole("navigation", { name: "Kinds" });
+    expect(within(rail).getByRole("button", { name: /All widgets/ })).toBeInTheDocument();
+    expect(within(rail).getByRole("button", { name: /Sports/ })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(within(rail).getByText("Your ticker")).toBeInTheDocument();
+  });
+
+  it("a search hit groups results by kind and hides group headers", async () => {
+    mount("/catalog?q=soccer");
+    expect(await screen.findByRole("heading", { level: 1, name: "Sports" })).toBeInTheDocument();
+    // The bar's summary and each block's sub both count matches.
+    expect(screen.getAllByText(/\d+ matches/).length).toBeGreaterThan(1);
+    expect(screen.queryByRole("heading", { level: 2, name: "Soccer" })).not.toBeInTheDocument();
+    expect(screen.getByText("Premier League")).toBeInTheDocument();
+    expect(screen.queryByText("NFL")).not.toBeInTheDocument();
+  });
+
+  it("a miss shows the request card and the closest group", async () => {
+    mount("/catalog?q=Eredivisie");
+    expect(await screen.findByText("No “Eredivisie” widget yet")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Closest matches" })).toBeInTheDocument();
+    expect(screen.getByText("Soccer")).toBeInTheDocument();
+    expect(screen.getByText("Premier League")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Request Eredivisie" }));
+    expect(await screen.findByText(/3 people have asked/)).toBeInTheDocument();
+  });
+
+  it("picking a rail kind clears the query; clearing the field keeps the kind", async () => {
+    const { router } = mount("/catalog?kind=news&q=soccer");
+    const rail = await screen.findByRole("navigation", { name: "Kinds" });
+    fireEvent.click(within(rail).getByRole("button", { name: /Finance/ }));
+    await waitFor(() => expect(router.state.location.search).toEqual({ kind: "finance" }));
+
+    fireEvent.change(screen.getByLabelText("Search widgets"), { target: { value: "btc" } });
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({ kind: "finance", q: "btc" }),
+    );
+    expect(await screen.findByText("Crypto")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search widgets"), { target: { value: "" } });
+    await waitFor(() => expect(router.state.location.search).toEqual({ kind: "finance" }));
+  });
+
+  it("Overview returns to the hub", async () => {
+    const { router } = mount("/catalog?kind=sports");
+    fireEvent.click(await screen.findByRole("button", { name: "Overview" }));
+    await waitFor(() => expect(router.state.location.search).toEqual({}));
+    expect(
+      await screen.findByRole("heading", { name: "What do you want on your ticker?" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reads the cap on the rail and the bar, and the ✓ is a remove button", async () => {
+    mount("/catalog?kind=sports", {
+      tier: "free",
+      widgets: ["sports_nfl", "sports_nba", "finance_stocks"],
+    });
+    const rail = await screen.findByRole("navigation", { name: "Kinds" });
+    expect(within(rail).getByText("3/3")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /All 3 slots used/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove NFL" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add NHL" })).toBeInTheDocument();
+  });
+});
+
+describe("buildBlocks sorts", () => {
+  const items = getCatalogItems().filter((i) => !i.hidden);
+  const none = new Set<string>();
+
+  it("A–Z flattens a kind into one alphabetical shelf", () => {
+    const { blocks } = buildBlocks(items, "sports", "", "az", none);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].showHeads).toBe(false);
+    const names = blocks[0].shelves[0].items.map((i) => i.name);
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("newest-first is one block across every kind, dated first", () => {
+    const { blocks } = buildBlocks(items, "all", "", "new", none);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].title).toBe("Newest first");
+    expect(blocks[0].shelves[0].items[0].id).toBe("news_drudge");
+  });
+
+  it("by kind shelves Sports by group with headers, Finance without", () => {
+    const sports = buildBlocks(items, "sports", "", undefined, none).blocks[0];
+    expect(sports.showHeads).toBe(true);
+    expect(sports.shelves.map((s) => s.key)).toContain("Soccer");
+    const finance = buildBlocks(items, "finance", "", undefined, none).blocks[0];
+    expect(finance.showHeads).toBe(false);
+  });
+});

--- a/desktop/src/routes/catalog.tsx
+++ b/desktop/src/routes/catalog.tsx
@@ -1,95 +1,95 @@
 /**
- * Catalog — browse and act.
+ * Catalog — one route, two views (design_handoff_catalog/, REL-215).
  *
- * Was a browse-only grid split into "Your widgets" / "Discover", with
- * every transaction one navigation away on the widget's info page. It's
- * a store now: cards add in place, and details open in a slide-over so
- * you keep your place in the shelf you were reading.
+ * The HUB is where you arrive: a search hero, one tile per kind, what's
+ * new, what's yours. A tile or a typed query drops into the DIRECTORY: a
+ * kind rail on the left, grouped rows on the right. Both are sub-states
+ * of this one route — `?kind=` / `?q=` select the directory, neither is
+ * the hub — so Back and deep links work and the two views never drift
+ * on gating, slots or the open panel.
  *
- * Browsing All shows one shelf per category in canonical order, which
- * beats Your/Discover for the thing people actually do here — look for a
- * kind of thing. Filtering or searching collapses to a single section,
- * and the "In your ticker" strip (which subsumed both the old Your
- * section and the slot banner) hides, because at that point you are
- * shopping, not auditing.
+ * Rules (the design's Behavior card):
+ *   - typing anywhere → directory results grouped by kind; clearing the
+ *     field returns to the last kind, not the hub;
+ *   - picking a kind in the rail clears the query;
+ *   - + adds in place; ✓ removes with a toast undo; the row body opens
+ *     the slide-over panel;
+ *   - zero matches → request card + closest group;
+ *   - at slot cap, + opens the panel (where the upgrade path lives) and
+ *     the cap reads on the sidebar chip, the rail and the hub line.
  */
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { Check, Plus, Search } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
-import clsx from "clsx";
 
 import {
   CATEGORY_LABELS,
   canonicalOrder,
+  catalogItemById,
   getCatalogItems,
-  readableTextOn,
 } from "../marketplace";
-import type { CatalogItem, WidgetCategory } from "../marketplace";
+import type { CatalogItem } from "../marketplace";
 import { dashboardQueryOptions } from "../api/queries";
 import { useShell, useShellData } from "../shell-context";
 import { useCatalog } from "../hooks/useCatalog";
 import { useAddWidget } from "../hooks/useAddWidget";
 import { useRemoveWidget } from "../hooks/useRemoveWidget";
 import { getMaxWidgets, tierMeets } from "../tierLimits";
-import { SlotPills, useSlotUsage } from "../components/SlotMeter";
-import CatalogCard from "../components/marketplace/CatalogCard";
+import { useSlotUsage } from "../components/SlotMeter";
 import WidgetPanel from "../components/marketplace/WidgetPanel";
+import CatalogHub from "../components/marketplace/CatalogHub";
+import CatalogDirectory from "../components/marketplace/CatalogDirectory";
+import { kindFromSearch } from "../components/marketplace/catalogSearch";
+import type { CatalogKind, CatalogSort } from "../components/marketplace/catalogSearch";
 import QueryErrorBanner from "../components/QueryErrorBanner";
 import RouteError from "../components/RouteError";
 import PageLayout from "../components/layout/PageLayout";
-import EmptySection from "../components/layout/EmptySection";
-import { WidgetBar } from "../components/widget-bar/Bar";
-import { Segmented } from "../components/widget-bar/Segmented";
 
 // ── Route ───────────────────────────────────────────────────────
 
-type FilterTab = "all" | WidgetCategory;
+export interface CatalogSearch {
+  /** Open panel — deep-links and survives reload. */
+  widget?: string;
+  /** Directory kind. "all" or a category; anything else reads as all. */
+  kind?: string;
+  /** Directory query. Present (even with a kind) → search results. */
+  q?: string;
+  sort?: CatalogSort;
+}
 
-const CATEGORY_ORDER: WidgetCategory[] = [
-  "sports",
-  "finance",
-  "news",
-  "fantasy",
-  "predictions",
-  "utility",
-];
+const SORTS: CatalogSort[] = ["az", "popular", "new"];
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" && v ? v : undefined;
 
 export const Route = createFileRoute("/catalog")({
   component: CatalogPage,
   errorComponent: RouteError,
-  // The open panel is a search param so it deep-links, survives reload,
-  // and gives Back somewhere sensible to go.
-  validateSearch: (search: Record<string, unknown>): { widget?: string } =>
-    typeof search.widget === "string" && search.widget
-      ? { widget: search.widget }
-      : {},
+  validateSearch: (search: Record<string, unknown>): CatalogSearch => {
+    const out: CatalogSearch = {};
+    const widget = str(search.widget);
+    const kind = str(search.kind);
+    const q = str(search.q);
+    const sort = str(search.sort);
+    if (widget) out.widget = widget;
+    if (kind) out.kind = kind;
+    if (q) out.q = q;
+    if (sort && (SORTS as string[]).includes(sort)) out.sort = sort as CatalogSort;
+    return out;
+  },
 });
 
-// ── Spotlight ───────────────────────────────────────────────────
-//
-// Editorial, so it is hardcoded rather than derived: the point is a
-// human saying "start here", and all three are zero-config — nothing to
-// set up before they show you something.
-
-const SPOTLIGHT: { id: string; tagline: string }[] = [
-  { id: "finance_stocks", tagline: "Instant quotes" },
-  { id: "predictions", tagline: "Read the room" },
-  { id: "clock", tagline: "Always on time" },
-];
+export const UPGRADE_URL = "https://myscrollr.com/uplink";
 
 // ── Page ────────────────────────────────────────────────────────
 
 function CatalogPage() {
   const navigate = useNavigate();
-  const { widget: openId } = Route.useSearch();
+  const search = Route.useSearch();
   const { prefs, authenticated, tier, onLogin } = useShell();
   const { widgets } = useShellData();
   const { error: dashboardError } = useQuery(dashboardQueryOptions());
-
-  const [filter, setFilter] = useState<FilterTab>("all");
-  const [query, setQuery] = useState("");
 
   const addWidget = useAddWidget();
   const removeWidget = useRemoveWidget();
@@ -97,9 +97,94 @@ function CatalogPage() {
   // The catalog is the one surface whose entire content IS the catalog,
   // so it subscribes: a refresh must swap the shelves underneath it.
   const catalogVersion = useCatalog();
-  // Hidden entries are off the add grid but still resolve by id, so a
-  // widget someone already has keeps its name, colour and page.
-  const allItems = useMemo(() => getCatalogItems().filter((i) => !i.hidden), [catalogVersion]);
+  // Hidden entries are off the shelves but still resolve by id, so a
+  // widget someone already has keeps its name, colour and page — and the
+  // hub's "Custom RSS" chip can open the hidden entry's panel.
+  const allItems = useMemo(() => {
+    const order = canonicalOrder();
+    const rank = (i: CatalogItem) => {
+      const at = order.indexOf(i.id);
+      return at === -1 ? Number.MAX_SAFE_INTEGER : at;
+    };
+    return getCatalogItems()
+      .filter((i) => !i.hidden)
+      .sort((a, b) => rank(a) - rank(b));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogVersion]);
+  const customRss = useMemo(
+    () => catalogItemById("rss_custom") ?? null,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [catalogVersion],
+  );
+
+  const view: "hub" | "dir" = search.kind || search.q ? "dir" : "hub";
+  const kind = kindFromSearch(search.kind);
+  const query = search.q ?? "";
+
+  // ── Navigation ────────────────────────────────────────────────
+
+  const go = useCallback(
+    (next: CatalogSearch, replace = false) =>
+      void navigate({ to: "/catalog", search: next, replace }),
+    [navigate],
+  );
+
+  const goHub = useCallback(() => go({}), [go]);
+  const goKind = useCallback(
+    (k: CatalogKind) => go({ kind: k, ...(search.sort ? { sort: search.sort } : {}) }),
+    [go, search.sort],
+  );
+  // Typing: the first keystroke enters the directory (a history entry
+  // Back can return from); the rest rewrite it in place. Clearing goes
+  // back to the last kind, never to the hub.
+  const onQueryChange = useCallback(
+    (q: string) => {
+      const base = search.sort ? { sort: search.sort } : {};
+      if (q === "") {
+        go({ ...base, kind: search.kind ?? "all" }, true);
+        return;
+      }
+      go(
+        { ...base, ...(search.kind ? { kind: search.kind } : {}), q },
+        Boolean(search.q),
+      );
+    },
+    [go, search.kind, search.q, search.sort],
+  );
+  const onSortChange = useCallback(
+    (sort: CatalogSort | undefined) =>
+      go(
+        {
+          kind: search.kind ?? "all",
+          ...(search.q ? { q: search.q } : {}),
+          ...(sort ? { sort } : {}),
+        },
+        true,
+      ),
+    [go, search.kind, search.q],
+  );
+
+  const setOpen = useCallback(
+    (item: CatalogItem | null) =>
+      go(
+        {
+          ...(search.kind ? { kind: search.kind } : {}),
+          ...(search.q ? { q: search.q } : {}),
+          ...(search.sort ? { sort: search.sort } : {}),
+          ...(item ? { widget: item.id } : {}),
+        },
+        true,
+      ),
+    [go, search.kind, search.q, search.sort],
+  );
+
+  const onUpgrade = useCallback(() => void open(UPGRADE_URL), []);
+  const onRequestWidget = useCallback(
+    () => void navigate({ to: "/support" }),
+    [navigate],
+  );
+
+  // ── Gating ────────────────────────────────────────────────────
 
   // Deliberately two different sets. "Added" counts every row so a
   // disabled widget still reads as added and can't be added twice; the
@@ -114,26 +199,6 @@ function CatalogPage() {
   );
 
   const slots = useSlotUsage();
-  const browsing = filter === "all" && query.trim() === "";
-
-  // ── Selection ─────────────────────────────────────────────────
-
-  const openItem = useMemo(
-    () => allItems.find((i) => i.id === openId) ?? null,
-    [allItems, openId],
-  );
-
-  const setOpen = useCallback(
-    (item: CatalogItem | null) => {
-      void navigate({
-        to: "/catalog",
-        search: item ? { widget: item.id } : {},
-        replace: true,
-      });
-    },
-    [navigate],
-  );
-
   const maxSlots = getMaxWidgets(tier);
   const capped = slots.finite && slots.used >= maxSlots;
 
@@ -167,63 +232,22 @@ function CatalogPage() {
     [addWidget, authenticated, lockedFor, setOpen],
   );
 
-  // ── Shelves ───────────────────────────────────────────────────
-
-  const matches = useCallback(
-    (item: CatalogItem) => {
-      const q = query.trim().toLowerCase();
-      if (!q) return true;
-      return `${item.name} ${item.description} ${CATEGORY_LABELS[item.category]}`
-        .toLowerCase()
-        .includes(q);
-    },
-    [query],
+  const handleRemove = useCallback(
+    (item: CatalogItem) => void removeWidget(item),
+    [removeWidget],
   );
 
-  const shelves = useMemo(() => {
-    const order = canonicalOrder();
-    const rank = (i: CatalogItem) => {
-      const at = order.indexOf(i.id);
-      return at === -1 ? Number.MAX_SAFE_INTEGER : at;
-    };
-    const pool = allItems
-      .filter((i) => (filter === "all" ? true : i.category === filter))
-      .filter(matches)
-      .sort((a, b) => rank(a) - rank(b));
+  // ── Panel ─────────────────────────────────────────────────────
 
-    if (browsing) {
-      return CATEGORY_ORDER.map((cat) => ({
-        key: cat as string,
-        title: CATEGORY_LABELS[cat],
-        items: pool.filter((i) => i.category === cat),
-      })).filter((s) => s.items.length > 0);
-    }
-    return [
-      {
-        key: "results",
-        title: filter === "all" ? "Results" : CATEGORY_LABELS[filter],
-        items: pool,
-      },
-    ].filter((s) => s.items.length > 0);
-  }, [allItems, filter, matches, browsing]);
-
-  const spotlight = useMemo(
-    () =>
-      browsing
-        ? SPOTLIGHT.map((s) => ({
-            ...s,
-            item: allItems.find((i) => i.id === s.id),
-          })).filter((s): s is typeof s & { item: CatalogItem } =>
-            Boolean(s.item),
-          )
-        : [],
-    [allItems, browsing],
-  );
-
-  const yourItems = useMemo(
-    () => allItems.filter((i) => addedIds.has(i.id)),
-    [allItems, addedIds],
-  );
+  const openItem = useMemo(() => {
+    if (!search.widget) return null;
+    return (
+      allItems.find((i) => i.id === search.widget) ??
+      // Hidden entries (Custom RSS) open from the hub's "Something else?"
+      catalogItemById(search.widget) ??
+      null
+    );
+  }, [allItems, search.widget]);
 
   const related = useMemo(() => {
     if (!openItem) return [];
@@ -232,254 +256,70 @@ function CatalogPage() {
       .slice(0, 3);
   }, [allItems, openItem]);
 
-  const cardFor = (item: CatalogItem, variant: "rich" | "compact") => {
-    const { added } = lockedFor(item);
-    return (
-      <CatalogCard
-        key={item.id}
-        item={item}
-        added={added}
-        variant={variant}
-        onOpen={setOpen}
-        onAdd={added ? undefined : handleAdd}
-      />
-    );
-  };
-
   const gating = openItem
     ? lockedFor(openItem)
     : { added: false, tierLocked: false, slotLocked: false };
+
+  const crumb = query
+    ? `Search “${query.trim()}”`
+    : kind === "all"
+      ? "All widgets"
+      : CATEGORY_LABELS[kind];
+
+  const shared = {
+    items: allItems,
+    addedIds,
+    slots,
+    capped,
+    onOpen: setOpen,
+    onAdd: handleAdd,
+    onRemove: handleRemove,
+    onUpgrade,
+    onCustomRss: customRss ? () => setOpen(customRss) : undefined,
+    onRequestWidget,
+  };
 
   return (
     <PageLayout
       // While the panel is open the page IS that widget, so the title
       // takes its name and "Catalog" steps back to being the parent —
       // otherwise the breadcrumb reads "Catalog / Catalog".
-      title={openItem ? openItem.name : "Catalog"}
+      title={openItem ? openItem.name : view === "dir" ? crumb : "Catalog"}
       width="wide"
-      noTopPadding
-      parentLabel={openItem ? "Catalog" : undefined}
-      onParentClick={openItem ? () => setOpen(null) : undefined}
+      fillHeight={view === "dir"}
+      noContentPadding={view === "dir"}
+      parentLabel={openItem || view === "dir" ? "Catalog" : undefined}
+      onParentClick={
+        openItem ? () => setOpen(null) : view === "dir" ? goHub : undefined
+      }
     >
-      <WidgetBar>
-        <Segmented
-          ariaLabel="Filter by category"
-          value={filter}
-          // Picking a category clears the query: the pill and a stale
-          // search term otherwise compose into a result set that looks
-          // like the pill is broken.
-          onChange={(k) => {
-            setFilter(k);
-            setQuery("");
-          }}
-          options={[
-            { value: "all" as FilterTab, label: "All" },
-            ...CATEGORY_ORDER.map((c) => ({
-              value: c as FilterTab,
-              label: CATEGORY_LABELS[c],
-            })),
-          ]}
-        />
-        <div className="relative ml-auto w-[220px]">
-          <Search
-            size={13}
-            aria-hidden
-            className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-fg-4"
-          />
-          <input
-            type="search"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            aria-label="Search widgets"
-            placeholder="Search widgets"
-            autoComplete="off"
-            className="w-full rounded-[7px] border border-edge/80 bg-surface-raised py-1.5 pr-2.5 pl-7 text-ui-meta text-fg placeholder:text-fg-4 focus:border-accent/50 focus:outline-none"
-          />
-        </div>
-      </WidgetBar>
-
       {dashboardError && (
-        <div className="mt-4">
+        <div className="mx-5 mt-4">
           <QueryErrorBanner error={dashboardError} />
         </div>
       )}
 
-      <div className="mx-auto w-full max-w-[1000px] pt-4 pb-8">
-        {/* ── In your ticker ─────────────────────────────────── */}
-        {browsing && yourItems.length > 0 && (
-          <section className="mb-5 flex flex-col gap-2.5 rounded-xl border border-edge/50 bg-base-150/45 px-3.5 py-3">
-            <div className="flex flex-wrap items-center gap-2.5">
-              <h2 className="font-mono text-ui-section text-fg-3">
-                In your ticker
-              </h2>
-              <div className="ml-auto flex items-center gap-2.5">
-                <SlotPills usage={slots} />
-                <span className="text-ui-chip text-fg-4">
-                  {slots.finite
-                    ? `${slots.used} of ${slots.max} slots free`
-                    : `${slots.used} added · unlimited slots`}
-                </span>
-                {capped && (
-                  <button
-                    type="button"
-                    onClick={() => void open("https://myscrollr.com/uplink")}
-                    className="shrink-0 cursor-pointer rounded-lg bg-warn/15 px-2.5 py-1 text-ui-chip font-semibold text-warn hover:bg-warn/25"
-                  >
-                    Upgrade
-                  </button>
-                )}
-              </div>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {yourItems.map((item) => (
-                <button
-                  key={item.id}
-                  type="button"
-                  onClick={() => setOpen(item)}
-                  className="flex cursor-pointer items-center gap-2 rounded-lg border border-edge/55 bg-surface-raised px-2.5 py-1.5 hover:border-edge"
-                >
-                  <span
-                    className="flex size-[18px] shrink-0 items-center justify-center rounded text-white"
-                    style={{
-                      background: `linear-gradient(135deg, ${item.hex} 0%, ${item.hex}b8 100%)`,
-                    }}
-                  >
-                    <item.icon size={10} />
-                  </span>
-                  <span className="text-ui-meta font-medium text-fg">
-                    {item.name}
-                  </span>
-                  <Check size={11} strokeWidth={3} className="text-accent" />
-                </button>
-              ))}
-              {/* Ghost chips make an abstract number concrete: three
-                  empty outlines read as "room for three more" faster
-                  than "3 of 6 slots free" does. */}
-              {slots.finite &&
-                Array.from({ length: Math.max(0, slots.max - slots.used) }).map(
-                  (_, i) => (
-                    <span
-                      key={`empty-${i}`}
-                      className="flex items-center gap-2 rounded-lg border border-dashed border-edge/70 px-2.5 py-1.5 text-ui-meta text-fg-4"
-                    >
-                      empty slot
-                    </span>
-                  ),
-                )}
-            </div>
-          </section>
-        )}
-
-        {/* ── Spotlight ──────────────────────────────────────── */}
-        {spotlight.length > 0 && (
-          <section className="mb-6">
-            <h2 className="mb-2 font-mono text-ui-section text-fg-3">
-              Spotlight
-            </h2>
-            <div className="grid grid-cols-3 gap-3">
-              {spotlight.map(({ item, tagline }) => {
-                const textOn = readableTextOn(item.hex);
-                return (
-                  <button
-                    key={item.id}
-                    type="button"
-                    onClick={() => setOpen(item)}
-                    className="flex cursor-pointer flex-col items-start gap-2.5 rounded-xl p-3.5 text-left"
-                    style={{
-                      background: `linear-gradient(135deg, ${item.hex} 0%, ${item.hex}d8 100%)`,
-                    }}
-                  >
-                    <div className="flex items-center gap-2.5">
-                      <span
-                        className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white"
-                        style={{ color: item.hex }}
-                      >
-                        <item.icon size={18} />
-                      </span>
-                      <span className="flex min-w-0 flex-col">
-                        <span
-                          className="text-ui-body font-bold"
-                          style={{ color: textOn }}
-                        >
-                          {item.name}
-                        </span>
-                        <span
-                          className="font-mono text-ui-section opacity-80"
-                          style={{ color: textOn }}
-                        >
-                          {tagline}
-                        </span>
-                      </span>
-                    </div>
-                    <p
-                      className="text-ui-meta leading-relaxed opacity-90"
-                      style={{ color: textOn }}
-                    >
-                      {item.description}
-                    </p>
-                  </button>
-                );
-              })}
-            </div>
-          </section>
-        )}
-
-        {/* ── Shelves ────────────────────────────────────────── */}
-        {shelves.length === 0 ? (
-          <EmptySection
-            icon={Search}
-            title="Nothing matches"
-            description="Try a different word, or pick another category."
-          />
-        ) : (
-          shelves.map((shelf) => (
-            <section key={shelf.key} className="mb-6 last:mb-0">
-              <div className="mb-2 flex items-center gap-2">
-                <h2 className="font-mono text-ui-section text-fg-3">
-                  {shelf.title}
-                </h2>
-                <span className="rounded-full bg-base-150 px-2 py-0.5 text-ui-chip font-semibold text-fg-3">
-                  {shelf.items.length}
-                </span>
-              </div>
-              {/* Sports go compact: league descriptions are boilerplate,
-                  so 14 rich cards would be 14 restatements of one
-                  sentence. */}
-              <div
-                className={clsx(
-                  "grid gap-2.5",
-                  shelf.key === "sports" ? "grid-cols-4" : "grid-cols-3 gap-3",
-                )}
-              >
-                {shelf.items.map((item) =>
-                  cardFor(item, shelf.key === "sports" ? "compact" : "rich"),
-                )}
-              </div>
-            </section>
-          ))
-        )}
-
-        {/* ── Request a widget ───────────────────────────────── */}
-        {browsing && (
-          <section className="mt-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dashed border-edge/70 px-4 py-3.5">
-            <div>
-              <div className="text-ui-body font-semibold text-fg">
-                Don't see what you want?
-              </div>
-              <div className="text-ui-meta text-fg-4">
-                Tell us what you'd put in your ticker.
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => void navigate({ to: "/support" })}
-              className="shrink-0 cursor-pointer rounded-[7px] border border-edge/80 px-3 py-1.5 text-ui-chip font-medium text-fg-3 hover:border-edge hover:text-fg"
-            >
-              Request a widget
-            </button>
-          </section>
-        )}
-      </div>
+      {view === "hub" ? (
+        <CatalogHub
+          {...shared}
+          onSearch={onQueryChange}
+          onKind={goKind}
+          onSeeAllNew={() => go({ kind: "all", sort: "new" })}
+        />
+      ) : (
+        <CatalogDirectory
+          {...shared}
+          kind={kind}
+          query={query}
+          sort={search.sort}
+          authenticated={authenticated}
+          onLogin={onLogin}
+          onQueryChange={onQueryChange}
+          onKindChange={goKind}
+          onSortChange={onSortChange}
+          onOverview={goHub}
+        />
+      )}
 
       <WidgetPanel
         item={openItem}
@@ -498,7 +338,7 @@ function CatalogPage() {
           void navigate({ to: "/widget/$id", params: { id: item.id } });
         }}
         onSignIn={onLogin}
-        onUpgrade={() => void open("https://myscrollr.com/uplink")}
+        onUpgrade={onUpgrade}
         onPick={setOpen}
       />
     </PageLayout>


### PR DESCRIPTION
Catalog redesign 2/2 — the desktop page for `design_handoff_catalog/` (REL-214 shipped the server fields and `POST /catalog/requests`).

**One route, two views.** `/catalog` is the hub; `?kind=` / `?q=` select the directory, so Back and deep links work. Typing anywhere drops into results grouped by kind; clearing the field returns to the last kind (never the hub); picking a rail kind clears the query. The open panel stays `?widget=`.

| | |
|---|---|
| ![hub](https://github.com/doughknee/myscrollr/blob/captures/rel-215/01-hub.png?raw=true) | ![directory](https://github.com/doughknee/myscrollr/blob/captures/rel-215/02-directory-sports.png?raw=true) |
| 01 Hub — search hero + Try chips, Browse by kind (count, five logos + "+n", "n new" from `added_at` ≤ 30 d, "n added"), "Something else?" last, New this month, In your ticker + slot line | 02 Directory · Sports — rail (Overview, Your ticker + count, one row per kind with count, Request a widget), block with group pills, rows shelved by `group` |
| ![hit](https://github.com/doughknee/myscrollr/blob/captures/rel-215/03-search-hit.png?raw=true) | ![miss](https://github.com/doughknee/myscrollr/blob/captures/rel-215/04-search-miss.png?raw=true) |
| 03 Search hit "soccer" — haystack = name + description + group + category label + keywords; results grouped by kind, no group headers | 04 Search miss "Eredivisie" — request card (`POST /catalog/requests`, count shown after), Custom RSS, closest group from the prototype's hints |
| ![cap](https://github.com/doughknee/myscrollr/blob/captures/rel-215/05-free-tier-cap.png?raw=true) | ![all](https://github.com/doughknee/myscrollr/blob/captures/rel-215/06-directory-all.png?raw=true) |
| 05 Free tier at cap — sidebar chip, hub line + Upgrade pill (and the [rail + bar](https://github.com/doughknee/myscrollr/blob/captures/rel-215/05b-free-tier-directory.png?raw=true)); + at cap opens the panel with the upgrade path, unchanged | 06 Directory · All widgets |

Also: [light theme hub](https://github.com/doughknee/myscrollr/blob/captures/rel-215/07-hub-light.png?raw=true) / [directory](https://github.com/doughknee/myscrollr/blob/captures/rel-215/08-directory-light.png?raw=true) (colours are theme tokens, not the prototype's hex), [✓ remove → toast undo](https://github.com/doughknee/myscrollr/blob/captures/rel-215/09-remove-undo-toast.png?raw=true), [Custom RSS chip → hidden entry's panel](https://github.com/doughknee/myscrollr/blob/captures/rel-215/10-custom-rss-panel.png?raw=true).

**What changed**
- `routes/catalog.tsx` — the state machine over search params; gating, slots and the panel shared by both views.
- `components/marketplace/CatalogHub.tsx`, `CatalogDirectory.tsx` — the two views; `catalogSearch.ts` — the pure pieces (haystack, grouping + header rule, closest-group hints, new-within-30-days, sorts).
- `CatalogCard` gains a `row` variant (compact anatomy + one description line) and an `onRemove` that turns the ✓ into a remove button.
- `useRemoveWidget` — data widgets now get an Undo too (re-creates the row with the config it had); utilities already had one.
- `marketplace.ts` — `group`, `keywords`, `addedAt` on `CatalogItem`; `client.ts` — `requestCatalogWidget()`.
- `PageLayout` — `noContentPadding` now also applies in `fillHeight` mode (the directory's rail runs edge to edge).
- Reused as-is: TopBar, Sidebar chip (already flips to "Get more slots"), WidgetBar chassis, Segmented, WidgetPanel, SlotPills/useSlotUsage. `catalogItemById` still resolves hidden entries.

**Deliberate calls**
- **Popular is a labelled stub**: the segment exists, selecting it shows the catalog's own order with a one-line note. There is no popularity data yet.
- The free cap in the app is 3 slots (the prototype shows 6); the copy adapts.
- Group headers hide under 8 widgets; pills show whenever headers do and always jump to their group (the ~24-row threshold is a constant, not yet enforced separately).
- "Request a widget" (rail + hub tile) still goes to Support; the counted request path is the miss card.
- The miss card's closest list falls back to the selected kind, and to nothing on All, rather than the prototype's hard-coded Soccer.

**Verified**
- `tsc --noEmit` clean; vitest 65 files / 712 tests green (new: `catalogSearch.test.ts`, `CatalogPage.test.tsx` — the real route mounted under a test root, against the snapshot catalog).
- Browser pane on `vite --port 5180` via the shim page (no Tauri); captures are headless Edge over CDP against the same page, on branch `captures/rel-215`.
- Real app run (sidebar slot count, add/remove toast) noted in a comment below once the dev build finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
