### PR TITLE
fix(desktop): catalog search keeps focus across hub → directory [REL-218]

### DIFF
--- a/desktop/src/components/marketplace/CatalogDirectory.tsx
+++ b/desktop/src/components/marketplace/CatalogDirectory.tsx
@@ -286,6 +286,9 @@ export default function CatalogDirectory({
           <input
             type="search"
             value={draft}
+            // The query came in from the hub's field or a Try chip, so
+            // the caret follows it here. Works on mount only because the
+            // chassis shell hides via :empty, not state (REL-218).
             autoFocus={query !== ""}
             onChange={(e) => {
               setDraft(e.target.value);

--- a/desktop/src/components/marketplace/CatalogPage.test.tsx
+++ b/desktop/src/components/marketplace/CatalogPage.test.tsx
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   Outlet,
   RouterProvider,
@@ -21,6 +22,7 @@ import { Route } from "../../routes/catalog";
 import { buildBlocks } from "./CatalogDirectory";
 import { getCatalogItems } from "../../marketplace";
 import { ShellContext, ShellDataContext } from "../../shell-context";
+import { BarChassisProvider, BarChassisSlot } from "../widget-bar/BarChassis";
 import type { ShellState } from "../../shell-context";
 import { loadPrefs } from "../../preferences";
 import type { SubscriptionTier } from "../../auth";
@@ -77,12 +79,17 @@ function mount(
     defaultOptions: { queries: { retry: false } },
   });
 
+  // The chassis is active on /catalog in the app, so the directory's bar
+  // row goes through the portal here too — that is where REL-218 lived.
   const rootRoute = createRootRoute({
     component: () => (
       <QueryClientProvider client={queryClient}>
         <ShellContext.Provider value={shell}>
           <ShellDataContext.Provider value={{ widgets, dashboard: undefined }}>
-            <Outlet />
+            <BarChassisProvider active>
+              <BarChassisSlot />
+              <Outlet />
+            </BarChassisProvider>
           </ShellDataContext.Provider>
         </ShellContext.Provider>
       </QueryClientProvider>
@@ -152,6 +159,38 @@ describe("hub", () => {
       target: { value: "soccer" },
     });
     await waitFor(() => expect(router.state.location.search).toEqual({ q: "soccer" }));
+  });
+
+  // REL-218: the first character swaps the hub's field for the
+  // directory's. Keys go to whatever is focused, so every character
+  // after the first is lost unless the new field takes the focus.
+  it("keeps every keystroke and the focus across the hub → directory swap", async () => {
+    const { router } = mount("/catalog");
+    const user = userEvent.setup({ delay: 40 });
+    await user.click(await screen.findByLabelText("Search widgets"));
+    await user.keyboard("bit");
+    await waitFor(() => expect(router.state.location.search).toEqual({ q: "bit" }));
+    const field = screen.getByLabelText<HTMLInputElement>("Search widgets");
+    expect(field).toHaveValue("bit");
+    await waitFor(() => expect(field).toHaveFocus());
+    expect(field.selectionStart).toBe(3);
+    expect(await screen.findByText("Crypto")).toBeInTheDocument();
+
+    // Backspace to empty: the last kind, still this field, still focused.
+    await user.keyboard("{Backspace}{Backspace}{Backspace}");
+    await waitFor(() => expect(router.state.location.search).toEqual({ kind: "all" }));
+    expect(screen.getByLabelText("Search widgets")).toBe(field);
+    expect(field).toHaveFocus();
+  });
+
+  it("a Try chip opens the directory with the query in a focused field", async () => {
+    const { router } = mount("/catalog");
+    fireEvent.click(await screen.findByRole("button", { name: "Bitcoin" }));
+    await waitFor(() => expect(router.state.location.search).toEqual({ q: "Bitcoin" }));
+    const field = screen.getByLabelText<HTMLInputElement>("Search widgets");
+    expect(field).toHaveValue("Bitcoin");
+    await waitFor(() => expect(field).toHaveFocus());
+    expect(field.selectionStart).toBe("Bitcoin".length);
   });
 });
 

--- a/desktop/src/components/widget-bar/Bar.tsx
+++ b/desktop/src/components/widget-bar/Bar.tsx
@@ -73,12 +73,9 @@ export function WidgetBar({ children }: { children: React.ReactNode }) {
     return () => io.disconnect();
   }, [sentinelEl, reportStuck]);
 
-  // Chassis-visibility bookkeeping (portal mode only). LAYOUT effect,
-  // not passive: the portal row enters/leaves the chassis DOM in the
-  // commit itself, so the shell's hidden-at-zero-rows class must flip
-  // pre-paint too — a passive effect painted one frame of empty band
-  // (or of a row inside a display:none shell) on every barless↔bar
-  // (e.g. predictions Markets↔Positions).
+  // Chassis row bookkeeping (portal mode only): at zero rows the chassis
+  // drops any pinned elevation. Visibility itself is CSS (`empty:hidden`
+  // on the shell), so it flips in the very commit the row lands.
   const report = chassis?.report;
   useLayoutEffect(() => {
     if (!report) return;

--- a/desktop/src/components/widget-bar/BarChassis.test.tsx
+++ b/desktop/src/components/widget-bar/BarChassis.test.tsx
@@ -13,7 +13,7 @@
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
-import { BarChassisProvider, BarChassisSlot, useBarChassis } from "./BarChassis";
+import { BarChassisProvider, BarChassisSlot } from "./BarChassis";
 import { WidgetBar } from "./Bar";
 
 // jsdom has no IntersectionObserver and WidgetBar constructs one on mount.
@@ -45,16 +45,13 @@ beforeEach(() => {
 });
 afterEach(() => vi.unstubAllGlobals());
 
-/** The chassis shell — the element carrying `hidden` and the elevation.
- *
- *  Selected via the grid-stacked host, which ONLY BarChassisSlot renders.
+/** The chassis shell — the grid-stacked portal host, carrying the
+ *  elevation and `empty:hidden`. ONLY BarChassisSlot renders a grid:
  *  `@container` alone is ambiguous — WidgetBar's standalone shell carries
  *  it too, so matching on that silently reads the wrong element in the
  *  no-provider case. */
 const shell = () =>
-  (document.querySelector(".grid.items-center")?.parentElement ?? null) as
-    | HTMLElement
-    | null;
+  document.querySelector(".grid.items-center") as HTMLElement | null;
 
 /** WidgetBar's own sticky shell, rendered only when there is no chassis. */
 const standaloneShell = () =>
@@ -112,24 +109,26 @@ describe("BarChassis", () => {
   it("hides the shell while no row is mounted, without unmounting the host", () => {
     const { rerender } = render(<Frame bars={0} />);
     // Hidden, NOT removed: the host node has to survive or the next
-    // bar's portal has nowhere to land.
+    // bar's portal has nowhere to land. Hiding is `:empty` in CSS so it
+    // can never lag the row by a commit (REL-218).
     expect(shell()).toBeTruthy();
-    expect(shell()).toHaveClass("hidden");
+    expect(shell()).toHaveClass("empty:hidden");
+    expect(shell()).toBeEmptyDOMElement();
 
     rerender(<Frame bars={1} />);
-    expect(shell()).not.toHaveClass("hidden");
+    expect(shell()).not.toBeEmptyDOMElement();
   });
 
   it("stays visible through a swap, then hides once the last row leaves", () => {
     // Two bars coexist mid-swap (outgoing + incoming, grid-stacked).
     const { rerender } = render(<Frame bars={2} />);
-    expect(shell()).not.toHaveClass("hidden");
+    expect(shell()!.childElementCount).toBe(2);
 
     rerender(<Frame bars={1} />);   // outgoing finishes exiting
-    expect(shell()).not.toHaveClass("hidden");
+    expect(shell()!.childElementCount).toBe(1);
 
     rerender(<Frame bars={0} />);   // barless page
-    expect(shell()).toHaveClass("hidden");
+    expect(shell()).toBeEmptyDOMElement();
   });
 
   it("raises elevation when the bar pins and drops it when it unpins", () => {
@@ -159,37 +158,3 @@ describe("BarChassis", () => {
   });
 });
 
-describe("BarChassis row bookkeeping", () => {
-  // report() fires from a layout effect on every bar mount/unmount, so an
-  // unbalanced -1 is reachable (double cleanup, StrictMode double-invoke).
-  // It must clamp at zero, because the shell hides on `rowCount === 0`
-  // exactly — a count of -1 is not 0, so the shell would render VISIBLE
-  // with no row portaled into it: an empty chrome band, the precise thing
-  // hiding-at-zero exists to prevent.
-  function Reporter({ onReady }: { onReady: (r: (d: 1 | -1) => void) => void }) {
-    const ctx = useBarChassis();
-    if (ctx) onReady(ctx.report);
-    return null;
-  }
-
-  it("clamps at zero so a stray unmount can't leave an empty band showing", () => {
-    let report!: (d: 1 | -1) => void;
-    render(
-      <BarChassisProvider active>
-        <BarChassisSlot />
-        <Reporter onReady={(r) => (report = r)} />
-      </BarChassisProvider>,
-    );
-    expect(shell()).toHaveClass("hidden");
-
-    // Stray cleanups with nothing mounted. Unclamped this reaches -2, and
-    // `rowCount === 0` is then false — the shell would un-hide itself.
-    act(() => { report(-1); report(-1); });
-    expect(shell()).toHaveClass("hidden");
-
-    // And the count must still be at zero, not -2: one real bar mounting
-    // has to be enough to show the shell.
-    act(() => { report(1); });
-    expect(shell()).not.toHaveClass("hidden");
-  });
-});

--- a/desktop/src/components/widget-bar/BarChassis.tsx
+++ b/desktop/src/components/widget-bar/BarChassis.tsx
@@ -29,8 +29,8 @@ interface BarChassisValue {
   /** DOM node WidgetBar portals its row into (null for a beat on boot
    *  while the slot's ref settles — render nothing, not a local shell). */
   host: HTMLElement | null;
-  /** Row mount bookkeeping — the shell hides itself at zero rows so
-   *  barless pages (e.g. widget info) don't show an empty chrome band. */
+  /** Row mount bookkeeping — at zero rows any pinned elevation is
+   *  dropped. (Hiding the shell on barless pages is CSS, see the slot.) */
   report: (delta: 1 | -1) => void;
   /** Pinned-state elevation, reported by the sentinel that still lives
    *  in the page's scroll flow. */
@@ -94,21 +94,22 @@ export function BarChassisSlot() {
     // Same anatomy as WidgetBar's standalone shell (rounded-t-xl seats
     // the bar against the content panel's top radius). backdrop-blur is gone:
     // nothing ever renders behind a non-overlapping chassis row.
+    //
+    // The shell IS the portal host, and it hides itself with `:empty`
+    // rather than off `rowCount`: state catches up one commit after a
+    // row lands, and for that commit the row sits inside a display:none
+    // shell — where a mounting control's autoFocus is silently dropped
+    // (REL-218, the catalog search). CSS sees the row the instant it is
+    // in the DOM. Grid-stacked: outgoing + incoming rows occupy the same
+    // cell during a swap so they overlap instead of stacking.
     <div
+      ref={ctx.setHost}
       className={clsx(
-        "@container relative z-20 shrink-0 rounded-t-xl border-b bg-surface px-3 py-1.5 ",
+        "@container relative z-20 grid shrink-0 items-center rounded-t-xl border-b bg-surface px-3 py-1.5 empty:hidden [&>*]:col-start-1 [&>*]:row-start-1",
         ctx.stuck
           ? "border-edge/50 shadow-[0_6px_16px_-8px_rgba(0,0,0,0.35)]"
           : "border-edge/30",
-        ctx.rowCount === 0 && "hidden",
       )}
-    >
-      {/* Grid-stacked host: outgoing + incoming rows occupy the same
-          cell during a swap so they overlap instead of stacking. */}
-      <div
-        ref={ctx.setHost}
-        className="grid items-center [&>*]:col-start-1 [&>*]:row-start-1"
-      />
-    </div>
+    />
   );
 }


### PR DESCRIPTION
## Summary

Release blocker for v1.6.0 (REL-218): typing in the catalog hub's search lost focus after the first character.

**Cause.** The first keystroke writes `?q=`, the route flips to the directory, the hub unmounts with the focused field and the directory mounts its own. That field already had `autoFocus`, but the directory's bar row is portaled into the bar chassis, whose shell was `display:none` in that same commit (its `rowCount` catches up one commit later). `focus()` on a hidden element is silently dropped, so keystrokes two onward went to `<body>`.

**Fix.** The chassis shell hides itself with CSS `:empty` (`empty:hidden`) instead of off `rowCount`, so it is visible in the very commit its first row lands and the existing `autoFocus` sticks. Shell and portal host are one element now; `rowCount` remains for the pinned-elevation reset only.

**Why not one shared input.** The directory's field is a chassis row (app-frame portal, with sort/summary/cap), the hub's is page content. React remounts portal children when the container changes, so one DOM node cannot serve both spots. A frame-delayed focus was tried first and the new test caught it dropping a mid-word key, hence the root-cause fix.

## Verification

Browser pane on `vite --port 5180` with the Tauri shim (no app):

- Hub → typed `bitcoin` one key at a time: value `bitcoin`, directory shows Finance / Crypto, `document.activeElement` is the chassis field, selection `[7,7]`.
- Native clear on the field: value empty, directory stays on **All widgets**, hub not shown, field still focused.
- Try chip **Bitcoin** from the hub: directory with `Bitcoin`, focused, caret at end.
- Served CSS confirmed to contain `.empty\:hidden:empty{display:none}`; the hub's empty chassis computes `display:none`, the directory's `grid`.

Before the fix the same probe logged `focusout` on the hub field and no `focusin` on the new one (activeElement `BODY`).

`npx tsc --noEmit` clean; `vitest run` 65 files / 715 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
