### PR TITLE
feat(sports): daily quota from the plan's limit header, live cadence keyed to it [REL-219]

### DIFF
--- a/channels/sports/.env.example
+++ b/channels/sports/.env.example
@@ -18,3 +18,14 @@ API_SPORTS_KEY=your-api-sports-key
 
 # Optional: override the default service port (default: 3002)
 # PORT=3002
+
+# Optional: daily request budget per api-sports host. Only a fallback — the
+# plan's real limit arrives in every response (x-ratelimit-requests-limit)
+# and overrides this in both directions. Default: 7500 (Pro).
+# SPORTS_DAILY_QUOTA=7500
+
+# Optional: live-poll cadence bounds in seconds. Live games poll every MIN
+# on a big plan (Ultra), every MAX on Pro; idle polls always use MAX.
+# Defaults: 15 / 60.
+# SPORTS_LIVE_POLL_MIN_SECS=15
+# SPORTS_LIVE_POLL_MAX_SECS=60

--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -11,7 +11,7 @@ use crate::database::{
     LeagueConfig, TrackedLeague, upsert_game, CleanedData, Team,
     StandingData, upsert_standing, TeamData, upsert_team,
 };
-pub use crate::types::{SportsHealth, RateLimiter};
+pub use crate::types::{live_poll_interval_secs, RateLimiter, SportsHealth, DEFAULT_DAILY_QUOTA};
 
 pub mod log;
 pub mod database;
@@ -127,6 +127,23 @@ pub async fn init_sports_service(
 
 // =============================================================================
 // Live polling (fast — today + yesterday when needed, every 30s-1min)
+/// Feed a response's daily-quota headers into the limiter for one host.
+/// `x-ratelimit-requests-limit` is the plan's daily allocation (adopted in
+/// both directions), `x-ratelimit-requests-remaining` what is left today
+/// (only ever clamps). Limit first, so a raised plan is reseeded before the
+/// remaining-clamp trims it to today's real balance.
+fn adopt_rate_headers(headers: &header::HeaderMap, host: &str, rate_limiter: &RateLimiter) {
+    let read = |name: &str| headers.get(name)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u32>().ok());
+    if let Some(limit) = read("x-ratelimit-requests-limit") {
+        rate_limiter.set_daily_quota(host, limit);
+    }
+    if let Some(remaining) = read("x-ratelimit-requests-remaining") {
+        rate_limiter.update(host, remaining);
+    }
+}
+
 // =============================================================================
 
 /// Poll today's games for live score updates. Called on the fast interval.
@@ -369,13 +386,7 @@ pub async fn poll_standings(
 
         match client.get(&url).send().await {
             Ok(resp) => {
-                if let Some(remaining) = resp.headers()
-                    .get("x-ratelimit-requests-remaining")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u32>().ok())
-                {
-                    rate_limiter.update(&league.sport_api, remaining);
-                }
+                adopt_rate_headers(resp.headers(), &league.sport_api, rate_limiter);
                 if !resp.status().is_success() {
                     warn!("[{}] Standings API returned {}", league.name, resp.status());
                     continue;
@@ -922,13 +933,7 @@ pub async fn poll_teams(
 
         match client.get(&url).send().await {
             Ok(resp) => {
-                if let Some(remaining) = resp.headers()
-                    .get("x-ratelimit-requests-remaining")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u32>().ok())
-                {
-                    rate_limiter.update(&league.sport_api, remaining);
-                }
+                adopt_rate_headers(resp.headers(), &league.sport_api, rate_limiter);
                 if !resp.status().is_success() {
                     warn!("[{}] Teams API returned {}", league.name, resp.status());
                     continue;
@@ -1037,13 +1042,7 @@ async fn poll_league(
     let resp = client.get(&url).send().await?;
 
     // Extract rate limit info from headers — update only this sport's bucket
-    if let Some(remaining) = resp.headers()
-        .get("x-ratelimit-requests-remaining")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u32>().ok())
-    {
-        rate_limiter.update(&league.sport_api, remaining);
-    }
+    adopt_rate_headers(resp.headers(), &league.sport_api, rate_limiter);
 
     let status = resp.status();
     if !status.is_success() {

--- a/channels/sports/service/src/main.rs
+++ b/channels/sports/service/src/main.rs
@@ -10,8 +10,8 @@ use sports_service::{
     init::{fatal, spawn_supervised, ReadinessGate, ReadinessSnapshot},
     init_sports_service,
     log::init_async_logger,
-    poll_live, poll_schedule, poll_standings, poll_teams,
-    InitError, RateLimiter, SportsHealth,
+    live_poll_interval_secs, poll_live, poll_schedule, poll_standings, poll_teams,
+    InitError, RateLimiter, SportsHealth, DEFAULT_DAILY_QUOTA,
 };
 
 #[derive(Clone)]
@@ -30,27 +30,53 @@ struct ReadyPayload {
 /// Interval for the schedule poll (upcoming games + cleanup).
 const SCHEDULE_POLL_SECS: u64 = 30 * 60; // 30 minutes
 
-/// Fastest "live" poll interval. Actual interval is adaptive (30s when
-/// leagues_live > 0, 60s otherwise) but for staleness calculations we use
-/// the widest reasonable gap.
+/// Live poll interval bounds (seconds), overridable via
+/// `SPORTS_LIVE_POLL_MIN_SECS` / `SPORTS_LIVE_POLL_MAX_SECS`. Idle polls run
+/// at MAX; live games run at an interval scaled from the effective daily
+/// quota: MAX on Pro, MIN on Ultra (see `live_poll_interval_secs`).
+const LIVE_POLL_MIN_INTERVAL_SECS: u64 = 15;
 const LIVE_POLL_MAX_INTERVAL_SECS: u64 = 60;
 
-/// Maximum acceptable staleness before `/health/ready` returns 503. The
-/// staleness threshold is deliberately 2x the widest expected gap between
-/// successful polls, so transient rate-limits or a slow external API don't
-/// flap readiness. If no poll has succeeded in this window something is
-/// actually wrong.
-const MAX_POLL_STALENESS_SECS: u64 = LIVE_POLL_MAX_INTERVAL_SECS * 2;
+/// Config knobs read once at startup. Every value has a compiled default;
+/// an unparsable env var logs and falls back to it.
+struct PollConfig {
+    /// Daily request budget per api-sports.io sport host. The fallback until
+    /// a response carries `x-ratelimit-requests-limit`; then the header wins.
+    daily_quota: u32,
+    live_min_secs: u64,
+    live_max_secs: u64,
+}
+
+impl PollConfig {
+    fn from_env() -> Self {
+        Self {
+            daily_quota: env_or("SPORTS_DAILY_QUOTA", DEFAULT_DAILY_QUOTA),
+            live_min_secs: env_or("SPORTS_LIVE_POLL_MIN_SECS", LIVE_POLL_MIN_INTERVAL_SECS),
+            live_max_secs: env_or("SPORTS_LIVE_POLL_MAX_SECS", LIVE_POLL_MAX_INTERVAL_SECS),
+        }
+    }
+
+    /// Maximum acceptable staleness before `/health/ready` returns 503:
+    /// deliberately 2x the widest expected gap between successful polls, so
+    /// transient rate-limits or a slow external API don't flap readiness.
+    fn max_poll_staleness_secs(&self) -> u64 {
+        self.live_max_secs * 2
+    }
+}
+
+fn env_or<T: std::str::FromStr + std::fmt::Display>(key: &str, default: T) -> T {
+    match std::env::var(key) {
+        Ok(v) => v.trim().parse().unwrap_or_else(|_| {
+            eprintln!("[Config] {key}={v:?} is not a valid number; using {default}");
+            default
+        }),
+        Err(_) => default,
+    }
+}
 
 /// How often the bridge loop checks `SportsHealth.last_poll` and forwards
 /// it to the readiness gate. Cheap, runs on a tight interval.
 const READINESS_BRIDGE_INTERVAL: Duration = Duration::from_secs(10);
-
-/// Daily request budget per api-sports.io sport host (Pro plan, 7,500/day).
-/// Used by both the initial budget allocation and the UTC-midnight daily
-/// reset. Keep these in lockstep — drift between them would silently corrupt
-/// the per-league budget allocation.
-const SPORTS_DAILY_QUOTA: u32 = 7500;
 
 /// Initialize Sentry. The returned guard MUST live for the lifetime of
 /// the process — Drop flushes pending events on shutdown. Sentry MUST
@@ -139,9 +165,10 @@ async fn run_service() -> Result<()> {
     // a Tokio 1.x runtime".
     let _ = init_async_logger("./logs");
 
+    let config = PollConfig::from_env();
     let health = Arc::new(Mutex::new(SportsHealth::new()));
     let readiness = Arc::new(ReadinessGate::new(Some(Duration::from_secs(
-        MAX_POLL_STALENESS_SECS,
+        config.max_poll_staleness_secs(),
     ))));
 
     // Cancellation token for coordinated shutdown
@@ -231,13 +258,20 @@ async fn run_service() -> Result<()> {
             }
         };
 
-        // Pro plan: 7,500 requests/day per sport host. Each league on a host
-        // gets a reserved share of host_budget / N_leagues_on_host. Off-season
-        // leagues donate their share to a per-host shared pool that any
-        // in-season league can borrow from when its reserved budget is
-        // exhausted. Prevents Champions League knockout nights from starving
-        // Premier League polls.
-        let rate_limiter = Arc::new(RateLimiter::new_per_league(&leagues, SPORTS_DAILY_QUOTA));
+        // Each league on a host gets a reserved share of
+        // host_budget / N_leagues_on_host. Off-season leagues donate their
+        // share to a per-host shared pool that any in-season league can
+        // borrow from when its reserved budget is exhausted. Prevents
+        // Champions League knockout nights from starving Premier League
+        // polls. The host budget starts at the config quota and follows
+        // `x-ratelimit-requests-limit` once responses arrive.
+        let rate_limiter = Arc::new(RateLimiter::new_per_league(&leagues, config.daily_quota));
+        for host in rate_limiter.hosts() {
+            println!(
+                "[Rate Budget] {host}: daily quota {}/day (config; header overrides)",
+                rate_limiter.daily_quota(&host)
+            );
+        }
 
         let client = Arc::new(client);
         let leagues = Arc::new(leagues);
@@ -269,15 +303,16 @@ async fn run_service() -> Result<()> {
             }
         });
 
-        // ── Fast poll: live scores (today only, 30s live / 1min idle) ─────
+        // ── Fast poll: live scores (today only, quota-scaled live / MAX idle) ─
         let pool_live = pool.clone();
         let client_live = client.clone();
         let leagues_live = leagues.clone();
         let health_live = health_bg.clone();
         let rl_live = rate_limiter.clone();
         let cancel_live = cancel_bg.clone();
+        let (live_min, live_max) = (config.live_min_secs, config.live_max_secs);
         spawn_supervised("sports-live-poll", async move {
-            println!("Starting live poll loop (adaptive intervals)...");
+            println!("Starting live poll loop (live {live_min}-{live_max}s by quota, idle {live_max}s)...");
             loop {
                 tokio::select! {
                     _ = cancel_live.cancelled() => {
@@ -287,14 +322,12 @@ async fn run_service() -> Result<()> {
                     _ = async {
                         poll_live(&pool_live, &client_live, &leagues_live, &health_live, &rl_live).await;
 
-                        // Adaptive interval: poll more frequently when there are live games
-                        let interval = {
-                            let h = health_live.lock().await;
-                            if h.leagues_live > 0 {
-                                30  // 30s when live games are happening
-                            } else {
-                                60  // 1 min when no live games
-                            }
+                        // Adaptive interval: live games poll at a cadence the
+                        // plan can afford (Ultra -> MIN, Pro -> MAX); idle at MAX.
+                        let interval = if health_live.lock().await.leagues_live > 0 {
+                            live_poll_interval_secs(rl_live.max_daily_quota(), live_min, live_max)
+                        } else {
+                            live_max
                         };
 
                         tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
@@ -395,8 +428,10 @@ async fn run_service() -> Result<()> {
                         break;
                     }
                     _ = tokio::time::sleep(std::time::Duration::from_secs(wait_secs)) => {
-                        rl_reset.reset_daily(&leagues_reset, SPORTS_DAILY_QUOTA);
-                        println!("[Rate Budget] Daily reset completed at UTC midnight");
+                        rl_reset.reset_daily(&leagues_reset);
+                        for host in rl_reset.hosts() {
+                            println!("[Rate Budget] {host}: daily reset to {}/day at UTC midnight", rl_reset.daily_quota(&host));
+                        }
                     }
                 }
             }

--- a/channels/sports/service/src/types.rs
+++ b/channels/sports/service/src/types.rs
@@ -4,6 +4,22 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::RwLock;
 
+/// api-sports.io Pro plan: 7,500 requests/day per sport host. The fallback
+/// daily quota until a response carries `x-ratelimit-requests-limit`, and the
+/// baseline the live-poll cadence is scaled from.
+pub const DEFAULT_DAILY_QUOTA: u32 = 7500;
+
+/// Live-poll interval for the effective daily quota, in seconds.
+///
+/// Pro (7,500/day) polls live games every `max_secs`; a bigger plan earns a
+/// proportionally shorter interval, floored at `min_secs`. Ultra (75,000/day)
+/// lands on the floor. The idle interval is always `max_secs`.
+pub fn live_poll_interval_secs(daily_quota: u32, min_secs: u64, max_secs: u64) -> u64 {
+    let pro = u64::from(DEFAULT_DAILY_QUOTA);
+    let quota = u64::from(daily_quota).max(1);
+    (max_secs * pro / quota).clamp(min_secs.min(max_secs), max_secs)
+}
+
 #[derive(Serialize, Clone)]
 pub struct SportsHealth {
     pub status: String,
@@ -68,6 +84,11 @@ impl SportsHealth {
 /// to a per-host shared pool. When a league exhausts its reserved budget, it
 /// falls back to the shared pool before being skipped.
 pub struct RateLimiter {
+    /// Effective daily quota per host: the config value until a response
+    /// carries `x-ratelimit-requests-limit`, then whatever upstream last said
+    /// (up or down). Buckets are reseeded from it at UTC midnight and whenever
+    /// it changes.
+    host_limit: HashMap<String, AtomicU32>,
     /// Legacy per-sport bucket — preserved for the health endpoint snapshot.
     /// Updated from `x-ratelimit-requests-remaining` headers as before, but
     /// no longer used for consumption decisions when per-league budgets are
@@ -96,6 +117,7 @@ impl RateLimiter {
             host_remaining.insert(s.clone(), AtomicU32::new(initial));
         }
         Self {
+            host_limit: HashMap::new(),
             host_remaining,
             league_reserved: HashMap::new(),
             league_to_host: HashMap::new(),
@@ -114,46 +136,54 @@ impl RateLimiter {
     ///   - Off-season leagues (current UTC month is in offseason_months) get
     ///     `reserved = 0` and donate their share to the host's shared pool.
     pub fn new_per_league(leagues: &[crate::database::TrackedLeague], daily_total: u32) -> Self {
-        use std::collections::HashMap as Map;
-
-        let current_month: i32 = Utc::now().month() as i32;
-
-        // Group leagues by host (== sport_api here; one host per sport_api in practice).
-        let mut by_host: Map<String, Vec<&crate::database::TrackedLeague>> = Map::new();
-        for l in leagues {
-            by_host.entry(l.sport_api.clone()).or_default().push(l);
-        }
-
         let mut league_reserved = HashMap::new();
         let mut league_to_host = HashMap::new();
         let mut host_shared = HashMap::new();
         let mut host_remaining = HashMap::new();
-        let mut offseason = HashSet::new();
-
-        for (host, host_leagues) in &by_host {
-            let n = host_leagues.len().max(1) as u32;
-            let share = daily_total / n;
-            let mut donated = 0u32;
-            for l in host_leagues {
-                let is_offseason = l.is_offseason(current_month);
-                let reserved = if is_offseason { 0 } else { share };
-                if is_offseason {
-                    donated += share;
-                    offseason.insert(l.name.clone());
-                }
-                league_reserved.insert(l.name.clone(), AtomicU32::new(reserved));
-                league_to_host.insert(l.name.clone(), host.clone());
-            }
-            host_shared.insert(host.clone(), AtomicU32::new(donated));
-            host_remaining.insert(host.clone(), AtomicU32::new(daily_total));
+        let mut host_limit = HashMap::new();
+        for l in leagues {
+            league_reserved.insert(l.name.clone(), AtomicU32::new(0));
+            league_to_host.insert(l.name.clone(), l.sport_api.clone());
+            host_shared.entry(l.sport_api.clone()).or_insert_with(|| AtomicU32::new(0));
+            host_remaining.entry(l.sport_api.clone()).or_insert_with(|| AtomicU32::new(daily_total));
+            host_limit.entry(l.sport_api.clone()).or_insert_with(|| AtomicU32::new(daily_total));
         }
-
-        Self {
+        let rl = Self {
+            host_limit,
             host_remaining,
             league_reserved,
             league_to_host,
             host_shared,
-            offseason_leagues: RwLock::new(offseason),
+            offseason_leagues: RwLock::new(HashSet::new()),
+        };
+        rl.reset_daily(leagues);
+        rl
+    }
+
+    /// Refill one host's buckets from `limit`: each league on the host gets
+    /// `limit / N`; in-season leagues keep their share as `reserved`,
+    /// off-season leagues donate theirs to the host's shared pool.
+    fn seed_host(&self, host: &str, limit: u32) {
+        let leagues: Vec<&String> = self.league_to_host.iter()
+            .filter(|(_, h)| h.as_str() == host)
+            .map(|(l, _)| l)
+            .collect();
+        let share = limit / leagues.len().max(1) as u32;
+        let offseason = self.offseason_leagues.read()
+            .map(|s| s.clone())
+            .unwrap_or_default();
+        let mut donated = 0u32;
+        for l in leagues {
+            let reserved = if offseason.contains(l) { donated += share; 0 } else { share };
+            if let Some(slot) = self.league_reserved.get(l) {
+                slot.store(reserved, Ordering::Relaxed);
+            }
+        }
+        if let Some(slot) = self.host_shared.get(host) {
+            slot.store(donated, Ordering::Relaxed);
+        }
+        if let Some(slot) = self.host_remaining.get(host) {
+            slot.store(limit, Ordering::Relaxed);
         }
     }
 
@@ -216,45 +246,62 @@ impl RateLimiter {
             .unwrap_or(0)
     }
 
-    /// Reset all per-league reserved + per-host shared pools. Called at UTC
-    /// midnight by the daily reset task in main.rs.
-    pub fn reset_daily(&self, leagues: &[crate::database::TrackedLeague], daily_total: u32) {
-        use std::collections::HashMap as Map;
+    /// Reset all per-league reserved + per-host shared pools from each host's
+    /// effective daily quota. Called at UTC midnight by the daily reset task
+    /// in main.rs.
+    pub fn reset_daily(&self, leagues: &[crate::database::TrackedLeague]) {
+        // Re-derive the off-season set first — the month may have rolled
+        // over, moving leagues into or out of their off-season window.
         let current_month: i32 = Utc::now().month() as i32;
-
-        let mut by_host: Map<String, Vec<&crate::database::TrackedLeague>> = Map::new();
-        for l in leagues {
-            by_host.entry(l.sport_api.clone()).or_default().push(l);
-        }
-
-        let mut offseason = HashSet::new();
-        for (host, host_leagues) in &by_host {
-            let n = host_leagues.len().max(1) as u32;
-            let share = daily_total / n;
-            let mut donated = 0u32;
-            for l in host_leagues {
-                let is_offseason = l.is_offseason(current_month);
-                let reserved = if is_offseason { 0 } else { share };
-                if is_offseason {
-                    donated += share;
-                    offseason.insert(l.name.clone());
-                }
-                if let Some(slot) = self.league_reserved.get(&l.name) {
-                    slot.store(reserved, Ordering::Relaxed);
-                }
-            }
-            if let Some(slot) = self.host_shared.get(host) {
-                slot.store(donated, Ordering::Relaxed);
-            }
-            if let Some(slot) = self.host_remaining.get(host) {
-                slot.store(daily_total, Ordering::Relaxed);
-            }
-        }
-        // Re-derive the off-season set — the month may have rolled over,
-        // moving leagues into or out of their off-season window.
+        let offseason: HashSet<String> = leagues.iter()
+            .filter(|l| l.is_offseason(current_month))
+            .map(|l| l.name.clone())
+            .collect();
         if let Ok(mut s) = self.offseason_leagues.write() {
             *s = offseason;
         }
+        for (host, limit) in &self.host_limit {
+            self.seed_host(host, limit.load(Ordering::Relaxed));
+        }
+    }
+
+    /// Adopt the plan's daily quota for a host from `x-ratelimit-requests-limit`.
+    /// Header truth in both directions: a raise (Pro → Ultra) reseeds the
+    /// host's buckets from the new quota, a cut reseeds them smaller. The
+    /// caller follows with `update(remaining)`, whose clamp then pulls the
+    /// fresh buckets down to what upstream says is actually left today.
+    pub fn set_daily_quota(&self, host: &str, limit: u32) {
+        let Some(slot) = self.host_limit.get(host) else { return };
+        let prev = slot.swap(limit, Ordering::Relaxed);
+        if prev != limit {
+            crate::log::info!("[Rate Budget] {host}: daily quota {prev} → {limit} (x-ratelimit-requests-limit)");
+            self.seed_host(host, limit);
+        }
+    }
+
+    /// Effective daily quota for a host (config until a header has been seen).
+    pub fn daily_quota(&self, host: &str) -> u32 {
+        self.host_limit.get(host)
+            .map(|c| c.load(Ordering::Relaxed))
+            .unwrap_or(DEFAULT_DAILY_QUOTA)
+    }
+
+    /// Plan-wide quota for cadence decisions: the largest any host has
+    /// reported. One key, one plan — a host that never gets polled (all its
+    /// leagues off-season) never sees a header and would otherwise pin the
+    /// cadence at the config fallback.
+    pub fn max_daily_quota(&self) -> u32 {
+        self.host_limit.values()
+            .map(|c| c.load(Ordering::Relaxed))
+            .max()
+            .unwrap_or(DEFAULT_DAILY_QUOTA)
+    }
+
+    /// Hosts known to the limiter, sorted, for startup logging.
+    pub fn hosts(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.host_limit.keys().cloned().collect();
+        v.sort();
+        v
     }
 
     // ── Legacy methods (preserved for the health endpoint + standings/teams polls) ──
@@ -541,7 +588,7 @@ mod tests {
         }
         assert!(!rl.try_consume("Premier League"));
         // Reset
-        rl.reset_daily(&leagues, 100);
+        rl.reset_daily(&leagues);
         assert_eq!(rl.reserved("Premier League"), 100);
     }
 
@@ -601,7 +648,7 @@ mod tests {
         assert_eq!(rl.shared_remaining("football"), 50);
 
         // Only the daily reset refills.
-        rl.reset_daily(&leagues, 1000);
+        rl.reset_daily(&leagues);
         assert_eq!(rl.reserved("Premier League"), 500);
     }
 
@@ -634,5 +681,74 @@ mod tests {
         rl.update("football", 10);
         assert_eq!(rl.reserved("Premier League"), 10);
         assert_eq!(rl.reserved("NBA"), 1000); // untouched
+    }
+
+    // ── Effective quota from the plan header (REL-219) ──────────────────────
+
+    #[test]
+    fn test_plan_header_pro_to_ultra_and_back() {
+        let leagues = vec![
+            make_league("Premier League", "football", None),
+            make_league("La Liga", "football", None),
+        ];
+        // Config fallback until a header has been seen.
+        let rl = RateLimiter::new_per_league(&leagues, DEFAULT_DAILY_QUOTA);
+        assert_eq!(rl.daily_quota("football"), 7500);
+        assert_eq!(rl.reserved("Premier League"), 3750);
+
+        // Pro header: same number, nothing moves.
+        rl.set_daily_quota("football", 7500);
+        rl.update("football", 7000);
+        assert_eq!(rl.daily_quota("football"), 7500);
+        assert_eq!(rl.reserved("Premier League"), 3500); // clamped to 7000/2
+
+        // Ultra header: buckets reseeded UP, then clamped to what is left.
+        rl.set_daily_quota("football", 75_000);
+        rl.update("football", 70_000);
+        assert_eq!(rl.daily_quota("football"), 75_000);
+        assert_eq!(rl.max_daily_quota(), 75_000);
+        assert_eq!(rl.reserved("Premier League"), 35_000);
+        assert_eq!(rl.remaining("football"), 70_000);
+
+        // Back to Pro: reseeded DOWN, clamp still applies.
+        rl.set_daily_quota("football", 7500);
+        rl.update("football", 400);
+        assert_eq!(rl.daily_quota("football"), 7500);
+        assert_eq!(rl.reserved("Premier League"), 200);
+
+        // Midnight refills from the last header, not the config.
+        rl.set_daily_quota("football", 75_000);
+        rl.update("football", 10);
+        rl.reset_daily(&leagues);
+        assert_eq!(rl.reserved("Premier League"), 37_500);
+        assert_eq!(rl.remaining("football"), 75_000);
+
+        // Unknown host: ignored, config fallback reported.
+        rl.set_daily_quota("hockey", 75_000);
+        assert_eq!(rl.daily_quota("hockey"), DEFAULT_DAILY_QUOTA);
+    }
+
+    #[test]
+    fn test_max_daily_quota_ignores_unpolled_hosts() {
+        let leagues = vec![
+            make_league("NHL", "hockey", None),
+            make_league("Premier League", "football", None),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 7500);
+        assert_eq!(rl.max_daily_quota(), 7500);
+        rl.set_daily_quota("football", 75_000);
+        assert_eq!(rl.max_daily_quota(), 75_000); // hockey never saw a header
+        assert_eq!(rl.hosts(), vec!["football".to_string(), "hockey".to_string()]);
+    }
+
+    #[test]
+    fn test_live_poll_interval_tracks_quota() {
+        assert_eq!(live_poll_interval_secs(7500, 15, 60), 60);   // Pro
+        assert_eq!(live_poll_interval_secs(75_000, 15, 60), 15); // Ultra -> floor
+        assert_eq!(live_poll_interval_secs(75_000, 20, 60), 20); // floor is config
+        assert_eq!(live_poll_interval_secs(15_000, 15, 60), 30); // in between
+        assert_eq!(live_poll_interval_secs(3000, 15, 60), 60);   // smaller plan -> ceiling
+        assert_eq!(live_poll_interval_secs(0, 15, 60), 60);      // never divide by zero
+        assert_eq!(live_poll_interval_secs(75_000, 90, 60), 60); // min > max -> max wins
     }
 }

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -110,7 +110,7 @@ it whenever you want a clean dataset back.
 leaves them blank on purpose, and the ingesters handle that correctly: they
 stay up, skip polling, and serve what is in Postgres. The keys that would
 work there are the production ones, and the quota they draw on belongs to
-real users — api-sports bills a shared 7,500 requests/day per sport host
+real users — api-sports bills a shared daily quota per sport host (7,500 on Pro, 75,000 on Ultra)
 across every league. Seeding gives you the same app without spending any of it.
 
 Loading also rebases timestamps, because several read paths are

--- a/k8s/configmap-channels.yaml
+++ b/k8s/configmap-channels.yaml
@@ -13,6 +13,14 @@ data:
   # fantasy is the one remaining channel service)
   FANTASY_CHANNEL_URL: "http://fantasy-api:8084"
 
+  # Sports ingester (sports-service). Fallback daily quota per api-sports
+  # host until a response carries x-ratelimit-requests-limit; the header
+  # then wins in both directions (Ultra for all sports until ~2026-12-06,
+  # REL-219). Live games poll every MIN seconds on Ultra, MAX on Pro.
+  SPORTS_DAILY_QUOTA: "7500"
+  SPORTS_LIVE_POLL_MIN_SECS: "15"
+  SPORTS_LIVE_POLL_MAX_SECS: "60"
+
   # Fantasy-specific
   YAHOO_CALLBACK_URL: "https://api.myscrollr.com/yahoo/callback"
   SYNC_ENABLED: "true"

--- a/k8s/sports-service.yaml
+++ b/k8s/sports-service.yaml
@@ -34,6 +34,24 @@ spec:
                   key: API_SPORTS_KEY
             - name: PORT
               value: "3002"
+            - name: SPORTS_DAILY_QUOTA
+              valueFrom:
+                configMapKeyRef:
+                  name: channels-config
+                  key: SPORTS_DAILY_QUOTA
+                  optional: true
+            - name: SPORTS_LIVE_POLL_MIN_SECS
+              valueFrom:
+                configMapKeyRef:
+                  name: channels-config
+                  key: SPORTS_LIVE_POLL_MIN_SECS
+                  optional: true
+            - name: SPORTS_LIVE_POLL_MAX_SECS
+              valueFrom:
+                configMapKeyRef:
+                  name: channels-config
+                  key: SPORTS_LIVE_POLL_MAX_SECS
+                  optional: true
             # Sentry — per-service DSN inlined (ingestion-only, not a leak).
             - name: SENTRY_DSN
               value: "https://e23940f923c6d8ff5d27c022de6c5a21@o4511384091033600.ingest.us.sentry.io/4511384414584832"


### PR DESCRIPTION
## REL-219 · Ultra plan 1/3: budget from the plan's real limit, faster live polling

api-sports is on the Ultra plan for all sports (3 months from 2026-09-06). The sports ingester was hard-wired to the Pro quota (7,500/day) and a fixed 30 s live cadence.

### Header
The plan's daily allocation arrives on every response as **`x-ratelimit-requests-limit`** (lowercase, paired with the `x-ratelimit-requests-remaining` we already read). Source: the API Commons rate-limit record for API-Sports, which was cross-checked against live `v3.football.api-sports.io/status` headers on 2026-09-02, plus 200+ public repos reading the same name. api-sports' own docs sit behind a Cloudflare bot check and an unauthenticated request gets no rate headers at all, so it could not be re-captured from this box.

### What changed
- **Quota is config, header wins.** `SPORTS_DAILY_QUOTA` (default 7500) seeds every host. When a response carries the limit header the limiter adopts it per host in both directions and reseeds that host's per-league buckets from it; the existing REL-52 remaining-clamp then trims the fresh buckets to what upstream says is actually left today. UTC-midnight reset now refills from each host's last-seen limit, not the constant. Same-value headers do not reseed (no mid-day refill).
- **Live cadence keyed to the effective quota.** Live games poll every `max * 7500 / quota` seconds clamped to `[MIN, MAX]`: 60 s on Pro, 15 s on Ultra. Idle stays at MAX. `SPORTS_LIVE_POLL_MIN_SECS` / `SPORTS_LIVE_POLL_MAX_SECS` are config (defaults 15 / 60); the readiness staleness window follows MAX. The cadence source is the *largest* quota any host reported, because it is one key / one plan and a host whose leagues are all off-season never sees a header.
- **Logging.** Effective quota per host at startup, on every header-driven change, and after the midnight reset.
- Config wired through `k8s/configmap-channels.yaml` (+ optional `configMapKeyRef`s in `sports-service.yaml`) and `channels/sports/.env.example`.

### Untouched
REL-52 header clamp semantics (only shrinks), UTC-midnight reset schedule, per-league reserved/shared split.

### Verify
- `cargo test --lib` in `channels/sports/service`: 52 passed (49 existing + 3 new: Pro → Ultra → Pro header sequence with clamps and midnight refill, unpolled-host cadence source, cadence table).
- `cargo clippy --all-targets`: no warnings on touched lines (remaining ones are pre-existing in `database.rs` and the Sentry init).
- **No live verification locally**: the ingester is keyless in dev, so no api-sports response can be observed here. After merge the deploy workflow ships it and the CI smoke test guards readiness. Expected first log lines in prod: `[Rate Budget] football: daily quota 7500/day (config; header overrides)` then `[Rate Budget] football: daily quota 7500 → 75000 (x-ratelimit-requests-limit)` on the first poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
