### PR TITLE
feat(sports): /health/ready reports the effective daily quota per host [REL-222]

### DIFF
--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -11,7 +11,7 @@ use crate::database::{
     LeagueConfig, TrackedLeague, upsert_game, CleanedData, Team,
     StandingData, upsert_standing, TeamData, upsert_team,
 };
-pub use crate::types::{live_poll_interval_secs, RateLimiter, SportsHealth, DEFAULT_DAILY_QUOTA};
+pub use crate::types::{live_poll_interval_secs, HostQuota, RateLimiter, SportsHealth, DEFAULT_DAILY_QUOTA};
 
 pub mod log;
 pub mod database;

--- a/channels/sports/service/src/main.rs
+++ b/channels/sports/service/src/main.rs
@@ -6,7 +6,7 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use sports_service::{
-    database::initialize_pool,
+    database::{get_tracked_leagues, initialize_pool},
     init::{fatal, spawn_supervised, ReadinessGate, ReadinessSnapshot},
     init_sports_service,
     log::init_async_logger,
@@ -39,6 +39,7 @@ const LIVE_POLL_MAX_INTERVAL_SECS: u64 = 60;
 
 /// Config knobs read once at startup. Every value has a compiled default;
 /// an unparsable env var logs and falls back to it.
+#[derive(Clone)]
 struct PollConfig {
     /// Daily request budget per api-sports.io sport host. The fallback until
     /// a response carries `x-ratelimit-requests-limit`; then the header wins.
@@ -243,6 +244,11 @@ async fn run_service() -> Result<()> {
                     "[Sports] API_SPORTS_KEY not set; not polling. \
                      Existing database rows are still served."
                 );
+                // Still report the config quota per host so /health/ready
+                // shows the same shape keyless as it does in production.
+                let leagues = get_tracked_leagues(pool.clone()).await;
+                let rl = RateLimiter::new_per_league(&leagues, config.daily_quota);
+                publish_quota(&health_bg, &rl, &config).await;
                 readiness_bg.mark_ready().await;
                 return;
             }
@@ -272,6 +278,7 @@ async fn run_service() -> Result<()> {
                 rate_limiter.daily_quota(&host)
             );
         }
+        publish_quota(&health_bg, &rate_limiter, &config).await;
 
         let client = Arc::new(client);
         let leagues = Arc::new(leagues);
@@ -311,6 +318,7 @@ async fn run_service() -> Result<()> {
         let rl_live = rate_limiter.clone();
         let cancel_live = cancel_bg.clone();
         let (live_min, live_max) = (config.live_min_secs, config.live_max_secs);
+        let config_live = config.clone();
         spawn_supervised("sports-live-poll", async move {
             println!("Starting live poll loop (live {live_min}-{live_max}s by quota, idle {live_max}s)...");
             loop {
@@ -324,8 +332,11 @@ async fn run_service() -> Result<()> {
 
                         // Adaptive interval: live games poll at a cadence the
                         // plan can afford (Ultra -> MIN, Pro -> MAX); idle at MAX.
+                        // The header may have moved the quota this cycle, so
+                        // republish before choosing.
+                        let live_secs = publish_quota(&health_live, &rl_live, &config_live).await;
                         let interval = if health_live.lock().await.leagues_live > 0 {
-                            live_poll_interval_secs(rl_live.max_daily_quota(), live_min, live_max)
+                            live_secs
                         } else {
                             live_max
                         };
@@ -470,6 +481,19 @@ async fn shutdown_signal() {
         _ = ctrl_c => {},
         _ = terminate => {},
     }
+}
+
+/// Copy the limiter's effective quota per host and the live cadence it earns
+/// into the health snapshot `/health/ready` serves. Returns that cadence.
+async fn publish_quota(
+    health: &Mutex<SportsHealth>,
+    rl: &RateLimiter,
+    config: &PollConfig,
+) -> u64 {
+    let live_secs =
+        live_poll_interval_secs(rl.max_daily_quota(), config.live_min_secs, config.live_max_secs);
+    health.lock().await.set_quota(rl.quota_snapshot(), live_secs);
+    live_secs
 }
 
 /// Liveness probe: 200 as long as the process is up.

--- a/channels/sports/service/src/types.rs
+++ b/channels/sports/service/src/types.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Datelike, Utc};
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::RwLock;
 
@@ -20,6 +20,16 @@ pub fn live_poll_interval_secs(daily_quota: u32, min_secs: u64, max_secs: u64) -
     (max_secs * pro / quota).clamp(min_secs.min(max_secs), max_secs)
 }
 
+/// One host's effective daily quota as `/health/ready` reports it (REL-222):
+/// the number the limiter is actually budgeting from and where it came from.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct HostQuota {
+    pub daily_quota: u32,
+    pub remaining: u32,
+    /// "header" once `x-ratelimit-requests-limit` has been adopted, else "config".
+    pub source: &'static str,
+}
+
 #[derive(Serialize, Clone)]
 pub struct SportsHealth {
     pub status: String,
@@ -27,6 +37,10 @@ pub struct SportsHealth {
     pub leagues_active: u32,
     pub leagues_live: u32,
     pub rate_limits: Option<HashMap<String, u32>>,
+    /// Effective daily quota per host; empty until the limiter exists.
+    pub quota: BTreeMap<String, HostQuota>,
+    /// What live games poll at right now, derived from the effective quota.
+    pub live_poll_secs: Option<u64>,
     pub error_count: u64,
     pub last_error: Option<String>,
 }
@@ -45,6 +59,8 @@ impl SportsHealth {
             leagues_active: 0,
             leagues_live: 0,
             rate_limits: None,
+            quota: BTreeMap::new(),
+            live_poll_secs: None,
             error_count: 0,
             last_error: None,
         }
@@ -65,6 +81,12 @@ impl SportsHealth {
 
     pub fn set_rate_limits(&mut self, limits: HashMap<String, u32>) {
         self.rate_limits = Some(limits);
+    }
+
+    /// Publish the limiter's effective quota and the live cadence it earns.
+    pub fn set_quota(&mut self, quota: BTreeMap<String, HostQuota>, live_poll_secs: u64) {
+        self.quota = quota;
+        self.live_poll_secs = Some(live_poll_secs);
     }
 
     pub fn get_health(&self) -> Self {
@@ -106,6 +128,9 @@ pub struct RateLimiter {
     /// donated. Refreshed at construction and at each daily reset (the month
     /// can change at UTC midnight).
     offseason_leagues: RwLock<HashSet<String>>,
+    /// Hosts whose quota has been adopted from `x-ratelimit-requests-limit`,
+    /// so the health snapshot can say header vs config.
+    header_seen: RwLock<HashSet<String>>,
 }
 
 impl RateLimiter {
@@ -123,6 +148,7 @@ impl RateLimiter {
             league_to_host: HashMap::new(),
             host_shared: HashMap::new(),
             offseason_leagues: RwLock::new(HashSet::new()),
+            header_seen: RwLock::new(HashSet::new()),
         }
     }
 
@@ -155,6 +181,7 @@ impl RateLimiter {
             league_to_host,
             host_shared,
             offseason_leagues: RwLock::new(HashSet::new()),
+            header_seen: RwLock::new(HashSet::new()),
         };
         rl.reset_daily(leagues);
         rl
@@ -272,6 +299,9 @@ impl RateLimiter {
     /// fresh buckets down to what upstream says is actually left today.
     pub fn set_daily_quota(&self, host: &str, limit: u32) {
         let Some(slot) = self.host_limit.get(host) else { return };
+        if let Ok(mut seen) = self.header_seen.write() {
+            seen.insert(host.to_string());
+        }
         let prev = slot.swap(limit, Ordering::Relaxed);
         if prev != limit {
             crate::log::info!("[Rate Budget] {host}: daily quota {prev} → {limit} (x-ratelimit-requests-limit)");
@@ -302,6 +332,22 @@ impl RateLimiter {
         let mut v: Vec<String> = self.host_limit.keys().cloned().collect();
         v.sort();
         v
+    }
+
+    /// Per-host effective quota for `/health/ready`: what is being budgeted
+    /// from, what is left, and whether the number came from the plan header
+    /// or the config fallback.
+    pub fn quota_snapshot(&self) -> BTreeMap<String, HostQuota> {
+        let seen = self.header_seen.read().ok();
+        self.hosts().into_iter().map(|host| {
+            let from_header = seen.as_ref().is_some_and(|s| s.contains(&host));
+            let q = HostQuota {
+                daily_quota: self.daily_quota(&host),
+                remaining: self.remaining(&host),
+                source: if from_header { "header" } else { "config" },
+            };
+            (host, q)
+        }).collect()
     }
 
     // ── Legacy methods (preserved for the health endpoint + standings/teams polls) ──
@@ -739,6 +785,26 @@ mod tests {
         rl.set_daily_quota("football", 75_000);
         assert_eq!(rl.max_daily_quota(), 75_000); // hockey never saw a header
         assert_eq!(rl.hosts(), vec!["football".to_string(), "hockey".to_string()]);
+    }
+
+    #[test]
+    fn test_quota_snapshot_names_its_source() {
+        let leagues = vec![
+            make_league("NHL", "hockey", None),
+            make_league("Premier League", "football", None),
+        ];
+        let rl = RateLimiter::new_per_league(&leagues, 7500);
+        let config = HostQuota { daily_quota: 7500, remaining: 7500, source: "config" };
+        assert_eq!(rl.quota_snapshot()["football"], config);
+        assert_eq!(rl.quota_snapshot()["hockey"], config);
+
+        // Ultra header on football only: it flips to "header", hockey stays config.
+        rl.set_daily_quota("football", 75_000);
+        rl.update("football", 74_980);
+        let snap = rl.quota_snapshot();
+        assert_eq!(snap["football"], HostQuota { daily_quota: 75_000, remaining: 74_980, source: "header" });
+        assert_eq!(snap["hockey"], config);
+        assert_eq!(snap.keys().collect::<Vec<_>>(), vec!["football", "hockey"]); // stable order
     }
 
     #[test]

--- a/scripts/smoke/production-readiness.sh
+++ b/scripts/smoke/production-readiness.sh
@@ -260,6 +260,16 @@ for line in "${SERVICES[@]}"; do
 
     if echo "$result" | jq -e '.ok == true' >/dev/null; then
         green "OK (HTTP $(echo "$result" | jq -r '.status'))"
+        # Sports: show the effective api-sports daily quota per host so the
+        # deploy log proves which plan the ingester is budgeting from
+        # (REL-222). Informational only — never a failure condition.
+        if [[ "$svc" == "sports-service" ]]; then
+            echo "$result" | jq -r '
+                .body.health as $h
+                | ($h.quota // {}) | to_entries[]
+                | "    \(.key): quota \(.value.daily_quota) (\(.value.source)), remaining \(.value.remaining), live poll \($h.live_poll_secs // "?")s"
+            ' 2>/dev/null || true
+        fi
     else
         reason=$(echo "$result" | jq -r '.reason // "unknown"')
         status=$(echo "$result" | jq -r '.status // "n/a"')


### PR DESCRIPTION
## Summary
- `SportsHealth` (served on `/health/ready`) gains `quota`: per host `daily_quota` (effective — header-adopted or `SPORTS_DAILY_QUOTA` fallback), `remaining`, `source` (`"header"` | `"config"`), plus `live_poll_secs` (the live-game cadence that quota earns, 60×7500/quota clamped to [MIN, MAX]).
- Published at init on both the keyed and keyless paths, refreshed after every live poll.
- `scripts/smoke/production-readiness.sh` prints one line per host under the sports-service OK line, e.g. `football: quota 75000 (header), remaining 74980, live poll 15s`. No new failure conditions: old or non-JSON bodies print nothing.
- Core's `/health` untouched (it does not pass the sports body through).

## Verification
- `cargo test --lib`: 53 passed (new: `test_quota_snapshot_names_its_source`).
- `cargo check --all-targets` clean.
- Branch binary run keyless beside the dev stack: `/health/ready` shows 11 hosts at `quota 7500 (config)`, `live_poll_secs: 60`.
- jq line exercised on a new body, an old body (prints nothing), and a string body (error swallowed).
- The deploy's smoke-test step after merge is the real evidence for REL-221 (expect `football: quota 75000 (header) …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
