### PR TITLE
fix(k8s): hold sports live poll at 60 s until the per-minute limit is honoured [REL-229]

### DIFF
--- a/k8s/configmap-channels.yaml
+++ b/k8s/configmap-channels.yaml
@@ -17,8 +17,12 @@ data:
   # host until a response carries x-ratelimit-requests-limit; the header
   # then wins in both directions (Ultra for all sports until ~2026-12-06,
   # REL-219). Live games poll every MIN seconds on Ultra, MAX on Pro.
+  # MIN is held at 60 (the pre-Ultra cadence) until the ingester honours
+  # the PER-MINUTE limit: 28 leagues at 15 s tripped api-sports'
+  # per-minute throttle and live rows froze (REL-229). Lower it again
+  # once the per-minute token bucket has shipped.
   SPORTS_DAILY_QUOTA: "7500"
-  SPORTS_LIVE_POLL_MIN_SECS: "15"
+  SPORTS_LIVE_POLL_MIN_SECS: "60"
   SPORTS_LIVE_POLL_MAX_SECS: "60"
 
   # Fantasy-specific


### PR DESCRIPTION
Interim mitigation for REL-229 / REL-230 (sports data frozen in production).

Since the REL-220 deploy (01:24 UTC) the sports-service log shows api-sports' **per-minute** throttle — `errors.rateLimit` in an HTTP 200 with an empty `response` — 18 times in 75 min across many leagues. REL-219 keyed the live cadence to the *daily* quota header and never read the per-minute pair, so 28 leagues at 15 s run into it.

This holds `SPORTS_LIVE_POLL_MIN_SECS` at 60 (the pre-Ultra cadence, which never throttled). A k8s-only change: deploy applies the configmap and restart-rolls sports-service.

The real fix (per-host per-minute token bucket from the `X-RateLimit-*` headers, in-band throttle backoff, a stale-live sweep by id, `updated_at` on `/public/feed`) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)