### PR TITLE
fix(sports): pace api-sports by its per-minute window, re-fetch frozen live rows by id, expose updated_at [REL-229] [REL-230]

### DIFF
--- a/api/internal/ingestread/sports.go
+++ b/api/internal/ingestread/sports.go
@@ -109,6 +109,12 @@ type Game struct {
 	Timer          string    `json:"timer,omitempty"`
 	Venue          string    `json:"venue,omitempty"`
 	Season         string    `json:"season,omitempty"`
+	// When the ingester last wrote this row. A live game whose updated_at
+	// is minutes old is being polled and upstream is what is stale; one
+	// whose updated_at is hours old has fallen out of the ingester's
+	// date window (REL-230). Visible on every games read so staleness can
+	// be told apart from outside.
+	UpdatedAt time.Time `json:"updated_at"`
 	// Current-season table row for each side, when the league keeps one.
 	// Attached on every games read so the desktop's detailed chip -- rank,
 	// record, differential or points under each team -- costs no second
@@ -631,7 +637,7 @@ func querySportsGames(ctx context.Context, limit int, favoriteTeams map[string]F
 			away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
 			start_time, COALESCE(short_detail, ''), state,
 			COALESCE(status_short, ''), COALESCE(status_long, ''),
-			COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, '')` + standingsColumns + `
+			COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at` + standingsColumns + `
 		FROM games g` + standingsJoin + `
 		WHERE %s
 		ORDER BY
@@ -732,7 +738,7 @@ func queryGamesByLeagues(ctx context.Context, leagues []string, limit int, favor
 					home_team_name, home_team_logo, home_team_score, home_team_code,
 					away_team_name, away_team_logo, away_team_score, away_team_code,
 					start_time, short_detail, state, status_short, status_long,
-					timer, venue, season,
+					timer, venue, season, updated_at,
 					(state IN ('in', 'pre')) AS upcoming_side,
 					ROW_NUMBER() OVER (
 						PARTITION BY league, (state IN ('in', 'pre'))
@@ -750,7 +756,7 @@ func queryGamesByLeagues(ctx context.Context, leagues []string, limit int, favor
 				away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
 				start_time, COALESCE(short_detail, ''), state,
 				COALESCE(status_short, ''), COALESCE(status_long, ''),
-				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, '')` + standingsColumns + `
+				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at` + standingsColumns + `
 			FROM ranked g` + standingsJoin + `
 			WHERE (upcoming_side AND side_rn <= %d)
 			   OR (NOT upcoming_side AND side_rn <= %d)
@@ -768,7 +774,7 @@ func queryGamesByLeagues(ctx context.Context, leagues []string, limit int, favor
 				away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
 				start_time, COALESCE(short_detail, ''), state,
 				COALESCE(status_short, ''), COALESCE(status_long, ''),
-				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, '')` + standingsColumns + `
+				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at` + standingsColumns + `
 			FROM games g` + standingsJoin + `
 			WHERE league = ANY($1) AND %s
 			ORDER BY
@@ -800,7 +806,7 @@ func scanGames(rows pgx.Rows) []Game {
 			&g.HomeTeamName, &g.HomeTeamLogo, &g.HomeTeamScore, &g.HomeTeamCode,
 			&g.AwayTeamName, &g.AwayTeamLogo, &g.AwayTeamScore, &g.AwayTeamCode,
 			&g.StartTime, &g.ShortDetail, &g.State,
-			&g.StatusShort, &g.StatusLong, &g.Timer, &g.Venue, &g.Season,
+			&g.StatusShort, &g.StatusLong, &g.Timer, &g.Venue, &g.Season, &g.UpdatedAt,
 			&h[0], &h[1], &h[2], &h[3], &h[4], &h[5], &h[6], &h[7], &h[8],
 			&a[0], &a[1], &a[2], &a[3], &a[4], &a[5], &a[6], &a[7], &a[8],
 		); err != nil {

--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -311,6 +311,51 @@ pub async fn get_live_yesterday_leagues(pool: &Arc<PgPool>) -> Vec<String> {
     }
 }
 
+/// A game row that should be moving but is not — see `get_stale_live_games`.
+#[derive(Debug, Clone, FromRow, PartialEq, Eq)]
+pub struct StaleGame {
+    pub league: String,
+    pub external_game_id: String,
+    pub state: String,
+    pub status_short: Option<String>,
+    pub updated_mins_ago: i64,
+    pub started_mins_ago: i64,
+}
+
+/// Rows the stale-live sweep re-fetches by id (REL-230), newest first, at
+/// most `limit`:
+///
+/// - any `in` / `pre` row nobody has written for `stale_after_mins` — its
+///   date fell out of the today/yesterday window, so the date polls will
+///   never see it again;
+/// - an `in` row that started more than 5 h ago — no game runs that long,
+///   upstream's date listing is stuck (Sep 6 2026: `IN8` for hours);
+/// - a `pre` row whose start is 15 min–5 h behind us — it should have kicked
+///   off; after 5 h it is an uncovered fixture and not worth a request.
+///
+/// Only the last two days: anything older is cleanup's business.
+pub async fn get_stale_live_games(pool: &Arc<PgPool>, stale_after_mins: i64, limit: i64) -> Result<Vec<StaleGame>> {
+    let mut conn = pool.acquire().await?;
+    let rows = query_as(
+        "SELECT league, external_game_id, state, status_short,
+                (EXTRACT(EPOCH FROM NOW() - updated_at) / 60)::bigint AS updated_mins_ago,
+                (EXTRACT(EPOCH FROM NOW() - start_time) / 60)::bigint AS started_mins_ago
+         FROM games
+         WHERE state IN ('in', 'pre')
+           AND start_time BETWEEN NOW() - INTERVAL '2 days' AND NOW() - INTERVAL '15 minutes'
+           AND (updated_at < NOW() - make_interval(mins => $1::int)
+                OR (state = 'in'  AND start_time < NOW() - INTERVAL '5 hours')
+                OR (state = 'pre' AND start_time > NOW() - INTERVAL '5 hours'))
+         ORDER BY start_time DESC
+         LIMIT $2"
+    )
+    .bind(stale_after_mins as i32)
+    .bind(limit)
+    .fetch_all(&mut *conn)
+    .await?;
+    Ok(rows)
+}
+
 /// Delete stale games using per-state thresholds.
 ///
 /// - `final` / `postponed`: 7 days past `start_time`. Was 12 hours until

--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -1,17 +1,17 @@
-use std::{env, fs, sync::Arc};
+use std::{collections::{BTreeMap, HashMap, VecDeque}, env, fs, sync::Arc};
 use anyhow::{Context, Result};
-use reqwest::{Client, header};
+use reqwest::{Client, header, StatusCode};
 use tokio::sync::Mutex;
 use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, Utc};
 use crate::log::{error, info, warn};
 use crate::database::{
     PgPool,
     get_tracked_leagues, seed_tracked_leagues, disable_stale_leagues,
-    cleanup_old_games, get_live_yesterday_leagues,
+    cleanup_old_games, get_live_yesterday_leagues, get_stale_live_games,
     LeagueConfig, TrackedLeague, upsert_game, CleanedData, Team,
     StandingData, upsert_standing, TeamData, upsert_team,
 };
-pub use crate::types::{live_poll_interval_secs, HostQuota, RateLimiter, SportsHealth, DEFAULT_DAILY_QUOTA};
+pub use crate::types::{live_poll_interval_secs, HostMinute, HostQuota, MinuteBudget, RateLimiter, SportsHealth, DEFAULT_DAILY_QUOTA};
 
 pub mod log;
 pub mod database;
@@ -31,6 +31,35 @@ const SCHEDULE_DAYS_AHEAD: i64 = 7;
 /// Delay between league requests on startup burst to avoid rate limits.
 /// 200ms spacing between requests spreads ~60 requests across ~12 seconds.
 const STARTUP_REQUEST_DELAY_MS: u64 = 200;
+
+/// Why a poll produced no data. `Throttled` is api-sports' per-minute limit
+/// answering — HTTP 200 with `errors.rateLimit` and an empty `response`, or a
+/// 429 — and is deliberately not an error: the limiter has already backed the
+/// host off, the poll is not counted, and no game row is touched (REL-229).
+#[derive(Debug)]
+pub enum PollError {
+    Throttled(std::time::Duration),
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for PollError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PollError::Throttled(backoff) => {
+                write!(f, "throttled by api-sports (per-minute limit), backing off {}s", backoff.as_secs())
+            }
+            PollError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<anyhow::Error> for PollError {
+    fn from(e: anyhow::Error) -> Self { PollError::Other(e) }
+}
+
+impl From<reqwest::Error> for PollError {
+    fn from(e: reqwest::Error) -> Self { PollError::Other(e.into()) }
+}
 
 // =============================================================================
 // Service initialization (runs once on startup)
@@ -127,11 +156,16 @@ pub async fn init_sports_service(
 
 // =============================================================================
 // Live polling (fast — today + yesterday when needed, every 30s-1min)
-/// Feed a response's daily-quota headers into the limiter for one host.
-/// `x-ratelimit-requests-limit` is the plan's daily allocation (adopted in
-/// both directions), `x-ratelimit-requests-remaining` what is left today
-/// (only ever clamps). Limit first, so a raised plan is reseeded before the
-/// remaining-clamp trims it to today's real balance.
+/// Feed a response's rate headers into the limiter for one host.
+///
+/// Daily: `x-ratelimit-requests-limit` is the plan's daily allocation
+/// (adopted in both directions), `x-ratelimit-requests-remaining` what is
+/// left today (only ever clamps). Limit first, so a raised plan is reseeded
+/// before the remaining-clamp trims it to today's real balance.
+///
+/// Per minute: the capitalised `X-RateLimit-Limit` / `X-RateLimit-Remaining`
+/// pair (header names are case-insensitive) sizes the shared token bucket
+/// (REL-229). Distinct names, distinct windows — do not conflate them.
 fn adopt_rate_headers(headers: &header::HeaderMap, host: &str, rate_limiter: &RateLimiter) {
     let read = |name: &str| headers.get(name)
         .and_then(|v| v.to_str().ok())
@@ -142,6 +176,51 @@ fn adopt_rate_headers(headers: &header::HeaderMap, host: &str, rate_limiter: &Ra
     if let Some(remaining) = read("x-ratelimit-requests-remaining") {
         rate_limiter.update(host, remaining);
     }
+    rate_limiter.note_minute_headers(host, read("x-ratelimit-limit"), read("x-ratelimit-remaining"));
+}
+
+/// One api-sports request, gated by the per-minute bucket.
+///
+/// Waits for a token, sends, feeds the rate headers back, and unwraps the
+/// `{"response": [...], "errors": {...}}` envelope. An in-band
+/// `errors.rateLimit` or a 429 backs the host off and returns
+/// [`PollError::Throttled`] — the caller must treat that as "no poll
+/// happened", never as an empty result.
+pub async fn fetch_response(
+    client: &Client,
+    host: &str,
+    label: &str,
+    url: &str,
+    rate_limiter: &RateLimiter,
+) -> Result<Vec<serde_json::Value>, PollError> {
+    rate_limiter.acquire_minute().await;
+    let resp = client.get(url).send().await?;
+    adopt_rate_headers(resp.headers(), host, rate_limiter);
+
+    let status = resp.status();
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        return Err(PollError::Throttled(rate_limiter.note_throttled(host)));
+    }
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow::anyhow!("[{}] API returned {}: {}", label, status, body).into());
+    }
+
+    let body: serde_json::Value = resp.json().await?;
+    if let Some(errors) = body.get("errors").and_then(|e| e.as_object())
+        && !errors.is_empty()
+    {
+        if errors.contains_key("rateLimit") {
+            return Err(PollError::Throttled(rate_limiter.note_throttled(host)));
+        }
+        warn!("[{}] API returned errors: {}", label, serde_json::Value::Object(errors.clone()));
+    }
+    rate_limiter.note_minute_ok();
+
+    Ok(body.get("response")
+        .and_then(|r| r.as_array())
+        .cloned()
+        .unwrap_or_default())
 }
 
 // =============================================================================
@@ -179,7 +258,9 @@ pub async fn poll_live(
 
     let current_month = now.month() as i32;
 
-    for league in leagues {
+    // Consecutive requests go to different hosts: whichever way api-sports
+    // scopes its per-minute window, no single host sees a burst from us.
+    for league in interleave_by_host(leagues) {
         // Off-season leagues have no fixtures — polling them burns the shared
         // budget pool on requests that return empty. Skip silently (this loop
         // runs every 30-60s; logging would flood).
@@ -187,39 +268,21 @@ pub async fn poll_live(
             continue;
         }
 
-        if !rate_limiter.try_consume(&league.name) {
-            warn!("[{}] Skipping live poll — per-league budget exhausted (reserved={}, shared={})",
-                league.name,
-                rate_limiter.reserved(&league.name),
-                rate_limiter.shared_remaining(&league.sport_api));
-            continue;
-        }
-
-        // Always poll today
-        match poll_league(client, league, &today, rate_limiter).await {
-            Ok(games) => {
-                let (upserted, failed, has_live) = upsert_games(pool, league, games).await;
-                if has_live {
-                    leagues_with_live += 1;
-                }
-                total_upserted += upserted;
-                total_failed += failed;
-                crate::database::record_poll_success(pool, &league.name).await;
-            }
-            Err(e) => {
-                error!("[{}] Live poll error: {}", league.name, e);
-                health_state.lock().await.record_error(e.to_string());
-                crate::database::record_poll_error(pool, &league.name, &e.to_string()).await;
-            }
-        }
-
-        // Also poll yesterday if this league has live games from yesterday
+        // Today always; yesterday too while this league still has live
+        // games from yesterday's UTC date.
+        let mut dates = vec![(&today, "Live poll")];
         if yesterday_set.contains(league.name.as_str()) {
+            dates.push((&yesterday, "Yesterday poll"));
+        }
+        for (date, what) in dates {
             if !rate_limiter.try_consume(&league.name) {
-                warn!("[{}] Skipping yesterday poll — per-league budget exhausted", league.name);
-                continue;
+                warn!("[{}] Skipping {} — per-league budget exhausted (reserved={}, shared={})",
+                    league.name, what.to_lowercase(),
+                    rate_limiter.reserved(&league.name),
+                    rate_limiter.shared_remaining(&league.sport_api));
+                break;
             }
-            match poll_league(client, league, &yesterday, rate_limiter).await {
+            match poll_league(client, league, date, rate_limiter).await {
                 Ok(games) => {
                     let (upserted, failed, has_live) = upsert_games(pool, league, games).await;
                     if has_live {
@@ -229,8 +292,14 @@ pub async fn poll_live(
                     total_failed += failed;
                     crate::database::record_poll_success(pool, &league.name).await;
                 }
-                Err(e) => {
-                    error!("[{}] Yesterday poll error: {}", league.name, e);
+                Err(PollError::Throttled(backoff)) => {
+                    // Not a poll: no success, no error, no row touched. The
+                    // host is backing off; the next cycle simply tries again.
+                    warn!("[{}] {} throttled — per-minute limit; backing off {}s", league.name, what, backoff.as_secs());
+                    health_state.lock().await.record_throttle();
+                }
+                Err(PollError::Other(e)) => {
+                    error!("[{}] {} error: {}", league.name, what, e);
                     health_state.lock().await.record_error(e.to_string());
                     crate::database::record_poll_error(pool, &league.name, &e.to_string()).await;
                 }
@@ -322,7 +391,12 @@ pub async fn poll_schedule(
                     total_failed += failed;
                     crate::database::record_poll_success(pool, &league.name).await;
                 }
-                Err(e) => {
+                Err(PollError::Throttled(backoff)) => {
+                    // The next 30-min cycle covers the same dates; nothing to record.
+                    warn!("[{}] Schedule poll for {} throttled — per-minute limit; backing off {}s",
+                        league.name, date, backoff.as_secs());
+                }
+                Err(PollError::Other(e)) => {
                     error!("[{}] Schedule poll error for {}: {}", league.name, date, e);
                     crate::database::record_poll_error(pool, &league.name, &e.to_string()).await;
                 }
@@ -372,34 +446,12 @@ pub async fn poll_standings(
         let default_season = compute_current_season(format_str);
         let season = league.season.as_deref().unwrap_or(&default_season).to_string();
 
-        let (base, is_mock) = match std::env::var("API_SPORTS_BASE_URL") {
-            Ok(override_url) => (override_url.trim_end_matches('/').to_string(), true),
-            Err(_) => (format!("https://{}", league.api_host), false),
-        };
-        let mut url = format!(
-            "{}/standings?league={}&season={}",
-            base, league.league_id, season
-        );
-        if is_mock {
-            url = format!("{}&sport={}", url, league.sport_api);
-        }
-
-        match client.get(&url).send().await {
-            Ok(resp) => {
-                adopt_rate_headers(resp.headers(), &league.sport_api, rate_limiter);
-                if !resp.status().is_success() {
-                    warn!("[{}] Standings API returned {}", league.name, resp.status());
-                    continue;
-                }
-                match resp.json::<serde_json::Value>().await {
-                    Ok(body) => {
-                        let response = body.get("response").and_then(|r| r.as_array()).cloned().unwrap_or_default();
-                        parse_and_upsert_standings(pool, &league.name, &season, &league.sport_api, &response).await;
-                    }
-                    Err(e) => warn!("[{}] Failed to parse standings JSON: {}", league.name, e),
-                }
+        let url = api_url(league, &format!("/standings?league={}&season={}", league.league_id, season));
+        match fetch_response(client, &league.sport_api, &league.name, &url, rate_limiter).await {
+            Ok(response) => {
+                parse_and_upsert_standings(pool, &league.name, &season, &league.sport_api, &response).await;
             }
-            Err(e) => error!("[{}] Standings request failed: {}", league.name, e),
+            Err(e) => warn!("[{}] Standings poll skipped: {}", league.name, e),
         }
 
         // Spread requests to avoid rate limiting on startup
@@ -919,52 +971,30 @@ pub async fn poll_teams(
         let default_season = compute_current_season(format_str);
         let season = league.season.as_deref().unwrap_or(&default_season).to_string();
 
-        let (base, is_mock) = match std::env::var("API_SPORTS_BASE_URL") {
-            Ok(override_url) => (override_url.trim_end_matches('/').to_string(), true),
-            Err(_) => (format!("https://{}", league.api_host), false),
-        };
-        let mut url = format!(
-            "{}/teams?league={}&season={}",
-            base, league.league_id, season
-        );
-        if is_mock {
-            url = format!("{}&sport={}", url, league.sport_api);
-        }
-
-        match client.get(&url).send().await {
-            Ok(resp) => {
-                adopt_rate_headers(resp.headers(), &league.sport_api, rate_limiter);
-                if !resp.status().is_success() {
-                    warn!("[{}] Teams API returned {}", league.name, resp.status());
-                    continue;
-                }
-                match resp.json::<serde_json::Value>().await {
-                    Ok(body) => {
-                        let response = body.get("response").and_then(|r| r.as_array()).cloned().unwrap_or_default();
-                        for item in &response {
-                            let team = item.get("team").or(Some(item));
-                            if let Some(t) = team {
-                                let ext_id = t.get("id").and_then(|i| i.as_i64()).unwrap_or(0) as i32;
-                                if ext_id == 0 { continue; }
-                                let data = TeamData {
-                                    league: league.name.clone(),
-                                    external_id: ext_id,
-                                    name: t.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string(),
-                                    code: t.get("code").and_then(|c| c.as_str()).map(|s| s.to_string()),
-                                    logo: t.get("logo").and_then(|l| l.as_str()).map(|s| s.to_string()),
-                                    country: t.get("country").and_then(|c| c.as_str()).map(|s| s.to_string()),
-                                    season: Some(season.clone()),
-                                };
-                                if let Err(e) = upsert_team(pool, data).await {
-                                    error!("[{}] Failed to upsert team: {}", league.name, e);
-                                }
-                            }
+        let url = api_url(league, &format!("/teams?league={}&season={}", league.league_id, season));
+        match fetch_response(client, &league.sport_api, &league.name, &url, rate_limiter).await {
+            Ok(response) => {
+                for item in &response {
+                    let team = item.get("team").or(Some(item));
+                    if let Some(t) = team {
+                        let ext_id = t.get("id").and_then(|i| i.as_i64()).unwrap_or(0) as i32;
+                        if ext_id == 0 { continue; }
+                        let data = TeamData {
+                            league: league.name.clone(),
+                            external_id: ext_id,
+                            name: t.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string(),
+                            code: t.get("code").and_then(|c| c.as_str()).map(|s| s.to_string()),
+                            logo: t.get("logo").and_then(|l| l.as_str()).map(|s| s.to_string()),
+                            country: t.get("country").and_then(|c| c.as_str()).map(|s| s.to_string()),
+                            season: Some(season.clone()),
+                        };
+                        if let Err(e) = upsert_team(pool, data).await {
+                            error!("[{}] Failed to upsert team: {}", league.name, e);
                         }
                     }
-                    Err(e) => warn!("[{}] Failed to parse teams JSON: {}", league.name, e),
                 }
             }
-            Err(e) => error!("[{}] Teams request failed: {}", league.name, e),
+            Err(e) => warn!("[{}] Teams poll skipped: {}", league.name, e),
         }
 
         // Spread requests to avoid rate limiting on startup
@@ -1006,6 +1036,110 @@ async fn upsert_games(
     (upserted, failed, has_live)
 }
 
+/// Round-robin the leagues across their hosts: consecutive requests hit
+/// different api-sports hosts, so a per-minute wait on one host is never
+/// immediately followed by another request to it.
+fn interleave_by_host(leagues: &[TrackedLeague]) -> Vec<&TrackedLeague> {
+    let mut by_host: BTreeMap<&str, VecDeque<&TrackedLeague>> = BTreeMap::new();
+    for l in leagues {
+        by_host.entry(l.sport_api.as_str()).or_default().push_back(l);
+    }
+    let mut out = Vec::with_capacity(leagues.len());
+    while out.len() < leagues.len() {
+        for queue in by_host.values_mut() {
+            if let Some(l) = queue.pop_front() {
+                out.push(l);
+            }
+        }
+    }
+    out
+}
+
+// =============================================================================
+// Stale-live sweep (every few minutes)
+// =============================================================================
+
+/// Most rows one sweep re-fetches. Each is one request on the game's host,
+/// budgeted like any poll; the cap keeps a Saturday of uncovered FCS
+/// fixtures from spending the day's quota on games nobody scores.
+const STALE_SWEEP_MAX_ROWS: i64 = 20;
+
+/// Re-fetch BY ID every game that should be moving but is not (REL-230).
+///
+/// The date-window polls only ever see today and, while something is still
+/// live, yesterday. A game that is still `in` (or `pre` past its start) once
+/// its date has fallen out of that window is never asked about again — it
+/// sits frozen until the 24 h cleanup deletes it. This sweep asks upstream
+/// about the row itself. It also re-asks about rows whose date poll keeps
+/// returning a stale status (the Sep 6 2026 MLB stall: `IN8` for hours while
+/// the game was final) — a second endpoint is a second chance, and the log
+/// line records when upstream still says the same thing, so a stale row can
+/// be told apart from a stale ingester.
+pub async fn sweep_stale_live(
+    pool: &Arc<PgPool>,
+    client: &Client,
+    leagues: &[TrackedLeague],
+    health_state: &Arc<Mutex<SportsHealth>>,
+    rate_limiter: &Arc<RateLimiter>,
+    stale_after_mins: i64,
+) {
+    let rows = match get_stale_live_games(pool, stale_after_mins, STALE_SWEEP_MAX_ROWS).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!("Stale-live sweep skipped — query failed: {}", e);
+            return;
+        }
+    };
+    if rows.is_empty() {
+        return;
+    }
+    info!("Stale-live sweep: {} row(s) to re-fetch by id", rows.len());
+
+    let by_name: HashMap<&str, &TrackedLeague> =
+        leagues.iter().map(|l| (l.name.as_str(), l)).collect();
+    let (mut refreshed, mut unchanged) = (0u32, 0u32);
+    for row in rows {
+        // A league that is no longer tracked keeps its rows until cleanup.
+        let Some(league) = by_name.get(row.league.as_str()) else { continue };
+        if !rate_limiter.try_consume(&league.name) {
+            warn!("[{}] Stale-live sweep skipped — per-league budget exhausted", league.name);
+            continue;
+        }
+        let url = build_api_url_by_id(league, &row.external_game_id);
+        match fetch_games(client, league, &url, rate_limiter).await {
+            Ok(games) => {
+                let Some(game) = games.into_iter().find(|g| g.external_game_id == row.external_game_id) else {
+                    warn!("[{}] Stale-live {}: upstream returned nothing for this id (was {} {}, started {} min ago)",
+                        league.name, row.external_game_id, row.state,
+                        row.status_short.as_deref().unwrap_or("?"), row.started_mins_ago);
+                    continue;
+                };
+                let same = game.status_short == row.status_short;
+                info!("[{}] Stale-live {}: {} {} → {} {} (row updated {} min ago, started {} min ago){}",
+                    league.name, row.external_game_id,
+                    row.state, row.status_short.as_deref().unwrap_or("?"),
+                    game.state, game.status_short.as_deref().unwrap_or("?"),
+                    row.updated_mins_ago, row.started_mins_ago,
+                    if same { " — unchanged upstream, api-sports lag" } else { "" });
+                if same { unchanged += 1 } else { refreshed += 1 }
+                if let Err(e) = upsert_game(pool.clone(), game).await {
+                    error!("[{}] Stale-live {}: upsert failed: {}", league.name, row.external_game_id, e);
+                }
+            }
+            Err(PollError::Throttled(backoff)) => {
+                warn!("[{}] Stale-live sweep throttled — per-minute limit; backing off {}s and stopping this round",
+                    league.name, backoff.as_secs());
+                health_state.lock().await.record_throttle();
+                break;
+            }
+            Err(PollError::Other(e)) => {
+                error!("[{}] Stale-live {}: {}", league.name, row.external_game_id, e);
+            }
+        }
+    }
+    info!("Stale-live sweep complete: {} moved, {} unchanged upstream", refreshed, unchanged);
+}
+
 // =============================================================================
 // HTTP client
 // =============================================================================
@@ -1036,43 +1170,20 @@ async fn poll_league(
     league: &TrackedLeague,
     date: &str,
     rate_limiter: &RateLimiter,
-) -> anyhow::Result<Vec<CleanedData>> {
-    let url = build_api_url(league, date);
+) -> Result<Vec<CleanedData>, PollError> {
+    fetch_games(client, league, &build_api_url(league, date), rate_limiter).await
+}
 
-    let resp = client.get(&url).send().await?;
-
-    // Extract rate limit info from headers — update only this sport's bucket
-    adopt_rate_headers(resp.headers(), &league.sport_api, rate_limiter);
-
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("[{}] API returned {}: {}", league.name, status, body);
-    }
-
-    let body: serde_json::Value = resp.json().await?;
-
-    // api-sports.io wraps all responses in: {"get": "...", "results": N, "response": [...]}
-    let response_array = body.get("response")
-        .and_then(|r| r.as_array())
-        .cloned()
-        .unwrap_or_default();
-
-    if let Some(errors) = body.get("errors")
-        && errors.is_object()
-        && errors.as_object().is_some_and(|m| !m.is_empty())
-    {
-        warn!("[{}] API returned errors: {}", league.name, errors);
-    }
-
-    let mut cleaned_games = Vec::new();
-    for item in &response_array {
-        if let Some(game) = parse_game(item, league) {
-            cleaned_games.push(game);
-        }
-    }
-
-    Ok(cleaned_games)
+/// Fetch one games URL for a league and parse every item the sport's
+/// parser accepts. The URL is the caller's so tests can point it at a mock.
+pub async fn fetch_games(
+    client: &Client,
+    league: &TrackedLeague,
+    url: &str,
+    rate_limiter: &RateLimiter,
+) -> Result<Vec<CleanedData>, PollError> {
+    let response = fetch_response(client, &league.sport_api, &league.name, url, rate_limiter).await?;
+    Ok(response.iter().filter_map(|item| parse_game(item, league)).collect())
 }
 
 /// Compute the current season string dynamically based on the league's
@@ -1110,31 +1221,26 @@ fn compute_current_season(season_format: &str) -> String {
     }
 }
 
-/// Build the correct API URL based on the sport type.
+/// Absolute URL for `path_and_query` on the league's api-sports host.
 ///
 /// When `API_SPORTS_BASE_URL` is set (e.g. `http://localhost:9090`), all
 /// requests are redirected to that host instead of the real api-sports.io
-/// endpoints.  The original `api_host` is sent as a query parameter so the
+/// endpoints. The original `sport_api` is sent as a query parameter so the
 /// mock server can distinguish between sports.
-fn build_api_url(league: &TrackedLeague, date: &str) -> String {
-    let (base, is_mock) = match std::env::var("API_SPORTS_BASE_URL") {
-        Ok(override_url) => (override_url.trim_end_matches('/').to_string(), true),
-        Err(_) => (format!("https://{}", league.api_host), false),
-    };
-    let format_str = league.season_format.as_deref().unwrap_or("calendar");
-    let default_season = compute_current_season(format_str);
-    let season = league.season.as_deref().unwrap_or(&default_season);
+fn api_url(league: &TrackedLeague, path_and_query: &str) -> String {
+    match std::env::var("API_SPORTS_BASE_URL") {
+        Ok(mock) => format!("{}{}&sport={}", mock.trim_end_matches('/'), path_and_query, league.sport_api),
+        Err(_) => format!("https://{}{}", league.api_host, path_and_query),
+    }
+}
 
-    let url = match league.sport_api.as_str() {
-        "football" => {
-            format!("{}/fixtures?league={}&season={}&date={}", base, league.league_id, season, date)
-        }
-        "formula-1" => {
-            format!("{}/races?season={}", base, season)
-        }
-        "mma" => {
-            format!("{}/fights?date={}", base, date)
-        }
+/// The endpoint that lists a league's games: football is `/fixtures`,
+/// Formula 1 `/races`, MMA `/fights`, every other host `/games`.
+fn games_endpoint(league: &TrackedLeague) -> &'static str {
+    match league.sport_api.as_str() {
+        "football" => "/fixtures",
+        "formula-1" => "/races",
+        "mma" => "/fights",
         other => {
             if !matches!(other,
                 "basketball" | "hockey" | "baseball" | "american-football" |
@@ -1142,15 +1248,31 @@ fn build_api_url(league: &TrackedLeague, date: &str) -> String {
             ) {
                 warn!("Unknown sport_api '{}', falling back to /games", other);
             }
-            format!("{}/games?league={}&season={}&date={}", base, league.league_id, season, date)
+            "/games"
         }
-    };
-
-    if is_mock {
-        format!("{}&sport={}", url, league.sport_api)
-    } else {
-        url
     }
+}
+
+/// Build the correct API URL for one league on one date.
+fn build_api_url(league: &TrackedLeague, date: &str) -> String {
+    let format_str = league.season_format.as_deref().unwrap_or("calendar");
+    let default_season = compute_current_season(format_str);
+    let season = league.season.as_deref().unwrap_or(&default_season);
+
+    let endpoint = games_endpoint(league);
+    let query = match league.sport_api.as_str() {
+        "formula-1" => format!("?season={}", season),
+        "mma" => format!("?date={}", date),
+        _ => format!("?league={}&season={}&date={}", league.league_id, season, date),
+    };
+    api_url(league, &format!("{endpoint}{query}"))
+}
+
+/// The same endpoint asked about one game by its api-sports id — every host
+/// supports `?id=` on its games listing (`/fixtures?id=` on football,
+/// `/races?id=` on Formula 1, `/fights?id=` on MMA, `/games?id=` elsewhere).
+fn build_api_url_by_id(league: &TrackedLeague, id: &str) -> String {
+    api_url(league, &format!("{}?id={}", games_endpoint(league), id))
 }
 
 // =============================================================================
@@ -2066,6 +2188,48 @@ mod tests {
         let mut practice = f1_race("Scheduled", Utc::now() + Duration::days(2));
         practice["type"] = serde_json::json!("Practice");
         assert!(parse_f1_race(&practice, &f1_league()).is_none());
+    }
+
+    fn league(name: &str, sport_api: &str) -> TrackedLeague {
+        TrackedLeague {
+            name: name.to_string(),
+            sport_api: sport_api.to_string(),
+            api_host: format!("v1.{sport_api}.api-sports.io"),
+            league_id: 7,
+            category: "Test".to_string(),
+            country: None,
+            logo_url: None,
+            season: Some("2026".to_string()),
+            season_format: None,
+            offseason_months: None,
+        }
+    }
+
+    #[test]
+    fn by_id_urls_use_each_hosts_games_endpoint() {
+        assert_eq!(build_api_url_by_id(&league("MLB", "baseball"), "184965"),
+            "https://v1.baseball.api-sports.io/games?id=184965");
+        assert_eq!(build_api_url_by_id(&league("Serie A", "football"), "99"),
+            "https://v1.football.api-sports.io/fixtures?id=99");
+        assert_eq!(build_api_url_by_id(&league("Formula 1", "formula-1"), "5"),
+            "https://v1.formula-1.api-sports.io/races?id=5");
+        assert_eq!(build_api_url_by_id(&league("UFC", "mma"), "12"),
+            "https://v1.mma.api-sports.io/fights?id=12");
+        // The date URL still carries league + season.
+        assert_eq!(build_api_url(&league("MLB", "baseball"), "2026-09-07"),
+            "https://v1.baseball.api-sports.io/games?league=7&season=2026&date=2026-09-07");
+    }
+
+    #[test]
+    fn live_polls_alternate_hosts() {
+        let leagues = vec![
+            league("MLB", "baseball"), league("NPB", "baseball"),
+            league("NFL", "american-football"), league("NCAA Football", "american-football"),
+            league("KHL", "hockey"),
+        ];
+        let order: Vec<&str> = interleave_by_host(&leagues).iter().map(|l| l.name.as_str()).collect();
+        assert_eq!(order, ["NFL", "MLB", "KHL", "NCAA Football", "NPB"]);
+        assert_eq!(interleave_by_host(&[]).len(), 0);
     }
 
     #[test]

--- a/channels/sports/service/src/main.rs
+++ b/channels/sports/service/src/main.rs
@@ -10,7 +10,7 @@ use sports_service::{
     init::{fatal, spawn_supervised, ReadinessGate, ReadinessSnapshot},
     init_sports_service,
     log::init_async_logger,
-    live_poll_interval_secs, poll_live, poll_schedule, poll_standings, poll_teams,
+    live_poll_interval_secs, poll_live, poll_schedule, poll_standings, poll_teams, sweep_stale_live,
     InitError, RateLimiter, SportsHealth, DEFAULT_DAILY_QUOTA,
 };
 
@@ -30,6 +30,14 @@ struct ReadyPayload {
 /// Interval for the schedule poll (upcoming games + cleanup).
 const SCHEDULE_POLL_SECS: u64 = 30 * 60; // 30 minutes
 
+/// Interval for the stale-live sweep (re-fetch frozen live rows by id).
+const STALE_SWEEP_SECS: u64 = 5 * 60;
+
+/// A live (or overdue) row nobody has written for this long has fallen out
+/// of the date-window polls; the sweep re-fetches it by id. Overridable via
+/// `SPORTS_STALE_LIVE_MINS`.
+const STALE_LIVE_MINS: i64 = 10;
+
 /// Live poll interval bounds (seconds), overridable via
 /// `SPORTS_LIVE_POLL_MIN_SECS` / `SPORTS_LIVE_POLL_MAX_SECS`. Idle polls run
 /// at MAX; live games run at an interval scaled from the effective daily
@@ -46,6 +54,7 @@ struct PollConfig {
     daily_quota: u32,
     live_min_secs: u64,
     live_max_secs: u64,
+    stale_live_mins: i64,
 }
 
 impl PollConfig {
@@ -54,6 +63,7 @@ impl PollConfig {
             daily_quota: env_or("SPORTS_DAILY_QUOTA", DEFAULT_DAILY_QUOTA),
             live_min_secs: env_or("SPORTS_LIVE_POLL_MIN_SECS", LIVE_POLL_MIN_INTERVAL_SECS),
             live_max_secs: env_or("SPORTS_LIVE_POLL_MAX_SECS", LIVE_POLL_MAX_INTERVAL_SECS),
+            stale_live_mins: env_or("SPORTS_STALE_LIVE_MINS", STALE_LIVE_MINS).max(1),
         }
     }
 
@@ -347,6 +357,30 @@ async fn run_service() -> Result<()> {
             }
         });
 
+        // ── Stale-live sweep: frozen live rows re-fetched by id (every 5 min) ─
+        let pool_sweep = pool.clone();
+        let client_sweep = client.clone();
+        let leagues_sweep = leagues.clone();
+        let health_sweep = health_bg.clone();
+        let rl_sweep = rate_limiter.clone();
+        let cancel_sweep = cancel_bg.clone();
+        let stale_live_mins = config.stale_live_mins;
+        spawn_supervised("sports-stale-sweep", async move {
+            println!("Starting stale-live sweep loop (every {} min, rows idle > {} min)...", STALE_SWEEP_SECS / 60, stale_live_mins);
+            loop {
+                tokio::select! {
+                    _ = cancel_sweep.cancelled() => {
+                        println!("Stale-live sweep loop shutting down...");
+                        break;
+                    }
+                    _ = async {
+                        tokio::time::sleep(std::time::Duration::from_secs(STALE_SWEEP_SECS)).await;
+                        sweep_stale_live(&pool_sweep, &client_sweep, &leagues_sweep, &health_sweep, &rl_sweep, stale_live_mins).await;
+                    } => {}
+                }
+            }
+        });
+
         // ── Slow poll: schedule + cleanup (today + 7 days, every 30 min) ──
         let pool_sched = pool.clone();
         let client_sched = client.clone();
@@ -483,8 +517,9 @@ async fn shutdown_signal() {
     }
 }
 
-/// Copy the limiter's effective quota per host and the live cadence it earns
-/// into the health snapshot `/health/ready` serves. Returns that cadence.
+/// Copy the limiter's effective quota and per-minute state per host, and the
+/// live cadence the quota earns, into the health snapshot `/health/ready`
+/// serves. Returns that cadence.
 async fn publish_quota(
     health: &Mutex<SportsHealth>,
     rl: &RateLimiter,
@@ -492,7 +527,10 @@ async fn publish_quota(
 ) -> u64 {
     let live_secs =
         live_poll_interval_secs(rl.max_daily_quota(), config.live_min_secs, config.live_max_secs);
-    health.lock().await.set_quota(rl.quota_snapshot(), live_secs);
+    let (hosts, budget) = rl.minute_snapshot();
+    let mut h = health.lock().await;
+    h.set_quota(rl.quota_snapshot(), live_secs);
+    h.set_minute(hosts, budget);
     live_secs
 }
 

--- a/channels/sports/service/src/types.rs
+++ b/channels/sports/service/src/types.rs
@@ -1,8 +1,9 @@
 use chrono::{DateTime, Datelike, Utc};
 use serde::Serialize;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::RwLock;
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, Instant};
 
 /// api-sports.io Pro plan: 7,500 requests/day per sport host. The fallback
 /// daily quota until a response carries `x-ratelimit-requests-limit`, and the
@@ -30,6 +31,88 @@ pub struct HostQuota {
     pub source: &'static str,
 }
 
+/// What one api-sports host advertises about the per-minute window, as
+/// `/health/ready` reports it (REL-229): the capitalised `X-RateLimit-Limit`
+/// / `X-RateLimit-Remaining` pair from its last response, and how often it
+/// has answered with the in-band throttle (HTTP 200, `errors.rateLimit`,
+/// empty `response` — not a 429).
+#[derive(Serialize, Clone, Debug, PartialEq, Eq, Default)]
+pub struct HostMinute {
+    pub limit: Option<u32>,
+    pub remaining: Option<u32>,
+    pub throttle_events: u32,
+}
+
+/// The per-minute budget this process paces itself to. It is ONE bucket for
+/// the whole key, not one per host: on 2026-09-07 a fresh pod was throttled
+/// on the rugby host after ~10 requests/min to it while the account as a
+/// whole was bursting at startup, so api-sports counts the minute across
+/// the subscription. The limit is the smallest any host has advertised.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq, Default)]
+pub struct MinuteBudget {
+    pub limit: Option<u32>,
+    /// Requests this process sent, to any host, in the last 60 s.
+    pub sent_last_minute: u32,
+    /// Seconds until the next request may go out; 0 when not backing off.
+    pub backoff_secs: u64,
+}
+
+/// First in-band throttle backs off this long; each consecutive one doubles
+/// it up to [`THROTTLE_BACKOFF_MAX`]. The window is a minute, so a longer
+/// wait than that would only leave tokens unused.
+pub const THROTTLE_BACKOFF_BASE: Duration = Duration::from_secs(10);
+pub const THROTTLE_BACKOFF_MAX: Duration = Duration::from_secs(120);
+const MINUTE: Duration = Duration::from_secs(60);
+
+#[derive(Default)]
+struct MinuteState {
+    hosts: HashMap<String, HostMinute>,
+    sent: VecDeque<Instant>,
+    blocked_until: Option<Instant>,
+    streak: u32,
+}
+
+impl MinuteState {
+    fn prune(&mut self, now: Instant) {
+        while self.sent.front().is_some_and(|t| now.duration_since(*t) >= MINUTE) {
+            self.sent.pop_front();
+        }
+    }
+
+    fn limit(&self) -> Option<u32> {
+        self.hosts.values().filter_map(|h| h.limit).min()
+    }
+
+    fn block_until(&mut self, until: Instant) {
+        self.blocked_until = Some(self.blocked_until.map_or(until, |b| b.max(until)));
+    }
+
+    /// How long the next request must wait, or `None` when it may go now.
+    fn wait(&mut self, now: Instant) -> Option<Duration> {
+        self.prune(now);
+        let mut until: Option<Instant> = self.blocked_until.filter(|b| *b > now);
+        if let Some(limit) = self.limit()
+            && self.sent.len() as u32 >= limit.max(1)
+            && let Some(oldest) = self.sent.front()
+        {
+            let free_at = *oldest + MINUTE;
+            until = Some(until.map_or(free_at, |u| u.max(free_at)));
+        }
+        until.map(|u| u.duration_since(now))
+    }
+
+    fn budget(&mut self, now: Instant) -> MinuteBudget {
+        self.prune(now);
+        MinuteBudget {
+            limit: self.limit(),
+            sent_last_minute: self.sent.len() as u32,
+            backoff_secs: self.blocked_until
+                .filter(|b| *b > now)
+                .map_or(0, |b| b.duration_since(now).as_secs()),
+        }
+    }
+}
+
 #[derive(Serialize, Clone)]
 pub struct SportsHealth {
     pub status: String,
@@ -41,6 +124,14 @@ pub struct SportsHealth {
     pub quota: BTreeMap<String, HostQuota>,
     /// What live games poll at right now, derived from the effective quota.
     pub live_poll_secs: Option<u64>,
+    /// Per host: the per-minute limit upstream advertises and how often it
+    /// has throttled us.
+    pub minute: BTreeMap<String, HostMinute>,
+    /// The one per-minute bucket the process paces itself to.
+    pub minute_budget: MinuteBudget,
+    /// Polls that came back throttled (in-band `errors.rateLimit` or 429).
+    /// They are not counted as polls and never touch a game row.
+    pub throttled_polls: u64,
     pub error_count: u64,
     pub last_error: Option<String>,
 }
@@ -61,6 +152,9 @@ impl SportsHealth {
             rate_limits: None,
             quota: BTreeMap::new(),
             live_poll_secs: None,
+            minute: BTreeMap::new(),
+            minute_budget: MinuteBudget::default(),
+            throttled_polls: 0,
             error_count: 0,
             last_error: None,
         }
@@ -87,6 +181,19 @@ impl SportsHealth {
     pub fn set_quota(&mut self, quota: BTreeMap<String, HostQuota>, live_poll_secs: u64) {
         self.quota = quota;
         self.live_poll_secs = Some(live_poll_secs);
+    }
+
+    /// Publish the per-minute picture: what each host advertises and the
+    /// bucket the process is pacing itself to.
+    pub fn set_minute(&mut self, hosts: BTreeMap<String, HostMinute>, budget: MinuteBudget) {
+        self.minute = hosts;
+        self.minute_budget = budget;
+    }
+
+    /// A poll was refused by the per-minute throttle. Not an error — the
+    /// limiter is already backing off — but worth counting.
+    pub fn record_throttle(&mut self) {
+        self.throttled_polls += 1;
     }
 
     pub fn get_health(&self) -> Self {
@@ -131,6 +238,8 @@ pub struct RateLimiter {
     /// Hosts whose quota has been adopted from `x-ratelimit-requests-limit`,
     /// so the health snapshot can say header vs config.
     header_seen: RwLock<HashSet<String>>,
+    /// The per-minute window (REL-229). Never held across an await.
+    minute: Mutex<MinuteState>,
 }
 
 impl RateLimiter {
@@ -149,6 +258,7 @@ impl RateLimiter {
             host_shared: HashMap::new(),
             offseason_leagues: RwLock::new(HashSet::new()),
             header_seen: RwLock::new(HashSet::new()),
+            minute: Mutex::new(MinuteState::default()),
         }
     }
 
@@ -182,6 +292,7 @@ impl RateLimiter {
             host_shared,
             offseason_leagues: RwLock::new(HashSet::new()),
             header_seen: RwLock::new(HashSet::new()),
+            minute: Mutex::new(MinuteState::default()),
         };
         rl.reset_daily(leagues);
         rl
@@ -348,6 +459,94 @@ impl RateLimiter {
             };
             (host, q)
         }).collect()
+    }
+
+    // ── Per-minute window (REL-229) ─────────────────────────────────────────
+
+    fn with_minute<T>(&self, f: impl FnOnce(&mut MinuteState, Instant) -> T) -> T {
+        let now = Instant::now();
+        let mut m = self.minute.lock().unwrap_or_else(|e| e.into_inner());
+        f(&mut m, now)
+    }
+
+    /// How long the next request has to wait for a per-minute token, or
+    /// `None` when it may go out now. Does not record the send.
+    pub fn minute_wait(&self) -> Option<Duration> {
+        self.with_minute(|m, now| m.wait(now))
+    }
+
+    /// Record that a request is going out now.
+    pub fn minute_sent(&self) {
+        self.with_minute(|m, now| {
+            m.prune(now);
+            m.sent.push_back(now);
+        });
+    }
+
+    /// Wait for a per-minute token, then take it. Sleeps outside the lock;
+    /// the loop re-checks because a throttle may land meanwhile.
+    pub async fn acquire_minute(&self) {
+        loop {
+            match self.minute_wait() {
+                Some(wait) => tokio::time::sleep(wait).await,
+                None => {
+                    self.minute_sent();
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Feed the capitalised per-minute pair from one host's response.
+    /// `remaining == 0` blocks for a minute: the window edge is not
+    /// reported, so a full minute is the only wait guaranteed to cross it.
+    pub fn note_minute_headers(&self, host: &str, limit: Option<u32>, remaining: Option<u32>) {
+        self.with_minute(|m, now| {
+            let h = m.hosts.entry(host.to_string()).or_default();
+            if limit.is_some() {
+                h.limit = limit;
+            }
+            if remaining.is_some() {
+                h.remaining = remaining;
+            }
+            if remaining == Some(0) {
+                m.block_until(now + MINUTE);
+            }
+        });
+    }
+
+    /// An in-band `errors.rateLimit` (or a 429) came back from `host`.
+    /// Backs everything off exponentially from [`THROTTLE_BACKOFF_BASE`],
+    /// capped at [`THROTTLE_BACKOFF_MAX`], and returns the backoff applied.
+    pub fn note_throttled(&self, host: &str) -> Duration {
+        self.with_minute(|m, now| {
+            m.hosts.entry(host.to_string()).or_default().throttle_events += 1;
+            let backoff = THROTTLE_BACKOFF_BASE
+                .checked_mul(1u32 << m.streak.min(10))
+                .unwrap_or(THROTTLE_BACKOFF_MAX)
+                .min(THROTTLE_BACKOFF_MAX);
+            m.streak += 1;
+            m.block_until(now + backoff);
+            backoff
+        })
+    }
+
+    /// A response carried data: the throttle streak is over.
+    pub fn note_minute_ok(&self) {
+        self.with_minute(|m, _| m.streak = 0);
+    }
+
+    /// Per-host advertised limits and the shared bucket, for `/health/ready`.
+    pub fn minute_snapshot(&self) -> (BTreeMap<String, HostMinute>, MinuteBudget) {
+        self.with_minute(|m, now| {
+            let mut hosts: BTreeMap<String, HostMinute> = self.hosts().into_iter()
+                .map(|h| (h, HostMinute::default()))
+                .collect();
+            for (host, h) in &m.hosts {
+                hosts.insert(host.clone(), h.clone());
+            }
+            (hosts, m.budget(now))
+        })
     }
 
     // ── Legacy methods (preserved for the health endpoint + standings/teams polls) ──
@@ -805,6 +1004,72 @@ mod tests {
         assert_eq!(snap["football"], HostQuota { daily_quota: 75_000, remaining: 74_980, source: "header" });
         assert_eq!(snap["hockey"], config);
         assert_eq!(snap.keys().collect::<Vec<_>>(), vec!["football", "hockey"]); // stable order
+    }
+
+    // ── Per-minute window (REL-229) ─────────────────────────────────────────
+
+    #[test]
+    fn test_minute_headers_gate_our_own_send_rate_across_hosts() {
+        let rl = RateLimiter::new(&["baseball".to_string(), "hockey".to_string()], 1000);
+        // Nothing known yet: no per-minute gating, only the daily budget.
+        assert_eq!(rl.minute_wait(), None);
+        rl.minute_sent();
+        rl.note_minute_headers("baseball", Some(300), Some(299));
+        rl.note_minute_headers("hockey", Some(3), Some(2));
+        rl.minute_sent();
+        rl.minute_sent();
+        // The bucket is shared and sized by the smallest advertised limit:
+        // three sent inside the window against hockey's 3 → wait ≤ 60 s,
+        // whichever host the next request is for.
+        let wait = rl.minute_wait().expect("must wait at the limit");
+        assert!(wait <= MINUTE && wait > Duration::from_secs(55), "wait {wait:?}");
+        let (hosts, budget) = rl.minute_snapshot();
+        assert_eq!(hosts["baseball"], HostMinute { limit: Some(300), remaining: Some(299), throttle_events: 0 });
+        assert_eq!(hosts["hockey"], HostMinute { limit: Some(3), remaining: Some(2), throttle_events: 0 });
+        assert_eq!(budget, MinuteBudget { limit: Some(3), sent_last_minute: 3, backoff_secs: 0 });
+    }
+
+    #[test]
+    fn test_remaining_zero_blocks_for_a_minute() {
+        let rl = RateLimiter::new(&["baseball".to_string()], 1000);
+        rl.note_minute_headers("baseball", Some(300), Some(0));
+        let wait = rl.minute_wait().expect("remaining 0 must block");
+        assert!(wait > Duration::from_secs(55) && wait <= MINUTE, "wait {wait:?}");
+        assert_eq!(rl.minute_snapshot().1.backoff_secs, 59);
+    }
+
+    #[test]
+    fn test_throttle_backoff_doubles_and_caps() {
+        let rl = RateLimiter::new(&["hockey".to_string()], 1000);
+        assert_eq!(rl.note_throttled("hockey"), Duration::from_secs(10));
+        assert_eq!(rl.note_throttled("hockey"), Duration::from_secs(20));
+        assert_eq!(rl.note_throttled("rugby"), Duration::from_secs(40));
+        assert_eq!(rl.note_throttled("hockey"), Duration::from_secs(80));
+        assert_eq!(rl.note_throttled("hockey"), THROTTLE_BACKOFF_MAX);
+        assert_eq!(rl.note_throttled("hockey"), THROTTLE_BACKOFF_MAX);
+        let wait = rl.minute_wait().expect("throttled account must wait");
+        assert!(wait > Duration::from_secs(115) && wait <= THROTTLE_BACKOFF_MAX);
+        let (hosts, budget) = rl.minute_snapshot();
+        assert_eq!(hosts["hockey"].throttle_events, 5);
+        assert_eq!(hosts["rugby"].throttle_events, 1);
+        assert_eq!(budget.backoff_secs, 119);
+
+        // A real response ends the streak; the next throttle starts small
+        // again, but the backoff already in force is not shortened.
+        rl.note_minute_ok();
+        assert_eq!(rl.note_throttled("hockey"), Duration::from_secs(10));
+        assert!(rl.minute_wait().unwrap() > Duration::from_secs(115));
+    }
+
+    #[tokio::test]
+    async fn test_acquire_minute_returns_immediately_when_free_and_records_the_send() {
+        let rl = RateLimiter::new(&["afl".to_string()], 1000);
+        rl.note_minute_headers("afl", Some(10), Some(10));
+        for _ in 0..10 {
+            rl.acquire_minute().await;
+        }
+        assert_eq!(rl.minute_snapshot().1.sent_last_minute, 10);
+        assert!(rl.minute_wait().is_some(), "11th send must wait");
     }
 
     #[test]

--- a/channels/sports/service/tests/common/mod.rs
+++ b/channels/sports/service/tests/common/mod.rs
@@ -1,0 +1,52 @@
+//! Shared bootstrap for the Postgres-backed integration tests. Gate on
+//! `TEST_DATABASE_URL`, matching the Go integration tests and CI.
+
+#![allow(dead_code)]
+
+use std::env;
+
+/// A pool on `TEST_DATABASE_URL` with the core schema present, or `None`
+/// (after printing why) when the test should skip.
+pub async fn test_pool(what: &str) -> Option<sqlx::PgPool> {
+    let Ok(url) = env::var("TEST_DATABASE_URL") else {
+        eprintln!("TEST_DATABASE_URL not set -- skipping {what}");
+        return None;
+    };
+    let pool = sqlx::PgPool::connect(&url)
+        .await
+        .expect("connect to TEST_DATABASE_URL");
+    ensure_schema(&pool).await;
+    Some(pool)
+}
+
+/// Apply core's migration chain when the database is empty. Core owns the
+/// schema (VISION 4.3); this service is a pure writer, so the tests read
+/// the same `.up.sql` files core runs at startup.
+pub async fn ensure_schema(pool: &sqlx::PgPool) {
+    let present: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = 'games')",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("probe schema");
+    if present {
+        return;
+    }
+
+    let dir = std::path::Path::new("../../../api/migrations");
+    let mut ups: Vec<_> = std::fs::read_dir(dir)
+        .expect("core owns the schema (VISION 4.3) -- api/migrations must be readable")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.to_string_lossy().ends_with(".up.sql"))
+        .collect();
+    ups.sort();
+
+    for path in ups {
+        let sql = std::fs::read_to_string(&path).expect("read migration");
+        sqlx::raw_sql(&sql)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|e| panic!("apply {}: {e}", path.display()));
+    }
+}

--- a/channels/sports/service/tests/schema_contract.rs
+++ b/channels/sports/service/tests/schema_contract.rs
@@ -18,8 +18,9 @@
 //!
 //! Add a column to a query in this service, add it here too.
 
+mod common;
+
 use std::collections::HashMap;
-use std::env;
 
 use sqlx::Row;
 
@@ -98,16 +99,7 @@ const CONTRACT: &[(&str, &[(&str, &str)])] = &[
 
 #[tokio::test]
 async fn writes_match_the_live_schema() {
-    let Ok(url) = env::var("TEST_DATABASE_URL") else {
-        eprintln!("TEST_DATABASE_URL not set -- skipping schema contract");
-        return;
-    };
-
-    let pool = sqlx::PgPool::connect(&url)
-        .await
-        .expect("connect to TEST_DATABASE_URL");
-
-    ensure_schema(&pool).await;
+    let Some(pool) = common::test_pool("schema contract").await else { return };
 
     let mut problems = Vec::new();
     for (table, columns) in CONTRACT {
@@ -146,37 +138,4 @@ async fn writes_match_the_live_schema() {
         "schema drift between core's migrations and what this service writes:\n  {}",
         problems.join("\n  ")
     );
-}
-
-/// Apply core's migration chain when the database is empty. CI hands each job
-/// a fresh Postgres and this service has no migration tool of its own.
-async fn ensure_schema(pool: &sqlx::PgPool) {
-    let probe = CONTRACT[0].0;
-    let present: bool = sqlx::query_scalar(
-        "SELECT EXISTS (SELECT 1 FROM information_schema.tables
-         WHERE table_schema = 'public' AND table_name = $1)",
-    )
-    .bind(probe)
-    .fetch_one(pool)
-    .await
-    .expect("probe schema");
-    if present {
-        return;
-    }
-
-    let dir = std::path::Path::new("../../../api/migrations");
-    let mut ups: Vec<_> = std::fs::read_dir(dir)
-        .expect("core owns the schema (VISION 4.3) -- api/migrations must be readable")
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| p.to_string_lossy().ends_with(".up.sql"))
-        .collect();
-    ups.sort();
-
-    for path in ups {
-        let sql = std::fs::read_to_string(&path).expect("read migration");
-        sqlx::raw_sql(&sql)
-            .execute(pool)
-            .await
-            .unwrap_or_else(|e| panic!("apply {}: {e}", path.display()));
-    }
 }

--- a/channels/sports/service/tests/stale_sweep.rs
+++ b/channels/sports/service/tests/stale_sweep.rs
@@ -1,0 +1,62 @@
+//! Which rows the stale-live sweep picks up (REL-230): the query behind
+//! `sweep_stale_live`, against a real Postgres. Skips without
+//! `TEST_DATABASE_URL`.
+
+mod common;
+
+use std::sync::Arc;
+use sports_service::database::get_stale_live_games;
+use sqlx::query;
+
+const LEAGUE: &str = "__stale_sweep__";
+
+#[tokio::test]
+async fn sweep_picks_frozen_and_overdue_rows_only() {
+    let Some(pool) = common::test_pool("stale sweep").await else { return };
+    let pool = Arc::new(pool);
+
+    query("DELETE FROM games WHERE league = $1").bind(LEAGUE).execute(&*pool).await.unwrap();
+
+    // (id, state, status, start offset, updated offset) — offsets are SQL intervals from NOW().
+    let rows: &[(&str, &str, &str, &str, &str)] = &[
+        ("A_in_fell_out_of_window", "in", "IN8", "-3 hours", "-30 minutes"),
+        ("B_in_live_and_fresh", "in", "IN3", "-1 hour", "-20 seconds"),
+        ("C_in_stuck_upstream", "in", "IN1", "-6 hours", "-20 seconds"),
+        ("D_pre_should_have_started", "pre", "NS", "-1 hour", "-20 seconds"),
+        ("E_pre_uncovered_fixture", "pre", "NS", "-6 hours", "-20 seconds"),
+        ("F_pre_upcoming", "pre", "NS", "+2 hours", "-20 seconds"),
+        ("G_pre_just_started", "pre", "NS", "-5 minutes", "-20 seconds"),
+        ("H_final", "final", "FT", "-1 hour", "-2 hours"),
+        ("I_in_ancient", "in", "IN9", "-3 days", "-3 days"),
+    ];
+    for (id, state, status, start, updated) in rows {
+        query(&format!(
+            "INSERT INTO games (league, sport, external_game_id, home_team_name, away_team_name,
+                                start_time, state, status_short, updated_at)
+             VALUES ($1, 'baseball', $2, 'Home', 'Away',
+                     NOW() + INTERVAL '{start}', $3, $4, NOW() + INTERVAL '{updated}')"
+        ))
+        .bind(LEAGUE).bind(id).bind(state).bind(status)
+        .execute(&*pool).await.unwrap();
+    }
+
+    let picked = get_stale_live_games(&pool, 10, 20).await.unwrap();
+    let picked: Vec<_> = picked.into_iter().filter(|g| g.league == LEAGUE).collect();
+    let ids: Vec<&str> = picked.iter().map(|g| g.external_game_id.as_str()).collect();
+
+    // Newest first: D (1 h), A (3 h), C (6 h). Fresh live rows, upcoming and
+    // barely-late fixtures, old uncovered fixtures, finals and anything older
+    // than two days are left alone.
+    assert_eq!(ids, ["D_pre_should_have_started", "A_in_fell_out_of_window", "C_in_stuck_upstream"]);
+
+    let a = &picked[1];
+    assert_eq!((a.state.as_str(), a.status_short.as_deref()), ("in", Some("IN8")));
+    assert!((29..=31).contains(&a.updated_mins_ago), "{}", a.updated_mins_ago);
+    assert!((179..=181).contains(&a.started_mins_ago), "{}", a.started_mins_ago);
+
+    // The cap is honoured.
+    let capped = get_stale_live_games(&pool, 10, 1).await.unwrap();
+    assert!(capped.len() <= 1);
+
+    query("DELETE FROM games WHERE league = $1").bind(LEAGUE).execute(&*pool).await.unwrap();
+}

--- a/channels/sports/service/tests/throttle_and_by_id.rs
+++ b/channels/sports/service/tests/throttle_and_by_id.rs
@@ -1,0 +1,167 @@
+//! api-sports' per-minute throttle and the stale-live re-fetch by id, against
+//! a local mock of the api-sports envelope (REL-229 / REL-230).
+//!
+//! The throttle is in-band: HTTP 200, `errors.rateLimit`, empty `response`.
+//! Before REL-229 that read as "0 games found" and the league was marked
+//! healthy; a throttled poll must instead surface as `PollError::Throttled`,
+//! back the host off, and touch nothing.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use axum::{extract::{Query, State}, http::HeaderMap, response::IntoResponse, routing::get, Json, Router};
+use serde_json::{json, Value};
+use sports_service::{
+    database::TrackedLeague,
+    fetch_games, fetch_response, PollError, RateLimiter,
+};
+
+fn mlb() -> TrackedLeague {
+    TrackedLeague {
+        name: "MLB".to_string(),
+        sport_api: "baseball".to_string(),
+        api_host: "v1.baseball.api-sports.io".to_string(),
+        league_id: 1,
+        category: "Baseball".to_string(),
+        country: None,
+        logo_url: None,
+        season: Some("2026".to_string()),
+        season_format: None,
+        offseason_months: None,
+    }
+}
+
+fn game(id: i64, short: &str, long: &str, inning: Option<i64>) -> Value {
+    json!({
+        "id": id,
+        "date": "2026-09-06T22:20:00+00:00",
+        "timestamp": 1788740400,
+        "status": {"short": short, "long": long, "inning": inning},
+        "teams": {
+            "home": {"name": "Chicago White Sox", "code": "CWS", "logo": null},
+            "away": {"name": "Minnesota Twins", "code": "MIN", "logo": null}
+        },
+        "scores": {
+            "home": {"innings": {"1": 3, "2": 7}},
+            "away": {"innings": {"1": 1, "2": 0}}
+        }
+    })
+}
+
+/// The mock: `/games?date=` answers live-then-throttled-then-live,
+/// `/games?id=` answers final. Every response carries the per-minute pair.
+#[derive(Clone)]
+struct Mock {
+    date_calls: Arc<AtomicUsize>,
+}
+
+async fn games(State(mock): State<Mock>, Query(q): Query<std::collections::HashMap<String, String>>) -> impl IntoResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert("X-RateLimit-Limit", "300".parse().unwrap());
+    headers.insert("x-ratelimit-requests-limit", "75000".parse().unwrap());
+    headers.insert("x-ratelimit-requests-remaining", "74000".parse().unwrap());
+
+    let body = if q.contains_key("id") {
+        headers.insert("X-RateLimit-Remaining", "297".parse().unwrap());
+        json!({"get": "games", "results": 1, "errors": [],
+               "response": [game(184965, "FT", "Finished", None)]})
+    } else {
+        let n = mock.date_calls.fetch_add(1, Ordering::SeqCst);
+        if n == 1 {
+            // Exactly what production logged on 2026-09-07: a 200 with the
+            // throttle message and nothing else.
+            headers.insert("X-RateLimit-Remaining", "0".parse().unwrap());
+            json!({"get": "games", "results": 0, "response": [],
+                   "errors": {"rateLimit": "Too many requests. You have exceeded the limit of requests per minute of your subscription."}})
+        } else {
+            headers.insert("X-RateLimit-Remaining", "299".parse().unwrap());
+            json!({"get": "games", "results": 1, "errors": [],
+                   "response": [game(184965, "IN1", "Inning 1", Some(1))]})
+        }
+    };
+    (headers, Json(body))
+}
+
+async fn serve() -> (String, Mock) {
+    let mock = Mock { date_calls: Arc::new(AtomicUsize::new(0)) };
+    let app = Router::new().route("/games", get(games)).with_state(mock.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (base, mock)
+}
+
+#[tokio::test]
+async fn throttled_response_is_throttled_not_zero_games_and_by_id_finalises_the_row() {
+    let (base, mock) = serve().await;
+    let league = mlb();
+    let rl = RateLimiter::new_per_league(std::slice::from_ref(&league), 7500);
+    let client = reqwest::Client::new();
+    let by_date = format!("{base}/games?league=1&season=2026&date=2026-09-06");
+
+    // 1. Live: one game, in progress, per-minute limit adopted from the headers.
+    let games = fetch_games(&client, &league, &by_date, &rl).await.expect("first poll succeeds");
+    assert_eq!(games.len(), 1);
+    assert_eq!(games[0].state, "in");
+    assert_eq!(games[0].status_short.as_deref(), Some("IN1"));
+    let (hosts, budget) = rl.minute_snapshot();
+    assert_eq!((hosts["baseball"].limit, hosts["baseball"].remaining, hosts["baseball"].throttle_events), (Some(300), Some(299), 0));
+    assert_eq!((budget.limit, budget.sent_last_minute, budget.backoff_secs), (Some(300), 1, 0));
+
+    // 2. Gap: the throttle answers. Not an empty result — a throttle event
+    //    that backs the host off and is counted as such.
+    match fetch_games(&client, &league, &by_date, &rl).await {
+        Err(PollError::Throttled(backoff)) => assert_eq!(backoff.as_secs(), 10),
+        other => panic!("expected Throttled, got {other:?}"),
+    }
+    let (hosts, budget) = rl.minute_snapshot();
+    assert_eq!((hosts["baseball"].throttle_events, hosts["baseball"].remaining), (1, Some(0)));
+    // remaining == 0 blocks for a full minute, longer than the 10 s backoff,
+    // and the block is account-wide: the whole process waits, not one host.
+    assert!(budget.backoff_secs >= 55, "{budget:?}");
+    assert!(rl.minute_wait().unwrap().as_secs() >= 55);
+    assert_eq!(mock.date_calls.load(Ordering::SeqCst), 2);
+
+    // 3. Final by id: the sweep's request shape. A fresh limiter stands in
+    //    for the minute that would otherwise have to pass.
+    let rl2 = RateLimiter::new_per_league(std::slice::from_ref(&league), 7500);
+    let by_id = format!("{base}/games?id=184965");
+    let games = fetch_games(&client, &league, &by_id, &rl2).await.expect("by-id succeeds");
+    assert_eq!(games.len(), 1);
+    assert_eq!(games[0].external_game_id, "184965");
+    assert_eq!(games[0].state, "final");
+    assert_eq!(games[0].status_short.as_deref(), Some("FT"));
+    assert_eq!((games[0].home_team.score, games[0].away_team.score), (Some(10), Some(1)));
+    // The daily headers were adopted too.
+    assert_eq!(rl2.daily_quota("baseball"), 75_000);
+}
+
+#[tokio::test]
+async fn a_429_is_a_throttle_and_other_errors_are_errors() {
+    let app = Router::new()
+        .route("/games", get(|| async { (axum::http::StatusCode::TOO_MANY_REQUESTS, "slow down") }))
+        .route("/fixtures", get(|| async { (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom") }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let rl = RateLimiter::new(&["baseball".to_string(), "football".to_string()], 100);
+    let client = reqwest::Client::new();
+
+    // The 500 first: after the 429 the whole account backs off for 10 s.
+    match fetch_response(&client, "football", "Serie A", &format!("{base}/fixtures?id=1"), &rl).await {
+        Err(PollError::Other(e)) => assert!(e.to_string().contains("500"), "{e}"),
+        other => panic!("500 must be Other, got {other:?}"),
+    }
+    assert_eq!(rl.minute_snapshot().0["football"].throttle_events, 0);
+
+    match fetch_response(&client, "baseball", "MLB", &format!("{base}/games?id=1"), &rl).await {
+        Err(PollError::Throttled(backoff)) => assert_eq!(backoff.as_secs(), 10),
+        other => panic!("429 must be Throttled, got {other:?}"),
+    }
+    let (hosts, budget) = rl.minute_snapshot();
+    assert_eq!(hosts["baseball"].throttle_events, 1);
+    assert_eq!(budget.backoff_secs, 9);
+}

--- a/scripts/smoke/production-readiness.sh
+++ b/scripts/smoke/production-readiness.sh
@@ -262,12 +262,18 @@ for line in "${SERVICES[@]}"; do
         green "OK (HTTP $(echo "$result" | jq -r '.status'))"
         # Sports: show the effective api-sports daily quota per host so the
         # deploy log proves which plan the ingester is budgeting from
-        # (REL-222). Informational only — never a failure condition.
+        # (REL-222), and the per-minute window it is pacing itself to
+        # (REL-229). Informational only — never a failure condition.
         if [[ "$svc" == "sports-service" ]]; then
             echo "$result" | jq -r '
                 .body.health as $h
                 | ($h.quota // {}) | to_entries[]
-                | "    \(.key): quota \(.value.daily_quota) (\(.value.source)), remaining \(.value.remaining), live poll \($h.live_poll_secs // "?")s"
+                | ($h.minute[.key] // {}) as $m
+                | "    \(.key): quota \(.value.daily_quota) (\(.value.source)), remaining \(.value.remaining), per-minute \($m.limit // "?") (\($m.throttle_events // 0) throttles), live poll \($h.live_poll_secs // "?")s"
+            ' 2>/dev/null || true
+            echo "$result" | jq -r '
+                .body.health | .minute_budget as $b
+                | "    per-minute budget: limit \($b.limit // "?"), sent \($b.sent_last_minute // 0) in the last minute, backoff \($b.backoff_secs // 0)s; throttled polls since start: \(.throttled_polls // 0)"
             ' 2>/dev/null || true
         fi
     else


### PR DESCRIPTION
## Confirmed cause (REL-230)

Rows vs ground truth at 02:53 UTC, 2026-09-07:

| Game | Our row | statsapi / ESPN |
|---|---|---|
| NYY @ SD (Sep 6 20:10Z) | `in` IN9, 3–4 | Final 3–4 |
| ATH @ SEA (Sep 6 20:10Z) | `in` IN8, 0–2 | Final 0–2 |
| MIN @ CWS (Sep 6 22:20Z) | `in` IN1, 0–0 | Final 1–10 |
| WSH @ LAD (Sep 7 02:10Z) | `pre` Not Started | In progress, 3rd |
| Louisville @ Ole Miss, Wisconsin @ ND | Q4 | 4th quarter (match) |

All four stale MLB games are **inside** the polled windows (Sep 6 = the 17-game "yesterday" poll, Sep 7 = the 9-game "today" poll) and were upserted every cycle with `0 failed`. So "left the live window" and "date window misses it" are both false: **api-sports' baseball feed itself returned stale statuses** for 3+ hours. The NCAAF rows were not stale. The throttling (REL-229) is real and independent; it did not freeze these rows.

Two structural gaps remained and are closed here: a throttled 200 read as "0 games found" and marked the league healthy, and a live row that *does* fall out of the today/yesterday window is never re-fetched (it sits until the 24 h cleanup deletes it).

## Per-minute scope

The mitigation pod (60 s cadence, PR #335) was still throttled 95 times in its startup minute, including on the rugby host at ~10 requests/min. api-sports counts the minute across the subscription, so the bucket is **one per key**, sized by the smallest `X-RateLimit-Limit` any host advertises; per-host headers are kept for visibility. Steady state at 60 s since 03:04 UTC: zero throttles.

## Changes

- `channels/sports/service`: token bucket (`acquire_minute`) in front of every request incl. standings/teams; in-band `errors.rateLimit` / 429 → `PollError::Throttled` with 10 s → 120 s backoff, not counted as a poll, no row touched; live polls round-robin across hosts; stale-live sweep every 5 min re-fetching by id (cap 20/sweep); `/health/ready` gains `minute`, `minute_budget`, `throttled_polls`.
- `api/internal/ingestread/sports.go`: `updated_at` on every games read (incl. `/public/feed`).
- `scripts/smoke/production-readiness.sh`: prints the per-minute limit per host, the shared budget, and throttled polls.
- Tests: limiter header sequences + backoff (unit); mock api-sports envelope: throttled 200 → `Throttled`, final-by-id parses (integration); sweep row selection against Postgres (`TEST_DATABASE_URL`, runs in CI).

`SPORTS_LIVE_POLL_MIN_SECS` stays at 60 (main) until the deploy's smoke line shows the advertised per-minute limit; then a k8s-only PR can lower it with the bucket in place.

## Verification

- `cargo test` 59 unit + 12 integration green locally (DB tests against the dev Postgres).
- Go build/vet/test in `golang:1.25-alpine` green.
- Production logs read via the cluster API: 18 throttles 01:28–02:40 at 15 s; 95 in the startup minute of the 60 s pod; none since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
