### PR TITLE
fix(sports): consult MLB statsapi when api-sports keeps serving a stale live status [REL-233]

### DIFF
--- a/channels/sports/service/Cargo.toml
+++ b/channels/sports/service/Cargo.toml
@@ -36,6 +36,7 @@ sentry = { version = "0.42", default-features = false, features = [
 ] }
 sentry-anyhow = "0.42"
 dirs = "5"
+chrono-tz = "0.10"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/channels/sports/service/src/database.rs
+++ b/channels/sports/service/src/database.rs
@@ -383,6 +383,52 @@ pub async fn cleanup_old_games(pool: &Arc<PgPool>) -> Result<u64> {
     Ok(result.rows_affected())
 }
 
+/// Every column the MLB statsapi fallback (REL-233) needs to preserve on a
+/// row it's about to correct — everything api-sports last wrote except the
+/// score/state/status fields the fallback itself is replacing. Fetched fresh
+/// right before the fallback writes, rather than threaded through from
+/// `get_stale_live_games`, so the sweep's common path stays untouched.
+#[derive(Debug, Clone, FromRow)]
+pub struct GameRow {
+    pub league: String,
+    pub sport: String,
+    pub external_game_id: String,
+    pub link: Option<String>,
+    pub home_team_name: String,
+    pub home_team_logo: Option<String>,
+    pub home_team_score: Option<i32>,
+    pub home_team_code: Option<String>,
+    pub away_team_name: String,
+    pub away_team_logo: Option<String>,
+    pub away_team_score: Option<i32>,
+    pub away_team_code: Option<String>,
+    pub start_time: chrono::DateTime<Utc>,
+    pub short_detail: Option<String>,
+    pub state: String,
+    pub status_short: Option<String>,
+    pub status_long: Option<String>,
+    pub timer: Option<String>,
+    pub venue: Option<String>,
+    pub season: Option<String>,
+}
+
+/// Load one game row exactly as it stands right now.
+pub async fn get_game_row(pool: &Arc<PgPool>, league: &str, external_game_id: &str) -> Result<Option<GameRow>> {
+    let mut conn = pool.acquire().await?;
+    let row = query_as(
+        "SELECT league, sport, external_game_id, link,
+                home_team_name, home_team_logo, home_team_score, home_team_code,
+                away_team_name, away_team_logo, away_team_score, away_team_code,
+                start_time, short_detail, state, status_short, status_long, timer, venue, season
+         FROM games WHERE league = $1 AND external_game_id = $2"
+    )
+    .bind(league)
+    .bind(external_game_id)
+    .fetch_optional(&mut *conn)
+    .await?;
+    Ok(row)
+}
+
 // =============================================================================
 // Game upsert
 // =============================================================================

--- a/channels/sports/service/src/lib.rs
+++ b/channels/sports/service/src/lib.rs
@@ -10,6 +10,7 @@ use crate::database::{
     cleanup_old_games, get_live_yesterday_leagues, get_stale_live_games,
     LeagueConfig, TrackedLeague, upsert_game, CleanedData, Team,
     StandingData, upsert_standing, TeamData, upsert_team,
+    GameRow, get_game_row, StaleGame,
 };
 pub use crate::types::{live_poll_interval_secs, HostMinute, HostQuota, MinuteBudget, RateLimiter, SportsHealth, DEFAULT_DAILY_QUOTA};
 
@@ -1085,6 +1086,8 @@ pub async fn sweep_stale_live(
     let by_name: HashMap<&str, &TrackedLeague> =
         leagues.iter().map(|l| (l.name.as_str(), l)).collect();
     let (mut refreshed, mut unchanged) = (0u32, 0u32);
+    // One statsapi request per date per sweep, not per row (REL-233).
+    let mut statsapi_cache: HashMap<String, serde_json::Value> = HashMap::new();
     for row in rows {
         // A league that is no longer tracked keeps its rows until cleanup.
         let Some(league) = by_name.get(row.league.as_str()) else { continue };
@@ -1099,6 +1102,9 @@ pub async fn sweep_stale_live(
                     warn!("[{}] Stale-live {}: upstream returned nothing for this id (was {} {}, started {} min ago)",
                         league.name, row.external_game_id, row.state,
                         row.status_short.as_deref().unwrap_or("?"), row.started_mins_ago);
+                    if league.name == "MLB" {
+                        mlb_statsapi_fallback(pool, client, &row, &mut statsapi_cache).await;
+                    }
                     continue;
                 };
                 let same = game.status_short == row.status_short;
@@ -1109,8 +1115,15 @@ pub async fn sweep_stale_live(
                     row.updated_mins_ago, row.started_mins_ago,
                     if same { " — unchanged upstream, api-sports lag" } else { "" });
                 if same { unchanged += 1 } else { refreshed += 1 }
-                if let Err(e) = upsert_game(pool.clone(), game).await {
-                    error!("[{}] Stale-live {}: upsert failed: {}", league.name, row.external_game_id, e);
+                // Still stale upstream too — MLB gets a second opinion from
+                // statsapi before falling back to writing the same data.
+                let fixed_via_statsapi = same
+                    && league.name == "MLB"
+                    && mlb_statsapi_fallback(pool, client, &row, &mut statsapi_cache).await;
+                if !fixed_via_statsapi {
+                    if let Err(e) = upsert_game(pool.clone(), game).await {
+                        error!("[{}] Stale-live {}: upsert failed: {}", league.name, row.external_game_id, e);
+                    }
                 }
             }
             Err(PollError::Throttled(backoff)) => {
@@ -1125,6 +1138,195 @@ pub async fn sweep_stale_live(
         }
     }
     info!("Stale-live sweep complete: {} moved, {} unchanged upstream", refreshed, unchanged);
+}
+
+// =============================================================================
+// MLB statsapi fallback for stuck stale-live rows (REL-233)
+// =============================================================================
+//
+// api-sports occasionally keeps re-serving the same live status by id for
+// hours (the Sep 6 2026 MLB stall this ticket follows up on). MLB alone has a
+// free, keyless second source — statsapi.mlb.com — so when the by-id re-fetch
+// above comes back unchanged or empty for an MLB row, this checks statsapi's
+// schedule for the row's game date before giving up. Never primary, never
+// through the api-sports rate limiter (different host, different budget),
+// and MLB only: other baseball leagues (NPB) have no statsapi to fall back to.
+
+/// One game's relevant fields out of a statsapi `/schedule?hydrate=linescore`
+/// response.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StatsApiGame {
+    pub detailed_state: String,
+    pub home_name: String,
+    pub away_name: String,
+    pub home_score: Option<i32>,
+    pub away_score: Option<i32>,
+    pub inning: Option<i64>,
+}
+
+/// Pull every game out of a statsapi schedule response (one date, possibly
+/// several games). A game missing a field this needs is dropped rather than
+/// guessed at.
+pub fn parse_statsapi_schedule(body: &serde_json::Value) -> Vec<StatsApiGame> {
+    body.get("dates")
+        .and_then(|d| d.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|d| d.get("games")?.as_array())
+        .flatten()
+        .filter_map(|g| {
+            let status = g.get("status")?;
+            let detailed_state = status.get("detailedState")?.as_str()?.to_string();
+            let teams = g.get("teams")?;
+            let home = teams.get("home")?;
+            let away = teams.get("away")?;
+            let home_name = home.get("team")?.get("name")?.as_str()?.to_string();
+            let away_name = away.get("team")?.get("name")?.as_str()?.to_string();
+            let home_score = home.get("score").and_then(|s| s.as_i64()).map(|s| s as i32);
+            let away_score = away.get("score").and_then(|s| s.as_i64()).map(|s| s as i32);
+            let inning = g.get("linescore").and_then(|l| l.get("currentInning")).and_then(|i| i.as_i64());
+            Some(StatsApiGame { detailed_state, home_name, away_name, home_score, away_score, inning })
+        })
+        .collect()
+}
+
+/// Map statsapi's `detailedState` onto the api-sports short/long status
+/// vocabulary `map_status_to_state` and `build_detail` already render —
+/// exactly the vocabulary this ticket named, nothing guessed for the rest.
+pub fn statsapi_status_to_api_sports(detailed_state: &str, inning: Option<i64>) -> Option<(String, String)> {
+    match detailed_state {
+        "Final" | "Game Over" | "Completed Early" => Some(("FT".to_string(), detailed_state.to_string())),
+        "In Progress" => Some((format!("IN{}", inning.unwrap_or(0)), detailed_state.to_string())),
+        "Postponed" => Some(("PST".to_string(), detailed_state.to_string())),
+        "Suspended" => Some(("SUSP".to_string(), detailed_state.to_string())),
+        "Cancelled" => Some(("CANC".to_string(), detailed_state.to_string())),
+        _ => None,
+    }
+}
+
+/// Turn a statsapi match into the same `CleanedData` shape `parse_baseball_game`
+/// produces, so `upsert_game` and the chip formatter can't tell the
+/// difference. Everything statsapi doesn't know (logos, codes, venue, link,
+/// season, start_time) is carried forward from the row already in the
+/// database rather than nulled out.
+pub fn statsapi_game_to_cleaned_data(existing: &GameRow, game: &StatsApiGame, mapped: (String, String)) -> CleanedData {
+    let (status_short, status_long) = mapped;
+    let state = map_status_to_state(&status_short).to_string();
+    let timer = if state == "in" { game.inning.map(|i| format!("Inn {}", i)) } else { None };
+    let detail = build_detail(&status_short, Some(status_long.as_str()), timer.as_deref());
+    CleanedData {
+        league: existing.league.clone(),
+        sport: existing.sport.clone(),
+        external_game_id: existing.external_game_id.clone(),
+        link: existing.link.clone(),
+        home_team: Team {
+            name: existing.home_team_name.clone(),
+            logo: existing.home_team_logo.clone(),
+            score: game.home_score.or(existing.home_team_score),
+            code: existing.home_team_code.clone(),
+        },
+        away_team: Team {
+            name: existing.away_team_name.clone(),
+            logo: existing.away_team_logo.clone(),
+            score: game.away_score.or(existing.away_team_score),
+            code: existing.away_team_code.clone(),
+        },
+        start_time: existing.start_time,
+        short_detail: detail,
+        state,
+        status_short: Some(status_short),
+        status_long: Some(status_long),
+        timer,
+        venue: existing.venue.clone(),
+        season: existing.season.clone(),
+    }
+}
+
+/// `statsapi.mlb.com`'s schedule URL for one date. `STATSAPI_BASE_URL`
+/// redirects to a mock the same way `API_SPORTS_BASE_URL` does for
+/// api-sports, so tests never hit the real host.
+fn statsapi_schedule_url(date: &str) -> String {
+    let base = env::var("STATSAPI_BASE_URL").unwrap_or_else(|_| "https://statsapi.mlb.com".to_string());
+    format!("{}/api/v1/schedule?sportId=1&date={}&hydrate=linescore", base.trim_end_matches('/'), date)
+}
+
+/// One request, cached by the caller so a sweep never asks statsapi about
+/// the same date twice. Not routed through `RateLimiter` — a different host
+/// with its own (much looser) limits, not api-sports' per-minute budget.
+async fn fetch_statsapi_schedule(client: &Client, date: &str) -> Result<serde_json::Value> {
+    let url = statsapi_schedule_url(date);
+    let resp = client.get(&url).send().await.context("statsapi request failed")?;
+    if !resp.status().is_success() {
+        anyhow::bail!("statsapi returned HTTP {}", resp.status());
+    }
+    resp.json::<serde_json::Value>().await.context("statsapi response wasn't JSON")
+}
+
+/// Check statsapi for one stuck MLB row: today's (row's local date)
+/// schedule, then yesterday's if no match. Returns true when it found and
+/// wrote a match, so the caller can skip re-writing the still-stale
+/// api-sports data.
+async fn mlb_statsapi_fallback(
+    pool: &Arc<PgPool>,
+    client: &Client,
+    row: &StaleGame,
+    cache: &mut HashMap<String, serde_json::Value>,
+) -> bool {
+    let existing = match get_game_row(pool, &row.league, &row.external_game_id).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return false, // row vanished between the sweep query and now
+        Err(e) => {
+            warn!("[MLB] Stale-live {}: couldn't reload row for statsapi fallback: {}", row.external_game_id, e);
+            return false;
+        }
+    };
+
+    let ny_date = existing.start_time.with_timezone(&chrono_tz::America::New_York).date_naive();
+    let candidate_dates = [ny_date, ny_date - Duration::days(1)];
+    for date in candidate_dates {
+        let date_str = date.format("%Y-%m-%d").to_string();
+        let body = match cache.get(&date_str) {
+            Some(cached) => cached.clone(),
+            None => match fetch_statsapi_schedule(client, &date_str).await {
+                Ok(b) => {
+                    cache.insert(date_str.clone(), b.clone());
+                    b
+                }
+                Err(e) => {
+                    warn!("[MLB] statsapi schedule fetch for {} failed: {}", date_str, e);
+                    continue;
+                }
+            },
+        };
+        let games = parse_statsapi_schedule(&body);
+        let Some(g) = games.iter().find(|g| {
+            g.home_name == existing.home_team_name && g.away_name == existing.away_team_name
+        }) else {
+            continue;
+        };
+        let Some(mapped) = statsapi_status_to_api_sports(&g.detailed_state, g.inning) else {
+            warn!("[MLB] Stale-live {}: statsapi says '{}' — unrecognized, leaving row alone",
+                row.external_game_id, g.detailed_state);
+            return false;
+        };
+        let old_short = existing.status_short.as_deref().unwrap_or("?");
+        let (old_home, old_away) = (existing.home_team_score.unwrap_or(0), existing.away_team_score.unwrap_or(0));
+        let cleaned = statsapi_game_to_cleaned_data(&existing, g, mapped);
+        info!("[MLB] Stale-live {}: {} {}-{} → {} {}-{} via statsapi",
+            row.external_game_id, old_short, old_home, old_away,
+            cleaned.state, cleaned.home_team.score.unwrap_or(0), cleaned.away_team.score.unwrap_or(0));
+        return match upsert_game(pool.clone(), cleaned).await {
+            Ok(_) => true,
+            Err(e) => {
+                error!("[MLB] Stale-live {}: statsapi upsert failed: {}", row.external_game_id, e);
+                false
+            }
+        };
+    }
+    warn!("[MLB] Stale-live {}: no statsapi match for '{}' @ '{}' on {} or {} — leaving row alone",
+        row.external_game_id, existing.away_team_name, existing.home_team_name,
+        candidate_dates[0], candidate_dates[1]);
+    false
 }
 
 // =============================================================================

--- a/channels/sports/service/tests/stale_sweep.rs
+++ b/channels/sports/service/tests/stale_sweep.rs
@@ -1,11 +1,17 @@
 //! Which rows the stale-live sweep picks up (REL-230): the query behind
 //! `sweep_stale_live`, against a real Postgres. Skips without
 //! `TEST_DATABASE_URL`.
+//!
+//! The MLB statsapi fallback (REL-233) is covered below with a fixture
+//! response instead — it's pure parsing/mapping, no database needed.
 
 mod common;
 
 use std::sync::Arc;
-use sports_service::database::get_stale_live_games;
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+use sports_service::database::{get_stale_live_games, GameRow};
+use sports_service::{parse_statsapi_schedule, statsapi_game_to_cleaned_data, statsapi_status_to_api_sports};
 use sqlx::query;
 
 const LEAGUE: &str = "__stale_sweep__";
@@ -59,4 +65,81 @@ async fn sweep_picks_frozen_and_overdue_rows_only() {
     assert!(capped.len() <= 1);
 
     query("DELETE FROM games WHERE league = $1").bind(LEAGUE).execute(&*pool).await.unwrap();
+}
+
+/// A row stuck reporting "IN1" for hours (the Sep 6 2026 stall) gets
+/// corrected from a fixture statsapi schedule response: matched by exact
+/// team name, mapped onto the api-sports status vocabulary, and everything
+/// statsapi doesn't know (logo, code, venue, season, start_time) is carried
+/// forward from the row untouched — the fallback must never null those out.
+#[test]
+fn statsapi_fallback_maps_final_score_and_preserves_the_rest() {
+    let existing = GameRow {
+        league: "MLB".to_string(),
+        sport: "baseball".to_string(),
+        external_game_id: "184965".to_string(),
+        link: None,
+        home_team_name: "Chicago White Sox".to_string(),
+        home_team_logo: Some("https://example.com/cws.png".to_string()),
+        home_team_score: Some(0),
+        home_team_code: Some("CWS".to_string()),
+        away_team_name: "Minnesota Twins".to_string(),
+        away_team_logo: Some("https://example.com/min.png".to_string()),
+        away_team_score: Some(0),
+        away_team_code: Some("MIN".to_string()),
+        start_time: Utc.with_ymd_and_hms(2026, 9, 6, 22, 20, 0).unwrap(),
+        short_detail: Some("IN1 · Inn 1".to_string()),
+        state: "in".to_string(),
+        status_short: Some("IN1".to_string()),
+        status_long: Some("Inning 1".to_string()),
+        timer: Some("Inn 1".to_string()),
+        venue: Some("Guaranteed Rate Field".to_string()),
+        season: Some("2026".to_string()),
+    };
+
+    // Real statsapi shape: dates[].games[].{status.detailedState, teams.home/away.{score,team.name}, linescore.currentInning}.
+    let fixture = json!({
+        "dates": [{
+            "date": "2026-09-06",
+            "games": [{
+                "status": {"detailedState": "Final"},
+                "teams": {
+                    "home": {"score": 10, "team": {"name": "Chicago White Sox"}},
+                    "away": {"score": 1, "team": {"name": "Minnesota Twins"}}
+                },
+                "linescore": {"currentInning": 9}
+            }]
+        }]
+    });
+
+    let games = parse_statsapi_schedule(&fixture);
+    assert_eq!(games.len(), 1);
+    let game = games.into_iter()
+        .find(|g| g.home_name == existing.home_team_name && g.away_name == existing.away_team_name)
+        .expect("exact team-name match");
+    assert_eq!(game.detailed_state, "Final");
+    assert_eq!((game.home_score, game.away_score), (Some(10), Some(1)));
+
+    let mapped = statsapi_status_to_api_sports(&game.detailed_state, game.inning)
+        .expect("Final is recognized vocabulary");
+    assert_eq!(mapped, ("FT".to_string(), "Final".to_string()));
+
+    let cleaned = statsapi_game_to_cleaned_data(&existing, &game, mapped);
+    assert_eq!(cleaned.state, "final");
+    assert_eq!(cleaned.status_short.as_deref(), Some("FT"));
+    assert_eq!((cleaned.home_team.score, cleaned.away_team.score), (Some(10), Some(1)));
+    // Nothing statsapi doesn't know got nulled out.
+    assert_eq!(cleaned.home_team.logo.as_deref(), Some("https://example.com/cws.png"));
+    assert_eq!(cleaned.home_team.code.as_deref(), Some("CWS"));
+    assert_eq!(cleaned.venue.as_deref(), Some("Guaranteed Rate Field"));
+    assert_eq!(cleaned.season.as_deref(), Some("2026"));
+    assert_eq!(cleaned.start_time, existing.start_time);
+
+    // No match for a team pair not in the fixture: never guess.
+    let fixture_games = parse_statsapi_schedule(&fixture);
+    assert!(fixture_games.iter().find(|g| g.home_name == "Some Other Team").is_none());
+
+    // A detailedState this ticket didn't name maps to nothing — the fallback
+    // must leave the row alone rather than invent a status.
+    assert_eq!(statsapi_status_to_api_sports("Warmup", None), None);
 }


### PR DESCRIPTION
## Summary

`sweep_stale_live`'s by-id re-fetch (REL-230/#336) can itself get stuck: api-sports occasionally re-serves the exact same `status_short` for a live game for hours (the production stall on Sep 6 2026 that motivated this: `IN8` for hours after the game had actually finished). MLB has a free, keyless second source with no such lag — statsapi.mlb.com's `/schedule` endpoint.

When the sweep's by-id re-fetch for an **MLB** row comes back **unchanged** or **empty**, it now:
1. Reloads the row's current full data (logos, codes, venue, etc.) so nothing gets clobbered.
2. Computes the row's `start_time` as an America/New_York calendar date and queries `https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=YYYY-MM-DD&hydrate=linescore` for that date, then the previous date if no match — one request per date per sweep, cached locally.
3. Matches by **exact** home/away team name. No match → warn and leave the row alone (never guess).
4. Maps statsapi's `detailedState` onto the same status vocabulary the baseball parser already emits (`FT`, `INn`, `PST`, `SUSP`, `CANC`) so `map_status_to_state`/`build_detail`/the chip formatter can't tell the difference — only the vocabulary the ticket named (Final/Game Over/Completed Early, In Progress, Postponed/Cancelled/Suspended); anything else → warn and leave alone.
5. Writes the correction through the existing `upsert_game`.

Logs `[MLB] Stale-live <id>: IN1 0-0 → final 1-10 via statsapi` on a successful correction.

## Scope guarantees (per the ticket)
- **MLB only** — gated on `league.name == "MLB"`. NPB shares the baseball parser but has no statsapi to fall back to.
- **Never through the api-sports rate limiter/token bucket** — statsapi is a different host with its own budget; `SPORTS_LIVE_POLL_*` and the per-minute pacing from #336/#337 are untouched.
- **statsapi is never primary** — only consulted after the by-id re-fetch already ran and came back stuck.
- Preserves every field statsapi doesn't know (logo, code, venue, link, season, `start_time`) by reloading the row first, rather than nulling them out on write.

## Changes
- `channels/sports/service/src/database.rs`: new `GameRow` (full row) + `get_game_row` — used only by the fallback so the sweep's common path and its existing test stay untouched.
- `channels/sports/service/src/lib.rs`: `parse_statsapi_schedule`, `statsapi_status_to_api_sports`, `statsapi_game_to_cleaned_data`, `fetch_statsapi_schedule`, `mlb_statsapi_fallback`, wired into `sweep_stale_live`'s two stuck-row branches.
- `channels/sports/service/Cargo.toml`: added `chrono-tz` (needed for the correct DST-aware America/New_York calendar date — a fixed UTC offset would pick the wrong date across the two DST transitions a year, one of which falls inside a possible World Series window).
- `channels/sports/service/tests/stale_sweep.rs`: new unit test with a fixture statsapi JSON (no DB) covering exact-name match, `Final` → `final` with scores, an unmatched team pair, and an unrecognized `detailedState` mapping to "leave it alone".

## Verification
- `cargo test` (60 lib tests + all integration test files): all green, including against a real local Postgres (`TEST_DATABASE_URL` pointed at the dev stack's `scrollr-postgres` container) for `schema_contract.rs` and `stale_sweep.rs`.
- Manually verified the new `get_game_row` query round-trips every field (home/away name, logo, code, venue, status, score) against that real Postgres with an ad-hoc scratch test (not committed — the permanent test coverage is the fixture-JSON unit test above, per the ticket's ask for one unit test).
- `cargo build --lib` clean; `cargo clippy` shows only pre-existing warnings elsewhere in the crate plus one pre-existing-style nested-`if` nit in the new code (not fixed — matches the surrounding file's style and clippy flags the same pattern already present in `main.rs`).
- Not yet exercised against production: deploying and confirming a `via statsapi` log line requires a live MLB game that actually gets stuck, which is not reproducible on demand. Will confirm post-deploy via pod logs once one occurs, or note in the Linear comment if none occurs during this deploy's observation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)