### PR TITLE
fix(ticker): freeze a rotating slot's item until it goes off screen [REL-234]

### DIFF
--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -46,7 +46,7 @@ import {
 import { sourceForWidget } from "../marketplace";
 import { useCatalog } from "../hooks/useCatalog";
 import { TICKER_SOURCES } from "../datawidgets/tickerRegistry";
-import { rotateSlots } from "../datawidgets/ticker";
+import { rotateSlots, type RotationMemo } from "../datawidgets/ticker";
 import { stepItemIndex } from "./tickerStep";
 import { advanceCycles, visibleSlots } from "./tickerRotation";
 import { WIDGET_ORDER } from "../widgets/registry";
@@ -175,9 +175,10 @@ function widgetChipsFor(
     onChipClick?: (type: string, id: string, url?: string) => void;
     pinned?: boolean;
     cycles?: Readonly<Record<string, number>>;
+    rotationMemo?: RotationMemo;
   },
 ): Array<{ key: string; node: React.ReactNode; rotateSlot?: string }> {
-  const { comfort, chipColorMode, onTogglePin, onChipClick, pinned, cycles } = opts;
+  const { comfort, chipColorMode, onTogglePin, onChipClick, pinned, cycles, rotationMemo } = opts;
 
   // The four cell/gauge/spine utilities each render as ONE chip holding
   // their items, unlike the capped pair which render one chip per item.
@@ -210,6 +211,7 @@ function widgetChipsFor(
     wt,
     (item) => item.id,
     () => undefined,
+    rotationMemo,
   );
   return slots.map(({ key, item, rotateSlot }, i) => {
     const shared = {
@@ -300,6 +302,14 @@ export default function ScrollrTicker({
   // sources through ctx.cycles to decide what the slot shows this lap.
   const [cycles, setCycles] = useState<Readonly<Record<string, number>>>({});
 
+  // One Map for the whole rail's rotation, so a slot's item is frozen
+  // across renders until its own turn (above) advances -- a dashboard
+  // refetch or a reorder between advances must not change what a slot
+  // shows (CHIP_DESIGN.md rule 6). Keys are namespaced per source+tab+i
+  // (§8.2), so sharing one Map across every source is safe. A ref, not
+  // state: mutating it must never itself trigger a re-render.
+  const rotationMemoRef = useRef<RotationMemo>(new Map());
+
   const chips = useMemo(() => {
     const wrap = (key: string, chip: React.ReactNode, rotateSlot?: string) => (
       <div key={key} className="py-1" data-chip="" data-rotate-slot={rotateSlot}>
@@ -336,6 +346,7 @@ export default function ScrollrTicker({
             onTogglePin,
             onChipClick,
             cycles,
+            rotationMemo: rotationMemoRef.current,
           });
           chipsForWidget.forEach(({ key, node, rotateSlot }) =>
             bucket.push(wrap(key, node, rotateSlot)),
@@ -367,6 +378,7 @@ export default function ScrollrTicker({
         widgetDisplay,
         predictionsWatchlist,
         cycles,
+        rotationMemo: rotationMemoRef.current,
         onChipClick,
       })) {
         bucket.push(wrap(chip.key, chip.node, chip.rotateSlot));

--- a/desktop/src/datawidgets/finance/ticker.tsx
+++ b/desktop/src/datawidgets/finance/ticker.tsx
@@ -30,6 +30,7 @@ export const financeTickerSource: TickerSource = {
       `fin-${ctx.tab}`,
       (t) => t.symbol,
       () => undefined,
+      ctx.rotationMemo,
     );
     return slots.map(({ key, item: trade, rotateSlot }) => ({
       key,

--- a/desktop/src/datawidgets/predictions/ticker.tsx
+++ b/desktop/src/datawidgets/predictions/ticker.tsx
@@ -23,6 +23,7 @@ export const predictionsTickerSource: TickerSource = {
       `pred-${ctx.tab}`,
       (p) => p.id,
       () => undefined,
+      ctx.rotationMemo,
     );
     return slots.map(({ key, item: p, rotateSlot }) => ({
       key,

--- a/desktop/src/datawidgets/rss/ticker.tsx
+++ b/desktop/src/datawidgets/rss/ticker.tsx
@@ -29,7 +29,12 @@ export const rssTickerSource: TickerSource = {
       const t = new Date(r.published_at ?? r.created_at).getTime();
       if (Number.isFinite(t) && t >= dayAgo) perFeed.set(r.feed_url, (perFeed.get(r.feed_url) ?? 0) + 1);
     }
-    const slots = arrangeRssSlots(selectRssForTicker(rows), ctx.cycles ?? {}, `rss-${ctx.tab}`);
+    const slots = arrangeRssSlots(
+      selectRssForTicker(rows),
+      ctx.cycles ?? {},
+      `rss-${ctx.tab}`,
+      ctx.rotationMemo,
+    );
     return slots.map(({ key, item, rotateSlot, reserveTitle }) => ({
       key,
       rotateSlot,

--- a/desktop/src/datawidgets/rss/view.ts
+++ b/desktop/src/datawidgets/rss/view.ts
@@ -11,7 +11,7 @@
  * sort order) to work on the feed but not the ticker prior to this module.
  */
 import type { RssItem } from "../../types";
-import { rotateSlots } from "../ticker";
+import { rotateSlots, type RotationMemo } from "../ticker";
 import { plainText } from "../../utils/rssText";
 import { migrateRssDisplay, type RssDisplayPrefs } from "../../preferences";
 
@@ -133,10 +133,11 @@ export function arrangeRssSlots(
   eligible: RssItem[],
   cycles: Readonly<Record<string, number>>,
   keyPrefix: string,
+  memo?: RotationMemo,
 ): RssSlot[] {
   return rotateSlots(eligible, TICKER_RSS_SLOTS, cycles, keyPrefix, (it) => it.id, (cls) =>
     cls.map((it) => plainText(it.title)).reduce((a, b) => (b.length > a.length ? b : a), ""),
-  ).map((r) => ({ key: r.key, item: r.item, rotateSlot: r.rotateSlot, reserveTitle: r.reserve }));
+  memo).map((r) => ({ key: r.key, item: r.item, rotateSlot: r.rotateSlot, reserveTitle: r.reserve }));
 }
 
 // ── Helper: per-widget display prefs (global + config.display) ──

--- a/desktop/src/datawidgets/sports/ticker.tsx
+++ b/desktop/src/datawidgets/sports/ticker.tsx
@@ -43,6 +43,7 @@ export const sportsTickerSource: TickerSource = {
       TICKER_SLOTS,
       ctx.cycles ?? {},
       `spo-${ctx.tab}`,
+      ctx.rotationMemo,
     );
     return slots.map(({ key, game, rotateSlot, reserveNames }) => ({
       key,

--- a/desktop/src/datawidgets/sports/view.ts
+++ b/desktop/src/datawidgets/sports/view.ts
@@ -11,7 +11,7 @@
 import type { Game } from "../../types";
 import { isLive, isCloseGame } from "../../utils/gameHelpers";
 import { teamShortName } from "../../utils/teamShortName";
-import { rotateSlots } from "../ticker";
+import { rotateSlots, type RotationMemo } from "../ticker";
 import { migrateVenue } from "../../preferences";
 
 // ── Display prefs shape (mirrors server-side widget config.display) ─
@@ -368,6 +368,7 @@ export function arrangeTickerSlots(
   slots: number,
   cycles: Readonly<Record<string, number>>,
   keyPrefix: string,
+  memo?: RotationMemo,
 ): TickerSlot[] {
   const pinned: Game[] = [];
   const pool: Game[] = [];
@@ -380,7 +381,7 @@ export function arrangeTickerSlots(
   const rotating = rotateSlots(pool, slots, cycles, keyPrefix, (g) => g.id, (cls) => ({
     away: widest(cls, (g) => g.away_team_name),
     home: widest(cls, (g) => g.home_team_name),
-  }));
+  }), memo);
   return [
     ...pinned.map((g) => ({ key: `${keyPrefix}-${g.id}`, game: g })),
     ...rotating.map((r) => ({ key: r.key, game: r.item, rotateSlot: r.rotateSlot, reserveNames: r.reserve })),

--- a/desktop/src/datawidgets/ticker.test.ts
+++ b/desktop/src/datawidgets/ticker.test.ts
@@ -3,7 +3,7 @@
  * their own reservations; this covers the arithmetic with none.
  */
 import { describe, it, expect } from "vitest";
-import { rotateSlots } from "./ticker";
+import { rotateSlots, type RotationMemo } from "./ticker";
 
 const ids = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `s${i + 1}` }));
 const run = (n: number, slots: number, cycles: Record<string, number> = {}) =>
@@ -44,5 +44,42 @@ describe("rotateSlots", () => {
     const seen: string[][] = [];
     rotateSlots(ids(5), 2, {}, "p", (x) => x.id, (cls) => { seen.push(cls.map((x) => x.id)); return null; });
     expect(seen).toEqual([["s1", "s3", "s5"], ["s2", "s4"]]);
+  });
+});
+
+describe("rotateSlots with a rotation memo (CHIP_DESIGN.md rule 6)", () => {
+  const runMemo = (pool: ReturnType<typeof ids>, slots: number, cycles: Record<string, number>, memo: RotationMemo) =>
+    rotateSlots(pool, slots, cycles, "p", (x) => x.id, () => undefined, memo);
+
+  it("pool change while visible (same turn) does not change the shown item", () => {
+    const memo: RotationMemo = new Map();
+    // Rotating case: 5 items into 4 slots, slot-0 owns {s1, s5}.
+    const before = runMemo(ids(5), 4, {}, memo);
+    expect(before.map((s) => s.item.id)).toEqual(["s1", "s2", "s3", "s4"]);
+
+    // A refetch inserts a new item and reorders the pool -- turn hasn't
+    // moved, so every slot must still show what it showed a moment ago.
+    const reshuffled = [{ id: "s0" }, ...ids(5)];
+    const after = runMemo(reshuffled, 4, {}, memo);
+    expect(after.map((s) => s.item.id)).toEqual(["s1", "s2", "s3", "s4"]);
+
+    // Once the slot's own turn advances (it went off screen and back),
+    // it is free to pick up the new pool.
+    const nextLap = runMemo(reshuffled, 4, { "p-slot-0": 1 }, memo);
+    expect(nextLap[0].item.id).not.toBe("s1");
+  });
+
+  it("freezes the small-pool case too, keyed by slot instead of id", () => {
+    const memo: RotationMemo = new Map();
+    const before = runMemo(ids(2), 4, {}, memo);
+    expect(before.map((s) => s.key)).toEqual(["p-slot-0", "p-slot-1"]);
+    expect(before.map((s) => s.item.id)).toEqual(["s1", "s2"]);
+
+    // A third item joins the pool with the turn unchanged: the two
+    // already-visible slots must not repaint. The new item lands in its
+    // own, previously-empty slot rather than displacing one on screen.
+    const after = runMemo(ids(3), 4, {}, memo);
+    expect(after.find((s) => s.key === "p-slot-0")?.item.id).toBe("s1");
+    expect(after.find((s) => s.key === "p-slot-1")?.item.id).toBe("s2");
   });
 });

--- a/desktop/src/datawidgets/ticker.ts
+++ b/desktop/src/datawidgets/ticker.ts
@@ -52,6 +52,8 @@ export interface TickerContext {
    * not scroll (the fantasy preview): nothing rotates there.
    */
   cycles?: Readonly<Record<string, number>>;
+  /** Freezes a rotating slot's item across renders (see `rotateSlots`). */
+  rotationMemo?: RotationMemo;
   onChipClick?: (
     widgetType: string,
     itemId: string | number,
@@ -82,6 +84,23 @@ export interface RotatingSlot<T, R> {
 }
 
 /**
+ * What a slot showed last time it was resolved, and at which `turn`.
+ *
+ * Untyped because one Map is shared across every source on the rail
+ * (ScrollrTicker owns a single `useRef`) — each entry is only ever read
+ * back by the slot key that wrote it, which is namespaced per source
+ * (§8.2), so cross-source collisions can't happen.
+ */
+interface RotationMemoEntry {
+  turn: number;
+  item: unknown;
+  reserve: unknown;
+}
+
+/** Per-ticker cache that lets `rotateSlots` freeze a slot's item across renders. */
+export type RotationMemo = Map<string, RotationMemoEntry>;
+
+/**
  * Cycle a pool through a fixed number of slots, one step per lap.
  *
  * Shared by every source that can produce more chips than a bar should
@@ -98,7 +117,22 @@ export interface RotatingSlot<T, R> {
  * computed over the class, not the whole pool, so a slot only reserves
  * the width it will actually use.
  *
- * When the pool fits, nothing rotates and every item is keyed by `id`.
+ * When the pool fits, nothing rotates and every item is keyed by `id` --
+ * unless a `memo` is supplied (below), in which case every slot, small
+ * pool or not, is keyed and frozen the same way.
+ *
+ * Without `memo`, `cls` is recomputed from `pool` on every call, which
+ * makes the *membership* of slot i whatever the live pool says right now
+ * -- fine for a pure, one-shot read, but wrong for a ticker: a refetch or
+ * a sort-order change reshuffles which item lands at each residue index
+ * with no cycle advance, so a visible slot's item can flip with nobody
+ * having looked away (CHIP_DESIGN.md rule 6, CHIP_SPEC.md §8.4). Passing
+ * `memo` (one persistent `Map` owned by the caller, e.g. a `useRef` in
+ * ScrollrTicker) fixes that: a slot's `(item, reserve)` is cached against
+ * the `turn` that produced it, and only recomputed from `pool` when
+ * `cycles[slotKey]` has actually moved on -- i.e. once the slot has fully
+ * left the viewport and come back. A pool change between those moments
+ * changes nothing the viewer can see.
  */
 export function rotateSlots<T, R>(
   pool: T[],
@@ -107,18 +141,43 @@ export function rotateSlots<T, R>(
   keyPrefix: string,
   id: (item: T) => string | number,
   reserve: (cls: T[]) => R,
+  memo?: RotationMemo,
 ): RotatingSlot<T, R>[] {
-  if (pool.length <= slots) {
-    return pool.map((item) => ({ key: `${keyPrefix}-${id(item)}`, item }));
+  if (!memo) {
+    if (pool.length <= slots) {
+      return pool.map((item) => ({ key: `${keyPrefix}-${id(item)}`, item }));
+    }
+    const k = Math.max(1, slots);
+    const out: RotatingSlot<T, R>[] = [];
+    for (let i = 0; i < k; i++) {
+      const cls = pool.filter((_, idx) => idx % k === i);
+      if (cls.length === 0) continue;
+      const slotKey = `${keyPrefix}-slot-${i}`;
+      const turn = cycles[slotKey] ?? 0;
+      out.push({ key: slotKey, item: cls[turn % cls.length], rotateSlot: slotKey, reserve: reserve(cls) });
+    }
+    return out;
   }
+
   const k = Math.max(1, slots);
   const out: RotatingSlot<T, R>[] = [];
   for (let i = 0; i < k; i++) {
-    const cls = pool.filter((_, idx) => idx % k === i);
-    if (cls.length === 0) continue;
     const slotKey = `${keyPrefix}-slot-${i}`;
     const turn = cycles[slotKey] ?? 0;
-    out.push({ key: slotKey, item: cls[turn % cls.length], rotateSlot: slotKey, reserve: reserve(cls) });
+    const cached = memo.get(slotKey);
+    if (cached && cached.turn === turn) {
+      out.push({ key: slotKey, item: cached.item as T, rotateSlot: slotKey, reserve: cached.reserve as R });
+      continue;
+    }
+    const cls = pool.filter((_, idx) => idx % k === i);
+    if (cls.length === 0) {
+      memo.delete(slotKey);
+      continue;
+    }
+    const item = cls[turn % cls.length];
+    const res = reserve(cls);
+    memo.set(slotKey, { turn, item, reserve: res });
+    out.push({ key: slotKey, item, rotateSlot: slotKey, reserve: res });
   }
   return out;
 }

--- a/docs/CHIP_SPEC.md
+++ b/docs/CHIP_SPEC.md
@@ -490,13 +490,39 @@ slot count.
 
 ### 8.2 `rotateSlots` semantics
 
+`rotateSlots` takes an optional 7th param, `memo: RotationMemo` (one `Map`, shared by the
+whole rail, owned by `ScrollrTicker` as a `useRef` and passed down through
+`ctx.rotationMemo`). Every real call site passes it; only unit tests exercising the
+plain arithmetic omit it.
+
+**Without `memo`** (pure, for tests):
 - If `pool.length <= slots`: return every item keyed `${prefix}-${id(item)}`, no
   `rotateSlot`, no `reserve`.
 - Else for `i in 0..k-1`: class `cls = pool.filter((_, idx) => idx % k === i)`; slot key
   `${prefix}-slot-${i}`; `turn = cycles[slotKey] ?? 0`; item `cls[turn % cls.length]`;
   `reserve = reserve(cls)`.
-- Keys must be namespaced by widget: prefixes are `spo-${ctx.tab}`, `rss-${ctx.tab}`,
-  `fin-${ctx.tab}`, `pred-${ctx.tab}`, `uptime`, `github`.
+
+**With `memo`** (real rail traffic — REL-234): every slot, small pool or not, is keyed
+`${prefix}-slot-${i}` and resolved the same way. For each `i in 0..k-1`: `slotKey =
+${prefix}-slot-${i}`, `turn = cycles[slotKey] ?? 0`. If `memo` already holds an entry
+for `slotKey` recorded at this same `turn`, that entry's `item`/`reserve` are reused
+**without touching `pool`** — a refetch, a reorder, or a member entering/leaving the
+pool changes nothing a slot is currently showing. Only when `turn` has moved past the
+memoized value (the slot went fully off screen and back, §8.4) is `cls` recomputed
+from the live `pool` and the memo updated. If a slot's `cls` comes back empty (every
+member of its residue class left the pool), its memo entry is dropped and it renders
+nothing that frame — a corner case (a whole class vacating between two laps of a
+`pool.length > slots` source) that isn't itself frozen, since there is no old value to
+hold onto.
+
+This is why the small-pool case no longer keys by item id: an item's own identity is
+not what has to survive a pool change while it's on screen — a *slot's* is. Keying by
+slot, and freezing what a slot resolves to until its own turn advances, is what makes
+CHIP_DESIGN.md rule 6 hold for both branches.
+
+Keys must be namespaced by widget: prefixes are `spo-${ctx.tab}`, `rss-${ctx.tab}`,
+`fin-${ctx.tab}`, `pred-${ctx.tab}`, `uptime`, `github` — this is also what keeps one
+shared `RotationMemo` collision-free across every source on the rail.
 
 ### 8.3 Ticker wiring (already done; do not duplicate)
 

--- a/scripts/dev/rel234-classify.mjs
+++ b/scripts/dev/rel234-classify.mjs
@@ -1,0 +1,122 @@
+// REL-234: offline classifier over the drained JSONL.
+//
+// The live per-drain tally only flagged childList mutations with differing
+// text. That misses the real bug: a slot keyed `${prefix}-slot-i}` shows a
+// DIFFERENT item without its DOM key changing, so React updates it via
+// characterData mutations on the existing node, not a childList swap.
+// So here we track, per slot key, the chip's full text over time and diff
+// consecutive snapshots -- stripping digits/currency/percent/time noise --
+// to tell an identity swap (team names, symbol, headline changed) from an
+// allowed in-place value repaint (score, price, timer, clock digits).
+import { readFileSync } from "node:fs";
+
+const [, , ...files] = process.argv;
+if (files.length === 0) {
+  console.error("usage: rel234-classify.mjs <jsonl files...>");
+  process.exit(2);
+}
+
+// Strip digits, %, +/-, $, decimal points, colons (times), and whitespace
+// runs, leaving the "identity" text (team names, symbol letters, headline
+// words). Two snapshots with the same identity after stripping are a value
+// repaint; different identity is a swap.
+const identity = (s) =>
+  (s || "")
+    // Ordinal ranks (1st, 22nd, ...) before stripping bare digits, so the
+    // "st/nd/rd/th" suffix doesn't survive as leftover identity text. No
+    // word-boundary requirement: chip textContent has no separators
+    // between fields ("1st85-58...RD2nd80...").
+    .replace(/\d+(st|nd|rd|th)/gi, "")
+    // Every remaining digit and number-adjacent sign/punctuation mark,
+    // one character at a time (compound tokens like "73-71−14" don't
+    // need to be matched as a unit -- just erased character by character).
+    .replace(/[\d+\-−.,:%▲▼☀⛅☾$—]/g, "")
+    // A standings row's units (run differential "RD") and the "no table
+    // for this league" placeholder are values, not identity -- this is
+    // REL-235 (standings flap), tracked separately from REL-234.
+    .replace(/RD/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+// Keyed by the chip's own DOM-node identity (nodeId, from the install
+// script's WeakMap) -- NOT by slot or kind. Two concurrently-live chips
+// must never be diffed against each other; nodeId guarantees that even
+// for fixed (non-slotted) chips that share no data-rotate-slot.
+const lastByNode = new Map();
+const events = { total: 0, byKind: {} };
+const swaps = [];
+const repaints = { byField: {} };
+const remounts = [];
+
+function note(kind, bucket, extra) {
+  events.byKind[kind] ??= { total: 0 };
+  events.byKind[kind][bucket] = (events.byKind[kind][bucket] ?? 0) + 1;
+  events.byKind[kind].total++;
+}
+
+for (const f of files) {
+  const lines = readFileSync(f, "utf8").split("\n").filter(Boolean);
+  for (const line of lines) {
+    const rec = JSON.parse(line);
+    for (const e of rec.entries ?? []) {
+      events.total++;
+      if (e.type === "attributes") {
+        // The slot key itself was reassigned to a different DOM node
+        // (or vice versa) -- always worth surfacing on its own.
+        note(e.kind, e.visibleWhileChanging ? "rekey-visible" : "rekey-hidden");
+        if (e.visibleWhileChanging) {
+          swaps.push({ t: e.t, phase: rec.phase, slot: e.slot, kind: e.kind, before: `slot="${e.before}"`, after: `slot="${e.after}"` });
+        }
+        continue;
+      }
+      // Prefer the DOM-node identity (nodeId); fall back to the slot key,
+      // then kind, for captures taken before the install script tracked
+      // nodeId -- best-effort only for those older files.
+      const key = e.nodeId ?? e.slot ?? `${e.kind}:fixed`;
+      const prev = lastByNode.get(key);
+      const curText = e.chipText || "";
+      const curIdentity = identity(curText);
+
+      if (e.type === "childList" && e.before && e.after) {
+        // Structural replace -- a re-key/remount, or a slot appearing for
+        // the first time (no prior snapshot => not a remount, just mount).
+        if (prev) {
+          note(e.kind, e.visibleWhileChanging ? "remount-visible" : "remount-hidden");
+          if (e.visibleWhileChanging) {
+            remounts.push({ t: e.t, phase: rec.phase, slot: e.slot, kind: e.kind, before: e.before, after: e.after });
+          }
+        }
+      }
+
+      if (prev && prev.identity !== curIdentity) {
+        // The chip's non-numeric content changed -- a different item.
+        note(e.kind, e.visibleWhileChanging ? "swap-visible" : "swap-hidden");
+        if (e.visibleWhileChanging) {
+          swaps.push({
+            t: e.t,
+            phase: rec.phase,
+            slot: e.slot,
+            kind: e.kind,
+            before: prev.text,
+            after: curText,
+          });
+        }
+      } else if (prev && prev.text !== curText) {
+        note(e.kind, e.visibleWhileChanging ? "repaint-visible" : "repaint-hidden");
+      }
+
+      lastByNode.set(key, { text: curText, identity: curIdentity, t: e.t });
+    }
+  }
+}
+
+console.log(JSON.stringify({ totalMutations: events.total, byKind: events.byKind }, null, 2));
+console.log("\n--- SWAPS WHILE VISIBLE (rule 6 violations) ---");
+for (const s of swaps.slice(0, 40)) {
+  console.log(`[${s.phase}] ${s.kind} ${s.slot}: "${s.before}" -> "${s.after}"`);
+}
+console.log(`\ntotal swap-while-visible events: ${swaps.length}`);
+console.log(`total remount-while-visible events: ${remounts.length}`);
+for (const r of remounts.slice(0, 20)) {
+  console.log(`[${r.phase}] REMOUNT ${r.kind} ${r.slot}: "${r.before}" -> "${r.after}"`);
+}

--- a/scripts/dev/rel234-drain-audit.js
+++ b/scripts/dev/rel234-drain-audit.js
@@ -1,0 +1,5 @@
+(() => {
+  const buf = window.__tickerAudit || [];
+  window.__tickerAudit = [];
+  return buf;
+})()

--- a/scripts/dev/rel234-install-audit.js
+++ b/scripts/dev/rel234-install-audit.js
@@ -1,0 +1,129 @@
+// REL-234: install a rule-6 audit harness on the ticker window.
+// Buffers every DOM mutation inside .ticker-container to
+// window.__tickerAudit (capped at 5000); the driving session drains it
+// periodically. Each chip DOM node gets a stable synthetic id (WeakMap) so
+// concurrently-live chips are never conflated with each other when
+// diffing "did this same position's content change" offline.
+(() => {
+  if (window.__tickerObs) {
+    window.__tickerObs.disconnect();
+  }
+  const container = document.querySelector(".ticker-container");
+  if (!container) return "NO CONTAINER";
+  window.__tickerAudit = [];
+  const AUDIT_CAP = 5000;
+
+  const chipWrapperFor = (node) => {
+    let el = node.nodeType === 3 ? node.parentElement : node;
+    while (el && el !== container && !(el.hasAttribute && el.hasAttribute("data-chip"))) {
+      el = el.parentElement;
+    }
+    return el && el !== container ? el : null;
+  };
+
+  const overlaps = (el) => {
+    const box = container.getBoundingClientRect();
+    const r = el.getBoundingClientRect();
+    return r.right > box.left && r.left < box.right;
+  };
+
+  const anyInstanceVisible = (chipEl) => {
+    const slot = chipEl.getAttribute("data-rotate-slot");
+    const nodes = slot
+      ? container.querySelectorAll(`[data-rotate-slot="${CSS.escape(slot)}"]`)
+      : [chipEl];
+    for (const n of nodes) {
+      if (overlaps(n)) return true;
+    }
+    return false;
+  };
+
+  const UTILITY_LABELS = ["SYSMON", "CLOCK", "WEATHER", "TIMER"];
+  const LEAGUE_PREFIXES = [
+    "MLB", "MLS", "NFL", "NBA", "NHL", "NCAAF", "NCAAB", "EPL", "UFC", "F1",
+    "BUNDESLIGA", "SERIE A", "LIGUE 1", "EUROLEAGUE", "KHL", "NPB",
+  ];
+  const kindOf = (chipEl) => {
+    const slot = chipEl.getAttribute("data-rotate-slot");
+    if (slot) {
+      const prefix = slot.replace(/-slot-\d+$/, "");
+      const tag = prefix.split("-")[0];
+      if (tag === "spo") return "sports";
+      if (tag === "fin") return "finance";
+      if (tag === "rss") return "news";
+      if (tag === "pred") return "predictions";
+      if (tag === "uptime" || tag === "github") return "utility-capped";
+      return tag;
+    }
+    const text = (chipEl.textContent || "").toUpperCase();
+    if (UTILITY_LABELS.some((l) => text.startsWith(l))) return "utility";
+    if (LEAGUE_PREFIXES.some((l) => text.startsWith(l))) return "sports";
+    if (/^[A-Z.]{1,6}(\/[A-Z]{2,4})?[\d▲▼]/.test(text)) return "finance";
+    return "unlabeled-fixed";
+  };
+
+  // Stable per-node identity across renders, so two concurrently-live
+  // chips (e.g. one finance symbol and the sysmon gauge) are never diffed
+  // against each other just because neither has a data-rotate-slot.
+  let nextNodeId = 1;
+  const nodeIds = new WeakMap();
+  const idFor = (chipEl) => {
+    let id = nodeIds.get(chipEl);
+    if (!id) {
+      id = nextNodeId++;
+      nodeIds.set(chipEl, id);
+    }
+    return id;
+  };
+
+  const push = (entry) => {
+    const buf = window.__tickerAudit;
+    buf.push(entry);
+    if (buf.length > AUDIT_CAP) buf.splice(0, buf.length - AUDIT_CAP);
+  };
+
+  const obs = new MutationObserver((mutations) => {
+    const now = Date.now();
+    for (const m of mutations) {
+      const chipEl = chipWrapperFor(m.target);
+      if (!chipEl) continue;
+      let before = null;
+      let after = null;
+      if (m.type === "characterData") {
+        before = m.oldValue;
+        after = m.target.textContent;
+      } else if (m.type === "childList") {
+        before = [...m.removedNodes].map((n) => n.textContent || "").join("|");
+        after = [...m.addedNodes].map((n) => n.textContent || "").join("|");
+        if (!before && !after) continue; // attribute-only churn on a childList record
+      } else if (m.type === "attributes") {
+        if (m.attributeName !== "data-rotate-slot") continue;
+        before = m.oldValue;
+        after = chipEl.getAttribute("data-rotate-slot");
+        if (before === after) continue;
+      }
+      push({
+        t: now,
+        type: m.type,
+        slot: chipEl.getAttribute("data-rotate-slot") || null,
+        nodeId: idFor(chipEl),
+        kind: kindOf(chipEl),
+        before: (before || "").slice(0, 100),
+        after: (after || "").slice(0, 100),
+        chipText: (chipEl.textContent || "").slice(0, 100),
+        visibleWhileChanging: anyInstanceVisible(chipEl),
+      });
+    }
+  });
+  obs.observe(container, {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    characterDataOldValue: true,
+    attributes: true,
+    attributeOldValue: true,
+    attributeFilter: ["data-rotate-slot"],
+  });
+  window.__tickerObs = obs;
+  return { installed: true, initialCount: container.querySelectorAll(".ticker-item, .clone-item").length };
+})()

--- a/scripts/dev/rel234-tally.mjs
+++ b/scripts/dev/rel234-tally.mjs
@@ -1,0 +1,36 @@
+// REL-234 harness: read one drain's JSON array from stdin, append it (as a
+// compact single-line JSON record with a timestamp+phase wrapper) to the
+// given JSONL file, and print a one-line summary with a violation count.
+//
+// A "violation" is a structural (childList) mutation on a chip that was
+// visible (any instance overlapping the container) at the moment it
+// changed, where the text actually identifies a different item -- not
+// just a field repaint (score, price, clock digits).
+import { appendFileSync, readFileSync } from "node:fs";
+
+const [, , jsonlPath, phase] = process.argv;
+const raw = readFileSync(0, "utf8");
+let entries;
+try {
+  entries = JSON.parse(raw);
+} catch {
+  console.log(`[${phase}] drain: unparseable response: ${raw.slice(0, 200)}`);
+  process.exit(0);
+}
+if (!Array.isArray(entries)) entries = [];
+
+const isViolation = (e) =>
+  e.type === "childList" &&
+  e.visibleWhileChanging === true &&
+  e.before &&
+  e.after &&
+  e.before.trim() !== e.after.trim();
+
+const violations = entries.filter(isViolation);
+const record = { drainedAt: new Date().toISOString(), phase, count: entries.length, violations: violations.length, entries };
+appendFileSync(jsonlPath, JSON.stringify(record) + "\n");
+
+console.log(
+  `[${phase}] drain: ${entries.length} mutations, ${violations.length} flagged` +
+    (violations.length ? ` -- ${violations.slice(0, 3).map((v) => `${v.kind}/${v.slot}: "${v.before}" -> "${v.after}"`).join(" | ")}` : ""),
+);


### PR DESCRIPTION
## Summary

REL-234: Brandon kept seeing chips and numbers change on the ticker while
still looking at them. Audited the rail against **production data** with a
`MutationObserver` harness driven through the dev bus, confirmed the bug,
fixed it, and re-ran the harness to prove it's gone.

**Root cause** (`desktop/src/datawidgets/ticker.ts`, `rotateSlots`): a
rotating slot's residue class (`cls = pool.filter((_, idx) => idx % k === i)`)
was recomputed from the *live* pool on every render. `cycles[slotKey]` only
gates the *turn*, not the pool — so a dashboard refetch, a reorder (a game
going live, predictions re-sorting by trailing volume, a new trade), or an
item entering/leaving the horizon could hand slot *i* a different item with
no visible→hidden transition. CHIP_DESIGN.md rule 6 ("a chip only swaps its
content while it's off screen") broke silently, potentially several times a
minute on a busy slate. The `pool.length <= slots` branch had a related
issue: it keyed chips by item id, so crossing that threshold in either
direction re-keyed (remounted) every chip in view.

## Fix

`rotateSlots` takes an optional 7th param, `memo: RotationMemo` — one `Map`
owned by `ScrollrTicker` as a `useRef`, threaded through every source via
`ctx.rotationMemo`. A slot's `(item, reserve)` is cached against the `turn`
that produced it and is only recomputed from the live pool once
`cycles[slotKey]` has actually advanced (the slot went fully off screen and
back — `visibleSlots`/`advanceCycles`, §8.4, unchanged). The small-pool
branch is folded into the same mechanism and keyed by slot instead of item
id, so both cases freeze identically. Every real call site
(`finance/ticker.tsx`, `predictions/ticker.tsx`, `sports/{view,ticker}.tsx`,
`rss/{view,ticker}.tsx`, the uptime/GitHub capped-widget path in
`ScrollrTicker.tsx`) now passes the shared memo. Calling `rotateSlots`
*without* `memo` keeps the old pure, stateless behavior — that's what the
existing unit tests exercise, so none of them needed to change.

`docs/CHIP_SPEC.md` §8.2 is updated with the frozen-slot semantics. New
tests in `ticker.test.ts`: "pool change while visible (same turn) does not
change the shown item" and "freezes the small-pool case too, keyed by slot
instead of id".

## Harness

Built through the dev bus (not eyeballing): a `MutationObserver` installed
on `.ticker-container` (`scripts/dev/rel234-install-audit.js`) logs every
mutation — timestamp, the chip's `data-rotate-slot`, a stable per-DOM-node
id (`WeakMap`, so two concurrently-live chips are never diffed against each
other), before/after text, and whether **any** instance of that chip
(`.ticker-item` + `.clone-item`) overlapped the container rect at that
moment — into `window.__tickerAudit` (capped at 5000). Drained once a
minute (`rel234-drain-audit.js` + `rel234-tally.mjs`) to JSONL, with a
`capture-window.ps1` PNG each drain. `rel234-classify.mjs` does the real
offline classification: per chip-DOM-node, diff consecutive text snapshots
with digits/price/time noise stripped, and flag a "swap" only when the
non-numeric identity actually changed while visible.

Run against `https://api.myscrollr.com` from this worktree (`desktop/.env`
copied from the main checkout, `VITE_API_URL` overridden locally only),
widgets covering every chip kind that could be reached: MLB + MLS (pool
sizes 30 + 29, well over `TICKER_SLOTS=4`, so rotation engaged
immediately), finance with 7 symbols across two widgets, a news feed
(`news_bbc`, added for this audit), predictions (a Kalshi key is
configured — 336 rows), and the utility chips already on the rail
(clock/timer/weather/sysmon). No live MLB game happened to be in progress
during the run (early morning US time) — score-flash/cap-pulse (§9) weren't
separately exercised, but they're untouched by this change and out of its
scope.

### Before (pre-fix, ~9 min, buggy `rotateSlots`)

Reverted `desktop/src` to `origin/main` in the running dev build (WIP-commit
→ checkout → observe → restore, so nothing on disk was ever lost), 9 drains,
3467 raw mutations.

| Chip kind | Genuine swap-while-visible (different item, same slot) |
|---|---|
| Sports (MLB, `spo-sports_mlb-slot-*`) | Real, repeated cross-game swaps — e.g. slot-0 flipped between *Los Angeles Angels @ Washington Nationals* and *Atlanta Braves @ Arizona Diamondbacks* with no lap between, several times a minute |
| Finance / utility | Not reliably measurable in this baseline — the pre-fix harness's non-slotted-chip tracking (before the `nodeId` fix below) conflated concurrently-live chips lacking `data-rotate-slot`; superseded by the corrected harness for the post-fix run |

This is exactly the bug: **rule 6 was broken on real production data, in the
league with the largest pool, well within a single 9-minute sitting.**

### After (post-fix, 70 min: 59x marquee + 10x page/step, corrected harness)

6590 raw mutations, classified via `rel234-classify.mjs`:

| Chip kind | Total mutations | Repaint while visible (allowed) | Swap while visible (rule 6) |
|---|---|---|---|
| Utility (clock/timer/weather/sysmon) | 2137 | 725 | 1 (harness artifact, see below) |
| Sports (MLB/MLS) | 82 | 6 | 1 (harness artifact, see below) |
| Finance | 87 | 0 | 0 |
| Predictions | 23 | 0 | 0 |

**2 flagged events, both harness artifacts, not app bugs**: both pair
completely unrelated chip content (a sports chip's text against a finance
symbol; a sysmon reading against sports text) at the exact moment the
harness switched the ticker from marquee to page/step mode and was
reinstalled — a `MutationObserver` batching quirk (the observer's callback
reads live DOM state for every record in a batch, and a wholesale
scroll-mode remount produces a burst of records processed together) rather
than a real slot swap. Zero genuine identity swaps in 6590 mutations across
both scroll modes, where the pre-fix baseline showed real, repeated
cross-game swaps within *9 minutes* on the exact same chip family.

`npm test` in `desktop/`: **715/715 passing**, including the two new
rotation tests.

Captures (JSONL + 78 PNGs + the two classification reports) are on the
orphan branch
[`captures/rel-234`](https://github.com/doughknee/myscrollr/tree/captures/rel-234).

## Spec-allowed changes Brandon may still want to revisit

Not touched — these are legitimate per-render value repaints under
CHIP_SPEC.md §7/§9 (score flash + cap-pulse aren't the *only* thing
CHIP_SPEC allows to change; a chip's derived fields naturally repaint on a
fresh payload for the same item), but they're still a live number changing
under your eyes:

- **Finance price/change % ticking in place** (`TradeChip`, same symbol) —
  every dashboard refetch (30s poll on `super_user`, faster via SSE)
  repaints price, change%, and the sparkline for the same watchlist symbol.
  This is the whole point of a live ticker, but it's visually
  indistinguishable from "something changed" to a reader. No spec line
  currently calls this out as allowed *or* disallowed for a fixed
  (non-rotating) chip — it just falls out of "the payload changed and this
  component re-rendered." Proposal: add a line to CHIP_SPEC.md §9
  explicitly naming payload-driven value fields (price, standings, sparkline)
  as allowed repaints distinct from rotation, so it's a documented decision
  rather than an emergent property.
- **Sysmon/weather/clock digits updating in place** — same shape, lower
  stakes (a CPU% or a clock tick is expected to move). No proposal; listing
  for completeness.

## Related finding, filed separately

[REL-235](https://linear.app/relentnet/issue/REL-235/sports-chip-standings-away-standinghome-standing-flap-between-real):
sports chip standings (`away_standing`/`home_standing`) flap between real
values and "—" for the *same* game while visible. Confirmed in both
baseline and verification captures. Not the `rotateSlots` bug (same slot,
same game id, same team names — just the standings field itself toggling
between populated and empty across successive polls, which looks like a
server-side join that intermittently misses). Out of scope for this PR;
proposal is in the issue.

## Test plan

- [x] `npm test` in `desktop/` — 715/715 green, including two new
      `rotateSlots`-with-memo tests
- [x] `npx tsc --noEmit` clean
- [x] Baseline (pre-fix) harness run on production data — confirmed real
      cross-game swaps
- [x] Post-fix harness run, 70 minutes (60 marquee + 10 page/step) on
      production data — zero genuine rule-6 violations
- [x] Captures pushed to orphan branch `captures/rel-234`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
