### PR TITLE
fix(sports): carry standings on the CDC games record so the chip stops flapping to a dash [REL-235]

### DIFF
--- a/api/internal/events/handlers_webhook.go
+++ b/api/internal/events/handlers_webhook.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/brandon-relentnet/myscrollr/api/internal/ingestread"
 	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
 	"github.com/gofiber/fiber/v2"
 )
@@ -81,6 +82,12 @@ func parseCDCRecords(body []byte) ([]CDCRecord, error) {
 // to all subscribed clients in-memory.
 func routeCDCRecord(ctx context.Context, rec CDCRecord) {
 	table := rec.Metadata.TableName
+
+	// A games row is relayed as the desktop's whole picture of that game,
+	// so it needs the standings the polled payload joins in (REL-235).
+	if table == "games" {
+		ingestread.AttachStandings(ctx, rec.Record)
+	}
 
 	// Build the SSE payload envelope
 	envelope := map[string]interface{}{

--- a/api/internal/ingestread/sports.go
+++ b/api/internal/ingestread/sports.go
@@ -372,7 +372,7 @@ func loadLeagueStatus(ctx context.Context, names []string) (map[string]leagueSta
 			       COUNT(*) FILTER (WHERE state = 'in') AS live_count,
 			       MIN(start_time) FILTER (WHERE state = 'pre') AS next_game
 			FROM games
-			WHERE ` + notStaleUpcoming + `
+			WHERE `+notStaleUpcoming+`
 			GROUP BY league`)
 	} else {
 		rows, err = platform.DBPool.Query(ctx, `
@@ -381,7 +381,7 @@ func loadLeagueStatus(ctx context.Context, names []string) (map[string]leagueSta
 			       COUNT(*) FILTER (WHERE state = 'in') AS live_count,
 			       MIN(start_time) FILTER (WHERE state = 'pre') AS next_game
 			FROM games
-			WHERE league = ANY($1) AND ` + notStaleUpcoming + `
+			WHERE league = ANY($1) AND `+notStaleUpcoming+`
 			GROUP BY league`, names)
 	}
 	if err != nil {
@@ -637,8 +637,8 @@ func querySportsGames(ctx context.Context, limit int, favoriteTeams map[string]F
 			away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
 			start_time, COALESCE(short_detail, ''), state,
 			COALESCE(status_short, ''), COALESCE(status_long, ''),
-			COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at` + standingsColumns + `
-		FROM games g` + standingsJoin + `
+			COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at`+standingsColumns+`
+		FROM games g`+standingsJoin+`
 		WHERE %s
 		ORDER BY
 			CASE state WHEN 'in' THEN 0 WHEN 'pre' THEN 1 ELSE 2 END,
@@ -756,8 +756,8 @@ func queryGamesByLeagues(ctx context.Context, leagues []string, limit int, favor
 				away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
 				start_time, COALESCE(short_detail, ''), state,
 				COALESCE(status_short, ''), COALESCE(status_long, ''),
-				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at` + standingsColumns + `
-			FROM ranked g` + standingsJoin + `
+				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at`+standingsColumns+`
+			FROM ranked g`+standingsJoin+`
 			WHERE (upcoming_side AND side_rn <= %d)
 			   OR (NOT upcoming_side AND side_rn <= %d)
 			ORDER BY
@@ -774,8 +774,8 @@ func queryGamesByLeagues(ctx context.Context, leagues []string, limit int, favor
 				away_team_name, COALESCE(away_team_logo, ''), COALESCE(away_team_score::text, ''), COALESCE(away_team_code, ''),
 				start_time, COALESCE(short_detail, ''), state,
 				COALESCE(status_short, ''), COALESCE(status_long, ''),
-				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at` + standingsColumns + `
-			FROM games g` + standingsJoin + `
+				COALESCE(timer, ''), COALESCE(venue, ''), COALESCE(season, ''), g.updated_at`+standingsColumns+`
+			FROM games g`+standingsJoin+`
 			WHERE league = ANY($1) AND %s
 			ORDER BY
 				CASE state WHEN 'in' THEN 0 WHEN 'pre' THEN 1 ELSE 2 END,
@@ -836,6 +836,44 @@ func standingFrom(c [9]*int) *TeamStanding {
 	return &TeamStanding{
 		Rank: *c[0], Wins: v(c[1]), Losses: v(c[2]), Draws: v(c[3]), Points: v(c[4]),
 		GoalDiff: v(c[5]), PointsFor: v(c[6]), PointsAgainst: v(c[7]), OTL: v(c[8]),
+	}
+}
+
+// AttachStandings adds home_standing / away_standing to a raw games row --
+// a Sequin CDC record -- so it carries what every games query above
+// carries. The desktop merges a CDC record by REPLACING the game in its
+// dashboard cache, so a bare row stripped both sides' standings and the
+// chip flapped to "--" every live-poll upsert until the next poll put them
+// back (REL-235). Same join, same presence rule as scanGames; a side with
+// no row stays absent, as it is in the polled payload. A lookup failure
+// leaves the record as it came -- a stale chip beats a dropped event.
+func AttachStandings(ctx context.Context, record map[string]interface{}) {
+	league, _ := record["league"].(string)
+	home, _ := record["home_team_name"].(string)
+	away, _ := record["away_team_name"].(string)
+	if league == "" || home == "" || away == "" {
+		return
+	}
+	var h, a [9]*int
+	// standingsColumns opens with the comma that follows a games SELECT
+	// list; here it is the whole list.
+	err := platform.DBPool.QueryRow(ctx, `SELECT`+standingsColumns[1:]+`
+		FROM (SELECT $1::text AS league, $2::text AS home_team_name, $3::text AS away_team_name) g`+standingsJoin,
+		league, home, away).Scan(
+		&h[0], &h[1], &h[2], &h[3], &h[4], &h[5], &h[6], &h[7], &h[8],
+		&a[0], &a[1], &a[2], &a[3], &a[4], &a[5], &a[6], &a[7], &a[8],
+	)
+	if err != nil {
+		log.Printf("[Sports] standings lookup for CDC game %v failed: %v", record["id"], err)
+		return
+	}
+	delete(record, "home_standing")
+	delete(record, "away_standing")
+	if s := standingFrom(h); s != nil {
+		record["home_standing"] = s
+	}
+	if s := standingFrom(a); s != nil {
+		record["away_standing"] = s
 	}
 }
 

--- a/api/internal/ingestread/sports_test.go
+++ b/api/internal/ingestread/sports_test.go
@@ -277,6 +277,62 @@ func TestGamesCarryCurrentSeasonStandings(t *testing.T) {
 }
 
 // A season whose only row is a blank team must not win the season pick.
+// A Sequin CDC games record is a bare table row; the desktop replaces
+// its copy of the game with it, so it must carry the same standings the
+// polled payload does, or the chip flaps to a dash on every live upsert
+// (REL-235).
+func TestCDCGameRecordCarriesStandings(t *testing.T) {
+	if platform.DBPool == nil {
+		t.Skip("needs TEST_DATABASE_URL")
+	}
+	ctx := context.Background()
+	const league = "TestCDCStandingsLeague"
+	clean := func() {
+		_, _ = platform.DBPool.Exec(ctx, `DELETE FROM standings WHERE league = $1`, league)
+	}
+	clean()
+	defer clean()
+
+	for _, r := range []struct {
+		team, season string
+		rank         int
+	}{
+		{"Home FC", "2025", 1}, // last season: must NOT be attached
+		{"Home FC", "2026", 3},
+	} {
+		if _, err := platform.DBPool.Exec(ctx, `
+			INSERT INTO standings (league, team_name, season, rank, wins, losses, draws, games_played)
+			VALUES ($1, $2, $3, $4, 2, 1, 0, 3)`, league, r.team, r.season, r.rank); err != nil {
+			t.Fatalf("insert standing: %v", err)
+		}
+	}
+
+	record := map[string]interface{}{
+		"id": float64(1), "league": league,
+		"home_team_name": "Home FC", "away_team_name": "Away FC",
+		"away_standing": "stale value from an earlier merge",
+	}
+	AttachStandings(ctx, record)
+
+	hs, ok := record["home_standing"].(*TeamStanding)
+	if !ok || hs == nil {
+		t.Fatalf("home_standing not attached: %#v", record["home_standing"])
+	}
+	if hs.Rank != 3 || hs.Wins != 2 {
+		t.Errorf("home carries %+v; want this season (3rd, 2-1)", *hs)
+	}
+	if _, present := record["away_standing"]; present {
+		t.Errorf("away has no standings row but the record still says %v; want the key absent, as the polled payload leaves it", record["away_standing"])
+	}
+
+	// A record that isn't a game (no team names) is left alone, not errored on.
+	partial := map[string]interface{}{"league": league}
+	AttachStandings(ctx, partial)
+	if len(partial) != 1 {
+		t.Errorf("partial record was rewritten: %v", partial)
+	}
+}
+
 // NCAA Football 2026 was one such row beside 293 real 2025 rows, and every
 // game in the league joined to nothing.
 func TestBlankSeasonRowDoesNotHideStandings(t *testing.T) {


### PR DESCRIPTION
## Root cause

The standings flap in the REL-234 audit was not a read-path or write-path gap. Every games query in core joins each side's standings, standings are upserted (never deleted), and both core-api replicas run the same image. The gap was the **Sequin CDC relay**: `routeCDCRecord` published the bare `games` table row, which has no `home_standing` / `away_standing`. The desktop merges a CDC record by **replacing** its copy of the game (`mergeTableRecords`, `next[idx] = record`), so every live-poll upsert stripped both sides' standings from the visible chip until the next dashboard poll restored them.

That matches the audit exactly: the `1st 85-58 +120 RD` → `—` → `1st …` transitions in `captures/rel-234` happen about once a minute (the dashboard poll) and revert within 0–2 s (the next CDC record vs. the poll), only on the signed-in desktop (SSE tier).

## Fix

`ingestread.AttachStandings` runs the **same LATERAL join, verbatim** (`standingsJoin` + `standingsColumns`) against the record's league + team names and sets `home_standing` / `away_standing` exactly as `scanGames` does: absent when a side has no row. The webhook relay calls it for `games` records before publishing. A lookup failure leaves the record as it came.

## Evidence

**Before (production, 2026-09-07 08:47–08:49 UTC)** — 24 × `GET /public/feed` over 2 min, one per 5 s:

| responses | cache hits | MLB games | games flapping | games never with standings |
|---|---|---|---|---|
| 24 | 20 | 22 | 0 | 0 |

`withStandings=196` of 200 games on every response (the 4 without are UFC bouts and two NCAA teams with no standings row). So the polled payload was already clean; the flap is CDC-only, which is why neither poll nor the `/dashboard` query ever showed it.

**Audit record** (`captures/rel-234`, `rel234-baseline.jsonl`): slot `spo-sports_mlb-slot-0`, `"+120RD" -> ""` and `"1st" -> "—"` at 06:47:55, back to `"1st"` / `"+120RD"` at 06:47:57, again at 06:48:59 — the same game, the same slot.

## Tests

- `TestCDCGameRecordCarriesStandings` (DB-backed): a record gets this season's row (not last season's), a side with no row stays absent, a stale `away_standing` on the incoming record is cleared, and a non-game record is left alone.
- `go build ./... && go vet` on both packages; `go test ./internal/ingestread/ -run Standings` and `go test ./internal/events/` green in `golang:1.25-alpine`.

## Not touched

Desktop (the merge-by-replace stays; the server now sends the whole picture), the standings format / chip, the api-sports rate limiter (#336/#337).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
