### PR TITLE
feat(ticker): a pin follows a subject, not a widget [REL-239]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,8 @@ ui-review-out/
 # Per-machine compose tweaks (host port remaps when something else already
 # owns 5432/6379, extra mounts, etc). Local to whoever wrote it.
 docker/compose.override.yml
+
+# Vite optimize-deps cache. Written when the dev server runs out of
+# desktop/ (npm run dev / a bare `vite`); tauri dev puts it elsewhere,
+# which is why it took until REL-239 for one to be committed by accident.
+desktop/.vite/

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -12,6 +12,8 @@ import { onStoreChange, setStore } from "./lib/store";
 import ScrollrTicker from "./components/ScrollrTicker";
 import { useToggleOnTicker } from "./hooks/useToggleOnTicker";
 import { isOnTicker } from "./utils/tickerMembership";
+import { pinTargetAt } from "./utils/pinTarget";
+import type { PinTarget } from "./utils/pinTarget";
 import {
   getValidToken,
   isAuthenticated as checkAuth,
@@ -28,7 +30,10 @@ import {
   loadPrefs,
   savePrefs,
   TICKER_HEIGHTS,
-  toggleWidgetPin,
+  togglePin,
+  isPinned,
+  pinCount,
+  MAX_PINS,
   } from "./preferences";
 import type { SubscriptionTier } from "./auth";
 import type { DeliveryMode } from "./types";
@@ -506,16 +511,22 @@ export default function App() {
 
   // ── Widget pin toggle (hover icon on consolidated chip) ─────────
 
-  const handleTogglePin = useCallback(
-    (widgetId: string) => {
-      setPrefs((prev) => {
-        const updated = toggleWidgetPin(prev, widgetId);
-        savePrefs(updated);
-        return updated;
-      });
-    },
-    [],
-  );
+  /**
+   * Pin or unpin one subject, from the ticker's own right-click menu.
+   *
+   * Refuses rather than evicts when the side is full (REL-239): `togglePin`
+   * hands back the same object, so nothing is written and nothing moves.
+   * The menu item is already disabled in that case; this is the guard for
+   * the path that does not go through the menu.
+   */
+  const handleTogglePin = useCallback((pin: PinTarget) => {
+    setPrefs((prev) => {
+      const updated = togglePin(prev, { ...pin, side: "right" });
+      if (updated === prev) return prev;
+      savePrefs(updated);
+      return updated;
+    });
+  }, []);
 
   // ── Ticker position toggle ─────────────────────────────────────
 
@@ -576,6 +587,37 @@ export default function App() {
 
       const items: (Submenu | CheckMenuItem | MenuItem | PredefinedMenuItem)[] = [];
       const chs = widgetsRef.current;
+
+      // ── Pin the subject under the cursor ─────────────────────────
+      //
+      // This is where the pin control lives now (REL-239). It used to be
+      // a hover icon on the chip itself, which meant a control on a
+      // moving target on a bar you are meant to glance at -- and it
+      // could only ever say "pin this WIDGET", because a hover icon has
+      // no room to say which of the widget's items you meant.
+      //
+      // The chip under the cursor carries its subject on the wrapper, so
+      // the menu can name the actual thing: "Pin Yankees", not "Pin MLB".
+      const target = pinTargetAt(e.target);
+      if (target) {
+        const pinned = isPinned(prefsRef.current, target.widget, target.subject);
+        const full =
+          !pinned && pinCount(prefsRef.current) >= MAX_PINS;
+        items.push(
+          await MenuItem.new({
+            // Refuse, never evict: a full zone says so instead of
+            // silently dropping something the user parked there.
+            text: pinned
+              ? `Unpin ${target.label}`
+              : full
+                ? `Pin ${target.label} — bar is full`
+                : `Pin ${target.label}`,
+            enabled: !full,
+            action: () => handleTogglePin(target),
+          }),
+        );
+        items.push(await PredefinedMenuItem.new({ item: "Separator" }));
+      }
 
       // Open Scrollr — most common action, top of menu
       items.push(
@@ -726,7 +768,7 @@ export default function App() {
     }
     document.addEventListener("contextmenu", onContextMenu);
     return () => document.removeEventListener("contextmenu", onContextMenu);
-  }, [toggleOnTicker, handleTogglePosition, navigateMainWindow]);
+  }, [toggleOnTicker, handleTogglePosition, navigateMainWindow, handleTogglePin]);
 
   // ── Merge widget + widget tabs ──────────────────────────────
   const activeTabs = useMemo(
@@ -758,8 +800,7 @@ export default function App() {
             //                   itself; this just says "if you have
             //                   nothing, here's the recovery UI".
             //                   CTA -> per-widget chips.
-            const hasAnyPinnedWidget =
-              Object.keys(prefs.widgets.pinnedWidgets ?? {}).length > 0;
+            const hasAnyPinnedWidget = prefs.widgets.pins.length > 0;
             const showSourcelessCTA =
               authenticated && widgets.length === 0 && !hasAnyPinnedWidget;
             const showInstalledOffCTA =
@@ -772,8 +813,7 @@ export default function App() {
                 activeTabs={activeTabs}
                 widgetData={widgetData}
                 onChipClick={handleChipClick}
-                onTogglePin={handleTogglePin}
-                pinnedWidgets={prefs.widgets.pinnedWidgets}
+                pins={prefs.widgets.pins}
                 speed={prefs.ticker.tickerSpeed}
                 onHover={prefs.ticker.onHover}
                 mixMode={prefs.ticker.mixMode}

--- a/desktop/src/components/PinSubjectButton.tsx
+++ b/desktop/src/components/PinSubjectButton.tsx
@@ -1,0 +1,64 @@
+/**
+ * Pin control for a widget page's item rows.
+ *
+ * The chip's hover pin icon is gone (REL-239): it sat on a moving target
+ * and could only ever say "pin this widget". A widget page row already
+ * names one durable subject -- a symbol, a feed, a team -- so the pin
+ * belongs beside it, where the thing being pinned is unambiguous.
+ *
+ * Deliberately NOT the star / favourite / watchlist control next to it.
+ * A star means "always on the tape, exempt from slots"; a pin means
+ * "parked in the fixed zone, out of the tape". They compose, so they
+ * stay two controls.
+ */
+import { clsx } from "clsx";
+import { Pin, PinOff } from "lucide-react";
+
+import { usePinSubject } from "../hooks/usePinSubject";
+
+export default function PinSubjectButton({
+  widget,
+  subject,
+  label,
+  className,
+}: {
+  widget: string;
+  subject: string;
+  /** Human name for the subject, used in the tooltip and the toast. */
+  label: string;
+  className?: string;
+}) {
+  const { isPinned, hasRoom, toggle } = usePinSubject();
+  const pinned = isPinned(widget, subject);
+  const full = !pinned && !hasRoom;
+  const Icon = pinned ? PinOff : Pin;
+  const title = pinned
+    ? `Unpin ${label} from the ticker`
+    : full
+      ? "The ticker's pinned zone is full"
+      : `Pin ${label} to the ticker`;
+
+  return (
+    <button
+      type="button"
+      aria-label={title}
+      aria-pressed={pinned}
+      title={title}
+      disabled={full}
+      onClick={(e) => {
+        e.stopPropagation();
+        toggle(widget, subject, label);
+      }}
+      className={clsx(
+        "rounded p-1 transition-colors",
+        pinned
+          ? "text-primary hover:text-primary/80"
+          : "text-fg-4 hover:text-fg-2 disabled:hover:text-fg-4",
+        "disabled:opacity-40 disabled:cursor-not-allowed",
+        className,
+      )}
+    >
+      <Icon size={14} />
+    </button>
+  );
+}

--- a/desktop/src/components/PinSubjectButton.tsx
+++ b/desktop/src/components/PinSubjectButton.tsx
@@ -30,6 +30,9 @@ export default function PinSubjectButton({
 }) {
   const { isPinned, hasRoom, toggle } = usePinSubject();
   const pinned = isPinned(widget, subject);
+  // A row whose subject is missing (a standings row with no team name)
+  // gets no control rather than a dead one.
+  if (!subject) return null;
   const full = !pinned && !hasRoom;
   const Icon = pinned ? PinOff : Pin;
   const title = pinned

--- a/desktop/src/components/ScrollrTicker.test.tsx
+++ b/desktop/src/components/ScrollrTicker.test.tsx
@@ -64,13 +64,13 @@ describe("ScrollrTicker", () => {
     expect(screen.getByText("01:05")).toBeInTheDocument();
   });
 
-  it("does not render a pinned widget that is not in activeTabs", () => {
+  it("does not render a pinned subject whose widget is not in activeTabs", () => {
     render(
       <ScrollrTicker
         dashboard={null}
         activeTabs={["finance"]}
         widgetData={widgetData}
-        pinnedWidgets={{ timer: { side: "right" } }}
+        pins={[{ widget: "timer", subject: "timer", side: "right" }]}
       />,
     );
 
@@ -78,17 +78,50 @@ describe("ScrollrTicker", () => {
     expect(screen.queryByText("01:05")).not.toBeInTheDocument();
   });
 
-  it("renders a pinned widget that is in activeTabs", () => {
+  it("renders a pinned subject whose widget is in activeTabs", () => {
     render(
       <ScrollrTicker
         dashboard={null}
         activeTabs={["timer"]}
         widgetData={widgetData}
-        pinnedWidgets={{ timer: { side: "right" } }}
+        pins={[{ widget: "timer", subject: "timer", side: "right" }]}
       />,
     );
 
     expect(screen.getByText("Timer")).toBeInTheDocument();
     expect(screen.getByText("01:05")).toBeInTheDocument();
+  });
+
+  // The de-duplication rule (§8.5): a pinned subject is lifted OUT of the
+  // scrolling tape, so it is on the bar exactly once. Before REL-239 a
+  // pinned widget was skipped by widget id; now it is skipped by subject,
+  // and this is the test that the swap did not quietly drop the rule.
+  it("renders a pinned single-chip utility exactly once", () => {
+    render(
+      <ScrollrTicker
+        dashboard={null}
+        activeTabs={["timer"]}
+        widgetData={widgetData}
+        pins={[{ widget: "timer", subject: "timer", side: "right" }]}
+      />,
+    );
+
+    expect(screen.getAllByText("01:05")).toHaveLength(1);
+  });
+
+  it("renders nothing for a pinned subject the widget has no chip for", () => {
+    render(
+      <ScrollrTicker
+        dashboard={null}
+        activeTabs={["timer"]}
+        widgetData={widgetData}
+        pins={[{ widget: "timer", subject: "not-a-subject", side: "right" }]}
+      />,
+    );
+
+    // The pin resolves to nothing, so the zone is empty -- and the timer
+    // is NOT lifted out of the tape, because that subject was never pinned.
+    expect(screen.getAllByText("01:05")).toHaveLength(1);
+    expect(document.querySelector(".ticker-pinned-zone")).toBeNull();
   });
 });

--- a/desktop/src/components/ScrollrTicker.tsx
+++ b/desktop/src/components/ScrollrTicker.tsx
@@ -1,5 +1,4 @@
 import {
-  Fragment,
   useMemo,
   useEffect,
   useRef,
@@ -28,7 +27,7 @@ import type {
   MixMode,
   ChipColorMode,
   ScrollMode,
-  WidgetPinConfig,
+  WidgetPin,
   WidgetDisplayPrefs,
 } from "../preferences";
 import type { LeagueResponse as FantasyLeague } from "../datawidgets/fantasy/types";
@@ -43,7 +42,7 @@ import {
   getWatchlist,
   onWatchlistChange,
 } from "../datawidgets/predictions/watchlist";
-import { sourceForWidget } from "../marketplace";
+import { catalogItemById, sourceForWidget } from "../marketplace";
 import { useCatalog } from "../hooks/useCatalog";
 import { TICKER_SOURCES } from "../datawidgets/tickerRegistry";
 import { rotateSlots, type RotationMemo } from "../datawidgets/ticker";
@@ -67,10 +66,9 @@ interface ScrollrTickerProps {
     itemId: string | number,
     url?: string,
   ) => void;
-  /** Toggle pin state for a widget (hover pin icon). */
-  onTogglePin?: (widgetId: string) => void;
-  /** Which widgets are pinned (excluded from scrolling ticker). */
-  pinnedWidgets?: Record<string, WidgetPinConfig>;
+  /** The fixed zone, in order. Each entry pins one SUBJECT (REL-239);
+   *  that subject's current chip is lifted out of the scrolling tape. */
+  pins?: WidgetPin[];
   /** Scroll speed in px/sec (default 40) */
   speed?: number;
   /** Gap between chips in px (default 8) */
@@ -162,34 +160,51 @@ function EmptyTickerRow({
  * Total over WIDGET_ORDER — every widget type has a branch, which is
  * what let ConsolidatedChip and its fallbacks go.
  *
- * The pin toggle rides the FIRST chip only. Pinning is a per-widget
- * setting; a pin on every chip would imply each monitor pins on its own.
+ * Subjects (REL-239): a single-chip utility IS its own subject, so the
+ * widget id is the subject. A capped widget pins per monitor / per repo,
+ * so the item id is. `pinnedSubject` asks for exactly one subject's chip
+ * for the fixed zone; `pinnedSubjects` removes those from the tape so
+ * nothing is on the bar twice.
  */
+interface WidgetChip {
+  key: string;
+  node: React.ReactNode;
+  rotateSlot?: string;
+  subject: string;
+  pinLabel: string;
+}
+
 function widgetChipsFor(
   wt: keyof WidgetTickerData,
   items: WidgetTickerData[keyof WidgetTickerData],
   opts: {
     comfort?: boolean;
     chipColorMode?: ChipColorMode;
-    onTogglePin?: (id: string) => void;
     onChipClick?: (type: string, id: string, url?: string) => void;
-    pinned?: boolean;
+    /** Subjects of this widget that live in the fixed zone. */
+    pinnedSubjects?: ReadonlySet<string>;
+    /** Ask for ONE subject's chip (the fixed zone) instead of the tape. */
+    pinnedSubject?: string;
     cycles?: Readonly<Record<string, number>>;
     rotationMemo?: RotationMemo;
   },
-): Array<{ key: string; node: React.ReactNode; rotateSlot?: string }> {
-  const { comfort, chipColorMode, onTogglePin, onChipClick, pinned, cycles, rotationMemo } = opts;
+): WidgetChip[] {
+  const { comfort, chipColorMode, onChipClick, pinnedSubjects, pinnedSubject, cycles, rotationMemo } = opts;
+  const widgetLabel = catalogItemById(wt)?.name ?? wt;
 
   // The four cell/gauge/spine utilities each render as ONE chip holding
   // their items, unlike the capped pair which render one chip per item.
   // That split is the design's, not an accident: three clocks are one
   // glanceable group, three failing monitors are three separate alarms.
+  //
+  // One chip means one subject, which is why a pinned clock looks exactly
+  // as it did before REL-239 -- the widget and the subject coincide.
   if (wt === "clock" || wt === "timer" || wt === "weather" || wt === "sysmon") {
+    if (pinnedSubject !== undefined && pinnedSubject !== wt) return [];
+    if (pinnedSubject === undefined && pinnedSubjects?.has(wt)) return [];
     const shared = {
       comfort,
       colorMode: chipColorMode,
-      pinned,
-      onTogglePin: onTogglePin ? () => onTogglePin(wt) : undefined,
       onClick: () => onChipClick?.(wt, wt),
     };
     const node =
@@ -197,15 +212,40 @@ function widgetChipsFor(
       : wt === "timer" ? <TimerChip items={items as ClockChipData[]} {...shared} />
       : wt === "weather" ? <WeatherChip items={items as WeatherChipData[]} {...shared} />
       : <SysmonChip items={items as SysmonChipData[]} {...shared} />;
-    return [{ key: `${wt}-chip`, node }];
+    return [{ key: `${wt}-chip`, node, subject: wt, pinLabel: widgetLabel }];
+  }
+
+  const capped = items as Array<UptimeChipData | GitHubChipData>;
+  const render = (item: UptimeChipData | GitHubChipData) => {
+    const shared = {
+      comfort,
+      colorMode: chipColorMode,
+      onClick: () => onChipClick?.(wt, item.id),
+    };
+    return wt === "uptime" ? (
+      <UptimeCappedChip item={item as UptimeChipData} {...shared} />
+    ) : (
+      <GitHubCappedChip item={item as GitHubChipData} {...shared} />
+    );
+  };
+
+  // The fixed zone wants one monitor / one repo, whatever the rotation is
+  // doing. Gone from the payload -> nothing rendered.
+  if (pinnedSubject !== undefined) {
+    const item = capped.find((it) => it.id === pinnedSubject);
+    if (!item) return [];
+    return [{ key: `pin-${wt}-${item.id}`, node: render(item), subject: item.id, pinLabel: item.label }];
   }
 
   // One chip per monitor or repo, rotating through a fixed number of
   // slots once there are more than that -- thirty monitors is still four
   // chips, and a failing one still comes round. Fixed-width chips, so the
   // slot needs no reservation.
+  const pool = pinnedSubjects?.size
+    ? capped.filter((it) => !pinnedSubjects.has(it.id))
+    : capped;
   const slots = rotateSlots(
-    items as Array<UptimeChipData | GitHubChipData>,
+    pool,
     CAPPED_WIDGET_SLOTS,
     cycles ?? {},
     wt,
@@ -213,22 +253,13 @@ function widgetChipsFor(
     () => undefined,
     rotationMemo,
   );
-  return slots.map(({ key, item, rotateSlot }, i) => {
-    const shared = {
-      comfort,
-      colorMode: chipColorMode,
-      pinned,
-      onTogglePin: i === 0 && onTogglePin ? () => onTogglePin(wt) : undefined,
-      onClick: () => onChipClick?.(wt, item.id),
-    };
-    const node =
-      wt === "uptime" ? (
-        <UptimeCappedChip item={item as UptimeChipData} {...shared} />
-      ) : (
-        <GitHubCappedChip item={item as GitHubChipData} {...shared} />
-      );
-    return { key, node, rotateSlot };
-  });
+  return slots.map(({ key, item, rotateSlot }) => ({
+    key,
+    node: render(item),
+    rotateSlot,
+    subject: item.id,
+    pinLabel: item.label,
+  }));
 }
 
 /** Monitors or workflow runs on the rail at once. Not a setting. */
@@ -255,8 +286,7 @@ export default function ScrollrTicker({
   activeTabs,
   widgetData,
   onChipClick,
-  onTogglePin,
-  pinnedWidgets = {},
+  pins = [],
   speed = 25,
   gap = 8,
   onHover = "slow",
@@ -310,9 +340,43 @@ export default function ScrollrTicker({
   // state: mutating it must never itself trigger a re-render.
   const rotationMemoRef = useRef<RotationMemo>(new Map());
 
+  // Pinned subjects, grouped by the widget that owns them. Every source
+  // gets its own set so it can drop them from its pool before rotating --
+  // filtering the POOL, not the rendered chips, is what stops a slot from
+  // resolving to a pinned item and rendering a hole (§8.5).
+  const pinnedByWidget = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const p of pins) {
+      const set = map.get(p.widget) ?? new Set<string>();
+      set.add(p.subject);
+      map.set(p.widget, set);
+    }
+    return map;
+  }, [pins]);
+
   const chips = useMemo(() => {
-    const wrap = (key: string, chip: React.ReactNode, rotateSlot?: string) => (
-      <div key={key} className="py-1" data-chip="" data-rotate-slot={rotateSlot}>
+    const wrap = (
+      tab: string,
+      key: string,
+      chip: React.ReactNode,
+      rotateSlot?: string,
+      subject?: string,
+      pinLabel?: string,
+    ) => (
+      <div
+        key={key}
+        className="py-1"
+        data-chip=""
+        data-rotate-slot={rotateSlot}
+        // What a right-click resolves the chip under the cursor to
+        // (App.tsx). One attribute, because the menu needs all three
+        // parts together and a chip with no pinnable subject has none.
+        data-pin-subject={
+          subject === undefined
+            ? undefined
+            : JSON.stringify({ widget: tab, subject, label: pinLabel ?? subject })
+        }
+      >
         {chip}
       </div>
     );
@@ -321,37 +385,31 @@ export default function ScrollrTicker({
 
     for (const tab of activeTabs) {
       const bucket: React.ReactNode[] = [];
+      const pinnedSubjects = pinnedByWidget.get(tab);
 
-      // Pinned widgets never scroll — they render in a pinned zone on
-      // their assigned row (pin.row). See render-time pinned loop below.
-      const isPinnedAnywhere = !!pinnedWidgets[tab];
-
-      // ── Widget tabs: consolidated chips (skip if pinned) ────────
+      // ── Widget tabs: consolidated chips ─────────────────────────
       // Membership comes from the widget registry, not a second list
       // maintained by hand here.
       if (WIDGET_ORDER.includes(tab)) {
         const wt = tab as keyof WidgetTickerData;
         const items = widgetData?.[wt];
-        if (items?.length && !isPinnedAnywhere) {
+        if (items?.length) {
           // Capped widgets render ONE chip per item. Packing every
           // monitor into a single pipe-separated chip made a lone
           // failure impossible to pick out of the row, which is the
           // whole point of a status cap.
-          //
-          // The pin toggle rides the first chip only: pinning is
-          // per-widget, and N pins on N chips would suggest otherwise.
           const chipsForWidget = widgetChipsFor(wt, items, {
             comfort,
             chipColorMode,
-            onTogglePin,
             onChipClick,
+            pinnedSubjects,
             cycles,
             rotationMemo: rotationMemoRef.current,
           });
-          chipsForWidget.forEach(({ key, node, rotateSlot }) =>
-            bucket.push(wrap(key, node, rotateSlot)),
+          chipsForWidget.forEach(({ key, node, rotateSlot, subject, pinLabel }) =>
+            bucket.push(wrap(tab, key, node, rotateSlot, subject, pinLabel)),
           );
-          buckets.push(bucket);
+          if (bucket.length > 0) buckets.push(bucket);
         }
         continue;
       }
@@ -379,9 +437,12 @@ export default function ScrollrTicker({
         predictionsWatchlist,
         cycles,
         rotationMemo: rotationMemoRef.current,
+        pinnedSubjects,
         onChipClick,
       })) {
-        bucket.push(wrap(chip.key, chip.node, chip.rotateSlot));
+        bucket.push(
+          wrap(tab, chip.key, chip.node, chip.rotateSlot, chip.subject, chip.pinLabel),
+        );
       }
 
       // Only push a bucket that actually has chips in it.
@@ -400,8 +461,7 @@ export default function ScrollrTicker({
     activeTabs,
     widgetData,
     onChipClick,
-    onTogglePin,
-    pinnedWidgets,
+    pinnedByWidget,
     comfort,
     effectiveMixMode,
     chipColorMode,
@@ -529,33 +589,74 @@ export default function ScrollrTicker({
     transitionDuration,
   ]);
 
-  // ── Build pinned chip arrays (rendered inside this row) ─────────
+  // ── Build the fixed zone ────────────────────────────────────────
   //
-  // Pinned widgets are visually static, single-instance elements. With
+  // One pin, one subject, one chip. The zone shows that subject's CURRENT
+  // chip -- a pinned team's live game becomes its final becomes its next
+  // fixture, in place, without the pin ever pointing at a stale row.
+  //
+  // Three rules make it a pin rather than a slice of the tape:
+  //   1. It never scrolls and never rotates (so no `cycles`, no memo).
+  //   2. It bypasses the source's horizon: the user already said "this
+  //      one", so a fixture nine days out still shows.
+  //   3. Nothing to show renders NOTHING. An empty space is honest; a
+  //      placeholder would be a fabricated value (§1.7).
 
   const pinnedLeft: React.ReactNode[] = [];
   const pinnedRight: React.ReactNode[] = [];
 
-  for (const [widgetId, pin] of Object.entries(pinnedWidgets)) {
-    if (!activeTabs.includes(widgetId)) continue;
+  for (const pin of pins) {
+    if (!activeTabs.includes(pin.widget)) continue;
     const target = pin.side === "left" ? pinnedLeft : pinnedRight;
+    const key = `pin-${pin.widget}-${pin.subject}`;
+    // Same `data-chip` / `data-pin-subject` pair the tape carries, so a
+    // right-click on a pinned chip resolves to the same subject and the
+    // menu reads "Unpin" without the zone needing its own control.
+    const park = (node: React.ReactNode, label: string) =>
+      target.push(
+        <div
+          key={key}
+          className="flex items-center"
+          data-chip=""
+          data-pin-subject={JSON.stringify({
+            widget: pin.widget,
+            subject: pin.subject,
+            label,
+          })}
+        >
+          {node}
+        </div>,
+      );
 
-    if (WIDGET_ORDER.includes(widgetId)) {
-      const wt = widgetId as keyof WidgetTickerData;
+    if (WIDGET_ORDER.includes(pin.widget)) {
+      const wt = pin.widget as keyof WidgetTickerData;
       const items = widgetData?.[wt];
-      if (items?.length) {
-        const pinnedChips = widgetChipsFor(wt, items, {
-          comfort,
-          chipColorMode,
-          onTogglePin,
-          onChipClick,
-          pinned: true,
-        });
-        pinnedChips.forEach(({ node }, i) =>
-          target.push(<Fragment key={`pinned-${wt}-${i}`}>{node}</Fragment>),
-        );
+      if (!items?.length) continue;
+      for (const { node, pinLabel } of widgetChipsFor(wt, items, {
+        comfort,
+        chipColorMode,
+        onChipClick,
+        pinnedSubject: pin.subject,
+      })) {
+        park(node, pinLabel);
       }
+      continue;
     }
+
+    const source = sourceForWidget(pin.widget) ?? pin.widget;
+    const tickerSource = TICKER_SOURCES[source];
+    const chip = tickerSource?.pinnedChip?.(dashboard?.data?.[source], {
+      tab: pin.widget,
+      source,
+      dashboard,
+      comfort,
+      chipColorMode,
+      widgetDisplay,
+      predictionsWatchlist,
+      pinnedSubject: pin.subject,
+      onChipClick,
+    });
+    if (chip) park(chip.node, chip.pinLabel ?? pin.subject);
   }
 
   // ── Render ────────────────────────────────────────────────────

--- a/desktop/src/components/Sidebar.test.tsx
+++ b/desktop/src/components/Sidebar.test.tsx
@@ -64,6 +64,7 @@ function renderSidebar(opts: {
         onSelectItem={() => {}}
         onInfoItem={() => {}}
         onToggleItemTicker={() => {}}
+        onToggleItemPin={() => {}}
         onMoveItem={onMoveItem}
         onRemoveItem={() => {}}
       />
@@ -262,7 +263,7 @@ describe("Sidebar ticker mark", () => {
           onNavigateHome={() => {}} onNavigateToMarketplace={() => {}} onNavigateToCustomize={() => {}}
           onNavigateToAccount={() => {}} onNavigateToSupport={() => {}} onNavigateToReleases={() => {}}
           onNavigateToStatus={() => {}} onSelectItem={onSelectItem} onInfoItem={() => {}}
-          onToggleItemTicker={onToggleItemTicker} onMoveItem={() => {}} onRemoveItem={() => {}}
+          onToggleItemTicker={onToggleItemTicker} onToggleItemPin={() => {}} onMoveItem={() => {}} onRemoveItem={() => {}}
         />
       </div>,
     );

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -36,6 +36,7 @@ import {
   Home,
   Info,
   LifeBuoy,
+  Pin,
   Plus,
   RadioTower,
   SlidersHorizontal,
@@ -53,6 +54,7 @@ import { DELIVERY_STATE_META } from "./ConnectionIndicator";
 import { controlTransition } from "../lib/motion";
 import type { DataWidgetManifest, WidgetManifest } from "../types";
 import { TIER_LABELS, getUserIdentity } from "../auth";
+import { isSingleChipWidget } from "../preferences";
 import type { SubscriptionTier } from "../auth";
 import type { DeliveryHealth } from "../hooks/useDeliveryHealth";
 import { getMaxWidgets } from "../tierLimits";
@@ -159,6 +161,17 @@ interface SidebarProps {
   onInfoItem: (id: string) => void;
   /** Toggle the source's presence on the ticker. */
   onToggleItemTicker: (source: SidebarSource) => void;
+  /**
+   * Pin / unpin a single-chip widget (REL-239).
+   *
+   * Only offered for clock, timer, weather and sysmon: those render one
+   * chip for the whole widget, so the widget IS the subject and the row
+   * can pin it without asking which item you meant. Everything else pins
+   * per item, from the widget's own page or the ticker's right-click.
+   */
+  onToggleItemPin: (source: SidebarSource) => void;
+  /** Which single-chip widgets are currently pinned. */
+  pinnedWidgetIds?: ReadonlySet<string>;
   /** Move the widget within the shared sidebar order. */
   onMoveItem: (id: string, direction: "up" | "down") => void;
   /** Remove the widget (frees its slot). */
@@ -190,6 +203,8 @@ export default function Sidebar({
   onSelectItem,
   onInfoItem,
   onToggleItemTicker,
+  onToggleItemPin,
+  pinnedWidgetIds,
   onMoveItem,
   onRemoveItem,
 }: SidebarProps) {
@@ -471,6 +486,18 @@ export default function Sidebar({
                   icon: RadioTower,
                   onSelect: () => onToggleItemTicker(menu.source),
                 },
+                ...(isSingleChipWidget(menu.source.id)
+                  ? [
+                      {
+                        key: "pin",
+                        label: pinnedWidgetIds?.has(menu.source.id)
+                          ? "Unpin from ticker"
+                          : "Pin to ticker",
+                        icon: Pin,
+                        onSelect: () => onToggleItemPin(menu.source),
+                      },
+                    ]
+                  : []),
                 {
                   key: "info",
                   label: "Widget page",

--- a/desktop/src/components/chips/CappedChip.tsx
+++ b/desktop/src/components/chips/CappedChip.tsx
@@ -13,8 +13,6 @@
  * point of a cap is that a red block is visible without reading.
  */
 import { clsx } from "clsx";
-import { Pin, PinOff } from "lucide-react";
-import Tooltip from "../Tooltip";
 import type { ChipColorMode } from "../../preferences";
 import { getChipColors, chipBaseClasses } from "./chipColors";
 import { ChipCap, cappedChipClasses } from "./ChipCap";
@@ -59,8 +57,6 @@ interface ShellProps {
   colorMode?: ChipColorMode;
   dim?: boolean;
   alert?: boolean;
-  pinned?: boolean;
-  onTogglePin?: () => void;
   onClick?: () => void;
   /** Right-hand fixed cell: the one value that changes while on screen. */
   end?: React.ReactNode;
@@ -74,14 +70,11 @@ function CapShell({
   colorMode = "widget",
   dim,
   alert,
-  pinned,
-  onTogglePin,
   onClick,
   end,
   children,
 }: ShellProps) {
   const c = getChipColors(colorMode, type);
-  const PinIcon = pinned ? PinOff : Pin;
   return (
     <button
       onClick={onClick}
@@ -94,34 +87,6 @@ function CapShell({
         dim && "opacity-60",
       )}
     >
-      {onTogglePin && (
-        <Tooltip content={pinned ? "Unpin widget" : "Pin widget"}>
-          <span
-            role="button"
-            tabIndex={0}
-            aria-label={pinned ? "Unpin widget" : "Pin widget"}
-            onClick={(e) => {
-              e.stopPropagation();
-              onTogglePin();
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.stopPropagation();
-                onTogglePin();
-              }
-            }}
-            className={clsx(
-              "absolute -right-1 -top-1 z-10 rounded-full border p-0.5 transition-opacity",
-              "border-edge/50 bg-surface",
-              pinned
-                ? "opacity-80"
-                : "opacity-0 focus:opacity-80 group-hover:opacity-80",
-            )}
-          >
-            <PinIcon size={10} className={c.textDim} />
-          </span>
-        </Tooltip>
-      )}
       <ChipCap
         tone={cap.tone}
         pulse={cap.pulse}
@@ -208,15 +173,11 @@ export function UptimeCappedChip({
   item,
   comfort,
   colorMode,
-  pinned,
-  onTogglePin,
   onClick,
 }: {
   item: UptimeChipData;
   comfort?: boolean;
   colorMode?: ChipColorMode;
-  pinned?: boolean;
-  onTogglePin?: () => void;
   onClick?: () => void;
 }) {
   const cap = UPTIME_CAP[item.status] ?? UPTIME_CAP.pending;
@@ -234,8 +195,6 @@ export function UptimeCappedChip({
       comfort={comfort}
       colorMode={colorMode}
       alert={down}
-      pinned={pinned}
-      onTogglePin={onTogglePin}
       onClick={onClick}
       end={
         <span className={down ? "text-down" : c.textDim}>{value}</span>
@@ -273,15 +232,11 @@ export function GitHubCappedChip({
   item,
   comfort,
   colorMode,
-  pinned,
-  onTogglePin,
   onClick,
 }: {
   item: GitHubChipData;
   comfort?: boolean;
   colorMode?: ChipColorMode;
-  pinned?: boolean;
-  onTogglePin?: () => void;
   onClick?: () => void;
 }) {
   const cap = GITHUB_CAP[item.status] ?? GITHUB_CAP.unavailable;
@@ -306,8 +261,6 @@ export function GitHubCappedChip({
       colorMode={colorMode}
       alert={failed}
       dim={queued}
-      pinned={pinned}
-      onTogglePin={onTogglePin}
       onClick={onClick}
     >
       <span className="flex items-baseline gap-1.5">

--- a/desktop/src/components/chips/UtilityChips.tsx
+++ b/desktop/src/components/chips/UtilityChips.tsx
@@ -28,8 +28,6 @@
  * CappedChip.
  */
 import { clsx } from "clsx";
-import { Pin, PinOff } from "lucide-react";
-import Tooltip from "../Tooltip";
 import type { ChipColorMode } from "../../preferences";
 import { getChipColors, chipShellClasses } from "./chipColors";
 import { Sparkline } from "./Sparkline";
@@ -60,8 +58,6 @@ function UtilityShell({
   tab,
   comfort,
   colorMode = "widget",
-  pinned,
-  onTogglePin,
   onClick,
   cols,
   extra,
@@ -73,8 +69,6 @@ function UtilityShell({
   tab: string;
   comfort?: boolean;
   colorMode?: ChipColorMode;
-  pinned?: boolean;
-  onTogglePin?: () => void;
   onClick?: () => void;
   /** Grid template for the item cells, tab column excluded. */
   cols: string;
@@ -83,7 +77,6 @@ function UtilityShell({
   children: React.ReactNode;
 }) {
   const c = getChipColors(colorMode, type);
-  const PinIcon = pinned ? PinOff : Pin;
   return (
     <button
       onClick={onClick}
@@ -96,34 +89,6 @@ function UtilityShell({
         extra,
       )}
     >
-      {onTogglePin && (
-        <Tooltip content={pinned ? "Unpin widget" : "Pin widget"}>
-          <span
-            role="button"
-            tabIndex={0}
-            aria-label={pinned ? "Unpin widget" : "Pin widget"}
-            onClick={(e) => {
-              e.stopPropagation();
-              onTogglePin();
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.stopPropagation();
-                onTogglePin();
-              }
-            }}
-            className={clsx(
-              "absolute -right-1 -top-1 z-10 rounded-full border p-0.5 transition-opacity",
-              "border-edge/50 bg-surface",
-              pinned
-                ? "opacity-80"
-                : "opacity-0 focus:opacity-80 group-hover:opacity-80",
-            )}
-          >
-            <PinIcon size={10} className={c.textDim} />
-          </span>
-        </Tooltip>
-      )}
       {/* The tab: the widget's name, painted, spanning both rows. */}
       <span
         className={clsx(
@@ -212,8 +177,6 @@ interface ChipProps<T> {
   items: T[];
   comfort?: boolean;
   colorMode?: ChipColorMode;
-  pinned?: boolean;
-  onTogglePin?: () => void;
   onClick?: () => void;
 }
 
@@ -223,8 +186,6 @@ export function ClockChip({
   items,
   comfort,
   colorMode,
-  pinned,
-  onTogglePin,
   onClick,
 }: ChipProps<ClockChipData>) {
   const c = getChipColors(colorMode ?? "widget", "clock");
@@ -237,8 +198,6 @@ export function ClockChip({
       cols={colsFor(items.length)}
       comfort={comfort}
       colorMode={colorMode}
-      pinned={pinned}
-      onTogglePin={onTogglePin}
       onClick={onClick}
     >
       {items.map((item, i) => (
@@ -282,8 +241,6 @@ export function TimerChip({
   items,
   comfort,
   colorMode,
-  pinned,
-  onTogglePin,
   onClick,
 }: ChipProps<ClockChipData>) {
   const c = getChipColors(colorMode ?? "widget", "timer");
@@ -298,8 +255,6 @@ export function TimerChip({
       cols={colsFor(items.length)}
       comfort={comfort}
       colorMode={colorMode}
-      pinned={pinned}
-      onTogglePin={onTogglePin}
       onClick={onClick}
       // The last minute borrows the live palette — the same red the rest
       // of the app uses for "happening now".
@@ -363,8 +318,6 @@ export function WeatherChip({
   items,
   comfort,
   colorMode,
-  pinned,
-  onTogglePin,
   onClick,
 }: ChipProps<WeatherChipData>) {
   const c = getChipColors(colorMode ?? "widget", "weather");
@@ -378,8 +331,6 @@ export function WeatherChip({
       cols={colsFor(items.length)}
       comfort={comfort}
       colorMode={colorMode}
-      pinned={pinned}
-      onTogglePin={onTogglePin}
       onClick={onClick}
       extra={anyAlert ? "border-warning/45" : undefined}
     >
@@ -457,8 +408,6 @@ export function SysmonChip({
   items,
   comfort,
   colorMode,
-  pinned,
-  onTogglePin,
   onClick,
 }: ChipProps<SysmonChipData>) {
   const c = getChipColors(colorMode ?? "widget", "sysmon");
@@ -479,8 +428,6 @@ export function SysmonChip({
       cols={colsFor(items.length)}
       comfort={comfort}
       colorMode={colorMode}
-      pinned={pinned}
-      onTogglePin={onTogglePin}
       onClick={onClick}
       extra={anyHot ? "border-error/30" : undefined}
     >

--- a/desktop/src/datawidgets/finance/FeedTab.tsx
+++ b/desktop/src/datawidgets/finance/FeedTab.tsx
@@ -34,6 +34,7 @@ import { SearchBox, useSlashFocus } from "../../components/widget-bar/SearchBox"
 import { MultiSelectMenu } from "../../components/widget-bar/MultiSelectMenu";
 import { SelectMenu } from "../../components/widget-bar/SelectMenu";
 import { useDataWidgetConfig } from "../../hooks/useDataWidgetConfig";
+import PinSubjectButton from "../../components/PinSubjectButton";
 import { useShell } from "../../shell-context";
 import { useNow } from "../../hooks/useNow";
 import { useCatalog } from "../../hooks/useCatalog";
@@ -445,6 +446,11 @@ function FinanceFeedTab({ mode: callerMode, feedContext, widgetId }: FeedTabProp
                   (!isWatchlist || !trackedSet.has(trade.symbol))
                 }
                 saving={symbolsSaving}
+                pinWidget={
+                  isComfort && trackedSet.has(trade.symbol)
+                    ? widgetType
+                    : undefined
+                }
               />
             ))}
           </div>
@@ -472,6 +478,9 @@ interface TradeItemProps {
   saving?: boolean;
   /** Shared "now" from `useNow()` in the parent list — drives the `Xs ago` label. */
   now: number;
+  /** Widget id, set only for symbols on the watchlist: it enables the pin
+   *  control, and the symbol is the subject it pins (REL-239). */
+  pinWidget?: string;
 }
 
 const TradeItem = memo(function TradeItem({
@@ -483,6 +492,7 @@ const TradeItem = memo(function TradeItem({
   onRemove,
   actionVisible = false,
   saving,
+  pinWidget,
 }: TradeItemProps) {
   const isUp = trade.direction === "up";
   const isDown = trade.direction === "down";
@@ -569,6 +579,15 @@ const TradeItem = memo(function TradeItem({
               {relativeTime(trade.last_updated, now, { includeSeconds: true })}
             </span>
           )}
+          {/* Pin, not star: the watchlist is already "always on the tape".
+              A pin lifts this symbol out of the tape into the fixed zone. */}
+          {pinWidget && (
+            <PinSubjectButton
+              widget={pinWidget}
+              subject={trade.symbol}
+              label={trade.symbol}
+            />
+          )}
         </div>
       </div>
       {(onAdd || onRemove) && (
@@ -607,6 +626,7 @@ const TradeItem = memo(function TradeItem({
   prev.onRemove === next.onRemove &&
   prev.actionVisible === next.actionVisible &&
   prev.saving === next.saving &&
+  prev.pinWidget === next.pinWidget &&
   // `now` must trigger a re-render while the "Xs ago" label is visible
   // so it advances on every tick. Compact mode has no label — skip the
   // tick there to avoid churning the whole list.

--- a/desktop/src/datawidgets/finance/ticker.tsx
+++ b/desktop/src/datawidgets/finance/ticker.tsx
@@ -2,8 +2,18 @@ import type { Trade } from "../../types";
 import TradeChip from "../../components/chips/TradeChip";
 import { chipUrlForFinance } from "../../utils/chipUrl";
 import type { TickerChip, TickerContext, TickerSource } from "../ticker";
-import { scopedRows, rotateSlots } from "../ticker";
+import { scopedRows, rotateSlots, dropPinned } from "../ticker";
 import { selectFinanceForTicker, TICKER_FINANCE_SLOTS } from "./view";
+
+/** The finance subject is the symbol: durable, and what the user typed. */
+function watchlistOf(ctx: TickerContext): string[] {
+  const config = ctx.dashboard?.widgets?.find((c) => c.widget_type === ctx.tab)?.config as
+    | { symbols?: unknown }
+    | undefined;
+  return Array.isArray(config?.symbols)
+    ? config.symbols.filter((s): s is string => typeof s === "string")
+    : [];
+}
 
 /**
  * Finance ticker chips.
@@ -17,14 +27,13 @@ import { selectFinanceForTicker, TICKER_FINANCE_SLOTS } from "./view";
 export const financeTickerSource: TickerSource = {
   chips(raw: unknown, ctx: TickerContext): TickerChip[] {
     const rows = scopedRows<Trade>(raw, ctx);
-    const config = ctx.dashboard?.widgets?.find((c) => c.widget_type === ctx.tab)?.config as
-      | { symbols?: unknown }
-      | undefined;
-    const watchlist = Array.isArray(config?.symbols)
-      ? config.symbols.filter((s): s is string => typeof s === "string")
-      : [];
+    const pool = dropPinned(
+      selectFinanceForTicker(rows, watchlistOf(ctx)),
+      ctx,
+      (t) => t.symbol,
+    );
     const slots = rotateSlots(
-      selectFinanceForTicker(rows, watchlist),
+      pool,
       TICKER_FINANCE_SLOTS,
       ctx.cycles ?? {},
       `fin-${ctx.tab}`,
@@ -35,6 +44,8 @@ export const financeTickerSource: TickerSource = {
     return slots.map(({ key, item: trade, rotateSlot }) => ({
       key,
       rotateSlot,
+      subject: trade.symbol,
+      pinLabel: trade.symbol,
       node: (
         <TradeChip
           trade={trade}
@@ -44,5 +55,31 @@ export const financeTickerSource: TickerSource = {
         />
       ),
     }));
+  },
+
+  // No horizon to bypass: finance shows whatever the server last traded
+  // for the symbol. Nothing quoted yet -> nothing rendered.
+  pinnedChip(raw: unknown, ctx: TickerContext): TickerChip | null {
+    const trade = scopedRows<Trade>(raw, ctx).find(
+      (t) => t.symbol === ctx.pinnedSubject,
+    );
+    if (!trade) return null;
+    return {
+      key: `pin-fin-${ctx.tab}-${trade.symbol}`,
+      subject: trade.symbol,
+      pinLabel: trade.symbol,
+      node: (
+        <TradeChip
+          trade={trade}
+          comfort={ctx.comfort}
+          colorMode={ctx.chipColorMode}
+          onClick={() => ctx.onChipClick?.("finance", trade.symbol, chipUrlForFinance(trade))}
+        />
+      ),
+    };
+  },
+
+  subjects(_raw: unknown, ctx: TickerContext) {
+    return watchlistOf(ctx).map((symbol) => ({ subject: symbol, label: symbol }));
   },
 };

--- a/desktop/src/datawidgets/predictions/FeedTab.tsx
+++ b/desktop/src/datawidgets/predictions/FeedTab.tsx
@@ -158,7 +158,7 @@ function formatDelta(delta: number): string {
 
 // ── FeedTab ──────────────────────────────────────────────────────
 
-function PredictionsFeedTab({ mode: callerMode, feedContext }: FeedTabProps) {
+function PredictionsFeedTab({ mode: callerMode, feedContext, widgetId }: FeedTabProps) {
   const { prefs, onPrefsChange } = useShell();
   const dp = prefs.widgetDisplay.predictions;
 
@@ -835,6 +835,7 @@ function PredictionsFeedTab({ mode: callerMode, feedContext }: FeedTabProps) {
             now={now}
             watched={watchedSet.has(liveDetail.ticker)}
             onToggleWatch={() => toggleWatch(liveDetail.ticker)}
+            pinWidget={widgetId}
             alerts={alerts}
             onAddAlert={addAlertCb}
             onRemoveAlert={removeAlertCb}

--- a/desktop/src/datawidgets/predictions/MarketDetail.tsx
+++ b/desktop/src/datawidgets/predictions/MarketDetail.tsx
@@ -49,6 +49,7 @@ import { outcomeLabel } from "./search";
 import ProbabilityPill from "./ProbabilityPill";
 import { SelectMenu } from "../../components/widget-bar/SelectMenu";
 import type { Prediction } from "../../types";
+import PinSubjectButton from "../../components/PinSubjectButton";
 
 interface MarketDetailProps {
   market: Prediction;
@@ -59,6 +60,10 @@ interface MarketDetailProps {
   now: number;
   watched: boolean;
   onToggleWatch: () => void;
+  /** Widget id, so this market can be pinned to the ticker (REL-239).
+   *  Separate from Watch on purpose: watching puts it on the tape,
+   *  pinning parks it in the fixed zone. */
+  pinWidget?: string;
   alerts: PredictionAlert[];
   onAddAlert: (input: {
     ticker: string;
@@ -101,6 +106,7 @@ export default function MarketDetail({
   now,
   watched,
   onToggleWatch,
+  pinWidget,
   alerts,
   onAddAlert,
   onRemoveAlert,
@@ -402,6 +408,13 @@ export default function MarketDetail({
             <Star size={13} className={watched ? "fill-current" : ""} />
             {watched ? "Watching" : "Watch"}
           </button>
+          {pinWidget && (
+            <PinSubjectButton
+              widget={pinWidget}
+              subject={market.ticker}
+              label={market.event_title || market.title}
+            />
+          )}
           {market.link && (
             <button
               type="button"

--- a/desktop/src/datawidgets/predictions/ticker.tsx
+++ b/desktop/src/datawidgets/predictions/ticker.tsx
@@ -1,8 +1,14 @@
 import type { Prediction } from "../../types";
 import PredictionChip from "../../components/chips/PredictionChip";
 import type { TickerChip, TickerContext, TickerSource } from "../ticker";
-import { scopedRows, rotateSlots } from "../ticker";
+import { scopedRows, rotateSlots, dropPinned } from "../ticker";
 import { selectPredictionsForTicker, TICKER_PREDICTIONS_SLOTS } from "./view";
+
+/** What a market is called in a menu: the event question if the sweep has
+ *  backfilled one, else this leg's own title. */
+function labelFor(p: Prediction): string {
+  return p.event_title || p.title;
+}
 
 /**
  * Prediction-market ticker chips.
@@ -17,7 +23,14 @@ export const predictionsTickerSource: TickerSource = {
   chips(raw: unknown, ctx: TickerContext): TickerChip[] {
     const rows = scopedRows<Prediction>(raw, ctx);
     const slots = rotateSlots(
-      selectPredictionsForTicker(rows, ctx.predictionsWatchlist),
+      // Subject is the market TICKER, not the row id: it is what the
+      // watchlist keys on and what survives a re-ingest of the same
+      // market, so a pin outlives the row it was made from.
+      dropPinned(
+        selectPredictionsForTicker(rows, ctx.predictionsWatchlist),
+        ctx,
+        (p) => p.ticker,
+      ),
       TICKER_PREDICTIONS_SLOTS,
       ctx.cycles ?? {},
       `pred-${ctx.tab}`,
@@ -28,6 +41,8 @@ export const predictionsTickerSource: TickerSource = {
     return slots.map(({ key, item: p, rotateSlot }) => ({
       key,
       rotateSlot,
+      subject: p.ticker,
+      pinLabel: labelFor(p),
       node: (
         <PredictionChip
           prediction={p}
@@ -37,5 +52,35 @@ export const predictionsTickerSource: TickerSource = {
         />
       ),
     }));
+  },
+
+  // Stars and the trending fallback both come off: a pinned market is on
+  // the bar because the user parked it there, not because it is moving.
+  // A market that has resolved out of the payload renders nothing.
+  pinnedChip(raw: unknown, ctx: TickerContext): TickerChip | null {
+    const p = scopedRows<Prediction>(raw, ctx).find(
+      (m) => m.ticker === ctx.pinnedSubject,
+    );
+    if (!p) return null;
+    return {
+      key: `pin-pred-${ctx.tab}-${p.ticker}`,
+      subject: p.ticker,
+      pinLabel: labelFor(p),
+      node: (
+        <PredictionChip
+          prediction={p}
+          comfort={ctx.comfort}
+          colorMode={ctx.chipColorMode}
+          onClick={() => ctx.onChipClick?.("predictions", p.id, p.link)}
+        />
+      ),
+    };
+  },
+
+  subjects(raw: unknown, ctx: TickerContext) {
+    return selectPredictionsForTicker(
+      scopedRows<Prediction>(raw, ctx),
+      ctx.predictionsWatchlist,
+    ).map((p) => ({ subject: p.ticker, label: labelFor(p) }));
   },
 };

--- a/desktop/src/datawidgets/rss/FeedManager.tsx
+++ b/desktop/src/datawidgets/rss/FeedManager.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "motion/react";
+import PinSubjectButton from "../../components/PinSubjectButton";
 import Tooltip from "../../components/Tooltip";
 import EmptySection from "../../components/layout/EmptySection";
 import QueryErrorBanner from "../../components/QueryErrorBanner";
@@ -48,6 +49,8 @@ interface FeedManagerProps {
   onRetry: () => void;
   retrying: boolean;
   saving: boolean;
+  /** Widget id, so a subscribed feed row can pin the feed (REL-239). */
+  widgetId?: string;
 }
 
 type SortKey = "default" | "name" | "category" | "activity";
@@ -76,6 +79,7 @@ export default function FeedManager({
   onRetry,
   retrying,
   saving,
+  widgetId,
 }: FeedManagerProps) {
   const [search, setSearch] = useState("");
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(
@@ -436,6 +440,7 @@ export default function FeedManager({
                 trackedSubscription={tracked}
                 saving={saving}
                 onToggle={() => toggleFeed(feed)}
+                pinWidget={feed.isTracked ? widgetId : undefined}
               />
             );
           })}
@@ -452,24 +457,36 @@ interface FeedRowProps {
   trackedSubscription: SubscribedFeed | undefined;
   saving: boolean;
   onToggle: () => void;
+  /** Set for a subscribed feed: enables the pin, whose subject is the
+   *  feed url -- the durable thing behind every headline it produces. */
+  pinWidget?: string;
 }
 
-function FeedRow({ feed, saving, onToggle }: FeedRowProps) {
+function FeedRow({ feed, saving, onToggle, pinWidget }: FeedRowProps) {
   const tracked = feed.isTracked;
   const health = feedHealth(feed);
 
+  // The row holds two independent actions now (subscribe, pin), so the
+  // row is a container and the subscribe target is a button inside it --
+  // a button inside a button is invalid and swallows the inner click.
   return (
-    <button
-      type="button"
+    <div
       role="listitem"
-      onClick={onToggle}
-      disabled={saving}
-      aria-label={tracked ? `Remove ${feed.name}` : `Add ${feed.name}`}
       className={clsx(
         "w-full flex items-center gap-2.5 px-3 py-2 text-left group",
         tracked
           ? "bg-accent/[0.04] hover:bg-accent/[0.08]"
-          : "hover:bg-base-200/50 cursor-pointer",
+          : "hover:bg-base-200/50",
+      )}
+    >
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={saving}
+      aria-label={tracked ? `Remove ${feed.name}` : `Add ${feed.name}`}
+      className={clsx(
+        "flex flex-1 min-w-0 items-center gap-2.5 text-left",
+        !tracked && "cursor-pointer",
         saving && "cursor-wait",
       )}
     >
@@ -533,6 +550,15 @@ function FeedRow({ feed, saving, onToggle }: FeedRowProps) {
         </Tooltip>
       )}
     </button>
+      {pinWidget && (
+        <PinSubjectButton
+          widget={pinWidget}
+          subject={feed.url}
+          label={feed.name}
+          className="shrink-0"
+        />
+      )}
+    </div>
   );
 }
 

--- a/desktop/src/datawidgets/rss/FeedTab.tsx
+++ b/desktop/src/datawidgets/rss/FeedTab.tsx
@@ -590,6 +590,7 @@ function RssFeedsPanel({
         }}
         retrying={catalogFetching || catalogAllFetching}
         saving={saving}
+        widgetId={widgetType}
       />
     </div>
   );

--- a/desktop/src/datawidgets/rss/ticker.tsx
+++ b/desktop/src/datawidgets/rss/ticker.tsx
@@ -2,7 +2,7 @@ import type { RssItem } from "../../types";
 import RssChip from "../../components/chips/RssChip";
 import { chipUrlForRss } from "../../utils/chipUrl";
 import type { TickerChip, TickerContext, TickerSource } from "../ticker";
-import { scopedRows } from "../ticker";
+import { scopedRows, dropPinned } from "../ticker";
 import { selectRssForTicker, arrangeRssSlots } from "./view";
 import { catalogItemById } from "../../marketplace";
 
@@ -30,7 +30,7 @@ export const rssTickerSource: TickerSource = {
       if (Number.isFinite(t) && t >= dayAgo) perFeed.set(r.feed_url, (perFeed.get(r.feed_url) ?? 0) + 1);
     }
     const slots = arrangeRssSlots(
-      selectRssForTicker(rows),
+      dropPinned(selectRssForTicker(rows), ctx, (i) => i.feed_url),
       ctx.cycles ?? {},
       `rss-${ctx.tab}`,
       ctx.rotationMemo,
@@ -38,6 +38,8 @@ export const rssTickerSource: TickerSource = {
     return slots.map(({ key, item, rotateSlot, reserveTitle }) => ({
       key,
       rotateSlot,
+      subject: item.feed_url,
+      pinLabel: item.source_name,
       node: (
         <RssChip
           item={item}
@@ -50,5 +52,42 @@ export const rssTickerSource: TickerSource = {
         />
       ),
     }));
+  },
+
+  // A pinned feed is "this wire, always" -- so the 6h horizon and the 48h
+  // floor both come off and the newest item the widget holds for that feed
+  // is shown, however old. A feed that has published nothing renders nothing.
+  pinnedChip(raw: unknown, ctx: TickerContext): TickerChip | null {
+    const rows = scopedRows<RssItem>(raw, ctx).filter(
+      (r) => r.feed_url === ctx.pinnedSubject,
+    );
+    if (rows.length === 0) return null;
+    const at = (r: RssItem) => new Date(r.published_at ?? r.created_at).getTime();
+    const newest = rows.reduce((a, b) => (at(b) > at(a) ? b : a));
+    const dayAgo = Date.now() - 86_400_000;
+    const today = rows.filter((r) => at(r) >= dayAgo).length;
+    return {
+      key: `pin-rss-${ctx.tab}-${newest.feed_url}`,
+      subject: newest.feed_url,
+      pinLabel: newest.source_name,
+      node: (
+        <RssChip
+          item={newest}
+          comfort={ctx.comfort}
+          colorMode={ctx.chipColorMode}
+          accent={catalogItemById(ctx.tab)?.hex}
+          feedCountToday={today}
+          onClick={() => ctx.onChipClick?.("rss", newest.id, chipUrlForRss(newest))}
+        />
+      ),
+    };
+  },
+
+  subjects(raw: unknown, ctx: TickerContext) {
+    const seen = new Map<string, string>();
+    for (const r of scopedRows<RssItem>(raw, ctx)) {
+      if (!seen.has(r.feed_url)) seen.set(r.feed_url, r.source_name);
+    }
+    return [...seen].map(([subject, label]) => ({ subject, label }));
   },
 };

--- a/desktop/src/datawidgets/sports/FeedTab.tsx
+++ b/desktop/src/datawidgets/sports/FeedTab.tsx
@@ -191,6 +191,7 @@ function SportsFeedTab({ mode, feedContext, widgetId }: FeedTabProps) {
               <StandingsTab
                 leagues={leagues}
                 favoriteTeams={favoriteTeamNames}
+                widgetId={widgetId}
               />
             )}
           </>

--- a/desktop/src/datawidgets/sports/StandingsTab.tsx
+++ b/desktop/src/datawidgets/sports/StandingsTab.tsx
@@ -6,12 +6,15 @@ import { ChevronDown } from "lucide-react";
 import TeamLogo from "../../components/TeamLogo";
 import QueryErrorBanner from "../../components/QueryErrorBanner";
 import { SelectMenu } from "../../components/widget-bar/SelectMenu";
+import PinSubjectButton from "../../components/PinSubjectButton";
 import { standingsOptions } from "../../api/queries";
 import type { Standing } from "../../api/queries";
 
 interface StandingsTabProps {
   leagues: string[];
   favoriteTeams: Set<string>;
+  /** Widget id, so a standings row can pin its team to the ticker. */
+  widgetId?: string;
 }
 
 type SportType = "soccer" | "nfl" | "nba" | "nhl" | "mlb" | "other";
@@ -118,17 +121,21 @@ function GroupHeader({
   name,
   isCollapsed,
   onToggle,
+  span,
 }: {
   name: string;
   isCollapsed: boolean;
   onToggle: () => void;
+  /** Column count, so the header still spans the table after the pin
+   *  column was added (REL-239). Was a hardcoded 9. */
+  span: number;
 }) {
   return (
     <tr
       className="bg-surface-hover cursor-pointer select-none hover:bg-surface-hover/80 "
       onClick={onToggle}
     >
-      <td colSpan={9} className="px-3 py-1.5 text-xs font-semibold text-fg-2">
+      <td colSpan={span} className="px-3 py-1.5 text-xs font-semibold text-fg-2">
         <div className="flex items-center gap-1.5">
           <ChevronDown
             size={14}
@@ -153,7 +160,7 @@ function getZoneColor(description?: string): string | null {
   return null;
 }
 
-export function StandingsTab({ leagues, favoriteTeams }: StandingsTabProps) {
+export function StandingsTab({ leagues, favoriteTeams, widgetId }: StandingsTabProps) {
   const reduceMotion = useReducedMotion();
   const [selected, setSelected] = useState(leagues[0] ?? "");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
@@ -289,6 +296,10 @@ export function StandingsTab({ leagues, favoriteTeams }: StandingsTabProps) {
                     {col.label}
                   </th>
                 ))}
+                {/* Header for the pin column. No label: the icon in each
+                    row says what it is, and a word here would widen a
+                    table that is already fighting for horizontal room. */}
+                <th className="w-8 px-1 py-2" aria-label="Pin to ticker" />
               </tr>
             </thead>
             <tbody>
@@ -301,6 +312,7 @@ export function StandingsTab({ leagues, favoriteTeams }: StandingsTabProps) {
                         name={group.groupName}
                         isCollapsed={collapsed.has(group.groupName)}
                         onToggle={() => toggleGroup(group.groupName)}
+                        span={columns.length + 1}
                       />
                     )}
                     {!collapsed.has(group.groupName) &&
@@ -336,6 +348,19 @@ export function StandingsTab({ leagues, favoriteTeams }: StandingsTabProps) {
                                 {col.getValue(s)}
                               </td>
                             ))}
+                            {/* One row is one team, which is exactly one
+                                pinnable subject -- the only sports surface
+                                where that is true without asking which of
+                                two teams was meant (REL-239). */}
+                            <td className="w-8 px-1 py-1.5 text-right">
+                              {widgetId && (
+                                <PinSubjectButton
+                                  widget={widgetId}
+                                  subject={s.team_name}
+                                  label={s.team_name}
+                                />
+                              )}
+                            </td>
                           </tr>
                         );
                       })}

--- a/desktop/src/datawidgets/sports/ticker.tsx
+++ b/desktop/src/datawidgets/sports/ticker.tsx
@@ -2,13 +2,16 @@ import type { Game } from "../../types";
 import GameChip from "../../components/chips/GameChip";
 import { chipUrlForSports } from "../../utils/chipUrl";
 import type { TickerChip, TickerContext, TickerSource } from "../ticker";
-import { scopedRows } from "../ticker";
+import { scopedRows, dropPinned } from "../ticker";
 import {
   selectSportsForTicker,
   getSportsDisplayConfig,
   arrangeTickerSlots,
+  gamesForTeam,
+  widestShortName,
   TICKER_SLOTS,
 } from "./view";
+import { teamShortName } from "../../utils/teamShortName";
 import { catalogItemById } from "../../marketplace";
 
 /**
@@ -36,7 +39,13 @@ export const sportsTickerSource: TickerSource = {
     // league the old single "sports channel" red; it now takes the widget's
     // own colour, as the catalog cards and Home ticker already do.
     const accent = catalogItemById(ctx.tab)?.hex;
-    const eligible = selectSportsForTicker(rows, config);
+    // A pinned team's fixture is in the fixed zone; drop it from the tape
+    // so the same game is not on the bar twice. Both sides are checked --
+    // a fixture is about both teams (§8.5).
+    const eligible = dropPinned(selectSportsForTicker(rows, config), ctx, (g) => [
+      g.home_team_name,
+      g.away_team_name,
+    ]);
     const slots = arrangeTickerSlots(
       eligible,
       favorites,
@@ -48,6 +57,12 @@ export const sportsTickerSource: TickerSource = {
     return slots.map(({ key, game, rotateSlot, reserveNames }) => ({
       key,
       rotateSlot,
+      // A game chip is about two subjects. The one a right-click offers is
+      // the home team: it is the durable half of "who is playing at home
+      // tonight", and offering both would need a submenu on a bar you are
+      // meant to glance at. The away team is pinnable from the widget page.
+      subject: game.home_team_name,
+      pinLabel: teamShortName(game.league, game.home_team_name),
       node: (
         <GameChip
           game={game}
@@ -61,6 +76,48 @@ export const sportsTickerSource: TickerSource = {
         />
       ),
     }));
+  },
+
+  pinnedChip(raw: unknown, ctx: TickerContext): TickerChip | null {
+    const team = ctx.pinnedSubject;
+    if (!team) return null;
+    // No horizon and no day window: the pin IS the selection (§8.5).
+    const mine = gamesForTeam(scopedRows<Game>(raw, ctx), team);
+    const game = mine[0];
+    if (!game) return null;
+    return {
+      key: `pin-spo-${ctx.tab}-${team}`,
+      subject: team,
+      pinLabel: teamShortName(game.league, team),
+      node: (
+        <GameChip
+          game={game}
+          comfort={ctx.comfort}
+          colorMode={ctx.chipColorMode}
+          accent={catalogItemById(ctx.tab)?.hex}
+          // The pinned team is fixed; the opponent is not. Reserving the
+          // widest opponent across its own fixtures is what keeps the chip
+          // from resizing when tonight's final rolls to Sunday's fixture.
+          reserveNames={{
+            away: widestShortName(mine, (g) => g.away_team_name),
+            home: widestShortName(mine, (g) => g.home_team_name),
+          }}
+          onClick={() =>
+            ctx.onChipClick?.("sports", game.id, chipUrlForSports(game))
+          }
+        />
+      ),
+    };
+  },
+
+  subjects(raw: unknown, ctx: TickerContext) {
+    const seen = new Map<string, string>();
+    for (const g of scopedRows<Game>(raw, ctx)) {
+      for (const name of [g.home_team_name, g.away_team_name]) {
+        if (!seen.has(name)) seen.set(name, teamShortName(g.league, name));
+      }
+    }
+    return [...seen].map(([subject, label]) => ({ subject, label }));
   },
 };
 

--- a/desktop/src/datawidgets/sports/view.test.ts
+++ b/desktop/src/datawidgets/sports/view.test.ts
@@ -466,3 +466,62 @@ describe("arrangeTickerSlots", () => {
     expect(out.map((s) => s.key)).toEqual(["p-1", "p-2", "p-3", "p-4"]);
   });
 });
+
+// ── REL-239: a pin bypasses the horizon ───────────────────────────
+
+import { gamesForTeam, widestShortName } from "./view";
+
+const DAY = 86_400_000;
+const HOUR = 3_600_000;
+
+describe("gamesForTeam", () => {
+  const yanks = (over: Partial<Game> & { id: number }): Game =>
+    ({ ...mk({ id: over.id }), ...over, home_team_name: "New York Yankees" });
+
+  it("shows the next fixture even when every horizon would hide it", () => {
+    // Nine days out: past TICKER_UPCOMING_HOURS (24h) and past the
+    // 7-day floor, so the rail would show nothing for this team. The
+    // pin is the user overriding exactly that.
+    const far = yanks({ id: 1, state: "pre", start_time: new Date(NOW.getTime() + 9 * DAY).toISOString() });
+    expect(selectSportsForTicker([far], {})).toEqual([]);
+    expect(gamesForTeam([far], "New York Yankees")[0]).toBe(far);
+  });
+
+  it("prefers live, then the soonest upcoming, then the newest final", () => {
+    const live = yanks({ ...liveGame(1), id: 1 });
+    const soon = yanks({ id: 2, state: "pre", start_time: new Date(NOW.getTime() + 2 * DAY).toISOString() });
+    const later = yanks({ id: 3, state: "pre", start_time: new Date(NOW.getTime() + 5 * DAY).toISOString() });
+    const oldFinal = yanks({ id: 4, state: "final", start_time: new Date(NOW.getTime() - 5 * DAY).toISOString() });
+    const newFinal = yanks({ id: 5, state: "final", start_time: new Date(NOW.getTime() - 30 * HOUR).toISOString() });
+
+    const order = gamesForTeam([oldFinal, later, newFinal, soon, live], "New York Yankees");
+    expect(order.map((g) => g.id)).toEqual([1, 2, 3, 5, 4]);
+  });
+
+  it("matches on either side of the fixture", () => {
+    const away = mk({ id: 6, away_team_name: "New York Yankees" });
+    expect(gamesForTeam([away], "New York Yankees")).toEqual([away]);
+  });
+
+  it("returns nothing for a team the widget holds no games for", () => {
+    // The fixed zone then renders nothing, rather than a placeholder.
+    expect(gamesForTeam([mk({ id: 7 })], "New York Yankees")).toEqual([]);
+  });
+});
+
+describe("widestShortName", () => {
+  it("reserves what the chip actually renders, post-shortening", () => {
+    const games = [
+      mk({ id: 1, league: "MLB", home_team_name: "New York Yankees" }),
+      mk({ id: 2, league: "MLB", home_team_name: "Philadelphia Phillies" }),
+    ];
+    // The LONGER raw name is not the widest: 21 chars is over
+    // SHORT_NAME_BUDGET, so the chip renders "Phillies" (8). Measuring
+    // before shortening would reserve 13 characters the chip never uses.
+    expect(widestShortName(games, (g) => g.home_team_name)).toBe("New York Yankees");
+  });
+
+  it("is the empty string for an empty class", () => {
+    expect(widestShortName([], (g) => g.home_team_name)).toBe("");
+  });
+});

--- a/desktop/src/datawidgets/sports/view.ts
+++ b/desktop/src/datawidgets/sports/view.ts
@@ -370,20 +370,62 @@ export function arrangeTickerSlots(
   keyPrefix: string,
   memo?: RotationMemo,
 ): TickerSlot[] {
-  const pinned: Game[] = [];
+  // "favorites", not "pinned": a favourite is exempt from the slot count
+  // and always on the TAPE. A pin (REL-239) is a different thing -- it
+  // lifts one subject out of the tape into the fixed zone. Two features,
+  // two words, since one word for both is what started the confusion.
+  const favorites: Game[] = [];
   const pool: Game[] = [];
   for (const g of eligible) {
     const fav = favoriteTeams.has(g.home_team_name) || favoriteTeams.has(g.away_team_name);
-    (fav ? pinned : pool).push(g);
+    (fav ? favorites : pool).push(g);
   }
-  const widest = (cls: Game[], pick: (g: Game) => string) =>
-    cls.map((g) => teamShortName(g.league, pick(g))).reduce((a, b) => (b.length > a.length ? b : a), "");
   const rotating = rotateSlots(pool, slots, cycles, keyPrefix, (g) => g.id, (cls) => ({
-    away: widest(cls, (g) => g.away_team_name),
-    home: widest(cls, (g) => g.home_team_name),
+    away: widestShortName(cls, (g) => g.away_team_name),
+    home: widestShortName(cls, (g) => g.home_team_name),
   }), memo);
   return [
-    ...pinned.map((g) => ({ key: `${keyPrefix}-${g.id}`, game: g })),
+    ...favorites.map((g) => ({ key: `${keyPrefix}-${g.id}`, game: g })),
     ...rotating.map((r) => ({ key: r.key, game: r.item, rotateSlot: r.rotateSlot, reserveNames: r.reserve })),
   ];
+}
+
+/** Widest rendered short name across a set of games (CHIP_SPEC §4.4). */
+export function widestShortName(games: Game[], pick: (g: Game) => string): string {
+  return games
+    .map((g) => teamShortName(g.league, pick(g)))
+    .reduce((a, b) => (b.length > a.length ? b : a), "");
+}
+
+/**
+ * Every game a team is in, newest-relevant first, with NO horizon.
+ *
+ * The rail's horizon (`onTicker`) is a rule about a glanceable bar: what
+ * is on soon. A pin is the user overriding that for one subject -- "this
+ * team, always" -- so a pinned team shows its next fixture even when the
+ * fixture is nine days out and every horizon would have hidden it.
+ *
+ * Order: live first, then the soonest upcoming, then the most recent
+ * final. Returns [] when the widget holds nothing for the team, and the
+ * fixed zone then renders nothing rather than a placeholder.
+ */
+export function gamesForTeam(
+  games: Game[],
+  team: string,
+  now: number = Date.now(),
+): Game[] {
+  const mine = games.filter(
+    (g) => g.home_team_name === team || g.away_team_name === team,
+  );
+  const at = (g: Game) => {
+    const t = new Date(g.start_time).getTime();
+    return Number.isFinite(t) ? t : now;
+  };
+  const bucket = (g: Game) => (isLive(g) ? 0 : g.state === "final" ? 2 : 1);
+  return mine.sort((a, b) => {
+    const d = bucket(a) - bucket(b);
+    if (d !== 0) return d;
+    // Upcoming: soonest first. Finals: most recent first.
+    return bucket(a) === 2 ? at(b) - at(a) : at(a) - at(b);
+  });
 }

--- a/desktop/src/datawidgets/ticker.test.ts
+++ b/desktop/src/datawidgets/ticker.test.ts
@@ -3,7 +3,7 @@
  * their own reservations; this covers the arithmetic with none.
  */
 import { describe, it, expect } from "vitest";
-import { rotateSlots, type RotationMemo } from "./ticker";
+import { rotateSlots, dropPinned, type RotationMemo, type TickerContext } from "./ticker";
 
 const ids = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `s${i + 1}` }));
 const run = (n: number, slots: number, cycles: Record<string, number> = {}) =>
@@ -81,5 +81,44 @@ describe("rotateSlots with a rotation memo (CHIP_DESIGN.md rule 6)", () => {
     const after = runMemo(ids(3), 4, {}, memo);
     expect(after.find((s) => s.key === "p-slot-0")?.item.id).toBe("s1");
     expect(after.find((s) => s.key === "p-slot-1")?.item.id).toBe("s2");
+  });
+});
+
+// ── REL-239: a pinned subject is on the bar exactly once ──────────
+
+describe("dropPinned", () => {
+  const ctx = (subjects?: string[]) =>
+    ({ pinnedSubjects: subjects && new Set(subjects) }) as unknown as TickerContext;
+
+  it("leaves the pool alone when nothing is pinned", () => {
+    const pool = ids(3);
+    expect(dropPinned(pool, ctx(), (x) => x.id)).toBe(pool);
+    expect(dropPinned(pool, ctx([]), (x) => x.id)).toBe(pool);
+  });
+
+  it("removes a pinned subject before the pool is sliced into slots", () => {
+    // Filtering the POOL, not the rendered chips, is the whole point: a
+    // slot that resolved to a pinned item would render a hole instead.
+    expect(
+      dropPinned(ids(4), ctx(["s2"]), (x) => x.id).map((x) => x.id),
+    ).toEqual(["s1", "s3", "s4"]);
+  });
+
+  it("removes an item pinned under ANY of its subjects", () => {
+    // A fixture is about both teams, so pinning either one lifts the game.
+    const games = [
+      { away: "Yankees", home: "Red Sox" },
+      { away: "Mets", home: "Braves" },
+    ];
+    const left = dropPinned(games, ctx(["Braves"]), (g) => [g.away, g.home]);
+    expect(left).toEqual([{ away: "Yankees", home: "Red Sox" }]);
+  });
+
+  it("rotates over the reduced pool, so the pin frees a slot", () => {
+    const pool = dropPinned(ids(5), ctx(["s1"]), (x) => x.id);
+    const out = rotateSlots(pool, 4, {}, "p", (x) => x.id, () => undefined);
+    expect(out.map((s) => s.item.id)).toEqual(["s2", "s3", "s4", "s5"]);
+    // Four left for four slots: nothing rotates, and s1 is not among them.
+    expect(out.every((s) => s.rotateSlot === undefined)).toBe(true);
   });
 });

--- a/desktop/src/datawidgets/ticker.ts
+++ b/desktop/src/datawidgets/ticker.ts
@@ -31,6 +31,16 @@ export interface TickerChip {
    * slot shows this lap.
    */
   rotateSlot?: string;
+  /**
+   * The durable thing this chip is about -- the team, symbol, feed,
+   * market or monitor behind it, not the item currently showing (REL-239).
+   * It is what a pin attaches to, and what the ticker writes into
+   * `data-pin-subject` so a right-click can resolve the chip under the
+   * cursor back to a pinnable subject.
+   */
+  subject?: string;
+  /** How to name the subject in a menu ("Yankees", "AAPL", "BBC News"). */
+  pinLabel?: string;
 }
 
 /** Everything a source needs to build its chips. */
@@ -54,6 +64,21 @@ export interface TickerContext {
   cycles?: Readonly<Record<string, number>>;
   /** Freezes a rotating slot's item across renders (see `rotateSlots`). */
   rotationMemo?: RotationMemo;
+  /**
+   * Subjects of THIS widget that are pinned to the fixed zone. A source
+   * drops them from its pool before rotating (`dropPinned`) so a pinned
+   * subject is never on the bar twice -- once parked, once scrolling past.
+   * Filtering the pool rather than the rendered chips is what keeps a
+   * rotating slot from resolving to a pinned item and rendering a hole.
+   */
+  pinnedSubjects?: ReadonlySet<string>;
+  /**
+   * Set when the source is being asked for ONE pinned subject's chip
+   * rather than for the rail. A pin bypasses the horizon: the fixed zone
+   * is the user saying "this one, always", so a pinned team shows its
+   * next fixture even when that is a week out.
+   */
+  pinnedSubject?: string;
   onChipClick?: (
     widgetType: string,
     itemId: string | number,
@@ -70,6 +95,41 @@ export interface TickerSource {
    * nothing to show (missing prefs, empty payload).
    */
   chips(raw: unknown, ctx: TickerContext): TickerChip[];
+  /**
+   * The one chip for `ctx.pinnedSubject`, ignoring this source's horizon
+   * and slot count (REL-239).
+   *
+   * Returns null when the subject has nothing to show right now -- a
+   * team between seasons, a feed that has never published, a symbol the
+   * server has no trade for. The fixed zone then renders nothing for it
+   * rather than a placeholder: an empty space is honest, and the pin
+   * comes back on its own when the subject does.
+   */
+  pinnedChip?(raw: unknown, ctx: TickerContext): TickerChip | null;
+  /**
+   * Every subject this widget could pin, for the surfaces that offer a
+   * pin without a chip under the cursor (the widget page, the sidebar).
+   */
+  subjects?(raw: unknown, ctx: TickerContext): Array<{ subject: string; label: string }>;
+}
+
+/**
+ * Drop pinned subjects from a pool before it rotates.
+ *
+ * `subjects` returns every subject an item belongs to -- one for a
+ * symbol or a feed, two for a game (a fixture is about both teams).
+ */
+export function dropPinned<T>(
+  pool: T[],
+  ctx: TickerContext,
+  subjects: (item: T) => string | readonly string[],
+): T[] {
+  const pinned = ctx.pinnedSubjects;
+  if (!pinned || pinned.size === 0) return pool;
+  return pool.filter((item) => {
+    const s = subjects(item);
+    return typeof s === "string" ? !pinned.has(s) : !s.some((x) => pinned.has(x));
+  });
 }
 
 /** One rotating position on the rail. */

--- a/desktop/src/hooks/useAddWidget.ts
+++ b/desktop/src/hooks/useAddWidget.ts
@@ -6,8 +6,7 @@
  *   - DATA widget → POST /users/me/widgets (with the widget's addConfig),
  *     optimistically inserted into the dashboard cache so the Sidebar +
  *     "Added" badge flip on the next paint, then reconciled with the server.
- *   - UTILITY widget → written into preferences (enabled + on-ticker +
- *     auto-pinned to the static zone).
+ *   - UTILITY widget → written into preferences (enabled + on-ticker).
  * Both then navigate to the new widget's feed.
  *
  * Extracted from catalog.tsx (2026-07-01) when the Info page grew its own
@@ -19,7 +18,6 @@ import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { defaultPinForNewWidget } from "../preferences";
 import type { CatalogItem } from "../marketplace";
 import { dataWidgetsApi } from "../api/client";
 import type { DataWidgetRow, WidgetId } from "../api/client";
@@ -92,7 +90,7 @@ export function useAddWidget(): (item: CatalogItem) => Promise<void> {
           to: "/widget/$id",
           params: { id: item.id },
         });
-        toast.success(`${item.name} added`);
+        toast.success(`${item.name} added to the ticker`);
 
         // Fire the network call without blocking the UI. On success
         // we reconcile the optimistic row with the server response.
@@ -148,25 +146,21 @@ export function useAddWidget(): (item: CatalogItem) => Promise<void> {
       } else {
         const nextEnabled = [...prefs.widgets.enabledWidgets, item.id];
         const nextOnTicker = [...prefs.widgets.widgetsOnTicker, item.id];
-        // Auto-pin newly added widgets to the right side so they land
-        // in the static pinned zone instead of disappearing into the
-        // scrolling tape. Preserve any existing pin config (re-adding
-        // a previously-removed widget honors the user's last choice).
-        // Walkthrough fix 2026-05-11 — see preferences.ts:defaultPinForNewWidget.
-        const nextPinned = { ...prefs.widgets.pinnedWidgets };
-        if (!nextPinned[item.id]) {
-          nextPinned[item.id] = defaultPinForNewWidget();
-        }
+        // No auto-pin (REL-239). Every new widget used to be pinned to the
+        // right so the user saw SOMETHING happen -- which quietly spent the
+        // fixed zone on whatever was added last, and for a multi-item widget
+        // froze its rotation on the first few items. The cue the walkthrough
+        // fix was really after is the toast below: it names what was added
+        // and where it went, without deciding the shape of the bar.
         onPrefsChange({
           ...prefs,
           widgets: {
             ...prefs.widgets,
             enabledWidgets: nextEnabled,
             widgetsOnTicker: nextOnTicker,
-            pinnedWidgets: nextPinned,
           },
         });
-        toast.success(`${item.name} added`);
+        toast.success(`${item.name} added to the ticker`);
         navigate({ to: "/widget/$id", params: { id: item.id } });
       }
     },

--- a/desktop/src/hooks/usePinSubject.ts
+++ b/desktop/src/hooks/usePinSubject.ts
@@ -1,0 +1,80 @@
+/**
+ * The one place a pin is written outside the ticker window.
+ *
+ * The ticker's right-click menu writes prefs directly (it owns its own
+ * copy in App.tsx). Every surface inside the main window -- the sidebar
+ * row menu, a widget page's item rows -- goes through here, so the cap
+ * and the refusal message stay in one place instead of three.
+ *
+ * REL-239: a pin is on a SUBJECT (a team, a symbol, a feed, a market, a
+ * single-chip utility), never on a widget.
+ */
+import { useCallback } from "react";
+import { toast } from "sonner";
+
+import { useShell } from "../shell-context";
+import {
+  MAX_PINS,
+  isPinned as isPinnedIn,
+  pinCount,
+  togglePin,
+} from "../preferences";
+import type { AppPreferences } from "../preferences";
+
+/**
+ * Pin or unpin one subject, and say what happened.
+ *
+ * Exported plain (not just through the hook) because `__root.tsx` OWNS
+ * prefs -- it is the provider, so it sits above the context the hook
+ * reads. Two call sites, one implementation, so the cap and the refusal
+ * message cannot drift between the sidebar and a widget page.
+ */
+export function applyPinToggle(
+  prefs: AppPreferences,
+  onPrefsChange: (next: AppPreferences) => void,
+  widget: string,
+  subject: string,
+  label: string,
+): void {
+  const wasPinned = isPinnedIn(prefs, widget, subject);
+  const next = togglePin(prefs, { widget, subject, side: "right" });
+  if (next === prefs) {
+    // Refused, not evicted: the zone holds what the user put there.
+    toast.error(
+      `The ticker already holds ${MAX_PINS} pins — unpin one to pin ${label}`,
+    );
+    return;
+  }
+  onPrefsChange(next);
+  toast.success(wasPinned ? `${label} unpinned` : `${label} pinned to the ticker`);
+}
+
+export interface PinSubjectApi {
+  /** Is this subject in the fixed zone? */
+  isPinned: (widget: string, subject: string) => boolean;
+  /** Is there room for another pin? */
+  hasRoom: boolean;
+  /** Pin or unpin. `label` is only used for the toast. */
+  toggle: (widget: string, subject: string, label: string) => void;
+}
+
+export function usePinSubject(): PinSubjectApi {
+  const { prefs, onPrefsChange } = useShell();
+
+  const isPinned = useCallback(
+    (widget: string, subject: string) => isPinnedIn(prefs, widget, subject),
+    [prefs],
+  );
+
+  const toggle = useCallback(
+    (widget: string, subject: string, label: string) =>
+      applyPinToggle(prefs, onPrefsChange, widget, subject, label),
+    [prefs, onPrefsChange],
+  );
+
+  return {
+    isPinned,
+    hasRoom: pinCount(prefs) < MAX_PINS,
+    toggle,
+  };
+}

--- a/desktop/src/hooks/useWidgetTickerData.test.ts
+++ b/desktop/src/hooks/useWidgetTickerData.test.ts
@@ -21,7 +21,7 @@ function makeWidgetPrefs(widgetsOnTicker: string[]): WidgetPrefs {
     enabledWidgets: widgetsOnTicker,
     sidebarOrder: [],
     widgetsOnTicker,
-    pinnedWidgets: {},
+    pins: [],
     timer: {
       pomodoro: {
         workMins: 25,

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -30,8 +30,12 @@ import {
   resetAll,
   savePrefs,
   migrateUnits,
+  togglePin,
+  isPinned,
+  pinCount,
+  MAX_PINS,
 } from "./preferences";
-import type { AppPreferences, WidgetPrefs } from "./preferences";
+import type { AppPreferences, WidgetPrefs, WidgetPin } from "./preferences";
 
 const storeValues = vi.hoisted(() => new Map<string, unknown>());
 
@@ -885,5 +889,148 @@ describe("ticker values renamed to match their labels (REL-207)", () => {
     loadPrefs();
     expect(storeValues.has("scrollr:widget:weather:unit")).toBe(false);
     expect(storeValues.has("scrollr:widget:clock:format")).toBe(false);
+  });
+});
+
+// ── REL-239: a pin follows a subject, not a widget ────────────────
+
+describe("pin migration (pinnedWidgets → pins)", () => {
+  it("carries a pinned single-chip utility over unchanged", () => {
+    const prefs = mergeWidgetPrefs({
+      pinnedWidgets: { clock: { side: "left" }, weather: { side: "right" } },
+    } as unknown as Partial<WidgetPrefs>);
+
+    // A utility renders one chip, so its old widget pin already WAS a pin
+    // on a subject. The user must not be able to tell the model changed.
+    expect(prefs.pins).toEqual([
+      { widget: "clock", subject: "clock", side: "left" },
+      { widget: "weather", subject: "weather", side: "right" },
+    ]);
+  });
+
+  it("drops a pin on a multi-item widget", () => {
+    const prefs = mergeWidgetPrefs({
+      pinnedWidgets: {
+        clock: { side: "right" },
+        sports_mlb: { side: "right" },
+        finance_stocks: { side: "left" },
+        uptime: { side: "right" },
+        github: { side: "right" },
+      },
+    } as unknown as Partial<WidgetPrefs>);
+
+    // Those pins meant "park this widget's first N chips", which froze
+    // its rotation. There is no subject in them to translate to.
+    expect(prefs.pins).toEqual([
+      { widget: "clock", subject: "clock", side: "right" },
+    ]);
+  });
+
+  it("keeps an already-migrated pins array", () => {
+    const prefs = mergeWidgetPrefs({
+      pins: [
+        { widget: "sports_mlb", subject: "New York Yankees", side: "left" },
+        { widget: "finance_stocks", subject: "AAPL", side: "right", row: 1 },
+      ],
+    } as unknown as Partial<WidgetPrefs>);
+
+    expect(prefs.pins).toEqual([
+      { widget: "sports_mlb", subject: "New York Yankees", side: "left" },
+      { widget: "finance_stocks", subject: "AAPL", side: "right", row: 1 },
+    ]);
+  });
+
+  it("discards malformed entries and defaults a bad side", () => {
+    const prefs = mergeWidgetPrefs({
+      pins: [
+        null,
+        "clock",
+        { widget: "clock" },
+        { subject: "AAPL" },
+        { widget: "finance_stocks", subject: "AAPL", side: "sideways" },
+      ],
+    } as unknown as Partial<WidgetPrefs>);
+
+    expect(prefs.pins).toEqual([
+      { widget: "finance_stocks", subject: "AAPL", side: "right" },
+    ]);
+  });
+
+  it("returns no pins when nothing was stored", () => {
+    expect(mergeWidgetPrefs({}).pins).toEqual([]);
+    expect(
+      mergeWidgetPrefs({ pinnedWidgets: [] } as unknown as Partial<WidgetPrefs>).pins,
+    ).toEqual([]);
+  });
+});
+
+describe("togglePin", () => {
+  const base = (pins: WidgetPin[]): AppPreferences =>
+    ({ widgets: { ...mergeWidgetPrefs({}), pins } }) as AppPreferences;
+
+  it("adds and removes one subject", () => {
+    const pin = { widget: "finance_stocks", subject: "AAPL", side: "right" } as const;
+    const added = togglePin(base([]), pin);
+    expect(added.widgets.pins).toEqual([pin]);
+    expect(togglePin(added, pin).widgets.pins).toEqual([]);
+  });
+
+  it("refuses a pin past the cap instead of evicting one", () => {
+    const full = base(
+      Array.from({ length: MAX_PINS }, (_, i) => ({
+        widget: "finance_stocks",
+        subject: `SYM${i}`,
+        side: "right" as const,
+      })),
+    );
+    const after = togglePin(full, {
+      widget: "finance_stocks",
+      subject: "ONE-MORE",
+      side: "right",
+    });
+
+    // Same reference back: nothing was written, and nothing the user
+    // parked there was quietly dropped to make room.
+    expect(after).toBe(full);
+    expect(after.widgets.pins).toHaveLength(MAX_PINS);
+  });
+
+  it("counts the cap across both sides, not per side", () => {
+    // The two zones sit at opposite ends of ONE bar and take their width
+    // out of the same tape, so a left-side pin is not free.
+    const full = base(
+      Array.from({ length: MAX_PINS }, (_, i) => ({
+        widget: "finance_stocks",
+        subject: `SYM${i}`,
+        side: "right" as const,
+      })),
+    );
+    expect(pinCount(full)).toBe(MAX_PINS);
+    const after = togglePin(full, {
+      widget: "finance_stocks",
+      subject: "LEFTY",
+      side: "left",
+    });
+    expect(after).toBe(full);
+  });
+
+  it("unpins even when the side is full", () => {
+    const pins = Array.from({ length: MAX_PINS }, (_, i) => ({
+      widget: "finance_stocks",
+      subject: `SYM${i}`,
+      side: "right" as const,
+    }));
+    const after = togglePin(base(pins), pins[0]);
+    expect(after.widgets.pins).toHaveLength(MAX_PINS - 1);
+  });
+
+  it("reports whether a subject is pinned", () => {
+    const prefs = base([
+      { widget: "sports_mlb", subject: "New York Yankees", side: "right" },
+    ]);
+    expect(isPinned(prefs, "sports_mlb", "New York Yankees")).toBe(true);
+    expect(isPinned(prefs, "sports_mlb", "Boston Red Sox")).toBe(false);
+    // Same subject name under a different widget is a different pin.
+    expect(isPinned(prefs, "sports_nfl", "New York Yankees")).toBe(false);
   });
 });

--- a/desktop/src/preferences.test.ts
+++ b/desktop/src/preferences.test.ts
@@ -947,6 +947,10 @@ describe("pin migration (pinnedWidgets → pins)", () => {
         "clock",
         { widget: "clock" },
         { subject: "AAPL" },
+        // An empty subject names nothing — shed it on load, so a pin
+        // already written by an earlier build stops holding a slot.
+        { widget: "sports_mlb", subject: "", side: "right" },
+        { widget: "", subject: "AAPL", side: "right" },
         { widget: "finance_stocks", subject: "AAPL", side: "sideways" },
       ],
     } as unknown as Partial<WidgetPrefs>);
@@ -1022,6 +1026,16 @@ describe("togglePin", () => {
     }));
     const after = togglePin(base(pins), pins[0]);
     expect(after.widgets.pins).toHaveLength(MAX_PINS - 1);
+  });
+
+  it("refuses a pin with no subject", () => {
+    // Found on the running app: an MLB standings row with an empty
+    // `team_name` produced {subject: ""}, a pin holding a slot in a
+    // capped zone that could never resolve to a chip. Guarded in
+    // togglePin because every write routes through it.
+    const prefs = base([]);
+    expect(togglePin(prefs, { widget: "sports_mlb", subject: "", side: "right" })).toBe(prefs);
+    expect(togglePin(prefs, { widget: "", subject: "AAPL", side: "right" })).toBe(prefs);
   });
 
   it("reports whether a subject is pinned", () => {

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -1396,7 +1396,11 @@ function migratePins(saved: Record<string, unknown>): WidgetPin[] {
           p != null &&
           typeof p === "object" &&
           typeof (p as WidgetPin).widget === "string" &&
-          typeof (p as WidgetPin).subject === "string",
+          (p as WidgetPin).widget !== "" &&
+          typeof (p as WidgetPin).subject === "string" &&
+          // An empty subject names nothing, so its chip can never resolve:
+          // it would hold a slot in a capped zone forever. Shed it on load.
+          (p as WidgetPin).subject !== "",
       )
       .map((p) => ({
         widget: p.widget,
@@ -1457,6 +1461,12 @@ export function togglePin(
   prefs: AppPreferences,
   pin: WidgetPin,
 ): AppPreferences {
+  // An empty subject names nothing. Guarded here rather than at each call
+  // site because every write routes through this function, and a source
+  // row with a missing name is a data gap, not a caller's mistake -- a
+  // standings row with no `team_name` produced exactly this, and the pin
+  // it made held a slot in the zone that could never render a chip.
+  if (pin.widget === "" || pin.subject === "") return prefs;
   const pins = prefs.widgets.pins;
   const at = pins.findIndex(
     (p) => p.widget === pin.widget && p.subject === pin.subject,

--- a/desktop/src/preferences.ts
+++ b/desktop/src/preferences.ts
@@ -273,8 +273,80 @@ export interface GitHubWidgetConfig {
   repos: Array<{ owner: string; repo: string }>;
 }
 
-export interface WidgetPinConfig {
+/**
+ * One pin on the ticker's fixed zone.
+ *
+ * A pin attaches to a durable SUBJECT -- a team, a symbol, a feed, a
+ * market, a monitor, or a single-chip utility -- never to a widget.
+ * The fixed zone shows that subject's current chip, and shows nothing
+ * when the subject has nothing to show. Pinning a whole multi-item
+ * widget (what `pinnedWidgets` did until REL-239) froze that widget's
+ * rotation on its first N items, which is the opposite of what a pin
+ * on a glanceable bar should mean.
+ *
+ * `subject` is the source's own durable id for the thing:
+ *   sports      -> team name           ("New York Yankees")
+ *   finance     -> symbol              ("AAPL")
+ *   rss         -> feed url
+ *   predictions -> market id
+ *   uptime      -> monitor id          github -> repo id
+ *   clock / timer / weather / sysmon -> the widget id itself (one chip)
+ */
+export interface WidgetPin {
+  /** Widget id that owns the subject (sports_mlb, finance_stocks, clock…). */
+  widget: string;
+  /** The durable thing the pin follows. */
+  subject: string;
   side: PinSide;
+  /** Reserved for a multi-row bar. Unused today; carried so a stored
+   *  value survives a round-trip rather than being silently dropped. */
+  row?: number;
+}
+
+/**
+ * How many subjects the fixed zone will hold.
+ *
+ * MEASURED, not guessed (CHIP_SPEC §10.2). Real chip widths, fonts
+ * loaded, from the §10.3 harness:
+ *
+ *   clock 1 zone / timer   221      rss feed (long headline)  527
+ *   weather 1 city         239      game (MLB)                541
+ *   symbol / market /               clock 3 zones             554
+ *     monitor / repo       264      weather 3 cities          583
+ *                                   game (worst NCAA names)   605
+ *                                   sysmon 4 metrics          614
+ *                                   any content-sized chip
+ *                                     at CHIP_MAX_PX          640
+ *
+ * Narrowest bar the app runs on: 1280 logical px (a 4K panel at 300%
+ * scaling; also a 1280x800 laptop). The zone's own chrome is 17px
+ * (px-2 + the divider) and chips sit 8px apart.
+ *
+ * The tape has to stay a tape: it keeps at least one full-width chip,
+ * CHIP_MAX_PX = 640. That leaves the fixed zone 1280 - 640 = 640px.
+ * Against the TYPICAL pinned chip (264px -- every fixed-width chip, and
+ * a one-zone clock is smaller still):
+ *
+ *   2 pins -> 264*2 + 8 + 17 = 553  <= 640   fits, 727px of tape
+ *   3 pins -> 264*3 + 16 + 17 = 825  > 640   tape drops to 455px,
+ *                                            less than one chip wide
+ *
+ * So: two. Accepted cost (§8.6): the cap is on COUNT, not width, so two
+ * pinned wide chips (a game plus a four-metric sysmon, 541 + 614) still
+ * overrun a 1280px bar. Capping width instead would mean truncating a
+ * pinned chip, which §1.2 forbids outright.
+ *
+ * A pin past the cap is REFUSED -- the zone never evicts something the
+ * user deliberately parked there.
+ */
+export const MAX_PINS = 2;
+
+/** Widgets whose ticker chip is a single chip for the whole widget, so
+ *  the widget IS the subject. Everything else pins per item. */
+export const SINGLE_CHIP_WIDGETS = ["clock", "timer", "weather", "sysmon"] as const;
+
+export function isSingleChipWidget(widgetId: string): boolean {
+  return (SINGLE_CHIP_WIDGETS as readonly string[]).includes(widgetId);
 }
 
 export interface WidgetPrefs {
@@ -284,9 +356,9 @@ export interface WidgetPrefs {
   sidebarOrder: string[];
   /** Widget IDs whose data appears on the ticker. Subset of enabledWidgets. */
   widgetsOnTicker: string[];
-  /** Per-widget pin state: removes the chip from the scrolling ticker and
-   *  places it as a static element on the chosen side. Keyed by widget ID. */
-  pinnedWidgets: Record<string, WidgetPinConfig>;
+  /** The fixed zone, in render order. Each entry pins one SUBJECT, whose
+   *  current chip is lifted out of the scrolling tape (REL-239). */
+  pins: WidgetPin[];
   timer: TimerWidgetConfig;
   sysmon: SysmonWidgetConfig;
   uptime: UptimeWidgetConfig;
@@ -553,7 +625,7 @@ const DEFAULT_WIDGETS: WidgetPrefs = {
   enabledWidgets: ["clock"],
   sidebarOrder: [],
   widgetsOnTicker: ["clock"],
-  pinnedWidgets: {},
+  pins: [],
   timer: {
     pomodoro: { ...DEFAULT_TIMER_POMODORO },
   },
@@ -706,12 +778,7 @@ export function mergeWidgetPrefs(saved?: Partial<WidgetPrefs>): WidgetPrefs {
       : [],
     // Migration: if widgetsOnTicker doesn't exist, default to enabledWidgets
     widgetsOnTicker,
-    pinnedWidgets:
-      saved.pinnedWidgets != null &&
-      typeof saved.pinnedWidgets === "object" &&
-      !Array.isArray(saved.pinnedWidgets)
-        ? (saved.pinnedWidgets as Record<string, WidgetPinConfig>)
-        : {},
+    pins: migratePins(saved as Record<string, unknown>),
     // Stored clock/weather blocks and the per-widget `ticker` sub-configs
     // (other than sysmon's) are dropped here: the fields were force-reset
     // on every load since 2026-07-17 and REL-208 removed them outright.
@@ -1299,46 +1366,119 @@ export function disableWidget(
       widgetsOnTicker: prefs.widgets.widgetsOnTicker.filter(
         (id) => id !== widgetId,
       ),
+      // A pin outlives a refetch on purpose, but not the widget that owns
+      // its subject: a pinned symbol from a deleted watchlist would hold a
+      // slot in the fixed zone that can never render anything again.
+      pins: prefs.widgets.pins.filter((p) => p.widget !== widgetId),
     },
   };
 }
 
 /**
- * Default pin config for a newly-added widget.
+ * Read the stored pin list, migrating the pre-REL-239 blob.
  *
- * Walkthrough fix 2026-05-11 — testers added widgets and saw nothing
- * "happen" because the widget joined the scrolling ticker tape rather
- * than appearing in the static pinned zone where they expected widget-
- * style controls (clock, weather, etc.) to live. Defaulting to a
- * right-side pin on row 0 means a newly-added widget appears in the
- * pinned zone immediately. Users can still drag or re-pin to the left
- * or unpin to make it scroll.
+ * `pinnedWidgets` was `Record<widgetId, {side}>` -- a pin on a WIDGET.
+ * For a multi-item widget that meant "park this widget's first N chips
+ * in the fixed zone", which froze its rotation: the ninth monitor or
+ * the twentieth symbol could never come round. Those pins are dropped,
+ * not translated, because there is no subject in them to translate to.
  *
- * Lives in one place so the catalog add path, the sidebar toggle path,
- * and the first-time toggleWidgetPin default all stay consistent.
+ * A single-chip utility (clock, timer, weather, sysmon) has exactly one
+ * chip, so its old pin already WAS a pin on a subject. Those carry over
+ * unchanged -- a pinned clock looks and behaves identically after the
+ * migration, which is the point.
  */
-export function defaultPinForNewWidget(): WidgetPinConfig {
-  return { side: "right" };
+function migratePins(saved: Record<string, unknown>): WidgetPin[] {
+  if (Array.isArray(saved.pins)) {
+    return saved.pins
+      .filter(
+        (p): p is WidgetPin =>
+          p != null &&
+          typeof p === "object" &&
+          typeof (p as WidgetPin).widget === "string" &&
+          typeof (p as WidgetPin).subject === "string",
+      )
+      .map((p) => ({
+        widget: p.widget,
+        subject: p.subject,
+        side: (p.side === "left" ? "left" : "right") as PinSide,
+        ...(typeof p.row === "number" ? { row: p.row } : {}),
+      }))
+      .slice(0, MAX_PINS);
+  }
+
+  const legacy = saved.pinnedWidgets;
+  if (legacy == null || typeof legacy !== "object" || Array.isArray(legacy)) {
+    return [];
+  }
+  return Object.entries(legacy as Record<string, { side?: unknown }>)
+    .filter(([widgetId]) => isSingleChipWidget(widgetId))
+    .map(([widgetId, cfg]) => ({
+      widget: widgetId,
+      subject: widgetId,
+      side: (cfg?.side === "left" ? "left" : "right") as PinSide,
+    }))
+    .slice(0, MAX_PINS);
 }
 
-/** Toggle a widget's pin state. Returns a new AppPreferences. */
-export function toggleWidgetPin(
+/** Is this subject currently pinned? */
+export function isPinned(
+  prefs: AppPreferences,
+  widget: string,
+  subject: string,
+): boolean {
+  return prefs.widgets.pins.some(
+    (p) => p.widget === widget && p.subject === subject,
+  );
+}
+
+/**
+ * Pins in the fixed zone.
+ *
+ * Counted across both sides, not per side: the two zones sit at opposite
+ * ends of ONE bar and take their width out of the same tape. Only the
+ * right side is reachable from the UI anyway -- a left-side pin can now
+ * only arrive from the pre-REL-239 migration.
+ */
+export function pinCount(prefs: AppPreferences): number {
+  return prefs.widgets.pins.length;
+}
+
+/**
+ * Toggle a pin on one subject.
+ *
+ * Adding past `MAX_PINS` is REFUSED: the same `prefs` reference comes
+ * back, so the caller can tell nothing happened and say so. The zone
+ * never evicts an existing pin to make room -- the user put it there on
+ * purpose and a bar that silently drops things is worse than one that
+ * says "full".
+ */
+export function togglePin(
+  prefs: AppPreferences,
+  pin: WidgetPin,
+): AppPreferences {
+  const pins = prefs.widgets.pins;
+  const at = pins.findIndex(
+    (p) => p.widget === pin.widget && p.subject === pin.subject,
+  );
+  if (at >= 0) {
+    return {
+      ...prefs,
+      widgets: { ...prefs.widgets, pins: pins.filter((_, i) => i !== at) },
+    };
+  }
+  if (pinCount(prefs) >= MAX_PINS) return prefs;
+  return { ...prefs, widgets: { ...prefs.widgets, pins: [...pins, pin] } };
+}
+
+/** Drop every pin belonging to a widget. Used when the widget is removed. */
+export function dropPinsForWidget(
   prefs: AppPreferences,
   widgetId: string,
 ): AppPreferences {
-  const pinned = { ...prefs.widgets.pinnedWidgets };
-  if (pinned[widgetId]) {
-    delete pinned[widgetId];
-  } else {
-    // First-time pin from the toggle uses the same default as a
-    // brand-new widget so the manual-pin path doesn't diverge from
-    // the auto-pin path.
-    pinned[widgetId] = defaultPinForNewWidget();
-  }
-  return {
-    ...prefs,
-    widgets: { ...prefs.widgets, pinnedWidgets: pinned },
-  };
+  const pins = prefs.widgets.pins.filter((p) => p.widget !== widgetId);
+  if (pins.length === prefs.widgets.pins.length) return prefs;
+  return { ...prefs, widgets: { ...prefs.widgets, pins } };
 }
 
 /** Shallow-merge a patch into a widget's config. Returns a new AppPreferences. */

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import {
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { applyPinToggle } from "../hooks/usePinSubject";
 import {
   enable as enableAutostart,
   disable as disableAutostart,
@@ -593,6 +594,18 @@ function RootLayout() {
     [toggleOnTicker],
   );
 
+  // A single-chip widget IS its own subject, so the sidebar row can pin
+  // it without asking which item was meant (REL-239).
+  const handleToggleItemPin = useCallback(
+    (source: { id: string; name: string }) =>
+      applyPinToggle(prefs, persistPrefs, source.id, source.id, source.name),
+    [prefs, persistPrefs],
+  );
+  const pinnedWidgetIds = useMemo(
+    () => new Set(prefs.widgets.pins.map((p) => p.widget)),
+    [prefs.widgets.pins],
+  );
+
   const handleRemoveItem = useCallback(
     (source: { id: string }) => {
       const item = catalogItemById(source.id);
@@ -913,6 +926,8 @@ function RootLayout() {
               onSelectItem={handleSelectPinned}
               onInfoItem={handleInfoItem}
               onToggleItemTicker={handleToggleItemTicker}
+              onToggleItemPin={handleToggleItemPin}
+              pinnedWidgetIds={pinnedWidgetIds}
               onMoveItem={handleMoveSidebarItem}
               onRemoveItem={handleRemoveItem}
             />

--- a/desktop/src/utils/pinTarget.test.ts
+++ b/desktop/src/utils/pinTarget.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The right-click menu reads its pin target out of the DOM, so the parse
+ * is the trust boundary: whatever is on the wrapper has to either yield a
+ * usable target or nothing at all (REL-239).
+ */
+import { describe, it, expect } from "vitest";
+import { parsePinTarget, pinTargetAt } from "./pinTarget";
+
+describe("parsePinTarget", () => {
+  it("reads a well-formed subject", () => {
+    expect(
+      parsePinTarget('{"widget":"sports_mlb","subject":"New York Yankees","label":"Yankees"}'),
+    ).toEqual({
+      widget: "sports_mlb",
+      subject: "New York Yankees",
+      label: "Yankees",
+    });
+  });
+
+  it("falls back to the subject when no label is carried", () => {
+    expect(parsePinTarget('{"widget":"finance_stocks","subject":"AAPL"}')).toEqual({
+      widget: "finance_stocks",
+      subject: "AAPL",
+      label: "AAPL",
+    });
+  });
+
+  it("returns null for anything it cannot vouch for", () => {
+    expect(parsePinTarget(null)).toBeNull();
+    expect(parsePinTarget(undefined)).toBeNull();
+    expect(parsePinTarget("")).toBeNull();
+    expect(parsePinTarget("not json")).toBeNull();
+    expect(parsePinTarget("[]")).toBeNull();
+    expect(parsePinTarget('"clock"')).toBeNull();
+    expect(parsePinTarget('{"widget":"clock"}')).toBeNull();
+    expect(parsePinTarget('{"subject":"clock"}')).toBeNull();
+    // An empty subject is not a subject; it would pin "nothing".
+    expect(parsePinTarget('{"widget":"clock","subject":""}')).toBeNull();
+  });
+});
+
+describe("pinTargetAt", () => {
+  it("walks up from the clicked node to the chip wrapper", () => {
+    document.body.innerHTML = `
+      <div data-chip="" data-pin-subject='{"widget":"clock","subject":"clock","label":"Clock"}'>
+        <button><span id="inner">12:04</span></button>
+      </div>`;
+    expect(pinTargetAt(document.getElementById("inner"))).toEqual({
+      widget: "clock",
+      subject: "clock",
+      label: "Clock",
+    });
+  });
+
+  it("returns null off a chip, and for a non-element target", () => {
+    document.body.innerHTML = `<div id="bare">nothing here</div>`;
+    expect(pinTargetAt(document.getElementById("bare"))).toBeNull();
+    expect(pinTargetAt(null)).toBeNull();
+    expect(pinTargetAt(window)).toBeNull();
+  });
+});

--- a/desktop/src/utils/pinTarget.ts
+++ b/desktop/src/utils/pinTarget.ts
@@ -1,0 +1,49 @@
+/**
+ * Resolve the chip under the cursor to a pinnable subject.
+ *
+ * The ticker tags every chip wrapper (the existing `data-chip` element)
+ * with `data-pin-subject`, a JSON `{widget, subject, label}`. One
+ * attribute rather than three because the three parts are only ever
+ * useful together, and a chip with no pinnable subject then simply has
+ * no attribute rather than a half-filled set.
+ *
+ * Written as a module, not inline in the context-menu handler, because
+ * the parse has to survive whatever is on the wrapper: a chip from an
+ * older render, a hand-edited DOM, a subject that is the empty string.
+ * Anything it cannot vouch for returns null and the menu just omits the
+ * item (REL-239).
+ */
+export interface PinTarget {
+  /** Widget id that owns the subject (sports_mlb, finance_stocks, clock…). */
+  widget: string;
+  /** The durable thing the pin follows (team name, symbol, feed url…). */
+  subject: string;
+  /** How to name it in the menu. */
+  label: string;
+}
+
+/** Parse one `data-pin-subject` value. Null for anything malformed. */
+export function parsePinTarget(raw: string | null | undefined): PinTarget | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed == null || typeof parsed !== "object") return null;
+  const { widget, subject, label } = parsed as Record<string, unknown>;
+  if (typeof widget !== "string" || widget === "") return null;
+  if (typeof subject !== "string" || subject === "") return null;
+  return {
+    widget,
+    subject,
+    label: typeof label === "string" && label !== "" ? label : subject,
+  };
+}
+
+/** Walk up from an event target to the nearest pinnable chip. */
+export function pinTargetAt(node: EventTarget | null): PinTarget | null {
+  const el = node instanceof Element ? node.closest("[data-pin-subject]") : null;
+  return parsePinTarget(el?.getAttribute("data-pin-subject"));
+}

--- a/docs/CHIP_DESIGN.md
+++ b/docs/CHIP_DESIGN.md
@@ -108,8 +108,11 @@ system metrics matter to you, which monitors and repos to watch. These are *what
 care about*, and they're yours everywhere.
 
 **You control how the bar looks and moves.** Compact or detailed. Speed, direction, gap,
-whether it pauses on hover. Continuous, step or flip. Grouped or woven. Colour mode. Pin a
-widget so it never scrolls. Where the bar sits.
+whether it pauses on hover. Continuous, step or flip. Grouped or woven. Colour mode.
+Where the bar sits.
+
+**You can pin two things.** See below — a pin is its own thing, and it's the one control
+that's a bit of both.
 
 **You don't control selection.** How many of a widget's things are on the bar at once,
 which of them, in what order, how far back or ahead it looks, or how the rotation runs.
@@ -139,10 +142,56 @@ it. Nothing on the ticker can be misconfigured because nothing on it is configur
 6. **A chip only swaps its content while it's off screen.** Never under your eyes.
 7. **The bar doesn't care how you sorted the list.** Sorting and filtering are for reading
    the widget page; they don't rearrange the ticker.
+8. **Two things can sit still at the end of the bar** — see "Pinning", next.
 
 The honest cost: a short name sharing a place with a long one carries the long one's
 width, and a full slate takes a few laps to see. Fifty college games through four places
 is about thirteen laps.
+
+## Pinning
+
+A pin parks something at the end of the bar so it never scrolls away. It's the one thing
+on the ticker you get to decide the position of, and it works like this:
+
+**You pin a thing, not a widget.** A team. A symbol. A feed. A market. A monitor. Your
+clock. Never "the MLB widget" — that used to be the only thing a pin could mean, and it
+had a nasty side effect: parking a widget froze its rotation, so the ninth monitor or the
+twentieth symbol could never come round. Pin the Yankees and you get the Yankees.
+
+For a clock or the weather this looks exactly like it always did, because there's only
+ever one clock chip. That's the point: it reads as "you can pin anything", without a
+busy widget ever eating the bar.
+
+**A pinned thing shows whatever it's doing now.** Pin a team and the same spot carries
+tonight's live game, then the final, then Sunday's fixture — in place, without you
+touching it.
+
+**A pin ignores the time window.** The bar normally only shows a game starting within a
+day. A pin is you overriding that for one thing, so a pinned team's next fixture shows
+even if it's nine days out.
+
+**Nothing to show shows nothing.** A team between seasons leaves an empty space, not a
+placeholder. The chip comes back when the team does.
+
+**A pinned thing isn't also on the tape.** It's in one place, not two.
+
+**Two, and then it says no.** The bar is 1280 pixels wide on the narrowest screen we
+support and a chip can be 640 of them, so two is what fits with a tape still left over.
+Pin a third and it tells you the bar is full rather than quietly dropping one of yours.
+
+**Pinning is not starring.** A star, a favourite, a watchlist entry all mean "always on
+the tape, never rotated out". A pin means "out of the tape, parked at the end". They're
+different jobs and they stack: pin your favourite team and the rest of your favourites
+carry on scrolling.
+
+**You pin by right-clicking the bar** — on the chip itself, so the menu can say "Pin
+Yankees" and mean it. Also from a widget's own page, next to the thing, and from the
+sidebar for the one-chip widgets. There's no icon on the chip any more; a control that
+small, on something that's moving, was never going to work.
+
+**Nothing gets pinned for you.** Adding a widget used to park it at the end of the bar
+automatically, which spent your pinned space on whatever you added last. Now adding a
+widget just tells you it was added.
 
 ## Keep it honest
 
@@ -164,7 +213,9 @@ Two different layouts for the two densities. Every chip the same width. Dots and
 decoration. A dash where a score should be blank. A shared red for close games. The
 weather range squeezed into the compact row. Monitors packed into one chip as cells. A
 per-widget "how many on the bar" control. Naming a time zone twice. Dropping items instead
-of rotating them.
+of rotating them. Pinning a whole widget. A pin icon on the chip. Auto-pinning what you
+just added. Merging pins with stars and favourites. A pinned zone that rotates. Evicting
+someone's pin to make room for a new one.
 
 ## Still to do
 

--- a/docs/CHIP_SPEC.md
+++ b/docs/CHIP_SPEC.md
@@ -442,7 +442,7 @@ shrinks or jumps as a slate fills.
 
 | Widget | Inputs the user owns |
 |---|---|
-| All | Which widgets are on the ticker (`widgetsOnTicker`); pinned widgets |
+| All | Which widgets are on the ticker (`widgetsOnTicker`); which subjects are pinned to the fixed zone (§8.5) |
 | Finance | `config.symbols` (the watchlist, in the user's order) |
 | Predictions | starred markets (`predictionsWatchlist`) |
 | Sports | `config.favoriteTeams[league]` |
@@ -458,7 +458,12 @@ shrinks or jumps as a slate fills.
 `onHover` (keep / slow / pause), `tickerMode` (compact / detailed),
 `mixMode` (grouped / mixed), `chipColors` (widget / theme / subtle),
 `scrollMode` (continuous / page), `stepPause`, `tickerPosition`,
-`hideOnFullscreen`, pinning.
+`hideOnFullscreen`.
+
+Pinning is deliberately NOT in either list above: a pin names a subject, so it is an
+input, but it also decides that the subject leaves the tape, so it touches selection.
+It is the one control that does both, and §8.5 is where it is specified. It does not
+open the door to any other selection setting.
 
 **The user does not control selection.** Never add a setting for: how many chips a
 widget contributes; which eligible items appear; their order; the horizon or floor;
@@ -477,6 +482,8 @@ since they are an input.
 | Source | Eligible (horizon) | Floor | Slots | Pool order | Reserve |
 |---|---|---|---|---|---|
 | Sports | live always; `pre` with `0 <= h <= 24`; `final` with `h >= -18` (from kickoff) | soonest `pre` within 7 days | `TICKER_SLOTS = 4` | `sortForDisplay`: live+close 100, live 80, pre 60 (soonest first), final 30 (newest first) | widest short names per class |
+
+Every pool above is first stripped of the widget's pinned subjects (`dropPinned`, §8.5).
 | News | items within `TICKER_RSS_HOURS = 6` | newest per feed if within `TICKER_RSS_FLOOR_HOURS = 48`; undated counts as current | `TICKER_RSS_SLOTS = 3` | newest first, **interleaved by feed** (round-robin, feeds ordered by their newest item) | longest `plainText(title)` per class |
 | Finance | the widget's `symbols` | — | `TICKER_FINANCE_SLOTS = 4` | watchlist order; unlisted rows trail alphabetically | none |
 | Predictions | stars if any (drop `in_sweep===false` unless resolved); else top `TICKER_FALLBACK_LIMIT = 15` rank-1 by trailing volume | — | `TICKER_PREDICTIONS_SLOTS = 4` | `sortPredictions(..., "trending")` | none |
@@ -485,8 +492,13 @@ since they are an input.
 | Fantasy | bounded by the fantasy ticker dial | — | n/a | as built | n/a |
 
 Sports favourites (`config.favoriteTeams[league].teamName` matching either team name)
-are **pinned**: every one is on the rail, keyed `spo-<tab>-<gameId>`, exempt from the
-slot count.
+are **exempt from the slot count**: every one is on the rail, keyed `spo-<tab>-<gameId>`.
+
+A favourite is not a pin, and the two do not merge (REL-239). A favourite — like a
+finance watchlist entry or a starred market — means *always on the tape, exempt from
+slots*. A pin means *out of the tape, parked in the fixed zone*. They compose: pinning a
+favourite lifts that team's fixture into the zone, and the rest of the favourites stay
+on the tape. Do not rename either one into the other.
 
 ### 8.2 `rotateSlots` semantics
 
@@ -539,10 +551,70 @@ instance's rect overlaps the container's rect horizontally. `advanceCycles` incr
 slot only on a visible→hidden transition and returns the same object when nothing
 changed.
 
-### 8.5 Pinned widgets
+### 8.5 Pins (the fixed zone)
 
-`pinnedWidgets[tab]` render in a static zone via `widgetChipsFor(..., { pinned: true })`;
-they never scroll, so `cycles` stays `{}` there and the first `slots` items hold.
+**A pin attaches to a SUBJECT, never to a widget** (REL-239, decided with Brandon
+2026-09-07). The fixed zone keeps its name and its place — that is what users expect a
+pin to mean — but what it holds is one durable thing, and the zone shows that thing's
+current chip.
+
+`prefs.widgets.pins` is an ordered `WidgetPin[]` of `{widget, subject, side, row?}`.
+The subject is the source's own durable id:
+
+| Widget | Subject | Label |
+|---|---|---|
+| Sports | team name (`home_team_name` from the chip) | `teamShortName(league, name)` |
+| Finance | `symbol` | the symbol |
+| News | `feed_url` | `source_name` |
+| Predictions | market `ticker` (not the row `id`) | `event_title \|\| title` |
+| Uptime / GitHub | item `id` | item `label` |
+| Clock / Timer / Weather / Sysmon | the widget id | the catalog name |
+
+The last row is why this reads as universal without a multi-item widget eating the bar:
+a single-chip utility IS its own subject, so a pinned Clock or Weather looks and behaves
+exactly as it did before the model changed.
+
+**Rules:**
+
+1. **One pin, one chip.** `TickerSource.pinnedChip(raw, ctx)` resolves `ctx.pinnedSubject`
+   to exactly one chip. Utilities and capped widgets resolve through
+   `widgetChipsFor(..., { pinnedSubject })` instead, since they have no `TickerSource`.
+2. **A pin bypasses the horizon.** The user already said "this one", so a pinned team
+   shows its next fixture past `TICKER_UPCOMING_HOURS` and past `TICKER_FLOOR_DAYS`
+   (`gamesForTeam`), and a pinned feed shows its newest item past `TICKER_RSS_HOURS`.
+3. **Nothing to show renders nothing.** No placeholder, no dash (§1.7). The pin stays,
+   and the chip returns when the subject does.
+4. **It never scrolls and never rotates.** No `cycles`, no `RotationMemo` in the zone.
+5. **A pinned subject is excluded from the tape**, so it is on the bar exactly once. Each
+   source drops `ctx.pinnedSubjects` from its **pool** via `dropPinned` *before*
+   `rotateSlots` — filtering the rendered chips instead would let a slot resolve to a
+   pinned item and render a hole.
+
+   One accepted overlap, verified on the running bar: if a slot is *currently showing*
+   the subject at the moment it is pinned, that slot keeps it until its own next lap.
+   The rotation memo (§8.2, REL-234) freezes a slot's item until it has gone fully off
+   screen, and that rule outranks this one — a chip must not vanish from under the
+   reader's eyes, not even to enforce de-duplication. It clears itself on the next lap.
+6. **The cap refuses, it never evicts.** `MAX_PINS = 2`, measured (§10.2) against the
+   narrowest bar; the derivation and the chip widths are in `preferences.ts`. `togglePin`
+   returns the same `prefs` reference when full, and every surface says so.
+
+**The control is not on the chip.** The hover pin icon is gone. Pins are set from:
+
+- the ticker's native right-click menu — `App.tsx` resolves the chip under the cursor
+  through `data-pin-subject` on the existing `data-chip` wrapper (`utils/pinTarget.ts`),
+  so the menu names the actual subject ("Pin Yankees", not "Pin MLB");
+- a widget page's item rows (`components/PinSubjectButton.tsx`): the finance watchlist,
+  the news feed manager, a standings row, an open prediction market;
+- the sidebar row's right-click, for single-chip widgets only.
+
+**Nothing is auto-pinned.** A newly added widget used to be pinned to the right so the
+user saw something happen; the cue is a toast naming what was added.
+
+`pinnedWidgets` (the old `Record<widgetId, {side}>`) is migrated in `loadPrefs`:
+single-chip utilities carry over unchanged, and every data-widget pin is **dropped** —
+it meant "park this widget's first N chips", which froze that widget's rotation, and
+there is no subject in it to translate to.
 
 ### 8.6 Costs to state in any PR that adds rotation
 


### PR DESCRIPTION
Pinning keeps the fixed zone and keeps the name, because that is what users expect a pin to mean. What changes is **what a pin attaches to**: one durable *subject* — a team, a symbol, a feed, a market, a monitor, or a single-chip utility — never a widget. The zone shows that subject's current chip.

Decided with Brandon, 2026-09-07. Closes REL-239 and settles REL-195.

## Why the old model was wrong

`prefs.widgets.pinnedWidgets` was `Record<widgetId, {side}>`. For a multi-item widget that meant *"park this widget's first N chips"*, which **froze that widget's rotation** — the ninth monitor or the twentieth symbol could never come round. For a clock or the weather it happened to be right, because those render exactly one chip.

That coincidence is now the design. A single-chip utility **is** its own subject, so **a pinned Clock or Weather looks and behaves exactly as before** — which is what lets the feature read as universal without a busy widget ever eating the bar.

## What's in it

- **Model.** `pins: WidgetPin[]`, an ordered list of `{widget, subject, side, row?}`. Migrated in `loadPrefs`: single-chip utilities carry over unchanged; **every data-widget pin is dropped**, because there is no subject in it to translate to.
- **Resolution.** `TickerSource.pinnedChip()` resolves one subject to one chip. **A pin bypasses the horizon** — a pinned team shows its next fixture past the 24h horizon *and* past the 7-day floor (`gamesForTeam`); a pinned feed shows its newest item past the 6h window. **Nothing to show renders nothing**, no placeholder (§1.7).
- **De-duplication.** A pinned subject is dropped from the source's **pool** via `dropPinned`, *before* `rotateSlots` — filtering rendered chips instead would let a slot resolve to a pinned item and render a hole.
- **Controls.** The hover pin icon is deleted from `CappedChip` and `UtilityChips` (−100 lines): a control that small, on a moving target, could only ever say "pin this widget". It moves to the ticker's **native right-click menu** (resolving the chip under the cursor via `data-pin-subject` on the existing `data-chip` wrapper, so it says *"Pin Yankees"*, not *"Pin MLB"*), to **widget page item rows**, and to the **sidebar right-click** for single-chip widgets.
- **No auto-pin.** `defaultPinForNewWidget` is gone. Adding a widget no longer spends the fixed zone on whatever you added last; the "nothing happened" cue it was fixing is the toast, which now names what was added and where it went.

Favourites, stars and the finance watchlist are untouched — they still mean *always on the tape, exempt from slots*, and they compose with pins. `rotateSlots` and the #339 rotation memo are untouched.

## The cap: `MAX_PINS = 2`

Measured, not guessed (CHIP_SPEC §10.2). Real chip widths from a throwaway §10.3 harness, fonts loaded:

| pinned chip | px | | pinned chip | px |
|---|---:|---|---|---:|
| clock (1 zone) / timer | 221 | | rss feed, long headline | 527 |
| weather (1 city) | 239 | | game (MLB) | 541 |
| symbol / market / monitor / repo | 264 | | clock (3 zones) | 554 |
| | | | weather (3 cities) | 583 |
| | | | game (worst NCAA names) | 605 |
| | | | sysmon (4 metrics) | 614 |
| | | | any content-sized chip at `CHIP_MAX_PX` | 640 |

Narrowest bar the app runs on: **1280 logical px** (a 4K panel at 300% scaling — the dev box has one; also a 1280×800 laptop). Zone chrome is 17px (`px-2` + divider), chips sit 8px apart.

The tape has to stay a tape, so it keeps at least one full-width chip — 640px. That leaves the zone `1280 − 640 = 640px`. Against the **typical** pinned chip (264px, every fixed-width chip; a one-zone clock is smaller still):

- **2 pins** → `264×2 + 8 + 17 = 553` ≤ 640 ✅ — 727px of tape left
- **3 pins** → `264×3 + 16 + 17 = 825` > 640 ❌ — tape drops to 455px, narrower than a single chip

**Accepted cost (§8.6):** the cap is on **count**, not width, so two *wide* pins still overrun a 1280px bar — measured live at **724px** for a clock plus a game (capture 04). Capping width instead would mean truncating a pinned chip, which §1.2 forbids outright.

**Past the cap a pin is refused, never evicted.** `togglePin` returns the same `prefs` reference and each surface says the bar is full — the zone holds what the user deliberately put there.

## Verified on the running bar

Captures on the orphan branch [`captures/rel-239`](https://github.com/doughknee/myscrollr/tree/captures/rel-239) — a pinned clock, a pinned **live** team, a pinned symbol, and both pins at the cap. Shot from the Tauri debug build with `scripts/dev/capture-window.ps1` (PrintWindow, no screen grab).

Also verified live: `pinTargetAt` resolves a nested node inside a tape chip to its subject, a node in the fixed zone to the pinned subject (so the menu reads "Unpin"), and anything off the bar to `null`.

**One accepted overlap, found by looking:** if a slot is *currently showing* the subject at the moment it is pinned, that slot keeps it until its own next lap. The #339 rotation memo freezes a slot's item until it is fully off screen, and that rule outranks de-duplication — a chip must not vanish from under the reader's eyes, not even to enforce this. It clears itself on the next lap (confirmed on the bar). Written into §8.5.

## Docs

CHIP_SPEC §8.5 rewritten (subject table, the six rules, the migration, where the control lives), plus the "What you control" table and the favourites-are-not-pins note in §8.1. CHIP_DESIGN gains a plain-English **Pinning** section and six new entries under "Things we've already decided against".

## Tests

`npm test` green: **747 passed**, including new coverage for the migration (utilities carry over, data-widget pins dropped, malformed entries discarded), de-duplication (`dropPinned`, including a game pinned under either team, and that rotation runs over the reduced pool), the cap (refuses without evicting, counts across both sides, unpins when full), the empty subject (`gamesForTeam` returns nothing → the zone renders nothing), the horizon bypass, and the DOM resolution (`pinTarget`).

## Not in scope

The predictions **card** rows keep only the existing star; the pin there is on the opened market's detail panel. Fantasy has no `pinnedChip` yet — it is rebuilt under REL-184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
