### PR TITLE
fix(auth): a dead session says so, instead of failing every write [REL-238]

### DIFF
--- a/api/internal/widgets/widgets.go
+++ b/api/internal/widgets/widgets.go
@@ -118,6 +118,7 @@ func GetWidgets(c *fiber.Ctx) error {
 func CreateWidget(c *fiber.Ctx) error {
 	userID := platform.GetUserID(c)
 	if userID == "" {
+		log.Printf("[Widgets] create rejected: no user on request")
 		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
 			Status: "unauthorized",
 			Error:  "Authentication required",
@@ -135,6 +136,7 @@ func CreateWidget(c *fiber.Ctx) error {
 		LocalWidgets int `json:"local_widgets"`
 	}
 	if err := c.BodyParser(&req); err != nil {
+		log.Printf("[Widgets] create body parse failed for %s: %v", userID, err)
 		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
 			Status: "error",
 			Error:  "Invalid request body",
@@ -152,6 +154,7 @@ func CreateWidget(c *fiber.Ctx) error {
 	// so coarse types ("sports") kept working during the widget/slot
 	// transition; that transition is over and those types no longer exist.
 	if !platform.IsKnownWidgetType(req.WidgetType) {
+		log.Printf("[Widgets] create rejected for %s: unknown widget type %q", userID, req.WidgetType)
 		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
 			Status: "error",
 			Error:  "Unknown widget type",
@@ -162,6 +165,7 @@ func CreateWidget(c *fiber.Ctx) error {
 	// double-count against the slot cap (once here, once via
 	// local_widgets), so reject it outright.
 	if platform.IsUtilityWidgetType(req.WidgetType) {
+		log.Printf("[Widgets] create rejected for %s: %s is a local utility widget", userID, req.WidgetType)
 		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
 			Status: "error",
 			Error:  "Utility widgets are stored locally, not as server-side widgets",
@@ -230,6 +234,7 @@ func CreateWidget(c *fiber.Ctx) error {
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "unique") || strings.Contains(err.Error(), "duplicate") {
+			log.Printf("[Widgets] create conflict for %s: %s already added", userID, req.WidgetType)
 			return c.Status(fiber.StatusConflict).JSON(platform.ErrorResponse{
 				Status: "error",
 				Error:  "That widget is already added",
@@ -269,6 +274,11 @@ func CreateWidget(c *fiber.Ctx) error {
 func UpdateWidget(c *fiber.Ctx) error {
 	userID := platform.GetUserID(c)
 	if userID == "" {
+		// Every early return below logs. Before REL-238 none of them did,
+		// and a desktop stuck on an expired token produced a per-action
+		// toast on the client and total silence in both replicas — hours
+		// of narrowing to find a 401 nobody had recorded.
+		log.Printf("[Widgets] update rejected: no user on request for %q", c.Params("type"))
 		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
 			Status: "unauthorized",
 			Error:  "Authentication required",
@@ -278,6 +288,7 @@ func UpdateWidget(c *fiber.Ctx) error {
 	widgetType := c.Params("type")
 	// Catalog-only, same as CreateWidget — see the note there.
 	if !platform.IsKnownWidgetType(widgetType) {
+		log.Printf("[Widgets] update rejected for %s: unknown widget type %q", userID, widgetType)
 		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
 			Status: "error",
 			Error:  "Unknown widget type",
@@ -294,6 +305,7 @@ func UpdateWidget(c *fiber.Ctx) error {
 		LocalWidgets int `json:"local_widgets"`
 	}
 	if err := c.BodyParser(&req); err != nil {
+		log.Printf("[Widgets] update body parse failed for %s on %s: %v", userID, widgetType, err)
 		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
 			Status: "error",
 			Error:  "Invalid request body",
@@ -379,6 +391,7 @@ func UpdateWidget(c *fiber.Ctx) error {
 	if err != nil {
 		errStr := err.Error()
 		if strings.Contains(errStr, "no rows") {
+			log.Printf("[Widgets] update 404 for %s: no %s row", userID, widgetType)
 			return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
 				Status: "error",
 				Error:  "Widget not found",
@@ -415,6 +428,7 @@ func UpdateWidget(c *fiber.Ctx) error {
 func DeleteWidget(c *fiber.Ctx) error {
 	userID := platform.GetUserID(c)
 	if userID == "" {
+		log.Printf("[Widgets] delete rejected: no user on request for %q", c.Params("type"))
 		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
 			Status: "unauthorized",
 			Error:  "Authentication required",
@@ -441,6 +455,7 @@ func DeleteWidget(c *fiber.Ctx) error {
 	}
 
 	if tag.RowsAffected() == 0 {
+		log.Printf("[Widgets] delete 404 for %s: no %s row", userID, widgetType)
 		return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
 			Status: "error",
 			Error:  "Widget not found",

--- a/api/internal/widgets/widgets_logging_test.go
+++ b/api/internal/widgets/widgets_logging_test.go
@@ -1,0 +1,192 @@
+package widgets
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// REL-238: a desktop stuck on an expired token failed every widget write
+// with a per-action toast, and both core-api replicas logged NOTHING —
+// the early returns here all returned silently. These tests pin the log
+// lines in place, because a silent rejection is what made the original
+// bug take hours to narrow.
+//
+// Only the returns reachable without a database are exercised: unknown
+// widget type, body-parse failure and the unauthenticated guard. The
+// `no rows` 404 needs a DB round trip and lives with the integration
+// tests; its log line is one `log.Printf` on the same pattern.
+
+// logApp mounts the handlers behind a stand-in for LogtoAuth that seeds
+// user_id from a header, the same shape requestsApp() uses.
+func logApp() *fiber.App {
+	app := fiber.New()
+	seed := func(c *fiber.Ctx) error {
+		if u := c.Get("X-Test-User"); u != "" {
+			c.Locals("user_id", u)
+		}
+		return c.Next()
+	}
+	app.Post("/users/me/widgets", seed, CreateWidget)
+	app.Put("/users/me/widgets/:type", seed, UpdateWidget)
+	app.Delete("/users/me/widgets/:type", seed, DeleteWidget)
+	return app
+}
+
+// captureLog swaps the standard logger's sink for the duration of fn and
+// returns everything written to it.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+	fn()
+	return buf.String()
+}
+
+func doRequest(t *testing.T, app *fiber.App, method, path, user, body string) int {
+	t.Helper()
+	var rdr *strings.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	} else {
+		rdr = strings.NewReader("")
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	req.Header.Set("Content-Type", "application/json")
+	if user != "" {
+		req.Header.Set("X-Test-User", user)
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// wantLog asserts the captured output contains every fragment. Fragments
+// rather than a whole line so the wording can be tuned without breaking
+// the test — what matters is that userID and widgetType are in there.
+func wantLog(t *testing.T, out string, fragments ...string) {
+	t.Helper()
+	for _, f := range fragments {
+		if !strings.Contains(out, f) {
+			t.Errorf("log output missing %q\ngot: %s", f, out)
+		}
+	}
+}
+
+func TestUpdateWidgetLogsUnknownType(t *testing.T) {
+	const user = "logto|rel238"
+	unknown := "definitely_not_a_widget"
+	if platform.IsKnownWidgetType(unknown) {
+		t.Fatalf("%q is unexpectedly a known widget type", unknown)
+	}
+
+	var status int
+	out := captureLog(t, func() {
+		status = doRequest(t, logApp(), http.MethodPut,
+			"/users/me/widgets/"+unknown, user, `{"ticker_enabled":false}`)
+	})
+
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", status)
+	}
+	wantLog(t, out, "[Widgets]", user, unknown)
+}
+
+func TestUpdateWidgetLogsBodyParseFailure(t *testing.T) {
+	const user = "logto|rel238"
+	// A known type so we reach the body parser, with a body that is not JSON.
+	widget := firstKnownWidgetType(t)
+
+	var status int
+	out := captureLog(t, func() {
+		status = doRequest(t, logApp(), http.MethodPut,
+			"/users/me/widgets/"+widget, user, `{"ticker_enabled":`)
+	})
+
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", status)
+	}
+	wantLog(t, out, "[Widgets]", user, widget)
+}
+
+func TestCreateWidgetLogsUnknownType(t *testing.T) {
+	const user = "logto|rel238"
+	unknown := "definitely_not_a_widget"
+
+	var status int
+	out := captureLog(t, func() {
+		status = doRequest(t, logApp(), http.MethodPost,
+			"/users/me/widgets", user, `{"widget_type":"`+unknown+`"}`)
+	})
+
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", status)
+	}
+	wantLog(t, out, "[Widgets]", user, unknown)
+}
+
+func TestCreateWidgetLogsBodyParseFailure(t *testing.T) {
+	const user = "logto|rel238"
+
+	var status int
+	out := captureLog(t, func() {
+		status = doRequest(t, logApp(), http.MethodPost,
+			"/users/me/widgets", user, `{"widget_type":`)
+	})
+
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", status)
+	}
+	wantLog(t, out, "[Widgets]", user)
+}
+
+// The 401 guards are the ones REL-238 actually tripped, so they log too.
+func TestWidgetWritesLogUnauthenticated(t *testing.T) {
+	widget := firstKnownWidgetType(t)
+	cases := []struct{ name, method, path string }{
+		{"create", http.MethodPost, "/users/me/widgets"},
+		{"update", http.MethodPut, "/users/me/widgets/" + widget},
+		{"delete", http.MethodDelete, "/users/me/widgets/" + widget},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var status int
+			out := captureLog(t, func() {
+				status = doRequest(t, logApp(), tc.method, tc.path, "", `{}`)
+			})
+			if status != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401", status)
+			}
+			wantLog(t, out, "[Widgets]", "no user on request")
+		})
+	}
+}
+
+// firstKnownWidgetType returns any non-utility catalog id, so the tests
+// don't hard-code a widget that may be renamed out of the catalog.
+func firstKnownWidgetType(t *testing.T) string {
+	t.Helper()
+	for _, def := range platform.Catalog() {
+		if !platform.IsUtilityWidgetType(def.ID) {
+			return def.ID
+		}
+	}
+	t.Fatal("no non-utility widget in the catalog")
+	return ""
+}

--- a/desktop/app-shim.html
+++ b/desktop/app-shim.html
@@ -1,0 +1,213 @@
+<!--
+  app-shim.html — the main window WITHOUT Tauri, for verifying REL-238.
+
+  Serve with `npx vite --port 5180` and open /app-shim.html in any browser.
+  A fake __TAURI_INTERNALS__ supplies an in-memory store and a stub
+  plugin:http, seeded to reproduce the production failure exactly:
+
+    scrollr:auth looks valid on disk (expiresAt is a day out)
+      → GET  /dashboard                 401  invalid or expired token
+      → POST /extension/token/refresh   400  invalid_grant, refresh expired
+      → clearAuth() deletes scrollr:auth
+      → GET  /public/feed               200  app still renders, looks healthy
+
+  Before the fix that ended with a silent dead session and one toast per
+  write. Now it ends with the session-expired banner and a Sign in CTA.
+  `window.__shimCalls` holds the full invoke trace. Dev-only; not a build
+  input (vite builds index/app/identify).
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scrollr</title>
+    <script>
+      // Pre-paint theme resolution to prevent dark-flash on light-system users
+      // AND to honour the user's chosen theme family (Catppuccin, Dracula, …).
+      //
+      // Reads a small mirror written to localStorage by useTheme on every
+      // theme change. Two formats are tolerated:
+      //
+      //   1. Current format (multi-theme):
+      //        { family: "catppuccin", mode: "system" }
+      //   2. Legacy format (pre-multi-theme):
+      //        "light" | "dark" | "system"
+      //
+      // Falls back to Scrollr + system if no mirror exists yet (first launch).
+      // Sets data-theme on <html> before React or any stylesheet paints so
+      // the body background matches the resolved theme.
+      (function () {
+        var KNOWN_FAMILIES = [
+          "scrollr",
+          "catppuccin",
+          "dracula",
+          "tokyo-night",
+          "nord",
+          "gruvbox",
+          "solarized",
+          "rose-pine",
+          "one",
+          "everforest",
+        ];
+
+        function resolveMode(mode) {
+          if (mode === "light" || mode === "dark") return mode;
+          // mode === "system" or anything else -> use OS preference
+          return window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+        }
+
+        var family = "scrollr";
+        var mode = "system";
+        try {
+          var saved = localStorage.getItem("scrollr:theme-mirror");
+          if (saved) {
+            if (saved.charAt(0) === "{") {
+              // New JSON format.
+              var parsed = JSON.parse(saved);
+              if (parsed && typeof parsed === "object") {
+                if (KNOWN_FAMILIES.indexOf(parsed.family) !== -1) {
+                  family = parsed.family;
+                }
+                if (
+                  parsed.mode === "light" ||
+                  parsed.mode === "dark" ||
+                  parsed.mode === "system"
+                ) {
+                  mode = parsed.mode;
+                }
+              }
+            } else if (saved === "light" || saved === "dark" || saved === "system") {
+              // Legacy format from pre-multi-theme builds.
+              mode = saved;
+            }
+          }
+        } catch (e) {
+          // Defensive: any failure -> Scrollr + system default.
+        }
+
+        var resolvedMode = resolveMode(mode);
+        document.documentElement.setAttribute(
+          "data-theme",
+          family + "-" + resolvedMode,
+        );
+        // Also expose the resolved mode separately so the inline style
+        // block below can paint the correct background colour without
+        // having to enumerate every family.
+        document.documentElement.setAttribute("data-mode", resolvedMode);
+      })();
+    </script>
+    <style>
+      /* Prevent flash on load — paint a sane background that matches the
+         resolved mode. Per-family backgrounds are applied by style.css
+         once the stylesheet loads; this just covers the brief gap. */
+      html, body { margin: 0; padding: 0; }
+      html[data-mode="dark"], html[data-mode="dark"] body { background: #141420; }
+      html[data-mode="light"], html[data-mode="light"] body { background: #ffffff; }
+    </style>
+  </head>
+    <script>
+      // ── REL-238 verification shim ─────────────────────────────────
+      // Runs the main window in a plain browser with no Tauri. Seeds a
+      // session that LOOKS valid on disk, then has the server reject it
+      // (401) and Logto refuse the refresh (400 invalid_grant) — exactly
+      // Brandon's production picture on 1.6.1.
+      (function () {
+        var label = "main";
+        var store = new Map([
+          ["scrollr:store-migrated", true],
+          ["scrollr:auth", {
+            accessToken: "expired.access.token",
+            refreshToken: "expired-refresh-token",
+            // Looks fresh on disk — the whole point. The server disagrees.
+            expiresAt: Date.now() + 864e5,
+            userSub: "logto|rel238",
+          }],
+        ]);
+
+        var bodies = new Map();
+        var nextRid = 1;
+
+        function reply(url) {
+          if (/\/extension\/token\/refresh/.test(url)) {
+            // Logto: the refresh token is expired too. This is the branch
+            // that runs clearAuth() and leaves the app with no session.
+            return [400, '{"error":"invalid_grant","error_description":"refresh token expired"}'];
+          }
+          if (/\/dashboard/.test(url)) {
+            return [401, '{"status":"error","error":"Invalid or expired token"}'];
+          }
+          if (/\/public\/feed/.test(url)) {
+            // The fallback that keeps the app looking healthy.
+            return [200, '{"data":{}}'];
+          }
+          if (/\/catalog/.test(url)) return [200, '{"widgets":[]}'];
+          if (/\/health/.test(url)) return [200, '{"status":"healthy","database":"healthy","redis":"healthy","services":{}}'];
+          return [500, '{"error":"not stubbed"}'];
+        }
+
+        window.__shimCalls = [];
+        function invoke(cmd, args) {
+          window.__shimCalls.push(cmd + " " + JSON.stringify(args || {}).slice(0, 160));
+          if (cmd.indexOf("plugin:event|") === 0) return Promise.resolve(1);
+          if (cmd === "plugin:store|load" || cmd === "plugin:store|get_store") return Promise.resolve(1);
+          if (cmd === "plugin:store|entries") return Promise.resolve([...store.entries()]);
+          if (cmd === "plugin:store|keys") return Promise.resolve([...store.keys()]);
+          if (cmd === "plugin:store|get") {
+            var v = store.get(args.key);
+            return Promise.resolve([v, v !== undefined]);
+          }
+          if (cmd === "plugin:store|set") { store.set(args.key, args.value); return Promise.resolve(); }
+          if (cmd === "plugin:store|delete") { store.delete(args.key); return Promise.resolve(true); }
+          if (cmd === "plugin:store|save" || cmd === "plugin:store|reload") return Promise.resolve();
+          if (cmd === "plugin:http|fetch") {
+            var rid = nextRid++;
+            bodies.set(rid, args.clientConfig.url);
+            return Promise.resolve(rid);
+          }
+          if (cmd === "plugin:http|fetch_send") {
+            var url = bodies.get(args.rid);
+            var r = reply(url);
+            bodies.set(args.rid, r[1]);
+            return Promise.resolve({
+              status: r[0], statusText: "", url: url,
+              headers: [["content-type", "application/json"]], rid: args.rid,
+            });
+          }
+          if (cmd === "plugin:http|fetch_read_body") {
+            var body = bodies.get(args.rid);
+            if (typeof body === "string") {
+              bodies.set(args.rid, null);
+              return Promise.resolve([...new TextEncoder().encode(body), 0]);
+            }
+            return Promise.resolve([1]);
+          }
+          if (cmd === "get_system_info") {
+            return Promise.resolve({ cpu_usage: 12, memory_used: 8e9, memory_total: 32e9, disk_used: 2e11, disk_total: 1e12 });
+          }
+          window.__shimCalls.push("!! UNHANDLED " + cmd);
+          return Promise.reject("shim: no handler for " + cmd);
+        }
+
+        window.__TAURI_INTERNALS__ = {
+          metadata: {
+            currentWindow: { label: label },
+            currentWebview: { label: label, windowLabel: label },
+            windows: [{ label: label }],
+            webviews: [{ label: label, windowLabel: label }],
+          },
+          transformCallback: function () { return Math.floor(Math.random() * 1e9); },
+          convertFileSrc: function (p) { return p; },
+          postMessage: function () {},
+          unregisterListener: function () {},
+          invoke: invoke,
+        };
+      })();
+    </script>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/app-main.tsx"></script>
+  </body>
+</html>

--- a/desktop/src/api/authFetch.test.ts
+++ b/desktop/src/api/authFetch.test.ts
@@ -1,0 +1,161 @@
+/**
+ * REL-238 — a stale session must announce itself, not fail one write at a time.
+ *
+ * On production 1.6.1 every server-backed widget toggle answered
+ * "Couldn't hide Crypto" while the app looked perfectly healthy: reads
+ * came from `fetchDashboard`, which catches its own 401 and falls back to
+ * /public/feed. Both core-api replicas logged `[SSE] Auth failed: token is
+ * expired` for the account. The only escape anyone found was uninstalling
+ * Scrollr — which "works" purely because it deletes scrollr.json, and with
+ * it `scrollr:auth`.
+ *
+ * Two defects fed that:
+ *   1. the 401 retry only fired when the refreshed token differed from the
+ *      one that failed, so a refresh returning the same string fell through
+ *      to the throw;
+ *   2. when no token could be obtained at all, nothing set session-expired,
+ *      so the already-built "Your session has expired — Sign in" banner
+ *      never appeared.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: (...args: unknown[]) => fetchMock(...args),
+}));
+
+const getValidToken = vi.fn();
+const isSignedOut = vi.fn();
+
+vi.mock("../auth", async () => {
+  // Keep the real listener set so the test asserts the actual wiring
+  // useAuthState subscribes through, not a stub of it.
+  const listeners = new Set<() => void>();
+  return {
+    getValidToken: (...a: unknown[]) => getValidToken(...a),
+    isSignedOut: () => isSignedOut(),
+    notifySessionExpired: () => {
+      for (const l of [...listeners]) l();
+    },
+    onSessionExpired: (l: () => void) => {
+      listeners.add(l);
+      return () => listeners.delete(l);
+    },
+  };
+});
+
+const { authFetch } = await import("./client");
+const { onSessionExpired } = await import("../auth");
+
+const unauthorized = () => ({
+  ok: false,
+  status: 401,
+  json: async () => ({ error: "Invalid or expired token" }),
+});
+const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+
+let expired: Mock<() => void>;
+let unsubscribe: () => void;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  getValidToken.mockReset();
+  isSignedOut.mockReset();
+  expired = vi.fn<() => void>();
+  unsubscribe = onSessionExpired(expired);
+});
+
+afterEach(() => unsubscribe());
+
+describe("authFetch on 401", () => {
+  it("retries with a refreshed token even when it is byte-identical", async () => {
+    // doRefresh short-circuits to the STORED access token on both of its
+    // cross-window race checks, so "same string back" is a normal outcome
+    // of a successful refresh — not a reason to give up.
+    getValidToken.mockResolvedValueOnce("T").mockResolvedValueOnce("T");
+    isSignedOut.mockReturnValue(false);
+    fetchMock
+      .mockResolvedValueOnce(unauthorized())
+      .mockResolvedValueOnce(ok({ status: "ok" }));
+
+    await expect(authFetch("/users/me/widgets/finance_btc", { method: "PUT" }))
+      .resolves.toEqual({ status: "ok" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(getValidToken).toHaveBeenLastCalledWith(true);
+    expect(expired).not.toHaveBeenCalled();
+  });
+
+  it("retries with a rotated token and succeeds", async () => {
+    getValidToken.mockResolvedValueOnce("stale").mockResolvedValueOnce("fresh");
+    isSignedOut.mockReturnValue(false);
+    fetchMock
+      .mockResolvedValueOnce(unauthorized())
+      .mockResolvedValueOnce(ok({ status: "ok" }));
+
+    await authFetch("/users/me/widgets");
+
+    const retryHeaders = (fetchMock.mock.calls[1][1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(retryHeaders.Authorization).toBe("Bearer fresh");
+  });
+
+  it("announces the expired session when the refresh is refused", async () => {
+    // getValidToken(true) → doRefresh → Logto 4xx → clearAuth() → null.
+    // Auth is gone; nothing but this signal can tell the UI.
+    getValidToken.mockResolvedValueOnce("expired").mockResolvedValueOnce(null);
+    isSignedOut.mockReturnValue(true);
+    fetchMock.mockResolvedValue(unauthorized());
+
+    await expect(
+      authFetch("/users/me/widgets/finance_btc", { method: "PUT" }),
+    ).rejects.toMatchObject({ status: 401 });
+
+    expect(expired).toHaveBeenCalledTimes(1);
+    // Exactly one attempt: no token to retry with.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when the refresh merely failed on the network", async () => {
+    // doRefresh keeps the refresh token on a network error and the
+    // proactive timer retries every 30s — that is not a dead session, and
+    // declaring one would push a signed-in user at a sign-in banner.
+    getValidToken.mockResolvedValueOnce("valid").mockResolvedValueOnce(null);
+    isSignedOut.mockReturnValue(false);
+    fetchMock.mockResolvedValue(unauthorized());
+
+    await expect(authFetch("/users/me/widgets")).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(expired).not.toHaveBeenCalled();
+  });
+
+  it("announces when the retry itself comes back 401 and auth is gone", async () => {
+    getValidToken.mockResolvedValueOnce("a").mockResolvedValueOnce("b");
+    isSignedOut.mockReturnValue(true);
+    fetchMock.mockResolvedValue(unauthorized());
+
+    await expect(authFetch("/users/me/widgets")).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(expired).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the server's error string onto the thrown ApiError", async () => {
+    // The toggle's onError prints this; before REL-238 it printed only
+    // "ApiError" and the server logged nothing, so neither end said why.
+    getValidToken.mockResolvedValueOnce(null);
+    isSignedOut.mockReturnValue(false);
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "Widget not found" }),
+    });
+
+    await expect(authFetch("/users/me/widgets/nope")).rejects.toMatchObject({
+      status: 404,
+      message: "Widget not found",
+    });
+  });
+});

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -7,7 +7,7 @@
  *   - `authFetch<T>()` — automatically attaches Bearer token via getValidToken()
  */
 import { fetch } from "@tauri-apps/plugin-http";
-import { getValidToken } from "../auth";
+import { getValidToken, isSignedOut, notifySessionExpired } from "../auth";
 import type { Widget, HealthResponse } from "../types/api.generated";
 
 // ── Constants ────────────────────────────────────────────────────
@@ -167,16 +167,35 @@ export async function authFetch<T>(
     headers,
   });
 
-  // 401 retry: force a token refresh and retry the request once
-  if (response.status === 401 && token) {
-    const newToken = await getValidToken(true);
-    if (newToken && newToken !== token) {
+  // 401: force a token refresh and retry the request once.
+  //
+  // Two REL-238 bugs lived here. The retry used to require a token
+  // DIFFERENT from the one that just failed, so a refresh handing back
+  // the same string — which `doRefresh` does on both of its race
+  // short-circuits — fell straight through to the throw. And when no
+  // token could be had at all, the 401 surfaced as whatever the caller
+  // called the action ("Couldn't hide Crypto") while nothing told the
+  // user their session was over: `fetchDashboard` swallows its own 401
+  // and falls back to /public/feed, so reads kept the app looking
+  // healthy and only writes failed.
+  //
+  // Now: retry on ANY token we manage to obtain, and if we end up with
+  // no stored auth at all, say so once so the sign-in banner appears.
+  if (response.status === 401) {
+    const newToken = token ? await getValidToken(true) : null;
+    if (newToken) {
       const retryResponse = await fetchWithTimeout(`${API_BASE}${path}`, {
         ...options,
         headers: { ...options.headers, Authorization: `Bearer ${newToken}` },
       });
+      if (retryResponse.status === 401 && isSignedOut()) notifySessionExpired();
       return handleResponse<T>(retryResponse);
     }
+    // No token. `isSignedOut()` separates "the refresh was refused and
+    // clearAuth() ran" from "the refresh call failed on the network" —
+    // the latter keeps the refresh token and the proactive timer retries
+    // every 30s, so it is not a session to declare dead.
+    if (isSignedOut()) notifySessionExpired();
   }
 
   return handleResponse<T>(response);

--- a/desktop/src/auth.ts
+++ b/desktop/src/auth.ts
@@ -218,6 +218,24 @@ function extractSub(jwt: string): string | null {
 }
 
 /**
+ * When the access token actually expires.
+ *
+ * `expires_in` is a duration measured against OUR clock at the moment the
+ * response lands; the JWT's own `exp` is the absolute instant every API
+ * replica checks. When the two disagree — a system clock that was wrong at
+ * save time and later corrected, a suspended laptop, a slow exchange —
+ * `Date.now() + expires_in` can sit comfortably in the future while the
+ * token is already dead. getValidToken() then hands that corpse to every
+ * request, never refreshes it (it looks fresh), and the server answers 401
+ * with "token is expired". That is how a session gets stuck (REL-238).
+ * Prefer `exp`; fall back to `expires_in` only when the JWT has none.
+ */
+function expiryOf(accessToken: string, expiresIn: number): number {
+  const exp = decodeJwtPayload(accessToken)?.exp;
+  return typeof exp === "number" ? exp * 1000 : Date.now() + expiresIn * 1000;
+}
+
+/**
  * Extract the subscription tier from the JWT's `roles` claim.
  * Logto injects roles via Custom JWT (e.g. ["uplink_ultimate"]).
  *
@@ -448,7 +466,7 @@ export async function login(): Promise<AuthState | null> {
     const authState: AuthState = {
       accessToken: tokenRes.access_token,
       refreshToken: tokenRes.refresh_token ?? null,
-      expiresAt: Date.now() + tokenRes.expires_in * 1000,
+      expiresAt: expiryOf(tokenRes.access_token, tokenRes.expires_in),
       userSub: extractSub(tokenRes.access_token),
     };
 
@@ -531,7 +549,7 @@ async function doRefresh(refreshToken: string): Promise<string | null> {
     const authState: AuthState = {
       accessToken: tokenRes.access_token,
       refreshToken: tokenRes.refresh_token ?? null,
-      expiresAt: Date.now() + tokenRes.expires_in * 1000,
+      expiresAt: expiryOf(tokenRes.access_token, tokenRes.expires_in),
       userSub: extractSub(tokenRes.access_token),
     };
 
@@ -635,6 +653,46 @@ export function logout(): Promise<void> {
 export function hasRefreshToken(): boolean {
   const auth = loadAuth();
   return auth !== null && auth.refreshToken !== null;
+}
+
+/**
+ * True when nothing usable is stored at all — never signed in, or signed
+ * out by `clearAuth()` after a refresh the server refused. Distinct from
+ * `!isAuthenticated()`, which is also true while a refresh token could
+ * still restore the session.
+ */
+export function isSignedOut(): boolean {
+  return loadAuth() === null;
+}
+
+// ── Session-expired signal ───────────────────────────────────────
+//
+// A 401 nobody can refresh past means the session is over, but until
+// REL-238 nothing in the UI said so. `fetchDashboard` catches the 401
+// and falls back to /public/feed, so reads kept rendering and the app
+// looked healthy; only writes failed, one per-action toast at a time
+// ("Couldn't hide Crypto"). With no way back to a sign-in prompt, the
+// only escape anyone found was reinstalling — which works solely
+// because it deletes scrollr.json.
+//
+// A plain module-level listener set rather than the store: this is a
+// per-window signal about the here and now, not state to persist, and
+// each window's React tree wants it immediately.
+
+const sessionExpiredListeners = new Set<() => void>();
+
+/** Subscribe to the signal. Returns an unsubscribe fn. */
+export function onSessionExpired(listener: () => void): () => void {
+  sessionExpiredListeners.add(listener);
+  return () => {
+    sessionExpiredListeners.delete(listener);
+  };
+}
+
+/** Announce that the stored session is gone and cannot be refreshed. */
+export function notifySessionExpired(): void {
+  // Copy first: a listener may unsubscribe itself while we iterate.
+  for (const listener of [...sessionExpiredListeners]) listener();
 }
 
 // ── Initialize proactive refresh on module load ──────────────────

--- a/desktop/src/hooks/useAuthState.test.ts
+++ b/desktop/src/hooks/useAuthState.test.ts
@@ -1,0 +1,72 @@
+/**
+ * REL-238 — the other half of the fix.
+ *
+ * `authFetch` fires notifySessionExpired() when a 401 outlives the
+ * refresh; this is the subscription that turns it into the banner
+ * `__root.tsx` already renders ("Your session has expired. Sign in
+ * again…"). Before it existed, the only thing that could set
+ * `sessionExpired` was `syncAuthFromDashboard` — and that never ran,
+ * because `fetchDashboard` catches its own 401 and serves /public/feed
+ * instead. Result: cached reads looked fine, every write toasted, and
+ * reinstalling the app was the only known way out.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => {}) }));
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+const authed = vi.fn(() => true);
+
+vi.mock("../auth", async () => {
+  const listeners = new Set<() => void>();
+  return {
+    login: vi.fn(),
+    logout: vi.fn(async () => {}),
+    isAuthenticated: () => authed(),
+    isAuthConfigured: () => true,
+    getLastLoginError: () => null,
+    getTier: () => "uplink_pro",
+    onSessionExpired: (l: () => void) => {
+      listeners.add(l);
+      return () => listeners.delete(l);
+    },
+    // Test-only handle on the module-level signal authFetch calls.
+    __fire: () => {
+      for (const l of [...listeners]) l();
+    },
+  };
+});
+
+const { useAuthState } = await import("./useAuthState");
+const auth = (await import("../auth")) as unknown as { __fire: () => void };
+
+beforeEach(() => authed.mockReturnValue(true));
+
+describe("useAuthState", () => {
+  it("raises the session-expired banner when a 401 outlives the refresh", () => {
+    const { result } = renderHook(() => useAuthState());
+
+    expect(result.current.authenticated).toBe(true);
+    expect(result.current.sessionExpired).toBe(false);
+
+    act(() => auth.__fire());
+
+    expect(result.current.sessionExpired).toBe(true);
+    expect(result.current.authenticated).toBe(false);
+    // Tier drops with the session so gated UI stops promising paid features.
+    expect(result.current.tier).toBe("free");
+  });
+
+  it("stops listening once unmounted", () => {
+    const { result, unmount } = renderHook(() => useAuthState());
+    unmount();
+    // No act(): if the listener survived, React warns about setting state
+    // on an unmounted tree and the assertion below would read stale state.
+    expect(() => auth.__fire()).not.toThrow();
+    expect(result.current.sessionExpired).toBe(false);
+  });
+});

--- a/desktop/src/hooks/useAuthState.ts
+++ b/desktop/src/hooks/useAuthState.ts
@@ -4,7 +4,7 @@
  * Manages authentication state, login/logout handlers, session expiry
  * tracking, and tier synchronization on dashboard load.
  */
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -15,6 +15,7 @@ import {
   isAuthConfigured,
   getLastLoginError,
   getTier,
+  onSessionExpired,
 } from "../auth";
 import { queryKeys } from "../api/queries";
 import type { SubscriptionTier } from "../auth";
@@ -45,6 +46,23 @@ export function useAuthState(): UseAuthStateReturn {
   const authenticatedRef = useRef(authenticated);
   authenticatedRef.current = authenticated;
 
+  // A write that 401s and cannot be refreshed past clears auth deep
+  // inside authFetch, where no React state can see it. Without this
+  // subscription the banner only appeared if the dashboard query happened
+  // to re-run (syncAuthFromDashboard) — and it does not, because
+  // fetchDashboard swallows the same 401 and serves the public feed. So
+  // the app looked signed in, every write failed with its own toast, and
+  // reinstalling was the only way back (REL-238).
+  useEffect(
+    () =>
+      onSessionExpired(() => {
+        setAuthenticated(false);
+        setTier("free");
+        setSessionExpired(true);
+      }),
+    [],
+  );
+
   const handleLogin = useCallback(async () => {
     if (!isAuthConfigured()) {
       toast.error("Desktop auth is not configured for this build");
@@ -72,7 +90,11 @@ export function useAuthState(): UseAuthStateReturn {
 
   const handleLogout = useCallback(async () => {
     await invoke("stop_sse").catch(() => {});
-    authLogout();
+    // Await it: clearAuth persists the removal, and an unawaited
+    // rejection here would leave scrollr:auth on disk after a "sign out".
+    await authLogout().catch((err) =>
+      console.error("[Scrollr] Sign-out failed to clear stored auth:", err),
+    );
     setAuthenticated(false);
     setTier("free");
     setSessionExpired(false);

--- a/desktop/src/routes/__root.tsx
+++ b/desktop/src/routes/__root.tsx
@@ -84,7 +84,7 @@ import { useDeliveryHealth } from "../hooks/useDeliveryHealth";
 import { useNavHistory } from "../hooks/useNavHistory";
 import { useStartupUpdateCheck } from "../hooks/useStartupUpdateCheck";
 import { weatherQueryOptions } from "../api/queries";
-import { fetchSubscription } from "../api/client";
+import { fetchSubscription, ApiError } from "../api/client";
 import { useToggleOnTicker } from "../hooks/useToggleOnTicker";
 import { isOnTicker } from "../utils/tickerMembership";
 import { queryKeys } from "../api/queries";
@@ -379,8 +379,16 @@ function RootLayout() {
   // users land directly on /feed which renders an empty hero card.
   // Demo mode (VITE_DEMO=1) bypasses the Logto auth wall so the live Kalshi
   // demo runs signed-out against the no-auth bridge. Strictly dev-only.
-  const showAuthGate = !auth.authenticated && !DEMO;
-  const showApp = auth.authenticated || DEMO;
+  //
+  // `sessionExpired` holds the shell open. Without it the banner below is
+  // unreachable code: it renders inside `showApp`, but the only things that
+  // set `sessionExpired` also set `authenticated` false, which swaps the
+  // whole shell for the full-screen gate in the same commit. A session that
+  // dies mid-use should be recoverable where the user is standing — banner,
+  // one "Sign in", back to work — not by throwing their view away. A fresh
+  // install (never authenticated, never expired) still gets the gate.
+  const showAuthGate = !auth.authenticated && !auth.sessionExpired && !DEMO;
+  const showApp = auth.authenticated || auth.sessionExpired || DEMO;
 
   // ── SSE status tracking ─────────────────────────────────────
   // Listen directly for SSE status events from the Rust backend.
@@ -585,8 +593,25 @@ function RootLayout() {
     getPrefs: () => prefsRef.current,
     persistPrefs,
     onError: (id, on, err) => {
-      console.error("[Scrollr] Widget toggle failed:", err);
-      toast.error(`Couldn't ${on ? "show" : "hide"} ${catalogItemById(id)?.name ?? id}`);
+      // Status + the server's own `error` string, because "Widget toggle
+      // failed: ApiError" cost hours on REL-238: the console said nothing
+      // about WHICH failure it was and the server logged nothing at all.
+      const status = err instanceof ApiError ? err.status : undefined;
+      console.error(
+        `[Scrollr] Widget toggle failed: ${on ? "show" : "hide"} ${id}` +
+          (status ? ` — HTTP ${status}` : "") +
+          (err instanceof Error ? `: ${err.message}` : ""),
+        err,
+      );
+      const name = catalogItemById(id)?.name ?? id;
+      // A 401 is not "that widget wouldn't budge", it is "you are signed
+      // out". The session-expired banner is already up by now (authFetch
+      // fires notifySessionExpired); this stops the toast contradicting it.
+      toast.error(
+        status === 401
+          ? `Your session expired — sign in again to change ${name}`
+          : `Couldn't ${on ? "show" : "hide"} ${name}`,
+      );
     },
   });
   const handleToggleItemTicker = useCallback(


### PR DESCRIPTION
Fixes REL-238.

## What happened

On production 1.6.1 every server-backed widget toggle answered `Couldn't hide Crypto`. Utility toggles worked — they never leave the device. The app otherwise looked healthy. Both core-api replicas logged `[SSE] Auth failed: token is expired` for the account and **nothing else at all**. Uninstalling and reinstalling Scrollr fixed it, which works only because it deletes `%APPDATA%\com.scrollr.desktop\scrollr.json`, and with it `scrollr:auth`.

Already ruled out with evidence on the issue, not re-checked here: tier and slot cap, missing rows, unknown widget ids, CORS, Tauri capability scope, cache invalidation, any server-side error.

## Root cause

The session was dead and **nothing in the app could say so**. Four things stacked up:

1. **`fetchDashboard` swallows its own 401** and falls back to `/public/feed` ([queries.ts:76-89](desktop/src/api/queries.ts#L76)). Reads kept rendering, so the window looked signed in.
2. **The 401 retry required a *different* token.** `authFetch` only retried when `getValidToken(true)` returned something other than the token that had just failed — but `doRefresh` returns the **stored** access token on both of its cross-window race short-circuits, so "the same string back" is a normal outcome of a *successful* refresh. It fell straight through to the throw.
3. **No token at all set nothing.** When the refresh was refused, `clearAuth()` ran deep inside `authFetch` where no React state could see it. The 401 surfaced as whatever the caller called the action.
4. **The banner was unreachable code.** `{auth.sessionExpired && <BillingBanner …>}` renders inside `showApp`, but everything that set `sessionExpired` also set `authenticated` false in the same commit — which swaps the shell for the full-screen auth gate. It could never paint.

So: writes failed one toast at a time, reads looked fine, and there was no route back to a sign-in prompt. A reinstall was genuinely the only escape.

## The fix

**Client**

- `authFetch` retries on **any** token it obtains, and when auth has been cleared announces it once through a new module-level signal (`onSessionExpired` / `notifySessionExpired` in `auth.ts`). A refresh that failed on the **network** keeps its refresh token and the 30s proactive timer — that is not a dead session and does not raise the banner.
- `useAuthState` subscribes to the signal. `showAuthGate`/`showApp` now keep the shell open while `sessionExpired`, so the existing banner is reachable and recovery is one **Sign in** where the user is standing. A fresh install (never authenticated, never expired) still gets the full gate.
- **`expiresAt` now comes from the JWT's own `exp`**, not `Date.now() + expires_in`. The two diverge across a clock correction or a suspend, and a token that looks fresh on disk but is dead on the wire is never refreshed — it is just handed to every request, forever. That is the shape of `token is expired` in the pod log while the client thought all was well.
- Sign-out awaits `clearAuth`. To answer the question on the issue directly: **sign-out does clear `scrollr:auth`** — `removeStorePersisted` deletes and saves, confirmed live in the trace below. It was never the problem; the problem was that nothing ever offered a sign-out or sign-in in that state.
- `useToggleOnTicker`'s `onError` logs the HTTP status and the server's `error` string, and a 401 toasts *"Your session expired — sign in again to change X"* instead of *"Couldn't hide Crypto"*. The optimistic revert is untouched — it is correct.

**Server** — every silent early return in `CreateWidget` / `UpdateWidget` / `DeleteWidget` now logs with userID and widgetType: unknown widget type, body-parse failure, the `no rows` 404, the duplicate 409, and the unauthenticated guards. Those silent returns are why this took hours to narrow.

## Evidence

`desktop/app-shim.html` runs the main window in a plain browser with no Tauri, seeded to reproduce the production failure exactly. `window.__shimCalls` captured the real chain:

```
plugin:http|fetch  GET  /dashboard  headers:[["authorization","Bearer expired.access.token"]]
plugin:http|fetch  POST /extension/token/refresh          → 400 invalid_grant
plugin:store|delete {"key":"scrollr:auth"}                ← clearAuth() ran
plugin:store|save
plugin:http|fetch  GET  /public/feed                      → 200, app renders "healthy"
```

Before this PR that ended in a silent dead session. Now it ends here:

> **Your session has expired. Sign in again to access your widgets.**   `Sign in`  `Dismiss`

rendered as a banner across the top of the live app shell, with the user's view intact behind it. (Screenshot in the Linear issue — `Home` route, banner directly under the connection banner.)

## Tests

- `desktop/src/api/authFetch.test.ts` — 6 cases: retry on a byte-identical refreshed token, retry on a rotated token, refusal → banner + no wasted retry, network failure → **no** banner, retry-that-401s → banner, server `error` string reaches `ApiError.message`.
- `desktop/src/hooks/useAuthState.test.ts` — the signal raises `sessionExpired`, drops tier, and unsubscribes on unmount.
- `api/internal/widgets/widgets_logging_test.go` — 8 cases pinning the new log lines (unknown type, body-parse, the three 401 guards). The `no rows` 404 needs a DB round trip; its line is the same one-line pattern.

`npm test` in `desktop/`: **756 passed / 68 files**. `tsc --noEmit` clean. `go build ./...`, `go vet`, `go test ./internal/widgets/` green, `gofmt` clean.

## Not touched

The rotation memo (#339), the pinning work (#343), REL-237's SSE ownership.

## After merge

Send a deliberately malformed widget PUT and confirm the new `[Widgets] update body parse failed for …` line appears in the core-api pod log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
