### PR TITLE
feat(support): case database — support_cases + support_messages [REL-243]

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,6 +17,8 @@ RUN go mod download
 
 # Build the Go app
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+# Support case backfill (REL-243) — run in-cluster via k8s/jobs/support-backfill.yaml
+RUN CGO_ENABLED=0 GOOS=linux go build -o support-backfill ./cmd/support-backfill
 # ── Dev stage: hot reload (NOT the default build target) ─────────────
 # Deliberately placed BEFORE the runtime stage: deploy.yml runs
 # `docker build` with no --target, which builds the LAST stage. Keeping the
@@ -56,6 +58,7 @@ RUN apk --no-cache add curl
 
 # Copy the Pre-built binary from the previous stage
 COPY --from=builder /app/main .
+COPY --from=builder /app/support-backfill .
 COPY --from=builder /app/migrations ./migrations
 
 # Expose port 8080 to the outside world

--- a/api/cmd/support-backfill/main.go
+++ b/api/cmd/support-backfill/main.go
@@ -1,0 +1,57 @@
+// Command support-backfill fills support_cases + support_messages from
+// osTicket (REL-243). Walks the scrollr-reply-api plugin's list/detail
+// endpoints with the server's OSTICKET_API_KEY, links every existing
+// support_drafts row, and is idempotent by osTicket entry id — run it
+// twice and the counts don't move.
+//
+// The plugin key is IP-bound to the cluster egress, so this runs from
+// inside the cluster: k8s/jobs/support-backfill.yaml. The same pass runs
+// nightly in-process (support.StartSupportCaseReconciler) for tickets
+// updated in the last 48 h.
+//
+// Usage:
+//
+//	go run ./cmd/support-backfill              # every ticket
+//	go run ./cmd/support-backfill -since 48h   # only recently updated
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/support"
+)
+
+func main() {
+	since := flag.Duration("since", 0, "only tickets osTicket updated within this window (0 = all)")
+	flag.Parse()
+	_ = godotenv.Load()
+
+	platform.ConnectDB()
+	defer platform.DBPool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	var from time.Time
+	if *since > 0 {
+		from = time.Now().Add(-*since)
+	}
+	stats, err := support.BackfillFromOSTicket(ctx, from)
+	out, _ := json.Marshal(stats)
+	fmt.Println(string(out))
+	if err != nil {
+		log.Fatalf("backfill: %v", err)
+	}
+	if stats.Errors > 0 {
+		os.Exit(2)
+	}
+}

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -240,6 +240,9 @@ func (s *Server) setupRoutes() {
 	s.App.Get("/support/edit", support.HandleSupportEdit)
 	s.App.Get("/support/skip", support.HandleSupportSkip)
 	s.App.Post("/support/edit/submit", support.HandleSupportEditSubmit)
+	// Case DB full-text search (REL-243). Server-to-server: gated by the
+	// osTicket webhook's shared secret inside the handler.
+	s.App.Get("/internal/support/cases", support.HandleSearchSupportCases)
 
 	// Invite (no auth — user isn't logged in yet, token-verified server-side)
 	s.App.Post("/invite/complete", accounts.HandleCompleteInvite)

--- a/api/internal/support/ai_triage.go
+++ b/api/internal/support/ai_triage.go
@@ -11,58 +11,7 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
 )
-
-// --- Recent ticket summaries (Redis sliding window) ---
-// Sliding window of the last N ticket summaries, used as context when
-// asking Claude to dupe-detect against recent submissions. Keyed by a
-// single global list; entries are LPUSHed and trimmed to the cap.
-
-const (
-	RedisRecentTicketsKey   = "support:recent_tickets"
-	RedisRecentTicketsLimit = 50
-)
-
-// PushRecentTicketSummary adds a summary to the head of the sliding
-// window. Atomic — uses LPUSH+LTRIM in a pipeline.
-func PushRecentTicketSummary(ctx context.Context, summary RecentTicketSummary) {
-	if platform.Rdb == nil {
-		return
-	}
-	bytes, err := json.Marshal(summary)
-	if err != nil {
-		log.Printf("[Redis] marshal recent ticket: %v", err)
-		return
-	}
-	pipe := platform.Rdb.Pipeline()
-	pipe.LPush(ctx, RedisRecentTicketsKey, string(bytes))
-	pipe.LTrim(ctx, RedisRecentTicketsKey, 0, int64(RedisRecentTicketsLimit-1))
-	if _, err := pipe.Exec(ctx); err != nil {
-		log.Printf("[Redis] push recent ticket: %v", err)
-	}
-}
-
-// FetchRecentTicketSummaries returns the last N summaries (most recent first).
-func FetchRecentTicketSummaries(ctx context.Context) []RecentTicketSummary {
-	if platform.Rdb == nil {
-		return nil
-	}
-	rawList, err := platform.Rdb.LRange(ctx, RedisRecentTicketsKey, 0, int64(RedisRecentTicketsLimit-1)).Result()
-	if err != nil {
-		log.Printf("[Redis] fetch recent tickets: %v", err)
-		return nil
-	}
-	out := make([]RecentTicketSummary, 0, len(rawList))
-	for _, s := range rawList {
-		var sum RecentTicketSummary
-		if err := json.Unmarshal([]byte(s), &sum); err == nil {
-			out = append(out, sum)
-		}
-	}
-	return out
-}
 
 // =============================================================================
 // AI Support Triage — Anthropic Haiku integration
@@ -104,7 +53,7 @@ type TriageResult struct {
 
 // TriageInput is what we pass to triageTicket. Builds the prompt
 // from these fields plus a small bundle of recent ticket summaries
-// pulled from Redis (for dupe detection) and a static FAQ snippet.
+// pulled from support_cases (for dupe detection) and a static FAQ snippet.
 type TriageInput struct {
 	UserCategory    string
 	UserEmail       string
@@ -123,8 +72,9 @@ type TriageInput struct {
 	PreviousAIReplyHTML string // most recent AI reply we sent on this ticket, if known
 }
 
-// RecentTicketSummary is what we cache in Redis for dupe-detection
-// context. Kept compact — this list is sent on every triage call.
+// RecentTicketSummary is one line of dupe-detection context for the
+// triage prompt: the last 50 support_cases (FetchRecentTicketSummaries
+// in support_cases.go). Kept compact — the list rides on every call.
 type RecentTicketSummary struct {
 	TicketNumber string `json:"ticket_number"`
 	Category     string `json:"category"`

--- a/api/internal/support/discord.go
+++ b/api/internal/support/discord.go
@@ -896,6 +896,9 @@ func upsertSupportTicketThread(ctx context.Context, t *SupportTicketThread) erro
 	if err != nil {
 		return fmt.Errorf("upsert ticket thread: %w", err)
 	}
+	_, _ = platform.DBPool.Exec(ctx,
+		`UPDATE support_cases SET discord_thread_id = $2 WHERE ticket_number = $1`,
+		t.TicketNumber, t.DiscordThreadID)
 	return nil
 }
 

--- a/api/internal/support/handlers_osticket_webhook.go
+++ b/api/internal/support/handlers_osticket_webhook.go
@@ -139,6 +139,23 @@ func processReplyTriageAsync(ev osTicketThreadMessageEvent) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Case DB first: the user's follow-up is an event whether or not
+	// triage produces a draft. A user reply reopens the ticket in osTicket,
+	// so the case goes back to open too.
+	if platform.DBPool != nil {
+		if err := upsertSupportCase(ctx, SupportCase{
+			TicketNumber: ev.TicketNumber, UserEmail: ev.UserEmail, Subject: ev.Subject, Status: "open",
+		}); err != nil {
+			log.Printf("[Cases] %v", err)
+		}
+		if err := recordSupportMessage(ctx, SupportMessage{
+			TicketNumber: ev.TicketNumber, Kind: "user", BodyHTML: ev.MessageHTML,
+			OSTicketEntryID: ev.ThreadEntryID,
+		}); err != nil {
+			log.Printf("[Cases] %v", err)
+		}
+	}
+
 	// Pull the most recent SENT reply on this ticket so the triage
 	// prompt has continuity context. Best-effort — empty string is OK.
 	previousReply := loadLatestSentDraftBody(ctx, ev.TicketNumber)

--- a/api/internal/support/handlers_support_public.go
+++ b/api/internal/support/handlers_support_public.go
@@ -176,6 +176,13 @@ func HandleSubmitPublicSupportTicket(c *fiber.Ctx) error {
 	log.Printf("[PublicSupport] Ticket created from ip=%s email=%s category=%s osTicket=%s",
 		redactIP(ip), redactEmail(req.Email), req.Category, ticketNumber)
 
+	recordTicketOpened(c.Context(), SupportCase{
+		TicketNumber: ticketNumber,
+		UserEmail:    req.Email,
+		Subject:      subjectFull,
+		Category:     effectiveCategory,
+	}, originalBody)
+
 	if triage != nil && ticketNumber != "" {
 		persistTriageSideEffects(ticketNumber, req.Email, fallbackName(req.Name, req.Email), subjectFull, originalBody, triage)
 	}

--- a/api/internal/support/main_test.go
+++ b/api/internal/support/main_test.go
@@ -1,0 +1,13 @@
+package support
+
+import (
+	"os"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// TestMain switches the package into integration mode when
+// TEST_DATABASE_URL is set (real migrations in a package-private schema);
+// DB-backed tests skip otherwise. See testsupport.Main.
+func TestMain(m *testing.M) { os.Exit(testsupport.Main(m)) }

--- a/api/internal/support/support.go
+++ b/api/internal/support/support.go
@@ -320,6 +320,20 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 	// they didn't earn — see allowedBySupportRateLimit.
 	recordSupportSubmission(userID)
 
+	// Case DB: the ticket row plus the user's opening message. Before the
+	// triage side effects so the draft has a case to attach to.
+	appVersion, osName := caseFieldsFromDiagnostics(req.Diagnostics)
+	recordTicketOpened(c.Context(), SupportCase{
+		TicketNumber: ticketNumber,
+		UserEmail:    email,
+		LogtoSub:     userID,
+		Subject:      subject,
+		Category:     effectiveCategory,
+		AppVersion:   appVersion,
+		OS:           osName,
+		TierAtOpen:   platform.TierFromRoles(platform.GetUserRoles(c)),
+	}, originalBody)
+
 	// Side effects after successful ticket creation: persist the AI
 	// draft for partner approval, push to the recent-tickets sliding
 	// window, and notify the partner. All best-effort — failures here
@@ -399,19 +413,33 @@ func persistTriageSideEffects(ticketNumber, userEmail, userName, subject, origin
 			log.Printf("[Support] createSupportDraft failed for ticket %s: %v", ticketNumber, err)
 		}
 
-		// Recent-tickets sliding window for dupe detection on subsequent submissions.
-		PushRecentTicketSummary(ctx, RecentTicketSummary{
-			TicketNumber: ticketNumber,
-			Category:     triage.Category,
-			Summary:      triage.Summary,
-			CreatedAt:    time.Now().UTC().Format(time.RFC3339),
-		})
-
 		// Partner notification — wired in Phase 1D once SendPartnerNotification exists.
 		if draft != nil {
 			notifyPartnerAfterDraft(ctx, draft)
 		}
 	}()
+}
+
+// recordTicketOpened writes the case row and the user's opening message
+// when a ticket has been accepted by osTicket. Best-effort: the user
+// already has their ticket; a case-DB failure is logged, never surfaced.
+// Its ticket number is the only thing osTicket's create response gives
+// us, so the message has no entry id yet — the nightly reconcile claims
+// it (see support_backfill.go).
+func recordTicketOpened(ctx context.Context, sc SupportCase, userBodyHTML string) {
+	if platform.DBPool == nil || sc.TicketNumber == "" {
+		return
+	}
+	sc.Status = "open"
+	if err := upsertSupportCase(ctx, sc); err != nil {
+		log.Printf("[Cases] %v", err)
+		return
+	}
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: sc.TicketNumber, Kind: "user", BodyHTML: userBodyHTML,
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
 }
 
 // ===== OS Ticket forwarding helper =====
@@ -474,6 +502,12 @@ func forwardToOSTicket(ctx context.Context, payload OSTicketPayload) (string, er
 // Used by both the create-ticket flow (forwardToOSTicket) and the
 // reply flow (postOSTicketReply in support_drafts.go).
 func postOSTicketJSON(ctx context.Context, path string, payloadBytes []byte) (int, []byte, error) {
+	return osTicketRequest(ctx, "POST", path, payloadBytes)
+}
+
+// osTicketRequest is postOSTicketJSON for any method; the backfill reads
+// the plugin's GET endpoints through it (nil payload).
+func osTicketRequest(ctx context.Context, method, path string, payloadBytes []byte) (int, []byte, error) {
 	osTicketURL := os.Getenv("OSTICKET_URL")
 	apiKeysRaw := os.Getenv("OSTICKET_API_KEY")
 	if osTicketURL == "" || apiKeysRaw == "" {
@@ -494,12 +528,14 @@ func postOSTicketJSON(ctx context.Context, path string, payloadBytes []byte) (in
 			continue
 		}
 
-		httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewReader(payloadBytes))
+		httpReq, err := http.NewRequestWithContext(ctx, method, fullURL, bytes.NewReader(payloadBytes))
 		if err != nil {
 			log.Printf("[Support] Failed to create OS Ticket request: %v", err)
 			continue
 		}
-		httpReq.Header.Set("Content-Type", "application/json")
+		if payloadBytes != nil {
+			httpReq.Header.Set("Content-Type", "application/json")
+		}
 		httpReq.Header.Set("X-API-Key", key)
 
 		resp, err := client.Do(httpReq)

--- a/api/internal/support/support_backfill.go
+++ b/api/internal/support/support_backfill.go
@@ -1,0 +1,320 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// =============================================================================
+// Backfill + nightly reconcile from the osTicket plugin's read endpoints
+// =============================================================================
+//
+// GET /api/tickets.json?status=all&topic=all and GET /api/tickets/{n}.json
+// (scripts/osticket-plugin/api.list.php). The API key is IP-bound to the
+// cluster egress, so this only runs from inside the cluster: the
+// cmd/support-backfill binary via k8s/jobs/support-backfill.yaml for the
+// one-off, and StartSupportCaseReconciler in-process every night.
+//
+// Two passes, in this order:
+//
+//  1. linkDrafts — every support_drafts row becomes its case (fill-only)
+//     plus an ai_draft message, a sent message when it went out (the
+//     edited body when there was one) and a note when it was skipped.
+//     Follow-up drafts also record the user message they answer, keyed on
+//     the osTicket entry id the webhook gave them.
+//  2. syncFromOSTicket — every ticket's thread entries. An entry whose id
+//     we already hold is skipped; otherwise it CLAIMS the oldest message of
+//     the same kind on that ticket that has no entry id yet (the live paths
+//     don't know the entry id at ticket-create time, and pre-existing
+//     drafts never did), and only inserts when nothing is left to claim.
+//
+// Run it twice and the counts don't move — that's the idempotency test.
+
+// BackfillStats is what a run reports.
+type BackfillStats struct {
+	Tickets  int `json:"tickets"`
+	Cases    int `json:"cases"`
+	Messages int `json:"messages"`
+	Drafts   int `json:"drafts"`
+	Errors   int `json:"errors"`
+}
+
+type osTicketListResponse struct {
+	Count   int `json:"count"`
+	Tickets []struct {
+		Number string `json:"number"`
+	} `json:"tickets"`
+}
+
+type osTicketDetail struct {
+	Number      string  `json:"number"`
+	Subject     string  `json:"subject"`
+	Topic       *string `json:"topic"`
+	Status      *string `json:"status"`
+	StatusState *string `json:"status_state"`
+	Priority    string  `json:"priority"`
+	Created     *string `json:"created"`
+	Updated     *string `json:"updated"`
+	Closed      bool    `json:"closed"`
+	UserEmail   string  `json:"user_email"`
+	Thread      []struct {
+		ID        int64   `json:"id"`
+		Type      string  `json:"type"`
+		Created   *string `json:"created"`
+		BodyPlain string  `json:"body_plain"`
+	} `json:"thread"`
+}
+
+// BackfillFromOSTicket runs both passes. A zero `since` walks every
+// ticket; otherwise only tickets osTicket updated since then.
+func BackfillFromOSTicket(ctx context.Context, since time.Time) (BackfillStats, error) {
+	var st BackfillStats
+	if platform.DBPool == nil {
+		return st, fmt.Errorf("DB not initialized")
+	}
+	st.Drafts, st.Errors = linkDrafts(ctx)
+
+	q := url.Values{"status": {"all"}, "topic": {"all"}, "limit": {"100"}}
+	if !since.IsZero() {
+		q.Set("since", since.UTC().Format(time.RFC3339))
+	}
+	// ponytail: the plugin's list endpoint caps at 100 and has no offset;
+	// page with ?since= by last `updated` when the ticket count passes 100.
+	status, body, err := osTicketRequest(ctx, "GET", "/api/tickets.json?"+q.Encode(), nil)
+	if err != nil {
+		return st, fmt.Errorf("list tickets (status %d): %w", status, err)
+	}
+	var list osTicketListResponse
+	if err := json.Unmarshal(body, &list); err != nil {
+		return st, fmt.Errorf("decode ticket list: %w", err)
+	}
+	for _, t := range list.Tickets {
+		st.Tickets++
+		if err := syncTicket(ctx, t.Number, &st); err != nil {
+			st.Errors++
+			log.Printf("[Backfill] ticket %s: %v", t.Number, err)
+		}
+	}
+	// Discord threads the live path created before cases existed.
+	_, _ = platform.DBPool.Exec(ctx, `
+		UPDATE support_cases c SET discord_thread_id = t.discord_thread_id
+		FROM support_ticket_threads t
+		WHERE t.ticket_number = c.ticket_number AND c.discord_thread_id IS NULL`)
+	return st, nil
+}
+
+// linkDrafts is pass 1. Returns (drafts seen, errors).
+func linkDrafts(ctx context.Context) (int, int) {
+	rows, err := platform.DBPool.Query(ctx, `
+		SELECT id, ticket_number, user_email, original_subject,
+			   COALESCE(user_message_html,''), draft_body_html, COALESCE(edited_body_html,''),
+			   COALESCE(ai_summary,''), COALESCE(ai_category,''), COALESCE(ai_priority,''),
+			   status, COALESCE(osticket_thread_entry_id,0), decided_at, sent_at, created_at
+		FROM support_drafts ORDER BY created_at, id`)
+	if err != nil {
+		log.Printf("[Backfill] read drafts: %v", err)
+		return 0, 1
+	}
+	defer rows.Close()
+	var n, errs int
+	for rows.Next() {
+		var d SupportDraft
+		var summary, category, priority string
+		if err := rows.Scan(&d.ID, &d.TicketNumber, &d.UserEmail, &d.OriginalSubject,
+			&d.UserMessageHTML, &d.DraftBodyHTML, &d.EditedBodyHTML, &summary, &category, &priority,
+			&d.Status, &d.OSTicketThreadEntryID, &d.DecidedAt, &d.SentAt, &d.CreatedAt); err != nil {
+			errs++
+			continue
+		}
+		n++
+		if err := upsertSupportCase(ctx, SupportCase{
+			TicketNumber: d.TicketNumber, UserEmail: d.UserEmail, Subject: d.OriginalSubject,
+			Category: category, Priority: priority, Summary: summary,
+			OpenedAt: d.CreatedAt, UpdatedAt: d.CreatedAt,
+		}); err != nil {
+			errs++
+			log.Printf("[Backfill] %v", err)
+			continue
+		}
+		// Only follow-up drafts know their entry id; an opening message
+		// without one has no idempotency key here, so the thread walk in
+		// syncTicket records it instead.
+		if d.UserMessageHTML != "" && d.OSTicketThreadEntryID > 0 {
+			errs += logged(recordSupportMessage(ctx, SupportMessage{
+				TicketNumber: d.TicketNumber, Kind: "user", BodyHTML: d.UserMessageHTML,
+				OSTicketEntryID: d.OSTicketThreadEntryID, CreatedAt: d.CreatedAt,
+			}))
+		}
+		errs += logged(recordSupportMessage(ctx, SupportMessage{
+			TicketNumber: d.TicketNumber, Kind: "ai_draft", BodyHTML: d.DraftBodyHTML,
+			AIDraftID: d.ID, CreatedAt: d.CreatedAt,
+		}))
+		switch d.Status {
+		case "sent", "approved", "edited":
+			body := d.DraftBodyHTML
+			if d.EditedBodyHTML != "" {
+				body = d.EditedBodyHTML
+			}
+			at := d.CreatedAt
+			if d.DecidedAt != nil {
+				at = *d.DecidedAt
+			}
+			if d.SentAt != nil {
+				at = *d.SentAt
+			}
+			errs += logged(recordSupportMessage(ctx, SupportMessage{
+				TicketNumber: d.TicketNumber, Kind: "sent", BodyHTML: body, AIDraftID: d.ID, CreatedAt: at,
+			}))
+		case "skipped":
+			at := d.CreatedAt
+			if d.DecidedAt != nil {
+				at = *d.DecidedAt
+			}
+			errs += logged(recordSupportMessage(ctx, SupportMessage{
+				TicketNumber: d.TicketNumber, Kind: "note", BodyText: "AI draft skipped", AIDraftID: d.ID, CreatedAt: at,
+			}))
+		}
+	}
+	return n, errs
+}
+
+func logged(err error) int {
+	if err != nil {
+		log.Printf("[Backfill] %v", err)
+		return 1
+	}
+	return 0
+}
+
+// syncTicket is pass 2 for one ticket.
+func syncTicket(ctx context.Context, number string, st *BackfillStats) error {
+	status, body, err := osTicketRequest(ctx, "GET", "/api/tickets/"+url.PathEscape(number)+".json", nil)
+	if err != nil {
+		return fmt.Errorf("detail (status %d): %w", status, err)
+	}
+	var d osTicketDetail
+	if err := json.Unmarshal(body, &d); err != nil {
+		return fmt.Errorf("decode detail: %w", err)
+	}
+	caseStatus := "open"
+	if d.Closed || (d.StatusState != nil && *d.StatusState != "open") {
+		caseStatus = "closed"
+	}
+	sc := SupportCase{
+		TicketNumber: number, UserEmail: d.UserEmail, Subject: d.Subject,
+		Category: categoryFromTopic(d.Topic), Priority: d.Priority, Status: caseStatus,
+		OpenedAt: parseISO(d.Created), UpdatedAt: parseISO(d.Updated),
+	}
+	if caseStatus == "closed" {
+		closed := sc.UpdatedAt
+		if closed.IsZero() {
+			closed = time.Now()
+		}
+		sc.ClosedAt = &closed
+	}
+	if err := upsertSupportCase(ctx, sc); err != nil {
+		return err
+	}
+	st.Cases++
+
+	kinds := map[string]string{"M": "user", "R": "sent", "N": "note"}
+	for _, e := range d.Thread {
+		kind, ok := kinds[e.Type]
+		if !ok || e.ID == 0 {
+			continue
+		}
+		// Claim the oldest unlinked message of this kind on the ticket;
+		// thread entries arrive in id order, so the zip lines up.
+		tag, err := platform.DBPool.Exec(ctx, `
+			UPDATE support_messages SET osticket_entry_id = $3
+			WHERE id = (SELECT id FROM support_messages
+						WHERE ticket_number = $1 AND kind = $2 AND osticket_entry_id IS NULL
+						ORDER BY created_at, id LIMIT 1)
+			  AND NOT EXISTS (SELECT 1 FROM support_messages WHERE osticket_entry_id = $3)`,
+			number, kind, e.ID)
+		if err != nil {
+			return fmt.Errorf("claim entry %d: %w", e.ID, err)
+		}
+		if tag.RowsAffected() > 0 {
+			st.Messages++
+			continue
+		}
+		if err := recordSupportMessage(ctx, SupportMessage{
+			TicketNumber: number, Kind: kind, BodyText: strings.TrimSpace(e.BodyPlain),
+			OSTicketEntryID: e.ID, CreatedAt: parseISO(e.Created),
+		}); err != nil {
+			return err
+		}
+		st.Messages++
+	}
+	return nil
+}
+
+// categoryFromTopic maps an osTicket help-topic name onto the category
+// vocabulary the submit form uses.
+func categoryFromTopic(topic *string) string {
+	if topic == nil {
+		return ""
+	}
+	t := strings.ToLower(*topic)
+	for _, c := range []string{"bug", "feature", "feedback", "billing", "account", "widget"} {
+		if strings.Contains(t, c) {
+			return c
+		}
+	}
+	if strings.Contains(t, "channel") {
+		return "widget"
+	}
+	return strings.TrimSpace(t)
+}
+
+func parseISO(s *string) time.Time {
+	if s == nil {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, *s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// StartSupportCaseReconciler re-syncs tickets osTicket updated in the
+// last 48 h, once a day, so status changes and replies made inside
+// osTicket's own UI reach the case DB. Redis-locked so one replica runs
+// it. No-op when osTicket isn't configured.
+func StartSupportCaseReconciler(ctx context.Context) {
+	if os.Getenv("OSTICKET_URL") == "" || os.Getenv("OSTICKET_API_KEY") == "" {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(24 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if platform.Rdb != nil {
+					locked, err := platform.Rdb.SetNX(ctx, "support:reconcile:lock", "1", 12*time.Hour).Result()
+					if err != nil || !locked {
+						continue
+					}
+				}
+				runCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+				st, err := BackfillFromOSTicket(runCtx, time.Now().Add(-48*time.Hour))
+				cancel()
+				log.Printf("[Cases] nightly reconcile: %+v err=%v", st, err)
+			}
+		}
+	}()
+	log.Println("[Cases] nightly osTicket reconcile started (24h interval, 48h window)")
+}

--- a/api/internal/support/support_cases.go
+++ b/api/internal/support/support_cases.go
@@ -1,0 +1,311 @@
+package support
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+)
+
+// =============================================================================
+// Support case database — support_cases + support_messages (REL-243)
+// =============================================================================
+//
+// osTicket owns the tickets. This is the searchable copy the support bot
+// reads: one row per ticket, one row per thread event. Every path that
+// already sees an event writes here (ticket create on both submit paths,
+// the osTicket follow-up webhook, draft create / send / skip) and the
+// backfill in support_backfill.go fills in whatever happened elsewhere.
+
+// SupportCase mirrors one support_cases row. Empty strings and zero
+// times mean "unknown" on write and are never used to blank a stored
+// value — see upsertSupportCase.
+type SupportCase struct {
+	TicketNumber    string     `json:"ticket_number"`
+	UserEmail       string     `json:"-"`
+	LogtoSub        string     `json:"-"`
+	Subject         string     `json:"subject"`
+	Category        string     `json:"category,omitempty"`
+	Priority        string     `json:"priority,omitempty"`
+	Status          string     `json:"status"`
+	Summary         string     `json:"summary,omitempty"`
+	AppVersion      string     `json:"app_version,omitempty"`
+	OS              string     `json:"os,omitempty"`
+	TierAtOpen      string     `json:"tier_at_open,omitempty"`
+	LinearIssueKey  string     `json:"linear_issue_key,omitempty"`
+	DiscordThreadID string     `json:"discord_thread_id,omitempty"`
+	OpenedAt        time.Time  `json:"opened_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	ClosedAt        *time.Time `json:"closed_at,omitempty"`
+}
+
+// SupportMessage mirrors one support_messages row.
+type SupportMessage struct {
+	TicketNumber    string
+	Kind            string // user | ai_draft | sent | note
+	BodyHTML        string
+	BodyText        string // derived from BodyHTML when empty
+	AIDraftID       int64  // 0 = none
+	OSTicketEntryID int64  // 0 = unknown
+	CreatedAt       time.Time
+}
+
+// upsertSupportCase inserts the case or fills in what the stored row
+// doesn't know yet. Descriptive fields (category, priority, summary,
+// app_version, os, tier) are FIRST writer wins, so the nightly osTicket
+// reconcile never overwrites what triage or the JWT told us at open time;
+// subject and status are LAST writer wins, because osTicket is the
+// authority for those and the reconcile is the newest source. Timestamps
+// widen: opened_at only moves earlier, updated_at only later.
+func upsertSupportCase(ctx context.Context, sc SupportCase) error {
+	if platform.DBPool == nil {
+		return fmt.Errorf("DB not initialized")
+	}
+	var opened, updated *time.Time
+	if !sc.OpenedAt.IsZero() {
+		opened = &sc.OpenedAt
+	}
+	if !sc.UpdatedAt.IsZero() {
+		updated = &sc.UpdatedAt
+	}
+	const q = `
+		INSERT INTO support_cases
+			(ticket_number, user_email, logto_sub, subject, category, priority, status,
+			 summary, app_version, os, tier_at_open, opened_at, updated_at, closed_at)
+		VALUES ($1, NULLIF($2,''), NULLIF($3,''), $4, NULLIF($5,''), NULLIF($6,''),
+			COALESCE(NULLIF($7,''), 'open'), NULLIF($8,''), NULLIF($9,''), NULLIF($10,''),
+			NULLIF($11,''), COALESCE($12, now()), COALESCE($13, now()), $14)
+		ON CONFLICT (ticket_number) DO UPDATE SET
+			user_email   = COALESCE(EXCLUDED.user_email, support_cases.user_email),
+			logto_sub    = COALESCE(support_cases.logto_sub, EXCLUDED.logto_sub),
+			subject      = CASE WHEN EXCLUDED.subject <> '' THEN EXCLUDED.subject ELSE support_cases.subject END,
+			category     = COALESCE(support_cases.category, EXCLUDED.category),
+			priority     = COALESCE(support_cases.priority, EXCLUDED.priority),
+			status       = COALESCE(NULLIF($7,''), support_cases.status),
+			summary      = COALESCE(support_cases.summary, EXCLUDED.summary),
+			app_version  = COALESCE(support_cases.app_version, EXCLUDED.app_version),
+			os           = COALESCE(support_cases.os, EXCLUDED.os),
+			tier_at_open = COALESCE(support_cases.tier_at_open, EXCLUDED.tier_at_open),
+			opened_at    = LEAST(support_cases.opened_at, EXCLUDED.opened_at),
+			updated_at   = GREATEST(support_cases.updated_at, EXCLUDED.updated_at),
+			closed_at    = CASE WHEN $7 = '' THEN support_cases.closed_at ELSE EXCLUDED.closed_at END
+	`
+	_, err := platform.DBPool.Exec(ctx, q,
+		sc.TicketNumber, sc.UserEmail, sc.LogtoSub, sc.Subject, sc.Category,
+		strings.ToLower(sc.Priority), sc.Status, sc.Summary, sc.AppVersion, sc.OS,
+		sc.TierAtOpen, opened, updated, sc.ClosedAt)
+	if err != nil {
+		return fmt.Errorf("upsertSupportCase %s: %w", sc.TicketNumber, err)
+	}
+	return nil
+}
+
+// applyTriageToCase overwrites the triage-owned fields on a case. The
+// AI's latest read of a ticket beats both the user's pick and the osTicket
+// topic, which is why this is not routed through the fill-only upsert.
+func applyTriageToCase(ctx context.Context, ticketNumber string, t *TriageResult) {
+	if platform.DBPool == nil || t == nil {
+		return
+	}
+	const q = `
+		UPDATE support_cases SET
+			category   = COALESCE(NULLIF($2,''), category),
+			priority   = COALESCE(NULLIF($3,''), priority),
+			summary    = COALESCE(NULLIF($4,''), summary),
+			updated_at = GREATEST(updated_at, now())
+		WHERE ticket_number = $1
+	`
+	if _, err := platform.DBPool.Exec(ctx, q, ticketNumber, t.Category, strings.ToLower(t.Priority), t.Summary); err != nil {
+		log.Printf("[Cases] applyTriageToCase %s: %v", ticketNumber, err)
+	}
+}
+
+// recordSupportMessage appends one event to a case's timeline. Idempotent
+// through the two partial unique indexes (osticket_entry_id, and
+// ai_draft_id+kind): a second write of the same event is a no-op. Creates
+// a bare case row first so a message for a ticket this API never saw
+// created (IMAP-only tickets, legacy drafts) still lands.
+func recordSupportMessage(ctx context.Context, m SupportMessage) error {
+	if platform.DBPool == nil {
+		return fmt.Errorf("DB not initialized")
+	}
+	if m.BodyText == "" {
+		m.BodyText = strings.TrimSpace(htmlToPlain(m.BodyHTML))
+	}
+	var created *time.Time
+	if !m.CreatedAt.IsZero() {
+		created = &m.CreatedAt
+	}
+	if _, err := platform.DBPool.Exec(ctx,
+		`INSERT INTO support_cases (ticket_number) VALUES ($1) ON CONFLICT DO NOTHING`, m.TicketNumber); err != nil {
+		return fmt.Errorf("recordSupportMessage case %s: %w", m.TicketNumber, err)
+	}
+	const q = `
+		INSERT INTO support_messages
+			(ticket_number, kind, body_html, body_text, ai_draft_id, osticket_entry_id, created_at)
+		VALUES ($1, $2, NULLIF($3,''), $4, NULLIF($5,0), NULLIF($6,0), COALESCE($7, now()))
+		ON CONFLICT DO NOTHING
+	`
+	tag, err := platform.DBPool.Exec(ctx, q, m.TicketNumber, m.Kind, m.BodyHTML, m.BodyText,
+		m.AIDraftID, m.OSTicketEntryID, created)
+	if err != nil {
+		return fmt.Errorf("recordSupportMessage %s/%s: %w", m.TicketNumber, m.Kind, err)
+	}
+	if tag.RowsAffected() > 0 {
+		_, _ = platform.DBPool.Exec(ctx,
+			`UPDATE support_cases SET updated_at = GREATEST(updated_at, COALESCE($2, now())) WHERE ticket_number = $1`,
+			m.TicketNumber, created)
+	}
+	return nil
+}
+
+// setCaseStatus flips a case open/closed. Used by the send path when the
+// approved reply also closes the ticket in osTicket.
+func setCaseStatus(ctx context.Context, ticketNumber, status string) {
+	if platform.DBPool == nil {
+		return
+	}
+	const q = `
+		UPDATE support_cases SET
+			status     = $2,
+			closed_at  = CASE WHEN $2 = 'closed' THEN now() ELSE NULL END,
+			updated_at = now()
+		WHERE ticket_number = $1
+	`
+	if _, err := platform.DBPool.Exec(ctx, q, ticketNumber, status); err != nil {
+		log.Printf("[Cases] setCaseStatus %s=%s: %v", ticketNumber, status, err)
+	}
+}
+
+// caseFieldsFromDiagnostics pulls app version and OS out of the desktop's
+// collect_diagnostics blob (`app.version`, `system.osName`, falling back
+// to `app.platform`). Only these two leave the blob; the rest stays in the
+// osTicket thread where it always was.
+func caseFieldsFromDiagnostics(diag map[string]interface{}) (appVersion, osName string) {
+	get := func(section, key string) string {
+		s, _ := diag[section].(map[string]interface{})
+		v, _ := s[key].(string)
+		return strings.TrimSpace(v)
+	}
+	appVersion = get("app", "version")
+	osName = get("system", "osName")
+	if osName == "" {
+		osName = get("app", "platform")
+	}
+	return appVersion, osName
+}
+
+// FetchRecentTicketSummaries returns the last 50 cases, newest first, as
+// the dupe-detection context for triage. Reads support_cases; this
+// replaced the Redis sliding window, which only ever held what this
+// process had pushed and forgot everything on a Redis flush.
+func FetchRecentTicketSummaries(ctx context.Context) []RecentTicketSummary {
+	if platform.DBPool == nil {
+		return nil
+	}
+	const q = `
+		SELECT ticket_number, COALESCE(category, ''), COALESCE(summary, subject), opened_at
+		FROM support_cases
+		ORDER BY opened_at DESC
+		LIMIT 50
+	`
+	rows, err := platform.DBPool.Query(ctx, q)
+	if err != nil {
+		log.Printf("[Cases] FetchRecentTicketSummaries: %v", err)
+		return nil
+	}
+	defer rows.Close()
+	var out []RecentTicketSummary
+	for rows.Next() {
+		var s RecentTicketSummary
+		var opened time.Time
+		if err := rows.Scan(&s.TicketNumber, &s.Category, &s.Summary, &opened); err != nil {
+			continue
+		}
+		s.CreatedAt = opened.UTC().Format(time.RFC3339)
+		out = append(out, s)
+	}
+	return out
+}
+
+// SearchSupportCases is Postgres full-text search over cases and their
+// messages. An empty q lists by recency; otherwise results are ranked by
+// the best match across subject/summary and any message body.
+func SearchSupportCases(ctx context.Context, q, category, status string, limit int) ([]SupportCase, error) {
+	if platform.DBPool == nil {
+		return nil, fmt.Errorf("DB not initialized")
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	const sql = `
+		WITH query AS (SELECT websearch_to_tsquery('english', $1) AS tsq)
+		SELECT c.ticket_number, c.subject, COALESCE(c.category,''), COALESCE(c.priority,''), c.status,
+			   COALESCE(c.summary,''), COALESCE(c.app_version,''), COALESCE(c.os,''),
+			   COALESCE(c.tier_at_open,''), COALESCE(c.linear_issue_key,''),
+			   COALESCE(c.discord_thread_id,''), c.opened_at, c.updated_at, c.closed_at
+		FROM support_cases c, query
+		WHERE ($2 = '' OR c.category = $2)
+		  AND ($3 = '' OR c.status = $3)
+		  AND ($1 = '' OR c.search @@ query.tsq OR EXISTS (
+				SELECT 1 FROM support_messages m
+				WHERE m.ticket_number = c.ticket_number AND m.search @@ query.tsq))
+		ORDER BY
+			CASE WHEN $1 = '' THEN 0 ELSE
+				ts_rank(c.search, query.tsq) + COALESCE((
+					SELECT max(ts_rank(m.search, query.tsq)) FROM support_messages m
+					WHERE m.ticket_number = c.ticket_number), 0)
+			END DESC,
+			c.updated_at DESC
+		LIMIT $4
+	`
+	rows, err := platform.DBPool.Query(ctx, sql, strings.TrimSpace(q), category, status, limit)
+	if err != nil {
+		return nil, fmt.Errorf("SearchSupportCases: %w", err)
+	}
+	defer rows.Close()
+	out := []SupportCase{}
+	for rows.Next() {
+		var c SupportCase
+		if err := rows.Scan(&c.TicketNumber, &c.Subject, &c.Category, &c.Priority, &c.Status,
+			&c.Summary, &c.AppVersion, &c.OS, &c.TierAtOpen, &c.LinearIssueKey,
+			&c.DiscordThreadID, &c.OpenedAt, &c.UpdatedAt, &c.ClosedAt); err != nil {
+			return nil, fmt.Errorf("SearchSupportCases scan: %w", err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// HandleSearchSupportCases serves GET /internal/support/cases?q=&category=&status=&limit=.
+// Server-to-server only: it is gated by the same shared secret the
+// osTicket webhook uses (X-Scrollr-Webhook-Secret), which is the trust
+// domain this data belongs to. Bodies are not returned — cases only.
+func HandleSearchSupportCases(c *fiber.Ctx) error {
+	expected := os.Getenv("SCROLLR_WEBHOOK_SECRET")
+	provided := c.Get("X-Scrollr-Webhook-Secret")
+	if expected == "" || provided == "" ||
+		subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
+			Status: "error", Error: "unauthorized",
+		})
+	}
+	limit, _ := strconv.Atoi(c.Query("limit"))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cases, err := SearchSupportCases(ctx, c.Query("q"), c.Query("category"), c.Query("status"), limit)
+	if err != nil {
+		log.Printf("[Cases] search: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "search failed",
+		})
+	}
+	return c.JSON(fiber.Map{"count": len(cases), "cases": cases})
+}

--- a/api/internal/support/support_cases_test.go
+++ b/api/internal/support/support_cases_test.go
@@ -1,0 +1,305 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+	"github.com/gofiber/fiber/v2"
+)
+
+// resetCases empties the case tables between tests (schema is private to
+// this package, see testsupport.Main).
+func resetCases(t *testing.T) {
+	t.Helper()
+	testsupport.MustExec(t, `TRUNCATE support_messages, support_cases, support_drafts, support_ticket_threads RESTART IDENTITY CASCADE`)
+}
+
+func countMessages(t *testing.T, ticket, kind string) int {
+	t.Helper()
+	var n int
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM support_messages WHERE ticket_number = $1 AND ($2 = '' OR kind = $2)`,
+		ticket, kind).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// fakeOSTicket is the plugin's reply + list + detail surface, enough for
+// the send path and the backfill. Threads are keyed by ticket number.
+type fakeOSTicket struct {
+	tickets map[string]map[string]interface{}
+}
+
+func (f *fakeOSTicket) handler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "k1" {
+			w.WriteHeader(401)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/reply.json"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "entry_id": 9001, "closed": true})
+		case r.Method == "GET" && r.URL.Path == "/api/tickets.json":
+			if r.URL.Query().Get("status") != "all" || r.URL.Query().Get("topic") != "all" {
+				t.Errorf("list must ask for every ticket, got %s", r.URL.RawQuery)
+			}
+			list := []map[string]interface{}{}
+			for n := range f.tickets {
+				list = append(list, map[string]interface{}{"number": n})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"count": len(list), "tickets": list})
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/tickets/"):
+			n := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/tickets/"), ".json")
+			d, ok := f.tickets[n]
+			if !ok {
+				w.WriteHeader(404)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(d)
+		default:
+			w.WriteHeader(404)
+		}
+	})
+}
+
+func entry(id int64, typ, body string) map[string]interface{} {
+	return map[string]interface{}{"id": id, "type": typ, "created": "2026-06-01T10:00:00Z", "body_plain": body}
+}
+
+func setOSTicketEnv(t *testing.T, url string) {
+	t.Helper()
+	t.Setenv("OSTICKET_URL", url)
+	t.Setenv("OSTICKET_API_KEY", "k1")
+}
+
+// TestCases_IngestOnEveryEvent walks the four live paths: ticket open,
+// draft create, follow-up webhook, send (with close) and skip.
+func TestCases_IngestOnEveryEvent(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+	srv := httptest.NewServer((&fakeOSTicket{}).handler(t))
+	defer srv.Close()
+	setOSTicketEnv(t, srv.URL)
+
+	diag := map[string]interface{}{
+		"app":    map[string]interface{}{"version": "1.6.2", "platform": "windows"},
+		"system": map[string]interface{}{"osName": "Windows 11"},
+	}
+	appVersion, osName := caseFieldsFromDiagnostics(diag)
+	recordTicketOpened(ctx, SupportCase{
+		TicketNumber: "100", UserEmail: "u@example.com", LogtoSub: "sub-1", Subject: "Ticker froze",
+		Category: "bug", AppVersion: appVersion, OS: osName, TierAtOpen: platform.TierFromRoles([]string{"uplink_pro"}),
+	}, "<p>The ticker stopped scrolling after sleep</p>")
+
+	draft, err := createSupportDraft(ctx, &SupportDraft{
+		TicketNumber: "100", UserEmail: "u@example.com", OriginalSubject: "Ticker froze",
+		DraftBodyHTML: "<p>Try restarting the app</p>", AISummary: "ticker freezes after sleep",
+		AICategory: "bug", AIPriority: "High",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Follow-up via the webhook path. No ANTHROPIC_API_KEY → triage is nil
+	// and the function returns right after the case-DB write.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	processReplyTriageAsync(osTicketThreadMessageEvent{
+		Event: "thread.message", TicketNumber: "100", ThreadEntryID: 555,
+		UserEmail: "u@example.com", Subject: "Ticker froze", MessageHTML: "<p>Restart did not help</p>",
+	})
+	processReplyTriageAsync(osTicketThreadMessageEvent{ // same entry twice = one row
+		Event: "thread.message", TicketNumber: "100", ThreadEntryID: 555,
+		UserEmail: "u@example.com", Subject: "Ticker froze", MessageHTML: "<p>Restart did not help</p>",
+	})
+
+	if err := markDraftDecided(ctx, draft.ID, "edited", "<p>Edited: update to 1.6.2</p>"); err != nil {
+		t.Fatal(err)
+	}
+	if err := doSendApprovedReply(ctx, draft, "<p>Edited: update to 1.6.2</p>"); err != nil {
+		t.Fatal(err)
+	}
+
+	skip, _ := createSupportDraft(ctx, &SupportDraft{TicketNumber: "100", UserEmail: "u@example.com",
+		OriginalSubject: "Ticker froze", DraftBodyHTML: "<p>second draft</p>"})
+	if err := markDraftDecided(ctx, skip.ID, "skipped", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	var c SupportCase
+	var tier, appV, osV, cat, prio, sum string
+	if err := platform.DBPool.QueryRow(ctx, `SELECT status, tier_at_open, app_version, os, category, priority, summary FROM support_cases WHERE ticket_number='100'`).
+		Scan(&c.Status, &tier, &appV, &osV, &cat, &prio, &sum); err != nil {
+		t.Fatal(err)
+	}
+	if c.Status != "closed" || tier != "uplink_pro" || appV != "1.6.2" || osV != "Windows 11" || cat != "bug" || prio != "high" || sum == "" {
+		t.Fatalf("case row wrong: status=%s tier=%s app=%s os=%s cat=%s prio=%s sum=%q", c.Status, tier, appV, osV, cat, prio, sum)
+	}
+	for kind, want := range map[string]int{"user": 2, "ai_draft": 2, "sent": 1, "note": 1} {
+		if got := countMessages(t, "100", kind); got != want {
+			t.Errorf("%s messages: got %d want %d", kind, got, want)
+		}
+	}
+	var sentEntry int64
+	var sentBody string
+	_ = platform.DBPool.QueryRow(ctx, `SELECT osticket_entry_id, body_html FROM support_messages WHERE kind='sent'`).Scan(&sentEntry, &sentBody)
+	if sentEntry != 9001 || !strings.Contains(sentBody, "Edited") {
+		t.Fatalf("sent message: entry=%d body=%q", sentEntry, sentBody)
+	}
+
+	recent := FetchRecentTicketSummaries(ctx)
+	if len(recent) != 1 || recent[0].TicketNumber != "100" || recent[0].Summary != "ticker freezes after sleep" {
+		t.Fatalf("recent summaries: %+v", recent)
+	}
+}
+
+// TestBackfill_Idempotent runs the osTicket walk twice: an existing
+// edited draft gets linked to its R entry, the unlinked opening message
+// gets its entry id, and the second run changes nothing.
+func TestBackfill_Idempotent(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+
+	// A draft from before the case DB existed: edited, sent, no entry id.
+	var draftID int64
+	if err := platform.DBPool.QueryRow(ctx, `
+		INSERT INTO support_drafts (ticket_number, user_email, original_subject, user_message_html,
+			draft_body_html, edited_body_html, ai_summary, ai_category, status, decided_at, sent_at, created_at)
+		VALUES ('200','a@example.com','Cannot log in','<p>Login loops</p>','<p>AI: clear cache</p>',
+			'<p>Human: we shipped a fix in 1.6.1</p>','login loop','account','edited',
+			'2026-06-01T11:00:00Z','2026-06-01T11:00:00Z','2026-06-01T10:00:00Z') RETURNING id`).Scan(&draftID); err != nil {
+		t.Fatal(err)
+	}
+	testsupport.MustExec(t, `INSERT INTO support_ticket_threads (ticket_number, discord_thread_id, channel_id) VALUES ('200','thr-1','chan-1')`)
+
+	fake := &fakeOSTicket{tickets: map[string]map[string]interface{}{
+		"200": {
+			"number": "200", "subject": "Cannot log in", "topic": "Account & Login", "status": "Closed",
+			"status_state": "closed", "priority": "Normal", "created": "2026-06-01T10:00:00Z",
+			"updated": "2026-06-02T10:00:00Z", "closed": true, "user_email": "a@example.com",
+			"thread": []map[string]interface{}{
+				entry(1, "M", "Login loops"), entry(2, "R", "Human: we shipped a fix in 1.6.1"), entry(3, "N", "internal note"),
+			},
+		},
+		"201": { // never seen by this API (IMAP-only ticket)
+			"number": "201", "subject": "Weather widget shows nothing", "topic": "Bug Report", "status": "Open",
+			"status_state": "open", "priority": "High", "created": "2026-06-03T10:00:00Z",
+			"updated": "2026-06-03T10:00:00Z", "closed": false, "user_email": "b@example.com",
+			"thread": []map[string]interface{}{entry(10, "M", "Weather widget is blank since the update")},
+		},
+	}}
+	srv := httptest.NewServer(fake.handler(t))
+	defer srv.Close()
+	setOSTicketEnv(t, srv.URL)
+
+	first, err := BackfillFromOSTicket(ctx, time.Time{})
+	if err != nil || first.Errors != 0 {
+		t.Fatalf("first run: %+v err=%v", first, err)
+	}
+	second, err := BackfillFromOSTicket(ctx, time.Time{})
+	if err != nil || second.Errors != 0 {
+		t.Fatalf("second run: %+v err=%v", second, err)
+	}
+	if first.Tickets != 2 || second.Tickets != 2 || first.Drafts != 1 {
+		t.Fatalf("stats: first=%+v second=%+v", first, second)
+	}
+
+	var cases int
+	_ = platform.DBPool.QueryRow(ctx, `SELECT count(*) FROM support_cases`).Scan(&cases)
+	if cases != 2 {
+		t.Fatalf("cases: %d", cases)
+	}
+	if got := countMessages(t, "200", ""); got != 4 { // user, ai_draft, sent, note
+		t.Fatalf("ticket 200 messages: %d", got)
+	}
+	if got := countMessages(t, "201", ""); got != 1 {
+		t.Fatalf("ticket 201 messages: %d", got)
+	}
+
+	// The draft's sent copy was claimed by the R entry, and it differs
+	// from the AI draft (the edited body went out).
+	var sentEntry int64
+	var sentBody, draftBody string
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT COALESCE(osticket_entry_id,0), body_html FROM support_messages WHERE kind='sent' AND ai_draft_id=$1`, draftID).
+		Scan(&sentEntry, &sentBody); err != nil {
+		t.Fatal(err)
+	}
+	_ = platform.DBPool.QueryRow(ctx, `SELECT body_html FROM support_messages WHERE kind='ai_draft' AND ai_draft_id=$1`, draftID).Scan(&draftBody)
+	if sentEntry != 2 || sentBody == draftBody {
+		t.Fatalf("sent link: entry=%d sent=%q draft=%q", sentEntry, sentBody, draftBody)
+	}
+	var userEntry int64
+	_ = platform.DBPool.QueryRow(ctx, `SELECT COALESCE(osticket_entry_id,0) FROM support_messages WHERE kind='user' AND ticket_number='200'`).Scan(&userEntry)
+	if userEntry != 1 {
+		t.Fatalf("user message not claimed: entry=%d", userEntry)
+	}
+
+	var status, cat, thread string
+	var closedAt *time.Time
+	_ = platform.DBPool.QueryRow(ctx, `SELECT status, category, COALESCE(discord_thread_id,''), closed_at FROM support_cases WHERE ticket_number='200'`).
+		Scan(&status, &cat, &thread, &closedAt)
+	if status != "closed" || closedAt == nil || cat != "account" || thread != "thr-1" {
+		t.Fatalf("case 200: status=%s closed=%v cat=%s thread=%s", status, closedAt, cat, thread)
+	}
+
+	// Search: a word only in a message body finds the case; the handler
+	// gates on the shared secret.
+	hits, err := SearchSupportCases(ctx, "blank weather", "", "", 10)
+	if err != nil || len(hits) != 1 || hits[0].TicketNumber != "201" {
+		t.Fatalf("search: %+v err=%v", hits, err)
+	}
+	hits, _ = SearchSupportCases(ctx, "", "account", "closed", 10)
+	if len(hits) != 1 || hits[0].TicketNumber != "200" {
+		t.Fatalf("filter search: %+v", hits)
+	}
+
+	t.Setenv("SCROLLR_WEBHOOK_SECRET", "s3cret")
+	app := fiber.New()
+	app.Get("/internal/support/cases", HandleSearchSupportCases)
+	req := httptest.NewRequest("GET", "/internal/support/cases?q=weather", nil)
+	resp, _ := app.Test(req)
+	if resp.StatusCode != 401 {
+		t.Fatalf("no secret: %d", resp.StatusCode)
+	}
+	req.Header.Set("X-Scrollr-Webhook-Secret", "s3cret")
+	resp, _ = app.Test(req)
+	var body struct {
+		Count int           `json:"count"`
+		Cases []SupportCase `json:"cases"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if resp.StatusCode != 200 || body.Count != 1 || body.Cases[0].TicketNumber != "201" {
+		t.Fatalf("handler: %d %+v", resp.StatusCode, body)
+	}
+}
+
+// TestCategoryFromTopic pins the topic → category mapping.
+func TestCategoryFromTopic(t *testing.T) {
+	for in, want := range map[string]string{"Bug Report": "bug", "Feature Request": "feature",
+		"Account & Login": "account", "Channel Help": "widget", "Other": "other"} {
+		s := in
+		if got := categoryFromTopic(&s); got != want {
+			t.Errorf("%s: got %s want %s", in, got, want)
+		}
+	}
+	if categoryFromTopic(nil) != "" {
+		t.Error("nil topic")
+	}
+	_ = fmt.Sprint
+}

--- a/api/internal/support/support_drafts.go
+++ b/api/internal/support/support_drafts.go
@@ -110,6 +110,18 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 		return nil, fmt.Errorf("createSupportDraft: %w", err)
 	}
 	draft.Status = "pending"
+
+	// Case DB: the draft is an event on the case, and triage's read of
+	// the ticket (category / priority / summary) is the best one we have.
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: draft.TicketNumber, Kind: "ai_draft", BodyHTML: draft.DraftBodyHTML,
+		AIDraftID: draft.ID, CreatedAt: draft.CreatedAt,
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
+	applyTriageToCase(ctx, draft.TicketNumber, &TriageResult{
+		Category: draft.AICategory, Priority: draft.AIPriority, Summary: draft.AISummary,
+	})
 	return draft, nil
 }
 
@@ -192,6 +204,19 @@ func markDraftDecided(ctx context.Context, id int64, newStatus string, editedBod
 	}
 	if tag.RowsAffected() == 0 {
 		return ErrAlreadyDecided
+	}
+	// A skip is the one decision with no send behind it, so it leaves its
+	// mark here; approve/edit are recorded by doSendApprovedReply with
+	// the body that actually went out.
+	if newStatus == "skipped" {
+		var ticket string
+		if err := platform.DBPool.QueryRow(ctx, `SELECT ticket_number FROM support_drafts WHERE id = $1`, id).Scan(&ticket); err == nil {
+			if err := recordSupportMessage(ctx, SupportMessage{
+				TicketNumber: ticket, Kind: "note", BodyText: "AI draft skipped", AIDraftID: id,
+			}); err != nil {
+				log.Printf("[Cases] %v", err)
+			}
+		}
 	}
 	return nil
 }
@@ -320,6 +345,24 @@ func doSendApprovedReply(ctx context.Context, draft *SupportDraft, body string) 
 
 	log.Printf("[Drafts] reply posted to osTicket for ticket=%s status=%d body=%s",
 		draft.TicketNumber, status, string(respBody))
+
+	// Case DB: what went out (the edited body when there was one), keyed
+	// on the osTicket entry id the plugin returns so the nightly reconcile
+	// recognises it instead of inserting the same reply again.
+	var reply struct {
+		EntryID int64 `json:"entry_id"`
+		Closed  bool  `json:"closed"`
+	}
+	_ = json.Unmarshal(respBody, &reply)
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: draft.TicketNumber, Kind: "sent", BodyHTML: body,
+		AIDraftID: draft.ID, OSTicketEntryID: reply.EntryID,
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
+	if reply.Closed {
+		setCaseStatus(ctx, draft.TicketNumber, "closed")
+	}
 	return nil
 }
 

--- a/api/main.go
+++ b/api/main.go
@@ -101,6 +101,9 @@ func main() {
 	// configured). No-op if Discord env vars aren't set.
 	support.RegisterDiscordSlashCommandsAtBoot(ctx)
 
+	// Nightly re-sync of the support case DB from osTicket (REL-243).
+	support.StartSupportCaseReconciler(ctx)
+
 	// Build and start the gateway server
 	srv := core.NewServer()
 	srv.Setup()

--- a/api/migrations/000010_support_cases.down.sql
+++ b/api/migrations/000010_support_cases.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE support_messages;
+DROP TABLE support_cases;

--- a/api/migrations/000010_support_cases.up.sql
+++ b/api/migrations/000010_support_cases.up.sql
@@ -1,0 +1,60 @@
+-- Support case database (REL-243).
+--
+-- osTicket holds the tickets; this is the copy the support bot can read
+-- and search. One row per ticket, one row per thread event. Written on
+-- every event the API already sees (ticket create, osTicket follow-up
+-- webhook, draft send/edit/skip) and backfilled from the osTicket plugin's
+-- list/detail endpoints by cmd/support-backfill, which also runs nightly
+-- for tickets updated in the last 48 h.
+--
+-- Deliberately no PII beyond what support_drafts already stores: the user
+-- email (the ticket's identity in osTicket) and the parsed app version + OS
+-- from the desktop diagnostics blob. Not the diagnostics blob itself.
+--
+-- Search is Postgres full-text (tsvector generated columns + GIN). No
+-- embeddings, no pgvector.
+
+CREATE TABLE support_cases (
+    ticket_number     text PRIMARY KEY,
+    user_email        text,
+    logto_sub         text,
+    subject           text NOT NULL DEFAULT '',
+    category          text,
+    priority          text,
+    status            text NOT NULL DEFAULT 'open',
+    summary           text,
+    app_version       text,
+    os                text,
+    tier_at_open      text,
+    linear_issue_key  text,
+    discord_thread_id text,
+    opened_at         timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at        timestamp with time zone NOT NULL DEFAULT now(),
+    closed_at         timestamp with time zone,
+    search            tsvector GENERATED ALWAYS AS
+        (to_tsvector('english', coalesce(subject, '') || ' ' || coalesce(summary, ''))) STORED
+);
+
+CREATE INDEX support_cases_updated_idx ON support_cases (updated_at DESC);
+CREATE INDEX support_cases_search_idx  ON support_cases USING GIN (search);
+
+CREATE TABLE support_messages (
+    id                 bigserial PRIMARY KEY,
+    ticket_number      text NOT NULL REFERENCES support_cases (ticket_number),
+    kind               text NOT NULL CHECK (kind IN ('user', 'ai_draft', 'sent', 'note')),
+    body_html          text,
+    body_text          text NOT NULL,
+    ai_draft_id        bigint REFERENCES support_drafts (id),
+    osticket_entry_id  bigint,
+    created_at         timestamp with time zone NOT NULL DEFAULT now(),
+    search             tsvector GENERATED ALWAYS AS (to_tsvector('english', body_text)) STORED
+);
+
+-- Idempotency: an osTicket thread entry lands once, and a draft yields at
+-- most one message per kind (its ai_draft, its sent copy, its skip note).
+CREATE UNIQUE INDEX support_messages_entry_idx ON support_messages (osticket_entry_id)
+    WHERE osticket_entry_id IS NOT NULL;
+CREATE UNIQUE INDEX support_messages_draft_idx ON support_messages (ai_draft_id, kind)
+    WHERE ai_draft_id IS NOT NULL;
+CREATE INDEX support_messages_ticket_idx ON support_messages (ticket_number, created_at);
+CREATE INDEX support_messages_search_idx ON support_messages USING GIN (search);

--- a/k8s/jobs/support-backfill.yaml
+++ b/k8s/jobs/support-backfill.yaml
@@ -1,0 +1,39 @@
+# One-off: backfill support_cases + support_messages from osTicket (REL-243).
+#
+# NOT applied by deploy.yml (it lists manifests explicitly). Run by hand:
+#
+#   # pin to the image core-api is running right now
+#   IMG=$(kubectl -n scrollr get deploy core-api -o jsonpath='{.spec.template.spec.containers[0].image}')
+#   sed "s|IMAGE_PLACEHOLDER|$IMG|" k8s/jobs/support-backfill.yaml | kubectl apply -f -
+#   kubectl -n scrollr logs -f job/support-backfill
+#   kubectl -n scrollr delete job support-backfill
+#
+# Must run in-cluster: the osTicket plugin's API key is bound to the
+# cluster's egress IP. Idempotent — safe to re-run.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: support-backfill
+  namespace: scrollr
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: support-backfill
+          image: IMAGE_PLACEHOLDER
+          command: ["./support-backfill"]
+          envFrom:
+            - configMapRef:
+                name: core-config
+            - secretRef:
+                name: scrollr-secrets
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi


### PR DESCRIPTION
## Summary

Support case database (REL-243). osTicket keeps the tickets; this is the copy the support bot can read and search.

- **Migration `000010_support_cases`** — `support_cases` (one row per ticket: number, user email, subject, category, priority, status, app version + OS parsed from the desktop diagnostics, tier at open from JWT roles, timestamps, `linear_issue_key`, `discord_thread_id`) and `support_messages` (`user | ai_draft | sent | note`, body html + text, `ai_draft_id`, `osticket_entry_id`). Additive; full-text via generated `tsvector` + GIN. No pgvector.
- **Ingest on every event we already receive**: ticket create on both submit paths, the osTicket follow-up webhook, draft create, send (with the osTicket `entry_id` from the reply response, and close), skip. Discord thread id lands when the thread is created.
- **`go run ./cmd/support-backfill`** walks `GET /api/tickets.json?status=all&topic=all` + `GET /api/tickets/{n}.json`, links every existing `support_drafts` row, and is idempotent by entry id (drafts first, then thread entries claim the live-recorded messages that had no entry id yet). Ships in the core-api image; `k8s/jobs/support-backfill.yaml` runs it in-cluster (the plugin key is IP-bound). Not touched by deploy.yml.
- **Nightly reconcile** of tickets updated in the last 48 h, Redis-locked to one replica.
- **`GET /internal/support/cases?q=&category=&status=&limit=`** — gated by the existing osTicket webhook secret.
- **`FetchRecentTicketSummaries`** reads the last 50 cases from Postgres (same signature); the Redis sliding window is removed.

Not changed: triage prompt, Discord UI, no new PII (email already lives in `support_drafts`; only app version + OS leave the diagnostics blob).

## Test plan

- [x] `go test ./...` green against the dev Postgres, incl. new `TestCases_IngestOnEveryEvent` (all five paths), `TestBackfill_Idempotent` (run twice, same counts, edited draft linked to its `R` entry and differs from the draft, search hit, handler auth) and the topic mapping
- [x] Production image builds with both binaries; `./support-backfill -h` runs
- [x] `scripts/migrations/check-additive.sh` passes
- [ ] After merge: run the Job, confirm `support_cases` ≈ osTicket ticket count, every draft linked, `/inbox` + `/ticket` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
