### PR TITLE
feat(support): the Discord queue becomes a workspace [REL-245]

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -58,3 +58,42 @@ jobs:
 
           curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @payload.json "$WEBHOOK"
           echo "Announced $NAME"
+
+      # The same publish event tells the support queue to draft "this is
+      # fixed in X" for cases whose linked Linear issue is Done (REL-245).
+      # It rides here rather than in a second workflow on the same trigger:
+      # one event, one place to look when the follow-ups don't appear.
+      #
+      # core-api does the work because the Linear and osTicket credentials
+      # live there, not on a runner — same reasoning as auto-close-osticket.yml,
+      # and the same shared secret. Best-effort: a failure here never fails
+      # the release announcement.
+      - name: Queue shipped-fix follow-ups
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          URL: ${{ github.event.release.html_url }}
+          API_BASE: ${{ vars.SCROLLR_API_BASE_URL }}
+          WEBHOOK_SECRET: ${{ secrets.OSTICKET_PR_WEBHOOK_SECRET }}
+        run: |
+          if [ -z "$WEBHOOK_SECRET" ]; then
+            echo "::warning::OSTICKET_PR_WEBHOOK_SECRET not set; skipping shipped follow-ups."
+            exit 0
+          fi
+          API="${API_BASE:-https://api.myscrollr.com}"
+          PAYLOAD=$(jq -n --arg v "$TAG" --arg u "$URL" '{version: $v, release_url: $u}')
+
+          set +e
+          RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Webhook-Secret: $WEBHOOK_SECRET" \
+            -d "$PAYLOAD" \
+            "$API/webhooks/github/release-published")
+          CURL_EXIT=$?
+          set -e
+
+          HTTP_CODE=$(printf '%s' "$RESPONSE" | tail -n1)
+          if [ "$CURL_EXIT" -ne 0 ] || [ "$HTTP_CODE" -ge 400 ]; then
+            echo "::warning::Follow-up queue call failed (curl=$CURL_EXIT http=$HTTP_CODE). Release announcement unaffected."
+            exit 0
+          fi
+          echo "Queued shipped follow-ups for $TAG"

--- a/api/cmd/kbgen/main.go
+++ b/api/cmd/kbgen/main.go
@@ -243,12 +243,24 @@ func hashJSON(v any) string {
 
 // tierOrder sorts plans lowest first, using the same priority the API
 // uses to pick a user's tier from their roles.
+// tierOrder lists plan ids weakest-first.
+//
+// It has to be deterministic or its own CI guard flakes, and the rank
+// comparator alone is not: TierFromRoles returns "super_user" the moment it
+// SEES that role, wherever in the slice, so super_user and uplink_ultimate
+// compare false in both directions — equal. sort.Slice is unstable, so the
+// pair's order then followed Go's randomised map iteration and the table
+// came out differently run to run.
+//
+// Sorting by id first gives every tie a fixed answer; the stable rank sort
+// on top of it keeps that answer while ordering by plan strength.
 func tierOrder(m map[string]widgets.WidgetLimits) []string {
 	ids := make([]string, 0, len(m))
 	for id := range m {
 		ids = append(ids, id)
 	}
-	sort.Slice(ids, func(i, j int) bool {
+	sort.Strings(ids)
+	sort.SliceStable(ids, func(i, j int) bool {
 		return platform.TierFromRoles([]string{ids[i], ids[j]}) == ids[j]
 	})
 	return ids

--- a/api/cmd/kbgen/main_test.go
+++ b/api/cmd/kbgen/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/widgets"
+)
+
+// TestTierOrderIsDeterministic guards the generator's own CI gate.
+//
+// The plan table is built by ranging a map, and the rank comparator alone
+// leaves super_user and uplink_ultimate comparing equal in both directions
+// (TierFromRoles short-circuits on super_user wherever it appears). With an
+// unstable sort on top of Go's randomised map iteration, the two rows
+// swapped run to run — so `git diff --exit-code` on the committed knowledge
+// base failed on unrelated pull requests, at random.
+//
+// Ranging the same map repeatedly is exactly the shuffle that exposed it.
+func TestTierOrderIsDeterministic(t *testing.T) {
+	first := tierOrder(widgets.DefaultTierLimits)
+	for i := 0; i < 200; i++ {
+		got := tierOrder(widgets.DefaultTierLimits)
+		if len(got) != len(first) {
+			t.Fatalf("run %d returned %d ids, first run returned %d", i, len(got), len(first))
+		}
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("run %d differs at %d: %q vs %q\n got: %v\nfirst: %v",
+					i, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}
+
+// The table still has to read weakest-first, which is the reason the rank
+// sort is there at all.
+func TestTierOrderRunsWeakestFirst(t *testing.T) {
+	ids := tierOrder(widgets.DefaultTierLimits)
+	if len(ids) < 2 {
+		t.Skip("not enough plans to order")
+	}
+	if ids[0] != "free" {
+		t.Errorf("first plan is %q, want free", ids[0])
+	}
+	for i, id := range ids {
+		if id == "uplink_pro" {
+			for _, weaker := range []string{"free", "uplink"} {
+				if indexOf(ids, weaker) > i {
+					t.Errorf("%s sorts after uplink_pro", weaker)
+				}
+			}
+		}
+	}
+}
+
+func indexOf(ids []string, want string) int {
+	for i, id := range ids {
+		if id == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/api/core/handlers_github_webhook.go
+++ b/api/core/handlers_github_webhook.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/support"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -279,4 +280,67 @@ func htmlEscape(s string) string {
 		"'", "&#39;",
 	)
 	return r.Replace(s)
+}
+
+// =============================================================================
+// GitHub release-published webhook — "this is fixed now" follow-ups
+// =============================================================================
+//
+// The Announce Release workflow already fires on `release: published` with
+// the tag and URL in hand; it POSTs them here on the way to Discord rather
+// than a second workflow watching the same event. Auth is the same shared
+// secret the PR-close Action uses, for the same reason: osTicket and Linear
+// credentials belong on this side of the wall, not on a GitHub runner.
+//
+// Everything this queues lands as an ordinary pending draft in the support
+// queue. Nothing is sent to a user without someone clicking Send.
+
+type githubReleasePublishedEvent struct {
+	Version    string `json:"version"`     // tag name, e.g. "desktop-v1.6.3"
+	ReleaseURL string `json:"release_url"` // link to the published notes
+}
+
+// HandleGitHubReleasePublished drafts shipped-follow-ups for cases whose
+// linked Linear issue is Done. Answers immediately; the Linear round-trips
+// happen in the background so a slow API never stalls the release workflow.
+func HandleGitHubReleasePublished(c *fiber.Ctx) error {
+	expected := os.Getenv("GITHUB_PR_WEBHOOK_SECRET")
+	if expected == "" {
+		log.Println("[GitHubWebhook] GITHUB_PR_WEBHOOK_SECRET not set; rejecting")
+		return c.Status(fiber.StatusServiceUnavailable).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "webhook secret not configured",
+		})
+	}
+	provided := c.Get("X-GitHub-Webhook-Secret")
+	if provided == "" || subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+		log.Println("[GitHubWebhook] missing or invalid X-GitHub-Webhook-Secret")
+		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
+			Status: "unauthorized",
+			Error:  "invalid webhook secret",
+		})
+	}
+
+	var ev githubReleasePublishedEvent
+	if err := json.Unmarshal(c.Body(), &ev); err != nil {
+		log.Printf("[GitHubWebhook] release body parse error: %v", err)
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "invalid JSON body",
+		})
+	}
+	if strings.TrimSpace(ev.Version) == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "missing version",
+		})
+	}
+
+	go func(version, url string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		support.DraftShippedFollowUps(ctx, version, url)
+	}(ev.Version, ev.ReleaseURL)
+
+	return c.JSON(fiber.Map{"status": "accepted", "version": ev.Version})
 }

--- a/api/core/server.go
+++ b/api/core/server.go
@@ -117,19 +117,20 @@ func (s *Server) setupMiddleware() {
 
 	// Core paths always exempt from rate limiting
 	coreExemptPaths := map[string]bool{
-		"/health":                           true,
-		"/events":                           true,
-		"/webhooks/sequin":                  true,
-		"/webhooks/stripe":                  true,
-		"/webhooks/osticket/thread-message": true,
-		"/webhooks/discord/interactions":    true, // Discord retries on rate-limit and we want them to succeed
-		"/webhooks/github/pr-closed":        true, // GitHub Action calls this when a PR with [fixes #N] tags merges
-		"/channels":                         true,
-		"/catalog":                          true,
-		"/tier-limits":                      true,
-		"/extension/token":                  true,
-		"/extension/token/refresh":          true,
-		"/support/ticket":                   true,
+		"/health":                            true,
+		"/events":                            true,
+		"/webhooks/sequin":                   true,
+		"/webhooks/stripe":                   true,
+		"/webhooks/osticket/thread-message":  true,
+		"/webhooks/discord/interactions":     true, // Discord retries on rate-limit and we want them to succeed
+		"/webhooks/github/pr-closed":         true, // GitHub Action calls this when a PR with [fixes #N] tags merges
+		"/webhooks/github/release-published": true, // Announce Release workflow calls this when a desktop release publishes
+		"/channels":                          true,
+		"/catalog":                           true,
+		"/tier-limits":                       true,
+		"/extension/token":                   true,
+		"/extension/token/refresh":           true,
+		"/support/ticket":                    true,
 	}
 
 	// Counters live in Redis so all replicas share one per-IP budget
@@ -201,6 +202,7 @@ func (s *Server) setupRoutes() {
 	s.App.Post("/webhooks/osticket/thread-message", support.HandleOSTicketThreadMessage)
 	s.App.Post("/webhooks/discord/interactions", support.HandleDiscordInteractions)
 	s.App.Post("/webhooks/github/pr-closed", HandleGitHubPRClosed)
+	s.App.Post("/webhooks/github/release-published", HandleGitHubReleasePublished)
 
 	// Extension auth proxy
 	s.App.Options("/extension/token", accounts.HandleExtensionAuthPreflight)
@@ -243,6 +245,7 @@ func (s *Server) setupRoutes() {
 	// Case DB full-text search (REL-243). Server-to-server: gated by the
 	// osTicket webhook's shared secret inside the handler.
 	s.App.Get("/internal/support/cases", support.HandleSearchSupportCases)
+	s.App.Post("/internal/support/digest", support.HandleRunSupportDigest)
 
 	// Invite (no auth — user isn't logged in yet, token-verified server-side)
 	s.App.Post("/invite/complete", accounts.HandleCompleteInvite)

--- a/api/internal/support/autosend.go
+++ b/api/internal/support/autosend.go
@@ -1,0 +1,182 @@
+package support
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+// =============================================================================
+// Auto-send — the delayed, opt-in, never-for-bugs path (REL-245)
+// =============================================================================
+//
+// Off by default. When SUPPORT_AUTOSEND=on, a draft that clears every gate
+// below is sent on its own after a delay, with a live countdown posted in
+// the thread; clicking Skip, Edit or Ask before the timer fires cancels it,
+// because those all move the draft off 'pending' and the timer re-reads the
+// status before sending.
+//
+// The gate is deliberately narrow. A wrong answer to "when does Uplink Pro
+// renew" costs a follow-up; a wrong answer to a billing or account question
+// costs trust and possibly money, and a wrong answer to a bug report tells
+// someone their broken app is working as intended. Those three categories
+// are refused here regardless of configuration — there is no env var that
+// turns them on.
+
+// autosendNeverCategories can never auto-send. Not configurable: see above.
+var autosendNeverCategories = map[string]struct{}{
+	"bug":     {},
+	"billing": {},
+	"account": {},
+}
+
+const (
+	autosendDefaultCategories = "feature,feedback"
+	autosendDefaultDelay      = 30 * time.Minute
+)
+
+// autosendEnabled reports whether SUPPORT_AUTOSEND is switched on.
+func autosendEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("SUPPORT_AUTOSEND")), "on")
+}
+
+// autosendCategories is the allow-list from SUPPORT_AUTOSEND_CATEGORIES,
+// lowercased. Empty env falls back to feature + feedback.
+func autosendCategories() map[string]struct{} {
+	raw := strings.TrimSpace(os.Getenv("SUPPORT_AUTOSEND_CATEGORIES"))
+	if raw == "" {
+		raw = autosendDefaultCategories
+	}
+	out := map[string]struct{}{}
+	for _, c := range strings.Split(raw, ",") {
+		if c = strings.ToLower(strings.TrimSpace(c)); c != "" {
+			out[c] = struct{}{}
+		}
+	}
+	return out
+}
+
+// autosendDelay is how long the partner has to intervene.
+func autosendDelay() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("SUPPORT_AUTOSEND_DELAY"))
+	if raw == "" {
+		return autosendDefaultDelay
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		log.Printf("[Autosend] SUPPORT_AUTOSEND_DELAY=%q is not a positive duration; using %s", raw, autosendDefaultDelay)
+		return autosendDefaultDelay
+	}
+	return d
+}
+
+// autosendAllowed is the whole decision, in one pure function so the gate
+// is testable without a database, a clock or Discord.
+//
+// Every condition must hold: the feature is on, the AI is confident, the
+// category is on the allow-list AND not one of the three that are never
+// eligible, the AI is not waiting on information from the user, and the
+// draft is still pending and has a body to send.
+func autosendAllowed(draft *SupportDraft) bool {
+	if draft == nil || !autosendEnabled() {
+		return false
+	}
+	if draft.Status != "pending" {
+		return false
+	}
+	if strings.TrimSpace(draft.DraftBodyHTML) == "" {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(draft.AIConfidence), "high") {
+		return false
+	}
+	if strings.TrimSpace(draft.AskUserFor) != "" {
+		return false
+	}
+	category := strings.ToLower(strings.TrimSpace(draft.AICategory))
+	if _, never := autosendNeverCategories[category]; never {
+		return false
+	}
+	_, ok := autosendCategories()[category]
+	return ok
+}
+
+// scheduleAutoSend arms the timer for a freshly-posted draft and announces
+// the deadline in its thread. No-op when the draft doesn't clear the gate.
+//
+// ponytail: the timer lives in this process, so a pod restart drops it and
+// the draft simply stays pending — the failure direction is "a human still
+// has to click", which is the safe one. Move it to a scanned deadline
+// column if auto-send ever becomes the main path.
+func scheduleAutoSend(draft *SupportDraft) {
+	if !autosendAllowed(draft) {
+		return
+	}
+	delay := autosendDelay()
+	deadline := time.Now().Add(delay)
+
+	// Discord renders <t:unix:R> as a live "in 29 minutes" that keeps
+	// counting down in place — a real countdown, not a printed duration.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		t, err := loadSupportTicketThread(ctx, draft.TicketNumber)
+		if err != nil || t == nil {
+			return
+		}
+		msg := fmt.Sprintf(
+			"⏳ Auto-sending <t:%d:R> — `%s` · confidence `%s`. Skip, Edit or Ask cancels it.",
+			deadline.Unix(), draft.AICategory, draft.AIConfidence)
+		if _, err := discordPostMessage(ctx, t.DiscordThreadID, msg, nil); err != nil {
+			log.Printf("[Autosend] countdown post for ticket %s: %v", draft.TicketNumber, err)
+		}
+	}()
+
+	draftID := draft.ID
+	time.AfterFunc(delay, func() { fireAutoSend(draftID) })
+	log.Printf("[Autosend] draft %d (ticket %s) armed for %s", draft.ID, draft.TicketNumber, deadline.Format(time.RFC3339))
+}
+
+// fireAutoSend re-reads the draft when the timer expires and sends it only
+// if nobody got there first. The status re-check is what makes Skip / Edit
+// / Ask a cancel, and markDraftDecided's `WHERE status = 'pending'` makes
+// the whole thing safe to run on several replicas at once.
+func fireAutoSend(draftID int64) {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil || draft == nil {
+		log.Printf("[Autosend] draft %d gone at fire time (err=%v)", draftID, err)
+		return
+	}
+	if !autosendAllowed(draft) {
+		log.Printf("[Autosend] draft %d no longer eligible (status=%s); cancelled", draftID, draft.Status)
+		return
+	}
+
+	if err := markDraftDecided(ctx, draftID, "approved", ""); err != nil {
+		log.Printf("[Autosend] draft %d not claimed: %v", draftID, err)
+		return
+	}
+	draft, _ = loadSupportDraft(ctx, draftID)
+	if draft == nil {
+		return
+	}
+	if err := sendApprovedReply(ctx, draft, draft.DraftBodyHTML); err != nil {
+		log.Printf("[Autosend] send for ticket %s: %v", draft.TicketNumber, err)
+		return
+	}
+	applySendStateToThread(ctx, draft, draft.ShouldClose)
+
+	if t, err := loadSupportTicketThread(ctx, draft.TicketNumber); err == nil && t != nil {
+		if _, err := discordPostMessage(ctx, t.DiscordThreadID,
+			"🤖 Auto-sent — nobody intervened before the timer.", nil); err != nil {
+			log.Printf("[Autosend] confirmation post for ticket %s: %v", draft.TicketNumber, err)
+		}
+	}
+	log.Printf("[Autosend] draft %d auto-sent for ticket %s", draftID, draft.TicketNumber)
+}

--- a/api/internal/support/autosend_test.go
+++ b/api/internal/support/autosend_test.go
@@ -1,0 +1,150 @@
+package support
+
+import (
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// The auto-send gate
+// =============================================================================
+//
+// This is the one piece of the queue that can talk to a user with nobody
+// watching, so the gate gets a test per way it can be wrong. The rule that
+// matters most is the last one: bug, billing and account never auto-send,
+// no matter how the environment is configured.
+
+// eligibleDraft is a draft that clears every condition. Each test breaks
+// exactly one thing so a failure names the condition that regressed.
+func eligibleDraft() *SupportDraft {
+	return &SupportDraft{
+		ID:            1,
+		TicketNumber:  "239171",
+		Status:        "pending",
+		DraftBodyHTML: "<p>Thanks for the suggestion — logged it.</p>",
+		AICategory:    "feature",
+		AIConfidence:  "high",
+	}
+}
+
+// autosendOn switches the feature on for one test and restores the
+// environment afterwards.
+func autosendOn(t *testing.T) {
+	t.Helper()
+	t.Setenv("SUPPORT_AUTOSEND", "on")
+}
+
+func TestAutosendAllowed_EligibleDraft(t *testing.T) {
+	autosendOn(t)
+	if !autosendAllowed(eligibleDraft()) {
+		t.Fatal("a high-confidence feature draft should auto-send when the feature is on")
+	}
+}
+
+func TestAutosendAllowed_OffByDefault(t *testing.T) {
+	t.Setenv("SUPPORT_AUTOSEND", "")
+	if autosendAllowed(eligibleDraft()) {
+		t.Fatal("auto-send must be off unless SUPPORT_AUTOSEND is explicitly on")
+	}
+	t.Setenv("SUPPORT_AUTOSEND", "true") // not "on"
+	if autosendAllowed(eligibleDraft()) {
+		t.Fatal(`only the exact value "on" enables auto-send`)
+	}
+}
+
+// TestAutosendAllowed_NeverForBugsBillingOrAccount is the rule the ticket
+// states outright. Configuration cannot override it: the categories are on
+// the allow-list here and must STILL be refused.
+func TestAutosendAllowed_NeverForBugsBillingOrAccount(t *testing.T) {
+	autosendOn(t)
+	t.Setenv("SUPPORT_AUTOSEND_CATEGORIES", "feature,feedback,bug,billing,account")
+
+	for _, category := range []string{"bug", "billing", "account", "Bug", "BILLING"} {
+		d := eligibleDraft()
+		d.AICategory = category
+		if autosendAllowed(d) {
+			t.Errorf("category %q auto-sent — it must never, whatever the config says", category)
+		}
+	}
+}
+
+func TestAutosendAllowed_OnlyAllowListedCategories(t *testing.T) {
+	autosendOn(t)
+	d := eligibleDraft()
+	d.AICategory = "widget"
+	if autosendAllowed(d) {
+		t.Error("a category outside SUPPORT_AUTOSEND_CATEGORIES auto-sent")
+	}
+
+	t.Setenv("SUPPORT_AUTOSEND_CATEGORIES", "widget")
+	if !autosendAllowed(d) {
+		t.Error("a category explicitly allow-listed did not auto-send")
+	}
+}
+
+func TestAutosendAllowed_RequiresHighConfidence(t *testing.T) {
+	autosendOn(t)
+	for _, confidence := range []string{"medium", "low", ""} {
+		d := eligibleDraft()
+		d.AIConfidence = confidence
+		if autosendAllowed(d) {
+			t.Errorf("confidence %q auto-sent; only high may", confidence)
+		}
+	}
+}
+
+// A draft that is still waiting on the user is, by definition, an
+// incomplete answer — sending it unattended is the worst case.
+func TestAutosendAllowed_RefusesWhenTriageNeedsMoreFromTheUser(t *testing.T) {
+	autosendOn(t)
+	d := eligibleDraft()
+	d.AskUserFor = "which version they're on"
+	if autosendAllowed(d) {
+		t.Error("a draft with ask_user_for set auto-sent")
+	}
+}
+
+// Skip / Edit / Ask all work by moving the draft off 'pending'; the timer
+// re-checks at fire time, so this one assertion covers all three cancels.
+func TestAutosendAllowed_RefusesOnceDecided(t *testing.T) {
+	autosendOn(t)
+	for _, status := range []string{"skipped", "edited", "asked", "approved", "sent", "failed"} {
+		d := eligibleDraft()
+		d.Status = status
+		if autosendAllowed(d) {
+			t.Errorf("status %q auto-sent; only a pending draft may", status)
+		}
+	}
+}
+
+func TestAutosendAllowed_RefusesEmptyBody(t *testing.T) {
+	autosendOn(t)
+	d := eligibleDraft()
+	d.DraftBodyHTML = ""
+	if autosendAllowed(d) {
+		t.Error("an empty draft body auto-sent")
+	}
+	if autosendAllowed(nil) {
+		t.Error("a nil draft auto-sent")
+	}
+}
+
+func TestAutosendDelay(t *testing.T) {
+	t.Setenv("SUPPORT_AUTOSEND_DELAY", "")
+	if got := autosendDelay(); got != 30*time.Minute {
+		t.Errorf("default delay = %s, want 30m", got)
+	}
+	t.Setenv("SUPPORT_AUTOSEND_DELAY", "5m")
+	if got := autosendDelay(); got != 5*time.Minute {
+		t.Errorf("delay = %s, want 5m", got)
+	}
+	// A typo must not become "send immediately".
+	t.Setenv("SUPPORT_AUTOSEND_DELAY", "30 minutes")
+	if got := autosendDelay(); got != 30*time.Minute {
+		t.Errorf("unparseable delay = %s, want the 30m default", got)
+	}
+	t.Setenv("SUPPORT_AUTOSEND_DELAY", "-5m")
+	if got := autosendDelay(); got != 30*time.Minute {
+		t.Errorf("negative delay = %s, want the 30m default", got)
+	}
+}

--- a/api/internal/support/discord.go
+++ b/api/internal/support/discord.go
@@ -12,9 +12,11 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
 )
@@ -202,6 +204,7 @@ var supportForumTagSpecs = []supportForumTagSpec{
 	{"pending", "⏳"},
 	{"sent", "✅"},
 	{"edited", "✏️"},
+	{"asked", "❓"},
 	{"skipped", "⏭️"},
 	{"closed", "🔒"},
 	// Category tags (mutually exclusive within their category set)
@@ -239,6 +242,7 @@ var statusTagNames = map[string]struct{}{
 	"pending": {},
 	"sent":    {},
 	"edited":  {},
+	"asked":   {},
 	"skipped": {},
 	"closed":  {},
 }
@@ -281,13 +285,13 @@ func discordCreateThread(
 	ctx context.Context,
 	channelID, name string,
 	starterContent string,
+	starterEmbed *discordEmbed,
 	starterComponents []DiscordActionRow,
 	appliedTagIDs []string,
 ) (*DiscordThread, error) {
-	if len(name) > 100 {
-		// Discord's hard limit on thread names is 100 chars.
-		name = name[:100]
-	}
+	// Discord's hard limit on thread names is 100 characters, and it
+	// rejects a name cut inside a multi-byte character outright.
+	name = truncateRunes(name, 100)
 
 	parentType, err := discordGetChannelType(ctx, channelID)
 	if err != nil {
@@ -296,12 +300,12 @@ func discordCreateThread(
 
 	switch parentType {
 	case discordChannelTypeForum, discordChannelTypeMedia:
-		return discordCreateForumThread(ctx, channelID, name, starterContent, starterComponents, appliedTagIDs)
+		return discordCreateForumThread(ctx, channelID, name, starterContent, starterEmbed, starterComponents, appliedTagIDs)
 	default:
 		// Text channels don't support tags — appliedTagIDs is silently
 		// dropped. Caller should still pass them; supports the case
 		// where someone migrates a forum-channel parent to text.
-		return discordCreateTextThread(ctx, channelID, name, starterContent, starterComponents)
+		return discordCreateTextThread(ctx, channelID, name, starterContent, starterEmbed, starterComponents)
 	}
 }
 
@@ -350,10 +354,11 @@ func discordGetChannelType(ctx context.Context, channelID string) (int, error) {
 func discordCreateForumThread(
 	ctx context.Context,
 	channelID, name, starterContent string,
+	starterEmbed *discordEmbed,
 	starterComponents []DiscordActionRow,
 	appliedTagIDs []string,
 ) (*DiscordThread, error) {
-	if starterContent == "" {
+	if starterContent == "" && starterEmbed == nil {
 		// Forum threads require a starter message; fall back to a
 		// placeholder so the create call doesn't 400.
 		starterContent = "(creating thread)"
@@ -361,6 +366,9 @@ func discordCreateForumThread(
 	msg := map[string]interface{}{
 		"content":          starterContent,
 		"allowed_mentions": map[string]interface{}{"parse": []string{}},
+	}
+	if starterEmbed != nil {
+		msg["embeds"] = []*discordEmbed{starterEmbed}
 	}
 	if len(starterComponents) > 0 {
 		msg["components"] = starterComponents
@@ -396,6 +404,7 @@ func discordCreateForumThread(
 func discordCreateTextThread(
 	ctx context.Context,
 	channelID, name, starterContent string,
+	starterEmbed *discordEmbed,
 	starterComponents []DiscordActionRow,
 ) (*DiscordThread, error) {
 	body := map[string]interface{}{
@@ -417,8 +426,8 @@ func discordCreateTextThread(
 	}
 
 	// Post starter content as the first thread message.
-	if starterContent != "" {
-		if _, err := discordPostMessage(ctx, t.ID, starterContent, starterComponents); err != nil {
+	if starterContent != "" || starterEmbed != nil {
+		if _, err := discordPostEmbed(ctx, t.ID, starterContent, starterEmbed, starterComponents); err != nil {
 			// Thread is created in Discord; we just couldn't post the
 			// starter message. Return the thread anyway — caller
 			// shouldn't fail the whole flow over this.
@@ -445,15 +454,45 @@ type DiscordActionRow struct {
 	Components []DiscordMessageButton `json:"components"`
 }
 
+// discordEmbed is the subset of Discord's embed object the support queue
+// uses: a titled block of name/value fields that reads as a header above
+// the message content. Field values are capped at 1024 chars by Discord.
+type discordEmbed struct {
+	Title       string              `json:"title,omitempty"`
+	Description string              `json:"description,omitempty"`
+	URL         string              `json:"url,omitempty"`
+	Color       int                 `json:"color,omitempty"`
+	Fields      []discordEmbedField `json:"fields,omitempty"`
+	Footer      *discordEmbedFooter `json:"footer,omitempty"`
+}
+
+type discordEmbedField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline,omitempty"`
+}
+
+type discordEmbedFooter struct {
+	Text string `json:"text"`
+}
+
 // discordPostMessage posts a message in a channel or thread, optionally
 // with components (buttons). Returns the new message's ID.
 //
 // channelOrThreadID is either a channel ID or thread ID — Discord
 // treats threads as channels for the purpose of posting.
 func discordPostMessage(ctx context.Context, channelOrThreadID, content string, components []DiscordActionRow) (string, error) {
+	return discordPostEmbed(ctx, channelOrThreadID, content, nil, components)
+}
+
+// discordPostEmbed is discordPostMessage with an optional embed attached.
+func discordPostEmbed(ctx context.Context, channelOrThreadID, content string, embed *discordEmbed, components []DiscordActionRow) (string, error) {
 	body := map[string]interface{}{
 		"content":          content,
 		"allowed_mentions": map[string]interface{}{"parse": []string{}}, // suppress @ mentions
+	}
+	if embed != nil {
+		body["embeds"] = []*discordEmbed{embed}
 	}
 	if len(components) > 0 {
 		body["components"] = components
@@ -496,6 +535,62 @@ func discordArchiveThread(ctx context.Context, threadID string) error {
 	return nil
 }
 
+// discordUnarchiveThread flips `archived` back to false so a user's
+// follow-up lands in the thread the conversation already lives in rather
+// than a fresh one. No-op when the thread is gone.
+func discordUnarchiveThread(ctx context.Context, threadID string) error {
+	body := map[string]interface{}{"archived": false, "locked": false}
+	respBody, status, err := discordRequest(ctx, http.MethodPatch, "/channels/"+threadID, body)
+	if err != nil {
+		return err
+	}
+	if status == http.StatusNotFound {
+		return nil
+	}
+	if status >= 400 {
+		return fmt.Errorf("discord unarchive thread: status %d body %s", status, string(respBody))
+	}
+	return nil
+}
+
+// discordPinForumThread pins a forum post to the top of the channel.
+// Discord models this as a channel flag (1 << 1) on the thread, not as a
+// pinned message. Used once, for the digest's Queue thread.
+func discordPinForumThread(ctx context.Context, threadID string) error {
+	body := map[string]interface{}{"flags": 2}
+	respBody, status, err := discordRequest(ctx, http.MethodPatch, "/channels/"+threadID, body)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("discord pin thread: status %d body %s", status, string(respBody))
+	}
+	return nil
+}
+
+// discordCompleteDeferred fills in the placeholder left by a deferred
+// interaction response. Interaction tokens stay valid for 15 minutes,
+// which is what lets a slow path (Linear) answer long after Discord's
+// 3-second deadline.
+//
+// It PATCHes @original rather than POSTing a follow-up: a POST would add
+// a second message and leave "the bot is thinking…" sitting there forever.
+func discordCompleteDeferred(ctx context.Context, applicationID, interactionToken, content string) error {
+	body := map[string]interface{}{
+		"content":          content,
+		"allowed_mentions": map[string]interface{}{"parse": []string{}},
+	}
+	path := fmt.Sprintf("/webhooks/%s/%s/messages/@original", applicationID, interactionToken)
+	respBody, status, err := discordRequest(ctx, http.MethodPatch, path, body)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("discord complete deferred: status %d body %s", status, string(respBody))
+	}
+	return nil
+}
+
 // =============================================================================
 // Slash command registration
 // =============================================================================
@@ -532,8 +627,34 @@ func registerDiscordSlashCommands(ctx context.Context) error {
 	commands := []discordSlashCommand{
 		{
 			Name:        "inbox",
-			Description: "Show pending support drafts (most recent 5)",
+			Description: "Browse pending support drafts, 10 at a time",
 			Type:        1,
+		},
+		{
+			Name:        "case",
+			Description: "Show the full timeline for a ticket number",
+			Type:        1,
+			Options: []discordSlashCommandOption{
+				{
+					Name:        "number",
+					Description: "osTicket ticket number (e.g. 239171)",
+					Type:        3,
+					Required:    true,
+				},
+			},
+		},
+		{
+			Name:        "search",
+			Description: "Full-text search across support cases and their messages",
+			Type:        1,
+			Options: []discordSlashCommandOption{
+				{
+					Name:        "text",
+					Description: "What to look for (e.g. \"weather widget crash\")",
+					Type:        3,
+					Required:    true,
+				},
+			},
 		},
 		{
 			Name:        "ticket",
@@ -593,7 +714,7 @@ func RegisterDiscordSlashCommandsAtBoot(ctx context.Context) {
 		log.Printf("[Discord] register slash commands: %v", err)
 		// Continue to tag bootstrap even if commands failed.
 	} else {
-		log.Println("[Discord] slash commands registered (/inbox, /ticket, /stats)")
+		log.Println("[Discord] slash commands registered (/inbox, /case, /search, /ticket, /stats)")
 	}
 
 	if err := ensureSupportForumTags(ctx, cfg.SupportChannelID); err != nil {
@@ -718,9 +839,7 @@ func priorityEmojiPrefix(priority string) string {
 // field. Used when transitioning between states (sent/closed/skipped)
 // so the prefix flips visibly in the thread list.
 func discordUpdateThreadName(ctx context.Context, threadID, newName string) error {
-	if len(newName) > 100 {
-		newName = newName[:100]
-	}
+	newName = truncateRunes(newName, 100)
 	body := map[string]interface{}{"name": newName}
 	respBody, status, err := discordRequest(ctx, http.MethodPatch, "/channels/"+threadID, body)
 	if err != nil {
@@ -935,6 +1054,80 @@ func markSupportTicketThreadArchived(ctx context.Context, ticketNumber string) e
 	return err
 }
 
+// markSupportTicketThreadUnarchived clears the archived flag so the next
+// draft threads into the existing conversation instead of opening a new one.
+func markSupportTicketThreadUnarchived(ctx context.Context, ticketNumber string) error {
+	const q = `UPDATE support_ticket_threads SET archived = FALSE WHERE ticket_number = $1`
+	_, err := platform.DBPool.Exec(ctx, q, ticketNumber)
+	return err
+}
+
+// notifyDiscordForUserReply puts a user's follow-up into the thread that
+// already holds their conversation, before triage has drafted anything.
+//
+// Previously a reply only surfaced once the AI had finished drafting, and
+// on an archived thread it surfaced in a brand-new one — so a conversation
+// scattered across threads and the partner saw the answer before the
+// question. Here the thread wakes, the reply lands, the title says [REPLY]
+// and the tag goes back to pending; the draft follows a few seconds later.
+//
+// Fail-open throughout: nothing in here may stop the draft being created.
+func notifyDiscordForUserReply(ctx context.Context, ticketNumber, subject, priority, messageHTML string) {
+	if !shouldNotifyDiscord() {
+		return
+	}
+	t, err := loadSupportTicketThread(ctx, ticketNumber)
+	if err != nil || t == nil {
+		// No thread yet — the draft's own path will create one carrying
+		// this same message.
+		return
+	}
+
+	if t.Archived {
+		if err := discordUnarchiveThread(ctx, t.DiscordThreadID); err != nil {
+			log.Printf("[Discord] unarchive thread for ticket %s: %v", ticketNumber, err)
+			return
+		}
+		if err := markSupportTicketThreadUnarchived(ctx, ticketNumber); err != nil {
+			log.Printf("[Discord] clear archived flag for ticket %s: %v", ticketNumber, err)
+		}
+	}
+
+	body := strings.TrimSpace(htmlToPlain(messageHTML))
+	if body == "" {
+		body = "(empty message)"
+	}
+	content := "📨 **The user replied**\n" + blockquoteText(body, len(body))
+	for _, chunk := range splitForDiscord(content, discordMessageLimit) {
+		if _, err := discordPostMessage(ctx, t.DiscordThreadID, chunk, nil); err != nil {
+			log.Printf("[Discord] post user reply for ticket %s: %v", ticketNumber, err)
+			return
+		}
+	}
+
+	transitionThreadStatus(ctx, t, "pending", false)
+
+	name := fmt.Sprintf("[REPLY] %s[#%s] %s",
+		priorityEmojiPrefix(priority), ticketNumber, truncateForThreadName(subject, ticketNumber, priority))
+	if err := discordUpdateThreadName(ctx, t.DiscordThreadID, name); err != nil {
+		log.Printf("[Discord] rename thread (reply) for ticket %s: %v", ticketNumber, err)
+	}
+}
+
+// truncateForThreadName trims a subject to whatever is left of Discord's
+// 100-char thread-name budget after the "[REPLY] " prefix, the priority
+// emoji and the ticket number.
+func truncateForThreadName(subject, ticketNumber, priority string) string {
+	if subject == "" {
+		subject = "support ticket"
+	}
+	budget := 100 - len("[REPLY] ") - len(priorityEmojiPrefix(priority)) - len(ticketNumber) - 4
+	if budget < 10 {
+		return ""
+	}
+	return truncateRunes(subject, budget)
+}
+
 // =============================================================================
 // Notification entry point — called from notifyPartnerAfterDraft
 // =============================================================================
@@ -960,25 +1153,54 @@ func notifyDiscordForDraft(ctx context.Context, draft *SupportDraft) {
 	}
 	cfg, _ := loadDiscordConfig() // ok already verified by shouldNotifyDiscord
 
-	content := buildDraftMessageContent(draft)
+	// A reply-loop draft answers a message notifyDiscordForUserReply has
+	// already quoted into this thread. Quoting it twice is noise, so the
+	// draft leads with the reply itself — unless there was no thread to
+	// post into, in which case this draft's own starter carries it.
+	existing, _ := loadSupportTicketThread(ctx, draft.TicketNumber)
+	includeUserMessage := !(draft.OSTicketThreadEntryID > 0 && existing != nil && !existing.Archived)
+
+	embed := buildDraftHeaderEmbed(ctx, draft)
+	starter, rest := buildDraftMessages(draft, includeUserMessage)
 	components := buildDraftActionButtons(draft.ID)
 
-	threadID, isNew, err := getOrCreateThreadForTicket(ctx, cfg, draft, content, components)
+	// Buttons ride on the LAST message so the partner never has to scroll
+	// back up past a long draft to act on what they just read. When the
+	// draft fits in the starter, that is the starter.
+	starterComponents := components
+	if len(rest) > 0 {
+		starterComponents = nil
+	}
+
+	threadID, isNew, err := getOrCreateThreadForTicket(ctx, cfg, draft, starter, embed, starterComponents)
 	if err != nil {
 		log.Printf("[Discord] getOrCreateThread for ticket %s: %v", draft.TicketNumber, err)
 		return
 	}
 
-	// If we just created the thread, the starter message IS the draft
-	// content; no separate post-message call needed (and posting again
-	// would duplicate). Only post follow-up when threading into an
-	// existing thread.
+	// If we just created the thread, the starter message went out with it;
+	// posting it again would duplicate. Only re-post when threading into
+	// an existing thread.
 	if !isNew {
-		if _, err := discordPostMessage(ctx, threadID, content, components); err != nil {
-			log.Printf("[Discord] post draft message for ticket %s: %v", draft.TicketNumber, err)
+		if _, err := discordPostEmbed(ctx, threadID, starter, embed, starterComponents); err != nil {
+			log.Printf("[Discord] post draft starter for ticket %s: %v", draft.TicketNumber, err)
 			return
 		}
 	}
+
+	for i, chunk := range rest {
+		var comps []DiscordActionRow
+		if i == len(rest)-1 {
+			comps = components
+		}
+		if _, err := discordPostMessage(ctx, threadID, chunk, comps); err != nil {
+			log.Printf("[Discord] post draft part %d/%d for ticket %s: %v",
+				i+1, len(rest), draft.TicketNumber, err)
+			return
+		}
+	}
+
+	scheduleAutoSend(draft)
 }
 
 // getOrCreateThreadForTicket looks up an existing thread or creates a
@@ -999,6 +1221,7 @@ func getOrCreateThreadForTicket(
 	cfg DiscordConfig,
 	draft *SupportDraft,
 	starterContent string,
+	starterEmbed *discordEmbed,
 	starterComponents []DiscordActionRow,
 ) (string, bool, error) {
 	existing, err := loadSupportTicketThread(ctx, draft.TicketNumber)
@@ -1035,7 +1258,7 @@ func getOrCreateThreadForTicket(
 		initialTags = append(initialTags, id)
 	}
 
-	thread, err := discordCreateThread(ctx, cfg.SupportChannelID, name, starterContent, starterComponents, initialTags)
+	thread, err := discordCreateThread(ctx, cfg.SupportChannelID, name, starterContent, starterEmbed, starterComponents, initialTags)
 	if err != nil {
 		return "", false, fmt.Errorf("create thread: %w", err)
 	}
@@ -1057,76 +1280,259 @@ func getOrCreateThreadForTicket(
 	return thread.ID, true, nil
 }
 
-// buildDraftMessageContent renders the user message + AI metadata +
-// drafted reply into Discord's text content. Discord supports basic
-// markdown (bold, blockquote, code) and a 2000-char limit per message.
+// discordMessageLimit is Discord's hard per-message content cap.
+const discordMessageLimit = 2000
+
+// userMessageHeadLimit is how much of the user's own message rides on the
+// starter message. The rest continues in follow-up messages — a support
+// reply is only as good as the complaint behind it, so nothing is dropped.
+const userMessageHeadLimit = 1500
+
+// splitForDiscord breaks s into chunks of at most max bytes, preferring to
+// cut at a blank line, then at a line break, then at a space. A word is
+// only ever split when the word itself is longer than a whole chunk, and
+// then only on a rune boundary.
 //
-// We trim aggressively so the content fits even with verbose user
-// bodies.
-func buildDraftMessageContent(draft *SupportDraft) string {
-	var b strings.Builder
-
-	header := fmt.Sprintf("**Ticket #%s** — `%s` · `%s` · confidence: `%s`",
-		draft.TicketNumber, draft.AICategory, draft.AIPriority, draft.AIConfidence)
-	b.WriteString(header)
-	b.WriteString("\n\n")
-
-	if draft.UserMessageHTML != "" {
-		b.WriteString("**What the user wrote:**\n")
-		b.WriteString(blockquoteText(htmlToPlain(draft.UserMessageHTML), 600))
-		b.WriteString("\n\n")
+// Byte length is the budget rather than rune count: Discord counts
+// characters, and bytes >= characters for UTF-8, so this is conservative
+// in the safe direction.
+func splitForDiscord(s string, max int) []string {
+	if max <= 0 {
+		return nil
 	}
-
-	b.WriteString("**AI summary:** ")
-	b.WriteString(draft.AISummary)
-	b.WriteString("\n\n")
-
-	b.WriteString("**Drafted reply:**\n")
-	b.WriteString(blockquoteText(htmlToPlain(draft.DraftBodyHTML), 800))
-
-	// Reserve some headroom for Discord's hard 2000-char limit.
-	out := b.String()
-	if len(out) > 1900 {
-		out = out[:1900] + "\n\n_...truncated_"
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for len(s) > max {
+		cut := breakPoint(s, max)
+		out = append(out, strings.TrimRight(s[:cut], " \t\n"))
+		s = strings.TrimLeft(s[cut:], " \t\n")
+	}
+	if s != "" {
+		out = append(out, s)
 	}
 	return out
 }
 
-// buildDraftActionButtons returns the action-row components for a
-// pending draft.
-func buildDraftActionButtons(draftID int64) []DiscordActionRow {
-	send := DiscordMessageButton{
-		Type:     2,
-		Style:    3, // success / green
-		Label:    "Send",
-		CustomID: fmt.Sprintf("support_send:%d", draftID),
+// breakPoint returns the index to cut s at so the first piece is <= max
+// bytes and lands on the nicest boundary available in the last third of
+// the budget.
+func breakPoint(s string, max int) int {
+	window := s[:max]
+	floor := max / 3 // don't accept a boundary so early it wastes the message
+	for _, sep := range []string{"\n\n", "\n", " "} {
+		if i := strings.LastIndex(window, sep); i > floor {
+			return i + len(sep)
+		}
 	}
-	send.Emoji = &struct {
-		Name string `json:"name"`
-	}{Name: "✅"}
-	edit := DiscordMessageButton{
-		Type:     2,
-		Style:    1, // primary / blue
-		Label:    "Edit",
-		CustomID: fmt.Sprintf("support_edit:%d", draftID),
+	// One unbroken run longer than a whole message (a URL, a stack trace,
+	// a log line). Back up to a rune boundary so the cut is still valid
+	// UTF-8; the caller's chunk stays under max either way.
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
 	}
-	edit.Emoji = &struct {
-		Name string `json:"name"`
-	}{Name: "✏️"}
-	skip := DiscordMessageButton{
-		Type:     2,
-		Style:    2, // secondary / gray
-		Label:    "Skip",
-		CustomID: fmt.Sprintf("support_skip:%d", draftID),
-	}
-	skip.Emoji = &struct {
-		Name string `json:"name"`
-	}{Name: "⏭️"}
+	return cut
+}
 
+// buildDraftMessages renders one draft as the starter message plus however
+// many follow-up messages the full text needs. Nothing is truncated: the
+// partner reads the complete draft in the thread and decides from it,
+// which was the whole failure of the old single 2000-char message.
+//
+// Returns (starter, rest). The caller puts the action buttons on the last
+// message of the pair. includeUserMessage is false when the thread already
+// shows the message this draft answers.
+func buildDraftMessages(draft *SupportDraft, includeUserMessage bool) (string, []string) {
+	var head, tail string
+	if includeUserMessage {
+		head, tail = splitAtLimit(htmlToPlain(draft.UserMessageHTML), userMessageHeadLimit)
+	}
+
+	var msgs []string
+	if head != "" {
+		// Split after quoting, not before: the "> " on every line is part
+		// of what has to fit, and a many-line message can gain hundreds of
+		// bytes from it.
+		section := "**What the user wrote**\n" + blockquoteText(head, len(head))
+		if tail != "" {
+			section += "\n_…continues below_"
+		}
+		msgs = append(msgs, splitForDiscord(section, discordMessageLimit)...)
+	}
+	if tail != "" {
+		msgs = append(msgs, splitForDiscord(blockquoteText(tail, len(tail)), discordMessageLimit)...)
+	}
+
+	draftText := strings.TrimSpace(htmlToPlain(draft.DraftBodyHTML))
+	if draftText == "" {
+		draftText = "_(the AI produced no reply body)_"
+	}
+	draftChunks := splitForDiscord("**Drafted reply**\n"+draftText, discordMessageLimit)
+
+	// A short ticket is one message: fold the draft in rather than posting
+	// a two-line message of its own under a three-line one.
+	if len(msgs) == 1 && len(draftChunks) == 1 &&
+		len(msgs[0])+len(draftChunks[0])+2 <= discordMessageLimit {
+		return msgs[0] + "\n\n" + draftChunks[0], nil
+	}
+
+	msgs = append(msgs, draftChunks...)
+	return msgs[0], msgs[1:]
+}
+
+// splitAtLimit cuts s into a head of at most limit bytes (on a whitespace
+// and rune boundary) and the remainder.
+func splitAtLimit(s string, limit int) (string, string) {
+	s = strings.TrimSpace(s)
+	if len(s) <= limit {
+		return s, ""
+	}
+	cut := breakPoint(s, limit)
+	return strings.TrimRight(s[:cut], " \t\n"), strings.TrimLeft(s[cut:], " \t\n")
+}
+
+// buildDraftHeaderEmbed is the at-a-glance block above the draft: what the
+// ticket is, how sure the AI is, and whether the user is even on a version
+// that could still have the bug. The internal note (REL-244) shows here
+// and only here — it is the AI talking to us, never to the user.
+func buildDraftHeaderEmbed(ctx context.Context, draft *SupportDraft) *discordEmbed {
+	subject := draft.OriginalSubject
+	if subject == "" {
+		subject = "(no subject)"
+	}
+	subject = truncateRunes(subject, 200) // embed titles cap at 256 characters
+
+	e := &discordEmbed{
+		Title: fmt.Sprintf("Ticket #%s — %s", draft.TicketNumber, subject),
+		Color: 0x5865F2, // Discord blurple
+		Fields: []discordEmbedField{
+			{Name: "Category", Value: codeOrDash(draft.AICategory), Inline: true},
+			{Name: "Priority", Value: codeOrDash(draft.AIPriority), Inline: true},
+			{Name: "Confidence", Value: codeOrDash(draft.AIConfidence), Inline: true},
+			{Name: "App version", Value: appVersionField(ctx, draft.TicketNumber), Inline: true},
+		},
+		Footer: &discordEmbedFooter{Text: fmt.Sprintf("draft #%d", draft.ID)},
+	}
+	if draft.AISummary != "" {
+		e.Description = truncateRunes(draft.AISummary, 400)
+	}
+	if note := strings.TrimSpace(draft.InternalNote); note != "" {
+		e.Fields = append(e.Fields, discordEmbedField{
+			Name: "Note (internal — not sent)", Value: truncateRunes(note, 1000),
+		})
+	}
+	if ask := strings.TrimSpace(draft.AskUserFor); ask != "" {
+		e.Fields = append(e.Fields, discordEmbedField{
+			Name: "Needs from the user", Value: truncateRunes(ask, 1000),
+		})
+	}
+	if src := strings.TrimSpace(draft.GroundedIn); src != "" {
+		e.Fields = append(e.Fields, discordEmbedField{
+			Name: "Grounded in", Value: truncateRunes(src, 1000),
+		})
+	}
+	return e
+}
+
+func codeOrDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "—"
+	}
+	return "`" + s + "`"
+}
+
+// truncateRunes caps a string at n runes (never mid-character), for the
+// embed fields Discord limits by character count.
+func truncateRunes(s string, n int) string {
+	if utf8.RuneCountInString(s) <= n {
+		return s
+	}
+	count := 0
+	for i := range s {
+		if count == n {
+			return s[:i] + "…"
+		}
+		count++
+	}
+	return s
+}
+
+// appVersionField renders the reporter's app version against the version
+// we ship today, so "this was fixed two releases ago" is visible before
+// anyone reads the draft.
+func appVersionField(ctx context.Context, ticketNumber string) string {
+	reported := caseAppVersion(ctx, ticketNumber)
+	current := currentDesktopVersion()
+	switch {
+	case reported == "" && current == "":
+		return "—"
+	case reported == "":
+		return fmt.Sprintf("unknown (current %s)", current)
+	case current == "" || reported == current:
+		return fmt.Sprintf("`%s` (current)", reported)
+	default:
+		return fmt.Sprintf("`%s` → current `%s`", reported, current)
+	}
+}
+
+// currentDesktopVersionRe pulls the version line the knowledge base is
+// generated with, so there is exactly one source of truth for "current"
+// and it is the same one the AI is told about.
+var currentDesktopVersionRe = regexp.MustCompile(`(?m)^Current desktop version: \*\*([^*]+)\*\*`)
+
+func currentDesktopVersion() string {
+	m := currentDesktopVersionRe.FindStringSubmatch(supportKnowledgeBase())
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// caseAppVersion reads the app version the desktop reported at ticket time.
+// Empty for web-form tickets and anything that arrived by email.
+func caseAppVersion(ctx context.Context, ticketNumber string) string {
+	if platform.DBPool == nil {
+		return ""
+	}
+	var v *string
+	err := platform.DBPool.QueryRow(ctx,
+		`SELECT app_version FROM support_cases WHERE ticket_number = $1`, ticketNumber).Scan(&v)
+	if err != nil || v == nil {
+		return ""
+	}
+	return strings.TrimSpace(*v)
+}
+
+// buildDraftActionButtons returns the action-row components for a
+// pending draft. Five buttons is Discord's per-row maximum and exactly
+// what the queue needs: three ways to answer, one to defer, one to turn
+// the ticket into engineering work.
+func buildDraftActionButtons(draftID int64) []DiscordActionRow {
+	button := func(style int, label, emoji, action string) DiscordMessageButton {
+		b := DiscordMessageButton{
+			Type:     2,
+			Style:    style,
+			Label:    label,
+			CustomID: fmt.Sprintf("%s:%d", action, draftID),
+		}
+		b.Emoji = &struct {
+			Name string `json:"name"`
+		}{Name: emoji}
+		return b
+	}
 	return []DiscordActionRow{
 		{
-			Type:       1,
-			Components: []DiscordMessageButton{send, edit, skip},
+			Type: 1,
+			Components: []DiscordMessageButton{
+				button(3, "Send", "✅", "support_send"),
+				button(1, "Edit", "✏️", "support_edit"),
+				button(1, "Ask", "❓", "support_ask"),
+				button(2, "Skip", "⏭️", "support_skip"),
+				button(4, "File as bug", "🐛", "support_bug"),
+			},
 		},
 	}
 }

--- a/api/internal/support/discord_digest.go
+++ b/api/internal/support/discord_digest.go
@@ -1,0 +1,312 @@
+package support
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+	_ "time/tzdata" // the scratch-based api image carries no zoneinfo
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+)
+
+// =============================================================================
+// Daily digest — one pinned Queue thread (REL-245)
+// =============================================================================
+//
+// The audit that produced this ticket found 13 drafts pending since May,
+// some for months. Nothing was broken; nobody was told. The digest is the
+// telling: one post a morning in a pinned thread, with what is waiting and
+// what happened yesterday. Silence means an empty queue, so an unbroken run
+// of no-post mornings is itself the signal that the queue is clear.
+
+const (
+	digestHour     = 9 // 09:00 local
+	digestTimezone = "America/Chicago"
+	// queueThreadKey squats one row in support_ticket_threads rather than
+	// adding a table for a single id. Ticket numbers are digits, so it can
+	// never collide with a real one.
+	queueThreadKey = "__queue__"
+)
+
+// StartSupportDigest posts the queue digest every morning at 09:00 Central.
+// Redis-locked so one replica posts. No-op when Discord isn't configured.
+func StartSupportDigest(ctx context.Context) {
+	if !shouldNotifyDiscord() {
+		log.Println("[Digest] Discord not configured; digest disabled")
+		return
+	}
+	loc, err := time.LoadLocation(digestTimezone)
+	if err != nil {
+		log.Printf("[Digest] load %s: %v; digest disabled", digestTimezone, err)
+		return
+	}
+
+	go func() {
+		for {
+			wait := time.Until(nextDigestTime(time.Now().In(loc), loc))
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(wait):
+			}
+
+			// Day-keyed lock: whichever replica wakes first posts, the
+			// rest find the key taken. 23h TTL so it always clears before
+			// the next morning.
+			if platform.Rdb != nil {
+				key := "support:digest:" + time.Now().In(loc).Format("2006-01-02")
+				locked, err := platform.Rdb.SetNX(ctx, key, "1", 23*time.Hour).Result()
+				if err != nil || !locked {
+					continue
+				}
+			}
+			runCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+			if err := postSupportDigest(runCtx, loc); err != nil {
+				log.Printf("[Digest] post: %v", err)
+			}
+			cancel()
+		}
+	}()
+	log.Printf("[Digest] daily queue digest started (%02d:00 %s)", digestHour, digestTimezone)
+}
+
+// nextDigestTime is the next digestHour in loc strictly after now.
+func nextDigestTime(now time.Time, loc *time.Location) time.Time {
+	next := time.Date(now.Year(), now.Month(), now.Day(), digestHour, 0, 0, 0, loc)
+	if !next.After(now) {
+		next = next.AddDate(0, 0, 1)
+	}
+	return next
+}
+
+// digestStats is one morning's numbers.
+type digestStats struct {
+	Pending   int
+	Stale     []staleDraft // pending > 48 h, oldest first
+	FollowUps int          // pending drafts that answer a user's reply
+	Sent      int
+	Edited    int
+	Skipped   int
+}
+
+type staleDraft struct {
+	TicketNumber string
+	Summary      string
+	Age          time.Duration
+}
+
+// Empty reports whether there is nothing worth posting. An empty queue and
+// a quiet yesterday means no digest at all.
+func (d digestStats) Empty() bool {
+	return d.Pending == 0 && d.Sent == 0 && d.Edited == 0 && d.Skipped == 0
+}
+
+// collectDigestStats reads the queue state in three queries.
+func collectDigestStats(ctx context.Context, loc *time.Location) (digestStats, error) {
+	var s digestStats
+	if platform.DBPool == nil {
+		return s, fmt.Errorf("DB not initialized")
+	}
+
+	// Yesterday in the digest's own timezone, not UTC — "yesterday" has to
+	// mean the day the person reading it just finished.
+	now := time.Now().In(loc)
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+	yesterdayStart := dayStart.AddDate(0, 0, -1)
+
+	const counts = `
+		SELECT
+			(SELECT COUNT(*) FROM support_drafts WHERE status = 'pending'),
+			(SELECT COUNT(*) FROM support_drafts
+			  WHERE status = 'pending' AND osticket_thread_entry_id IS NOT NULL),
+			(SELECT COUNT(*) FROM support_drafts
+			  WHERE status IN ('approved','sent') AND decided_at >= $1 AND decided_at < $2),
+			(SELECT COUNT(*) FROM support_drafts
+			  WHERE status = 'edited' AND decided_at >= $1 AND decided_at < $2),
+			(SELECT COUNT(*) FROM support_drafts
+			  WHERE status = 'skipped' AND decided_at >= $1 AND decided_at < $2)
+	`
+	if err := platform.DBPool.QueryRow(ctx, counts, yesterdayStart, dayStart).Scan(
+		&s.Pending, &s.FollowUps, &s.Sent, &s.Edited, &s.Skipped); err != nil {
+		return s, fmt.Errorf("digest counts: %w", err)
+	}
+
+	const stale = `
+		SELECT ticket_number, COALESCE(NULLIF(ai_summary,''), original_subject, ''), created_at
+		FROM support_drafts
+		WHERE status = 'pending' AND created_at < now() - interval '48 hours'
+		ORDER BY created_at ASC
+		LIMIT 15
+	`
+	rows, err := platform.DBPool.Query(ctx, stale)
+	if err != nil {
+		return s, fmt.Errorf("digest stale: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var d staleDraft
+		var created time.Time
+		if err := rows.Scan(&d.TicketNumber, &d.Summary, &created); err != nil {
+			continue
+		}
+		d.Age = time.Since(created)
+		s.Stale = append(s.Stale, d)
+	}
+	return s, rows.Err()
+}
+
+// renderDigest turns the numbers into the post. Kept separate from the
+// posting so the wording is readable — and testable — on its own.
+func renderDigest(s digestStats, day time.Time) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Support queue — %s**\n\n", day.Format("Mon 2 Jan"))
+
+	if s.Pending == 0 {
+		b.WriteString("📭 Nothing pending.\n")
+	} else {
+		fmt.Fprintf(&b, "⏳ **%d pending**", s.Pending)
+		if s.FollowUps > 0 {
+			fmt.Fprintf(&b, " · %d of them are follow-ups waiting on an answer", s.FollowUps)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(s.Stale) > 0 {
+		fmt.Fprintf(&b, "\n🔴 **Waiting more than 48 h (%d):**\n", len(s.Stale))
+		for _, d := range s.Stale {
+			summary := d.Summary
+			if summary == "" {
+				summary = "(no summary)"
+			}
+			summary = truncateRunes(summary, 90)
+			fmt.Fprintf(&b, "• **#%s** — %s _(%s)_\n", d.TicketNumber, summary, humanAge(d.Age))
+		}
+	}
+
+	fmt.Fprintf(&b, "\n**Yesterday:** %d sent · %d edited · %d skipped\n", s.Sent, s.Edited, s.Skipped)
+	b.WriteString("\n`/inbox` to work the queue · `/search <text>` to look something up")
+	return b.String()
+}
+
+// humanAge renders a duration the way a person reads a backlog: days when
+// it has been days, hours when it hasn't.
+func humanAge(d time.Duration) string {
+	if days := int(d.Hours() / 24); days >= 1 {
+		if days == 1 {
+			return "1 day"
+		}
+		return fmt.Sprintf("%d days", days)
+	}
+	return fmt.Sprintf("%dh", int(d.Hours()))
+}
+
+// postSupportDigest collects, renders and posts. Returns nil (having done
+// nothing) when the queue and yesterday were both empty.
+func postSupportDigest(ctx context.Context, loc *time.Location) error {
+	stats, err := collectDigestStats(ctx, loc)
+	if err != nil {
+		return err
+	}
+	if stats.Empty() {
+		log.Println("[Digest] queue empty and yesterday quiet; nothing posted")
+		return nil
+	}
+
+	threadID, err := ensureQueueThread(ctx)
+	if err != nil {
+		return err
+	}
+	content := renderDigest(stats, time.Now().In(loc))
+	for _, chunk := range splitForDiscord(content, discordMessageLimit) {
+		if _, err := discordPostMessage(ctx, threadID, chunk, nil); err != nil {
+			return fmt.Errorf("post digest: %w", err)
+		}
+	}
+	log.Printf("[Digest] posted (%d pending, %d stale)", stats.Pending, len(stats.Stale))
+	return nil
+}
+
+// HandleRunSupportDigest serves POST /internal/support/digest — the same
+// digest the scheduler posts at 09:00, on demand. Gated by the shared
+// webhook secret, like the case search beside it.
+//
+// It exists because a scheduled job you cannot trigger is a job you cannot
+// test: this is how the digest was verified on production, and how a
+// morning missed to a pod restart gets caught up.
+func HandleRunSupportDigest(c *fiber.Ctx) error {
+	expected := os.Getenv("SCROLLR_WEBHOOK_SECRET")
+	provided := c.Get("X-Scrollr-Webhook-Secret")
+	if expected == "" || provided == "" ||
+		subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
+			Status: "error", Error: "unauthorized",
+		})
+	}
+	loc, err := time.LoadLocation(digestTimezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stats, err := collectDigestStats(ctx, loc)
+	if err != nil {
+		log.Printf("[Digest] manual run: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "digest failed",
+		})
+	}
+	if err := postSupportDigest(ctx, loc); err != nil {
+		log.Printf("[Digest] manual run: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: err.Error(),
+		})
+	}
+	return c.JSON(fiber.Map{
+		"status": "ok", "posted": !stats.Empty(),
+		"pending": stats.Pending, "stale": len(stats.Stale),
+	})
+}
+
+// ensureQueueThread returns the pinned Queue thread's id, creating and
+// pinning it the first time. The id is stored in support_ticket_threads
+// under queueThreadKey so it survives restarts.
+func ensureQueueThread(ctx context.Context) (string, error) {
+	if existing, err := loadSupportTicketThread(ctx, queueThreadKey); err == nil && existing != nil {
+		// A digest thread is never archived deliberately, but 3 days of
+		// silence does it for us. Wake it rather than starting a new one.
+		if existing.Archived {
+			_ = discordUnarchiveThread(ctx, existing.DiscordThreadID)
+		}
+		return existing.DiscordThreadID, nil
+	}
+
+	cfg, ok := loadDiscordConfig()
+	if !ok {
+		return "", fmt.Errorf("discord not configured")
+	}
+	thread, err := discordCreateThread(ctx, cfg.SupportChannelID, "📋 Queue",
+		"The morning digest lands here: what is waiting, what is old, what happened yesterday.",
+		nil, nil, nil)
+	if err != nil {
+		return "", fmt.Errorf("create queue thread: %w", err)
+	}
+	if err := upsertSupportTicketThread(ctx, &SupportTicketThread{
+		TicketNumber:    queueThreadKey,
+		DiscordThreadID: thread.ID,
+		ChannelID:       cfg.SupportChannelID,
+	}); err != nil {
+		// Losing the mapping means tomorrow makes a second Queue thread.
+		// Worth a loud log, not worth failing today's digest.
+		log.Printf("[Digest] persist queue thread id: %v", err)
+	}
+	if err := discordPinForumThread(ctx, thread.ID); err != nil {
+		log.Printf("[Digest] pin queue thread: %v", err)
+	}
+	return thread.ID, nil
+}

--- a/api/internal/support/discord_test.go
+++ b/api/internal/support/discord_test.go
@@ -1,0 +1,360 @@
+package support
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// =============================================================================
+// Message splitting
+// =============================================================================
+//
+// The bug this replaced: buildDraftMessageContent cut every draft at 1900
+// bytes and appended "_...truncated_". Nobody could read a long reply
+// without opening the database, so long replies were skipped. These tests
+// pin the two properties that make the new path trustworthy — every chunk
+// fits, and nothing is lost or mangled between them.
+
+// paragraphs builds a body of n paragraphs, each ~120 chars.
+func paragraphs(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(strings.Repeat("the quick brown fox jumps over the lazy dog. ", 3))
+	}
+	return b.String()
+}
+
+func TestSplitForDiscord_EveryChunkFitsTheLimit(t *testing.T) {
+	body := paragraphs(120) // comfortably over 10 messages' worth
+	chunks := splitForDiscord(body, discordMessageLimit)
+
+	if len(chunks) < 5 {
+		t.Fatalf("expected the body to need several messages, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		if len(c) > discordMessageLimit {
+			t.Errorf("chunk %d is %d bytes, over Discord's %d limit", i, len(c), discordMessageLimit)
+		}
+		if !utf8.ValidString(c) {
+			t.Errorf("chunk %d is not valid UTF-8", i)
+		}
+	}
+}
+
+func TestSplitForDiscord_NeverCutsMidWord(t *testing.T) {
+	// Distinct words so a mid-word cut produces a token that isn't in the
+	// source vocabulary — which is exactly what we assert against.
+	var words []string
+	for i := 0; i < 900; i++ {
+		words = append(words, "word"+strings.Repeat("x", i%7)+string(rune('a'+i%26)))
+	}
+	body := strings.Join(words, " ")
+	vocabulary := map[string]struct{}{}
+	for _, w := range words {
+		vocabulary[w] = struct{}{}
+	}
+
+	chunks := splitForDiscord(body, discordMessageLimit)
+	if len(chunks) < 2 {
+		t.Fatalf("test body should span several messages, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		for _, tok := range strings.Fields(c) {
+			if _, ok := vocabulary[tok]; !ok {
+				t.Fatalf("chunk %d contains %q, which is not a whole source word — a word was split", i, tok)
+			}
+		}
+	}
+}
+
+func TestSplitForDiscord_LosesNothing(t *testing.T) {
+	body := paragraphs(40)
+	joined := strings.Join(splitForDiscord(body, discordMessageLimit), " ")
+
+	want := strings.Join(strings.Fields(body), " ")
+	got := strings.Join(strings.Fields(joined), " ")
+	if got != want {
+		t.Fatalf("round-trip lost or altered content\n got %d chars\nwant %d chars", len(got), len(want))
+	}
+}
+
+func TestSplitForDiscord_UnbreakableRunSplitsOnRuneBoundary(t *testing.T) {
+	// A single 5000-char token of multi-byte runes: no space, no newline,
+	// so the splitter has to make a hard cut. It must still be valid UTF-8.
+	body := strings.Repeat("é", 5000)
+	chunks := splitForDiscord(body, discordMessageLimit)
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected several chunks, got %d", len(chunks))
+	}
+	rejoined := strings.Join(chunks, "")
+	for i, c := range chunks {
+		if len(c) > discordMessageLimit {
+			t.Errorf("chunk %d is %d bytes, over the limit", i, len(c))
+		}
+		if !utf8.ValidString(c) {
+			t.Fatalf("chunk %d has a cut inside a multi-byte rune", i)
+		}
+	}
+	if rejoined != body {
+		t.Errorf("hard-cut chunks did not rejoin to the original (%d vs %d bytes)", len(rejoined), len(body))
+	}
+}
+
+func TestSplitForDiscord_PrefersParagraphBoundaries(t *testing.T) {
+	// Two paragraphs that together exceed one message: the cut should land
+	// on the blank line, so neither chunk contains half of both.
+	first := strings.Repeat("alpha ", 250)  // ~1500 bytes
+	second := strings.Repeat("bravo ", 250) // ~1500 bytes
+	chunks := splitForDiscord(first+"\n\n"+second, discordMessageLimit)
+
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if strings.Contains(chunks[0], "bravo") {
+		t.Error("first chunk leaked into the second paragraph — the blank-line boundary was ignored")
+	}
+	if strings.Contains(chunks[1], "alpha") {
+		t.Error("second chunk carries the first paragraph")
+	}
+}
+
+// =============================================================================
+// Draft messages
+// =============================================================================
+
+func TestBuildDraftMessages_ShortDraftIsOneMessage(t *testing.T) {
+	starter, rest := buildDraftMessages(&SupportDraft{
+		TicketNumber:    "239171",
+		UserMessageHTML: "<p>The ticker vanished after I updated.</p>",
+		DraftBodyHTML:   "<p>Sorry about that. Try toggling it from the tray icon.</p>",
+	}, true)
+
+	if len(rest) != 0 {
+		t.Fatalf("a short ticket should be one message, got 1+%d", len(rest))
+	}
+	if !strings.Contains(starter, "ticker vanished") {
+		t.Error("starter is missing the user's message")
+	}
+	if !strings.Contains(starter, "tray icon") {
+		t.Error("starter is missing the drafted reply")
+	}
+}
+
+func TestBuildDraftMessages_LongDraftIsFullyReadable(t *testing.T) {
+	// The case from the ticket: a > 2500-char draft on a > 2000-char user
+	// message. Every word of both has to survive into some message.
+	userBody := paragraphs(30)
+	draftBody := paragraphs(60)
+
+	starter, rest := buildDraftMessages(&SupportDraft{
+		TicketNumber:    "239171",
+		UserMessageHTML: "<p>" + userBody + "</p>",
+		DraftBodyHTML:   "<p>" + draftBody + "</p>",
+	}, true)
+
+	all := append([]string{starter}, rest...)
+	for i, m := range all {
+		if len(m) > discordMessageLimit {
+			t.Errorf("message %d is %d bytes, over Discord's limit", i, len(m))
+		}
+	}
+	if !strings.Contains(starter, "…continues below") {
+		t.Error("a truncated user message must say it continues below")
+	}
+
+	// Draft text present in full: compare word multisets of the drafted
+	// reply against everything posted after the header lines.
+	posted := strings.Join(all, "\n")
+	for _, word := range strings.Fields(draftBody) {
+		if !strings.Contains(posted, word) {
+			t.Fatalf("drafted reply lost the word %q — the draft is not fully readable", word)
+		}
+	}
+	if !strings.Contains(posted, "**Drafted reply**") {
+		t.Error("the drafted reply is not labelled")
+	}
+}
+
+// A message of many short lines gains two bytes per line from the "> "
+// blockquote prefix. Quoting before measuring is what keeps the starter
+// under the limit — a log dump pasted into a ticket is exactly this shape.
+func TestBuildDraftMessages_BlockquotePrefixCountsTowardTheLimit(t *testing.T) {
+	var log strings.Builder
+	for i := 0; i < 400; i++ {
+		log.WriteString("ERR frame drop\n")
+	}
+	starter, rest := buildDraftMessages(&SupportDraft{
+		TicketNumber:    "239171",
+		UserMessageHTML: "<p>" + log.String() + "</p>",
+		DraftBodyHTML:   "<p>Thanks, that helps.</p>",
+	}, true)
+
+	for i, m := range append([]string{starter}, rest...) {
+		if len(m) > discordMessageLimit {
+			t.Errorf("message %d is %d bytes — the blockquote prefix pushed it over the limit", i, len(m))
+		}
+	}
+}
+
+func TestBuildDraftMessages_OmitsUserMessageOnFollowUp(t *testing.T) {
+	starter, _ := buildDraftMessages(&SupportDraft{
+		TicketNumber:    "239171",
+		UserMessageHTML: "<p>Still broken, here is the log.</p>",
+		DraftBodyHTML:   "<p>Thanks — can you send the version number?</p>",
+	}, false)
+
+	if strings.Contains(starter, "Still broken") {
+		t.Error("a follow-up draft re-quoted a message the thread already shows")
+	}
+	if !strings.Contains(starter, "version number") {
+		t.Error("the drafted reply went missing")
+	}
+}
+
+// TestButtonsRideOnTheLastMessage is the property the ticket asked for by
+// name: whatever the length, the action row is on the message the partner
+// finishes reading, not one they have to scroll back to.
+func TestButtonsRideOnTheLastMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		draft *SupportDraft
+	}{
+		{"short", &SupportDraft{ID: 1, DraftBodyHTML: "<p>ok</p>"}},
+		{"long", &SupportDraft{ID: 2, DraftBodyHTML: "<p>" + paragraphs(60) + "</p>"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, rest := buildDraftMessages(tc.draft, true)
+			buttons := buildDraftActionButtons(tc.draft.ID)
+			if len(buttons) != 1 || len(buttons[0].Components) != 5 {
+				t.Fatalf("expected one row of 5 buttons, got %d row(s)", len(buttons))
+			}
+			// notifyDiscordForDraft attaches `buttons` to rest's last entry
+			// when rest is non-empty, and to the starter otherwise. Assert
+			// the shape that decision relies on: there is always exactly
+			// one "last message".
+			if len(rest) == 0 {
+				return // starter is the last message
+			}
+			if rest[len(rest)-1] == "" {
+				t.Error("last message is empty, so the buttons would land nowhere")
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Diff
+// =============================================================================
+
+func TestLineDiff_IdenticalIsEmpty(t *testing.T) {
+	if got := lineDiff("one\ntwo", "one\ntwo"); got != "" {
+		t.Errorf("identical bodies should produce no diff, got %q", got)
+	}
+}
+
+func TestLineDiff_MarksAddedAndRemovedLines(t *testing.T) {
+	got := lineDiff("Hi there\nWe do not have a weather widget.\nThanks",
+		"Hi there\nThe weather widget is in Settings › Catalog.\nThanks")
+
+	if !strings.Contains(got, "- We do not have a weather widget.") {
+		t.Errorf("removed line not marked:\n%s", got)
+	}
+	if !strings.Contains(got, "+ The weather widget is in Settings › Catalog.") {
+		t.Errorf("added line not marked:\n%s", got)
+	}
+	if !strings.Contains(got, "  Hi there") {
+		t.Errorf("unchanged line not carried:\n%s", got)
+	}
+}
+
+// =============================================================================
+// Digest
+// =============================================================================
+
+// An empty queue after a quiet day posts nothing at all — silence is the
+// signal that there's nothing to do, and a daily "0 pending" is the kind
+// of noise people learn to scroll past.
+func TestDigestStats_EmptyMeansNoPost(t *testing.T) {
+	if !(digestStats{}).Empty() {
+		t.Error("a queue with nothing in it and nothing yesterday should post nothing")
+	}
+	if (digestStats{Pending: 1}).Empty() {
+		t.Error("a pending draft must produce a digest")
+	}
+	if (digestStats{Skipped: 1}).Empty() {
+		t.Error("yesterday's activity must produce a digest even with an empty queue")
+	}
+}
+
+func TestRenderDigest_NamesWhatIsWaiting(t *testing.T) {
+	out := renderDigest(digestStats{
+		Pending:   4,
+		FollowUps: 1,
+		Sent:      2,
+		Edited:    1,
+		Skipped:   3,
+		Stale: []staleDraft{
+			{TicketNumber: "239171", Summary: "ticker blank on second monitor", Age: 72 * time.Hour},
+		},
+	}, time.Date(2026, 9, 9, 9, 0, 0, 0, time.UTC))
+
+	for _, want := range []string{
+		"4 pending", "1 of them are follow-ups", "239171", "3 days",
+		"2 sent · 1 edited · 3 skipped",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("digest is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestNextDigestTime_IsAlwaysInTheFuture(t *testing.T) {
+	loc := time.UTC
+	for _, hour := range []int{0, 8, 9, 10, 23} {
+		now := time.Date(2026, 9, 9, hour, 30, 0, 0, loc)
+		next := nextDigestTime(now, loc)
+		if !next.After(now) {
+			t.Errorf("from %s the next digest is %s, which is not in the future", now, next)
+		}
+		if next.Hour() != digestHour {
+			t.Errorf("next digest at %02d:00, want %02d:00", next.Hour(), digestHour)
+		}
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	for _, tc := range []struct {
+		d    time.Duration
+		want string
+	}{
+		{3 * time.Hour, "3h"},
+		{25 * time.Hour, "1 day"},
+		{72 * time.Hour, "3 days"},
+	} {
+		if got := humanAge(tc.d); got != tc.want {
+			t.Errorf("humanAge(%s) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+// =============================================================================
+// Version rendering
+// =============================================================================
+
+func TestCurrentDesktopVersion_ReadsTheKnowledgeBase(t *testing.T) {
+	// Not pinned to a literal: the KB regenerates every release. What must
+	// hold is that the line is found and looks like a version.
+	v := currentDesktopVersion()
+	if v == "" {
+		t.Fatal("no current desktop version found in the knowledge base — the header line's format changed")
+	}
+	if !strings.Contains(v, ".") {
+		t.Errorf("parsed %q, which does not look like a version", v)
+	}
+}

--- a/api/internal/support/handlers_discord_interactions.go
+++ b/api/internal/support/handlers_discord_interactions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -179,6 +180,16 @@ func handleDiscordButtonClick(c *fiber.Ctx, ix *discordInteraction) error {
 		return discordEphemeralResponse(c, "malformed custom_id")
 	}
 	prefix, idStr := parts[0], parts[1]
+
+	// /inbox paging carries an offset, not a draft id.
+	if prefix == "support_inbox" {
+		offset, err := strconv.Atoi(idStr)
+		if err != nil || offset < 0 {
+			return discordEphemeralResponse(c, "malformed page offset")
+		}
+		return respondWithInboxPage(c, offset, discordResponseUpdateMessage)
+	}
+
 	draftID, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		return discordEphemeralResponse(c, "malformed draft id")
@@ -189,8 +200,12 @@ func handleDiscordButtonClick(c *fiber.Ctx, ix *discordInteraction) error {
 		return handleDiscordSendAction(c, ix, draftID)
 	case "support_edit":
 		return handleDiscordEditOpenModal(c, ix, draftID)
+	case "support_ask":
+		return handleDiscordAskOpenModal(c, ix, draftID)
 	case "support_skip":
 		return handleDiscordSkipAction(c, ix, draftID)
+	case "support_bug":
+		return handleDiscordFileAsBug(c, ix, draftID)
 	default:
 		log.Printf("[DiscordInteraction] unknown button prefix %q", prefix)
 		return discordEphemeralResponse(c, "unknown action")
@@ -249,11 +264,12 @@ func handleDiscordSendAction(c *fiber.Ctx, ix *discordInteraction, draftID int64
 // buildSendConfirmation renders the post-Send message visible in the
 // thread. Includes the ticket number, recipient, and close-state hint
 // so the partner doesn't need to scroll back up to see what they sent.
+// The reporter's email address is deliberately NOT in here. The thread is
+// a queue, not a CRM: the ticket number identifies the case, and osTicket
+// holds the address.
 func buildSendConfirmation(draft *SupportDraft) string {
 	var b strings.Builder
-	b.WriteString("✅ Sent to ")
-	b.WriteString(draft.UserEmail)
-	b.WriteString(" — ticket #")
+	b.WriteString("✅ Sent — ticket #")
 	b.WriteString(draft.TicketNumber)
 	b.WriteString(" marked answered in osTicket.")
 	if draft.ShouldClose {
@@ -341,9 +357,7 @@ func buildPrefixedThreadName(prefix string, draft *SupportDraft) string {
 		// Extreme case — drop subject entirely.
 		return fmt.Sprintf("%s%s[#%s]", prefix, priority, draft.TicketNumber)
 	}
-	if len(subject) > budget {
-		subject = subject[:budget-3] + "..."
-	}
+	subject = truncateRunes(subject, budget)
 	return fmt.Sprintf("%s%s[#%s] %s", prefix, priority, draft.TicketNumber, subject)
 }
 
@@ -369,31 +383,100 @@ func handleDiscordEditOpenModal(c *fiber.Ctx, ix *discordInteraction, draftID in
 	}
 
 	// Convert draft HTML to plain text for the modal's text area.
-	prefilled := htmlToPlain(draft.DraftBodyHTML)
-	if len(prefilled) > 4000 {
-		// Discord text-area max is 4000 chars.
-		prefilled = prefilled[:4000]
+	prefilled := truncateRunes(htmlToPlain(draft.DraftBodyHTML), 4000)
+
+	components := []fiber.Map{
+		{
+			"type": 1,
+			"components": []fiber.Map{
+				{
+					"type":        4,
+					"custom_id":   "edited_body",
+					"label":       "Reply body (plain text)",
+					"style":       2, // Paragraph
+					"value":       prefilled,
+					"min_length":  1,
+					"max_length":  4000,
+					"required":    true,
+					"placeholder": "Edit the reply...",
+				},
+			},
+		},
+	}
+
+	// Second field: the user's own words, pre-filled and optional. Discord
+	// has no read-only input, so this is the only way to keep the question
+	// in front of whoever is rewriting the answer — the modal covers the
+	// thread while it is open, and the old flow made people cancel out to
+	// re-read what was asked. Its submitted value is ignored.
+	if userMsg := strings.TrimSpace(htmlToPlain(draft.UserMessageHTML)); userMsg != "" {
+		components = append(components, fiber.Map{
+			"type": 1,
+			"components": []fiber.Map{
+				{
+					"type":       4,
+					"custom_id":  "user_message_context",
+					"label":      "What the user asked (reference only)",
+					"style":      2,
+					"value":      truncateRunes(userMsg, 4000),
+					"max_length": 4000,
+					"required":   false,
+				},
+			},
+		})
 	}
 
 	resp := fiber.Map{
 		"type": discordResponseModal,
 		"data": fiber.Map{
-			"custom_id": fmt.Sprintf("support_edit_modal:%d", draftID),
-			"title":     fmt.Sprintf("Edit reply for #%s", draft.TicketNumber),
+			"custom_id":  fmt.Sprintf("support_edit_modal:%d", draftID),
+			"title":      fmt.Sprintf("Edit reply for #%s", draft.TicketNumber),
+			"components": components,
+		},
+	}
+	return c.JSON(resp)
+}
+
+// handleDiscordAskOpenModal opens the one-field modal behind the Ask
+// button: a single clarifying question, sent to the user in place of the
+// drafted answer. A draft that needs information the ticket does not carry
+// is worse than no draft, and this is the cheap way out of that corner.
+func handleDiscordAskOpenModal(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil || draft == nil {
+		return discordEphemeralResponse(c, "Could not load draft.")
+	}
+	if draft.Status != "pending" {
+		return discordEphemeralResponse(c,
+			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
+	}
+
+	// Triage's own "what I still need" line (REL-244) is the obvious
+	// first draft of the question, so it pre-fills the box.
+	prefilled := truncateRunes(strings.TrimSpace(draft.AskUserFor), 1000)
+
+	resp := fiber.Map{
+		"type": discordResponseModal,
+		"data": fiber.Map{
+			"custom_id": fmt.Sprintf("support_ask_modal:%d", draftID),
+			"title":     fmt.Sprintf("Ask about #%s", draft.TicketNumber),
 			"components": []fiber.Map{
 				{
 					"type": 1,
 					"components": []fiber.Map{
 						{
 							"type":        4,
-							"custom_id":   "edited_body",
-							"label":       "Reply body (plain text)",
-							"style":       2, // Paragraph
+							"custom_id":   "ask_body",
+							"label":       "Question to send the user",
+							"style":       2,
 							"value":       prefilled,
 							"min_length":  1,
-							"max_length":  4000,
+							"max_length":  1000,
 							"required":    true,
-							"placeholder": "Edit the reply...",
+							"placeholder": "Which version are you on, and does it happen on every launch?",
 						},
 					},
 				},
@@ -449,25 +532,22 @@ func handleDiscordModalSubmit(c *fiber.Ctx, ix *discordInteraction) error {
 	}
 	customID := ix.Data.CustomID
 	parts := strings.SplitN(customID, ":", 2)
-	if len(parts) != 2 || parts[0] != "support_edit_modal" {
+	if len(parts) != 2 {
 		return discordEphemeralResponse(c, "malformed modal custom_id")
 	}
 	draftID, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
 		return discordEphemeralResponse(c, "malformed draft id")
 	}
-
-	// Discord nests modal field values one level deep: components is
-	// a list of action rows, each containing one input component.
-	var editedBody string
-	for _, row := range ix.Data.Components {
-		for _, comp := range row.Components {
-			if comp.CustomID == "edited_body" {
-				editedBody = comp.Value
-			}
-		}
+	switch parts[0] {
+	case "support_edit_modal":
+	case "support_ask_modal":
+		return handleDiscordAskSubmit(c, ix, draftID)
+	default:
+		return discordEphemeralResponse(c, "malformed modal custom_id")
 	}
-	editedBody = strings.TrimSpace(editedBody)
+
+	editedBody := strings.TrimSpace(modalFieldValue(ix, "edited_body"))
 	if editedBody == "" {
 		return discordEphemeralResponse(c, "Edited body is empty.")
 	}
@@ -495,6 +575,7 @@ func handleDiscordModalSubmit(c *fiber.Ctx, ix *discordInteraction) error {
 	}
 	draft, _ = loadSupportDraft(ctx, draftID)
 
+	originalBody := draft.DraftBodyHTML
 	go func() {
 		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer bgCancel()
@@ -507,6 +588,7 @@ func handleDiscordModalSubmit(c *fiber.Ctx, ix *discordInteraction) error {
 		// transitions as plain Send. Tag flips to "edited" instead of
 		// "sent" so we can distinguish them in /stats.
 		applyEditStateToThread(bgCtx, draft, draft.ShouldClose)
+		postEditDiff(bgCtx, draft, htmlToPlain(originalBody), editedBody)
 	}()
 
 	confirmation := buildEditConfirmation(draft)
@@ -517,9 +599,7 @@ func handleDiscordModalSubmit(c *fiber.Ctx, ix *discordInteraction) error {
 // edited-then-sent path so the partner sees the same level of detail.
 func buildEditConfirmation(draft *SupportDraft) string {
 	var b strings.Builder
-	b.WriteString("✏️ Edited and sent to ")
-	b.WriteString(draft.UserEmail)
-	b.WriteString(" — ticket #")
+	b.WriteString("✏️ Edited and sent — ticket #")
 	b.WriteString(draft.TicketNumber)
 	b.WriteString(" marked answered in osTicket.")
 	if draft.ShouldClose {
@@ -560,8 +640,357 @@ func applyEditStateToThread(ctx context.Context, draft *SupportDraft, closing bo
 	}
 }
 
+// modalFieldValue pulls one input's value out of a modal submission.
+// Discord nests them one level deep: components is a list of action rows,
+// each holding a single input.
+func modalFieldValue(ix *discordInteraction, customID string) string {
+	for _, row := range ix.Data.Components {
+		for _, comp := range row.Components {
+			if comp.CustomID == customID {
+				return comp.Value
+			}
+		}
+	}
+	return ""
+}
+
+// handleDiscordAskSubmit sends the partner's clarifying question to the
+// user in place of the drafted reply and parks the draft as 'asked'.
+//
+// The question goes out on the same osTicket reply path an approved draft
+// takes, so the user gets it as a normal support email and their answer
+// comes back through the thread-message webhook — which drafts a fresh
+// reply with the new information in it.
+func handleDiscordAskSubmit(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
+	question := strings.TrimSpace(modalFieldValue(ix, "ask_body"))
+	if question == "" {
+		return discordEphemeralResponse(c, "Question is empty.")
+	}
+	questionHTML := plainToHTMLParagraphs(question)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil || draft == nil {
+		return discordEphemeralResponse(c, "Draft not found.")
+	}
+	if draft.Status != "pending" {
+		return discordEphemeralResponse(c,
+			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
+	}
+
+	if err := markDraftDecided(ctx, draftID, "asked", questionHTML); err != nil {
+		log.Printf("[DiscordInteraction] markDraftDecided (asked) %d: %v", draftID, err)
+		return discordEphemeralResponse(c, "Could not record the question.")
+	}
+	draft, _ = loadSupportDraft(ctx, draftID)
+	if draft == nil {
+		return discordEphemeralResponse(c, "Draft vanished mid-ask.")
+	}
+	// A question never closes a ticket, whatever triage thought of the
+	// reply it replaces.
+	draft.ShouldClose = false
+
+	go func() {
+		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer bgCancel()
+		if err := sendApprovedReply(bgCtx, draft, questionHTML); err != nil {
+			log.Printf("[DiscordInteraction] send question for ticket %s: %v", draft.TicketNumber, err)
+			return
+		}
+		applyAskStateToThread(bgCtx, draft)
+	}()
+
+	return discordVisibleResponse(c, fmt.Sprintf(
+		"❓ Asked on ticket #%s — waiting on the user:\n> %s",
+		draft.TicketNumber, strings.ReplaceAll(question, "\n", "\n> ")))
+}
+
+// applyAskStateToThread is the Ask analog of applySendStateToThread. The
+// thread stays open and un-archived: an answer is expected.
+func applyAskStateToThread(ctx context.Context, draft *SupportDraft) {
+	t, err := loadSupportTicketThread(ctx, draft.TicketNumber)
+	if err != nil || t == nil {
+		return
+	}
+	transitionThreadStatus(ctx, t, "asked", false)
+	if newName := buildPrefixedThreadName("[ASKED] ", draft); newName != "" {
+		if err := discordUpdateThreadName(ctx, t.DiscordThreadID, newName); err != nil {
+			log.Printf("[DiscordInteraction] rename thread (asked) for ticket %s: %v",
+				draft.TicketNumber, err)
+		}
+	}
+}
+
 // =============================================================================
-// Slash commands — /inbox and /ticket <number>
+// Draft-vs-edited diff
+// =============================================================================
+
+// postEditDiff posts what the partner actually changed into the thread.
+// Half of every actioned draft in the May–September audit was rewritten
+// before sending, and nothing recorded what was wrong with it — so the
+// prompt never improved. This is that record, in the place someone reading
+// the thread will see it.
+func postEditDiff(ctx context.Context, draft *SupportDraft, original, edited string) {
+	t, err := loadSupportTicketThread(ctx, draft.TicketNumber)
+	if err != nil || t == nil {
+		return
+	}
+	diff := lineDiff(original, edited)
+	if diff == "" {
+		return
+	}
+	content := "**What changed before sending**\n```diff\n" + diff + "\n```"
+	for _, chunk := range splitForDiscord(content, discordMessageLimit) {
+		if _, err := discordPostMessage(ctx, t.DiscordThreadID, chunk, nil); err != nil {
+			log.Printf("[DiscordInteraction] post edit diff for ticket %s: %v", draft.TicketNumber, err)
+			return
+		}
+	}
+}
+
+// lineDiff renders a line-level diff of before → after in `diff` fence
+// syntax (`-` removed, `+` added, ` ` kept). Returns "" when the two are
+// identical after trimming.
+//
+// Standard LCS over lines. The inputs are support replies — tens of lines,
+// not thousands — so the O(n·m) table is the right amount of machinery.
+func lineDiff(before, after string) string {
+	a := splitLines(before)
+	b := splitLines(after)
+	if strings.Join(a, "\n") == strings.Join(b, "\n") {
+		return ""
+	}
+
+	// lcs[i][j] = length of the longest common subsequence of a[i:] and b[j:].
+	lcs := make([][]int, len(a)+1)
+	for i := range lcs {
+		lcs[i] = make([]int, len(b)+1)
+	}
+	for i := len(a) - 1; i >= 0; i-- {
+		for j := len(b) - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+
+	var out []string
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] == b[j]:
+			out = append(out, "  "+a[i])
+			i, j = i+1, j+1
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			out = append(out, "- "+a[i])
+			i++
+		default:
+			out = append(out, "+ "+b[j])
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		out = append(out, "- "+a[i])
+	}
+	for ; j < len(b); j++ {
+		out = append(out, "+ "+b[j])
+	}
+	return strings.Join(out, "\n")
+}
+
+// splitLines splits on newlines, dropping blank lines so a reflowed
+// paragraph doesn't read as a wall of changes.
+func splitLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(strings.TrimSpace(s), "\n") {
+		if l = strings.TrimSpace(l); l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// =============================================================================
+// File as bug — support thread → Linear issue
+// =============================================================================
+
+// handleDiscordFileAsBug turns the ticket into a Linear issue and links it
+// on the case. Deferred because the Linear round-trip does not reliably
+// fit inside Discord's 3-second interaction budget.
+//
+// A second click links the issue that already exists rather than filing a
+// duplicate — the same button on the same thread is how someone checks
+// whether it was already filed.
+func handleDiscordFileAsBug(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
+	appID, token := ix.ApplicationID, ix.Token
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+		msg := fileDraftAsBug(ctx, draftID)
+		if err := discordCompleteDeferred(ctx, appID, token, msg); err != nil {
+			log.Printf("[DiscordInteraction] file-as-bug follow-up for draft %d: %v", draftID, err)
+		}
+	}()
+	return c.JSON(fiber.Map{"type": discordResponseDeferredChannelMessage})
+}
+
+// fileDraftAsBug does the work and returns the message to post in the
+// thread — success, "already filed", or why it failed. Never returns an
+// error: whatever happened, the partner needs to read it in Discord.
+func fileDraftAsBug(ctx context.Context, draftID int64) string {
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil || draft == nil {
+		return "Could not load draft."
+	}
+
+	if existing := caseLinearIssueKey(ctx, draft.TicketNumber); existing != "" {
+		return fmt.Sprintf("🐛 Already filed as **%s** — %s",
+			existing, linearIssueURL(existing))
+	}
+
+	title := strings.TrimSpace(draft.AISummary)
+	if title == "" {
+		title = strings.TrimSpace(draft.OriginalSubject)
+	}
+	if title == "" {
+		title = "Support ticket #" + draft.TicketNumber
+	}
+	title = truncateRunes(title, 120)
+
+	issue, err := linearCreateIssue(ctx, title, buildLinearIssueBody(ctx, draft))
+	if err != nil {
+		log.Printf("[DiscordInteraction] linear create for ticket %s: %v", draft.TicketNumber, err)
+		return "⚠️ Could not file in Linear: " + err.Error()
+	}
+
+	if err := setCaseLinearIssueKey(ctx, draft.TicketNumber, issue.Identifier); err != nil {
+		// The issue exists; we just can't remember it. Say so, or the next
+		// click files a second one silently.
+		log.Printf("[DiscordInteraction] link %s to ticket %s: %v", issue.Identifier, draft.TicketNumber, err)
+		return fmt.Sprintf("🐛 Filed **%s** (%s) — but the link back to ticket #%s did not save; a second click will file a duplicate.",
+			issue.Identifier, issue.URL, draft.TicketNumber)
+	}
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: draft.TicketNumber, Kind: "note",
+		BodyText: "filed as " + issue.Identifier, AIDraftID: draft.ID,
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
+	return fmt.Sprintf("🐛 Filed as **%s** — %s", issue.Identifier, issue.URL)
+}
+
+// buildLinearIssueBody is what an engineer needs to pick the issue up: the
+// reporter's own words, the two diagnostics fields the case DB keeps, and
+// a link back to the ticket. No email address, and no diagnostics beyond
+// what the thread already shows.
+func buildLinearIssueBody(ctx context.Context, draft *SupportDraft) string {
+	var b strings.Builder
+	b.WriteString("**Reported via support ticket #")
+	b.WriteString(draft.TicketNumber)
+	b.WriteString("**\n\n")
+
+	if userText := strings.TrimSpace(htmlToPlain(draft.UserMessageHTML)); userText != "" {
+		b.WriteString("> ")
+		b.WriteString(strings.ReplaceAll(userText, "\n", "\n> "))
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("| | |\n|---|---|\n")
+	fmt.Fprintf(&b, "| Category | %s |\n", orDash(draft.AICategory))
+	fmt.Fprintf(&b, "| Priority | %s |\n", orDash(draft.AIPriority))
+	fmt.Fprintf(&b, "| App version | %s |\n", orDash(caseAppVersion(ctx, draft.TicketNumber)))
+	fmt.Fprintf(&b, "| OS | %s |\n", orDash(caseOS(ctx, draft.TicketNumber)))
+	fmt.Fprintf(&b, "| Opened | %s |\n", draft.CreatedAt.UTC().Format("2006-01-02"))
+
+	if note := strings.TrimSpace(draft.InternalNote); note != "" {
+		b.WriteString("\n**Triage note:** ")
+		b.WriteString(note)
+		b.WriteString("\n")
+	}
+	if url := osTicketTicketURL(draft.TicketNumber); url != "" {
+		fmt.Fprintf(&b, "\n[Open ticket #%s in osTicket](%s)\n", draft.TicketNumber, url)
+	}
+	return b.String()
+}
+
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "—"
+	}
+	return s
+}
+
+// osTicketTicketURL builds the agent-side link to a ticket, or "" when
+// OSTICKET_URL isn't configured.
+func osTicketTicketURL(ticketNumber string) string {
+	base := strings.TrimRight(strings.TrimSpace(os.Getenv("OSTICKET_URL")), "/")
+	if base == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/scp/tickets.php?number=%s", base, ticketNumber)
+}
+
+// linearIssueURL reconstructs the browser link for an identifier. Linear
+// redirects any workspace slug to the right issue, so "scrollr" here is a
+// path placeholder, not a lookup.
+func linearIssueURL(identifier string) string {
+	return "https://linear.app/scrollr/issue/" + identifier
+}
+
+// caseLinearIssueKey returns the Linear issue already linked to a ticket,
+// or "" when none is.
+func caseLinearIssueKey(ctx context.Context, ticketNumber string) string {
+	if platform.DBPool == nil {
+		return ""
+	}
+	var key *string
+	err := platform.DBPool.QueryRow(ctx,
+		`SELECT linear_issue_key FROM support_cases WHERE ticket_number = $1`, ticketNumber).Scan(&key)
+	if err != nil || key == nil {
+		return ""
+	}
+	return strings.TrimSpace(*key)
+}
+
+// setCaseLinearIssueKey links the issue to the case, refusing to overwrite
+// an existing link — two people clicking at once file one issue and keep
+// the first answer.
+func setCaseLinearIssueKey(ctx context.Context, ticketNumber, key string) error {
+	if platform.DBPool == nil {
+		return fmt.Errorf("DB not initialized")
+	}
+	if _, err := platform.DBPool.Exec(ctx,
+		`INSERT INTO support_cases (ticket_number) VALUES ($1) ON CONFLICT DO NOTHING`, ticketNumber); err != nil {
+		return err
+	}
+	_, err := platform.DBPool.Exec(ctx,
+		`UPDATE support_cases SET linear_issue_key = $2, updated_at = now()
+		 WHERE ticket_number = $1 AND linear_issue_key IS NULL`, ticketNumber, key)
+	return err
+}
+
+// caseOS returns the reporter's OS from the case DB, or "".
+func caseOS(ctx context.Context, ticketNumber string) string {
+	if platform.DBPool == nil {
+		return ""
+	}
+	var v *string
+	err := platform.DBPool.QueryRow(ctx,
+		`SELECT os FROM support_cases WHERE ticket_number = $1`, ticketNumber).Scan(&v)
+	if err != nil || v == nil {
+		return ""
+	}
+	return strings.TrimSpace(*v)
+}
+
+// =============================================================================
+// Slash commands — /inbox, /case, /search, /ticket, /stats
 // =============================================================================
 
 func handleDiscordSlashCommand(c *fiber.Ctx, ix *discordInteraction) error {
@@ -570,7 +999,11 @@ func handleDiscordSlashCommand(c *fiber.Ctx, ix *discordInteraction) error {
 	}
 	switch ix.Data.Name {
 	case "inbox":
-		return handleDiscordInboxCommand(c, ix)
+		return respondWithInboxPage(c, 0, discordResponseChannelMessageWithSource)
+	case "case":
+		return handleDiscordCaseCommand(c, ix)
+	case "search":
+		return handleDiscordSearchCommand(c, ix)
 	case "ticket":
 		return handleDiscordTicketCommand(c, ix)
 	case "stats":
@@ -743,19 +1176,31 @@ func handleDiscordStatsCommand(c *fiber.Ctx, ix *discordInteraction) error {
 	return discordEphemeralResponse(c, b.String())
 }
 
-// handleDiscordInboxCommand lists the 5 most recent pending drafts.
-func handleDiscordInboxCommand(c *fiber.Ctx, ix *discordInteraction) error {
+// inboxPageSize is how many pending drafts one /inbox page shows. Ten
+// fits an ephemeral message with room for the Next button and reads as a
+// working set rather than a wall.
+const inboxPageSize = 10
+
+// respondWithInboxPage renders one page of the pending queue, oldest
+// first — the queue is worked from the back, and the audit's problem was
+// old drafts, not new ones.
+//
+// responseType is CHANNEL_MESSAGE_WITH_SOURCE when /inbox is typed, and
+// UPDATE_MESSAGE when Next is clicked, so paging replaces the message in
+// place instead of stacking pages down the channel.
+func respondWithInboxPage(c *fiber.Ctx, offset, responseType int) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	const q = `
-		SELECT id, ticket_number, ai_summary, ai_priority, created_at
+		SELECT ticket_number, ai_summary, ai_priority, ai_category, created_at,
+			   COUNT(*) OVER () AS total
 		FROM support_drafts
 		WHERE status = 'pending'
-		ORDER BY created_at DESC
-		LIMIT 5
+		ORDER BY created_at ASC
+		LIMIT $1 OFFSET $2
 	`
-	rows, err := platform.DBPool.Query(ctx, q)
+	rows, err := platform.DBPool.Query(ctx, q, inboxPageSize, offset)
 	if err != nil {
 		log.Printf("[DiscordInteraction] /inbox query: %v", err)
 		return discordEphemeralResponse(c, "Database query failed.")
@@ -763,40 +1208,213 @@ func handleDiscordInboxCommand(c *fiber.Ctx, ix *discordInteraction) error {
 	defer rows.Close()
 
 	var lines []string
+	total := 0
 	for rows.Next() {
 		var (
-			id           int64
-			ticketNumber string
-			summary      *string
-			priority     *string
-			createdAt    time.Time
+			ticketNumber                string
+			summary, priority, category *string
+			createdAt                   time.Time
 		)
-		if err := rows.Scan(&id, &ticketNumber, &summary, &priority, &createdAt); err != nil {
+		if err := rows.Scan(&ticketNumber, &summary, &priority, &category, &createdAt, &total); err != nil {
 			continue
 		}
 		summaryText := "(no summary)"
 		if summary != nil && *summary != "" {
-			summaryText = *summary
+			summaryText = truncateRunes(*summary, 110)
 		}
-		priorityText := ""
+		tags := ""
+		if category != nil && *category != "" {
+			tags += " · `" + *category + "`"
+		}
 		if priority != nil && *priority != "" {
-			priorityText = " · `" + *priority + "`"
+			tags += " · `" + *priority + "`"
 		}
-		age := time.Since(createdAt).Round(time.Minute)
-		lines = append(lines,
-			fmt.Sprintf("• **#%s**%s — %s _(%s ago)_",
-				ticketNumber, priorityText, summaryText, age))
+		lines = append(lines, fmt.Sprintf("• **#%s**%s — %s _(%s old)_",
+			ticketNumber, tags, summaryText, humanAge(time.Since(createdAt))))
 	}
 	if err := rows.Err(); err != nil {
 		log.Printf("[DiscordInteraction] /inbox rows: %v", err)
 	}
 
 	if len(lines) == 0 {
-		return discordEphemeralResponse(c, "📭 Inbox is empty — no pending drafts.")
+		if offset == 0 {
+			return discordEphemeralResponse(c, "📭 Inbox is empty — no pending drafts.")
+		}
+		return discordEphemeralResponse(c, "That was the last page.")
 	}
 
-	content := "**Pending support drafts:**\n" + strings.Join(lines, "\n")
-	return discordEphemeralResponse(c, content)
+	shown := offset + len(lines)
+	content := fmt.Sprintf("**Pending support drafts — %d–%d of %d** (oldest first)\n%s",
+		offset+1, shown, total, strings.Join(lines, "\n"))
+
+	data := fiber.Map{
+		"content":          content,
+		"flags":            discordInteractionFlagEphemeral,
+		"allowed_mentions": fiber.Map{"parse": []string{}},
+	}
+	// Discord clears components when they're omitted on an UPDATE_MESSAGE,
+	// which is what we want on the final page.
+	components := []DiscordActionRow{}
+	if shown < total {
+		next := DiscordMessageButton{
+			Type: 2, Style: 1, Label: "Next",
+			CustomID: fmt.Sprintf("support_inbox:%d", shown),
+		}
+		next.Emoji = &struct {
+			Name string `json:"name"`
+		}{Name: "➡️"}
+		components = append(components, DiscordActionRow{Type: 1, Components: []DiscordMessageButton{next}})
+	}
+	data["components"] = components
+
+	return c.JSON(fiber.Map{"type": responseType, "data": data})
+}
+
+// handleDiscordCaseCommand prints one case's timeline out of the case DB:
+// what the user said, what we drafted, what actually went out, in order.
+// Bodies are snippets — the full text lives in the thread and in osTicket;
+// this is for finding your place in a conversation quickly.
+func handleDiscordCaseCommand(c *fiber.Ctx, ix *discordInteraction) error {
+	ticketNumber := strings.TrimSpace(commandOption(ix, "number"))
+	if ticketNumber == "" {
+		return discordEphemeralResponse(c, "Missing `number` option.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		subject, category, priority, status, summary string
+		appVersion, osName, linearKey, threadID      string
+		opened, updated                              time.Time
+	)
+	const caseQ = `
+		SELECT subject, COALESCE(category,''), COALESCE(priority,''), status,
+			   COALESCE(summary,''), COALESCE(app_version,''), COALESCE(os,''),
+			   COALESCE(linear_issue_key,''), COALESCE(discord_thread_id,''),
+			   opened_at, updated_at
+		FROM support_cases WHERE ticket_number = $1
+	`
+	err := platform.DBPool.QueryRow(ctx, caseQ, ticketNumber).Scan(
+		&subject, &category, &priority, &status, &summary,
+		&appVersion, &osName, &linearKey, &threadID, &opened, &updated)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return discordEphemeralResponse(c, fmt.Sprintf("No case for ticket #%s.", ticketNumber))
+		}
+		log.Printf("[DiscordInteraction] /case query: %v", err)
+		return discordEphemeralResponse(c, "Database query failed.")
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "**#%s — %s**\n", ticketNumber, truncateRunes(subject, 120))
+	fmt.Fprintf(&b, "`%s` · %s · %s · opened %s\n",
+		status, orDash(category), orDash(priority), opened.UTC().Format("2006-01-02"))
+	if appVersion != "" || osName != "" {
+		fmt.Fprintf(&b, "Reported on %s / %s\n", orDash(appVersion), orDash(osName))
+	}
+	if summary != "" {
+		fmt.Fprintf(&b, "_%s_\n", truncateRunes(summary, 300))
+	}
+	if linearKey != "" {
+		fmt.Fprintf(&b, "🐛 %s — %s\n", linearKey, linearIssueURL(linearKey))
+	}
+	if threadID != "" {
+		fmt.Fprintf(&b, "🧵 https://discord.com/channels/%s/%s\n", ix.GuildID, threadID)
+	}
+
+	const msgQ = `
+		SELECT kind, body_text, created_at FROM support_messages
+		WHERE ticket_number = $1 ORDER BY created_at DESC, id DESC LIMIT 20
+	`
+	rows, err := platform.DBPool.Query(ctx, msgQ, ticketNumber)
+	if err != nil {
+		log.Printf("[DiscordInteraction] /case messages: %v", err)
+		return discordEphemeralResponse(c, b.String())
+	}
+	defer rows.Close()
+
+	kindIcon := map[string]string{"user": "👤", "ai_draft": "🤖", "sent": "📨", "note": "📝"}
+	var events []string
+	for rows.Next() {
+		var kind, body string
+		var created time.Time
+		if err := rows.Scan(&kind, &body, &created); err != nil {
+			continue
+		}
+		icon := kindIcon[kind]
+		if icon == "" {
+			icon = "•"
+		}
+		snippet := truncateRunes(strings.Join(strings.Fields(body), " "), 140)
+		events = append(events, fmt.Sprintf("%s `%s` %s — %s",
+			icon, created.UTC().Format("Jan 2 15:04"), kind, snippet))
+	}
+	// Oldest first reads as a conversation; the query took the newest 20.
+	for i := len(events) - 1; i >= 0; i-- {
+		b.WriteString("\n")
+		b.WriteString(events[i])
+	}
+	if len(events) == 0 {
+		b.WriteString("\n_(no recorded messages)_")
+	}
+
+	return discordEphemeralResponse(c, truncateRunes(b.String(), 1990))
+}
+
+// handleDiscordSearchCommand runs the case DB's full-text search — the
+// same one the support bot reads — and lists what it found.
+func handleDiscordSearchCommand(c *fiber.Ctx, ix *discordInteraction) error {
+	query := strings.TrimSpace(commandOption(ix, "text"))
+	if query == "" {
+		return discordEphemeralResponse(c, "Missing `text` option.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cases, err := SearchSupportCases(ctx, query, "", "", 10)
+	if err != nil {
+		log.Printf("[DiscordInteraction] /search: %v", err)
+		return discordEphemeralResponse(c, "Search failed.")
+	}
+	if len(cases) == 0 {
+		return discordEphemeralResponse(c, fmt.Sprintf("🔍 Nothing matched `%s`.", query))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "🔍 **%d result(s) for `%s`**\n", len(cases), query)
+	for _, sc := range cases {
+		text := sc.Summary
+		if text == "" {
+			text = sc.Subject
+		}
+		fmt.Fprintf(&b, "• **#%s** `%s`%s — %s _(%s)_\n",
+			sc.TicketNumber, sc.Status, categoryTag(sc.Category),
+			truncateRunes(text, 110), sc.UpdatedAt.UTC().Format("2006-01-02"))
+	}
+	b.WriteString("\n`/case <number>` for the full timeline.")
+	return discordEphemeralResponse(c, truncateRunes(b.String(), 1990))
+}
+
+func categoryTag(category string) string {
+	if category == "" {
+		return ""
+	}
+	return " · `" + category + "`"
+}
+
+// commandOption reads one slash-command option by name.
+func commandOption(ix *discordInteraction, name string) string {
+	if ix.Data == nil {
+		return ""
+	}
+	for _, opt := range ix.Data.Options {
+		if opt.Name == name {
+			return opt.Value
+		}
+	}
+	return ""
 }
 
 // handleDiscordTicketCommand shows the latest draft for a specific
@@ -870,8 +1488,19 @@ func handleDiscordTicketCommand(c *fiber.Ctx, ix *discordInteraction) error {
 		d.AIConfidence = *confidence
 	}
 
-	content := buildDraftMessageContent(&d) +
-		fmt.Sprintf("\n\n_Status: `%s`_", d.Status)
+	// Ephemeral replies are one message, so this is the one place a draft
+	// is still abridged — the thread itself carries the unabridged copy,
+	// and /case points at it.
+	starter, rest := buildDraftMessages(&d, true)
+	content := starter
+	if len(rest) > 0 {
+		content += "\n\n" + rest[0]
+	}
+	content = truncateRunes(content, 1900)
+	if len(rest) > 1 {
+		content += "\n\n_…full draft in the ticket's thread._"
+	}
+	content += fmt.Sprintf("\n_Status: `%s`_", d.Status)
 
 	// Buttons only if still pending.
 	var components []DiscordActionRow
@@ -883,6 +1512,7 @@ func handleDiscordTicketCommand(c *fiber.Ctx, ix *discordInteraction) error {
 		"type": discordResponseChannelMessageWithSource,
 		"data": fiber.Map{
 			"content":          content,
+			"embeds":           []*discordEmbed{buildDraftHeaderEmbed(ctx, &d)},
 			"components":       components,
 			"flags":            discordInteractionFlagEphemeral,
 			"allowed_mentions": fiber.Map{"parse": []string{}},

--- a/api/internal/support/handlers_osticket_webhook.go
+++ b/api/internal/support/handlers_osticket_webhook.go
@@ -156,6 +156,11 @@ func processReplyTriageAsync(ev osTicketThreadMessageEvent) {
 		}
 	}
 
+	// Surface the reply in Discord immediately, before triage runs. The
+	// partner sees the question the moment it arrives rather than several
+	// seconds later underneath the AI's answer to it.
+	notifyDiscordForUserReply(ctx, ev.TicketNumber, ev.Subject, "", ev.MessageHTML)
+
 	// Pull the most recent SENT reply on this ticket so the triage
 	// prompt has continuity context. Best-effort — empty string is OK.
 	previousReply := loadLatestSentDraftBody(ctx, ev.TicketNumber)

--- a/api/internal/support/kb/kb.generated.md
+++ b/api/internal/support/kb/kb.generated.md
@@ -114,8 +114,8 @@ The widget cap is the only per-plan limit. Plan names and wording are in Policie
 | `free` | 3 |
 | `uplink` | 6 |
 | `uplink_pro` | 12 |
-| `uplink_ultimate` | unlimited |
 | `super_user` | unlimited |
+| `uplink_ultimate` | unlimited |
 
 ## Widget catalog
 

--- a/api/internal/support/linear.go
+++ b/api/internal/support/linear.go
@@ -1,0 +1,197 @@
+package support
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// =============================================================================
+// Linear — file a bug from a support thread (REL-245)
+// =============================================================================
+//
+// One button in the Discord queue turns a ticket into a Linear issue, and
+// one release webhook asks whether the issue behind a case is Done yet.
+// That is the whole surface, so this is a hand-rolled GraphQL client over
+// net/http rather than a generated one: three queries, no schema to track.
+//
+// LINEAR_API_KEY lives in the scrollr-secrets Secret. When it is absent
+// every entry point here returns an error the caller shows in the thread —
+// nothing else in the pipeline degrades.
+
+const (
+	linearAPIURL  = "https://api.linear.app/graphql"
+	linearTimeout = 10 * time.Second
+)
+
+// linearTeamKey is the team new issues are filed into. Scrollr's work all
+// lives in one Linear team, so this is a config value, not a picker.
+func linearTeamKey() string {
+	if k := strings.TrimSpace(os.Getenv("LINEAR_TEAM_KEY")); k != "" {
+		return k
+	}
+	return "REL"
+}
+
+var linearHTTPClient = &http.Client{Timeout: linearTimeout}
+
+// linearTeamIDCache memoises the team-key → team-id lookup. Team ids never
+// change, so once per pod is enough.
+var linearTeamIDCache sync.Map // map[teamKey string] -> teamID string
+
+// linearGraphQL runs one query and unmarshals `data` into out. GraphQL
+// answers 200 with an `errors` array on failure, so the status check alone
+// is not enough.
+func linearGraphQL(ctx context.Context, query string, vars map[string]interface{}, out interface{}) error {
+	apiKey := strings.TrimSpace(os.Getenv("LINEAR_API_KEY"))
+	if apiKey == "" {
+		return fmt.Errorf("LINEAR_API_KEY not configured")
+	}
+
+	body, err := json.Marshal(map[string]interface{}{"query": query, "variables": vars})
+	if err != nil {
+		return fmt.Errorf("marshal query: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, linearAPIURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := linearHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("linear request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("linear status %d: %s", resp.StatusCode, truncateForLog(string(respBody)))
+	}
+
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(respBody, &envelope); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		return fmt.Errorf("linear: %s", envelope.Errors[0].Message)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(envelope.Data, out); err != nil {
+		return fmt.Errorf("parse data: %w", err)
+	}
+	return nil
+}
+
+// linearResolveTeamID turns the team key ("REL") into the UUID the issue
+// mutation wants.
+func linearResolveTeamID(ctx context.Context) (string, error) {
+	key := linearTeamKey()
+	if v, ok := linearTeamIDCache.Load(key); ok {
+		return v.(string), nil
+	}
+	const q = `query($key: String!) { teams(filter: { key: { eq: $key } }, first: 1) { nodes { id } } }`
+	var out struct {
+		Teams struct {
+			Nodes []struct {
+				ID string `json:"id"`
+			} `json:"nodes"`
+		} `json:"teams"`
+	}
+	if err := linearGraphQL(ctx, q, map[string]interface{}{"key": key}, &out); err != nil {
+		return "", err
+	}
+	if len(out.Teams.Nodes) == 0 {
+		return "", fmt.Errorf("no Linear team with key %q", key)
+	}
+	id := out.Teams.Nodes[0].ID
+	linearTeamIDCache.Store(key, id)
+	return id, nil
+}
+
+// LinearIssue is the slice of a created issue we surface back in Discord.
+type LinearIssue struct {
+	Identifier string `json:"identifier"` // e.g. "REL-251"
+	URL        string `json:"url"`
+}
+
+// linearCreateIssue files one issue in the configured team. LINEAR_PROJECT_ID
+// is optional — when set the issue lands in that project, otherwise in the
+// team's backlog.
+func linearCreateIssue(ctx context.Context, title, description string) (*LinearIssue, error) {
+	teamID, err := linearResolveTeamID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	input := map[string]interface{}{
+		"teamId":      teamID,
+		"title":       title,
+		"description": description,
+	}
+	if p := strings.TrimSpace(os.Getenv("LINEAR_PROJECT_ID")); p != "" {
+		input["projectId"] = p
+	}
+
+	const q = `mutation($input: IssueCreateInput!) {
+		issueCreate(input: $input) { success issue { identifier url } }
+	}`
+	var out struct {
+		IssueCreate struct {
+			Success bool         `json:"success"`
+			Issue   *LinearIssue `json:"issue"`
+		} `json:"issueCreate"`
+	}
+	if err := linearGraphQL(ctx, q, map[string]interface{}{"input": input}, &out); err != nil {
+		return nil, err
+	}
+	if !out.IssueCreate.Success || out.IssueCreate.Issue == nil {
+		return nil, fmt.Errorf("linear issueCreate returned no issue")
+	}
+	return out.IssueCreate.Issue, nil
+}
+
+// linearIssueIsDone reports whether the issue identified by e.g. "REL-239"
+// sits in a completed workflow state. Linear's state `type` is the stable
+// field here — the display name is per-team and renameable.
+func linearIssueIsDone(ctx context.Context, identifier string) (bool, error) {
+	const q = `query($id: String!) { issue(id: $id) { state { type } } }`
+	var out struct {
+		Issue *struct {
+			State struct {
+				Type string `json:"type"`
+			} `json:"state"`
+		} `json:"issue"`
+	}
+	if err := linearGraphQL(ctx, q, map[string]interface{}{"id": identifier}, &out); err != nil {
+		return false, err
+	}
+	if out.Issue == nil {
+		return false, fmt.Errorf("no Linear issue %q", identifier)
+	}
+	return out.Issue.State.Type == "completed", nil
+}
+
+// truncateForLog keeps an upstream error body out of the log at full length.
+func truncateForLog(s string) string {
+	if len(s) > 300 {
+		return s[:300] + "…"
+	}
+	return s
+}

--- a/api/internal/support/shipped_followup.go
+++ b/api/internal/support/shipped_followup.go
@@ -1,0 +1,148 @@
+package support
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// =============================================================================
+// "This is fixed now" — release → the people who reported it (REL-245)
+// =============================================================================
+//
+// A ticket filed as a bug gets a Linear issue (the File as bug button). When
+// a desktop release publishes, every case whose issue is now Done gets a
+// drafted follow-up telling the reporter it shipped — as an ordinary pending
+// draft in the Discord queue, with the same Send / Edit / Ask / Skip buttons
+// as any other. Nothing goes out on its own.
+//
+// The body is templated rather than AI-written: "it shipped, here's where to
+// get it" has one correct shape, and a Haiku call per case inside a webhook
+// buys nothing but latency and a chance to hallucinate a changelog.
+
+// shippedFollowUpLimit caps one release's follow-ups. A release that
+// suddenly matches fifty cases means a query bug, not fifty happy users, and
+// a cap makes it a small mess instead of a large one.
+const shippedFollowUpLimit = 25
+
+// DraftShippedFollowUps drafts a "fixed in <version>" reply for every open
+// case linked to a Linear issue that has reached a completed state. Returns
+// how many drafts it created.
+//
+// Idempotent per (case, issue): a note recording the follow-up is written
+// alongside the draft, and cases carrying that note are skipped, so
+// re-publishing a release — or publishing the next one — never re-drafts
+// the same news.
+func DraftShippedFollowUps(ctx context.Context, version, releaseURL string) int {
+	if platform.DBPool == nil {
+		return 0
+	}
+	version = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(version), "desktop-v"))
+	if version == "" {
+		log.Println("[Shipped] no version in release payload; nothing drafted")
+		return 0
+	}
+
+	const q = `
+		SELECT c.ticket_number, c.linear_issue_key, COALESCE(c.user_email,''),
+			   COALESCE(c.subject,''), COALESCE(c.category,''), COALESCE(c.summary,'')
+		FROM support_cases c
+		WHERE c.linear_issue_key IS NOT NULL
+		  AND c.status <> 'closed'
+		  AND NOT EXISTS (
+				SELECT 1 FROM support_drafts d
+				WHERE d.ticket_number = c.ticket_number AND d.status = 'pending')
+		  AND NOT EXISTS (
+				SELECT 1 FROM support_messages m
+				WHERE m.ticket_number = c.ticket_number AND m.kind = 'note'
+				  AND m.body_text = 'shipped follow-up for ' || c.linear_issue_key)
+		ORDER BY c.updated_at DESC
+		LIMIT $1
+	`
+	rows, err := platform.DBPool.Query(ctx, q, shippedFollowUpLimit)
+	if err != nil {
+		log.Printf("[Shipped] candidate query: %v", err)
+		return 0
+	}
+	type candidate struct {
+		ticket, issueKey, email, subject, category, summary string
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.ticket, &c.issueKey, &c.email, &c.subject, &c.category, &c.summary); err != nil {
+			continue
+		}
+		candidates = append(candidates, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		log.Printf("[Shipped] candidate rows: %v", err)
+	}
+
+	drafted := 0
+	for _, c := range candidates {
+		if c.email == "" {
+			// Nowhere to send it; skip rather than draft something undeliverable.
+			continue
+		}
+		done, err := linearIssueIsDone(ctx, c.issueKey)
+		if err != nil {
+			log.Printf("[Shipped] %s state lookup: %v", c.issueKey, err)
+			continue
+		}
+		if !done {
+			continue
+		}
+
+		draft, err := createSupportDraft(ctx, &SupportDraft{
+			TicketNumber:    c.ticket,
+			UserEmail:       c.email,
+			OriginalSubject: c.subject,
+			DraftBodyHTML:   shippedFollowUpHTML(version, releaseURL),
+			AISummary:       fmt.Sprintf("Fixed in %s — %s is Done", version, c.issueKey),
+			AICategory:      c.category,
+			AIPriority:      "low",
+			// Never "high": auto-send must not pick these up, and no human
+			// has read this pairing of ticket and fix yet.
+			AIConfidence: "medium",
+			InternalNote: fmt.Sprintf("Auto-drafted on the %s release because %s is Done. Check the fix actually matches what they reported before sending.", version, c.issueKey),
+		})
+		if err != nil {
+			log.Printf("[Shipped] draft for ticket %s: %v", c.ticket, err)
+			continue
+		}
+		if err := recordSupportMessage(ctx, SupportMessage{
+			TicketNumber: c.ticket, Kind: "note",
+			BodyText: "shipped follow-up for " + c.issueKey,
+		}); err != nil {
+			log.Printf("[Cases] %v", err)
+		}
+		notifyPartnerAfterDraft(ctx, draft)
+		drafted++
+	}
+
+	log.Printf("[Shipped] release %s: %d candidate(s), %d follow-up draft(s)", version, len(candidates), drafted)
+	return drafted
+}
+
+// shippedFollowUpHTML is the reply body. Deliberately short and checkable:
+// it claims only that a release is out, never that this user's exact
+// symptom is gone — the partner confirms that before sending.
+func shippedFollowUpHTML(version, releaseURL string) string {
+	notes := ""
+	if releaseURL != "" {
+		notes = fmt.Sprintf(`<p>The full release notes are here: <a href="%s">%s</a>.</p>`,
+			escapeHTML(releaseURL), escapeHTML(releaseURL))
+	}
+	return fmt.Sprintf(
+		`<p>Good news — the fix for what you reported went out in Scrollr %s.</p>`+
+			`<p>Scrollr updates itself, so you should get it within a day; to take it now, `+
+			`download the latest build from <a href="https://myscrollr.com/download">myscrollr.com/download</a>.</p>`+
+			`%s`+
+			`<p>If you are on %s and still seeing it, reply here and we'll pick it back up.</p>`,
+		escapeHTML(version), notes, escapeHTML(version))
+}

--- a/api/internal/support/support_drafts.go
+++ b/api/internal/support/support_drafts.go
@@ -32,21 +32,28 @@ import (
 
 // SupportDraft mirrors the support_drafts table.
 type SupportDraft struct {
-	ID                    int64
-	TicketNumber          string
-	UserEmail             string
-	UserName              string
-	OriginalSubject       string
-	UserMessageHTML       string // The user's actual message body (for partner-email context). Separate from DraftBodyHTML which is the AI-drafted reply.
-	DraftBodyHTML         string
-	AISummary             string
-	AICategory            string
-	AIPriority            string
-	AIWidget              string
-	AIDuplicateOf         string
-	AIConfidence          string
-	Status                string
-	EditedBodyHTML        string
+	ID              int64
+	TicketNumber    string
+	UserEmail       string
+	UserName        string
+	OriginalSubject string
+	UserMessageHTML string // The user's actual message body (for partner-email context). Separate from DraftBodyHTML which is the AI-drafted reply.
+	DraftBodyHTML   string
+	AISummary       string
+	AICategory      string
+	AIPriority      string
+	AIWidget        string
+	AIDuplicateOf   string
+	AIConfidence    string
+	Status          string
+	EditedBodyHTML  string
+	// Triage's notes to us rather than to the user (REL-244): what the AI
+	// is unsure about, what it still needs from the reporter, and which
+	// knowledge-base sections it based the draft on. All nullable; a draft
+	// written before REL-244 has all three empty and renders without them.
+	InternalNote          string
+	AskUserFor            string
+	GroundedIn            string
 	OSTicketThreadEntryID int64 // 0 = unknown (legacy rows + initial /support/ticket flow)
 	ShouldClose           bool  // AI-detected resolution signal — when true, send-time also closes the ticket
 	DecidedAt             *time.Time
@@ -72,8 +79,10 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 			 user_message_html,
 			 draft_body_html, ai_summary, ai_category, ai_priority,
 			 ai_widget, ai_duplicate_of, ai_confidence, status,
-			 osticket_thread_entry_id, should_close)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'pending',$13,$14)
+			 osticket_thread_entry_id, should_close,
+			 internal_note, ask_user_for, grounded_in)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'pending',$13,$14,
+			 NULLIF($15,''),NULLIF($16,''),NULLIF($17,''))
 		RETURNING id, created_at
 	`
 	// 0 → NULL via NULLIF so the partial unique index doesn't reject
@@ -105,6 +114,9 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 		draft.AIConfidence,
 		entryID,
 		draft.ShouldClose,
+		draft.InternalNote,
+		draft.AskUserFor,
+		draft.GroundedIn,
 	).Scan(&draft.ID, &draft.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("createSupportDraft: %w", err)
@@ -135,18 +147,19 @@ func loadSupportDraft(ctx context.Context, id int64) (*SupportDraft, error) {
 			   draft_body_html, ai_summary, ai_category, ai_priority,
 			   ai_widget, ai_duplicate_of, ai_confidence, status,
 			   edited_body_html, decided_at, sent_at, created_at,
-			   should_close
+			   should_close, internal_note, ask_user_for, grounded_in
 		FROM support_drafts WHERE id = $1
 	`
 	var d SupportDraft
 	var userName, userMsg, summary, category, priority, widget, dupOf, confidence, editedBody *string
+	var internalNote, askUserFor, groundedIn *string
 	err := platform.DBPool.QueryRow(ctx, q, id).Scan(
 		&d.ID, &d.TicketNumber, &d.UserEmail, &userName, &d.OriginalSubject,
 		&userMsg,
 		&d.DraftBodyHTML, &summary, &category, &priority, &widget,
 		&dupOf, &confidence, &d.Status,
 		&editedBody, &d.DecidedAt, &d.SentAt, &d.CreatedAt,
-		&d.ShouldClose,
+		&d.ShouldClose, &internalNote, &askUserFor, &groundedIn,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -180,6 +193,15 @@ func loadSupportDraft(ctx context.Context, id int64) (*SupportDraft, error) {
 	}
 	if editedBody != nil {
 		d.EditedBodyHTML = *editedBody
+	}
+	if internalNote != nil {
+		d.InternalNote = *internalNote
+	}
+	if askUserFor != nil {
+		d.AskUserFor = *askUserFor
+	}
+	if groundedIn != nil {
+		d.GroundedIn = *groundedIn
 	}
 	return &d, nil
 }

--- a/api/main.go
+++ b/api/main.go
@@ -104,6 +104,10 @@ func main() {
 	// Nightly re-sync of the support case DB from osTicket (REL-243).
 	support.StartSupportCaseReconciler(ctx)
 
+	// Morning digest of the support queue into its pinned Discord thread
+	// (REL-245). No-op when Discord isn't configured.
+	support.StartSupportDigest(ctx)
+
 	// Build and start the gateway server
 	srv := core.NewServer()
 	srv.Setup()

--- a/api/migrations/000011_support_ask_and_notes.down.sql
+++ b/api/migrations/000011_support_ask_and_notes.down.sql
@@ -1,0 +1,9 @@
+-- Reverse of 000011. The three triage columns are left in place: REL-244
+-- also declares them and dropping them here would break that migration's
+-- forward state. Only the status CHECK goes back to its baseline values.
+
+UPDATE support_drafts SET status = 'skipped' WHERE status = 'asked';
+
+ALTER TABLE support_drafts DROP CONSTRAINT IF EXISTS support_drafts_status_check;
+ALTER TABLE support_drafts ADD CONSTRAINT support_drafts_status_check
+    CHECK (status = ANY (ARRAY['pending', 'approved', 'edited', 'skipped', 'sent', 'failed']));

--- a/api/migrations/000011_support_ask_and_notes.down.sql
+++ b/api/migrations/000011_support_ask_and_notes.down.sql
@@ -4,6 +4,9 @@
 
 UPDATE support_drafts SET status = 'skipped' WHERE status = 'asked';
 
+-- The UPDATE above has already moved every 'asked' row out of the way, so
+-- the narrower constraint is satisfiable when it goes back on.
+-- allow-destructive: reverting the widened constraint is the point of a down
 ALTER TABLE support_drafts DROP CONSTRAINT IF EXISTS support_drafts_status_check;
 ALTER TABLE support_drafts ADD CONSTRAINT support_drafts_status_check
     CHECK (status = ANY (ARRAY['pending', 'approved', 'edited', 'skipped', 'sent', 'failed']));

--- a/api/migrations/000011_support_ask_and_notes.up.sql
+++ b/api/migrations/000011_support_ask_and_notes.up.sql
@@ -1,0 +1,22 @@
+-- Discord support workspace (REL-245).
+--
+-- Two things the Discord queue needs from support_drafts:
+--
+--   1. An 'asked' status. The Ask button sends a single clarifying line to
+--      the user instead of the drafted reply; the draft is decided but it
+--      is neither sent-as-drafted nor skipped, and the status CHECK from
+--      the baseline rejected anything outside its five values.
+--
+--   2. The three nullable triage columns REL-244 adds (internal_note,
+--      ask_user_for, grounded_in). Declared IF NOT EXISTS so whichever of
+--      the two migrations lands second is a no-op rather than a failure —
+--      the columns are read here (rendered in the thread header, and
+--      ask_user_for gates auto-send) and written there.
+
+ALTER TABLE support_drafts DROP CONSTRAINT IF EXISTS support_drafts_status_check;
+ALTER TABLE support_drafts ADD CONSTRAINT support_drafts_status_check
+    CHECK (status = ANY (ARRAY['pending', 'approved', 'edited', 'skipped', 'asked', 'sent', 'failed']));
+
+ALTER TABLE support_drafts ADD COLUMN IF NOT EXISTS internal_note text;
+ALTER TABLE support_drafts ADD COLUMN IF NOT EXISTS ask_user_for  text;
+ALTER TABLE support_drafts ADD COLUMN IF NOT EXISTS grounded_in   text;

--- a/api/migrations/000011_support_ask_and_notes.up.sql
+++ b/api/migrations/000011_support_ask_and_notes.up.sql
@@ -13,6 +13,10 @@
 --      the columns are read here (rendered in the thread header, and
 --      ask_user_for gates auto-send) and written there.
 
+-- The CHECK is dropped and re-added one statement later with a strictly
+-- WIDER set of values: no row that passed the old constraint can fail the
+-- new one, and nothing reads a constraint the way code reads a column.
+-- allow-destructive: same constraint, widened, in the same transaction
 ALTER TABLE support_drafts DROP CONSTRAINT IF EXISTS support_drafts_status_check;
 ALTER TABLE support_drafts ADD CONSTRAINT support_drafts_status_check
     CHECK (status = ANY (ARRAY['pending', 'approved', 'edited', 'skipped', 'asked', 'sent', 'failed']));

--- a/k8s/configmap-core.yaml
+++ b/k8s/configmap-core.yaml
@@ -77,6 +77,9 @@ data:
   #
   # The following secrets MUST be added manually to k8s/secrets.yaml:
   #   - ANTHROPIC_API_KEY              (Claude Haiku for triage; sk-ant-...)
+  #   - LINEAR_API_KEY                 (lin_api_...; "File as bug" in the
+  #     Discord support queue, and the release webhook's Done check. When
+  #     absent the button says so and nothing else degrades.)
   #   - SUPPORT_APPROVAL_HMAC_SECRET   (any high-entropy string ≥32 chars)
   #   - SCROLLR_WEBHOOK_SECRET         (any high-entropy string ≥32 chars)
   #     used to authenticate the osTicket reply-loop webhook coming
@@ -138,6 +141,29 @@ data:
   # If Discord env vars below are unset, "discord" and "both" silently
   # fall back to email-only — no error, no startup failure.
   SUPPORT_NOTIFY: "both"
+
+  # Auto-send (REL-245). OFF unless SUPPORT_AUTOSEND is exactly "on".
+  #
+  # When on, a draft is sent without a click only if ALL of these hold:
+  # AI confidence is "high", the category is in SUPPORT_AUTOSEND_CATEGORIES,
+  # triage isn't waiting on information from the user, and nobody pressed
+  # Skip, Edit or Ask before SUPPORT_AUTOSEND_DELAY elapsed (the thread
+  # shows a live countdown). `bug`, `billing` and `account` can NEVER
+  # auto-send — that list is in code, not here, and adding them to the
+  # categories below does nothing.
+  #
+  # The timer lives in the pod: a restart before it fires cancels the
+  # auto-send and leaves the draft pending for a human. That's deliberate.
+  SUPPORT_AUTOSEND: "off"
+  SUPPORT_AUTOSEND_CATEGORIES: "feature,feedback"
+  SUPPORT_AUTOSEND_DELAY: "30m"
+
+  # Linear (REL-245). LINEAR_API_KEY is a secret (see
+  # k8s/secrets.yaml.template); these two are not.
+  #   LINEAR_TEAM_KEY    — team new issues are filed into (default "REL")
+  #   LINEAR_PROJECT_ID  — optional project UUID; unset files to the
+  #                        team's backlog instead
+  LINEAR_TEAM_KEY: "REL"
 
   # Discord integration. The following secrets MUST be added manually
   # to k8s/secrets.yaml (none are configmap-safe):

--- a/k8s/secrets.yaml.template
+++ b/k8s/secrets.yaml.template
@@ -46,6 +46,13 @@ data:
   # Support (OS Ticket)
   OSTICKET_API_KEY: ""
 
+  # Linear — the "File as bug" button in the Discord support queue creates
+  # issues with this, and the release webhook asks it whether the issue
+  # behind a case is Done yet. Personal API key from Linear → Settings →
+  # Security & access → Personal API keys (starts `lin_api_`).
+  # Absent = the button reports it isn't configured; nothing else changes.
+  LINEAR_API_KEY: ""
+
   # Transactional email (Resend) — drives password-reset emails + invite scripts
   RESEND_API_KEY: ""
   RESEND_FROM_EMAIL: ""      # e.g. invites@myscrollr.com


### PR DESCRIPTION
The AI support pipeline could draft a reply but not show it: every draft was cut to 1900 characters with `_...truncated_` appended, so a long answer could not be read, let alone judged. The May–September audit found 13 drafts pending — some since May — with nothing telling anyone they were there. This turns the support forum into somewhere the queue is actually worked.

## Reading a draft

A ticket is now as many messages as it takes. The starter carries an embed header (ticket, category, priority, confidence, the reporter's app version against the current one, and triage's `internal_note`) plus up to 1500 characters of what they wrote; the rest continues below, split at paragraph boundaries — never mid-word, never mid-rune. **Action buttons ride on the last message**, so nobody scrolls back up to act on what they just read.

## Acting on it

Five buttons: **Send · Edit · Ask · Skip · File as bug**.

- **Ask** opens a one-field modal and sends that single line to the user in place of the draft, parking it as `asked`. Their answer returns through the existing reply webhook and drafts afresh with the new information.
- **File as bug** creates a Linear issue — title = the AI summary, body = the reporter's own words plus app version, OS and a link to the ticket — writes `linear_issue_key` onto the case and posts the key in the thread. A second click links the existing issue instead of filing a duplicate. Deferred + `PATCH @original`, so the Linear round-trip is not racing Discord's 3-second budget.
- The **Edit** modal keeps its 4000-character box and now shows the question beside the answer (Discord has no read-only input; the second field is pre-filled, optional and ignored on submit). After sending, the draft-vs-edited diff is posted in the thread — half of all actioned drafts were being rewritten and nothing recorded what was wrong with them.

## Not losing track of it

- A user's emailed reply lands in the thread it belongs to: **un-archived, renamed `[REPLY]`, tagged `pending`**, and quoted *before* triage runs rather than after. The draft that follows doesn't re-quote it.
- A **digest** posts at 09:00 America/Chicago into a pinned **Queue** thread: what is pending, what has waited more than 48 h and for how long, follow-ups owed, and yesterday's sent/edited/skipped. Nothing pending and a quiet yesterday posts nothing at all — silence is the signal.
- `/inbox` pages ten at a time, oldest first, updating in place. `/case <n>` prints a timeline out of `support_cases`; `/search <text>` runs the full-text search from REL-243. `/stats` is unchanged.

## Auto-send, off by default

`SUPPORT_AUTOSEND=on` lets a draft send itself after `SUPPORT_AUTOSEND_DELAY` (default `30m`, with a live `<t:…:R>` countdown in the thread) if confidence is `high`, the category is in `SUPPORT_AUTOSEND_CATEGORIES` (default `feature,feedback`), and triage is not waiting on the user. Skip, Edit and Ask all cancel it — the timer re-reads the draft's status before sending, and `markDraftDecided`'s `WHERE status = 'pending'` makes it safe across replicas.

**`bug`, `billing` and `account` can never auto-send.** That list is in code, not config; a test asserts they stay refused even when explicitly added to the allow-list.

The timer lives in the pod, so a restart cancels it and leaves the draft pending for a human — the safe failure direction, marked with a `ponytail:` comment.

## Shipped follow-ups

Publishing a desktop release asks Linear whether the issue behind each linked case is Done, and drafts "this is fixed in X" for the ones that are — as ordinary pending drafts, in the same queue, sent by a human. It rides on `discord-release.yml`'s existing `release: published` trigger rather than a second workflow on the same event, and hits core-api for the same reason `auto-close-osticket.yml` does: the credentials belong there, not on a runner.

## Config

`LINEAR_API_KEY` is new (secrets template + configmap comments). **Absent, the File as bug button says so and nothing else changes** — that is also the state of production until the key is added. `LINEAR_TEAM_KEY` (default `REL`) and the optional `LINEAR_PROJECT_ID` are configmap values.

Migration `000011` adds the `asked` status to the `support_drafts` CHECK and declares REL-244's three triage columns `IF NOT EXISTS`, so either migration may land first.

## Tests

`go test ./...` green against the dev Postgres (whole API, not just the package). New coverage:

- **Splitter** — every chunk within 2000 bytes, no mid-word cut (asserted against the source vocabulary), nothing lost across the round trip, a 5000-char unbroken multi-byte run cut on a rune boundary and rejoined byte-identical, and paragraph boundaries preferred over line and word.
- **Draft messages** — a short ticket is one message; a >2500-char draft over a >2000-char user message is fully readable with `…continues below` on the head; a 400-line log dump stays under the limit *after* the blockquote prefix is applied; a follow-up draft doesn't re-quote what the thread already shows; buttons land on the last message either way.
- **Auto-send gate** — one test per way it can be wrong, including that bug/billing/account stay refused while allow-listed, that only the exact string `on` enables it, that every decided status cancels, and that an unparseable or negative delay falls back to 30m rather than "immediately".
- **Digest** — empty queue posts nothing, the rendered post names what's waiting, the next fire time is always in the future.
- **Diff** — identical bodies produce nothing; changed lines are marked `-`/`+` with context kept.

## Live verification

Pending deploy — see the PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)