### PR TITLE
fix(support): auto_ask follows the drafter's question, not the classifier's flag [REL-249]

### DIFF
--- a/api/internal/support/disposition.go
+++ b/api/internal/support/disposition.go
@@ -104,8 +104,27 @@ func decideDisposition(s dispositionSignals) (disposition, reason string) {
 		return dispositionEscalate, fmt.Sprintf("the draft would promise something (%q)", hit)
 	}
 
-	if s.NeedsInfo && strings.TrimSpace(s.AskUserFor) != "" {
-		return dispositionAutoAsk, "asking the user for what we need to troubleshoot"
+	// A reply that asks the user for something is not a final answer, so the
+	// grounding gate below does not apply to it.
+	//
+	// The ticket wrote this rule as "needs_info AND ask_user_for", and the
+	// first production ticket showed why the server cannot lean on
+	// needs_info: the classifier returned false for "It stopped working.
+	// Nothing shows up in the bar any more", while the drafter wrote a pure
+	// question and listed four things in ask_user_for. Under the literal
+	// rule that escalated on `unknowns`, and the unknowns WERE the questions.
+	// The classifier's flag is a hint; what the reply actually does is the
+	// fact, and the drafter is the one that knows it.
+	//
+	// Everything with a consequence has already escalated above this line, so
+	// what is left is the case the ticket cares most about: someone waiting an
+	// hour to be asked which operating system they are on.
+	if ask := strings.TrimSpace(s.AskUserFor); ask != "" {
+		reason := "asking the user for what we need to troubleshoot: " + truncate(ask, 200)
+		if !s.NeedsInfo {
+			reason += " (the drafter asked; the classifier did not flag needs_info)"
+		}
+		return dispositionAutoAsk, reason
 	}
 	if s.ShouldClose {
 		return dispositionAutoClose, "the user confirmed the issue is resolved"

--- a/api/internal/support/disposition_test.go
+++ b/api/internal/support/disposition_test.go
@@ -63,6 +63,14 @@ func TestDisposition_Table(t *testing.T) {
 	nothing := sendableSignals()
 	nothing.HasDraft = false
 
+	// The production case that made the rule server-side: ticket #517866,
+	// "It stopped working. Nothing shows up in the bar any more." The
+	// classifier returned needs_info=false; the drafter wrote a pure question
+	// and listed four things in ask_user_for, which were also its unknowns.
+	// What the reply does is the fact. What the classifier flagged is a hint.
+	classifierMissedIt := askable
+	classifierMissedIt.NeedsInfo = false
+
 	cases := []struct {
 		name string
 		in   dispositionSignals
@@ -70,6 +78,7 @@ func TestDisposition_Table(t *testing.T) {
 	}{
 		{"grounded and complete", sendableSignals(), dispositionAutoSend},
 		{"needs information", askable, dispositionAutoAsk},
+		{"classifier missed needs_info", classifierMissedIt, dispositionAutoAsk},
 		{"user says it is fixed", closable, dispositionAutoClose},
 		{"triage produced nothing", nothing, dispositionEscalate},
 	}


### PR DESCRIPTION
Follow-up to #351, found by the production verification REL-249 asks for.

Ticket #517866, filed as a deliberately vague bug report ("It stopped working. Nothing shows up in the bar any more."), produced exactly the draft `auto_ask` exists for: four things in `ask_user_for`, no claims, a pure question. It escalated instead.

The classifier had returned `needs_info=false`. The literal rule from the issue — `needs_info` **and** `ask_user_for` — therefore did not match, and the draft fell through to the grounding checks, where the non-empty `unknowns` escalated it. The unknowns *were* the four questions.

So the headline win of the ticket ("asking a user which OS they are on carries almost no risk, and the waiting is the thing that has been costing us") was gated on a model flag that under-reports, which is also the thing the issue says not to do: the model reports, the server decides. `ask_user_for` is the stronger signal because the drafter is the one that actually wrote the question.

`auto_ask` now fires on a non-empty `ask_user_for`. Every consequence trigger — money, account access, a request for a human, anger, emergency, classifier/drafter disagreement, the reply cap, a demoted category, a promise in the draft, prompt injection — is checked before this line and still escalates. What is given up is the grounding gate on the answered half of a mixed answer-plus-question reply; what is bought is that nobody waits an hour to be asked which operating system they are on. The reason string records when the classifier disagreed, so the disagreement stays visible in the thread and the row.

Test: the production case is now a row in the disposition table (`classifier missed needs_info`). `go test ./internal/support/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)