### PR TITLE
feat(support): /regen re-triages a case against today's knowledge base [REL-246]

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,6 +19,8 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 # Support case backfill (REL-243) — run in-cluster via k8s/jobs/support-backfill.yaml
 RUN CGO_ENABLED=0 GOOS=linux go build -o support-backfill ./cmd/support-backfill
+# Support re-triage (REL-246) — run in-cluster via k8s/jobs/support-regen.yaml
+RUN CGO_ENABLED=0 GOOS=linux go build -o support-regen ./cmd/support-regen
 # ── Dev stage: hot reload (NOT the default build target) ─────────────
 # Deliberately placed BEFORE the runtime stage: deploy.yml runs
 # `docker build` with no --target, which builds the LAST stage. Keeping the
@@ -59,6 +61,7 @@ RUN apk --no-cache add curl
 # Copy the Pre-built binary from the previous stage
 COPY --from=builder /app/main .
 COPY --from=builder /app/support-backfill .
+COPY --from=builder /app/support-regen .
 COPY --from=builder /app/migrations ./migrations
 
 # Expose port 8080 to the outside world

--- a/api/cmd/support-regen/main.go
+++ b/api/cmd/support-regen/main.go
@@ -1,0 +1,64 @@
+// Command support-regen re-runs triage on tickets the support bot has
+// already seen (REL-246). Same work as the /regen slash command — a slash
+// command can only be run by a person typing it, and the backlog this exists
+// to clear had been waiting four months.
+//
+// Must run in-cluster: the reply goes out through the osTicket plugin, whose
+// API key is bound to the cluster's egress IP, and the drafts land in the
+// Discord queue with the bot's token. See k8s/jobs/support-regen.yaml.
+//
+// Usage:
+//
+//	./support-regen pending          # every draft sitting in 'pending'
+//	./support-regen 486932 269765    # these tickets, drafted or not
+//
+// Every regenerated draft is an ordinary draft: it reaches its Discord thread
+// with its disposition and its hold, and it sends itself when nobody
+// intervenes. Read them before the hold expires.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/support"
+)
+
+func main() {
+	flag.Parse()
+	tickets := flag.Args()
+	if len(tickets) == 0 {
+		log.Fatal("usage: support-regen <ticket>... | pending")
+	}
+	_ = godotenv.Load()
+
+	platform.ConnectDB()
+	defer platform.DBPool.Close()
+
+	// Two model calls per ticket, plus a Discord post and a disposition.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	outcomes := support.RegenTickets(ctx, tickets)
+	out, _ := json.Marshal(outcomes)
+	fmt.Println(string(out))
+
+	failed := 0
+	for _, o := range outcomes {
+		if !o.OK {
+			failed++
+		}
+	}
+	log.Printf("regenerated %d/%d", len(outcomes)-failed, len(outcomes))
+	if failed == len(outcomes) {
+		os.Exit(2)
+	}
+}

--- a/api/internal/support/discord.go
+++ b/api/internal/support/discord.go
@@ -687,6 +687,19 @@ func registerDiscordSlashCommands(ctx context.Context) error {
 			},
 		},
 		{
+			Name:        "regen",
+			Description: "Re-run triage on a ticket and replace its pending draft",
+			Type:        1,
+			Options: []discordSlashCommandOption{
+				{
+					Name:        "ticket",
+					Description: "Ticket number (e.g. 239171), or \"pending\" for every pending draft",
+					Type:        3,
+					Required:    true,
+				},
+			},
+		},
+		{
 			Name:        "pause",
 			Description: "Stop every unattended send immediately. Holds keep their clocks.",
 			Type:        1,
@@ -749,7 +762,7 @@ func RegisterDiscordSlashCommandsAtBoot(ctx context.Context) {
 		log.Printf("[Discord] register slash commands: %v", err)
 		// Continue to tag bootstrap even if commands failed.
 	} else {
-		log.Println("[Discord] slash commands registered (/inbox, /case, /search, /ticket, /stats, /pause, /resume)")
+		log.Println("[Discord] slash commands registered (/inbox, /case, /search, /ticket, /regen, /stats, /pause, /resume)")
 	}
 
 	if err := ensureSupportForumTags(ctx, cfg.SupportChannelID); err != nil {

--- a/api/internal/support/handlers_discord_interactions.go
+++ b/api/internal/support/handlers_discord_interactions.go
@@ -1058,6 +1058,8 @@ func handleDiscordSlashCommand(c *fiber.Ctx, ix *discordInteraction) error {
 		return handleDiscordSearchCommand(c, ix)
 	case "ticket":
 		return handleDiscordTicketCommand(c, ix)
+	case "regen":
+		return handleDiscordRegenCommand(c, ix)
 	case "stats":
 		return handleDiscordStatsCommand(c, ix)
 	case "pause":
@@ -1428,7 +1430,7 @@ func handleDiscordCaseCommand(c *fiber.Ctx, ix *discordInteraction) error {
 	}
 
 	const msgQ = `
-		SELECT kind, body_text, created_at FROM support_messages
+		SELECT kind, body_text, created_at, superseded FROM support_messages
 		WHERE ticket_number = $1 ORDER BY created_at DESC, id DESC LIMIT 20
 	`
 	rows, err := platform.DBPool.Query(ctx, msgQ, ticketNumber)
@@ -1443,12 +1445,18 @@ func handleDiscordCaseCommand(c *fiber.Ctx, ix *discordInteraction) error {
 	for rows.Next() {
 		var kind, body string
 		var created time.Time
-		if err := rows.Scan(&kind, &body, &created); err != nil {
+		var superseded bool
+		if err := rows.Scan(&kind, &body, &created, &superseded); err != nil {
 			continue
 		}
 		icon := kindIcon[kind]
 		if icon == "" {
 			icon = "•"
+		}
+		// A draft that was re-triaged away is still on the timeline, but it
+		// is not what this ticket is currently being answered with.
+		if superseded {
+			icon, kind = "🗑️", kind+" (superseded)"
 		}
 		snippet := truncateRunes(strings.Join(strings.Fields(body), " "), 140)
 		events = append(events, fmt.Sprintf("%s `%s` %s — %s",

--- a/api/internal/support/regen.go
+++ b/api/internal/support/regen.go
@@ -1,0 +1,425 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// =============================================================================
+// /regen — re-triage a case the pipeline has already seen (REL-246)
+// =============================================================================
+//
+// Everything the support bot knows has moved since the backlog was drafted:
+// the knowledge base is generated from the repo instead of remembered from
+// April, the drafter is Sonnet with the user's own context in front of it, and
+// the server decides what happens to a draft instead of waiting for a click.
+// None of that reaches a ticket that was already triaged. /regen is the thing
+// that reaches them.
+//
+// A regenerated draft is an ordinary draft. It goes into the same thread with
+// the same buttons and the same disposition, and — since REL-249 — it sends
+// itself when nobody intervenes. That is deliberate: a backlog that needed a
+// person to press Send is exactly how thirteen tickets sat unanswered since
+// May, and re-drafting them into the same queue would only produce a
+// better-written silence.
+//
+// The draft being replaced is not deleted. It stays on the case as an
+// `ai_draft` message flagged `superseded`, because the interesting question
+// six months from now is not what we said but what we nearly said.
+
+// regenLimit caps one `/regen pending` run. The pending queue is single
+// digits; a run that suddenly wants fifty triage calls is a query bug, and a
+// cap makes it a small bill instead of a large one.
+const regenLimit = 25
+
+// regenOutcome is one ticket's result, for the summary the operator reads.
+type regenOutcome struct {
+	Ticket      string
+	Disposition string // the new draft's disposition, or "" when nothing was drafted
+	Note        string // why it was skipped, when it was
+	OK          bool
+}
+
+// regenerateDraft re-runs triage on one case and replaces its pending draft.
+//
+// Fails closed in both directions that matter: a case we have never seen is
+// left alone, and a triage call that produces no reply leaves the existing
+// draft exactly where it was. The only way to lose a pending draft here is to
+// have a new one to put in its place.
+func regenerateDraft(ctx context.Context, ticketNumber string) regenOutcome {
+	out := regenOutcome{Ticket: ticketNumber}
+	if platform.DBPool == nil {
+		out.Note = "no database"
+		return out
+	}
+
+	src, err := loadRegenSource(ctx, ticketNumber)
+	if err != nil {
+		out.Note = err.Error()
+		return out
+	}
+
+	// The backfill read subjects and bodies out of osTicket but never looked
+	// inside them, so most of the backlog reads as "app version: unknown" —
+	// the one fact that decides whether the answer is "update" or "let's
+	// troubleshoot". Parse it back out of the user's own message first.
+	backfillCaseDiagnostics(ctx, ticketNumber, src.UserMessageHTML)
+
+	triage := triageTicket(ctx, TriageInput{
+		UserEmail:         src.UserEmail,
+		UserName:          src.UserName,
+		Subject:           src.Subject,
+		Body:              src.UserMessageHTML,
+		RecentSummaries:   FetchRecentTicketSummaries(ctx),
+		IsReply:           src.IsReply,
+		ReplyTicketNumber: ticketNumber,
+		Thread:            FetchCaseThread(ctx, ticketNumber),
+		Context:           ticketContextFromCase(ctx, ticketNumber),
+	})
+	if triage == nil || strings.TrimSpace(triage.DraftReplyHTML) == "" {
+		out.Note = "triage produced no reply; the existing draft is untouched"
+		return out
+	}
+
+	note, ask, grounded, unknowns := triage.groundingFields()
+	draft, err := createSupportDraft(ctx, &SupportDraft{
+		TicketNumber:          ticketNumber,
+		UserEmail:             src.UserEmail,
+		UserName:              src.UserName,
+		OriginalSubject:       src.Subject,
+		UserMessageHTML:       src.UserMessageHTML,
+		DraftBodyHTML:         triage.DraftReplyHTML,
+		AISummary:             triage.Summary,
+		AICategory:            triage.Category,
+		AIPriority:            triage.Priority,
+		AIWidget:              triage.Widget,
+		AIDuplicateOf:         triage.DuplicateOf,
+		AIConfidence:          triage.Confidence,
+		OSTicketThreadEntryID: src.ThreadEntryID,
+		ShouldClose:           triage.ShouldClose,
+		NeedsInfo:             triage.NeedsInfo,
+		Sentiment:             triage.Sentiment,
+		DrafterCategory:       triage.DrafterCategory,
+		InternalNote:          note,
+		AskUserFor:            ask,
+		GroundedIn:            grounded,
+		Unknowns:              unknowns,
+	})
+	if err != nil {
+		out.Note = "could not save the new draft: " + err.Error()
+		return out
+	}
+
+	// New draft first, then retire the old one: the reverse order loses a
+	// pending draft whenever the insert fails.
+	if src.DraftID > 0 {
+		supersedeDraft(ctx, ticketNumber, src.DraftID)
+		postToTicketThread(ctx, ticketNumber, fmt.Sprintf(
+			"♻️ **Re-triaged.** Draft %d is superseded by %d — re-read against today's knowledge base, not the one this ticket first met.",
+			src.DraftID, draft.ID))
+	} else {
+		postToTicketThread(ctx, ticketNumber, fmt.Sprintf(
+			"♻️ **Triaged for the first time.** Open since %s with no reply.",
+			src.OpenedAt.UTC().Format("2 Jan 2006")))
+	}
+
+	// The ordinary path: thread post with buttons, then the disposition and
+	// its countdown. Nothing about a regenerated draft is special from here.
+	notifyPartnerAfterDraft(ctx, draft)
+
+	out.OK = true
+	out.Disposition = draft.Disposition
+	if out.Disposition == "" {
+		out.Disposition = "pending"
+	}
+	log.Printf("[Regen] ticket %s: draft %d -> %d (%s)",
+		ticketNumber, src.DraftID, draft.ID, out.Disposition)
+	return out
+}
+
+// regenSource is what a re-triage needs about a case: who wrote, what they
+// said, and which draft (if any) is currently standing.
+type regenSource struct {
+	Subject         string
+	UserEmail       string
+	UserName        string
+	UserMessageHTML string
+	OpenedAt        time.Time
+	DraftID         int64 // 0 = this case has never been drafted
+	ThreadEntryID   int64
+	IsReply         bool
+}
+
+// loadRegenSource prefers the pending draft's own copy of the ticket, and
+// falls back to the case DB for the backlog that was imported from osTicket
+// and never drafted at all. Those are the tickets with the longest wait, so
+// "no draft to regenerate" is the wrong answer for them.
+func loadRegenSource(ctx context.Context, ticketNumber string) (*regenSource, error) {
+	var s regenSource
+	var status string
+	err := platform.DBPool.QueryRow(ctx, `
+		SELECT COALESCE(subject,''), COALESCE(user_email,''), opened_at, status
+		FROM support_cases WHERE ticket_number = $1`, ticketNumber).
+		Scan(&s.Subject, &s.UserEmail, &s.OpenedAt, &status)
+	if err != nil {
+		return nil, fmt.Errorf("no case for #%s", ticketNumber)
+	}
+	if status == "closed" {
+		return nil, fmt.Errorf("#%s is closed — reopen it in osTicket first if it still needs an answer", ticketNumber)
+	}
+
+	// The newest pending draft, when there is one. A decided draft is never
+	// replaced: somebody already answered with it, or deliberately did not.
+	var draftSubject, draftEmail, draftName, draftBody string
+	err = platform.DBPool.QueryRow(ctx, `
+		SELECT id, original_subject, user_email, COALESCE(user_name,''),
+		       COALESCE(user_message_html,''), COALESCE(osticket_thread_entry_id,0)
+		FROM support_drafts
+		WHERE ticket_number = $1 AND status = 'pending'
+		ORDER BY id DESC LIMIT 1`, ticketNumber).
+		Scan(&s.DraftID, &draftSubject, &draftEmail, &draftName, &draftBody, &s.ThreadEntryID)
+	if err == nil {
+		if draftSubject != "" {
+			s.Subject = draftSubject
+		}
+		if draftEmail != "" {
+			s.UserEmail = draftEmail
+		}
+		s.UserName = draftName
+		if strings.TrimSpace(draftBody) != "" {
+			s.UserMessageHTML = draftBody
+		}
+		s.IsReply = s.ThreadEntryID > 0
+	}
+
+	// No draft, or a draft that never stored the user's message: the case DB
+	// has it. More than one inbound message means we are answering a
+	// follow-up, and the newest one is what we owe an answer to.
+	if strings.TrimSpace(s.UserMessageHTML) == "" {
+		var body string
+		var n int
+		if err := platform.DBPool.QueryRow(ctx, `
+			SELECT COALESCE((SELECT COALESCE(NULLIF(body_html,''), body_text) FROM support_messages
+			                 WHERE ticket_number = $1 AND kind = 'user'
+			                 ORDER BY created_at DESC, id DESC LIMIT 1), ''),
+			       (SELECT count(*) FROM support_messages
+			        WHERE ticket_number = $1 AND kind = 'user')`,
+			ticketNumber).Scan(&body, &n); err != nil {
+			return nil, fmt.Errorf("nothing to re-read on #%s", ticketNumber)
+		}
+		s.UserMessageHTML = body
+		if n > 1 {
+			s.IsReply = true
+		}
+	}
+	if strings.TrimSpace(s.UserMessageHTML) == "" {
+		return nil, fmt.Errorf("#%s has no user message stored", ticketNumber)
+	}
+	if s.UserName == "" {
+		s.UserName = fallbackName("", s.UserEmail)
+	}
+	return &s, nil
+}
+
+// supersedeDraft retires the draft a regeneration replaces: off 'pending' so
+// no sweeper can send it, and flagged on the case so the timeline says which
+// of the two was the live one.
+//
+// The status is 'skipped' because that is the only decided value meaning "this
+// never went out", but the note beside it says what actually happened — the
+// reply was rewritten, not withdrawn. It deliberately does not call
+// markIntervened: nobody stepped in on this draft, so it is not evidence
+// against its category.
+func supersedeDraft(ctx context.Context, ticketNumber string, draftID int64) {
+	if _, err := platform.DBPool.Exec(ctx,
+		`UPDATE support_drafts SET status = 'skipped', hold_until = NULL, decided_at = NOW()
+		 WHERE id = $1 AND status = 'pending'`, draftID); err != nil {
+		log.Printf("[Regen] retire draft %d: %v", draftID, err)
+		return
+	}
+	if _, err := platform.DBPool.Exec(ctx,
+		`UPDATE support_messages SET superseded = true WHERE ai_draft_id = $1 AND kind = 'ai_draft'`,
+		draftID); err != nil {
+		log.Printf("[Regen] flag draft %d superseded: %v", draftID, err)
+	}
+	// No AIDraftID on the note: (ai_draft_id, kind) is unique, so hanging it
+	// off the draft would be silently dropped on any draft that already
+	// carries a note — the "filed as REL-nnn" one, most of the time.
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: ticketNumber, Kind: "note",
+		BodyText: fmt.Sprintf("AI draft %d superseded by a re-triage", draftID),
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
+}
+
+// diagnosticsBlockRe pulls the JSON out of the <pre> block the desktop's bug
+// form appends to every report. Non-greedy so a message with two blocks takes
+// the first, and tolerant of attributes because osTicket rewrites the markup.
+var diagnosticsBlockRe = regexp.MustCompile(`(?is)<pre[^>]*>\s*(\{.*?\})\s*</pre>`)
+
+// backfillCaseDiagnostics fills in app_version / os on a case that does not
+// have them, reading the diagnostics the user's own message carries.
+//
+// upsertSupportCase is first-writer-wins on these two columns, so this can
+// never overwrite what the desktop told us at open time — it only fills the
+// gap left by tickets that reached the case DB through the osTicket backfill,
+// which kept the message but never looked inside it.
+func backfillCaseDiagnostics(ctx context.Context, ticketNumber, userMessageHTML string) {
+	var version, osName string
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT COALESCE(app_version,''), COALESCE(os,'') FROM support_cases WHERE ticket_number = $1`,
+		ticketNumber).Scan(&version, &osName); err != nil {
+		return
+	}
+	if version != "" && osName != "" {
+		return
+	}
+	v, o := diagnosticsFields(userMessageHTML)
+	if v == "" && o == "" {
+		return
+	}
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: ticketNumber, AppVersion: v, OS: o,
+	}); err != nil {
+		log.Printf("[Regen] backfill diagnostics for %s: %v", ticketNumber, err)
+		return
+	}
+	log.Printf("[Regen] ticket %s: recovered app_version=%q os=%q from the message body",
+		ticketNumber, v, o)
+}
+
+// diagnosticsFields parses the desktop diagnostics blob out of a message body.
+// Pure, so the parsing is testable without a database.
+func diagnosticsFields(userMessageHTML string) (appVersion, osName string) {
+	m := diagnosticsBlockRe.FindStringSubmatch(userMessageHTML)
+	if len(m) < 2 {
+		return "", ""
+	}
+	var diag map[string]interface{}
+	if err := json.Unmarshal([]byte(html.UnescapeString(m[1])), &diag); err != nil {
+		return "", ""
+	}
+	return caseFieldsFromDiagnostics(diag)
+}
+
+// pendingRegenTickets lists the tickets `/regen pending` acts on: every draft
+// sitting in `pending`, oldest first.
+//
+// Deliberately the drafts, not "every case we never answered". A pending draft
+// is proof that triage has already read this ticket and written something for
+// a user; the rest of the backlog includes mail that reached the support
+// mailbox by accident, and picking one of those up is a decision for whoever
+// types the ticket number, not for a batch.
+func pendingRegenTickets(ctx context.Context) ([]string, error) {
+	// Oldest draft first, so the longest wait is answered first.
+	rows, err := platform.DBPool.Query(ctx, `
+		SELECT ticket_number FROM (
+			SELECT DISTINCT ON (ticket_number) ticket_number, id
+			FROM support_drafts WHERE status = 'pending'
+			ORDER BY ticket_number, id DESC
+		) p ORDER BY id LIMIT $1`, regenLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// =============================================================================
+// The Discord command
+// =============================================================================
+
+// handleDiscordRegenCommand runs `/regen ticket:<number>` or
+// `/regen ticket:pending`. Deferred in both cases: one re-triage is two model
+// calls, which is not a three-second answer.
+func handleDiscordRegenCommand(c *fiber.Ctx, ix *discordInteraction) error {
+	arg := strings.TrimSpace(commandOption(ix, "ticket"))
+	if arg == "" {
+		return discordEphemeralResponse(c, "Missing `ticket` option — a ticket number, or `pending`.")
+	}
+	appID, token := ix.ApplicationID, ix.Token
+	go func() {
+		// Generous: the cap is 25 tickets at two model calls each, and the
+		// interaction token outlives the request either way.
+		ctx, cancel := context.WithTimeout(context.Background(), 14*time.Minute)
+		defer cancel()
+		if err := discordCompleteDeferred(ctx, appID, token, runRegen(ctx, appID, token, arg)); err != nil {
+			log.Printf("[Regen] follow-up for %q: %v", arg, err)
+		}
+	}()
+	return c.JSON(fiber.Map{"type": discordResponseDeferredChannelMessage})
+}
+
+// runRegen does the work and returns what the operator should read. Never an
+// error: whatever happened, it has to be legible in Discord.
+func runRegen(ctx context.Context, appID, token, arg string) string {
+	if platform.DBPool == nil {
+		return "No database."
+	}
+	if !strings.EqualFold(arg, "pending") {
+		return renderRegenOutcome(regenerateDraft(ctx, strings.TrimPrefix(arg, "#")))
+	}
+
+	tickets, err := pendingRegenTickets(ctx)
+	if err != nil {
+		log.Printf("[Regen] pending list: %v", err)
+		return "Could not list pending drafts."
+	}
+	if len(tickets) == 0 {
+		return "Nothing pending — no draft to regenerate."
+	}
+	// Say what is about to happen before it takes several minutes, then
+	// overwrite the same message with the result.
+	if err := discordCompleteDeferred(ctx, appID, token, fmt.Sprintf(
+		"♻️ Re-triaging %d pending draft(s): #%s.\nEach lands in its own thread with its disposition; the summary replaces this message.",
+		len(tickets), strings.Join(tickets, ", #"))); err != nil {
+		log.Printf("[Regen] progress message: %v", err)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "♻️ **Re-triaged %d pending draft(s).**\n", len(tickets))
+	counts := map[string]int{}
+	for _, t := range tickets {
+		o := regenerateDraft(ctx, t)
+		if o.OK {
+			counts[o.Disposition]++
+		} else {
+			counts["skipped"]++
+		}
+		b.WriteString(renderRegenOutcome(o))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	for _, k := range []string{"auto_send", "auto_ask", "escalate", "auto_close", "pending", "skipped"} {
+		if counts[k] > 0 {
+			fmt.Fprintf(&b, "`%s` %d  ", k, counts[k])
+		}
+	}
+	return truncateRunes(strings.TrimSpace(b.String()), 1990)
+}
+
+func renderRegenOutcome(o regenOutcome) string {
+	if !o.OK {
+		return fmt.Sprintf("⏭️ **#%s** — %s", o.Ticket, o.Note)
+	}
+	return fmt.Sprintf("✅ **#%s** — `%s`", o.Ticket, o.Disposition)
+}

--- a/api/internal/support/regen.go
+++ b/api/internal/support/regen.go
@@ -42,12 +42,34 @@ import (
 // cap makes it a small bill instead of a large one.
 const regenLimit = 25
 
-// regenOutcome is one ticket's result, for the summary the operator reads.
-type regenOutcome struct {
-	Ticket      string
-	Disposition string // the new draft's disposition, or "" when nothing was drafted
-	Note        string // why it was skipped, when it was
-	OK          bool
+// RegenOutcome is one ticket's result, for the summary the operator reads.
+type RegenOutcome struct {
+	Ticket      string `json:"ticket"`
+	Disposition string `json:"disposition,omitempty"` // the new draft's, or "" when nothing was drafted
+	Note        string `json:"note,omitempty"`        // why it was skipped, when it was
+	OK          bool   `json:"ok"`
+}
+
+// RegenTickets is the one-off entry point behind cmd/support-regen: the same
+// work `/regen` does, for the tickets named on a command line. A slash command
+// can only be run by a person typing it, and clearing a backlog of tickets
+// that have been waiting four months is a Job, not an afternoon of typing.
+//
+// A single element "pending" means the pending queue, exactly as the slash
+// command's argument does.
+func RegenTickets(ctx context.Context, tickets []string) []RegenOutcome {
+	if len(tickets) == 1 && strings.EqualFold(tickets[0], "pending") {
+		pending, err := pendingRegenTickets(ctx)
+		if err != nil {
+			return []RegenOutcome{{Ticket: "pending", Note: err.Error()}}
+		}
+		tickets = pending
+	}
+	out := make([]RegenOutcome, 0, len(tickets))
+	for _, t := range tickets {
+		out = append(out, regenerateDraft(ctx, strings.TrimPrefix(strings.TrimSpace(t), "#")))
+	}
+	return out
 }
 
 // regenerateDraft re-runs triage on one case and replaces its pending draft.
@@ -56,8 +78,8 @@ type regenOutcome struct {
 // left alone, and a triage call that produces no reply leaves the existing
 // draft exactly where it was. The only way to lose a pending draft here is to
 // have a new one to put in its place.
-func regenerateDraft(ctx context.Context, ticketNumber string) regenOutcome {
-	out := regenOutcome{Ticket: ticketNumber}
+func regenerateDraft(ctx context.Context, ticketNumber string) RegenOutcome {
+	out := RegenOutcome{Ticket: ticketNumber}
 	if platform.DBPool == nil {
 		out.Note = "no database"
 		return out
@@ -417,7 +439,7 @@ func runRegen(ctx context.Context, appID, token, arg string) string {
 	return truncateRunes(strings.TrimSpace(b.String()), 1990)
 }
 
-func renderRegenOutcome(o regenOutcome) string {
+func renderRegenOutcome(o RegenOutcome) string {
 	if !o.OK {
 		return fmt.Sprintf("⏭️ **#%s** — %s", o.Ticket, o.Note)
 	}

--- a/api/internal/support/regen_test.go
+++ b/api/internal/support/regen_test.go
@@ -1,0 +1,214 @@
+package support
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// TestDiagnosticsFields pins the parser that recovers a reporter's app
+// version out of their own message. The backlog reaches the case DB through
+// the osTicket backfill, which kept the body and never read it, so this is
+// the only thing standing between a four-month-old ticket and a draft that
+// opens with "app version: unknown".
+func TestDiagnosticsFields(t *testing.T) {
+	const realBody = `<h3>What went wrong?</h3><p>Sports are not showing up</p>` +
+		`<details><summary><strong>System Diagnostics</strong></summary><pre>{
+  "app": {
+    "arch": "aarch64",
+    "platform": "macos",
+    "version": "1.0.20"
+  },
+  "environment": { "sessionType": "macOS" }
+}</pre></details>`
+
+	for _, tc := range []struct {
+		name, body, wantVersion, wantOS string
+	}{
+		{"desktop bug form", realBody, "1.0.20", "macos"},
+		{"osName wins over platform",
+			`<pre>{"app":{"version":"1.6.2","platform":"windows"},"system":{"osName":"Windows 11"}}</pre>`,
+			"1.6.2", "Windows 11"},
+		{"attributes on the tag",
+			`<pre class="diag" style="x">{"app":{"version":"1.5.0","platform":"linux"}}</pre>`,
+			"1.5.0", "linux"},
+		{"no diagnostics at all", `<p>Feature Request: Pinterest stock please</p>`, "", ""},
+		{"a pre block that is not JSON", `<pre>2026-05-01 ERROR {something}</pre>`, "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotVersion, gotOS := diagnosticsFields(tc.body)
+			if gotVersion != tc.wantVersion || gotOS != tc.wantOS {
+				t.Fatalf("got (%q, %q), want (%q, %q)", gotVersion, gotOS, tc.wantVersion, tc.wantOS)
+			}
+		})
+	}
+}
+
+// TestRegenSupersede covers the replacement contract end to end without the
+// two model calls in the middle: which ticket the batch picks up, what a
+// re-triage reads a ticket from, and what happens to the draft it replaces.
+func TestRegenSupersede(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	ctx := context.Background()
+	resetCases(t)
+
+	const diag = `<p>Ticker froze</p><pre>{"app":{"version":"1.0.13","platform":"windows"}}</pre>`
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: "700", UserEmail: "u@example.com", Subject: "Ticker froze", Status: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	old, err := createSupportDraft(ctx, &SupportDraft{
+		TicketNumber: "700", UserEmail: "u@example.com", UserName: "Sam",
+		OriginalSubject: "Ticker froze", UserMessageHTML: diag,
+		DraftBodyHTML: "<p>the old answer</p>", AICategory: "bug",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A decided draft on another ticket must not be picked up by the batch.
+	decided, err := createSupportDraft(ctx, &SupportDraft{
+		TicketNumber: "701", UserEmail: "v@example.com", OriginalSubject: "Already answered",
+		DraftBodyHTML: "<p>sent already</p>",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markDraftDecided(ctx, decided.ID, "skipped", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	tickets, err := pendingRegenTickets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tickets) != 1 || tickets[0] != "700" {
+		t.Fatalf("pending list = %v, want [700]", tickets)
+	}
+
+	// The source of a re-triage is the pending draft's own copy of the ticket.
+	src, err := loadRegenSource(ctx, "700")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.DraftID != old.ID || src.UserMessageHTML != diag || src.UserName != "Sam" {
+		t.Fatalf("source wrong: %+v", src)
+	}
+
+	// And the version buried in that message reaches the case row, which is
+	// what puts "you are on 1.0.13, we are on <current>" in front of the model.
+	backfillCaseDiagnostics(ctx, "700", src.UserMessageHTML)
+	if v := caseAppVersion(ctx, "700"); v != "1.0.13" {
+		t.Fatalf("app_version = %q, want 1.0.13", v)
+	}
+
+	replacement, err := createSupportDraft(ctx, &SupportDraft{
+		TicketNumber: "700", UserEmail: "u@example.com", OriginalSubject: "Ticker froze",
+		UserMessageHTML: diag, DraftBodyHTML: "<p>the new answer</p>", AICategory: "bug",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	supersedeDraft(ctx, "700", old.ID)
+
+	var status string
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT status FROM support_drafts WHERE id = $1`, old.ID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "skipped" {
+		t.Fatalf("superseded draft status = %q, want skipped", status)
+	}
+	// Its body is still on the case — flagged, not deleted.
+	var superseded bool
+	var body string
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT superseded, body_text FROM support_messages WHERE ai_draft_id = $1 AND kind = 'ai_draft'`,
+		old.ID).Scan(&superseded, &body); err != nil {
+		t.Fatal(err)
+	}
+	if !superseded || body == "" {
+		t.Fatalf("old draft message: superseded=%t body=%q", superseded, body)
+	}
+	var newSuperseded bool
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT superseded FROM support_messages WHERE ai_draft_id = $1 AND kind = 'ai_draft'`,
+		replacement.ID).Scan(&newSuperseded); err != nil {
+		t.Fatal(err)
+	}
+	if newSuperseded {
+		t.Fatal("the replacement draft was flagged superseded")
+	}
+	if n := countMessages(t, "700", "note"); n != 1 {
+		t.Fatalf("supersede notes = %d, want 1", n)
+	}
+
+	// The batch now sees only the replacement, once.
+	tickets, err = pendingRegenTickets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tickets) != 1 || tickets[0] != "700" {
+		t.Fatalf("pending list after supersede = %v, want [700]", tickets)
+	}
+	if src, err = loadRegenSource(ctx, "700"); err != nil || src.DraftID != replacement.ID {
+		t.Fatalf("source after supersede = %+v (err %v), want draft %d", src, err, replacement.ID)
+	}
+}
+
+// TestRegenSourceFallbacks covers the two cases the batch never reaches and
+// `/regen <ticket>` exists for: a ticket that was imported from osTicket and
+// never drafted at all, and one that is already closed.
+func TestRegenSourceFallbacks(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	ctx := context.Background()
+	resetCases(t)
+
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: "800", UserEmail: "old@example.com", Subject: "Sports missing", Status: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: "800", Kind: "user", BodyHTML: "<p>no sports on the ticker</p>",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	src, err := loadRegenSource(ctx, "800")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.DraftID != 0 || src.UserMessageHTML != "<p>no sports on the ticker</p>" || src.IsReply {
+		t.Fatalf("never-drafted source wrong: %+v", src)
+	}
+	if src.UserName != "old" {
+		t.Fatalf("user name = %q, want the local part of the address", src.UserName)
+	}
+	// A never-drafted ticket is not in the batch — only `/regen <ticket>`
+	// reaches it, because the rest of that backlog is mail that arrived by
+	// accident.
+	tickets, err := pendingRegenTickets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tickets) != 0 {
+		t.Fatalf("pending list = %v, want empty", tickets)
+	}
+
+	if err := upsertSupportCase(ctx, SupportCase{TicketNumber: "800", Status: "closed"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadRegenSource(ctx, "800"); err == nil {
+		t.Fatal("a closed ticket must not be re-triaged into a reply")
+	}
+	if _, err := loadRegenSource(ctx, "does-not-exist"); err == nil {
+		t.Fatal("an unknown ticket must not be re-triaged")
+	}
+}

--- a/api/migrations/000014_support_message_superseded.down.sql
+++ b/api/migrations/000014_support_message_superseded.down.sql
@@ -1,0 +1,2 @@
+-- allow-destructive: reverting exactly what this migration added
+ALTER TABLE support_messages DROP COLUMN IF EXISTS superseded;

--- a/api/migrations/000014_support_message_superseded.up.sql
+++ b/api/migrations/000014_support_message_superseded.up.sql
@@ -1,0 +1,13 @@
+-- A regenerated draft supersedes the one it replaces (REL-246).
+--
+-- /regen re-runs triage on a case and writes a NEW support_drafts row. The
+-- draft it replaces stays exactly where it is — an `ai_draft` message on the
+-- case, carrying the body a user was nearly sent — because the whole point of
+-- the case DB is that nothing we wrote disappears. What it lacked was a way to
+-- say "this was never the live answer", so a reader of the timeline can tell a
+-- draft that was replaced from the one that stands.
+--
+-- A boolean rather than a superseded_by pointer: the replacement is the next
+-- ai_draft on the same ticket, and no reader needs a join to find it.
+
+ALTER TABLE support_messages ADD COLUMN IF NOT EXISTS superseded boolean NOT NULL DEFAULT false;

--- a/k8s/jobs/support-regen.yaml
+++ b/k8s/jobs/support-regen.yaml
@@ -1,0 +1,52 @@
+# One-off: re-run triage on tickets the support bot has already seen (REL-246).
+#
+# NOT applied by deploy.yml (it lists manifests explicitly). Run by hand,
+# editing `args` to the tickets you mean:
+#
+#   IMG=$(kubectl -n scrollr get deploy core-api -o jsonpath='{.spec.template.spec.containers[0].image}')
+#   sed "s|IMAGE_PLACEHOLDER|$IMG|" k8s/jobs/support-regen.yaml | kubectl apply -f -
+#   kubectl -n scrollr logs -f job/support-regen
+#   kubectl -n scrollr delete job support-regen
+#
+# `args: ["pending"]` takes every draft sitting in 'pending'; a list of ticket
+# numbers takes those, drafted or not. Same work as the /regen slash command,
+# which is the everyday path — this exists because a slash command can only be
+# run by a person typing it, and a backlog is not typing work.
+#
+# ⚠️ Every draft this writes is an ordinary draft: it reaches its Discord
+# thread with a disposition and a hold, and it SENDS ITSELF when nobody
+# intervenes. Read the drafts before the hold expires; `/pause` stops the lot.
+#
+# Must run in-cluster: the reply goes out through the osTicket plugin, whose
+# API key is bound to the cluster's egress IP.
+#
+# Not idempotent in the way the backfill is — a second run supersedes the
+# draft the first one wrote and spends another two model calls per ticket.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: support-regen
+  namespace: scrollr
+spec:
+  backoffLimit: 0 # a retry would re-draft everything the first attempt already did
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: support-regen
+          image: IMAGE_PLACEHOLDER
+          command: ["./support-regen"]
+          args: ["pending"]
+          envFrom:
+            - configMapRef:
+                name: core-config
+            - secretRef:
+                name: scrollr-secrets
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi


### PR DESCRIPTION
Last link of the support-bot chain (REL-242 → REL-249). Adds `/regen <ticket>` and `/regen pending`, so a ticket that was triaged by the old bot can be read again by the current one.

## Why

The bot that drafted the backlog is gone. The knowledge base is generated from the repo now instead of remembered from April, the drafter is Sonnet with the reporter's own version and widgets in front of it, and since REL-249 the server decides what happens to a draft rather than waiting for a click. None of that reaches a ticket that was already triaged — and thirteen have been open since May.

## What it does

- **`/regen <ticket>`** — re-runs triage on one case and replaces its pending draft. Works on a case that was never drafted at all (the osTicket backfill imported a lot of those), and refuses a closed one.
- **`/regen pending`** — the same for every draft in the queue, oldest first, capped at 25.
- The new draft is an **ordinary draft**: same thread, same buttons, same disposition, same hold countdown. It sends itself when nobody intervenes. Re-drafting the backlog into a queue that needs a person to press Send would only produce a better-written silence.

## Three decisions worth reading

**The replaced draft is not deleted.** It moves off `pending` so no sweeper can send it, and its body stays on the case as an `ai_draft` message flagged `superseded` (migration `000014`, additive). `/case` renders it as such. What we nearly said is the interesting half of the audit.

**The batch takes pending drafts, not "every case we never answered".** A pending draft is proof triage has already read the ticket and written something for a user. The unanswered pile also contains mail that reached the support mailbox by accident — Google Workspace notices, upgrade reminders — and auto-replying to those is exactly the kind of unrecoverable mistake `auto_ask` (which has no hold) would make. Picking one of those up is a decision for whoever types the ticket number.

**The version comes back out of the message body.** The osTicket backfill kept the body and never looked inside it, so most of the backlog reads as "app version: unknown" — the one fact that decides whether the answer is "update" or "let's troubleshoot". `/regen` parses the diagnostics block the desktop's bug form appends and writes it onto the case before triage runs. `upsertSupportCase` is first-writer-wins on those columns, so it can only fill a gap, never overwrite what the desktop reported at open time.

## Tests

`TestDiagnosticsFields` pins the parser (including the two ways it must return nothing). `TestRegenSupersede` and `TestRegenSourceFallbacks` cover the replacement contract against a real database without the two model calls in the middle: what the batch picks up, what a re-triage reads the ticket from, what happens to the draft it replaces, and that a closed or unknown ticket is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
