### PR TITLE
fix(support): a re-triage must not reuse the osTicket entry id [REL-246]

### DIFF
--- a/api/internal/support/discord.go
+++ b/api/internal/support/discord.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -44,10 +45,11 @@ import (
 // Failure mode is fail-open: if Discord calls fail, we log and continue.
 // The email notification path stays active as a backup.
 
-const (
-	discordAPIBase     = "https://discord.com/api/v10"
-	discordHTTPTimeout = 10 * time.Second
-)
+const discordHTTPTimeout = 10 * time.Second
+
+// discordAPIBase is a var only so the rate-limit test can point the client at
+// a stub, the same seam anthropicEndpoint uses for the triage calls.
+var discordAPIBase = "https://discord.com/api/v10"
 
 // DiscordConfig groups the env-driven config in one struct so callers
 // can quick-check whether Discord integration is enabled (any missing
@@ -145,12 +147,16 @@ func discordRequest(ctx context.Context, method, path string, body interface{}) 
 		return nil, 0, errors.New("discord not configured")
 	}
 
+	// rawBody is kept so a retried request can re-read it — a consumed
+	// io.Reader would otherwise send an empty body the second time round.
+	var rawBody []byte
 	var bodyReader io.Reader
 	if body != nil {
 		buf, err := json.Marshal(body)
 		if err != nil {
 			return nil, 0, fmt.Errorf("marshal body: %w", err)
 		}
+		rawBody = buf
 		bodyReader = bytes.NewReader(buf)
 	}
 
@@ -165,17 +171,59 @@ func discordRequest(ctx context.Context, method, path string, body interface{}) 
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := discordHTTPClient.Do(req)
-	if err != nil {
-		return nil, 0, fmt.Errorf("discord request: %w", err)
+	for attempt := 0; ; attempt++ {
+		if bodyReader != nil && attempt > 0 {
+			bodyReader = bytes.NewReader(rawBody)
+			req.Body = io.NopCloser(bodyReader)
+		}
+		resp, err := discordHTTPClient.Do(req)
+		if err != nil {
+			return nil, 0, fmt.Errorf("discord request: %w", err)
+		}
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, resp.StatusCode, fmt.Errorf("read response: %w", err)
+		}
+		if resp.StatusCode != http.StatusTooManyRequests || attempt >= discordRateLimitRetries {
+			return respBody, resp.StatusCode, nil
+		}
+		wait := discordRetryAfter(resp, respBody)
+		log.Printf("[Discord] rate limited on %s %s; retrying in %s", method, path, wait)
+		select {
+		case <-ctx.Done():
+			return respBody, resp.StatusCode, ctx.Err()
+		case <-time.After(wait):
+		}
 	}
-	defer resp.Body.Close()
+}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, resp.StatusCode, fmt.Errorf("read response: %w", err)
+// discordRateLimitRetries is how many times a 429 is waited out before the
+// caller sees it. A long draft is split into as many as twenty messages, and
+// Discord rate-limits per channel, so the bucket runs dry mid-thread — which
+// used to drop the tail of a reply on the floor with nothing but a log line.
+const discordRateLimitRetries = 3
+
+// discordRetryAfter reads how long Discord wants us to wait. The header is
+// authoritative; the body carries the same number as a float and is the
+// fallback. Clamped at both ends: never a busy loop, never a stalled request.
+func discordRetryAfter(resp *http.Response, body []byte) time.Duration {
+	secs, _ := strconv.ParseFloat(resp.Header.Get("Retry-After"), 64)
+	if secs <= 0 {
+		var payload struct {
+			RetryAfter float64 `json:"retry_after"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		secs = payload.RetryAfter
 	}
-	return respBody, resp.StatusCode, nil
+	d := time.Duration(secs * float64(time.Second))
+	if d < 250*time.Millisecond {
+		d = 250 * time.Millisecond
+	}
+	if d > 10*time.Second {
+		d = 10 * time.Second
+	}
+	return d
 }
 
 // =============================================================================

--- a/api/internal/support/discord_ratelimit_test.go
+++ b/api/internal/support/discord_ratelimit_test.go
@@ -1,0 +1,115 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubDiscord points discordRequest at a local server with the five env vars
+// loadDiscordConfig insists on.
+func stubDiscord(t *testing.T, h http.Handler) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	old := discordAPIBase
+	discordAPIBase = srv.URL
+	t.Cleanup(func() { discordAPIBase = old })
+	for k, v := range map[string]string{
+		"DISCORD_BOT_TOKEN": "t", "DISCORD_PUBLIC_KEY": "p",
+		"DISCORD_APPLICATION_ID": "a", "DISCORD_GUILD_ID": "g",
+		"DISCORD_SUPPORT_CHANNEL_ID": "c",
+	} {
+		t.Setenv(k, v)
+	}
+}
+
+// TestDiscordRequestWaitsOutRateLimit — a long reply is split into as many as
+// twenty messages and Discord rate-limits per channel, so the bucket runs dry
+// mid-thread. That used to drop the tail of a draft with nothing but a log
+// line, which is how a user could be shown two thirds of an answer.
+func TestDiscordRequestWaitsOutRateLimit(t *testing.T) {
+	var calls int32
+	var bodies []string
+	stubDiscord(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(b))
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"message": "You are being rate limited.", "retry_after": 0.01, "global": false,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "42"})
+	}))
+
+	body, status, err := discordRequest(context.Background(), http.MethodPost, "/channels/c/messages",
+		map[string]string{"content": "the tail of a long reply"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 200 || !strings.Contains(string(body), `"42"`) {
+		t.Fatalf("status=%d body=%s, want the retried 200", status, body)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2 (one 429, one retry)", calls)
+	}
+	// The retry must carry the same payload — a consumed reader would send
+	// an empty body the second time and Discord would reject it.
+	if len(bodies) != 2 || bodies[0] != bodies[1] || !strings.Contains(bodies[1], "the tail of a long reply") {
+		t.Fatalf("retried body = %q, want the original %q", bodies[len(bodies)-1], bodies[0])
+	}
+}
+
+// TestDiscordRequestGivesUp stops the retry loop turning a persistent 429 into
+// an unbounded wait: the caller still gets the status and logs it, as before.
+func TestDiscordRequestGivesUp(t *testing.T) {
+	var calls int32
+	stubDiscord(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"retry_after":0.01}`))
+	}))
+
+	_, status, err := discordRequest(context.Background(), http.MethodGet, "/channels/c", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 handed back", status)
+	}
+	if want := int32(discordRateLimitRetries + 1); calls != want {
+		t.Fatalf("calls = %d, want %d", calls, want)
+	}
+}
+
+func TestDiscordRetryAfter(t *testing.T) {
+	for _, tc := range []struct {
+		name, header, body string
+		want               time.Duration
+	}{
+		{"header wins", "2", `{"retry_after":9}`, 2 * time.Second},
+		{"body is the fallback", "", `{"retry_after":0.705}`, 705 * time.Millisecond},
+		{"floor, never a busy loop", "", `{"retry_after":0}`, 250 * time.Millisecond},
+		{"nothing parseable", "", `not json`, 250 * time.Millisecond},
+		{"ceiling, never a stalled request", "600", ``, 10 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{}}
+			if tc.header != "" {
+				resp.Header.Set("Retry-After", tc.header)
+			}
+			if got := discordRetryAfter(resp, []byte(tc.body)); got != tc.want {
+				t.Fatalf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/api/internal/support/regen.go
+++ b/api/internal/support/regen.go
@@ -115,27 +115,32 @@ func regenerateDraft(ctx context.Context, ticketNumber string) RegenOutcome {
 
 	note, ask, grounded, unknowns := triage.groundingFields()
 	draft, err := createSupportDraft(ctx, &SupportDraft{
-		TicketNumber:          ticketNumber,
-		UserEmail:             src.UserEmail,
-		UserName:              src.UserName,
-		OriginalSubject:       src.Subject,
-		UserMessageHTML:       src.UserMessageHTML,
-		DraftBodyHTML:         triage.DraftReplyHTML,
-		AISummary:             triage.Summary,
-		AICategory:            triage.Category,
-		AIPriority:            triage.Priority,
-		AIWidget:              triage.Widget,
-		AIDuplicateOf:         triage.DuplicateOf,
-		AIConfidence:          triage.Confidence,
-		OSTicketThreadEntryID: src.ThreadEntryID,
-		ShouldClose:           triage.ShouldClose,
-		NeedsInfo:             triage.NeedsInfo,
-		Sentiment:             triage.Sentiment,
-		DrafterCategory:       triage.DrafterCategory,
-		InternalNote:          note,
-		AskUserFor:            ask,
-		GroundedIn:            grounded,
-		Unknowns:              unknowns,
+		TicketNumber:    ticketNumber,
+		UserEmail:       src.UserEmail,
+		UserName:        src.UserName,
+		OriginalSubject: src.Subject,
+		UserMessageHTML: src.UserMessageHTML,
+		DraftBodyHTML:   triage.DraftReplyHTML,
+		AISummary:       triage.Summary,
+		AICategory:      triage.Category,
+		AIPriority:      triage.Priority,
+		AIWidget:        triage.Widget,
+		AIDuplicateOf:   triage.DuplicateOf,
+		AIConfidence:    triage.Confidence,
+		// Deliberately NOT src.ThreadEntryID. osticket_thread_entry_id is
+		// uniquely indexed — it is how the follow-up webhook stays idempotent,
+		// "this entry has already produced a draft" — and the draft being
+		// replaced still holds it, so that guarantee is untouched. Copying it
+		// onto the replacement just makes every re-triage of a follow-up fail
+		// on the index, which is exactly what the first backlog run did.
+		ShouldClose:     triage.ShouldClose,
+		NeedsInfo:       triage.NeedsInfo,
+		Sentiment:       triage.Sentiment,
+		DrafterCategory: triage.DrafterCategory,
+		InternalNote:    note,
+		AskUserFor:      ask,
+		GroundedIn:      grounded,
+		Unknowns:        unknowns,
 	})
 	if err != nil {
 		out.Note = "could not save the new draft: " + err.Error()


### PR DESCRIPTION
Two bugs the first real `/regen pending` run found, one of them fatal to the feature.

## The unique index (3 of 5 tickets → 2 failures)

`osticket_thread_entry_id` carries a partial unique index. It is how the follow-up webhook stays idempotent — *this osTicket entry has already produced a draft* — and copying it onto the replacement draft meant every re-triage of a follow-up died on `23505`:

```
could not save the new draft: createSupportDraft: ERROR: duplicate key value
violates unique constraint "support_drafts_thread_entry_uniq" (SQLSTATE 23505)
```

That took out both reply-loop tickets in the run (#862586, #873863). The replacement no longer carries the entry id. The draft being superseded still holds it, so the webhook's guarantee is exactly as strong as before; the new draft is simply free to exist. Side effect, and a good one: `notifyDiscordForDraft` keys the "re-quote the user's message" decision off that field, so a re-triage now shows the message it is answering rather than assuming you scrolled up four months.

## The rate limit (1 truncated reply)

A long draft splits into as many as twenty Discord messages and Discord rate-limits per channel, so the bucket runs dry mid-thread. On #589914 part 5 of 19 came back 429 and the remaining fourteen were dropped with nothing but a log line — a reviewer would have been shown two thirds of a reply with no sign the rest existed.

`discordRequest` now waits out a 429 and retries, up to three times, with the delay taken from the `Retry-After` header (body `retry_after` as fallback) and clamped between 250 ms and 10 s. It is fixed in the one function every Discord call already routes through, not at the twenty call sites.

The part worth a test is that a retried request keeps its body — a consumed `io.Reader` would send an empty one the second time and Discord would reject it. `TestDiscordRequestWaitsOutRateLimit` asserts the two bodies are identical; `TestDiscordRequestGivesUp` pins the bound so a persistent 429 cannot become an unbounded wait.

`discordAPIBase` becomes a var to give the test a seam, the same one `anthropicEndpoint` already provides for the triage calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
