### PR TITLE
fix(support): load forum tag ids on first use, not only at boot [REL-246]

### DIFF
--- a/api/internal/support/discord.go
+++ b/api/internal/support/discord.go
@@ -271,16 +271,59 @@ var supportForumTagSpecs = []supportForumTagSpec{
 // missing tags.
 var tagIDByName sync.Map // map[name string] -> tagID string
 
+// tagLoad guards the one-time fill of tagIDByName for a process that never
+// ran the boot hook. `loaded` is set only on success, so a Discord outage at
+// first use costs one retry rather than the tags for the life of the process.
+var tagLoad struct {
+	sync.Mutex
+	loaded bool
+}
+
 // supportForumTagID returns the cached tag ID for a name, or "" when
-// not present (Text channel parent, ensure call hasn't run, or unknown
+// not present (Text channel parent, Discord not configured, or unknown
 // tag name).
+//
+// The cache is filled by RegisterDiscordSlashCommandsAtBoot in the API, and
+// on first miss here for everything else. cmd/support-regen is a Job: it
+// writes threads and transitions their status without ever running the API's
+// boot hook, so every thread it touched came out with no category tag and a
+// stale `pending` — a queue that lies about its own state. Filling on demand
+// fixes it for any entry point, present or future, rather than asking each
+// one to remember to bootstrap.
 func supportForumTagID(name string) string {
+	if id := cachedForumTagID(name); id != "" {
+		return id
+	}
+	loadForumTagsOnce()
+	return cachedForumTagID(name)
+}
+
+func cachedForumTagID(name string) string {
 	if v, ok := tagIDByName.Load(name); ok {
 		if s, ok := v.(string); ok {
 			return s
 		}
 	}
 	return ""
+}
+
+func loadForumTagsOnce() {
+	tagLoad.Lock()
+	defer tagLoad.Unlock()
+	if tagLoad.loaded {
+		return
+	}
+	cfg, ok := loadDiscordConfig()
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := ensureSupportForumTags(ctx, cfg.SupportChannelID); err != nil {
+		log.Printf("[Discord] forum tag lazy-load: %v", err)
+		return
+	}
+	tagLoad.loaded = true
 }
 
 // statusTagNames returns the set of status-tag names so callers can

--- a/api/internal/support/discord_ratelimit_test.go
+++ b/api/internal/support/discord_ratelimit_test.go
@@ -113,3 +113,45 @@ func TestDiscordRetryAfter(t *testing.T) {
 		})
 	}
 }
+
+// TestForumTagsLoadOnFirstUse — cmd/support-regen is a Job. It creates threads
+// and transitions their status without ever running the API's boot hook, so
+// with a boot-only tag cache every thread it touched came out with no category
+// tag and a `pending` that never moved: a queue lying about its own state.
+func TestForumTagsLoadOnFirstUse(t *testing.T) {
+	tagIDByName.Range(func(k, _ any) bool { tagIDByName.Delete(k); return true })
+	tagLoad.Lock()
+	tagLoad.loaded = false
+	tagLoad.Unlock()
+
+	var gets int32
+	stubDiscord(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&gets, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": "c", "type": 15, // 15 = forum
+			"available_tags": func() []map[string]string {
+				var out []map[string]string
+				for _, spec := range supportForumTagSpecs {
+					out = append(out, map[string]string{"id": "tag-" + spec.name, "name": spec.name})
+				}
+				return out
+			}(),
+		})
+	}))
+
+	if got := supportForumTagID("pending"); got != "tag-pending" {
+		t.Fatalf("first lookup = %q, want the lazily-loaded id", got)
+	}
+	if got := supportForumTagID("bug"); got != "tag-bug" {
+		t.Fatalf("second lookup = %q, want the cached id", got)
+	}
+	if got := supportForumTagID("not-a-tag"); got != "" {
+		t.Fatalf("unknown tag = %q, want empty", got)
+	}
+	// Once loaded, no lookup goes back to Discord — including the miss.
+	// (Two calls: discordGetChannelType, then the tag read.)
+	if gets > 2 {
+		t.Fatalf("channel fetched %d times, want the load to happen once", gets)
+	}
+}


### PR DESCRIPTION
Third and last thing the backlog run found.

`tagIDByName` was filled by `RegisterDiscordSlashCommandsAtBoot` and nowhere else, so any process that writes to the support queue without being the API has no tag ids at all. `cmd/support-regen` is exactly that process.

What that looked like in the real forum after the run:

- Nine newly-created threads with a correct name and **no category tag**.
- **#560485 still tagged `pending`** while its own thread title read `[ASKED]` and the reply had already gone out — 734 hours old and, to anyone reading the tags, still waiting.

The second one matters more than it looks: "no `pending` thread older than 48 h" is the check an operator runs off those tags, and this made the queue lie about its own state in the direction that hides work.

`supportForumTagID` now fills the cache on a miss. It is the single function every tag lookup already routes through — `getOrCreateThreadForTicket`'s initial tags and `transitionThreadStatus` both — so no entry point has to remember to bootstrap, including whatever the next one turns out to be. `loaded` is set only on success, so a Discord outage at first use costs one retry rather than the tags for the life of the process.

`TestForumTagsLoadOnFirstUse` starts from an empty cache, asserts the first lookup resolves, and asserts a second lookup (and an unknown-tag miss) do not go back to Discord.

Threads already mistagged by the run are repaired separately — this only stops it happening again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
