### PR TITLE
fix(ticker): the sports floor admits the next matchday, not one fixture [REL-251]

### DIFF
--- a/desktop/src/datawidgets/sports/view.test.ts
+++ b/desktop/src/datawidgets/sports/view.test.ts
@@ -45,6 +45,18 @@ function preGame(id: number, startInMs: number): Game {
   });
 }
 
+/**
+ * A `pre` fixture at a given hour on a given LOCAL calendar day, so the
+ * matchday floor can be exercised without the assertions depending on the
+ * runner's timezone.
+ */
+function preOnDay(id: number, dayOffset: number, hour: number): Game {
+  const d = new Date(NOW);
+  d.setDate(d.getDate() + dayOffset);
+  d.setHours(hour, 0, 0, 0);
+  return mk({ id, state: "pre", start_time: d.toISOString() });
+}
+
 function liveGame(id: number, closeScoreDiff = 10): Game {
   return mk({
     id,
@@ -358,6 +370,43 @@ describe("selectSportsForTicker", () => {
     expect(result.map((g) => g.id)).toEqual([1]); // the soonest, and only it
   });
 
+  it("admits the whole matchday, not one game out of fourteen", () => {
+    // Measured 2026-09-08: MLS had fourteen fixtures, every one 40-43h
+    // out, so none cleared the 24h horizon. The old floor put ONE of the
+    // fourteen on the bar and the ticker read as broken.
+    const saturday = [1, 2, 3, 4, 5].map((id) => preOnDay(id, 2, 12 + id));
+    const ids = selectSportsForTicker(saturday, { daysBack: 7, daysAhead: 365 })
+      .map((g) => g.id);
+    expect(ids).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("stops at the first matchday when the fixtures span two days", () => {
+    // NFL, same measurement: one Thursday game and one Sunday game. They
+    // are different days, so the floor is the Thursday alone -- widening
+    // it to "the next 48h" would have dragged Sunday onto the bar.
+    const games = [preOnDay(1, 2, 20), preOnDay(2, 3, 13), preOnDay(3, 3, 16)];
+    expect(
+      selectSportsForTicker(games, { daysBack: 7, daysAhead: 365 }).map((g) => g.id),
+    ).toEqual([1]);
+  });
+
+  it("never reaches the floor while anything is inside the horizon", () => {
+    // A game tonight is the league's news. A big slate two days out is
+    // not, and must not join it just because the same day is crowded.
+    const games = [
+      preGame(1, 3 * 3_600_000),
+      ...[2, 3, 4, 5].map((id) => preOnDay(id, 2, 10 + id)),
+    ];
+    expect(
+      selectSportsForTicker(games, { daysBack: 7, daysAhead: 365 }).map((g) => g.id),
+    ).toEqual([1]);
+  });
+
+  it("does not admit a matchday that starts on day eight", () => {
+    const games = [preOnDay(1, 8, 12), preOnDay(2, 8, 15)];
+    expect(selectSportsForTicker(games, { daysBack: 7, daysAhead: 365 })).toEqual([]);
+  });
+
   it("does not reach past a week for that one fixture", () => {
     // Uncapped, the floor surfaced fixtures a month out, which sat beside
     // a 19h chip reading as an arbitrary date rather than as "this is all
@@ -379,6 +428,14 @@ describe("selectSportsForTicker", () => {
     const wide = { daysBack: 7, daysAhead: 365 };
     expect(selectSportsForTicker(games, wide)).toHaveLength(1);
     expect(selectSportsForFeed(games, wide, new Set())).toHaveLength(2);
+  });
+
+  it("leaves the widget page showing every day, not just the matchday", () => {
+    // The floor is a rail rule too. The page keeps its full 7-day window.
+    const games = [preOnDay(1, 2, 14), preOnDay(2, 3, 14), preOnDay(3, 6, 14)];
+    const wide = { daysBack: 7, daysAhead: 365 };
+    expect(selectSportsForTicker(games, wide).map((g) => g.id)).toEqual([1]);
+    expect(selectSportsForFeed(games, wide, new Set())).toHaveLength(3);
   });
 });
 

--- a/desktop/src/datawidgets/sports/view.ts
+++ b/desktop/src/datawidgets/sports/view.ts
@@ -73,6 +73,20 @@ export const SPORTS_WINDOW_MAX_DAYS_AHEAD = 365;
 const DAY_MS = 86_400_000;
 
 /**
+ * Local midnight opening the calendar day that contains `t`.
+ *
+ * The one place `setHours(0, 0, 0, 0)` lives. Two rules are anchored to
+ * local calendar days rather than rolling 24h periods -- the widget's day
+ * window (`inDayWindow`) and the ticker's floor (`onTicker`) -- and both
+ * mean the same thing by "day": the one on the user's wall calendar.
+ */
+function startOfLocalDay(t: number): number {
+  const d = new Date(t);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/**
  * Window predicate shared by the ticker + feed selectors.
  *
  * Bounds are anchored to LOCAL CALENDAR DAYS, not rolling 24h periods:
@@ -92,10 +106,9 @@ function inDayWindow(
   // Defensive: an unparseable start_time stays visible rather than
   // silently vanishing from every surface.
   if (!Number.isFinite(t)) return true;
-  const dayStart = new Date(now);
-  dayStart.setHours(0, 0, 0, 0);
-  const lower = dayStart.getTime() - daysBack * DAY_MS;
-  const upper = dayStart.getTime() + (daysAhead + 1) * DAY_MS;
+  const dayStart = startOfLocalDay(now);
+  const lower = dayStart - daysBack * DAY_MS;
+  const upper = dayStart + (daysAhead + 1) * DAY_MS;
   return t >= lower && t < upper;
 }
 
@@ -188,7 +201,7 @@ export const TICKER_UPCOMING_HOURS = 24;
 export const TICKER_FINAL_HOURS = 18;
 
 /**
- * How far ahead the floor below will reach for a league's next fixture.
+ * How far ahead the floor below will reach for a league's next MATCHDAY.
  *
  * The floor exists so a league you follow is never absent from the bar.
  * Left unbounded it also surfaced fixtures a month out, which sat beside
@@ -197,6 +210,11 @@ export const TICKER_FINAL_HOURS = 18;
  * appear in the run-up to a fixture, and a league between seasons stays
  * off the bar entirely rather than advertising a date nobody is thinking
  * about yet.
+ *
+ * The cap picks the DAY, and the day picks the fixtures (see `onTicker`).
+ * A later kick-off on that same matchday is on the bar even if it lands
+ * a few hours past the seven days, because splitting a matchday down the
+ * middle is the thing this rule exists to stop.
  */
 export const TICKER_FLOOR_DAYS = 7;
 
@@ -207,12 +225,25 @@ export const TICKER_FLOOR_DAYS = 7;
  * be worth a slot on a bar you glance at.
  *
  * The floor matters as much as the horizon: if a league contributes
- * NOTHING, its single soonest fixture is admitted anyway, provided it is
- * within TICKER_FLOOR_DAYS. Without the floor, following Formula 1 --
- * races one to three weeks apart -- would mean an empty bar 13 days in
- * 14, and a widget you deliberately added would silently show nothing at
- * all. Without the cap, it reached a month out and the chip read as an
+ * NOTHING, its next MATCHDAY is admitted anyway -- every `pre` fixture on
+ * the local calendar day of its soonest one, provided that day is within
+ * TICKER_FLOOR_DAYS. Without the floor, following Formula 1 -- races one
+ * to three weeks apart -- would mean an empty bar 13 days in 14, and a
+ * widget you deliberately added would silently show nothing at all.
+ * Without the cap, it reached a month out and the chip read as an
  * arbitrary date rather than as the league's only news.
+ *
+ * A DAY rather than a single fixture because a single fixture is what a
+ * league's only news looks like for F1, and a lie for everyone else: with
+ * MLS's fourteen Saturday matches all 40-43h out (measured 2026-09-08),
+ * the one-fixture floor put one of fourteen on the bar and the ticker
+ * read as broken. The day is the unit a slate actually comes in, so a
+ * quiet league still shows one chip, a matchday shows the matchday, and
+ * neither needs a number that has to be tuned per sport. Slots and
+ * rotation (CHIP_SPEC §8.1/§8.2) absorb the volume from there.
+ *
+ * The floor never admits a final or a live game: a live game already
+ * passed the horizon above, and a final is not upcoming news.
  */
 function onTicker(games: Game[], now: number): Game[] {
   const kept = games.filter((g) => {
@@ -226,15 +257,17 @@ function onTicker(games: Game[], now: number): Game[] {
   });
   if (kept.length > 0) return kept;
 
-  const floorLimit = now + TICKER_FLOOR_DAYS * 86_400_000;
-  const soonest = games
-    .filter((g) => {
-      if (g.state !== "pre") return false;
-      const t = new Date(g.start_time).getTime();
-      return t > now && t <= floorLimit;
-    })
-    .sort((a, b) => +new Date(a.start_time) - +new Date(b.start_time))[0];
-  return soonest ? [soonest] : [];
+  // NaN (unparseable start_time) fails `> now`, so it never reaches here;
+  // the horizon above already kept it on the same defensive grounds.
+  const at = (g: Game) => new Date(g.start_time).getTime();
+  const upcoming = games.filter((g) => g.state === "pre" && at(g) > now);
+  const floorLimit = now + TICKER_FLOOR_DAYS * DAY_MS;
+  const soonest = upcoming
+    .filter((g) => at(g) <= floorLimit)
+    .sort((a, b) => at(a) - at(b))[0];
+  if (!soonest) return [];
+  const matchday = startOfLocalDay(at(soonest));
+  return upcoming.filter((g) => startOfLocalDay(at(g)) === matchday);
 }
 
 /** The day-window filter, shared by the ticker and the feed. */

--- a/docs/CHIP_SPEC.md
+++ b/docs/CHIP_SPEC.md
@@ -28,7 +28,7 @@ checklist) literally.
 | **pool** | Everything eligible for the rail from one source, in display order. |
 | **lap / cycle** | One complete trip of a slot off the right edge, across, and off the left. A slot's content advances once per lap. |
 | **horizon** | The per-source time rule deciding what is eligible. |
-| **floor** | The one item a quiet source still shows when nothing is inside its horizon. |
+| **floor** | What a quiet source still shows when nothing is inside its horizon — one item for most sources, the whole next matchday for Sports (§8.1). |
 | **palette** | The `ChipColors` object for a chip's colour mode and widget. |
 | **source** | A `TickerSource` in `desktop/src/datawidgets/<source>/ticker.tsx`, registered in `tickerRegistry.ts`. |
 
@@ -481,7 +481,7 @@ since they are an input.
 
 | Source | Eligible (horizon) | Floor | Slots | Pool order | Reserve |
 |---|---|---|---|---|---|
-| Sports | live always; `pre` with `0 <= h <= 24`; `final` with `h >= -18` (from kickoff) | soonest `pre` within 7 days | `TICKER_SLOTS = 4` | `sortForDisplay`: live+close 100, live 80, pre 60 (soonest first), final 30 (newest first) | widest short names per class |
+| Sports | live always; `pre` with `0 <= h <= 24`; `final` with `h >= -18` (from kickoff) | the next matchday: every `pre` on the LOCAL calendar day of the soonest `pre` within 7 days. Never a `final` or a live game. The 7-day cap picks the day, the day picks the fixtures — a late kick-off on that day is in even if it lands hours past the cap | `TICKER_SLOTS = 4` | `sortForDisplay`: live+close 100, live 80, pre 60 (soonest first), final 30 (newest first) | widest short names per class |
 
 Every pool above is first stripped of the widget's pinned subjects (`dropPinned`, §8.5).
 | News | items within `TICKER_RSS_HOURS = 6` | newest per feed if within `TICKER_RSS_FLOOR_HOURS = 48`; undated counts as current | `TICKER_RSS_SLOTS = 3` | newest first, **interleaved by feed** (round-robin, feeds ordered by their newest item) | longest `plainText(title)` per class |


### PR DESCRIPTION
## The problem

Measured against the live payload at **07:00 UTC 2026-09-08**:

| League | Fixtures | Soonest | Furthest |
|---|---|---|---|
| MLS | 14 | 40.3h | 43.3h |
| NFL | 2 | 41.1h | 65.3h |

`onTicker` admits live games, finals within `TICKER_FINAL_HOURS` (18h), and `pre` within `TICKER_UPCOMING_HOURS` (24h). Everything above is beyond all three, so the floor fired — and the floor admitted the **single soonest** `pre` within `TICKER_FLOOR_DAYS`. One chip out of fourteen. A user with an MLS widget on the day before a full slate sees a ticker that reads as broken, not as a quiet league.

## The fix

The floor admits the soonest upcoming **local calendar day**, not the soonest game: find the soonest `pre` within `TICKER_FLOOR_DAYS`, take its local day, admit every `pre` on that same local day. `sortForDisplay` and `rotateSlots` do the rest, unchanged.

The day is the unit a slate actually comes in, so a quiet league still shows one chip and a matchday shows the matchday — without a number that has to be tuned per sport.

The 7-day cap picks the **day**; the day picks the **fixtures**. A late kick-off on that matchday is in even if it lands a few hours past the cap, because splitting a matchday down the middle is the thing this rule exists to stop.

The local-day boundary maths `inDayWindow` carried inline (`setHours(0,0,0,0)`) is now one `startOfLocalDay` helper, shared by the window and the floor.

## Before / after, against that payload

| League | Before | After |
|---|---|---|
| MLS | 1 chip | **14 eligible** — four on the bar, cycling |
| NFL | 1 chip | **1 chip** (its two fixtures are on different local days — Thursday only) |
| Formula 1 | 1 chip | **1 chip** — unchanged |

## Rotation cost (CHIP_SPEC §8.6)

- A big slate day now fills four slots and takes **`ceil(pool/4)` laps** for full coverage where it previously showed one static chip. For the measured MLS slate that is `ceil(14/4) = 4` laps.
- A short chip sharing a slot with a long one carries the long one's width (`widestShortName` per residue class), as with every other rotating source.
- Chip count on the bar is unchanged: `TICKER_SLOTS = 4` is untouched, so the rail neither grows nor jumps.

## Deliberately not done

- **`TICKER_UPCOMING_HOURS` is untouched.** Widening the 24h horizon is a separate, larger decision.
- **No setting.** CHIP_SPEC §8.0.1 — "the user does not control selection".
- `sortForDisplay`, `gameEngagement`, `TICKER_SLOTS`, the rotation memo (#339) and the pinning path (#343) are all untouched.
- The floor still never admits a `final` or a live game.

## Spec

`docs/CHIP_SPEC.md` §8.1's Sports floor cell and §0's `floor` definition now state the matchday rule; the `TICKER_FLOOR_DAYS` and `onTicker` doc comments carry the reasoning.

## Verification

`npm test` — 766 passed / 69 files. `npx tsc --noEmit` clean.

Five tests in the existing `view.test.ts` style, using a `preOnDay(id, dayOffset, hour)` helper so the assertions do not depend on the runner's timezone:

- a clustered slate all beyond 24h admits the whole day
- a two-day spread admits only the first day
- a lone fixture still admits one (existing F1 test, unchanged)
- a league with something inside the horizon never reaches the floor
- a matchday starting on day 8 stays out
- the feed page is unaffected — `selectSportsForFeed` goes through `withinDayWindow` directly and keeps its full 7-day window

The first of these was confirmed to fail against the pre-change floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
