### PR TITLE
feat(support): the bot may only claim a fix it can prove [REL-259]

### DIFF
--- a/api/internal/support/ai_context.go
+++ b/api/internal/support/ai_context.go
@@ -124,9 +124,10 @@ func monitorCountsFromDiagnostics(diag map[string]interface{}) (attached, chosen
 	return attached, chosen
 }
 
-// render writes the context block. Version handling is the point of it: an
-// out-of-date user is told to update, and what changed, before anyone starts
-// troubleshooting a bug that may already be fixed.
+// render writes the context block. Version handling is the point of it, but
+// only as a DIAGNOSTIC: knowing somebody is three releases behind narrows the
+// problem. It is not permission to tell them updating is the answer — that
+// claim needs the FIX ON RECORD block (REL-259).
 func (tc TicketContext) render() string {
 	var b strings.Builder
 	b.WriteString("WHO IS WRITING (server-side facts, not the user's claims)\n")
@@ -141,9 +142,9 @@ func (tc TicketContext) render() string {
 		fmt.Fprintf(&b, "App version: unknown. Current release is %s.\n", current)
 	case compareVersions(tc.AppVersion, current) < 0:
 		fmt.Fprintf(&b, "Current release is %s; this user is on %s. THEY ARE OUT OF DATE.\n", current, tc.AppVersion)
-		b.WriteString("Before any troubleshooting, tell them to update and say what changed between " +
-			tc.AppVersion + " and " + current + ", from the release notes in the knowledge base. " +
-			"If the notes say their problem was fixed in one of those versions, updating IS the answer.\n")
+		b.WriteString("That is a useful diagnostic and nothing more. Do NOT tell them updating will " +
+			"fix what they reported unless the FIX ON RECORD block below names a version; the release " +
+			"notes do not record which report a change closed.\n")
 	default:
 		fmt.Fprintf(&b, "Current release is %s; this user is on %s. They are up to date.\n", current, tc.AppVersion)
 	}
@@ -209,6 +210,45 @@ func versionPart(parts []string, i int) int {
 	}
 	n, _ := strconv.Atoi(digits)
 	return n
+}
+
+// renderFixRecord is the FIX ON RECORD block: the one place in the prompt
+// permitted to say a fix exists, and the one place the drafter may read that
+// from (REL-259). It is a server-computed fact, never something to infer.
+//
+// staleDays is how long ago the user last wrote. Past the threshold with no
+// proven fix the only honest reply is a question, and the block says so in the
+// same voice the needs_info branch uses.
+func renderFixRecord(pf *ProvenFix, staleDays int, userVersion string) string {
+	var b strings.Builder
+	b.WriteString("FIX ON RECORD (server-computed; the ONLY thing that permits a fix claim)\n")
+
+	if pf == nil {
+		b.WriteString("None. No shipped fix is on record for this report.\n" +
+			"You may NOT say this was fixed, name a version as the remedy, or tell them to update as " +
+			"the answer. Asking which version they are running to narrow the problem is a different " +
+			"thing and is fine. If you think it may be fixed, ASK whether it is still happening " +
+			"rather than asserting that it is not.\n")
+		if staleDays >= staleTicketDays() {
+			fmt.Fprintf(&b, "\nTHIS TICKET IS %d DAYS OLD and nothing is on record as fixing it. Do not\n"+
+				"troubleshoot and do not guess. The reply is ONE short paragraph, then the sign-off:\n"+
+				"apologise briefly for the wait, say that several updates have shipped since they wrote\n"+
+				"in, and ask whether it is still happening and which version of Scrollr they are on now.\n"+
+				"List both of those in ask_user_for.\n", staleDays)
+		}
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "This user's report is linked to %s, which shipped in Scrollr %s.\n",
+		pf.IssueKey, pf.Version)
+	fmt.Fprintf(&b, "You MAY say the fix for what they reported went out in %s and point them at the "+
+		"update. Never put the issue key in the reply.\n", pf.Version)
+	if userVersion != "" && compareVersions(userVersion, pf.Version) >= 0 {
+		fmt.Fprintf(&b, "They are already on %s, which carries that fix, so updating is NOT the answer "+
+			"for them. Say the fix shipped in %s and ask what they are still seeing.\n",
+			userVersion, pf.Version)
+	}
+	return b.String()
 }
 
 // renderSimilarCases writes the "what we sent last time" block. The body is

--- a/api/internal/support/ai_known_issues.go
+++ b/api/internal/support/ai_known_issues.go
@@ -29,15 +29,19 @@ import (
 // not a broken one.
 
 const (
-	knownIssuesReleasesURL = "https://api.github.com/repos/doughknee/myscrollr/releases?per_page=3"
-	knownIssuesCacheKey    = "support:known_issues:v1"
-	knownIssuesTTL         = 10 * time.Minute
-	knownIssuesTimeout     = 8 * time.Second
+	knownIssuesReleaseCount = 3
+	knownIssuesCacheKey     = "support:known_issues:v1"
+	knownIssuesTTL          = 10 * time.Minute
+	knownIssuesTimeout      = 8 * time.Second
 	// Linear descriptions are whole bug reports; the drafter only needs
 	// enough to recognise a match.
 	maxIssueDescChars   = 240
 	maxReleaseBodyChars = 1800
 )
+
+// knownIssuesReleasesURL is a var (and a format string, %d = per_page) so the
+// proven-fix tests can serve a release list from a stub.
+var knownIssuesReleasesURL = "https://api.github.com/repos/doughknee/myscrollr/releases?per_page=%d"
 
 // knownIssuesBlock returns the rendered block, cached in Redis. A cache miss
 // costs one Linear call and one GitHub call; a total failure costs nothing
@@ -48,7 +52,7 @@ func knownIssuesBlock(ctx context.Context) string {
 			return cached
 		}
 	}
-	block := buildKnownIssuesBlock(fetchOpenLinearIssues(ctx), fetchRecentReleases(ctx))
+	block := buildKnownIssuesBlock(fetchOpenLinearIssues(ctx), fetchRecentReleases(ctx, knownIssuesReleaseCount))
 	if platform.Rdb != nil {
 		if err := platform.Rdb.Set(ctx, knownIssuesCacheKey, block, knownIssuesTTL).Err(); err != nil {
 			log.Printf("[Triage] cache known issues: %v", err)
@@ -74,6 +78,12 @@ type shippedRelease struct {
 	Name string
 	Date string
 	Body string
+	// URL, PublishedAt and Prerelease are read only by the proven-fix lookup
+	// (REL-259): which release carried a merged fix, and whether it is a build
+	// a user can actually be on.
+	URL         string
+	PublishedAt time.Time
+	Prerelease  bool
 }
 
 // buildKnownIssuesBlock renders the block. Pure, so the golden tests can pin
@@ -101,8 +111,9 @@ func buildKnownIssuesBlock(issues []openIssue, releases []shippedRelease) string
 	b.WriteString("\nHow to use this list:\n" +
 		"- The user's problem matches an OPEN issue: say it is a known issue and that it is being fixed. " +
 		"Give no date and no estimate. Put the issue key in internal_note.\n" +
-		"- The user's problem matches something the release notes below say was FIXED: name the version " +
-		"that fixed it and tell them to update.\n" +
+		"- The release notes below are context for what has changed, NOT evidence that this user's " +
+		"report was fixed. They are written for everyone and do not record which report a change " +
+		"closed. Only the FIX ON RECORD block may be used to claim a fix.\n" +
 		"- No match: do not mention the issue tracker at all. Never invent an issue key.\n" +
 		"- Issue keys, titles and descriptions here are internal. Never put one in the reply to the user.\n")
 
@@ -194,8 +205,12 @@ func linearPriorityName(p int) string {
 // fetchRecentReleases reads the last three published releases. The knowledge
 // base carries release notes too, but it is generated at build time; this
 // covers the window between a release going out and the next image build.
-func fetchRecentReleases(ctx context.Context) []shippedRelease {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, knownIssuesReleasesURL, nil)
+func fetchRecentReleases(ctx context.Context, count int) []shippedRelease {
+	if count <= 0 {
+		count = knownIssuesReleaseCount
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf(knownIssuesReleasesURL, count), nil)
 	if err != nil {
 		return nil
 	}
@@ -216,6 +231,8 @@ func fetchRecentReleases(ctx context.Context) []shippedRelease {
 		Name        string `json:"name"`
 		Body        string `json:"body"`
 		Draft       bool   `json:"draft"`
+		Prerelease  bool   `json:"prerelease"`
+		HTMLURL     string `json:"html_url"`
 		PublishedAt string `json:"published_at"`
 	}
 	if err := json.Unmarshal(raw, &rels); err != nil {
@@ -231,7 +248,11 @@ func fetchRecentReleases(ctx context.Context) []shippedRelease {
 		if len(date) >= 10 {
 			date = date[:10]
 		}
-		out = append(out, shippedRelease{Tag: r.TagName, Name: r.Name, Date: date, Body: r.Body})
+		published, _ := time.Parse(time.RFC3339, r.PublishedAt)
+		out = append(out, shippedRelease{
+			Tag: r.TagName, Name: r.Name, Date: date, Body: r.Body,
+			URL: r.HTMLURL, PublishedAt: published, Prerelease: r.Prerelease,
+		})
 	}
 	return out
 }

--- a/api/internal/support/ai_triage.go
+++ b/api/internal/support/ai_triage.go
@@ -117,6 +117,13 @@ type TriageInput struct {
 	KnownIssues string
 	Similar     []SimilarCase
 
+	// ProvenFix and StaleDays are the REL-259 facts: whether a shipped fix
+	// for THIS report is on record, and how long the reporter has been
+	// waiting. Both are computed server-side by triageTicket; a nil
+	// ProvenFix is the ordinary case and forbids every fix claim.
+	ProvenFix *ProvenFix
+	StaleDays int
+
 	// Reply-loop fields. Populated when this triage is for a user's
 	// follow-up on an existing ticket (osTicket thread-message webhook).
 	IsReply           bool
@@ -157,6 +164,17 @@ func triageTicket(ctx context.Context, input TriageInput) *TriageResult {
 	if input.Similar == nil {
 		input.Similar = FetchSimilarCases(ctx,
 			input.Subject+" "+htmlToPlain(input.Body), input.ReplyTicketNumber, similarCaseCount)
+	}
+	// A brand-new ticket has no case yet, so no link and no waiting: the zero
+	// values are already the truth for it, and they forbid a fix claim, which
+	// is the right default for a report nobody has looked at.
+	if input.ReplyTicketNumber != "" {
+		if input.ProvenFix == nil {
+			input.ProvenFix = lookupProvenFix(ctx, input.ReplyTicketNumber)
+		}
+		if input.StaleDays == 0 {
+			input.StaleDays = caseStaleDays(ctx, input.ReplyTicketNumber)
+		}
 	}
 
 	cls, clsUsage, err := classifyTicket(ctx, input)
@@ -490,6 +508,11 @@ HARD RULES for anything the user will read:
 - Never mention the Super User program, by name or by description.
 - Never give a date, an estimate or a promise for anything that has not shipped.
 - Never quote a dollar amount. Link https://myscrollr.com/uplink instead.
+- Never say something was fixed, name a version as the remedy, or tell someone to update as the
+  answer, unless the FIX ON RECORD block in the ticket says a fix shipped. Release notes are
+  written for everyone and do not record which report a change closed, so they are never proof.
+  Without that block you may ask whether it is still happening; you may not assert that it is not.
+  Asking which version someone is running in order to diagnose is a different thing and is fine.
 - Never use an em dash or an en dash. Commas, periods, parentheses and hyphens only.
 - Sentence case. Warm, plain, short. Answer the question asked and do not tour features.
 - End every reply with exactly these two lines, and nothing after them:
@@ -560,6 +583,7 @@ func buildDraftPrompt(in TriageInput, cls *classification) string {
 
 	b.WriteString(in.Context.render())
 	b.WriteString("\n" + in.KnownIssues + "\n")
+	b.WriteString("\n" + renderFixRecord(in.ProvenFix, in.StaleDays, in.Context.AppVersion))
 
 	if s := renderSimilarCases(in.Similar); s != "" {
 		b.WriteString("\n" + s)

--- a/api/internal/support/ai_triage_test.go
+++ b/api/internal/support/ai_triage_test.go
@@ -120,6 +120,18 @@ func TestPromptGoldens(t *testing.T) {
 	// the reply rather than its content, so it gets its own golden.
 	in := goldenFixtures()["anonymous"]
 	checkGolden(t, "needs_info_draft.txt", buildDraftPrompt(in, needsInfoCls))
+
+	// The two REL-259 states. What the reply is ALLOWED to assert is decided
+	// entirely by these blocks, so both get pinned: a months-old report with
+	// nothing on record behind it, and one whose fix demonstrably shipped.
+	stale := goldenFixtures()["signed_in"]
+	stale.StaleDays = 120
+	checkGolden(t, "stale_no_fix_draft.txt", buildDraftPrompt(stale, cls))
+
+	proven := goldenFixtures()["signed_in"]
+	proven.StaleDays = 120
+	proven.ProvenFix = &ProvenFix{IssueKey: "REL-235", Version: "1.6.1"}
+	checkGolden(t, "proven_fix_draft.txt", buildDraftPrompt(proven, cls))
 }
 
 // checkGolden compares against testdata, with the current release number

--- a/api/internal/support/discord.go
+++ b/api/internal/support/discord.go
@@ -684,9 +684,21 @@ func discordPinForumThread(ctx context.Context, threadID string) error {
 // It PATCHes @original rather than POSTing a follow-up: a POST would add
 // a second message and leave "the bot is thinking…" sitting there forever.
 func discordCompleteDeferred(ctx context.Context, applicationID, interactionToken, content string) error {
+	return discordCompleteDeferredWith(ctx, applicationID, interactionToken, content, nil)
+}
+
+// discordCompleteDeferredWith is the same edit with components, for the
+// deferred commands whose answer is a set of buttons rather than a paragraph
+// (/link, REL-259).
+func discordCompleteDeferredWith(ctx context.Context, applicationID, interactionToken, content string,
+	components []DiscordActionRow) error {
+
 	body := map[string]interface{}{
 		"content":          content,
 		"allowed_mentions": map[string]interface{}{"parse": []string{}},
+	}
+	if len(components) > 0 {
+		body["components"] = components
 	}
 	path := fmt.Sprintf("/webhooks/%s/%s/messages/@original", applicationID, interactionToken)
 	respBody, status, err := discordRequest(ctx, http.MethodPatch, path, body)
@@ -789,6 +801,11 @@ func registerDiscordSlashCommands(ctx context.Context) error {
 					Required:    true,
 				},
 			},
+		},
+		{
+			Name:        "link",
+			Description: "Propose Linear issues for unlinked open cases; you confirm each one",
+			Type:        1,
 		},
 		{
 			Name:        "pause",
@@ -1551,6 +1568,7 @@ func buildDraftHeaderEmbed(ctx context.Context, draft *SupportDraft) *discordEmb
 			{Name: "Confidence", Value: codeOrDash(draft.AIConfidence), Inline: true},
 			{Name: "App version", Value: appVersionField(ctx, draft.TicketNumber), Inline: true},
 			{Name: "Mood", Value: codeOrDash(draft.Sentiment), Inline: true},
+			{Name: "Fix", Value: fixRecordField(ctx, draft.TicketNumber), Inline: true},
 		},
 		Footer: &discordEmbedFooter{Text: fmt.Sprintf("draft #%d", draft.ID)},
 	}
@@ -1614,6 +1632,21 @@ func appVersionField(ctx context.Context, ticketNumber string) string {
 	default:
 		return fmt.Sprintf("`%s` → current `%s`", reported, current)
 	}
+}
+
+// fixRecordField renders the proven-fix state in the header (REL-259), so the
+// reason a draft asks rather than tells is visible without reading it. A case
+// linked to an issue that has not shipped yet says so rather than reading as
+// "none": "linked but unreleased" and "nobody has linked this" are different
+// problems for whoever is looking.
+func fixRecordField(ctx context.Context, ticketNumber string) string {
+	if pf := lookupProvenFix(ctx, ticketNumber); pf != nil {
+		return fmt.Sprintf("`%s`, shipped %s", pf.IssueKey, pf.Version)
+	}
+	if key := caseLinearIssueKey(ctx, ticketNumber); key != "" {
+		return fmt.Sprintf("`%s`, not shipped", key)
+	}
+	return "none on record"
 }
 
 // currentDesktopVersionRe pulls the version line the knowledge base is

--- a/api/internal/support/disposition.go
+++ b/api/internal/support/disposition.go
@@ -57,6 +57,14 @@ type dispositionSignals struct {
 	OutboundLast24h int
 	MaxAutoReplies  int
 	CategoryDemoted bool
+
+	// REL-259. HasProvenFix is the server's answer to "did a shipped release
+	// close THIS report" — a linked Linear issue, done, with a merged PR that
+	// went out. StaleDays is how long the reporter has been waiting and
+	// StaleAfter is the threshold, passed in so the decision stays pure.
+	HasProvenFix bool
+	StaleDays    int
+	StaleAfter   int
 }
 
 // decideDisposition is the whole policy, in order. The escalation checks run
@@ -102,6 +110,28 @@ func decideDisposition(s dispositionSignals) (disposition, reason string) {
 	}
 	if hit := firstMatch(s.DraftBody, promisePatterns); hit != "" {
 		return dispositionEscalate, fmt.Sprintf("the draft would promise something (%q)", hit)
+	}
+
+	// REL-259: the bot may only claim a fix it can prove. The system prompt
+	// forbids the unprovable claim and the FIX ON RECORD block tells the
+	// drafter what is on record — but the prompt is guidance and this is the
+	// guarantee. A reply that says something was fixed, or offers a version as
+	// the remedy, with nothing on record behind it does not leave the building.
+	if !s.HasProvenFix {
+		if hit := firstMatch(s.DraftBody, unprovenFixPatterns); hit != "" {
+			return dispositionEscalate, fmt.Sprintf(
+				"the draft offers a fix or an update as the answer (%q) and no shipped fix is on record", hit)
+		}
+		// An old ticket asks rather than tells. Nothing here has closed this
+		// report, and several releases have gone out since it was written, so
+		// asserting anything about it is a guess. The drafter is told to ask
+		// (renderFixRecord), and a reply that does ask falls through to the
+		// auto_ask branch below; one that does not gets a human.
+		if s.StaleAfter > 0 && s.StaleDays >= s.StaleAfter && strings.TrimSpace(s.AskUserFor) == "" {
+			return dispositionEscalate, fmt.Sprintf(
+				"the ticket is %d days old with no fix on record and the draft tells rather than asks",
+				s.StaleDays)
+		}
 	}
 
 	// A reply that asks the user for something is not a final answer, so the
@@ -207,6 +237,28 @@ var promisePatterns = []string{
 	"we plan to", "we will refund", "we'll refund", "we will credit",
 	"make an exception", "as an exception", "by the end of",
 	"next week", "next month", "estimated time", "guarantee",
+}
+
+// unprovenFixPatterns are checked against OUR draft, and only when nothing is
+// on record as having fixed the report (REL-259). Two shapes, one list because
+// they are the same mistake: asserting a fix shipped, and handing somebody an
+// update as the remedy. Both are claims about a change closing THIS report,
+// and release notes cannot support either.
+//
+// Deliberately loose, like promisePatterns. Escalating a reply that only meant
+// to be helpful costs one click; telling a four-month-old reporter their bug is
+// gone when nobody knows that costs the trust the reply was for. Asking which
+// version somebody runs is diagnostic and appears nowhere in this list.
+var unprovenFixPatterns = []string{
+	"was fixed", "were fixed", "has been fixed", "have been fixed", "is now fixed",
+	"we fixed", "already fixed", "should be fixed", "fixed in ", "fixed this in",
+	"resolved in ", "was resolved", "has been resolved", "addressed in ",
+	"shipped a fix", "shipped the fix", "the fix for", "went out in ",
+	"no longer an issue", "no longer happens", "patched in ", "corrected in ",
+	"update to", "updating to", "upgrade to", "update your scrollr", "update your app",
+	"install the latest", "download the latest", "get the latest version",
+	"once you update", "after you update", "updating should", "update should",
+	"update and let", "update fixes",
 }
 
 // injectionPatterns treat the ticket body as what it is: text a stranger
@@ -487,5 +539,8 @@ func gatherDispositionSignals(ctx context.Context, draft *SupportDraft) disposit
 		OutboundLast24h: outboundRepliesLast24h(ctx, draft.TicketNumber),
 		MaxAutoReplies:  maxAutoReplies(),
 		CategoryDemoted: interventionRate(ctx, draft.AICategory).Demoted,
+		HasProvenFix:    lookupProvenFix(ctx, draft.TicketNumber) != nil,
+		StaleDays:       caseStaleDays(ctx, draft.TicketNumber),
+		StaleAfter:      staleTicketDays(),
 	}
 }

--- a/api/internal/support/disposition_test.go
+++ b/api/internal/support/disposition_test.go
@@ -168,6 +168,86 @@ func TestDisposition_MoneyAndAccountNeverAutoSend(t *testing.T) {
 
 // The cap is "already sent this many", not "sent more than this many": at the
 // limit the next reply is the one too far.
+// =============================================================================
+// REL-259 — the bot may only claim a fix it can prove
+// =============================================================================
+
+// The prompt tells the drafter not to claim an unprovable fix. This is the
+// part that does not depend on the model having listened.
+func TestDisposition_FixClaimWithoutProofEscalates(t *testing.T) {
+	for _, body := range []string{
+		"Good news, this was fixed in 1.6.2. Please update.",
+		"That is fixed in a newer build.",
+		"Please update to the latest version and let us know.",
+		"Download the latest build from myscrollr.com and try again.",
+		"We shipped a fix for this.",
+	} {
+		s := sendableSignals()
+		s.DraftBody = body
+		got, reason := decide(t, s)
+		if got != dispositionEscalate {
+			t.Errorf("%q -> %s (%s), want escalate", body, got, reason)
+		}
+	}
+
+	// The same words with the proof behind them are exactly what the bot is
+	// for. Nothing here blocks a claim we can stand behind.
+	s := sendableSignals()
+	s.DraftBody = "Good news, this was fixed in 1.6.2. Please update to the latest version."
+	s.HasProvenFix = true
+	if got, reason := decide(t, s); got != dispositionAutoSend {
+		t.Errorf("a proven fix must still send: %s (%s)", got, reason)
+	}
+}
+
+// Asking somebody which version they run is a diagnostic, not a fix claim, and
+// the issue is explicit that it stays.
+func TestDisposition_AskingForAVersionIsNotAFixClaim(t *testing.T) {
+	s := sendableSignals()
+	s.Category, s.DrafterCategory = "bug", "bug"
+	s.DraftBody = "Sorry about that. Which version of Scrollr are you on? Settings then Updates shows it."
+	s.AskUserFor = "their Scrollr version"
+	if got, reason := decide(t, s); got != dispositionAutoAsk {
+		t.Errorf("got %s (%s), want auto_ask — asking for a version must stay sendable", got, reason)
+	}
+}
+
+// An old ticket asks rather than tells: a question goes out unattended, and a
+// reply that insists on telling gets a person instead.
+func TestDisposition_StaleTicketAsksRatherThanTells(t *testing.T) {
+	asks := sendableSignals()
+	asks.Category, asks.DrafterCategory = "bug", "bug"
+	asks.StaleDays, asks.StaleAfter = 40, 30
+	asks.DraftBody = "Sorry for the wait. Is this still happening, and which version are you on now?"
+	asks.AskUserFor = "whether it still happens; their Scrollr version"
+	if got, reason := decide(t, asks); got != dispositionAutoAsk {
+		t.Errorf("got %s (%s), want auto_ask on a 40-day-old ticket with no fix on record", got, reason)
+	}
+
+	tells := asks
+	tells.DraftBody = "Thanks for the report. Toggling the widget off and on should sort it."
+	tells.AskUserFor = ""
+	got, reason := decide(t, tells)
+	if got != dispositionEscalate || !strings.Contains(reason, "40 days old") {
+		t.Errorf("got %s (%s), want escalate naming the age", got, reason)
+	}
+
+	// Proof beats age. A stale ticket whose fix actually shipped is the one
+	// case where telling is the honest answer.
+	proven := tells
+	proven.HasProvenFix = true
+	if got, reason := decide(t, proven); got != dispositionAutoSend {
+		t.Errorf("got %s (%s), want auto_send when the fix is on record", got, reason)
+	}
+
+	// Fresh tickets are untouched by any of this.
+	fresh := tells
+	fresh.StaleDays = 3
+	if got, reason := decide(t, fresh); got != dispositionAutoSend {
+		t.Errorf("got %s (%s), want auto_send on a three-day-old ticket", got, reason)
+	}
+}
+
 func TestDisposition_ReplyCap(t *testing.T) {
 	for _, n := range []int{0, 1, 2} {
 		s := sendableSignals()

--- a/api/internal/support/handlers_discord_interactions.go
+++ b/api/internal/support/handlers_discord_interactions.go
@@ -182,7 +182,11 @@ func handleDiscordButtonClick(c *fiber.Ctx, ix *discordInteraction) error {
 	}
 	prefix, idStr := parts[0], parts[1]
 
-	// /inbox paging carries an offset, not a draft id.
+	// Two buttons carry something other than a draft id: /inbox paging carries
+	// an offset, and a /link confirmation carries the pair it is confirming.
+	if prefix == "support_link" {
+		return handleDiscordLinkConfirm(c, idStr)
+	}
 	if prefix == "support_inbox" {
 		offset, err := strconv.Atoi(idStr)
 		if err != nil || offset < 0 {
@@ -1060,6 +1064,8 @@ func handleDiscordSlashCommand(c *fiber.Ctx, ix *discordInteraction) error {
 		return handleDiscordTicketCommand(c, ix)
 	case "regen":
 		return handleDiscordRegenCommand(c, ix)
+	case "link":
+		return handleDiscordLinkCommand(c, ix)
 	case "stats":
 		return handleDiscordStatsCommand(c, ix)
 	case "pause":

--- a/api/internal/support/linear.go
+++ b/api/internal/support/linear.go
@@ -26,10 +26,11 @@ import (
 // every entry point here returns an error the caller shows in the thread —
 // nothing else in the pipeline degrades.
 
-const (
-	linearAPIURL  = "https://api.linear.app/graphql"
-	linearTimeout = 10 * time.Second
-)
+const linearTimeout = 10 * time.Second
+
+// linearAPIURL is a var so the proven-fix tests can point the client at a
+// stub, exactly as discordAPIBase does.
+var linearAPIURL = "https://api.linear.app/graphql"
 
 // linearTeamKey is the team new issues are filed into. Scrollr's work all
 // lives in one Linear team, so this is a config value, not a picker.

--- a/api/internal/support/link_backfill.go
+++ b/api/internal/support/link_backfill.go
@@ -1,0 +1,259 @@
+package support
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// =============================================================================
+// /link — backfill case → issue links, one confirmed click at a time (REL-259)
+// =============================================================================
+//
+// A proven fix starts with support_cases.linear_issue_key, and most of the
+// backlog has none: those cases were imported from osTicket long before the
+// File as bug button existed. Without a link they can never be told a fix
+// shipped, which is the safe direction but not a useful resting place.
+//
+// So this proposes matches and nothing more. The scoring is word overlap
+// between the ticket and the issue — deliberately dumb, because its job is to
+// put a plausible pair in front of a person, not to decide. Nothing here
+// writes a link on its own: a wrong link produces a confidently wrong "fixed
+// in X" months later, which is the exact failure REL-259 exists to prevent.
+
+// linkProposalCases is how many unlinked cases one /link shows. Discord allows
+// five action rows and each case takes one, with the sixth reserved for
+// nothing at all — four keeps the message readable.
+const linkProposalCases = 4
+
+// linkCandidatesPerCase is how many issues get a button per case. Two is the
+// point where a person is choosing rather than rubber-stamping.
+const linkCandidatesPerCase = 2
+
+// linkMinScore is the smallest overlap worth showing. One shared word is
+// noise; two distinctive ones is a proposal.
+const linkMinScore = 2
+
+// unlinkedCase is one open case with no issue behind it.
+type unlinkedCase struct {
+	TicketNumber string
+	Subject      string
+	Summary      string
+	OpenedAt     time.Time
+}
+
+// linkCandidate is one proposed pairing.
+type linkCandidate struct {
+	IssueKey string
+	Title    string
+	Score    int
+}
+
+// fetchUnlinkedCases lists open cases with no linear_issue_key, oldest first —
+// the longest-waiting reports are the ones most likely to have been fixed
+// without anybody recording it.
+func fetchUnlinkedCases(ctx context.Context, limit int) ([]unlinkedCase, error) {
+	if platform.DBPool == nil {
+		return nil, fmt.Errorf("DB not initialized")
+	}
+	rows, err := platform.DBPool.Query(ctx, `
+		SELECT ticket_number, COALESCE(subject,''), COALESCE(summary,''), opened_at
+		FROM support_cases
+		WHERE linear_issue_key IS NULL AND status <> 'closed'
+		ORDER BY opened_at ASC
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []unlinkedCase
+	for rows.Next() {
+		var u unlinkedCase
+		if err := rows.Scan(&u.TicketNumber, &u.Subject, &u.Summary, &u.OpenedAt); err != nil {
+			continue
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+// linkStopwords are the words that match everything and mean nothing. Support
+// tickets and bug titles share a lot of furniture ("the bar does not work"),
+// and without this every case proposes every issue.
+var linkStopwords = map[string]bool{
+	"the": true, "and": true, "for": true, "with": true, "that": true, "this": true,
+	"not": true, "but": true, "you": true, "your": true, "are": true, "was": true,
+	"were": true, "has": true, "have": true, "had": true, "can": true, "cannot": true,
+	"does": true, "did": true, "when": true, "what": true, "why": true, "how": true,
+	"from": true, "into": true, "out": true, "all": true, "any": true, "get": true,
+	"got": true, "its": true, "it's": true, "there": true, "here": true, "then": true,
+	"than": true, "just": true, "still": true, "some": true, "very": true, "will": true,
+	"would": true, "should": true, "could": true, "please": true, "thanks": true,
+	"issue": true, "problem": true, "bug": true, "report": true, "support": true,
+	"scrollr": true, "app": true, "using": true, "use": true, "after": true,
+}
+
+// linkTokens reduces a string to its distinctive lowercase words.
+func linkTokens(s string) map[string]bool {
+	out := map[string]bool{}
+	for _, f := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	}) {
+		if len(f) < 3 || linkStopwords[f] {
+			continue
+		}
+		out[f] = true
+	}
+	return out
+}
+
+// proposeLinks ranks open issues against one case by shared distinctive words.
+// Pure, so the scoring is testable without Linear or a database.
+func proposeLinks(uc unlinkedCase, issues []openIssue, limit int) []linkCandidate {
+	caseWords := linkTokens(uc.Subject + " " + uc.Summary)
+	if len(caseWords) == 0 {
+		return nil
+	}
+	var out []linkCandidate
+	for _, is := range issues {
+		score := 0
+		for w := range linkTokens(is.Title + " " + is.Description) {
+			if caseWords[w] {
+				score++
+			}
+		}
+		if score >= linkMinScore {
+			out = append(out, linkCandidate{IssueKey: is.Key, Title: is.Title, Score: score})
+		}
+	}
+	// Score first, then issue key, so the same input always proposes the same
+	// buttons in the same order — a list that reshuffles between runs is a
+	// list nobody trusts enough to click.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].IssueKey < out[j].IssueKey
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// ===== The command ================================================
+
+// handleDiscordLinkCommand proposes matches for the unlinked backlog.
+// Deferred: it reads Linear, which is not a three-second answer when the
+// cache is cold.
+func handleDiscordLinkCommand(c *fiber.Ctx, ix *discordInteraction) error {
+	appID, token := ix.ApplicationID, ix.Token
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		content, components := buildLinkProposals(ctx)
+		if err := discordCompleteDeferredWith(ctx, appID, token, content, components); err != nil {
+			log.Printf("[Link] follow-up: %v", err)
+		}
+	}()
+	return c.JSON(fiber.Map{"type": discordResponseDeferredChannelMessage})
+}
+
+// buildLinkProposals is the message: what is unlinked, what might match it,
+// and a button per candidate. Cases with no plausible candidate are listed
+// without buttons rather than hidden — "nothing matched this one" is the
+// answer for most of them, and it is worth seeing.
+func buildLinkProposals(ctx context.Context) (string, []DiscordActionRow) {
+	cases, err := fetchUnlinkedCases(ctx, linkProposalCases)
+	if err != nil {
+		log.Printf("[Link] unlinked cases: %v", err)
+		return "Could not read the case database.", nil
+	}
+	if len(cases) == 0 {
+		return "🔗 Every open case already has an issue linked to it.", nil
+	}
+
+	issues := fetchOpenLinearIssues(ctx)
+	if len(issues) == 0 {
+		return "🔗 Could not read open issues from Linear, so there is nothing to propose.", nil
+	}
+
+	var b strings.Builder
+	b.WriteString("🔗 **Unlinked open cases.** Confirm a match and that case can be told its fix " +
+		"shipped; leave it and it keeps asking instead. Nothing links itself.\n")
+	var rows []DiscordActionRow
+
+	for _, uc := range cases {
+		label := uc.Summary
+		if strings.TrimSpace(label) == "" {
+			label = uc.Subject
+		}
+		fmt.Fprintf(&b, "\n• **#%s** — %s _(%s old)_\n",
+			uc.TicketNumber, truncateRunes(label, 110), humanAge(time.Since(uc.OpenedAt)))
+
+		candidates := proposeLinks(uc, issues, linkCandidatesPerCase)
+		if len(candidates) == 0 {
+			b.WriteString("   nothing plausible in the open issues\n")
+			continue
+		}
+		var buttons []DiscordMessageButton
+		for _, cand := range candidates {
+			fmt.Fprintf(&b, "   `%s` %s\n", cand.IssueKey, truncateRunes(cand.Title, 90))
+			btn := DiscordMessageButton{
+				Type: 2, Style: 1,
+				Label:    fmt.Sprintf("#%s → %s", uc.TicketNumber, cand.IssueKey),
+				CustomID: fmt.Sprintf("support_link:%s|%s", uc.TicketNumber, cand.IssueKey),
+			}
+			btn.Emoji = &struct {
+				Name string `json:"name"`
+			}{Name: "🔗"}
+			buttons = append(buttons, btn)
+		}
+		rows = append(rows, DiscordActionRow{Type: 1, Components: buttons})
+	}
+	return truncateRunes(b.String(), 1990), rows
+}
+
+// ===== The confirmation button ====================================
+
+// handleDiscordLinkConfirm writes the link a person just confirmed. The
+// custom_id carries "<ticket>|<ISSUE-KEY>" because a link is a pair, not a
+// draft id.
+func handleDiscordLinkConfirm(c *fiber.Ctx, arg string) error {
+	ticket, issueKey, ok := strings.Cut(arg, "|")
+	ticket, issueKey = strings.TrimSpace(ticket), strings.ToUpper(strings.TrimSpace(issueKey))
+	if !ok || ticket == "" || issueKey == "" {
+		return discordEphemeralResponse(c, "malformed link target")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if existing := caseLinearIssueKey(ctx, ticket); existing != "" {
+		return discordEphemeralResponse(c,
+			fmt.Sprintf("#%s is already linked to **%s**.", ticket, existing))
+	}
+	if err := setCaseLinearIssueKey(ctx, ticket, issueKey); err != nil {
+		log.Printf("[Link] %s -> %s: %v", ticket, issueKey, err)
+		return discordEphemeralResponse(c, "Could not save the link.")
+	}
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: ticket, Kind: "note",
+		BodyText: "linked to " + issueKey + " by hand",
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
+	postToTicketThread(ctx, ticket, fmt.Sprintf(
+		"🔗 Linked to **%s** — %s. Drafts on this ticket may name the release that carries it once it ships.",
+		issueKey, linearIssueURL(issueKey)))
+
+	return discordVisibleResponse(c, fmt.Sprintf("🔗 **#%s → %s.** %s",
+		ticket, issueKey, linearIssueURL(issueKey)))
+}

--- a/api/internal/support/link_backfill_test.go
+++ b/api/internal/support/link_backfill_test.go
@@ -1,0 +1,110 @@
+package support
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// The proposal is allowed to be wrong; it is not allowed to be confident. What
+// matters is that it ranks the obvious match first and stays quiet when
+// nothing overlaps, because a list full of noise is a list that gets
+// rubber-stamped.
+func TestProposeLinks_RanksTheObviousMatchAndDeclinesTheRest(t *testing.T) {
+	issues := []openIssue{
+		{Key: "REL-253", Title: "The ticker never scrolls", Description: "The bar renders but the ticker does not scroll."},
+		{Key: "REL-254", Title: "GPU undetected on launch", Description: "Hardware acceleration is off."},
+		{Key: "REL-255", Title: "Linux AppImage login loop"},
+	}
+
+	got := proposeLinks(unlinkedCase{
+		TicketNumber: "486932",
+		Subject:      "Bug Report: ticker does not scroll",
+		Summary:      "ticker never scrolls on launch",
+	}, issues, 2)
+	if len(got) == 0 || got[0].IssueKey != "REL-253" {
+		t.Fatalf("got %+v, want REL-253 first", got)
+	}
+
+	// Shared furniture only ("the", "bug", "scrollr") must not propose
+	// anything: every ticket shares those with every issue.
+	if got := proposeLinks(unlinkedCase{
+		TicketNumber: "486933",
+		Subject:      "The Scrollr app has a bug",
+		Summary:      "a problem with the app",
+	}, issues, 2); len(got) != 0 {
+		t.Fatalf("got %+v, want nothing from stopwords alone", got)
+	}
+}
+
+// The whole point of /link is that it proposes. Confirming is what writes, and
+// it refuses to overwrite a link that already exists.
+func TestLinkConfirm_WritesOnceAndNeverOverwrites(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+
+	ticket := "900261"
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: ticket, Subject: "The ticker never scrolls", Status: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := caseLinearIssueKey(ctx, ticket); got != "" {
+		t.Fatalf("a fresh case starts unlinked, got %q", got)
+	}
+
+	if err := setCaseLinearIssueKey(ctx, ticket, "REL-253"); err != nil {
+		t.Fatal(err)
+	}
+	if got := caseLinearIssueKey(ctx, ticket); got != "REL-253" {
+		t.Fatalf("got %q, want REL-253", got)
+	}
+
+	// A second confirmation on the same case — two people looking at the same
+	// /link output — must not repoint it at something else.
+	if err := setCaseLinearIssueKey(ctx, ticket, "REL-254"); err != nil {
+		t.Fatal(err)
+	}
+	if got := caseLinearIssueKey(ctx, ticket); got != "REL-253" {
+		t.Fatalf("got %q, want the first link to stand", got)
+	}
+}
+
+// A linked case must drop out of the proposal list, or /link keeps offering
+// work that is already done.
+func TestUnlinkedCases_ExcludesLinkedAndClosed(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+
+	for _, tc := range []struct{ ticket, status, link string }{
+		{"900270", "open", ""},
+		{"900271", "open", "REL-253"},
+		{"900272", "closed", ""},
+	} {
+		if err := upsertSupportCase(ctx, SupportCase{
+			TicketNumber: tc.ticket, Subject: "s", Status: tc.status,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if tc.link != "" {
+			if err := setCaseLinearIssueKey(ctx, tc.ticket, tc.link); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	cases, err := fetchUnlinkedCases(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) != 1 || cases[0].TicketNumber != "900270" {
+		t.Fatalf("got %+v, want only the open unlinked case", cases)
+	}
+}

--- a/api/internal/support/proven_fix.go
+++ b/api/internal/support/proven_fix.go
@@ -1,0 +1,262 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// =============================================================================
+// Proven fixes — the bot may only claim a fix it can prove (REL-259)
+// =============================================================================
+//
+// The drafter used to work out "is this fixed?" by reading release notes.
+// Release notes are marketing prose written for everyone; they are not a
+// record of which report a change closed. So the bot had no way to KNOW, and
+// it was still allowed to SAY — which is how ten backlog drafts ended up
+// wanting to tell a four-month-old reporter to update without being able to
+// promise it did anything for their symptom.
+//
+// A fix is proven, and only proven, when all three of these hold:
+//
+//  1. a human linked the case to a Linear issue (support_cases.linear_issue_key,
+//     set by the File as bug button or the /link confirmation — never by the
+//     model, because a wrong link produces a confidently wrong "fixed in X"),
+//  2. that issue is in a completed state, and
+//  3. the pull request that closed it was merged before a published release.
+//
+// The answer goes into the drafting prompt as a FACT, never as something to
+// infer, and the disposition gate re-checks the finished reply against it.
+//
+// ponytail: (3) is "merged before the release was published", not "this commit
+// is an ancestor of that tag". Scrollr cuts releases from main, so the two
+// agree; if release branches ever appear, swap the timestamp compare for a
+// GitHub compare call against the tag.
+
+// ProvenFix is the record behind a permitted fix claim. A nil *ProvenFix is
+// the ordinary case and means exactly one thing: say nothing about a fix.
+type ProvenFix struct {
+	IssueKey   string    `json:"issue_key"`
+	Version    string    `json:"version"` // "1.6.2" — the release the PR shipped in
+	ReleaseURL string    `json:"release_url,omitempty"`
+	MergedAt   time.Time `json:"merged_at"`
+}
+
+const (
+	provenFixCachePrefix = "support:proven_fix:v1:"
+	provenFixCacheTTL    = 10 * time.Minute
+	// provenFixReleaseCount is how far back we look for the release that
+	// carried a fix. Deep enough for a ticket that has been waiting months,
+	// which is the whole population this exists for.
+	provenFixReleaseCount = 30
+
+	staleTicketDaysDefault = 30
+)
+
+// staleTicketDays is the age past which a ticket asks rather than tells.
+func staleTicketDays() int {
+	raw := strings.TrimSpace(os.Getenv("SUPPORT_STALE_TICKET_DAYS"))
+	if raw == "" {
+		return staleTicketDaysDefault
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		log.Printf("[ProvenFix] SUPPORT_STALE_TICKET_DAYS=%q is not a positive integer; using %d",
+			raw, staleTicketDaysDefault)
+		return staleTicketDaysDefault
+	}
+	return n
+}
+
+// lookupProvenFix answers the question for one ticket. Returns nil whenever
+// it cannot prove a fix, INCLUDING when the lookup itself failed: an
+// unreachable Linear is a reason to say nothing, never a reason to guess.
+func lookupProvenFix(ctx context.Context, ticketNumber string) *ProvenFix {
+	if strings.TrimSpace(ticketNumber) == "" {
+		return nil
+	}
+	issueKey := caseLinearIssueKey(ctx, ticketNumber)
+	if issueKey == "" {
+		return nil
+	}
+	return provenFixForIssue(ctx, issueKey)
+}
+
+// provenFixForIssue is the cached per-issue half. Cached on success only — a
+// Linear outage must not pin "no fix on record" for ten minutes on an issue
+// that has one.
+func provenFixForIssue(ctx context.Context, issueKey string) *ProvenFix {
+	cacheKey := provenFixCachePrefix + issueKey
+	if platform.Rdb != nil {
+		if raw, err := platform.Rdb.Get(ctx, cacheKey).Result(); err == nil {
+			if raw == "" {
+				return nil
+			}
+			var pf ProvenFix
+			if json.Unmarshal([]byte(raw), &pf) == nil {
+				return &pf
+			}
+		}
+	}
+
+	pf, err := computeProvenFix(ctx, issueKey)
+	if err != nil {
+		log.Printf("[ProvenFix] %s: %v (treating as no fix on record)", issueKey, err)
+		return nil
+	}
+	if platform.Rdb != nil {
+		payload := ""
+		if pf != nil {
+			if b, marshalErr := json.Marshal(pf); marshalErr == nil {
+				payload = string(b)
+			}
+		}
+		if err := platform.Rdb.Set(ctx, cacheKey, payload, provenFixCacheTTL).Err(); err != nil {
+			log.Printf("[ProvenFix] cache %s: %v", issueKey, err)
+		}
+	}
+	return pf
+}
+
+// linearClosingMerge returns when the pull request that closed an issue was
+// merged. A zero time means "nothing to prove": the issue is not completed, or
+// it is completed with no merged PR behind it — something moved the issue and
+// we cannot say which release carried it.
+func linearClosingMerge(ctx context.Context, issueKey string) (time.Time, error) {
+	const q = `query($id: String!) {
+		issue(id: $id) {
+			state { type }
+			attachments { nodes { sourceType metadata } }
+		}
+	}`
+	var out struct {
+		Issue *struct {
+			State struct {
+				Type string `json:"type"`
+			} `json:"state"`
+			Attachments struct {
+				Nodes []struct {
+					SourceType string                 `json:"sourceType"`
+					Metadata   map[string]interface{} `json:"metadata"`
+				} `json:"nodes"`
+			} `json:"attachments"`
+		} `json:"issue"`
+	}
+	if err := linearGraphQL(ctx, q, map[string]interface{}{"id": issueKey}, &out); err != nil {
+		return time.Time{}, err
+	}
+	if out.Issue == nil {
+		return time.Time{}, fmt.Errorf("no Linear issue %q", issueKey)
+	}
+	if out.Issue.State.Type != "completed" {
+		return time.Time{}, nil
+	}
+
+	// The last merge wins: an issue reopened and fixed again shipped in the
+	// later release, and naming the earlier one would be a lie about a bug the
+	// user may still have.
+	var mergedAt time.Time
+	for _, a := range out.Issue.Attachments.Nodes {
+		if a.SourceType != "github" || a.Metadata == nil {
+			continue
+		}
+		if s, _ := a.Metadata["status"].(string); !strings.EqualFold(s, "merged") {
+			continue
+		}
+		raw, _ := a.Metadata["mergedAt"].(string)
+		t, parseErr := time.Parse(time.RFC3339, raw)
+		if parseErr != nil {
+			continue
+		}
+		if t.After(mergedAt) {
+			mergedAt = t
+		}
+	}
+	return mergedAt, nil
+}
+
+// computeProvenFix does the three checks. (nil, nil) means "no fix on record",
+// which is a legitimate answer and gets cached; an error means we could not
+// find out, which does not.
+func computeProvenFix(ctx context.Context, issueKey string) (*ProvenFix, error) {
+	mergedAt, err := linearClosingMerge(ctx, issueKey)
+	if err != nil {
+		return nil, err
+	}
+	if mergedAt.IsZero() {
+		return nil, nil // not done, or done with nothing merged behind it
+	}
+	rel := firstReleaseAfter(fetchRecentReleases(ctx, provenFixReleaseCount), mergedAt)
+	if rel == nil {
+		return nil, nil // fixed, but it has not shipped yet
+	}
+	return &ProvenFix{
+		IssueKey:   issueKey,
+		Version:    releaseVersion(rel.Tag, rel.Name),
+		ReleaseURL: rel.URL,
+		MergedAt:   mergedAt,
+	}, nil
+}
+
+// firstReleaseAfter picks the earliest published, non-prerelease release that
+// went out after the fix was merged. Prereleases are excluded: telling
+// somebody their fix is in a build they cannot get is worse than saying
+// nothing.
+func firstReleaseAfter(releases []shippedRelease, mergedAt time.Time) *shippedRelease {
+	var best *shippedRelease
+	for i := range releases {
+		r := &releases[i]
+		if r.Prerelease || r.PublishedAt.IsZero() || !r.PublishedAt.After(mergedAt) {
+			continue
+		}
+		if best == nil || r.PublishedAt.Before(best.PublishedAt) {
+			best = r
+		}
+	}
+	return best
+}
+
+// releaseVersion turns "desktop-v1.6.3" into "1.6.3", falling back to the
+// release name when the tag is not shaped like one.
+func releaseVersion(tag, name string) string {
+	v := strings.TrimSpace(tag)
+	v = strings.TrimPrefix(v, "desktop-")
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return strings.TrimSpace(name)
+	}
+	return v
+}
+
+// ===== Staleness ==================================================
+
+// caseStaleDays is how many days ago the user last said anything on a ticket.
+// Zero when we do not know, which reads as "not stale" everywhere — the stale
+// rule adds a reason to ask, and a missing timestamp is not one.
+func caseStaleDays(ctx context.Context, ticketNumber string) int {
+	if platform.DBPool == nil || strings.TrimSpace(ticketNumber) == "" {
+		return 0
+	}
+	var last *time.Time
+	err := platform.DBPool.QueryRow(ctx, `
+		SELECT COALESCE(
+			(SELECT max(created_at) FROM support_messages
+			 WHERE ticket_number = $1 AND kind = 'user'),
+			(SELECT opened_at FROM support_cases WHERE ticket_number = $1))`,
+		ticketNumber).Scan(&last)
+	if err != nil || last == nil {
+		return 0
+	}
+	days := int(time.Since(*last).Hours() / 24)
+	if days < 0 {
+		return 0
+	}
+	return days
+}

--- a/api/internal/support/proven_fix_test.go
+++ b/api/internal/support/proven_fix_test.go
@@ -1,0 +1,314 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// =============================================================================
+// The bot may only claim a fix it can prove (REL-259)
+// =============================================================================
+//
+// Everything here is one question asked three ways: may this reply tell a user
+// their problem is gone? The answer is yes exactly when a person linked the
+// case to an issue, that issue is done, and the pull request that closed it
+// went out in a published release. Every other shape — done but unreleased,
+// done with nothing merged, not linked at all, Linear unreachable — is no.
+
+// stubLinearAndReleases points both upstreams at test servers for one test.
+// issueState is the Linear workflow state type ("completed", "started", ...);
+// mergedAt is the closing PR's merge time, empty for "no PR attached".
+func stubLinearAndReleases(t *testing.T, issueState, mergedAt string, releases []map[string]interface{}) {
+	t.Helper()
+
+	linear := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var attachments []map[string]interface{}
+		if mergedAt != "" {
+			attachments = append(attachments, map[string]interface{}{
+				"sourceType": "github",
+				"metadata":   map[string]interface{}{"status": "merged", "mergedAt": mergedAt},
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"issue": map[string]interface{}{
+					"state":       map[string]interface{}{"type": issueState},
+					"attachments": map[string]interface{}{"nodes": attachments},
+				},
+			},
+		})
+	}))
+	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+
+	oldLinear, oldGitHub := linearAPIURL, knownIssuesReleasesURL
+	linearAPIURL = linear.URL
+	knownIssuesReleasesURL = github.URL + "?per_page=%d"
+	t.Setenv("LINEAR_API_KEY", "test-key")
+	t.Cleanup(func() {
+		linearAPIURL, knownIssuesReleasesURL = oldLinear, oldGitHub
+		linear.Close()
+		github.Close()
+	})
+}
+
+func release(tag, published string, prerelease bool) map[string]interface{} {
+	return map[string]interface{}{
+		"tag_name": tag, "name": "Scrollr " + strings.TrimPrefix(tag, "desktop-v"),
+		"body": "notes", "draft": false, "prerelease": prerelease,
+		"published_at": published, "html_url": "https://example.invalid/" + tag,
+	}
+}
+
+func TestProvenFix_DoneAndShipped(t *testing.T) {
+	stubLinearAndReleases(t, "completed", "2026-09-01T10:00:00Z", []map[string]interface{}{
+		release("desktop-v1.6.2", "2026-09-02T12:00:00Z", false),
+		release("desktop-v1.6.3", "2026-09-07T12:00:00Z", false),
+		release("desktop-v1.6.0", "2026-08-20T12:00:00Z", false),
+	})
+
+	pf, err := computeProvenFix(context.Background(), "REL-253")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pf == nil {
+		t.Fatal("a done issue whose PR shipped is exactly the case that has proof")
+	}
+	// The FIRST release after the merge, not the newest one: 1.6.2 is when the
+	// user could have had it, and naming 1.6.3 would send someone chasing an
+	// update they did not need.
+	if pf.Version != "1.6.2" || pf.IssueKey != "REL-253" {
+		t.Fatalf("got %+v, want REL-253 shipped in 1.6.2", pf)
+	}
+}
+
+func TestProvenFix_DoneButUnreleased(t *testing.T) {
+	stubLinearAndReleases(t, "completed", "2026-09-08T10:00:00Z", []map[string]interface{}{
+		release("desktop-v1.6.3", "2026-09-07T12:00:00Z", false),
+	})
+
+	pf, err := computeProvenFix(context.Background(), "REL-259")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pf != nil {
+		t.Fatalf("a merge that no release has carried yet is not proof, got %+v", pf)
+	}
+}
+
+func TestProvenFix_PrereleaseIsNotAShippedFix(t *testing.T) {
+	stubLinearAndReleases(t, "completed", "2026-09-01T10:00:00Z", []map[string]interface{}{
+		release("desktop-v1.7.0-beta.1", "2026-09-02T12:00:00Z", true),
+	})
+
+	pf, err := computeProvenFix(context.Background(), "REL-253")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pf != nil {
+		t.Fatalf("telling somebody the fix is in a build they cannot get is worse than saying nothing, got %+v", pf)
+	}
+}
+
+func TestProvenFix_NotDoneAndNoMergedPR(t *testing.T) {
+	stubLinearAndReleases(t, "started", "2026-09-01T10:00:00Z", []map[string]interface{}{
+		release("desktop-v1.6.3", "2026-09-07T12:00:00Z", false),
+	})
+	if pf, err := computeProvenFix(context.Background(), "REL-253"); err != nil || pf != nil {
+		t.Fatalf("an open issue is never a shipped fix (pf=%+v err=%v)", pf, err)
+	}
+
+	// Done, but nothing merged behind it: something moved the issue and we
+	// cannot say which release carried it, so we say nothing.
+	stubLinearAndReleases(t, "completed", "", []map[string]interface{}{
+		release("desktop-v1.6.3", "2026-09-07T12:00:00Z", false),
+	})
+	if pf, err := computeProvenFix(context.Background(), "REL-253"); err != nil || pf != nil {
+		t.Fatalf("done with no merged PR is not proof (pf=%+v err=%v)", pf, err)
+	}
+}
+
+// A lookup we could not perform is a reason to say nothing, never a reason to
+// guess in either direction.
+func TestProvenFix_UnreachableLinearMeansNoClaim(t *testing.T) {
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer down.Close()
+	old := linearAPIURL
+	linearAPIURL = down.URL
+	t.Setenv("LINEAR_API_KEY", "test-key")
+	defer func() { linearAPIURL = old }()
+
+	if pf := provenFixForIssue(context.Background(), "REL-253"); pf != nil {
+		t.Fatalf("got %+v, want no claim when the tracker is unreachable", pf)
+	}
+}
+
+// An unlinked case can never have proof, whatever Linear would have said —
+// nothing is asked, because there is nothing to ask about.
+func TestProvenFix_UnlinkedCaseHasNone(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+
+	ticket := "900259"
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: ticket, Subject: "The ticker never scrolls", Status: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if pf := lookupProvenFix(ctx, ticket); pf != nil {
+		t.Fatalf("got %+v, want nil for a case nobody has linked", pf)
+	}
+}
+
+// caseStaleDays is what turns a four-month-old ticket into a question.
+func TestCaseStaleDays_ReadsTheLastUserMessage(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+
+	ticket := "900260"
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: ticket, Subject: "Scores stuck", Status: "open",
+		OpenedAt: time.Now().AddDate(0, 0, -120),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: ticket, Kind: "user", BodyText: "still stuck",
+		CreatedAt: time.Now().AddDate(0, 0, -40),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 40, not 120: what matters is how long the user has been waiting for an
+	// answer to what they last said, not how long the ticket has existed.
+	if got := caseStaleDays(ctx, ticket); got < 39 || got > 41 {
+		t.Fatalf("caseStaleDays = %d, want ~40", got)
+	}
+
+	// A reply of ours does not reset it — we are the ones who have been quiet.
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: ticket, Kind: "sent", BodyText: "looking into it",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := caseStaleDays(ctx, ticket); got < 39 || got > 41 {
+		t.Fatalf("caseStaleDays = %d after our own reply, want ~40", got)
+	}
+}
+
+// firstReleaseAfter is the whole "which version carried it" rule.
+func TestFirstReleaseAfter(t *testing.T) {
+	at := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ts
+	}
+	releases := []shippedRelease{
+		{Tag: "desktop-v1.6.0", PublishedAt: at("2026-08-20T12:00:00Z")},
+		{Tag: "desktop-v1.6.3", PublishedAt: at("2026-09-07T12:00:00Z")},
+		{Tag: "desktop-v1.6.2", PublishedAt: at("2026-09-02T12:00:00Z")},
+	}
+	got := firstReleaseAfter(releases, at("2026-09-01T10:00:00Z"))
+	if got == nil || got.Tag != "desktop-v1.6.2" {
+		t.Fatalf("got %+v, want desktop-v1.6.2", got)
+	}
+	if got := firstReleaseAfter(releases, at("2026-09-09T10:00:00Z")); got != nil {
+		t.Fatalf("got %+v, want nil when nothing has shipped since the merge", got)
+	}
+}
+
+func TestReleaseVersion(t *testing.T) {
+	for tag, want := range map[string]string{
+		"desktop-v1.6.3": "1.6.3", "v1.6.3": "1.6.3", "1.6.3": "1.6.3",
+	} {
+		if got := releaseVersion(tag, "Scrollr 1.6.3"); got != want {
+			t.Errorf("releaseVersion(%q) = %q, want %q", tag, got, want)
+		}
+	}
+	if got := releaseVersion("", "Scrollr 1.6.3"); got != "Scrollr 1.6.3" {
+		t.Errorf("an untagged release falls back to its name, got %q", got)
+	}
+}
+
+// ===== The prompt block ===========================================
+
+func TestFixRecordBlock_ForbidsTheUnprovableClaim(t *testing.T) {
+	none := renderFixRecord(nil, 0, "1.5.0")
+	for _, want := range []string{"No shipped fix is on record", "may NOT say this was fixed",
+		"tell them to update as the answer", "Asking which version"} {
+		if !strings.Contains(none, want) {
+			t.Errorf("the no-fix block must say %q:\n%s", want, none)
+		}
+	}
+
+	stale := renderFixRecord(nil, 40, "1.5.0")
+	if !strings.Contains(stale, "40 DAYS OLD") || !strings.Contains(stale, "ask_user_for") {
+		t.Errorf("a stale ticket must be told to ask:\n%s", stale)
+	}
+	if strings.Contains(none, "DAYS OLD") {
+		t.Error("a fresh ticket must not get the stale instruction")
+	}
+
+	proven := renderFixRecord(&ProvenFix{IssueKey: "REL-253", Version: "1.6.2"}, 40, "1.5.0")
+	if !strings.Contains(proven, "shipped in Scrollr 1.6.2") || !strings.Contains(proven, "You MAY") {
+		t.Errorf("a proven fix must permit the claim:\n%s", proven)
+	}
+	if strings.Contains(proven, "DAYS OLD") {
+		t.Error("proof beats age: an old ticket with a shipped fix gets told the fix, not told to ask")
+	}
+
+	// Already on the fixed build: the honest reply is "it shipped, what are
+	// you still seeing", not "please update".
+	upToDate := renderFixRecord(&ProvenFix{IssueKey: "REL-253", Version: "1.6.2"}, 0, "1.6.3")
+	if !strings.Contains(upToDate, "updating is NOT the answer") {
+		t.Errorf("a user already past the fix must not be told to update:\n%s", upToDate)
+	}
+}
+
+// The never-say rule has to be in the cached system prompt, not only in the
+// per-ticket block, because that is the half the model is told is law.
+func TestSystemPromptForbidsUnprovenFixClaims(t *testing.T) {
+	p := triageSystemPrompt()
+	for _, want := range []string{
+		"Never say something was fixed",
+		"FIX ON RECORD",
+		"Release notes are",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("system prompt is missing %q", want)
+		}
+	}
+}
+
+// The release notes must no longer be advertised as evidence of a fix — that
+// instruction is what produced the drafts this whole issue is about.
+func TestKnownIssuesNoLongerTreatsReleaseNotesAsProof(t *testing.T) {
+	block := buildKnownIssuesBlock(
+		[]openIssue{{Key: "REL-253", Title: "The ticker never scrolls", Priority: "high"}},
+		[]shippedRelease{{Tag: "desktop-v1.6.2", Name: "Scrollr 1.6.2", Date: "2026-09-05", Body: "fixes"}},
+	)
+	if strings.Contains(block, "name the version") || strings.Contains(block, "tell them to update") {
+		t.Errorf("the known-issues block still tells the drafter to promise an update:\n%s", block)
+	}
+	if !strings.Contains(block, "FIX ON RECORD") {
+		t.Errorf("the block must point at the one source that can prove a fix:\n%s", block)
+	}
+}

--- a/api/internal/support/testdata/anonymous_draft.txt
+++ b/api/internal/support/testdata/anonymous_draft.txt
@@ -18,7 +18,7 @@ Open and being worked on:
 
 How to use this list:
 - The user's problem matches an OPEN issue: say it is a known issue and that it is being fixed. Give no date and no estimate. Put the issue key in internal_note.
-- The user's problem matches something the release notes below say was FIXED: name the version that fixed it and tell them to update.
+- The release notes below are context for what has changed, NOT evidence that this user's report was fixed. They are written for everyone and do not record which report a change closed. Only the FIX ON RECORD block may be used to claim a fix.
 - No match: do not mention the issue tracker at all. Never invent an issue key.
 - Issue keys, titles and descriptions here are internal. Never put one in the reply to the user.
 
@@ -27,6 +27,10 @@ Shipped releases, newest first (live; may be newer than the knowledge base):
 ### Scrollr 1.5.0 — Chips, redrawn (desktop-v1.5.0, 2026-09-04)
 Every data chip on the ticker rebuilt in one language.
 
+
+FIX ON RECORD (server-computed; the ONLY thing that permits a fix claim)
+None. No shipped fix is on record for this report.
+You may NOT say this was fixed, name a version as the remedy, or tell them to update as the answer. Asking which version they are running to narrow the problem is a different thing and is fine. If you think it may be fixed, ASK whether it is still happening rather than asserting that it is not.
 
 HOW TO WRITE IT:
 - Two to four short paragraphs of HTML, <p> tags, no headings and no lists unless the answer

--- a/api/internal/support/testdata/follow_up_draft.txt
+++ b/api/internal/support/testdata/follow_up_draft.txt
@@ -17,7 +17,7 @@ Open and being worked on:
 
 How to use this list:
 - The user's problem matches an OPEN issue: say it is a known issue and that it is being fixed. Give no date and no estimate. Put the issue key in internal_note.
-- The user's problem matches something the release notes below say was FIXED: name the version that fixed it and tell them to update.
+- The release notes below are context for what has changed, NOT evidence that this user's report was fixed. They are written for everyone and do not record which report a change closed. Only the FIX ON RECORD block may be used to claim a fix.
 - No match: do not mention the issue tracker at all. Never invent an issue key.
 - Issue keys, titles and descriptions here are internal. Never put one in the reply to the user.
 
@@ -26,6 +26,10 @@ Shipped releases, newest first (live; may be newer than the knowledge base):
 ### Scrollr 1.5.0 — Chips, redrawn (desktop-v1.5.0, 2026-09-04)
 Every data chip on the ticker rebuilt in one language.
 
+
+FIX ON RECORD (server-computed; the ONLY thing that permits a fix claim)
+None. No shipped fix is on record for this report.
+You may NOT say this was fixed, name a version as the remedy, or tell them to update as the answer. Asking which version they are running to narrow the problem is a different thing and is fine. If you think it may be fixed, ASK whether it is still happening rather than asserting that it is not.
 
 SIMILAR PAST CASES — what we actually sent. Use them for approach and tone.
 NEVER copy one verbatim: the details in it belong to a different user.

--- a/api/internal/support/testdata/needs_info_draft.txt
+++ b/api/internal/support/testdata/needs_info_draft.txt
@@ -18,7 +18,7 @@ Open and being worked on:
 
 How to use this list:
 - The user's problem matches an OPEN issue: say it is a known issue and that it is being fixed. Give no date and no estimate. Put the issue key in internal_note.
-- The user's problem matches something the release notes below say was FIXED: name the version that fixed it and tell them to update.
+- The release notes below are context for what has changed, NOT evidence that this user's report was fixed. They are written for everyone and do not record which report a change closed. Only the FIX ON RECORD block may be used to claim a fix.
 - No match: do not mention the issue tracker at all. Never invent an issue key.
 - Issue keys, titles and descriptions here are internal. Never put one in the reply to the user.
 
@@ -27,6 +27,10 @@ Shipped releases, newest first (live; may be newer than the knowledge base):
 ### Scrollr 1.5.0 — Chips, redrawn (desktop-v1.5.0, 2026-09-04)
 Every data chip on the ticker rebuilt in one language.
 
+
+FIX ON RECORD (server-computed; the ONLY thing that permits a fix claim)
+None. No shipped fix is on record for this report.
+You may NOT say this was fixed, name a version as the remedy, or tell them to update as the answer. Asking which version they are running to narrow the problem is a different thing and is fine. If you think it may be fixed, ASK whether it is still happening rather than asserting that it is not.
 
 ASK FOR INFORMATION. We cannot troubleshoot this yet. The reply is ONE short paragraph, then
 the sign-off. That paragraph acknowledges the problem and asks for their operating system,

--- a/api/internal/support/testdata/proven_fix_draft.txt
+++ b/api/internal/support/testdata/proven_fix_draft.txt
@@ -32,8 +32,8 @@ Every data chip on the ticker rebuilt in one language.
 
 
 FIX ON RECORD (server-computed; the ONLY thing that permits a fix claim)
-None. No shipped fix is on record for this report.
-You may NOT say this was fixed, name a version as the remedy, or tell them to update as the answer. Asking which version they are running to narrow the problem is a different thing and is fine. If you think it may be fixed, ASK whether it is still happening rather than asserting that it is not.
+This user's report is linked to REL-235, which shipped in Scrollr 1.6.1.
+You MAY say the fix for what they reported went out in 1.6.1 and point them at the update. Never put the issue key in the reply.
 
 SIMILAR PAST CASES — what we actually sent. Use them for approach and tone.
 NEVER copy one verbatim: the details in it belong to a different user.

--- a/api/internal/support/testdata/signed_in_classify.txt
+++ b/api/internal/support/testdata/signed_in_classify.txt
@@ -24,7 +24,7 @@ happened. The context block below says whether diagnostics were attached.
 WHO IS WRITING (server-side facts, not the user's claims)
 Plan: uplink_pro
 Current release is {{CURRENT_VERSION}}; this user is on 1.6.0. THEY ARE OUT OF DATE.
-Before any troubleshooting, tell them to update and say what changed between 1.6.0 and {{CURRENT_VERSION}}, from the release notes in the knowledge base. If the notes say their problem was fixed in one of those versions, updating IS the answer.
+That is a useful diagnostic and nothing more. Do NOT tell them updating will fix what they reported unless the FIX ON RECORD block below names a version; the release notes do not record which report a change closed.
 Operating system: Windows 11 (26200)
 Monitors: 2 attached, 1 chosen for the ticker
 Widgets (2 added, 1 on the ticker):

--- a/api/internal/support/testdata/stale_no_fix_draft.txt
+++ b/api/internal/support/testdata/stale_no_fix_draft.txt
@@ -35,6 +35,12 @@ FIX ON RECORD (server-computed; the ONLY thing that permits a fix claim)
 None. No shipped fix is on record for this report.
 You may NOT say this was fixed, name a version as the remedy, or tell them to update as the answer. Asking which version they are running to narrow the problem is a different thing and is fine. If you think it may be fixed, ASK whether it is still happening rather than asserting that it is not.
 
+THIS TICKET IS 120 DAYS OLD and nothing is on record as fixing it. Do not
+troubleshoot and do not guess. The reply is ONE short paragraph, then the sign-off:
+apologise briefly for the wait, say that several updates have shipped since they wrote
+in, and ask whether it is still happening and which version of Scrollr they are on now.
+List both of those in ask_user_for.
+
 SIMILAR PAST CASES — what we actually sent. Use them for approach and tone.
 NEVER copy one verbatim: the details in it belong to a different user.
 1. Bug Report: scores stopped updating

--- a/k8s/jobs/support-regen.yaml
+++ b/k8s/jobs/support-regen.yaml
@@ -17,6 +17,17 @@
 # thread with a disposition and a hold, and it SENDS ITSELF when nobody
 # intervenes. Read the drafts before the hold expires; `/pause` stops the lot.
 #
+# To re-triage WITHOUT sending anything — reviewing a policy change against the
+# real backlog, which is what REL-259 did — add `SUPPORT_AUTOSEND=off` to this
+# Job only. The disposition is still decided and written, each thread says what
+# it WOULD have done, and nothing leaves the building. It is a per-pod env, so
+# the live API keeps answering normally while the Job runs:
+#
+#   ... | kubectl apply -f - --dry-run=client -o yaml  # then add under `image:`
+#     env:
+#       - name: SUPPORT_AUTOSEND
+#         value: "off"
+#
 # Must run in-cluster: the reply goes out through the osTicket plugin, whose
 # API key is bound to the cluster's egress IP.
 #


### PR DESCRIPTION
Closes REL-259.

Brandon, after watching the backlog re-triage: *"I feel like it retroactively going back and updating tickets isn't great because it doesn't know what has been fixed."*

Nothing wrong went out — of the four replies REL-246 actually sent, three were questions and the fourth made no fix claim. But the mechanism was wrong. The drafter decided "is this fixed?" by reading release notes, which are marketing prose written for everyone and are not a record of which report a change closed. So the bot had no way to **know** and was still allowed to **say**; what stopped it was the model happening to feel unsure, and that put ten items on a human's plate.

## The rule

A fix is proven, and only proven, when all three hold:

1. a person linked the case to a Linear issue (`support_cases.linear_issue_key`),
2. that issue is in a completed state, and
3. the pull request that closed it was merged before a **published** release.

`proven_fix.go` computes it server-side and hands the answer to the drafter as a fact in a `FIX ON RECORD` block. Never something to infer.

## Enforced twice

The prompt is guidance; the check is the guarantee.

- **Prompt** — a never-say rule beside dates and dollar amounts, plus the per-ticket block. The known-issues block's old instruction (*"the release notes say it was FIXED: name the version that fixed it and tell them to update"*) is gone, and so is the same inference in the version-context block.
- **Code** — `decideDisposition` re-reads the finished reply. A body that says something was fixed, or offers an update as the remedy, with nothing on record behind it is forced to `escalate` rather than sending.

Asking someone to confirm their version as a **diagnostic** is untouched and stays — there is a test for it.

## An old ticket asks rather than tells

Past `SUPPORT_STALE_TICKET_DAYS` (default 30) with no proven fix, the drafter is told to write one honest question: several updates have shipped since you wrote in, is this still happening, and on which version. That rides the existing `auto_ask` path, so it sends unattended, and a "no, it's fine now" closes the ticket by itself. A stale draft that insists on telling anyway hits the code check and gets a person.

## Links are backfilled by hand

`/link` proposes matches between unlinked open cases and open Linear issues on word overlap, and Brandon confirms each with a button. Nothing links itself: a wrong link produces a confidently wrong "fixed in X" months later, which is the exact failure this issue exists to prevent.

The Discord thread header now carries `REL-253, shipped 1.6.2` / `REL-259, not shipped` / `none on record`, so the reason a draft is asking rather than telling is visible without reading the reply.

## Before

The ten escalations sitting in production right now. Seven of them offer updating as the answer, and their own `unknowns` say why that was never safe:

| ticket | the draft says | its own unknowns |
|---|---|---|
| #134740 | "Please update to 1.6.2 and see if the weather temperature keeps up" | *Whether updating fully resolves this specific stale-weather-temperature symptom* |
| #852919 | "Could you update Scrollr and see how things look afterward?" | *Whether updating alone resolves the user's specific case, since REL-251 is still open* |
| #648945 | "the first step is updating… That alone may resolve what you're seeing" | *Whether the 1-game standings discrepancy is a known, ongoing data issue or will resolve with the update* |
| #589914 | "it's worth updating to first before we go further" | *Whether updating to 1.6.2 alone resolves the centering issue* |
| #542713 | "your GPU issue may already be resolved on the current version" | *Whether the GPU detection issue is a known bug or a detection limitation* |
| #269765 | "updating to 1.6.2 is the right first step" | *Whether the persistence bug itself is a known separate issue* |

That is a guess wearing a support reply's clothes, and it is what this changes.

## After

Filled in below once this is deployed and `/regen` has been re-run over the same ten with `SUPPORT_AUTOSEND=off` — decided and written, read, not sent.

## Tests

16 new, all green alongside the existing suite:

- proven fix from a done issue whose PR shipped, naming the **first** release after the merge rather than the newest;
- no proof for done-but-unreleased, for a prerelease, for done-with-no-merged-PR, for an open issue, for an unlinked case, and for a Linear we could not reach;
- a reply naming a version as a fix without proof is forced to `escalate`, and the same words **with** proof still send;
- asking for a version stays `auto_ask`;
- a 40-day-old case with no proof asks; one that tells escalates; proof beats age; a three-day-old ticket is untouched;
- `caseStaleDays` reads the last **user** message, and our own reply does not reset it;
- two new prompt goldens pin both states of the `FIX ON RECORD` block.

No migration: the answer is computed, not stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)