### PR TITLE
fix(support): every path that sends a reply records that it sent one [REL-256]

### DIFF
--- a/api/internal/support/autosend.go
+++ b/api/internal/support/autosend.go
@@ -238,7 +238,7 @@ func sendDraftNow(ctx context.Context, draftID int64, status string) {
 	if status == "asked" {
 		draft.ShouldClose = false
 	}
-	if err := sendApprovedReply(ctx, draft, draft.DraftBodyHTML); err != nil {
+	if err := sendDraftReply(ctx, draft, draft.DraftBodyHTML); err != nil {
 		log.Printf("[Autosend] send for ticket %s: %v", draft.TicketNumber, err)
 		postToTicketThread(ctx, draft.TicketNumber,
 			"⚠️ Auto-send failed: "+truncate(err.Error(), 300)+". The draft is still here.")

--- a/api/internal/support/disposition_test.go
+++ b/api/internal/support/disposition_test.go
@@ -2,7 +2,10 @@ package support
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -445,8 +448,11 @@ func TestPauseStopsAPendingTimer(t *testing.T) {
 	if err != nil || d == nil {
 		t.Fatal(err)
 	}
-	if d.Status != "sent" && d.Status != "approved" {
-		t.Errorf("status after an unattended send = %q", d.Status)
+	if d.Status != "sent" {
+		t.Errorf("status after an unattended send = %q, want sent", d.Status)
+	}
+	if d.SentAt == nil {
+		t.Error("sent_at is null after an unattended send; /stats and the digest count the day from it")
 	}
 }
 
@@ -508,5 +514,125 @@ func TestNeverDraftsInResponseToOurOwnMessage(t *testing.T) {
 	}
 	if isOurOwnOutbound(ctx, 0) {
 		t.Error("a missing entry id must not read as our own message")
+	}
+}
+
+// =============================================================================
+// REL-256 — every path that sends a reply records that it sent one
+// =============================================================================
+//
+// markDraftSent used to hang off the email approval-URL path alone, which
+// nobody uses. Both autonomous paths sent replies to real users and left
+// sent_at null, so the numbers REL-249 is measured on read an eight-reply day
+// as an idle one. The send now goes through sendDraftReply, and these pin the
+// two fields it has to leave behind.
+
+// An unattended ask is a reply going out just as much as a send is, but it is
+// still an ask: it keeps its own status, and the digest counts it separately.
+func TestAutonomousAskRecordsSentAtAndStaysAsked(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	t.Setenv("SUPPORT_AUTOSEND", "on")
+	ctx := context.Background()
+
+	original := sendApprovedReply
+	sendApprovedReply = func(context.Context, *SupportDraft, string) error { return nil }
+	t.Cleanup(func() { sendApprovedReply = original })
+
+	id := seedDraft(t, "960001", "bug", dispositionAutoAsk, false)
+	sendDraftNow(ctx, id, "asked")
+
+	d, err := loadSupportDraft(ctx, id)
+	if err != nil || d == nil {
+		t.Fatal(err)
+	}
+	if d.SentAt == nil {
+		t.Error("sent_at is null after an unattended ask; the question did reach the user")
+	}
+	if d.Status != "asked" {
+		t.Errorf("status = %q, want asked: an ask must not be counted as a plain send", d.Status)
+	}
+}
+
+// A failed send records nothing: sent_at is the claim that a user was
+// answered, and it has to stay false when nobody was.
+func TestFailedSendLeavesSentAtNull(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	t.Setenv("SUPPORT_AUTOSEND", "on")
+	ctx := context.Background()
+
+	original := sendApprovedReply
+	sendApprovedReply = func(context.Context, *SupportDraft, string) error {
+		return errors.New("osticket said no")
+	}
+	t.Cleanup(func() { sendApprovedReply = original })
+
+	id := seedDraft(t, "960002", "bug", dispositionAutoSend, false)
+	sendDraftNow(ctx, id, "approved")
+
+	d, _ := loadSupportDraft(ctx, id)
+	if d.SentAt != nil {
+		t.Errorf("sent_at = %v after a failed send", d.SentAt)
+	}
+	if d.Status != "failed" {
+		t.Errorf("status = %q, want failed: the digest counts 'approved' as a reply that went out", d.Status)
+	}
+}
+
+// The backfill reads the shipped migration rather than a copy of it, so the
+// statement under test is the one that runs against production.
+func TestBackfillOnlyTouchesDraftsThatWereSent(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+
+	sql, err := os.ReadFile(filepath.Join("..", "..", "migrations", "000015_support_draft_sent_at.up.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// One draft that went out, one that never did.
+	sentID := seedDraft(t, "960003", "bug", dispositionAutoSend, false)
+	neverID := seedDraft(t, "960004", "bug", dispositionAutoSend, false)
+	testsupport.MustExec(t, `UPDATE support_drafts SET status = 'approved' WHERE id = ANY($1)`,
+		[]int64{sentID, neverID})
+	wentOut := time.Date(2026, 9, 8, 22, 21, 0, 0, time.UTC)
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: "960003", Kind: "sent", BodyHTML: "<p>the reply</p>",
+		AIDraftID: sentID, CreatedAt: wentOut,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	testsupport.MustExec(t, string(sql))
+
+	sent, _ := loadSupportDraft(ctx, sentID)
+	if sent.SentAt == nil || !sent.SentAt.Equal(wentOut) {
+		t.Errorf("sent_at = %v, want the sent message's own timestamp %v", sent.SentAt, wentOut)
+	}
+	if sent.Status != "sent" {
+		t.Errorf("status = %q, want sent", sent.Status)
+	}
+
+	never, _ := loadSupportDraft(ctx, neverID)
+	if never.SentAt != nil {
+		t.Errorf("invented sent_at %v for a draft with no sent message", never.SentAt)
+	}
+	if never.Status != "approved" {
+		t.Errorf("status = %q, want approved: nothing went out, so nothing changed", never.Status)
+	}
+
+	// Idempotent: a second run must not move a timestamp it already wrote.
+	testsupport.MustExec(t, string(sql))
+	again, _ := loadSupportDraft(ctx, sentID)
+	if !again.SentAt.Equal(wentOut) {
+		t.Errorf("second run moved sent_at to %v", again.SentAt)
 	}
 }

--- a/api/internal/support/handlers_discord_interactions.go
+++ b/api/internal/support/handlers_discord_interactions.go
@@ -253,8 +253,8 @@ func handleDiscordSendAction(c *fiber.Ctx, ix *discordInteraction, draftID int64
 	go func() {
 		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer bgCancel()
-		if err := sendApprovedReply(bgCtx, draft, draft.DraftBodyHTML); err != nil {
-			log.Printf("[DiscordInteraction] sendApprovedReply for ticket %s: %v",
+		if err := sendDraftReply(bgCtx, draft, draft.DraftBodyHTML); err != nil {
+			log.Printf("[DiscordInteraction] sendDraftReply for ticket %s: %v",
 				draft.TicketNumber, err)
 			return
 		}
@@ -635,8 +635,8 @@ func handleDiscordModalSubmit(c *fiber.Ctx, ix *discordInteraction) error {
 	go func() {
 		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer bgCancel()
-		if err := sendApprovedReply(bgCtx, draft, editedBodyHTML); err != nil {
-			log.Printf("[DiscordInteraction] sendApprovedReply (edited) for ticket %s: %v",
+		if err := sendDraftReply(bgCtx, draft, editedBodyHTML); err != nil {
+			log.Printf("[DiscordInteraction] sendDraftReply (edited) for ticket %s: %v",
 				draft.TicketNumber, err)
 			return
 		}
@@ -751,7 +751,7 @@ func handleDiscordAskSubmit(c *fiber.Ctx, ix *discordInteraction, draftID int64)
 	go func() {
 		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer bgCancel()
-		if err := sendApprovedReply(bgCtx, draft, questionHTML); err != nil {
+		if err := sendDraftReply(bgCtx, draft, questionHTML); err != nil {
 			log.Printf("[DiscordInteraction] send question for ticket %s: %v", draft.TicketNumber, err)
 			return
 		}
@@ -1243,6 +1243,7 @@ func handleDiscordStatsCommand(c *fiber.Ctx, ix *discordInteraction) error {
 			"approved": "✅",
 			"edited":   "✏️",
 			"skipped":  "⏭️",
+			"asked":    "❓",
 			"sent":     "📨",
 			"failed":   "❌",
 		}

--- a/api/internal/support/handlers_support_approval.go
+++ b/api/internal/support/handlers_support_approval.go
@@ -221,12 +221,10 @@ func HandleSupportEditSubmit(c *fiber.Ctx) error {
 	// not about which surface the person used (REL-249).
 	markIntervened(c.Context(), draft.ID)
 
-	if err := sendApprovedReply(c.Context(), draft, editedBody); err != nil {
-		markDraftFailed(c.Context(), draft.ID)
-		log.Printf("[Approval] sendApprovedReply (edited): %v", err)
+	if err := sendDraftReply(c.Context(), draft, editedBody); err != nil {
+		log.Printf("[Approval] sendDraftReply (edited): %v", err)
 		return errorHTMLResponse(c, fiber.StatusBadGateway, "Failed to send reply")
 	}
-	markDraftSent(c.Context(), draft.ID)
 
 	return successHTMLResponse(c, "Edited reply sent — user will see it threaded into ticket "+draft.TicketNumber+".")
 }
@@ -249,12 +247,10 @@ func handleApprovalAction(c *fiber.Ctx, action string) error {
 			log.Printf("[Approval] markDraftDecided: %v", err)
 			return errorHTMLResponse(c, fiber.StatusInternalServerError, "Failed to save decision")
 		}
-		if err := sendApprovedReply(c.Context(), draft, draft.DraftBodyHTML); err != nil {
-			markDraftFailed(c.Context(), draft.ID)
-			log.Printf("[Approval] sendApprovedReply: %v", err)
+		if err := sendDraftReply(c.Context(), draft, draft.DraftBodyHTML); err != nil {
+			log.Printf("[Approval] sendDraftReply: %v", err)
 			return errorHTMLResponse(c, fiber.StatusBadGateway, "Failed to send reply")
 		}
-		markDraftSent(c.Context(), draft.ID)
 		return successHTMLResponse(c, "Reply sent. The user will see it threaded into ticket "+draft.TicketNumber+".")
 	case "skip":
 		if err := markDraftDecided(c.Context(), draft.ID, "skipped", ""); err != nil {
@@ -328,4 +324,24 @@ var sendApprovedReply = func(ctx context.Context, draft *SupportDraft, body stri
 	_ = draft
 	_ = body
 	return fmt.Errorf("sendApprovedReply not wired (Phase 1D not yet applied)")
+}
+
+// sendDraftReply is the one way a draft's body reaches a user. Every surface
+// goes through it — the approval URLs, the Discord Send/Edit/Ask buttons, and
+// the autonomous sweeper — so that recording the send cannot be attached to
+// one path and forgotten on the others.
+//
+// That is exactly how it went wrong: markDraftSent hung off the approval-URL
+// path alone, which nobody uses, so sent_at was null for every reply the
+// pipeline had ever sent and /stats read a busy day as an idle one (REL-256).
+// markDraftFailed had the same defect and is fixed the same way: a send that
+// failed on a Discord button or in the sweeper used to stay 'approved', and
+// the digest counts 'approved' as a reply that went out.
+func sendDraftReply(ctx context.Context, draft *SupportDraft, body string) error {
+	if err := sendApprovedReply(ctx, draft, body); err != nil {
+		markDraftFailed(ctx, draft.ID)
+		return err
+	}
+	markDraftSent(ctx, draft.ID)
+	return nil
 }

--- a/api/internal/support/support_drafts.go
+++ b/api/internal/support/support_drafts.go
@@ -336,11 +336,27 @@ func markDraftDecided(ctx context.Context, id int64, newStatus string, editedBod
 	return nil
 }
 
-// markDraftSent records that the outbound reply email actually left
-// our gateway. Best-effort — failures here only affect the audit
-// trail, not user-visible behavior.
+// markDraftSent records that the reply actually left our gateway.
+//
+// sent_at is the fact — a reply reached a user — and every send path writes
+// it, because it is how /stats and the digest count a day's work. The status
+// answers a different question: WHICH decision sent the reply. The digest
+// counts 'edited' and 'asked' separately from a plain send, so only an
+// 'approved' draft is promoted to 'sent'; an edited or asked one keeps the
+// status that already tells the truth about it.
+//
+// Best-effort — failures here only affect the audit trail, not the user.
 func markDraftSent(ctx context.Context, id int64) {
-	if _, err := platform.DBPool.Exec(ctx, `UPDATE support_drafts SET status='sent', sent_at=NOW() WHERE id=$1`, id); err != nil {
+	if platform.DBPool == nil {
+		return
+	}
+	const q = `
+		UPDATE support_drafts
+		SET sent_at = NOW(),
+			status = CASE WHEN status = 'approved' THEN 'sent' ELSE status END
+		WHERE id = $1
+	`
+	if _, err := platform.DBPool.Exec(ctx, q, id); err != nil {
 		log.Printf("[Drafts] markDraftSent for %d failed: %v", id, err)
 	}
 }
@@ -349,22 +365,30 @@ func markDraftSent(ctx context.Context, id int64) {
 // and got a hard error from Resend. The partner may need to retry
 // manually inside osTicket.
 func markDraftFailed(ctx context.Context, id int64) {
+	if platform.DBPool == nil {
+		return
+	}
 	if _, err := platform.DBPool.Exec(ctx, `UPDATE support_drafts SET status='failed' WHERE id=$1`, id); err != nil {
 		log.Printf("[Drafts] markDraftFailed for %d failed: %v", id, err)
 	}
 }
 
-// loadLatestSentDraftBody returns the most recent SENT reply we've
-// posted on this ticket. Used by the reply-loop webhook to give the
-// AI continuity (so it doesn't repeat the same suggestion verbatim
-// when the user follows up). Returns "" when no sent draft exists or
-// on any DB error — the triage call still succeeds without it.
+// loadLatestSentDraftBody returns the most recent reply we actually sent on
+// this ticket. Used by the reply-loop webhook to give the AI continuity (so
+// it doesn't repeat the same suggestion verbatim when the user follows up).
+// Returns "" when nothing has been sent or on any DB error — the triage call
+// still succeeds without it.
+//
+// Keyed on sent_at, the record of a reply going out. It used to ask for
+// status='sent', which only the unused email approval-URL path ever wrote, so
+// in practice it always returned "" and the AI never had the continuity this
+// function exists to give it (REL-256).
 func loadLatestSentDraftBody(ctx context.Context, ticketNumber string) string {
 	const q = `
 		SELECT COALESCE(NULLIF(edited_body_html, ''), draft_body_html)
 		FROM support_drafts
-		WHERE ticket_number = $1 AND status = 'sent'
-		ORDER BY sent_at DESC NULLS LAST, id DESC
+		WHERE ticket_number = $1 AND sent_at IS NOT NULL
+		ORDER BY sent_at DESC, id DESC
 		LIMIT 1
 	`
 	var body string

--- a/api/migrations/000015_support_draft_sent_at.down.sql
+++ b/api/migrations/000015_support_draft_sent_at.down.sql
@@ -1,0 +1,9 @@
+-- Reverse the backfill: forget when the reply went out, and put a promoted
+-- draft back on the status it had. Exact today — no row was 'sent' before this
+-- migration ran, so every 'sent' row is one it promoted.
+UPDATE support_drafts d
+SET sent_at = NULL,
+    status  = CASE WHEN d.status = 'sent' THEN 'approved' ELSE d.status END
+FROM support_messages m
+WHERE m.ai_draft_id = d.id
+  AND m.kind = 'sent';

--- a/api/migrations/000015_support_draft_sent_at.up.sql
+++ b/api/migrations/000015_support_draft_sent_at.up.sql
@@ -1,0 +1,24 @@
+-- Backfill support_drafts.sent_at from the reply that actually went out (REL-256).
+--
+-- markDraftSent was only ever called from the email approval-URL path, and
+-- nobody uses that surface: every real reply goes out through a Discord button
+-- or, since REL-249, by itself. So sent_at was null for all 23 replies the
+-- pipeline had sent as of 2026-09-08 — including the eight the bot sent
+-- unattended that day — and /stats read a busy day as an idle one.
+--
+-- The truth is in support_messages: doSendApprovedReply writes a kind='sent'
+-- row with the real body every time osTicket accepts the reply, and a unique
+-- index on (ai_draft_id, kind) means each draft has at most one. A draft with
+-- no such row was never sent and is left exactly as it is.
+--
+-- The status is fixed in the same pass, on the same rule the code now follows:
+-- 'sent' means an approved draft that went out, while 'edited' and 'asked' say
+-- which decision sent it and are counted separately by the digest, so they
+-- keep their status.
+UPDATE support_drafts d
+SET sent_at = m.created_at,
+    status  = CASE WHEN d.status = 'approved' THEN 'sent' ELSE d.status END
+FROM support_messages m
+WHERE m.ai_draft_id = d.id
+  AND m.kind = 'sent'
+  AND d.sent_at IS NULL;


### PR DESCRIPTION
`markDraftSent` was called from the email approval-URL path and nowhere else. Nobody uses that surface — replies go out through a Discord button or, since REL-249, by themselves.

So the scope is wider than the ticket: **not one reply the pipeline has ever sent has a `sent_at`**, going back to the first on 2026-08-18, and `status='sent'` matches no row in the table at all.

```
BEFORE (prod, 2026-09-08)
drafts with a linked kind='sent' message and sent_at IS NULL ....... 23
  by status:  approved 8 · asked 11 · edited 4
last 24 h:  sent messages 14  ·  drafts with sent_at  0
```

## The fix

One function, `sendDraftReply`, that every surface calls — the approval URLs, the Discord Send/Edit/Ask buttons, the autonomous sweeper. It records the outcome, so the bookkeeping can't be attached to one path and forgotten on the others.

- **`sent_at`** is the fact that a reply reached a user. Every path writes it.
- **`status`** stays the answer to a different question — *which* decision sent the reply. The digest counts `edited` and `asked` separately, so only a plain `approved` send is promoted to `sent`; an edited or asked draft keeps the status that already tells the truth.
- **`markDraftFailed`** had the identical defect and is fixed in the same place. A send that failed on a Discord button or in the sweeper used to stay `approved`, and the digest counts `approved` as a reply that went out.

Nothing about what the autonomous path *does* changed — no send, hold, escalation or thread transition is touched.

## The second defect: not reproduced

The comment reported ticket 134740 holding a sent message against a still-`pending` draft. No row in the table is in that state, and no path can produce one — `markDraftDecided` claims the row before the send:

```
pending/skipped/failed drafts WITH a linked sent message ... 0 rows
```

Draft 58 was created at `22:22:14.611` and decided at `22:22:15.636`, with its sent message at `22:22:15.926`. The 22:30 reading caught that one-second window. The five "correct" siblings and 134740 all behaved identically.

Also worth correcting for the REL-249 decision: `/stats` and the digest **don't** read `sent_at` — `/stats` groups by `status` and the digest counts off `decided_at`. What they were actually mis-reporting is that a successful autonomous send rested on `approved`, so the `📨 sent` bucket read zero on a day the bot answered eight people, and a *failed* send was counted by the digest as one that went out.

## Two consequences of the same bug, fixed here

- `loadLatestSentDraftBody` asked for `status='sent'`, which nothing wrote, so it always returned `""` and the reply-loop AI never got the continuity the function exists to give it. It now keys on `sent_at`. **This is the one user-visible change** — the follow-up drafter starts seeing our previous reply, which it never has. Called out rather than buried: after the status fix the old predicate would have begun half-firing anyway (approved sends only, never asks), and a half-firing predicate is worse than a correct one.
- `/stats` rendered `asked` as a bare bullet; the emoji map predates the Ask button.

## Backfill

Migration `000015`, applied at core-api startup like the rest of the chain. It reads `sent_at` from the linked `kind='sent'` message's `created_at` — the row `doSendApprovedReply` writes when osTicket accepts the reply, unique per draft by index — and only where such a message exists. A draft that was never sent is left exactly as it is. Idempotent (`WHERE d.sent_at IS NULL`).

Expected: **23 rows** — 8 `approved` → `sent`, 11 `asked` and 4 `edited` keeping their status, all 23 gaining `sent_at`. Post-deploy numbers go on REL-256.

## Tests

`golang:1.25-alpine` with a Postgres sidecar (Docker Desktop wouldn't start on this box, so the toolchain ran in-cluster). Full module suite green: 10 packages, 0 failures.

- `TestAutonomousAskRecordsSentAtAndStaysAsked` — an unattended ask sets `sent_at` and stays `asked`
- `TestPauseStopsAPendingTimer` — tightened from `sent || approved` to `sent`, plus `sent_at`
- `TestFailedSendLeavesSentAtNull` — a failed send invents no `sent_at` and lands on `failed`
- `TestBackfillOnlyTouchesDraftsThatWereSent` — reads the shipped migration file rather than a copy: a draft with no sent message keeps `sent_at` null and its status, and a second run doesn't move a timestamp it already wrote

Mutation-checked — reverting the one-line `markDraftSent` call fails the first two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
