### PR TITLE
feat(admin): a real admin list, the /admin shell, and an honest overview [REL-260]

### DIFF
--- a/api/core/server.go
+++ b/api/core/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/brandon-relentnet/myscrollr/api/internal/accounts"
+	"github.com/brandon-relentnet/myscrollr/api/internal/admin"
 	"github.com/brandon-relentnet/myscrollr/api/internal/billing"
 	"github.com/brandon-relentnet/myscrollr/api/internal/events"
 	"github.com/brandon-relentnet/myscrollr/api/internal/ingestread"
@@ -221,6 +222,22 @@ func (s *Server) setupRoutes() {
 	s.App.Get("/", s.landingPage)
 
 	// --- Protected Routes ---
+
+	// --- Staff console (REL-260) ---
+	//
+	// Two middlewares, in this order and never fewer: LogtoAuth proves who the
+	// caller is, RequireAdmin proves they are on the admin list. Admin is NOT
+	// derived from super_user or any Stripe plan - super_user is a product tier
+	// other users already hold, and gating staff tooling on it would hand them
+	// every user's email and ticket history.
+	s.App.Get("/admin/me", platform.LogtoAuth, admin.RequireAdmin, admin.HandleWhoAmI)
+	s.App.Get("/admin/overview", platform.LogtoAuth, admin.RequireAdmin, admin.HandleGetOverview)
+	s.App.Get("/admin/accounts", platform.LogtoAuth, admin.RequireAdmin, admin.HandleListAccounts)
+	s.App.Get("/admin/accounts/:sub", platform.LogtoAuth, admin.RequireAdmin, admin.HandleGetAccount)
+	s.App.Get("/admin/admins", platform.LogtoAuth, admin.RequireAdmin, admin.HandleListAdmins)
+	s.App.Post("/admin/admins", platform.LogtoAuth, admin.RequireAdmin, admin.HandleAddAdmin)
+	s.App.Delete("/admin/admins/:id", platform.LogtoAuth, admin.RequireAdmin, admin.HandleRemoveAdmin)
+
 	s.App.Get("/dashboard", platform.LogtoAuth, s.getDashboard)
 
 	// Support

--- a/api/internal/accounts/logto_admin.go
+++ b/api/internal/accounts/logto_admin.go
@@ -434,3 +434,55 @@ func DeleteLogtoUser(logtoSub string) error {
 	log.Printf("[Logto M2M] Deleted user %s", logtoSub)
 	return nil
 }
+
+// LogtoPrimaryEmail returns the Logto-verified primary email for a user.
+//
+// The access token carries an `email` claim (wired via Logto Custom JWT) but
+// no `email_verified`, so the claim alone cannot answer "is this address
+// actually this person's". Logto only sets `primaryEmail` on an address the
+// user has proven they control, which makes the Management API the honest
+// source. RequireAdmin calls this at most once per admin — the sub is pinned
+// on the first match and read from the row thereafter.
+//
+// Returns ("", nil) when the user has no primary email set.
+func LogtoPrimaryEmail(logtoSub string) (string, error) {
+	cfg := getM2MConfig()
+
+	token, err := getM2MToken()
+	if err != nil {
+		return "", err
+	}
+
+	reqURL := fmt.Sprintf("%s/api/users/%s", cfg.Endpoint, logtoSub)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create get user request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: platform.LogtoM2MTokenTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("get user request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("get user returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var user struct {
+		PrimaryEmail string `json:"primaryEmail"`
+		IsSuspended  bool   `json:"isSuspended"`
+	}
+	if err := json.Unmarshal(body, &user); err != nil {
+		return "", fmt.Errorf("decode user: %w", err)
+	}
+	// A suspended account keeps its primaryEmail. Treat it as having none so
+	// suspension revokes staff access too.
+	if user.IsSuspended {
+		return "", nil
+	}
+	return user.PrimaryEmail, nil
+}

--- a/api/internal/admin/auth.go
+++ b/api/internal/admin/auth.go
@@ -1,0 +1,138 @@
+// Package admin is the staff console's server half: who counts as staff,
+// and the read-only views of Scrollr that the /admin dashboard renders.
+//
+// Admin is its own list (`admin_users`), never a subscription tier. See
+// migration 000016 for why `super_user` is not, and must not become, the gate.
+package admin
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/accounts"
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+// lookupVerifiedEmail resolves a user's verified email from their Logto sub.
+// A package var so tests can substitute a stub instead of reaching Logto;
+// production always runs accounts.LogtoPrimaryEmail.
+var lookupVerifiedEmail = accounts.LogtoPrimaryEmail
+
+// adminEmailLocal is the Fiber local holding the acting admin's email, set by
+// RequireAdmin so handlers can attribute writes without a second lookup.
+const adminEmailLocal = "admin_email"
+
+// ActingAdmin returns the email of the admin behind the current request.
+func ActingAdmin(c *fiber.Ctx) string {
+	if email, ok := c.Locals(adminEmailLocal).(string); ok {
+		return email
+	}
+	return ""
+}
+
+func forbidden(c *fiber.Ctx) error {
+	return c.Status(fiber.StatusForbidden).JSON(platform.ErrorResponse{
+		Status: "forbidden",
+		Error:  "Staff access only",
+	})
+}
+
+// Handlers pass context.Background() to the pool rather than c.Context().
+// That is the convention everywhere else in this API, and it is not cosmetic:
+// Fiber's request context is already cancelled by the time a handler under
+// app.Test() reaches the database, so c.Context() turns every query in a test
+// into "context canceled" - which, on an auth check, silently reads as a
+// clean 403 and makes a deny-path test pass for entirely the wrong reason.
+//
+// RequireAdmin gates every /admin route. It runs AFTER platform.LogtoAuth,
+// which has already validated the JWT and put the sub in Locals.
+//
+// Two paths, in this order:
+//
+//  1. The sub is already pinned to an admin row — allow, no external call.
+//     This is every request after the first.
+//  2. No pinned row: ask Logto for this sub's VERIFIED primary email and
+//     claim the matching unpinned row, pinning the sub onto it. This is the
+//     bootstrap, and it happens once per admin.
+//
+// Nothing here reads roles or tier. A `super_user` token that is not on the
+// list gets the same 403 as anyone else — that is the point of the table.
+func RequireAdmin(c *fiber.Ctx) error {
+	sub := platform.GetUserID(c)
+	if sub == "" {
+		// LogtoAuth should have written a 401 already; if the chain is ever
+		// wired without it, fail closed rather than open.
+		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
+			Status: "unauthorized",
+			Error:  "Authentication required",
+		})
+	}
+	if platform.DBPool == nil {
+		return forbidden(c)
+	}
+
+	ctx := context.Background()
+
+	// 1. Pinned sub.
+	var email string
+	err := platform.DBPool.QueryRow(ctx,
+		`UPDATE admin_users SET last_seen_at = now() WHERE logto_sub = $1 RETURNING email`,
+		sub).Scan(&email)
+	if err == nil {
+		c.Locals(adminEmailLocal, email)
+		return c.Next()
+	}
+	if err != pgx.ErrNoRows {
+		log.Printf("[Admin] lookup by sub failed: %v", err)
+		return forbidden(c)
+	}
+
+	// 2. Bootstrap by verified email.
+	verified, lookupErr := lookupVerifiedEmail(sub)
+	if lookupErr != nil {
+		log.Printf("[Admin] verified-email lookup failed for %s: %v", platform.HashUserSub(sub), lookupErr)
+		return forbidden(c)
+	}
+	if strings.TrimSpace(verified) == "" {
+		return forbidden(c)
+	}
+
+	// `logto_sub IS NULL` matters: once a row is pinned, a second account that
+	// later acquires the same address cannot take it over.
+	err = platform.DBPool.QueryRow(ctx,
+		`UPDATE admin_users
+		    SET logto_sub = $1, last_seen_at = now()
+		  WHERE lower(email) = lower($2) AND logto_sub IS NULL
+		RETURNING email`,
+		sub, verified).Scan(&email)
+	if err != nil {
+		if err != pgx.ErrNoRows {
+			log.Printf("[Admin] claim by email failed: %v", err)
+		}
+		return forbidden(c)
+	}
+
+	log.Printf("[Admin] %s claimed by sub %s", email, platform.HashUserSub(sub))
+	c.Locals(adminEmailLocal, email)
+	return c.Next()
+}
+
+// countAdmins returns how many admin rows exist. Used by the delete guard.
+func countAdmins(ctx context.Context) (int, error) {
+	var n int
+	err := platform.DBPool.QueryRow(ctx, `SELECT count(*) FROM admin_users`).Scan(&n)
+	return n, err
+}
+
+// HandleWhoAmI - GET /admin/me
+//
+// The dashboard's gate. RequireAdmin has already decided; reaching this
+// handler at all is the answer, and the email lets the shell show who it
+// thinks you are. Cheapest possible call, so the shell can ask on every load
+// without paying for the Overview queries first.
+func HandleWhoAmI(c *fiber.Ctx) error {
+	return c.JSON(fiber.Map{"email": ActingAdmin(c)})
+}

--- a/api/internal/admin/auth_test.go
+++ b/api/internal/admin/auth_test.go
@@ -1,0 +1,400 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+	"github.com/gofiber/fiber/v2"
+)
+
+// stubAuth stands in for platform.LogtoAuth: it puts on the context exactly
+// what a validated token would, without minting one. That is what lets these
+// tests hand RequireAdmin a token bearing the super_user role.
+func stubAuth(sub string, roles ...string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Locals("user_id", sub)
+		c.Locals("user_roles", roles)
+		return c.Next()
+	}
+}
+
+// adminApp wires the real middleware in front of a sentinel handler. The
+// sentinel is the assertion: if it runs, the request got through.
+func adminApp(auth fiber.Handler, reached *bool) *fiber.App {
+	app := fiber.New()
+	if auth != nil {
+		app.Use(auth)
+	}
+	app.Get("/admin/ping", RequireAdmin, func(c *fiber.Ctx) error {
+		*reached = true
+		return c.JSON(fiber.Map{"admin": ActingAdmin(c)})
+	})
+	return app
+}
+
+// withVerifiedEmail swaps the Logto lookup for a fixed answer.
+func withVerifiedEmail(t *testing.T, sub, email string) {
+	t.Helper()
+	prev := lookupVerifiedEmail
+	lookupVerifiedEmail = func(s string) (string, error) {
+		if s == sub {
+			return email, nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { lookupVerifiedEmail = prev })
+}
+
+func resetAdmins(t *testing.T, seed ...string) {
+	t.Helper()
+	testsupport.MustExec(t, `DELETE FROM admin_users`)
+	for _, email := range seed {
+		testsupport.MustExec(t,
+			`INSERT INTO admin_users (email, added_by) VALUES ($1, 'test')`, email)
+	}
+}
+
+func do(t *testing.T, app *fiber.App, method, path string, body string) (int, string) {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, path, nil)
+	} else {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(raw)
+}
+
+// TestRequireAdminRejectsSuperUserNotOnTheList is the reason REL-260 exists.
+//
+// `super_user` is a PRODUCT tier - an invite-only early-access programme that
+// grants Ultimate caps for free - and other people already hold it. If admin
+// were ever derived from it, every one of those users would get the support
+// console and with it every user's email and ticket history. This test fails
+// the moment anyone reintroduces that shortcut.
+func TestRequireAdminRejectsSuperUserNotOnTheList(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "bch713@pm.me")
+	withVerifiedEmail(t, "sub-superuser", "someone-else@example.com")
+
+	var reached bool
+	app := adminApp(stubAuth("sub-superuser", "super_user", "uplink_ultimate"), &reached)
+
+	status, body := do(t, app, "GET", "/admin/ping", "")
+	if status != fiber.StatusForbidden {
+		t.Fatalf("super_user not on the admin list: got %d, want 403 (body: %s)", status, body)
+	}
+	if reached {
+		t.Fatal("a super_user token that is not on the admin list reached an admin handler")
+	}
+}
+
+// A super_user who IS on the list gets in - but because of the list, not the
+// role. The role is incidental; the row is what grants access.
+func TestRequireAdminAllowsSeededEmail(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "bch713@pm.me")
+	withVerifiedEmail(t, "sub-brandon", "bch713@pm.me")
+
+	var reached bool
+	app := adminApp(stubAuth("sub-brandon"), &reached)
+
+	status, body := do(t, app, "GET", "/admin/ping", "")
+	if status != fiber.StatusOK {
+		t.Fatalf("seeded admin: got %d, want 200 (body: %s)", status, body)
+	}
+	if !reached {
+		t.Fatal("seeded admin did not reach the handler")
+	}
+
+	// The sub must now be pinned, so the next request needs no Logto call.
+	var pinned string
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT coalesce(logto_sub, '') FROM admin_users WHERE lower(email) = 'bch713@pm.me'`).
+		Scan(&pinned); err != nil {
+		t.Fatalf("read pinned sub: %v", err)
+	}
+	if pinned != "sub-brandon" {
+		t.Errorf("logto_sub not pinned on first match: got %q", pinned)
+	}
+}
+
+// Matching on email forever would mean a stranger who later registers a
+// released address inherits staff access. Once a row is pinned, it is pinned.
+func TestRequireAdminRejectsSecondClaimOnAPinnedRow(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t)
+	testsupport.MustExec(t,
+		`INSERT INTO admin_users (email, logto_sub, added_by) VALUES ($1, $2, 'test')`,
+		"bch713@pm.me", "sub-original")
+	withVerifiedEmail(t, "sub-impostor", "bch713@pm.me")
+
+	var reached bool
+	app := adminApp(stubAuth("sub-impostor"), &reached)
+
+	status, _ := do(t, app, "GET", "/admin/ping", "")
+	if status != fiber.StatusForbidden {
+		t.Fatalf("second claim on a pinned row: got %d, want 403", status)
+	}
+	if reached {
+		t.Fatal("a second account with the same address took over a pinned admin row")
+	}
+}
+
+// Email match is case-insensitive: the unique index is on lower(email), and
+// the lookup must agree with it or an admin added as "Bch713@PM.me" would
+// never be able to sign in.
+func TestRequireAdminMatchesEmailCaseInsensitively(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "BCH713@PM.ME")
+	withVerifiedEmail(t, "sub-brandon", "bch713@pm.me")
+
+	var reached bool
+	app := adminApp(stubAuth("sub-brandon"), &reached)
+
+	if status, _ := do(t, app, "GET", "/admin/ping", ""); status != fiber.StatusOK {
+		t.Fatalf("case-insensitive email match: got %d, want 200", status)
+	}
+	if !reached {
+		t.Fatal("case difference blocked a real admin")
+	}
+}
+
+func TestRequireAdminRejectsUnauthenticated(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "bch713@pm.me")
+
+	var reached bool
+	// No auth middleware at all: nothing ever sets user_id.
+	app := adminApp(nil, &reached)
+
+	status, _ := do(t, app, "GET", "/admin/ping", "")
+	if status != fiber.StatusUnauthorized {
+		t.Fatalf("unauthenticated: got %d, want 401", status)
+	}
+	if reached {
+		t.Fatal("an unauthenticated request reached an admin handler")
+	}
+}
+
+// A Logto outage must not become an open door.
+func TestRequireAdminFailsClosedWhenLookupErrors(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "bch713@pm.me")
+
+	prev := lookupVerifiedEmail
+	lookupVerifiedEmail = func(string) (string, error) {
+		return "", errors.New("logto unreachable")
+	}
+	t.Cleanup(func() { lookupVerifiedEmail = prev })
+
+	var reached bool
+	app := adminApp(stubAuth("sub-brandon"), &reached)
+
+	if status, _ := do(t, app, "GET", "/admin/ping", ""); status != fiber.StatusForbidden {
+		t.Fatalf("lookup failure: got %d, want 403", status)
+	}
+	if reached {
+		t.Fatal("a failed verified-email lookup let the request through")
+	}
+}
+
+// --- The two anti-lockout rules ---
+
+// adminCRUDApp mounts the admin management routes behind the real middleware,
+// so these tests exercise the same path a real click takes.
+func adminCRUDApp(sub string) *fiber.App {
+	app := fiber.New()
+	app.Use(stubAuth(sub))
+	app.Get("/admin/admins", RequireAdmin, HandleListAdmins)
+	app.Post("/admin/admins", RequireAdmin, HandleAddAdmin)
+	app.Delete("/admin/admins/:id", RequireAdmin, HandleRemoveAdmin)
+	return app
+}
+
+func adminID(t *testing.T, email string) int64 {
+	t.Helper()
+	var id int64
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT id FROM admin_users WHERE lower(email) = lower($1)`, email).Scan(&id); err != nil {
+		t.Fatalf("read admin id for %s: %v", email, err)
+	}
+	return id
+}
+
+func TestRemoveAdminRefusesTheLastAdmin(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "bch713@pm.me")
+	withVerifiedEmail(t, "sub-brandon", "bch713@pm.me")
+
+	app := adminCRUDApp("sub-brandon")
+	id := adminID(t, "bch713@pm.me")
+
+	status, body := do(t, app, "DELETE", "/admin/admins/"+strconv.FormatInt(id, 10), "")
+	if status != fiber.StatusConflict {
+		t.Fatalf("removing the last admin: got %d, want 409 (body: %s)", status, body)
+	}
+
+	var n int
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM admin_users`).Scan(&n); err != nil {
+		t.Fatalf("count admins: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("admin list emptied: %d rows remain, want 1", n)
+	}
+}
+
+func TestRemoveAdminRefusesSelf(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	// Two admins, so the last-admin rule is not what does the refusing here.
+	resetAdmins(t, "bch713@pm.me", "second@example.com")
+	withVerifiedEmail(t, "sub-brandon", "bch713@pm.me")
+
+	app := adminCRUDApp("sub-brandon")
+	id := adminID(t, "bch713@pm.me")
+
+	status, body := do(t, app, "DELETE", "/admin/admins/"+strconv.FormatInt(id, 10), "")
+	if status != fiber.StatusConflict {
+		t.Fatalf("removing self: got %d, want 409 (body: %s)", status, body)
+	}
+
+	var stillThere bool
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT EXISTS (SELECT 1 FROM admin_users WHERE id = $1)`, id).Scan(&stillThere); err != nil {
+		t.Fatalf("check self row: %v", err)
+	}
+	if !stillThere {
+		t.Fatal("an admin removed their own access")
+	}
+}
+
+// Adding another admin is what makes this manageable without a deploy: the
+// row goes in unpinned, and RequireAdmin claims it on their first sign-in.
+func TestAddAdminGrantsAccessWithoutADeploy(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "bch713@pm.me")
+	withVerifiedEmail(t, "sub-brandon", "bch713@pm.me")
+
+	// Before: the second account is refused.
+	var reached bool
+	second := adminApp(stubAuth("sub-second"), &reached)
+	prev := lookupVerifiedEmail
+	lookupVerifiedEmail = func(s string) (string, error) {
+		switch s {
+		case "sub-brandon":
+			return "bch713@pm.me", nil
+		case "sub-second":
+			return "second@example.com", nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { lookupVerifiedEmail = prev })
+
+	if status, _ := do(t, second, "GET", "/admin/ping", ""); status != fiber.StatusForbidden {
+		t.Fatalf("non-admin before the grant: got %d, want 403", status)
+	}
+
+	// Brandon adds them from the dashboard.
+	app := adminCRUDApp("sub-brandon")
+	status, body := do(t, app, "POST", "/admin/admins",
+		`{"email":"second@example.com","note":"added in a test"}`)
+	if status != fiber.StatusCreated {
+		t.Fatalf("add admin: got %d, want 201 (body: %s)", status, body)
+	}
+
+	// After: the same account gets in, with no restart and no migration.
+	reached = false
+	if status, _ := do(t, second, "GET", "/admin/ping", ""); status != fiber.StatusOK {
+		t.Fatalf("newly added admin: got %d, want 200", status)
+	}
+	if !reached {
+		t.Fatal("a newly added admin could not reach an admin handler")
+	}
+}
+
+func TestAddAdminRejectsDuplicateAndGarbage(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "bch713@pm.me")
+	withVerifiedEmail(t, "sub-brandon", "bch713@pm.me")
+	app := adminCRUDApp("sub-brandon")
+
+	// Case-insensitive duplicate: the unique index is on lower(email).
+	if status, _ := do(t, app, "POST", "/admin/admins", `{"email":"BCH713@pm.me"}`); status != fiber.StatusConflict {
+		t.Errorf("duplicate address: got %d, want 409", status)
+	}
+	if status, _ := do(t, app, "POST", "/admin/admins", `{"email":"not-an-email"}`); status != fiber.StatusBadRequest {
+		t.Errorf("malformed address: got %d, want 400", status)
+	}
+	if status, _ := do(t, app, "POST", "/admin/admins", `{"email":"  "}`); status != fiber.StatusBadRequest {
+		t.Errorf("blank address: got %d, want 400", status)
+	}
+}
+
+// The list marks the caller's own row so the UI can hide a delete button that
+// the server would refuse anyway.
+func TestListAdminsMarksSelf(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAdmins(t, "bch713@pm.me", "second@example.com")
+	withVerifiedEmail(t, "sub-brandon", "bch713@pm.me")
+
+	app := adminCRUDApp("sub-brandon")
+	status, body := do(t, app, "GET", "/admin/admins", "")
+	if status != fiber.StatusOK {
+		t.Fatalf("list admins: got %d, want 200", status)
+	}
+
+	var payload struct {
+		Admins []AdminRow `json:"admins"`
+	}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("decode admins: %v (body: %s)", err, body)
+	}
+	if len(payload.Admins) != 2 {
+		t.Fatalf("got %d admins, want 2", len(payload.Admins))
+	}
+	for _, a := range payload.Admins {
+		want := strings.EqualFold(a.Email, "bch713@pm.me")
+		if a.Self != want {
+			t.Errorf("%s: self=%v, want %v", a.Email, a.Self, want)
+		}
+	}
+}

--- a/api/internal/admin/downloads.go
+++ b/api/internal/admin/downloads.go
@@ -1,0 +1,173 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// Downloads per release, from the GitHub Releases API.
+//
+// This is the closest thing to an install count that actually exists, and the
+// distance between the two is real: a download is one person fetching a file
+// once. It says nothing about whether the app was installed, kept, or ever
+// opened, and one person upgrading through five releases is five downloads.
+// So the field is named downloads, the tile is labelled downloads, and
+// OverviewResponse.Installs separately says installs are not measurable.
+const (
+	releasesURL       = "https://api.github.com/repos/brandon-relentnet/myscrollr/releases?per_page=30"
+	downloadsCacheKey = "scrollr:admin:downloads"
+	downloadsCacheTTL = 15 * time.Minute
+	downloadsTimeout  = 8 * time.Second
+	overviewTimeout   = 15 * time.Second
+)
+
+type DownloadsTile struct {
+	Total    int            `json:"total"`
+	Releases []ReleaseCount `json:"releases"`
+	// Stale marks a response served from cache after a failed refresh, so the
+	// page can say the numbers are older than they look.
+	Stale bool   `json:"stale"`
+	Error string `json:"error,omitempty"`
+}
+
+type ReleaseCount struct {
+	Tag         string `json:"tag"`
+	Name        string `json:"name"`
+	PublishedAt string `json:"published_at"`
+	Downloads   int    `json:"downloads"`
+	Prerelease  bool   `json:"prerelease"`
+}
+
+// githubToken mirrors the lookup in internal/support: optional, and only
+// there to lift the unauthenticated rate limit.
+func githubToken() string {
+	for _, k := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func downloadsTile(ctx context.Context) DownloadsTile {
+	if cached, ok := readDownloadsCache(ctx); ok {
+		return cached
+	}
+
+	tile, err := fetchDownloads(ctx)
+	if err != nil {
+		log.Printf("[Admin] downloads fetch: %v", err)
+		// GitHub rate limits are routine. Rather than blanking the tile, serve
+		// the last good answer and mark it stale.
+		if stale, ok := readDownloadsCache(ctx, true); ok {
+			stale.Stale = true
+			return stale
+		}
+		return DownloadsTile{Error: "GitHub releases are unavailable right now."}
+	}
+
+	writeDownloadsCache(ctx, tile)
+	return tile
+}
+
+func fetchDownloads(ctx context.Context) (DownloadsTile, error) {
+	var tile DownloadsTile
+
+	reqCtx, cancel := context.WithTimeout(ctx, downloadsTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, "GET", releasesURL, nil)
+	if err != nil {
+		return tile, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token := githubToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return tile, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return tile, &githubError{status: resp.StatusCode}
+	}
+
+	var releases []struct {
+		TagName     string `json:"tag_name"`
+		Name        string `json:"name"`
+		PublishedAt string `json:"published_at"`
+		Prerelease  bool   `json:"prerelease"`
+		Assets      []struct {
+			DownloadCount int `json:"download_count"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return tile, err
+	}
+
+	for _, r := range releases {
+		count := 0
+		for _, a := range r.Assets {
+			count += a.DownloadCount
+		}
+		tile.Releases = append(tile.Releases, ReleaseCount{
+			Tag:         r.TagName,
+			Name:        r.Name,
+			PublishedAt: r.PublishedAt,
+			Downloads:   count,
+			Prerelease:  r.Prerelease,
+		})
+		tile.Total += count
+	}
+	return tile, nil
+}
+
+type githubError struct{ status int }
+
+func (e *githubError) Error() string {
+	return "github releases returned " + http.StatusText(e.status)
+}
+
+// readDownloadsCache returns the cached tile. With ignoreTTL the value is
+// returned however old it is, which is what the stale fallback wants.
+func readDownloadsCache(ctx context.Context, ignoreTTL ...bool) (DownloadsTile, bool) {
+	var tile DownloadsTile
+	if platform.Rdb == nil {
+		return tile, false
+	}
+	key := downloadsCacheKey
+	if len(ignoreTTL) > 0 && ignoreTTL[0] {
+		key = downloadsCacheKey + ":last"
+	}
+	raw, err := platform.Rdb.Get(ctx, key).Result()
+	if err != nil || raw == "" {
+		return tile, false
+	}
+	if err := json.Unmarshal([]byte(raw), &tile); err != nil {
+		return DownloadsTile{}, false
+	}
+	return tile, true
+}
+
+func writeDownloadsCache(ctx context.Context, tile DownloadsTile) {
+	if platform.Rdb == nil {
+		return
+	}
+	raw, err := json.Marshal(tile)
+	if err != nil {
+		return
+	}
+	_ = platform.Rdb.Set(ctx, downloadsCacheKey, raw, downloadsCacheTTL).Err()
+	// A second, long-lived copy so a GitHub outage degrades to "these numbers
+	// are stale" instead of "no numbers".
+	_ = platform.Rdb.Set(ctx, downloadsCacheKey+":last", raw, 7*24*time.Hour).Err()
+}

--- a/api/internal/admin/handlers_accounts.go
+++ b/api/internal/admin/handlers_accounts.go
@@ -1,0 +1,229 @@
+package admin
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+// The Users section: read-only, deliberately.
+//
+// Reading another person's email, plan and ticket history is already the most
+// sensitive thing in this dashboard. Editing it is a separate decision with
+// separate consequences, so there is no write path here at all - not a
+// disabled button, not a guarded handler. Nothing to reach.
+//
+// The list is keyed on user_preferences because that is the account row. The
+// email is not stored locally; support_cases is the only table that has one,
+// so a user with no ticket has no email to show and the row says so rather
+// than reaching out to Logto for every row on every page.
+
+const accountsPageSize = 50
+
+type AccountRow struct {
+	LogtoSub      string  `json:"logto_sub"`
+	Email         *string `json:"email"`
+	Plan          string  `json:"plan"`
+	Status        string  `json:"status"`
+	Lifetime      bool    `json:"lifetime"`
+	Widgets       int     `json:"widgets"`
+	OnTicker      int     `json:"on_ticker"`
+	Fantasy       bool    `json:"fantasy"`
+	Tickets       int     `json:"tickets"`
+	CreatedAt     *string `json:"created_at"`
+	UpdatedAt     string  `json:"updated_at"`
+	DeletionState *string `json:"deletion_state"`
+}
+
+// accountsSelect is shared by the list and the detail read so the two can
+// never drift into disagreeing about the same user.
+const accountsSelect = `
+	SELECT p.logto_sub,
+	       (SELECT c.user_email FROM support_cases c
+	         WHERE c.logto_sub = p.logto_sub AND c.user_email IS NOT NULL
+	         ORDER BY c.opened_at DESC LIMIT 1),
+	       coalesce(s.plan, 'free'),
+	       coalesce(s.status, 'none'),
+	       coalesce(s.lifetime, false),
+	       (SELECT count(*) FROM user_widgets w WHERE w.logto_sub = p.logto_sub),
+	       (SELECT count(*) FROM user_widgets w
+	         WHERE w.logto_sub = p.logto_sub AND w.ticker_enabled),
+	       EXISTS (SELECT 1 FROM yahoo_users y WHERE y.logto_sub = p.logto_sub),
+	       (SELECT count(*) FROM support_cases c WHERE c.logto_sub = p.logto_sub),
+	       p.created_at,
+	       p.updated_at,
+	       (SELECT d.status FROM user_deletion_requests d
+	         WHERE d.logto_sub = p.logto_sub ORDER BY d.requested_at DESC LIMIT 1)
+	  FROM user_preferences p
+	  LEFT JOIN stripe_customers s ON s.logto_sub = p.logto_sub`
+
+func scanAccount(row pgx.Row) (AccountRow, error) {
+	var a AccountRow
+	var created *time.Time
+	var updated time.Time
+	err := row.Scan(&a.LogtoSub, &a.Email, &a.Plan, &a.Status, &a.Lifetime,
+		&a.Widgets, &a.OnTicker, &a.Fantasy, &a.Tickets, &created, &updated,
+		&a.DeletionState)
+	if err != nil {
+		return a, err
+	}
+	if created != nil {
+		s := created.UTC().Format(time.RFC3339)
+		a.CreatedAt = &s
+	}
+	a.UpdatedAt = updated.UTC().Format(time.RFC3339)
+	return a, nil
+}
+
+// HandleListAccounts - GET /admin/accounts?q=&page=
+//
+// The search matches the Logto sub or the email on any of the user's support
+// cases. There is no other email anywhere in this database to match against.
+func HandleListAccounts(c *fiber.Ctx) error {
+	query := strings.TrimSpace(c.Query("q"))
+	page, _ := strconv.Atoi(c.Query("page", "0"))
+	if page < 0 {
+		page = 0
+	}
+
+	// An empty q becomes the pattern '%', which LIKE matches against every
+	// row - so one query shape serves both browsing and searching, with no
+	// branch for "no search term".
+	pattern := "%" + strings.ToLower(query) + "%"
+
+	where := `
+		 WHERE (lower(p.logto_sub) LIKE $1
+		    OR EXISTS (SELECT 1 FROM support_cases c
+		                WHERE c.logto_sub = p.logto_sub
+		                  AND lower(c.user_email) LIKE $1))`
+
+	var total int
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM user_preferences p`+where, pattern).Scan(&total); err != nil {
+		log.Printf("[Admin] accounts count: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read accounts",
+		})
+	}
+
+	rows, err := platform.DBPool.Query(context.Background(),
+		accountsSelect+where+` ORDER BY p.updated_at DESC LIMIT $2 OFFSET $3`,
+		pattern, accountsPageSize, page*accountsPageSize)
+	if err != nil {
+		log.Printf("[Admin] accounts list: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read accounts",
+		})
+	}
+	defer rows.Close()
+
+	out := make([]AccountRow, 0, accountsPageSize)
+	for rows.Next() {
+		a, err := scanAccount(rows)
+		if err != nil {
+			log.Printf("[Admin] scan account: %v", err)
+			continue
+		}
+		out = append(out, a)
+	}
+
+	return c.JSON(fiber.Map{
+		"accounts":  out,
+		"total":     total,
+		"page":      page,
+		"page_size": accountsPageSize,
+	})
+}
+
+// AccountDetail is one user's page: the same row as the list, plus what they
+// have configured and every ticket they have opened.
+type AccountDetail struct {
+	Account AccountRow      `json:"account"`
+	Widgets []AccountWidget `json:"widgets"`
+	Cases   []AccountCase   `json:"cases"`
+}
+
+type AccountWidget struct {
+	Type          string `json:"type"`
+	Enabled       bool   `json:"enabled"`
+	TickerEnabled bool   `json:"ticker_enabled"`
+	UpdatedAt     string `json:"updated_at"`
+}
+
+type AccountCase struct {
+	TicketNumber string  `json:"ticket_number"`
+	Subject      string  `json:"subject"`
+	Status       string  `json:"status"`
+	Category     *string `json:"category"`
+	OpenedAt     string  `json:"opened_at"`
+}
+
+// HandleGetAccount - GET /admin/accounts/:sub
+func HandleGetAccount(c *fiber.Ctx) error {
+	sub := c.Params("sub")
+	if sub == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error", Error: "A user id is required",
+		})
+	}
+
+	account, err := scanAccount(platform.DBPool.QueryRow(context.Background(),
+		accountsSelect+` WHERE p.logto_sub = $1`, sub))
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
+				Status: "error", Error: "No such account",
+			})
+		}
+		log.Printf("[Admin] account detail: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read that account",
+		})
+	}
+
+	detail := AccountDetail{
+		Account: account,
+		Widgets: make([]AccountWidget, 0, 8),
+		Cases:   make([]AccountCase, 0, 4),
+	}
+
+	if rows, err := platform.DBPool.Query(context.Background(),
+		`SELECT widget_type, enabled, ticker_enabled, updated_at
+		   FROM user_widgets WHERE logto_sub = $1 ORDER BY widget_type`, sub); err != nil {
+		log.Printf("[Admin] account widgets: %v", err)
+	} else {
+		for rows.Next() {
+			var w AccountWidget
+			var updated time.Time
+			if err := rows.Scan(&w.Type, &w.Enabled, &w.TickerEnabled, &updated); err == nil {
+				w.UpdatedAt = updated.UTC().Format(time.RFC3339)
+				detail.Widgets = append(detail.Widgets, w)
+			}
+		}
+		rows.Close()
+	}
+
+	if rows, err := platform.DBPool.Query(context.Background(),
+		`SELECT ticket_number, subject, status, category, opened_at
+		   FROM support_cases WHERE logto_sub = $1 ORDER BY opened_at DESC LIMIT 50`, sub); err != nil {
+		log.Printf("[Admin] account cases: %v", err)
+	} else {
+		for rows.Next() {
+			var k AccountCase
+			var opened time.Time
+			if err := rows.Scan(&k.TicketNumber, &k.Subject, &k.Status, &k.Category, &opened); err == nil {
+				k.OpenedAt = opened.UTC().Format(time.RFC3339)
+				detail.Cases = append(detail.Cases, k)
+			}
+		}
+		rows.Close()
+	}
+
+	return c.JSON(detail)
+}

--- a/api/internal/admin/handlers_admins.go
+++ b/api/internal/admin/handlers_admins.go
@@ -1,0 +1,183 @@
+package admin
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+// AdminRow is one row of the Admins page. The Logto sub is exposed only as
+// `claimed` — the dashboard needs to know whether the invite has been used,
+// not the identifier itself.
+type AdminRow struct {
+	ID         int64   `json:"id"`
+	Email      string  `json:"email"`
+	Claimed    bool    `json:"claimed"`
+	AddedBy    *string `json:"added_by"`
+	AddedAt    string  `json:"added_at"`
+	LastSeenAt *string `json:"last_seen_at"`
+	Note       *string `json:"note"`
+	Self       bool    `json:"self"`
+}
+
+func rfc3339(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.Format(time.RFC3339)
+	return &s
+}
+
+// HandleListAdmins — GET /admin/admins
+func HandleListAdmins(c *fiber.Ctx) error {
+	rows, err := platform.DBPool.Query(context.Background(),
+		`SELECT id, email, logto_sub IS NOT NULL, added_by, added_at, last_seen_at, note
+		   FROM admin_users
+		  ORDER BY added_at`)
+	if err != nil {
+		log.Printf("[Admin] list admins: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read the admin list",
+		})
+	}
+	defer rows.Close()
+
+	me := ActingAdmin(c)
+	out := make([]AdminRow, 0, 8)
+	for rows.Next() {
+		var r AdminRow
+		var addedAt time.Time
+		var lastSeen *time.Time
+		if err := rows.Scan(&r.ID, &r.Email, &r.Claimed, &r.AddedBy, &addedAt, &lastSeen, &r.Note); err != nil {
+			log.Printf("[Admin] scan admin row: %v", err)
+			continue
+		}
+		r.AddedAt = addedAt.Format(time.RFC3339)
+		r.LastSeenAt = rfc3339(lastSeen)
+		r.Self = strings.EqualFold(r.Email, me)
+		out = append(out, r)
+	}
+	return c.JSON(fiber.Map{"admins": out})
+}
+
+type addAdminBody struct {
+	Email string `json:"email"`
+	Note  string `json:"note"`
+}
+
+// HandleAddAdmin — POST /admin/admins
+//
+// The new admin is stored by email with no sub. RequireAdmin pins their sub
+// the first time they sign in and their Logto-verified address matches, so
+// access is granted without a deploy and without trusting a claim.
+func HandleAddAdmin(c *fiber.Ctx) error {
+	var body addAdminBody
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Invalid request body",
+		})
+	}
+
+	email := strings.TrimSpace(body.Email)
+	// Deliberately shallow: Logto owns real address validation, and the row is
+	// inert until a verified Logto email matches it. This only rejects obvious
+	// nonsense so the list stays readable.
+	if email == "" || !strings.Contains(email, "@") || strings.ContainsAny(email, " \t\r\n") {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error", Error: "A valid email address is required",
+		})
+	}
+
+	var note *string
+	if n := strings.TrimSpace(body.Note); n != "" {
+		note = &n
+	}
+
+	me := ActingAdmin(c)
+	var id int64
+	err := platform.DBPool.QueryRow(context.Background(),
+		`INSERT INTO admin_users (email, added_by, note) VALUES ($1, $2, $3)
+		 ON CONFLICT (lower(email)) DO NOTHING
+		 RETURNING id`,
+		email, me, note).Scan(&id)
+	if err == pgx.ErrNoRows {
+		return c.Status(fiber.StatusConflict).JSON(platform.ErrorResponse{
+			Status: "error", Error: "That address is already an admin",
+		})
+	}
+	if err != nil {
+		log.Printf("[Admin] add admin: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not add that admin",
+		})
+	}
+
+	log.Printf("[Admin] GRANT %s added by %s", email, me)
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"status": "ok", "id": id})
+}
+
+// HandleRemoveAdmin — DELETE /admin/admins/:id
+//
+// Two refusals, and they are the whole reason this endpoint is safe to ship:
+// the last admin cannot be removed, and nobody can remove themselves. Between
+// them there is no sequence of clicks that ends with an empty list or with the
+// only signed-in admin locked out.
+func HandleRemoveAdmin(c *fiber.Ctx) error {
+	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Invalid admin id",
+		})
+	}
+
+	ctx := context.Background()
+	total, err := countAdmins(ctx)
+	if err != nil {
+		log.Printf("[Admin] count admins: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read the admin list",
+		})
+	}
+	if total <= 1 {
+		return c.Status(fiber.StatusConflict).JSON(platform.ErrorResponse{
+			Status: "error", Error: "The last admin cannot be removed",
+		})
+	}
+
+	var email string
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT email FROM admin_users WHERE id = $1`, id).Scan(&email); err != nil {
+		if err == pgx.ErrNoRows {
+			return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
+				Status: "error", Error: "No such admin",
+			})
+		}
+		log.Printf("[Admin] read admin %d: %v", id, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read that admin",
+		})
+	}
+
+	me := ActingAdmin(c)
+	if strings.EqualFold(email, me) {
+		return c.Status(fiber.StatusConflict).JSON(platform.ErrorResponse{
+			Status: "error", Error: "You cannot remove your own admin access",
+		})
+	}
+
+	if _, err := platform.DBPool.Exec(ctx, `DELETE FROM admin_users WHERE id = $1`, id); err != nil {
+		log.Printf("[Admin] remove admin %d: %v", id, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not remove that admin",
+		})
+	}
+
+	log.Printf("[Admin] REVOKE %s removed by %s", email, me)
+	return c.JSON(fiber.Map{"status": "ok"})
+}

--- a/api/internal/admin/handlers_overview.go
+++ b/api/internal/admin/handlers_overview.go
@@ -1,0 +1,322 @@
+package admin
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/events"
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+)
+
+// The Overview is the "everything about Scrollr in one spot" page. Its hard
+// rule: a tile shows a number we actually have, or it says it cannot be
+// measured. It never estimates and then presents the estimate as a
+// measurement.
+//
+// The number people always want here is active installs. There is no
+// telemetry or analytics anywhere in this API - a standing decision, not an
+// oversight - so installs are NOT measurable, and the Installs tile exists
+// purely to say so and point at downloads instead.
+
+// Measured wraps a number with whether it means what its label says. When
+// Available is false the client renders Note instead of Value.
+type Measured struct {
+	Value     int    `json:"value"`
+	Available bool   `json:"available"`
+	Note      string `json:"note,omitempty"`
+}
+
+type OverviewResponse struct {
+	GeneratedAt  string        `json:"generated_at"`
+	Accounts     AccountsTile  `json:"accounts"`
+	Plans        PlansTile     `json:"plans"`
+	Downloads    DownloadsTile `json:"downloads"`
+	Installs     Measured      `json:"installs"`
+	ConnectedNow ConnectedTile `json:"connected_now"`
+	Support      SupportTile   `json:"support"`
+	Demand       DemandTile    `json:"demand"`
+	Ingest       []IngestRow   `json:"ingest"`
+}
+
+// AccountsTile counts rows in user_preferences - the row created the first
+// time an account reads its preferences, and therefore the account itself.
+//
+// created_at was only added in migration 000016 and deliberately not
+// backfilled, so accounts that predate it have no signup date. Untracked is
+// how many, and TrackingSince is when the honest series starts.
+type AccountsTile struct {
+	Total         int          `json:"total"`
+	New7d         Measured     `json:"new_7d"`
+	New30d        Measured     `json:"new_30d"`
+	Untracked     int          `json:"untracked"`
+	TrackingSince string       `json:"tracking_since,omitempty"`
+	Daily         []DailyCount `json:"daily"`
+}
+
+type DailyCount struct {
+	Day   string `json:"day"`
+	Count int    `json:"count"`
+}
+
+// PlansTile is the mix from stripe_customers. Accounts with no Stripe row
+// have never started a checkout, so they are free - counted here rather than
+// dropped, or the mix would not add up to the account total.
+type PlansTile struct {
+	Free int       `json:"free"`
+	Rows []PlanRow `json:"rows"`
+}
+
+type PlanRow struct {
+	Plan     string `json:"plan"`
+	Status   string `json:"status"`
+	Lifetime bool   `json:"lifetime"`
+	Count    int    `json:"count"`
+}
+
+// ConnectedTile carries Replicas alongside Count on purpose: the count is a
+// sum over the replicas that reported, and a reader who cannot see how many
+// reported cannot tell a real dip from half the fleet going quiet.
+type ConnectedTile struct {
+	Count    int `json:"count"`
+	Replicas int `json:"replicas"`
+}
+
+type SupportTile struct {
+	OpenCases        int    `json:"open_cases"`
+	PendingDrafts    int    `json:"pending_drafts"`
+	AutoSent30d      int    `json:"auto_sent_30d"`
+	Intervened30d    int    `json:"intervened_30d"`
+	OldestOpenHours  int    `json:"oldest_open_hours"`
+	OldestOpenTicket string `json:"oldest_open_ticket,omitempty"`
+}
+
+type DemandTile struct {
+	CatalogRequests []CatalogRequestRow `json:"catalog_requests"`
+	BusinessLeads   int                 `json:"business_leads"`
+	LeadsUnreplied  int                 `json:"leads_unreplied"`
+}
+
+type CatalogRequestRow struct {
+	Query  string `json:"query"`
+	People int    `json:"people"`
+}
+
+// IngestRow answers "is this content still arriving". AgeSeconds is how long
+// ago the freshest row in the table was written.
+type IngestRow struct {
+	Table      string `json:"table"`
+	LastUpdate string `json:"last_update,omitempty"`
+	AgeSeconds int    `json:"age_seconds"`
+	HasData    bool   `json:"has_data"`
+}
+
+// HandleGetOverview - GET /admin/overview
+//
+// Every section is independent, so they run concurrently and a failure in one
+// leaves the rest of the page intact: a broken tile must not blank the page
+// that tells you what is broken.
+func HandleGetOverview(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(context.Background(), overviewTimeout)
+	defer cancel()
+
+	out := OverviewResponse{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Installs: Measured{
+			Available: false,
+			Note: "Not measurable. Scrollr ships no telemetry or analytics, by " +
+				"decision - nothing reports back that an install exists or is " +
+				"running. Downloads per release is the honest proxy.",
+		},
+	}
+
+	var wg sync.WaitGroup
+	run := func(name string, fn func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[Admin] overview section %s panicked: %v", name, r)
+				}
+			}()
+			fn()
+		}()
+	}
+
+	run("accounts", func() { out.Accounts = accountsTile(ctx) })
+	run("plans", func() { out.Plans = plansTile(ctx) })
+	run("downloads", func() { out.Downloads = downloadsTile(ctx) })
+	run("support", func() { out.Support = supportTile(ctx) })
+	run("demand", func() { out.Demand = demandTile(ctx) })
+	run("ingest", func() { out.Ingest = ingestRows(ctx) })
+	run("connected", func() {
+		count, replicas := events.FleetClientCount(ctx)
+		out.ConnectedNow = ConnectedTile{Count: count, Replicas: replicas}
+	})
+
+	wg.Wait()
+	return c.JSON(out)
+}
+
+func accountsTile(ctx context.Context) AccountsTile {
+	var t AccountsTile
+	var since *time.Time
+	err := platform.DBPool.QueryRow(ctx, `
+		SELECT count(*),
+		       count(*) FILTER (WHERE created_at IS NULL),
+		       count(*) FILTER (WHERE created_at >= now() - interval '7 days'),
+		       count(*) FILTER (WHERE created_at >= now() - interval '30 days'),
+		       min(created_at)
+		  FROM user_preferences`).
+		Scan(&t.Total, &t.Untracked, &t.New7d.Value, &t.New30d.Value, &since)
+	if err != nil {
+		log.Printf("[Admin] accounts tile: %v", err)
+		return t
+	}
+
+	// The windows only mean anything once tracking has been running. Before
+	// the first dated row exists, "0 new this week" would read as a fact about
+	// signups when it is only a fact about the column's age.
+	if since == nil {
+		note := "No signup dates recorded yet - tracking began with this release."
+		t.New7d = Measured{Available: false, Note: note}
+		t.New30d = Measured{Available: false, Note: note}
+		return t
+	}
+	t.TrackingSince = since.UTC().Format(time.RFC3339)
+	t.New7d.Available, t.New30d.Available = true, true
+
+	rows, err := platform.DBPool.Query(ctx, `
+		SELECT to_char(date_trunc('day', created_at), 'YYYY-MM-DD'), count(*)
+		  FROM user_preferences
+		 WHERE created_at >= now() - interval '30 days'
+		 GROUP BY 1 ORDER BY 1`)
+	if err != nil {
+		log.Printf("[Admin] accounts daily: %v", err)
+		return t
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var d DailyCount
+		if err := rows.Scan(&d.Day, &d.Count); err == nil {
+			t.Daily = append(t.Daily, d)
+		}
+	}
+	return t
+}
+
+func plansTile(ctx context.Context) PlansTile {
+	var t PlansTile
+	rows, err := platform.DBPool.Query(ctx, `
+		SELECT plan, status, lifetime, count(*)
+		  FROM stripe_customers
+		 GROUP BY 1, 2, 3
+		 ORDER BY 4 DESC`)
+	if err != nil {
+		log.Printf("[Admin] plans tile: %v", err)
+	} else {
+		for rows.Next() {
+			var r PlanRow
+			if err := rows.Scan(&r.Plan, &r.Status, &r.Lifetime, &r.Count); err == nil {
+				t.Rows = append(t.Rows, r)
+			}
+		}
+		rows.Close()
+	}
+
+	if err := platform.DBPool.QueryRow(ctx, `
+		SELECT count(*) FROM user_preferences p
+		 WHERE NOT EXISTS (SELECT 1 FROM stripe_customers s WHERE s.logto_sub = p.logto_sub)`).
+		Scan(&t.Free); err != nil {
+		log.Printf("[Admin] plans free count: %v", err)
+	}
+	return t
+}
+
+func supportTile(ctx context.Context) SupportTile {
+	var t SupportTile
+	var oldest *time.Time
+	var ticket *string
+
+	if err := platform.DBPool.QueryRow(ctx, `
+		SELECT count(*) FILTER (WHERE status <> 'closed'),
+		       min(opened_at) FILTER (WHERE status <> 'closed'),
+		       (SELECT ticket_number FROM support_cases
+		         WHERE status <> 'closed' ORDER BY opened_at LIMIT 1)
+		  FROM support_cases`).Scan(&t.OpenCases, &oldest, &ticket); err != nil {
+		log.Printf("[Admin] support cases: %v", err)
+	}
+	if oldest != nil {
+		t.OldestOpenHours = int(time.Since(*oldest).Hours())
+	}
+	if ticket != nil {
+		t.OldestOpenTicket = *ticket
+	}
+
+	if err := platform.DBPool.QueryRow(ctx, `
+		SELECT count(*) FILTER (WHERE status = 'pending'),
+		       count(*) FILTER (WHERE status = 'sent'
+		                          AND disposition = 'auto_send'
+		                          AND created_at >= now() - interval '30 days'),
+		       count(*) FILTER (WHERE intervened
+		                          AND created_at >= now() - interval '30 days')
+		  FROM support_drafts`).
+		Scan(&t.PendingDrafts, &t.AutoSent30d, &t.Intervened30d); err != nil {
+		log.Printf("[Admin] support drafts: %v", err)
+	}
+	return t
+}
+
+func demandTile(ctx context.Context) DemandTile {
+	var t DemandTile
+	rows, err := platform.DBPool.Query(ctx, `
+		SELECT query, count(*) FROM catalog_requests
+		 GROUP BY 1 ORDER BY 2 DESC, 1 LIMIT 10`)
+	if err != nil {
+		log.Printf("[Admin] catalog requests: %v", err)
+	} else {
+		for rows.Next() {
+			var r CatalogRequestRow
+			if err := rows.Scan(&r.Query, &r.People); err == nil {
+				t.CatalogRequests = append(t.CatalogRequests, r)
+			}
+		}
+		rows.Close()
+	}
+
+	if err := platform.DBPool.QueryRow(ctx, `
+		SELECT count(*), count(*) FILTER (WHERE replied_at IS NULL)
+		  FROM business_leads`).Scan(&t.BusinessLeads, &t.LeadsUnreplied); err != nil {
+		log.Printf("[Admin] business leads: %v", err)
+	}
+	return t
+}
+
+// ingestTables are the content tables whose freshness says whether the
+// product still has anything to show. All four carry updated_at.
+var ingestTables = []string{"games", "trades", "markets", "rss_items"}
+
+func ingestRows(ctx context.Context) []IngestRow {
+	out := make([]IngestRow, 0, len(ingestTables))
+	for _, table := range ingestTables {
+		row := IngestRow{Table: table}
+		var last *time.Time
+		// The table name comes from the constant slice above, never from input.
+		if err := platform.DBPool.QueryRow(ctx,
+			"SELECT max(updated_at) FROM "+table).Scan(&last); err != nil {
+			log.Printf("[Admin] ingest %s: %v", table, err)
+			out = append(out, row)
+			continue
+		}
+		if last != nil {
+			row.HasData = true
+			row.LastUpdate = last.UTC().Format(time.RFC3339)
+			row.AgeSeconds = int(time.Since(*last).Seconds())
+		}
+		out = append(out, row)
+	}
+	return out
+}

--- a/api/internal/admin/main_test.go
+++ b/api/internal/admin/main_test.go
@@ -1,0 +1,14 @@
+package admin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+)
+
+// TestMain switches this package into integration mode when
+// TEST_DATABASE_URL is set. See testsupport.Main for what that entails.
+func TestMain(m *testing.M) {
+	os.Exit(testsupport.Main(m))
+}

--- a/api/internal/events/events.go
+++ b/api/internal/events/events.go
@@ -170,6 +170,10 @@ func InitHub(ctx context.Context) {
 
 	go globalHub.listenToTopics(ctx)
 
+	// Heartbeat this replica's SSE client count so an admin read can sum the
+	// fleet instead of reporting one pod's share as the whole (fleet_count.go).
+	go publishFleetCount(ctx)
+
 	// Shutdown watcher
 	go func() {
 		<-ctx.Done()

--- a/api/internal/events/fleet_count.go
+++ b/api/internal/events/fleet_count.go
@@ -1,0 +1,126 @@
+package events
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// ClientCount() is per-replica, and core-api runs two (k8s/core-api.yaml).
+// Reading it from a request gives you whichever pod the load balancer picked,
+// so "connected now" silently reports about half the fleet — the failure is
+// invisible because the number still looks plausible.
+//
+// Each replica therefore heartbeats its own count into one Redis hash keyed by
+// pod name, and a reader sums the fields that are still fresh. One key, one
+// round trip, and a pod that dies ages out instead of inflating the total
+// forever.
+const (
+	fleetCountKey      = "scrollr:sse:fleet_counts"
+	fleetCountInterval = 10 * time.Second
+	// A field older than this belongs to a replica that stopped reporting.
+	fleetCountStale = 45 * time.Second
+)
+
+// replicaName identifies this pod. Kubernetes sets HOSTNAME to the pod name.
+func replicaName() string {
+	if h := os.Getenv("HOSTNAME"); h != "" {
+		return h
+	}
+	return "unknown"
+}
+
+// publishFleetCount heartbeats this replica's SSE client count until ctx ends.
+func publishFleetCount(ctx context.Context) {
+	name := replicaName()
+	ticker := time.NewTicker(fleetCountInterval)
+	defer ticker.Stop()
+
+	write := func() {
+		if platform.Rdb == nil {
+			return
+		}
+		value := strconv.Itoa(ClientCount()) + ":" + strconv.FormatInt(time.Now().Unix(), 10)
+		if err := platform.Rdb.HSet(ctx, fleetCountKey, name, value).Err(); err != nil {
+			log.Printf("[EventHub] fleet count heartbeat failed: %v", err)
+		}
+	}
+
+	write() // publish immediately so a fresh pod isn't invisible for 10s
+	for {
+		select {
+		case <-ctx.Done():
+			// Drop this replica's field on the way out rather than leaving a
+			// stale count for the reader to age out.
+			if platform.Rdb != nil {
+				_ = platform.Rdb.HDel(context.Background(), fleetCountKey, name).Err()
+			}
+			return
+		case <-ticker.C:
+			write()
+		}
+	}
+}
+
+// FleetClientCount sums the SSE client counts every live replica reported,
+// and returns how many replicas contributed. A caller showing the number must
+// show the replica count too: one replica reporting when two are running means
+// the total is understated, and the reader deserves to see that.
+//
+// Falls back to this replica's own count (and 1) when Redis is unavailable.
+func FleetClientCount(ctx context.Context) (total int, replicas int) {
+	if platform.Rdb == nil {
+		return ClientCount(), 1
+	}
+
+	fields, err := platform.Rdb.HGetAll(ctx, fleetCountKey).Result()
+	if err != nil {
+		log.Printf("[EventHub] fleet count read failed: %v", err)
+		return ClientCount(), 1
+	}
+
+	cutoff := time.Now().Add(-fleetCountStale).Unix()
+	var stale []string
+	for name, value := range fields {
+		count, at, ok := parseFleetField(value)
+		if !ok || at < cutoff {
+			stale = append(stale, name)
+			continue
+		}
+		total += count
+		replicas++
+	}
+
+	// Self-cleaning: a replica that was scaled down stops being counted above
+	// and stops occupying the hash here.
+	if len(stale) > 0 {
+		_ = platform.Rdb.HDel(ctx, fleetCountKey, stale...).Err()
+	}
+
+	if replicas == 0 {
+		return ClientCount(), 1
+	}
+	return total, replicas
+}
+
+// parseFleetField splits a "<count>:<unix>" heartbeat value.
+func parseFleetField(value string) (count int, at int64, ok bool) {
+	sep := strings.LastIndex(value, ":")
+	if sep < 0 {
+		return 0, 0, false
+	}
+	count, err := strconv.Atoi(value[:sep])
+	if err != nil {
+		return 0, 0, false
+	}
+	at, err = strconv.ParseInt(value[sep+1:], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return count, at, true
+}

--- a/api/migrations/000016_admin_users.down.sql
+++ b/api/migrations/000016_admin_users.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS user_preferences_created_at_idx;
+ALTER TABLE user_preferences DROP COLUMN IF EXISTS created_at;
+DROP TABLE IF EXISTS admin_users;

--- a/api/migrations/000016_admin_users.up.sql
+++ b/api/migrations/000016_admin_users.up.sql
@@ -1,0 +1,50 @@
+-- Staff access, as its own list (REL-260).
+--
+-- Admin is NOT a subscription tier. `super_user` is a product tier — an
+-- invite-only early-access programme granting Ultimate caps free — and other
+-- people already hold it. Deriving staff tooling from it would hand every
+-- user's email and ticket history to those people. So: an explicit list,
+-- seeded with exactly one row, extended from the dashboard itself.
+--
+-- `logto_sub` is pinned on the first successful match and used thereafter.
+-- Matching on email forever would mean a later email change locks the owner
+-- out, and a re-registered address lets a stranger in; matching on sub after
+-- the bootstrap closes both.
+--
+-- Email is `text` with a functional unique index rather than `citext`: the
+-- extension is not installed in this database and CREATE EXTENSION needs a
+-- privilege the migration runner is not guaranteed to have. lower(email)
+-- gives the same case-insensitive uniqueness with no privilege at all.
+
+CREATE TABLE admin_users (
+    id           bigserial PRIMARY KEY,
+    email        text NOT NULL,
+    logto_sub    text UNIQUE,
+    added_by     text,
+    added_at     timestamp with time zone NOT NULL DEFAULT now(),
+    last_seen_at timestamp with time zone,
+    note         text
+);
+
+CREATE UNIQUE INDEX admin_users_email_idx ON admin_users (lower(email));
+
+INSERT INTO admin_users (email, added_by, note)
+VALUES ('bch713@pm.me', 'migration 000016', 'Seeded by REL-260. Every other admin is added from the dashboard.');
+
+-- Signups over time.
+--
+-- The Overview page wants "new accounts per day". `user_preferences` is the
+-- account row (accounts/preferences.go creates it on first read) but has only
+-- `updated_at`, which every preference write moves — it cannot answer "when
+-- did this account appear".
+--
+-- Added nullable and deliberately NOT backfilled. A backfill would have to
+-- invent a date for all existing rows, and a dashboard that invents numbers
+-- is the exact thing REL-260 exists to avoid. NULL means "predates tracking",
+-- and the tile says so.
+ALTER TABLE user_preferences ADD COLUMN IF NOT EXISTS created_at timestamp with time zone;
+
+ALTER TABLE user_preferences ALTER COLUMN created_at SET DEFAULT now();
+
+CREATE INDEX user_preferences_created_at_idx ON user_preferences (created_at)
+    WHERE created_at IS NOT NULL;

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -1,0 +1,247 @@
+/**
+ * Staff console API client (REL-260).
+ *
+ * Deliberately its own module rather than another section of `client.ts`:
+ * `client.ts` is imported by marketing routes, so anything added there ships
+ * to every visitor. Nothing here is reachable except from the lazily-loaded
+ * `/admin` chunk.
+ *
+ * The API gate is the real boundary — every endpoint below is behind
+ * `LogtoAuth + RequireAdmin` and returns 403 to anyone not on the admin list.
+ * Keeping the code out of the public bundle is about not shipping internal UI
+ * to visitors, not about security.
+ */
+
+import { API_BASE } from '@/api/client'
+
+/** An API error that kept its status code, so 403 can be told from 500. */
+export class AdminApiError extends Error {
+  status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'AdminApiError'
+    this.status = status
+  }
+}
+
+async function adminFetch<T>(
+  path: string,
+  getToken: () => Promise<string | null>,
+  options: RequestInit = {},
+): Promise<T> {
+  const token = await getToken()
+  const headers: Record<string, string> = {
+    ...((options.headers as Record<string, string> | undefined) ?? {}),
+  }
+  if (token) headers.Authorization = `Bearer ${token}`
+  if (options.body) headers['Content-Type'] = 'application/json'
+
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers,
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    const body = await response
+      .json()
+      .catch(() => ({ error: 'Request failed' }))
+    throw new AdminApiError(body.error || 'Request failed', response.status)
+  }
+  // DELETE returns a body, but guard anyway so a 204 never explodes.
+  return response.status === 204 ? (undefined as T) : response.json()
+}
+
+// ── Overview ──────────────────────────────────────────────────────
+
+/**
+ * A number plus whether it means what its label says. `available: false` is
+ * not an error — it is the dashboard admitting the number does not exist.
+ */
+export interface Measured {
+  value: number
+  available: boolean
+  note?: string
+}
+
+export interface DailyCount {
+  day: string
+  count: number
+}
+
+export interface AccountsTile {
+  total: number
+  new_7d: Measured
+  new_30d: Measured
+  untracked: number
+  tracking_since?: string
+  daily: Array<DailyCount> | null
+}
+
+export interface PlanRow {
+  plan: string
+  status: string
+  lifetime: boolean
+  count: number
+}
+
+export interface PlansTile {
+  free: number
+  rows: Array<PlanRow> | null
+}
+
+export interface ReleaseCount {
+  tag: string
+  name: string
+  published_at: string
+  downloads: number
+  prerelease: boolean
+}
+
+export interface DownloadsTile {
+  total: number
+  releases: Array<ReleaseCount> | null
+  stale: boolean
+  error?: string
+}
+
+export interface ConnectedTile {
+  count: number
+  /** How many core-api replicas reported. See the tile's own caveat. */
+  replicas: number
+}
+
+export interface SupportTile {
+  open_cases: number
+  pending_drafts: number
+  auto_sent_30d: number
+  intervened_30d: number
+  oldest_open_hours: number
+  oldest_open_ticket?: string
+}
+
+export interface CatalogRequestRow {
+  query: string
+  people: number
+}
+
+export interface DemandTile {
+  catalog_requests: Array<CatalogRequestRow> | null
+  business_leads: number
+  leads_unreplied: number
+}
+
+export interface IngestRow {
+  table: string
+  last_update?: string
+  age_seconds: number
+  has_data: boolean
+}
+
+export interface AdminOverview {
+  generated_at: string
+  accounts: AccountsTile
+  plans: PlansTile
+  downloads: DownloadsTile
+  installs: Measured
+  connected_now: ConnectedTile
+  support: SupportTile
+  demand: DemandTile
+  ingest: Array<IngestRow> | null
+}
+
+// ── Accounts (read-only) ──────────────────────────────────────────
+
+export interface AccountRow {
+  logto_sub: string
+  email: string | null
+  plan: string
+  status: string
+  lifetime: boolean
+  widgets: number
+  on_ticker: number
+  fantasy: boolean
+  tickets: number
+  created_at: string | null
+  updated_at: string
+  deletion_state: string | null
+}
+
+export interface AccountsPage {
+  accounts: Array<AccountRow>
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface AccountWidget {
+  type: string
+  enabled: boolean
+  ticker_enabled: boolean
+  updated_at: string
+}
+
+export interface AccountCase {
+  ticket_number: string
+  subject: string
+  status: string
+  category: string | null
+  opened_at: string
+}
+
+export interface AccountDetail {
+  account: AccountRow
+  widgets: Array<AccountWidget>
+  cases: Array<AccountCase>
+}
+
+// ── Admins ────────────────────────────────────────────────────────
+
+export interface AdminRow {
+  id: number
+  email: string
+  /** True once this admin has signed in and their Logto sub was pinned. */
+  claimed: boolean
+  added_by: string | null
+  added_at: string
+  last_seen_at: string | null
+  note: string | null
+  /** True for the row belonging to the signed-in admin. Cannot be removed. */
+  self: boolean
+}
+
+type Token = () => Promise<string | null>
+
+export const adminApi = {
+  /** The gate. Resolves with the acting admin's email, or throws 403. */
+  me: (getToken: Token) => adminFetch<{ email: string }>('/admin/me', getToken),
+
+  overview: (getToken: Token) =>
+    adminFetch<AdminOverview>('/admin/overview', getToken),
+
+  accounts: (getToken: Token, query: string, page: number) =>
+    adminFetch<AccountsPage>(
+      `/admin/accounts?q=${encodeURIComponent(query)}&page=${page}`,
+      getToken,
+    ),
+
+  account: (getToken: Token, sub: string) =>
+    adminFetch<AccountDetail>(
+      `/admin/accounts/${encodeURIComponent(sub)}`,
+      getToken,
+    ),
+
+  admins: (getToken: Token) =>
+    adminFetch<{ admins: Array<AdminRow> }>('/admin/admins', getToken),
+
+  addAdmin: (getToken: Token, email: string, note: string) =>
+    adminFetch<{ status: string; id: number }>('/admin/admins', getToken, {
+      method: 'POST',
+      body: JSON.stringify({ email, note }),
+    }),
+
+  removeAdmin: (getToken: Token, id: number) =>
+    adminFetch<{ status: string }>(`/admin/admins/${id}`, getToken, {
+      method: 'DELETE',
+    }),
+}

--- a/myscrollr.com/src/components/admin/AdminShell.tsx
+++ b/myscrollr.com/src/components/admin/AdminShell.tsx
@@ -1,0 +1,184 @@
+import { Link, Outlet, useLocation } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import {
+  BarChart3,
+  LifeBuoy,
+  Loader2,
+  Lock,
+  ShieldCheck,
+  Users,
+} from 'lucide-react'
+import { AdminApiError, adminApi } from '@/api/admin'
+import { useGetToken } from '@/hooks/useGetToken'
+import { useScrollrAuth } from '@/hooks/useScrollrAuth'
+
+/**
+ * The staff console shell: one gate, one nav, one Outlet.
+ *
+ * The gate is a single `GET /admin/me`. The server has already decided by the
+ * time it answers, so the client never reasons about tiers or roles — it only
+ * reports what the API said. A non-admin gets a plain "staff only" page,
+ * which is a correct outcome rather than a broken one.
+ */
+
+const SECTIONS = [
+  { to: '/admin', label: 'Overview', Icon: BarChart3, exact: true },
+  { to: '/admin/support', label: 'Support', Icon: LifeBuoy },
+  { to: '/admin/users', label: 'Users', Icon: Users },
+  { to: '/admin/admins', label: 'Admins', Icon: ShieldCheck },
+] as const
+
+type GateState =
+  | { kind: 'checking' }
+  | { kind: 'allowed'; email: string }
+  | { kind: 'denied' }
+  | { kind: 'signed-out' }
+  | { kind: 'error'; message: string }
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 py-24 text-center">
+      {children}
+    </div>
+  )
+}
+
+export default function AdminShell() {
+  const { isAuthenticated, isLoading, signIn } = useScrollrAuth()
+  const getToken = useGetToken()
+  const location = useLocation()
+  const [gate, setGate] = useState<GateState>({ kind: 'checking' })
+
+  useEffect(() => {
+    if (isLoading) return
+    if (!isAuthenticated) {
+      setGate({ kind: 'signed-out' })
+      return
+    }
+    let cancelled = false
+    adminApi
+      .me(getToken)
+      .then((res) => {
+        if (!cancelled) setGate({ kind: 'allowed', email: res.email })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        // 403 is not a failure — it is the answer for everyone who is not
+        // staff, and it gets the plain page rather than an error page.
+        if (err instanceof AdminApiError && err.status === 403) {
+          setGate({ kind: 'denied' })
+          return
+        }
+        setGate({
+          kind: 'error',
+          message:
+            err instanceof Error ? err.message : 'Could not reach the API',
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated, isLoading, getToken])
+
+  if (isLoading || gate.kind === 'checking') {
+    return (
+      <Centered>
+        <Loader2 className="size-6 animate-spin text-base-content/40" />
+      </Centered>
+    )
+  }
+
+  if (gate.kind === 'signed-out') {
+    return (
+      <Centered>
+        <Lock className="size-8 text-base-content/30" />
+        <h1 className="mt-4 text-2xl font-bold">Sign in to continue</h1>
+        <p className="mt-2 max-w-sm text-sm text-base-content/60">
+          The Scrollr staff console is only available to signed-in staff
+          accounts.
+        </p>
+        <button
+          type="button"
+          onClick={() => signIn('/admin')}
+          className="mt-6 cursor-pointer rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-content transition-[filter] hover:brightness-110"
+        >
+          Sign in
+        </button>
+      </Centered>
+    )
+  }
+
+  if (gate.kind === 'denied') {
+    return (
+      <Centered>
+        <Lock className="size-8 text-base-content/30" />
+        <h1 className="mt-4 text-2xl font-bold">Staff only</h1>
+        <p className="mt-2 max-w-md text-sm text-base-content/60">
+          This area is limited to the Scrollr admin list. If you think you
+          should have access, ask an existing admin to add your account.
+        </p>
+        <Link
+          to="/account"
+          className="mt-6 rounded-lg px-5 py-2.5 text-sm font-semibold ring-1 ring-base-300 transition-colors hover:bg-base-200"
+        >
+          Back to your account
+        </Link>
+      </Centered>
+    )
+  }
+
+  if (gate.kind === 'error') {
+    return (
+      <Centered>
+        <h1 className="text-2xl font-bold">Could not check access</h1>
+        <p className="mt-2 max-w-md text-sm text-base-content/60">
+          {gate.message}
+        </p>
+      </Centered>
+    )
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-10 sm:px-6 lg:flex-row lg:gap-10">
+      <nav className="lg:w-52 lg:shrink-0">
+        <p className="px-3 text-xs font-semibold tracking-wide text-base-content/40 uppercase">
+          Staff
+        </p>
+        <p
+          className="mt-1 truncate px-3 text-xs text-base-content/60"
+          title={gate.email}
+        >
+          {gate.email}
+        </p>
+        <ul className="mt-4 flex gap-1 overflow-x-auto lg:flex-col lg:overflow-visible">
+          {SECTIONS.map(({ to, label, Icon, ...rest }) => {
+            const exact = 'exact' in rest && rest.exact
+            const active = exact
+              ? location.pathname === '/admin' ||
+                location.pathname === '/admin/'
+              : location.pathname.startsWith(to)
+            return (
+              <li key={to}>
+                <Link
+                  to={to}
+                  className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors ${
+                    active
+                      ? 'bg-base-200 text-base-content'
+                      : 'text-base-content/60 hover:bg-base-200/60 hover:text-base-content'
+                  }`}
+                >
+                  <Icon size={16} strokeWidth={2} />
+                  {label}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+
+      <main className="min-w-0 flex-1">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/myscrollr.com/src/components/admin/AdminsPage.tsx
+++ b/myscrollr.com/src/components/admin/AdminsPage.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Loader2, Trash2, UserPlus } from 'lucide-react'
+import type { AdminRow } from '@/api/admin'
+import { adminApi } from '@/api/admin'
+import { useGetToken } from '@/hooks/useGetToken'
+
+/**
+ * The Admins section: who has staff access, and the controls to change it
+ * without a deploy.
+ *
+ * A new admin is stored by email with no Logto sub. The server pins their sub
+ * the first time they sign in and their Logto-verified address matches, so
+ * "claimed" below means "has signed in at least once", not "is allowed".
+ *
+ * Two removals are refused by the server and hidden here: the last remaining
+ * admin, and your own row. Between them there is no sequence of clicks that
+ * ends with nobody able to get back in.
+ */
+
+export default function AdminsPage() {
+  const getToken = useGetToken()
+  const [admins, setAdmins] = useState<Array<AdminRow> | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [email, setEmail] = useState('')
+  const [note, setNote] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(() => {
+    adminApi
+      .admins(getToken)
+      .then((res) => setAdmins(res.admins))
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : 'Could not load admins'),
+      )
+  }, [getToken])
+
+  useEffect(load, [load])
+
+  async function add(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setBusy(true)
+    try {
+      await adminApi.addAdmin(getToken, email.trim(), note.trim())
+      setEmail('')
+      setNote('')
+      load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not add that admin')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function remove(row: AdminRow) {
+    if (!confirm(`Remove ${row.email} from the admin list?`)) return
+    setError(null)
+    try {
+      await adminApi.removeAdmin(getToken, row.id)
+      load()
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Could not remove that admin',
+      )
+    }
+  }
+
+  // The delete button is hidden for the two rows the server refuses, so the
+  // UI never offers a click that is guaranteed to fail.
+  const removable = (row: AdminRow) => !row.self && (admins?.length ?? 0) > 1
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight">Admins</h1>
+        <p className="mt-1 text-sm text-base-content/60">
+          Staff access is this list and nothing else — not a subscription tier,
+          not a Stripe plan, not <code className="text-xs">super_user</code>.
+        </p>
+      </header>
+
+      {error && (
+        <p className="rounded-lg bg-error/5 p-3 text-sm text-error ring-1 ring-error/20">
+          {error}
+        </p>
+      )}
+
+      <form
+        onSubmit={add}
+        className="flex flex-col gap-3 rounded-xl bg-base-200/40 p-4 ring-1 ring-base-300/60 sm:flex-row sm:items-end"
+      >
+        <label className="flex-1">
+          <span className="text-xs font-semibold text-base-content/50 uppercase">
+            Email
+          </span>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="person@example.com"
+            className="mt-1 w-full rounded-lg bg-base-100 px-3 py-2 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
+          />
+        </label>
+        <label className="flex-1">
+          <span className="text-xs font-semibold text-base-content/50 uppercase">
+            Note (optional)
+          </span>
+          <input
+            type="text"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="why they need access"
+            className="mt-1 w-full rounded-lg bg-base-100 px-3 py-2 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={busy}
+          className="flex cursor-pointer items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-content transition-[filter] hover:brightness-110 disabled:opacity-50"
+        >
+          {busy ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            <UserPlus size={16} />
+          )}
+          Add admin
+        </button>
+      </form>
+
+      {!admins ? (
+        <Loader2 className="size-5 animate-spin text-base-content/40" />
+      ) : (
+        <div className="overflow-x-auto rounded-xl ring-1 ring-base-300/60">
+          <table className="w-full min-w-[38rem] text-left text-sm">
+            <thead className="text-xs text-base-content/50 uppercase">
+              <tr className="border-b border-base-300/60">
+                <th className="p-3 font-semibold">Email</th>
+                <th className="p-3 font-semibold">Added</th>
+                <th className="p-3 font-semibold">Last seen</th>
+                <th className="p-3" />
+              </tr>
+            </thead>
+            <tbody>
+              {admins.map((row) => (
+                <tr
+                  key={row.id}
+                  className="border-b border-base-300/40 last:border-0"
+                >
+                  <td className="p-3">
+                    <span className="font-medium">{row.email}</span>
+                    {row.self && (
+                      <span className="ml-2 rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary">
+                        you
+                      </span>
+                    )}
+                    {!row.claimed && (
+                      <span className="ml-2 rounded bg-base-300/60 px-1.5 py-0.5 text-xs text-base-content/60">
+                        not signed in yet
+                      </span>
+                    )}
+                    {row.note && (
+                      <span className="block text-xs text-base-content/45">
+                        {row.note}
+                      </span>
+                    )}
+                  </td>
+                  <td className="p-3 text-base-content/60">
+                    {new Date(row.added_at).toLocaleDateString()}
+                    {row.added_by && (
+                      <span className="block text-xs text-base-content/45">
+                        by {row.added_by}
+                      </span>
+                    )}
+                  </td>
+                  <td className="p-3 text-base-content/60">
+                    {row.last_seen_at
+                      ? new Date(row.last_seen_at).toLocaleString()
+                      : '—'}
+                  </td>
+                  <td className="p-3 text-right">
+                    {removable(row) ? (
+                      <button
+                        type="button"
+                        onClick={() => remove(row)}
+                        aria-label={`Remove ${row.email}`}
+                        className="cursor-pointer rounded-lg p-1.5 text-base-content/50 transition-colors hover:bg-error/10 hover:text-error"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    ) : (
+                      <span className="text-xs text-base-content/35">
+                        {row.self ? 'cannot remove yourself' : 'last admin'}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/myscrollr.com/src/components/admin/OverviewPage.tsx
+++ b/myscrollr.com/src/components/admin/OverviewPage.tsx
@@ -1,0 +1,299 @@
+import { Link } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+import type { AdminOverview } from '@/api/admin'
+import { adminApi } from '@/api/admin'
+import { useGetToken } from '@/hooks/useGetToken'
+import {
+  DOWNLOADS_CAVEAT,
+  connectedCaveat,
+  formatAge,
+  ingestHealth,
+  measuredValue,
+} from '@/lib/adminFormat'
+
+/**
+ * "Everything about Scrollr in one spot."
+ *
+ * Every tile is either a number we hold or an explicit admission that we do
+ * not. The Installs tile is the second kind on purpose: Scrollr ships no
+ * telemetry, by decision, so active installs cannot be measured and the page
+ * says exactly that instead of substituting downloads and hoping nobody
+ * notices the difference.
+ */
+
+function Tile({
+  title,
+  caveat,
+  to,
+  children,
+}: {
+  title: string
+  caveat?: string
+  to?: string
+  children: ReactNode
+}) {
+  const body = (
+    <div className="flex h-full flex-col rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60 transition-colors hover:bg-base-200/70">
+      <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+        {title}
+      </h2>
+      <div className="mt-3 flex-1">{children}</div>
+      {caveat && (
+        <p className="mt-4 text-xs leading-relaxed text-base-content/45">
+          {caveat}
+        </p>
+      )}
+    </div>
+  )
+  return to ? (
+    <Link to={to} className="block h-full">
+      {body}
+    </Link>
+  ) : (
+    body
+  )
+}
+
+function Big({ children }: { children: ReactNode }) {
+  return <p className="text-3xl font-bold tabular-nums">{children}</p>
+}
+
+/** The house style for "we do not have this number." */
+function Unmeasurable({ note }: { note?: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <AlertTriangle size={16} className="mt-0.5 shrink-0 text-warning" />
+      <p className="text-sm leading-relaxed text-base-content/70">
+        {note ?? 'Not measurable.'}
+      </p>
+    </div>
+  )
+}
+
+function Row({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 py-1 text-sm">
+      <span className="truncate text-base-content/60">{label}</span>
+      <span className="font-semibold tabular-nums">{value}</span>
+    </div>
+  )
+}
+
+export default function OverviewPage() {
+  const getToken = useGetToken()
+  const [data, setData] = useState<AdminOverview | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    adminApi
+      .overview(getToken)
+      .then((res) => !cancelled && setData(res))
+      .catch(
+        (err: unknown) =>
+          !cancelled &&
+          setError(
+            err instanceof Error ? err.message : 'Could not load the overview',
+          ),
+      )
+    return () => {
+      cancelled = true
+    }
+  }, [getToken])
+
+  if (error) {
+    return (
+      <p className="rounded-xl bg-error/5 p-5 text-sm text-error ring-1 ring-error/20">
+        {error}
+      </p>
+    )
+  }
+  if (!data) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <Loader2 className="size-6 animate-spin text-base-content/40" />
+      </div>
+    )
+  }
+
+  const newAccounts = measuredValue(data.accounts.new_30d)
+  const installs = measuredValue(data.installs)
+  const releases = (data.downloads.releases ?? []).slice(0, 5)
+  const ingest = data.ingest ?? []
+  const plans = (data.plans.rows ?? []).filter((r) => r.plan !== 'free')
+  const requests = (data.demand.catalog_requests ?? []).slice(0, 5)
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight">Overview</h1>
+        <p className="mt-1 text-sm text-base-content/60">
+          Generated {new Date(data.generated_at).toLocaleString()}. Every tile
+          below is a direct read — where a number does not exist, the tile says
+          so rather than guessing.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Tile
+          title="Accounts"
+          to="/admin/users"
+          caveat={
+            data.accounts.untracked > 0
+              ? `${data.accounts.untracked.toLocaleString()} accounts predate signup-date tracking, so they are counted in the total but not in "new".`
+              : undefined
+          }
+        >
+          <Big>{data.accounts.total.toLocaleString()}</Big>
+          <div className="mt-3">
+            {newAccounts.display === null ? (
+              <Unmeasurable note={newAccounts.note} />
+            ) : (
+              <p className="text-sm text-base-content/60">
+                <span className="font-semibold text-base-content">
+                  {newAccounts.display}
+                </span>{' '}
+                new in the last 30 days
+              </p>
+            )}
+          </div>
+        </Tile>
+
+        <Tile
+          title="Active installs"
+          caveat="Use downloads per release instead — it is the closest real number."
+        >
+          <Unmeasurable note={installs.note} />
+        </Tile>
+
+        <Tile
+          title="Connected now"
+          caveat={connectedCaveat(data.connected_now)}
+        >
+          <Big>{data.connected_now.count.toLocaleString()}</Big>
+          <p className="mt-2 text-sm text-base-content/60">
+            open SSE connections
+          </p>
+        </Tile>
+
+        <Tile
+          title="Plans"
+          caveat="From Stripe. Accounts with no Stripe record are counted as free."
+        >
+          <Big>{data.plans.free.toLocaleString()}</Big>
+          <p className="mt-1 mb-2 text-sm text-base-content/60">free</p>
+          {plans.length === 0 ? (
+            <p className="text-sm text-base-content/50">
+              No paid subscriptions.
+            </p>
+          ) : (
+            plans.map((r) => (
+              <Row
+                key={`${r.plan}-${r.status}-${r.lifetime}`}
+                label={`${r.plan}${r.lifetime ? ' (lifetime)' : ''} · ${r.status}`}
+                value={r.count.toLocaleString()}
+              />
+            ))
+          )}
+        </Tile>
+
+        <Tile
+          title="Downloads"
+          caveat={
+            data.downloads.stale
+              ? `${DOWNLOADS_CAVEAT} These figures are cached — GitHub was unreachable on the last refresh.`
+              : DOWNLOADS_CAVEAT
+          }
+        >
+          {data.downloads.error ? (
+            <Unmeasurable note={data.downloads.error} />
+          ) : (
+            <>
+              <Big>{data.downloads.total.toLocaleString()}</Big>
+              <p className="mt-1 mb-2 text-sm text-base-content/60">
+                across all releases
+              </p>
+              {releases.map((r) => (
+                <Row
+                  key={r.tag}
+                  label={r.tag}
+                  value={r.downloads.toLocaleString()}
+                />
+              ))}
+            </>
+          )}
+        </Tile>
+
+        <Tile
+          title="Support"
+          to="/admin/support"
+          caveat={
+            data.support.oldest_open_ticket
+              ? `Oldest open ticket ${data.support.oldest_open_ticket}, ${data.support.oldest_open_hours}h old.`
+              : 'Nothing open.'
+          }
+        >
+          <Big>{data.support.open_cases.toLocaleString()}</Big>
+          <p className="mt-1 mb-2 text-sm text-base-content/60">open cases</p>
+          <Row label="Drafts waiting" value={data.support.pending_drafts} />
+          <Row label="Auto-sent (30d)" value={data.support.auto_sent_30d} />
+          <Row
+            label="Needed a person (30d)"
+            value={data.support.intervened_30d}
+          />
+        </Tile>
+
+        <Tile
+          title="Demand"
+          caveat="What people asked for and did not find, plus business enquiries."
+        >
+          <Row
+            label="Business leads"
+            value={`${data.demand.business_leads} (${data.demand.leads_unreplied} unreplied)`}
+          />
+          <div className="mt-2 border-t border-base-300/60 pt-2">
+            {requests.length === 0 ? (
+              <p className="text-sm text-base-content/50">
+                No widget requests yet.
+              </p>
+            ) : (
+              requests.map((r) => (
+                <Row key={r.query} label={r.query} value={r.people} />
+              ))
+            )}
+          </div>
+        </Tile>
+
+        <Tile
+          title="Ingest freshness"
+          caveat="How long ago each content table was last written. Sports can legitimately sit still overnight."
+        >
+          {ingest.map((row) => {
+            const health = ingestHealth(row)
+            return (
+              <Row
+                key={row.table}
+                label={row.table}
+                value={
+                  <span
+                    className={
+                      health === 'empty'
+                        ? 'text-error'
+                        : health === 'stale'
+                          ? 'text-warning'
+                          : 'text-success'
+                    }
+                  >
+                    {health === 'empty' ? 'empty' : formatAge(row.age_seconds)}
+                  </span>
+                }
+              />
+            )
+          })}
+        </Tile>
+      </div>
+    </div>
+  )
+}

--- a/myscrollr.com/src/components/admin/UsersPage.tsx
+++ b/myscrollr.com/src/components/admin/UsersPage.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useState } from 'react'
+import { ChevronLeft, Loader2, Search } from 'lucide-react'
+import type { AccountDetail, AccountRow, AccountsPage } from '@/api/admin'
+import { adminApi } from '@/api/admin'
+import { useGetToken } from '@/hooks/useGetToken'
+
+/**
+ * The Users section. Read-only, and not by omission.
+ *
+ * Reading another person's email, plan and ticket history is already the most
+ * sensitive thing in this console. Editing it is a separate decision with
+ * separate consequences, so there is no write path here at all — no disabled
+ * button, no "coming soon" affordance, nothing to reach for.
+ *
+ * Search matches the Logto sub or an email from the user's support cases,
+ * which is the only place this database keeps one.
+ */
+
+function planLabel(a: AccountRow): string {
+  if (a.plan === 'free' || a.status === 'none') return 'Free'
+  return `${a.plan}${a.lifetime ? ' · lifetime' : ''} · ${a.status}`
+}
+
+function DetailPanel({ sub, onBack }: { sub: string; onBack: () => void }) {
+  const getToken = useGetToken()
+  const [detail, setDetail] = useState<AccountDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setDetail(null)
+    adminApi
+      .account(getToken, sub)
+      .then((res) => !cancelled && setDetail(res))
+      .catch(
+        (err: unknown) =>
+          !cancelled &&
+          setError(
+            err instanceof Error ? err.message : 'Could not load that user',
+          ),
+      )
+    return () => {
+      cancelled = true
+    }
+  }, [getToken, sub])
+
+  return (
+    <div className="space-y-6">
+      <button
+        type="button"
+        onClick={onBack}
+        className="flex cursor-pointer items-center gap-1 text-sm text-base-content/60 hover:text-base-content"
+      >
+        <ChevronLeft size={16} /> All users
+      </button>
+
+      {error && <p className="text-sm text-error">{error}</p>}
+      {!detail && !error && (
+        <Loader2 className="size-5 animate-spin text-base-content/40" />
+      )}
+
+      {detail && (
+        <>
+          <header>
+            <h1 className="text-xl font-bold break-all">
+              {detail.account.email ?? detail.account.logto_sub}
+            </h1>
+            <p className="mt-1 font-mono text-xs break-all text-base-content/50">
+              {detail.account.logto_sub}
+            </p>
+            <p className="mt-2 text-sm text-base-content/60">
+              {planLabel(detail.account)}
+              {detail.account.fantasy && ' · fantasy connected'}
+              {detail.account.deletion_state &&
+                ` · deletion ${detail.account.deletion_state}`}
+            </p>
+            {!detail.account.email && (
+              <p className="mt-2 text-xs text-base-content/45">
+                No email on file — this database only stores an address once a
+                user opens a support ticket.
+              </p>
+            )}
+          </header>
+
+          <section>
+            <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+              Widgets ({detail.widgets.length})
+            </h2>
+            <div className="mt-2 rounded-xl ring-1 ring-base-300/60">
+              {detail.widgets.length === 0 ? (
+                <p className="p-4 text-sm text-base-content/50">
+                  No widgets configured.
+                </p>
+              ) : (
+                detail.widgets.map((w) => (
+                  <div
+                    key={w.type}
+                    className="flex items-center justify-between gap-3 border-b border-base-300/40 p-3 text-sm last:border-0"
+                  >
+                    <span className="font-medium">{w.type}</span>
+                    <span className="text-xs text-base-content/60">
+                      {w.enabled ? 'enabled' : 'disabled'}
+                      {w.ticker_enabled && ' · on the bar'}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+              Support history ({detail.cases.length})
+            </h2>
+            <div className="mt-2 rounded-xl ring-1 ring-base-300/60">
+              {detail.cases.length === 0 ? (
+                <p className="p-4 text-sm text-base-content/50">
+                  No tickets opened.
+                </p>
+              ) : (
+                detail.cases.map((k) => (
+                  <div
+                    key={k.ticket_number}
+                    className="border-b border-base-300/40 p-3 last:border-0"
+                  >
+                    <div className="flex items-baseline justify-between gap-3">
+                      <span className="truncate text-sm font-medium">
+                        {k.subject || '(no subject)'}
+                      </span>
+                      <span className="shrink-0 font-mono text-xs text-base-content/50">
+                        {k.ticket_number}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-base-content/50">
+                      {k.status}
+                      {k.category && ` · ${k.category}`} ·{' '}
+                      {new Date(k.opened_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default function UsersPage() {
+  const getToken = useGetToken()
+  const [query, setQuery] = useState('')
+  const [page, setPage] = useState(0)
+  const [data, setData] = useState<AccountsPage | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    // Debounced so typing does not fire a query per keystroke.
+    const timer = setTimeout(() => {
+      adminApi
+        .accounts(getToken, query, page)
+        .then((res) => !cancelled && setData(res))
+        .catch(
+          (err: unknown) =>
+            !cancelled &&
+            setError(
+              err instanceof Error ? err.message : 'Could not load users',
+            ),
+        )
+    }, 250)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [getToken, query, page])
+
+  if (selected) {
+    return <DetailPanel sub={selected} onBack={() => setSelected(null)} />
+  }
+
+  const pageCount = data ? Math.ceil(data.total / data.page_size) : 0
+
+  return (
+    <div className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight">Users</h1>
+        <p className="mt-1 text-sm text-base-content/60">
+          {data ? `${data.total.toLocaleString()} accounts. ` : ''}
+          Read-only — this console does not edit anyone&apos;s account.
+        </p>
+      </header>
+
+      <div className="relative">
+        <Search
+          size={16}
+          className="absolute top-1/2 left-3 -translate-y-1/2 text-base-content/40"
+        />
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setPage(0)
+          }}
+          placeholder="Search by user id or support email"
+          className="w-full rounded-lg bg-base-200/50 py-2.5 pr-3 pl-9 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
+        />
+      </div>
+
+      {error && <p className="text-sm text-error">{error}</p>}
+      {!data && !error && (
+        <Loader2 className="size-5 animate-spin text-base-content/40" />
+      )}
+
+      {data && (
+        <>
+          <div className="overflow-x-auto rounded-xl ring-1 ring-base-300/60">
+            <table className="w-full min-w-[42rem] text-left text-sm">
+              <thead className="text-xs text-base-content/50 uppercase">
+                <tr className="border-b border-base-300/60">
+                  <th className="p-3 font-semibold">User</th>
+                  <th className="p-3 font-semibold">Plan</th>
+                  <th className="p-3 font-semibold">Widgets</th>
+                  <th className="p-3 font-semibold">Tickets</th>
+                  <th className="p-3 font-semibold">Last seen</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.accounts.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="p-6 text-center text-base-content/50"
+                    >
+                      No accounts match that search.
+                    </td>
+                  </tr>
+                )}
+                {data.accounts.map((a) => (
+                  <tr
+                    key={a.logto_sub}
+                    onClick={() => setSelected(a.logto_sub)}
+                    className="cursor-pointer border-b border-base-300/40 transition-colors last:border-0 hover:bg-base-200/50"
+                  >
+                    <td className="max-w-[18rem] p-3">
+                      <span className="block truncate font-medium">
+                        {a.email ?? '—'}
+                      </span>
+                      <span className="block truncate font-mono text-xs text-base-content/45">
+                        {a.logto_sub}
+                      </span>
+                    </td>
+                    <td className="p-3 text-base-content/70">{planLabel(a)}</td>
+                    <td className="p-3 tabular-nums">
+                      {a.widgets}
+                      {a.on_ticker > 0 && (
+                        <span className="text-base-content/45">
+                          {' '}
+                          ({a.on_ticker} on bar)
+                        </span>
+                      )}
+                    </td>
+                    <td className="p-3 tabular-nums">{a.tickets}</td>
+                    <td className="p-3 text-base-content/60">
+                      {new Date(a.updated_at).toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {pageCount > 1 && (
+            <div className="flex items-center justify-between text-sm">
+              <button
+                type="button"
+                disabled={page === 0}
+                onClick={() => setPage((p) => p - 1)}
+                className="cursor-pointer rounded-lg px-3 py-1.5 ring-1 ring-base-300 disabled:cursor-default disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <span className="text-base-content/60">
+                Page {page + 1} of {pageCount}
+              </span>
+              <button
+                type="button"
+                disabled={page + 1 >= pageCount}
+                onClick={() => setPage((p) => p + 1)}
+                className="cursor-pointer rounded-lg px-3 py-1.5 ring-1 ring-base-300 disabled:cursor-default disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/myscrollr.com/src/lib/adminFormat.test.ts
+++ b/myscrollr.com/src/lib/adminFormat.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXPECTED_REPLICAS,
+  connectedCaveat,
+  formatAge,
+  ingestHealth,
+  measuredValue,
+} from './adminFormat'
+
+describe('measuredValue', () => {
+  it('renders a real number', () => {
+    expect(measuredValue({ value: 1234, available: true }).display).toBe(
+      (1234).toLocaleString(),
+    )
+  })
+
+  // The point of the whole Measured type: an unmeasurable thing must not
+  // render as "0". "0 active installs" is a claim; "not measurable" is true.
+  it('never renders an unavailable value as a number, not even zero', () => {
+    const tile = measuredValue({
+      value: 0,
+      available: false,
+      note: 'Not measurable. Scrollr ships no telemetry.',
+    })
+    expect(tile.display).toBeNull()
+    expect(tile.note).toContain('Not measurable')
+  })
+
+  it('treats a missing tile as unmeasurable rather than zero', () => {
+    expect(measuredValue(undefined).display).toBeNull()
+  })
+})
+
+describe('connectedCaveat', () => {
+  // The trap this exists for: ClientCount() is per-replica and core-api runs
+  // two, so a number sourced from one replica is silently about half.
+  it('flags an under-reported fleet instead of showing a halved number bare', () => {
+    const caveat = connectedCaveat({ count: 7, replicas: 1 })
+    expect(caveat).toContain('1 of 2')
+    expect(caveat).toContain('higher')
+  })
+
+  it('says how many replicas contributed when all of them did', () => {
+    expect(
+      connectedCaveat({ count: 14, replicas: EXPECTED_REPLICAS }),
+    ).toContain(`${EXPECTED_REPLICAS} replicas`)
+  })
+
+  it('calls a zero-replica reading untrustworthy', () => {
+    expect(connectedCaveat({ count: 0, replicas: 0 })).toContain(
+      'not trustworthy',
+    )
+  })
+})
+
+describe('formatAge', () => {
+  it('scales the unit to the age', () => {
+    expect(formatAge(5)).toBe('5s ago')
+    expect(formatAge(90)).toBe('1m ago')
+    expect(formatAge(7200)).toBe('2h ago')
+    expect(formatAge(172800)).toBe('2d ago')
+  })
+})
+
+describe('ingestHealth', () => {
+  it('calls an empty table empty, not merely stale', () => {
+    expect(
+      ingestHealth({ table: 'games', age_seconds: 0, has_data: false }),
+    ).toBe('empty')
+  })
+
+  it('is fresh within the window and stale past it', () => {
+    expect(
+      ingestHealth({ table: 'trades', age_seconds: 60, has_data: true }),
+    ).toBe('fresh')
+    expect(
+      ingestHealth({ table: 'trades', age_seconds: 7 * 3600, has_data: true }),
+    ).toBe('stale')
+  })
+})

--- a/myscrollr.com/src/lib/adminFormat.ts
+++ b/myscrollr.com/src/lib/adminFormat.ts
@@ -1,0 +1,79 @@
+/**
+ * Presentation rules for the staff Overview (REL-260).
+ *
+ * These live apart from the components because they encode the page's one
+ * hard promise — a tile shows a real number or says it cannot — and that
+ * promise is worth a test that does not need a DOM.
+ */
+
+import type { ConnectedTile, IngestRow, Measured } from '@/api/admin'
+
+/** What a tile should actually render for a Measured value. */
+export interface TileValue {
+  /** The number, or null when it must not be shown as one. */
+  display: string | null
+  /** Shown instead of (or under) the number. */
+  note?: string
+}
+
+/**
+ * A `Measured` with `available: false` must never render as a number — not
+ * even as "0", which reads as a measurement of zero rather than the absence
+ * of a measurement. That distinction is the whole reason the type exists.
+ */
+export function measuredValue(m: Measured | undefined): TileValue {
+  if (!m || !m.available) {
+    return { display: null, note: m?.note ?? 'Not measurable.' }
+  }
+  return { display: m.value.toLocaleString(), note: m.note }
+}
+
+/**
+ * The "connected now" caveat.
+ *
+ * `events.ClientCount()` is per-replica and core-api runs two, so the number
+ * is a sum over the replicas that reported in the last heartbeat window. When
+ * fewer than the expected two reported, the total is understated and the tile
+ * has to say so rather than showing a confidently halved number.
+ */
+export const EXPECTED_REPLICAS = 2
+
+export function connectedCaveat(tile: ConnectedTile): string {
+  if (tile.replicas >= EXPECTED_REPLICAS) {
+    return `Summed across ${tile.replicas} replicas.`
+  }
+  if (tile.replicas <= 0) {
+    return 'No replica reported — this number is not trustworthy.'
+  }
+  return `Only ${tile.replicas} of ${EXPECTED_REPLICAS} replicas reported — the real total is higher.`
+}
+
+/** Compact "how long ago", for ingest freshness. */
+export function formatAge(seconds: number): string {
+  if (seconds < 0) return 'in the future'
+  if (seconds < 60) return `${seconds}s ago`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
+  return `${Math.floor(seconds / 86400)}d ago`
+}
+
+/**
+ * Ingest health. The thresholds are deliberately loose: this answers "has
+ * this feed stopped", not "is it a few seconds behind". Sports rows can
+ * legitimately sit still overnight, so a stale table is a warning, never an
+ * error, and an empty one is the only genuinely broken state.
+ */
+export type IngestHealth = 'empty' | 'stale' | 'fresh'
+
+export function ingestHealth(row: IngestRow): IngestHealth {
+  if (!row.has_data) return 'empty'
+  return row.age_seconds > 6 * 3600 ? 'stale' : 'fresh'
+}
+
+/**
+ * Downloads are not installs, and the label has to carry that everywhere the
+ * number appears — a reader who sees the count without the caveat will file
+ * it away as an install count.
+ */
+export const DOWNLOADS_CAVEAT =
+  'Downloads, not installs. One person upgrading through five releases is five downloads, and nothing reports back whether the app was kept or opened.'

--- a/myscrollr.com/src/routeTree.gen.ts
+++ b/myscrollr.com/src/routeTree.gen.ts
@@ -23,11 +23,16 @@ import { Route as ChannelsRouteImport } from './routes/channels'
 import { Route as CallbackRouteImport } from './routes/callback'
 import { Route as BusinessRouteImport } from './routes/business'
 import { Route as ArchitectureRouteImport } from './routes/architecture'
+import { Route as AdminRouteImport } from './routes/admin'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AdminIndexRouteImport } from './routes/admin.index'
 import { Route as UplinkLifetimeRouteImport } from './routes/uplink_.lifetime'
 import { Route as UUsernameRouteImport } from './routes/u.$username'
 import { Route as DownloadOsRouteImport } from './routes/download_.$os'
+import { Route as AdminUsersRouteImport } from './routes/admin.users'
+import { Route as AdminSupportRouteImport } from './routes/admin.support'
+import { Route as AdminAdminsRouteImport } from './routes/admin.admins'
 
 const WidgetsRoute = WidgetsRouteImport.update({
   id: '/widgets',
@@ -99,6 +104,11 @@ const ArchitectureRoute = ArchitectureRouteImport.update({
   path: '/architecture',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminRoute = AdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AccountRoute = AccountRouteImport.update({
   id: '/account',
   path: '/account',
@@ -108,6 +118,11 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AdminIndexRoute = AdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AdminRoute,
 } as any)
 const UplinkLifetimeRoute = UplinkLifetimeRouteImport.update({
   id: '/uplink_/lifetime',
@@ -124,10 +139,26 @@ const DownloadOsRoute = DownloadOsRouteImport.update({
   path: '/download/$os',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminUsersRoute = AdminUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminSupportRoute = AdminSupportRouteImport.update({
+  id: '/support',
+  path: '/support',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminAdminsRoute = AdminAdminsRouteImport.update({
+  id: '/admins',
+  path: '/admins',
+  getParentRoute: () => AdminRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
+  '/admin': typeof AdminRouteWithChildren
   '/architecture': typeof ArchitectureRoute
   '/business': typeof BusinessRoute
   '/callback': typeof CallbackRoute
@@ -142,9 +173,13 @@ export interface FileRoutesByFullPath {
   '/tss-spa-shell': typeof TssSpaShellRoute
   '/uplink': typeof UplinkRoute
   '/widgets': typeof WidgetsRoute
+  '/admin/admins': typeof AdminAdminsRoute
+  '/admin/support': typeof AdminSupportRoute
+  '/admin/users': typeof AdminUsersRoute
   '/download/$os': typeof DownloadOsRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink/lifetime': typeof UplinkLifetimeRoute
+  '/admin/': typeof AdminIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -163,14 +198,19 @@ export interface FileRoutesByTo {
   '/tss-spa-shell': typeof TssSpaShellRoute
   '/uplink': typeof UplinkRoute
   '/widgets': typeof WidgetsRoute
+  '/admin/admins': typeof AdminAdminsRoute
+  '/admin/support': typeof AdminSupportRoute
+  '/admin/users': typeof AdminUsersRoute
   '/download/$os': typeof DownloadOsRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink/lifetime': typeof UplinkLifetimeRoute
+  '/admin': typeof AdminIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
+  '/admin': typeof AdminRouteWithChildren
   '/architecture': typeof ArchitectureRoute
   '/business': typeof BusinessRoute
   '/callback': typeof CallbackRoute
@@ -185,15 +225,20 @@ export interface FileRoutesById {
   '/tss-spa-shell': typeof TssSpaShellRoute
   '/uplink': typeof UplinkRoute
   '/widgets': typeof WidgetsRoute
+  '/admin/admins': typeof AdminAdminsRoute
+  '/admin/support': typeof AdminSupportRoute
+  '/admin/users': typeof AdminUsersRoute
   '/download_/$os': typeof DownloadOsRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink_/lifetime': typeof UplinkLifetimeRoute
+  '/admin/': typeof AdminIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/account'
+    | '/admin'
     | '/architecture'
     | '/business'
     | '/callback'
@@ -208,9 +253,13 @@ export interface FileRouteTypes {
     | '/tss-spa-shell'
     | '/uplink'
     | '/widgets'
+    | '/admin/admins'
+    | '/admin/support'
+    | '/admin/users'
     | '/download/$os'
     | '/u/$username'
     | '/uplink/lifetime'
+    | '/admin/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -229,13 +278,18 @@ export interface FileRouteTypes {
     | '/tss-spa-shell'
     | '/uplink'
     | '/widgets'
+    | '/admin/admins'
+    | '/admin/support'
+    | '/admin/users'
     | '/download/$os'
     | '/u/$username'
     | '/uplink/lifetime'
+    | '/admin'
   id:
     | '__root__'
     | '/'
     | '/account'
+    | '/admin'
     | '/architecture'
     | '/business'
     | '/callback'
@@ -250,14 +304,19 @@ export interface FileRouteTypes {
     | '/tss-spa-shell'
     | '/uplink'
     | '/widgets'
+    | '/admin/admins'
+    | '/admin/support'
+    | '/admin/users'
     | '/download_/$os'
     | '/u/$username'
     | '/uplink_/lifetime'
+    | '/admin/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AccountRoute: typeof AccountRoute
+  AdminRoute: typeof AdminRouteWithChildren
   ArchitectureRoute: typeof ArchitectureRoute
   BusinessRoute: typeof BusinessRoute
   CallbackRoute: typeof CallbackRoute
@@ -377,6 +436,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ArchitectureRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/account': {
       id: '/account'
       path: '/account'
@@ -390,6 +456,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/admin/': {
+      id: '/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AdminIndexRouteImport
+      parentRoute: typeof AdminRoute
     }
     '/uplink_/lifetime': {
       id: '/uplink_/lifetime'
@@ -412,12 +485,50 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DownloadOsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/users': {
+      id: '/admin/users'
+      path: '/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AdminUsersRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/support': {
+      id: '/admin/support'
+      path: '/support'
+      fullPath: '/admin/support'
+      preLoaderRoute: typeof AdminSupportRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/admins': {
+      id: '/admin/admins'
+      path: '/admins'
+      fullPath: '/admin/admins'
+      preLoaderRoute: typeof AdminAdminsRouteImport
+      parentRoute: typeof AdminRoute
+    }
   }
 }
+
+interface AdminRouteChildren {
+  AdminAdminsRoute: typeof AdminAdminsRoute
+  AdminSupportRoute: typeof AdminSupportRoute
+  AdminUsersRoute: typeof AdminUsersRoute
+  AdminIndexRoute: typeof AdminIndexRoute
+}
+
+const AdminRouteChildren: AdminRouteChildren = {
+  AdminAdminsRoute: AdminAdminsRoute,
+  AdminSupportRoute: AdminSupportRoute,
+  AdminUsersRoute: AdminUsersRoute,
+  AdminIndexRoute: AdminIndexRoute,
+}
+
+const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AccountRoute: AccountRoute,
+  AdminRoute: AdminRouteWithChildren,
   ArchitectureRoute: ArchitectureRoute,
   BusinessRoute: BusinessRoute,
   CallbackRoute: CallbackRoute,

--- a/myscrollr.com/src/routes/admin.admins.tsx
+++ b/myscrollr.com/src/routes/admin.admins.tsx
@@ -1,0 +1,21 @@
+/**
+ * Admins - the staff list, and add/remove without a deploy.
+ *
+ * The component is behind a dynamic import so the staff console lands in its
+ * own chunk: nothing in /admin ships to a marketing visitor. The API gate
+ * (LogtoAuth + RequireAdmin) is the real boundary — this split is about bundle
+ * weight and not leaking internal UI, never about access control.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import { Suspense, lazy } from 'react'
+
+const AdminsPage = lazy(() => import('@/components/admin/AdminsPage'))
+
+export const Route = createFileRoute('/admin/admins')({
+  component: () => (
+    <Suspense fallback={<div className="min-h-[40vh]" />}>
+      <AdminsPage />
+    </Suspense>
+  ),
+})

--- a/myscrollr.com/src/routes/admin.index.tsx
+++ b/myscrollr.com/src/routes/admin.index.tsx
@@ -1,0 +1,21 @@
+/**
+ * Overview - every number Scrollr actually has, in one place.
+ *
+ * The component is behind a dynamic import so the staff console lands in its
+ * own chunk: nothing in /admin ships to a marketing visitor. The API gate
+ * (LogtoAuth + RequireAdmin) is the real boundary — this split is about bundle
+ * weight and not leaking internal UI, never about access control.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import { Suspense, lazy } from 'react'
+
+const OverviewPage = lazy(() => import('@/components/admin/OverviewPage'))
+
+export const Route = createFileRoute('/admin/')({
+  component: () => (
+    <Suspense fallback={<div className="min-h-[40vh]" />}>
+      <OverviewPage />
+    </Suspense>
+  ),
+})

--- a/myscrollr.com/src/routes/admin.support.tsx
+++ b/myscrollr.com/src/routes/admin.support.tsx
@@ -1,0 +1,46 @@
+/**
+ * Support — a deliberate stub.
+ *
+ * The support queue is REL-263. It is a large surface (the queue, the drafts,
+ * the per-category intervention rates, the send/hold/skip controls) and
+ * building it here would have made REL-260 unreviewable. The nav entry exists
+ * now so the shell is complete and the section has somewhere to land.
+ *
+ * No dynamic import: there is nothing here worth a chunk.
+ */
+
+import { Link, createFileRoute } from '@tanstack/react-router'
+import { LifeBuoy } from 'lucide-react'
+
+export const Route = createFileRoute('/admin/support')({
+  component: SupportStub,
+})
+
+function SupportStub() {
+  return (
+    <div className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight">Support</h1>
+        <p className="mt-1 text-sm text-base-content/60">
+          The support queue lives here.
+        </p>
+      </header>
+
+      <div className="flex flex-col items-center rounded-xl bg-base-200/40 px-6 py-16 text-center ring-1 ring-base-300/60">
+        <LifeBuoy className="size-8 text-base-content/30" />
+        <h2 className="mt-4 text-lg font-semibold">Not built yet</h2>
+        <p className="mt-2 max-w-md text-sm text-base-content/60">
+          The queue, the AI drafts and the send controls are REL-263. Until
+          then, the Overview tile carries the numbers that already exist: open
+          cases, drafts waiting, what auto-sent, and what needed a person.
+        </p>
+        <Link
+          to="/admin"
+          className="mt-6 rounded-lg px-4 py-2 text-sm font-semibold ring-1 ring-base-300 transition-colors hover:bg-base-200"
+        >
+          Back to Overview
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/myscrollr.com/src/routes/admin.tsx
+++ b/myscrollr.com/src/routes/admin.tsx
@@ -1,0 +1,29 @@
+/**
+ * Staff console layout: the gate, the left navigation, and the Outlet.
+ *
+ * The component is behind a dynamic import so the staff console lands in its
+ * own chunk: nothing in /admin ships to a marketing visitor. The API gate
+ * (LogtoAuth + RequireAdmin) is the real boundary — this split is about bundle
+ * weight and not leaking internal UI, never about access control.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import { Suspense, lazy } from 'react'
+import { seo } from '@/lib/seo'
+
+const AdminShell = lazy(() => import('@/components/admin/AdminShell'))
+
+export const Route = createFileRoute('/admin')({
+  head: () =>
+    seo({
+      title: 'Staff | Scrollr',
+      description: 'Scrollr staff console.',
+      path: '/admin',
+      noindex: true,
+    }),
+  component: () => (
+    <Suspense fallback={<div className="min-h-[60vh]" />}>
+      <AdminShell />
+    </Suspense>
+  ),
+})

--- a/myscrollr.com/src/routes/admin.users.tsx
+++ b/myscrollr.com/src/routes/admin.users.tsx
@@ -1,0 +1,21 @@
+/**
+ * Users - a read-only directory of accounts.
+ *
+ * The component is behind a dynamic import so the staff console lands in its
+ * own chunk: nothing in /admin ships to a marketing visitor. The API gate
+ * (LogtoAuth + RequireAdmin) is the real boundary — this split is about bundle
+ * weight and not leaking internal UI, never about access control.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import { Suspense, lazy } from 'react'
+
+const UsersPage = lazy(() => import('@/components/admin/UsersPage'))
+
+export const Route = createFileRoute('/admin/users')({
+  component: () => (
+    <Suspense fallback={<div className="min-h-[40vh]" />}>
+      <UsersPage />
+    </Suspense>
+  ),
+})

--- a/myscrollr.com/vite.config.ts
+++ b/myscrollr.com/vite.config.ts
@@ -70,9 +70,12 @@ export default defineConfig({
         crawlLinks: true, // discover any internal links we forgot
         filter: ({ path }: { path: string }) => {
           // Auth/dynamic routes — stay client-rendered (SPA fallback)
-          const excluded = ['/account', '/callback', '/invite']
+          // /admin is the staff console: authed, noindex, and its chunk
+          // must never be pulled into a prerendered marketing page.
+          const excluded = ['/account', '/callback', '/invite', '/admin']
           if (excluded.includes(path)) return false
           if (path.startsWith('/u/')) return false // dynamic profile pages
+          if (path.startsWith('/admin')) return false // staff console
           // Note: /status IS prerendered (just the <head> meta for SEO;
           // the live health body hydrates on the client). Removed from the
           // exclusion list when we made it indexable.


### PR DESCRIPTION
Closes REL-260. Link 1 of 4 of the admin dashboard.

## Admin is its own list, never a tier

`super_user` is a **product** tier — an invite-only early-access programme that grants Uplink Ultimate caps for free, and the knowledge base says a small number of users already hold it. Gating staff tooling on it would have handed the support console, and with it every user's email and ticket history, to those people. So admin is a table.

- **`admin_users`** (migration `000016`), seeded with exactly `bch713@pm.me`.
- **`RequireAdmin`** runs after `platform.LogtoAuth`. It matches a pinned `logto_sub` first — no external call, which is every request after the first — and otherwise bootstraps once against the user's Logto-verified primary email, pinning the sub onto the row. Matching on email forever would let a re-registered address in and lock a changed one out; pinning closes both. Nothing in the path reads a role or a plan.
- **Add/remove from the dashboard**, so access is granted without a deploy. **The last admin cannot be removed and nobody can remove themselves** — between those two rules there is no sequence of clicks that ends in a lockout. Every grant and revoke is logged.

### Two deliberate deviations from the issue, both flagged

1. **The verified email comes from the Logto Management API, not a JWT claim.** The issue asked to match "the JWT's verified email claim", but the access token carries `email` via Custom JWT and **no `email_verified`** — nothing in the repo emits it. Trusting the bare claim would not be verification, and requiring a claim Logto does not send would have locked Brandon out on day one. `accounts.LogtoPrimaryEmail` asks Logto instead; it only sets `primaryEmail` on an address the user has proven they control. It costs one call per admin, ever.
2. **Routes are `/admin/admins` (staff list) and `/admin/accounts` (user directory)**, not `/admin/users` for the staff list. The issue's own section names are "Users" for app users and "Admins" for staff, and having the API mean the opposite of the UI would have aged badly.

Also: `email` is `text` with a `unique (lower(email))` index rather than `citext` — the extension is not installed here and `CREATE EXTENSION` needs a privilege the migration runner is not guaranteed to have. A migration that fails takes core-api down at boot; the functional index gives identical case-insensitive uniqueness with no privilege at all.

## The shell

A lazily code-split route tree at `/admin`: **Overview**, **Support** (stub — REL-263), **Users** (read-only), **Admins**. No new app, no new deployment, no second auth. A non-admin gets a plain "staff only" page, and a signed-out visitor gets a sign-in prompt — both correct outcomes, not broken ones.

**The split is verified, not assumed.** The home page statically loads four chunks and none of them is admin code; each route wrapper reaches its page through a dynamic import only:

```
Chunks the home page STATICALLY loads: 4
Admin chunks among them: NONE
  admin-CxsLev3j.js        -> AdminShell-I9I8SWGR.js   [DYNAMIC]
  admin.index-iiXl_hk4.js  -> OverviewPage-85zHSqbB.js [DYNAMIC]
  admin.users-Bjf699rh.js  -> UsersPage-BCpLn1QQ.js    [DYNAMIC]
  admin.admins-CfxXnNHZ.js -> AdminsPage-CC7EHdkj.js   [DYNAMIC]
```

`/admin` is also excluded from the prerender and the link crawler.

## Overview

![Overview](https://raw.githubusercontent.com/doughknee/myscrollr/captures/rel-260/rel260-overview.png)

Every tile is a number we hold or an explicit admission that we do not.

- **Active installs is not measurable and the tile says so.** There is no telemetry or analytics anywhere in this API, by standing decision. The `Measured` type carries `available`, and an unavailable value never renders as a number — not even `0`, which reads as a measurement of zero rather than the absence of one.
- **Downloads is labelled downloads**, with the caveat that one person upgrading through five releases is five downloads. Real per-release asset counts from the GitHub Releases API, Redis-cached, degrading to "these are stale" rather than "no numbers" when GitHub is unreachable.
- **Connected now is summed across replicas.** `events.ClientCount()` is per-replica and core-api runs two, so reading it from a request reports about half the fleet — and the number still looks plausible, which is what makes it dangerous. Each replica now heartbeats its count into one Redis hash and the tile shows how many replicas contributed, so an under-reporting fleet is visible instead of silent.
- **Signups over time**: `user_preferences` had no `created_at` — the issue assumed one. Added nullable and **deliberately not backfilled**; inventing a date for 82 existing rows is exactly what this page exists to avoid. The tile says how many accounts predate tracking.
- Plans from Stripe (accounts with no Stripe row counted as free, so the mix adds up), support queue numbers, `catalog_requests` / `business_leads` as demand signals, and ingest freshness.

Sections run concurrently, so one failing tile cannot blank the page that tells you what is broken.

## Users

Read-only, and not by omission — there is no write path at all, not a disabled button. Reading another person's data is already the sensitive part; editing it needs its own decision.

## Verification

- **The guard test is not vacuous.** `TestRequireAdminRejectsSuperUserNotOnTheList` was mutation-tested: reintroducing the `super_user` shortcut in `RequireAdmin` makes it fail with `got 200, want 403`.
- Go: `go build ./...`, `go vet ./...` and `go test ./...` all green against a real Postgres (run in-cluster — no Go and no working Docker on this box). Tests cover the seeded email, the `super_user` rejection, unauthenticated, a failed Logto lookup failing **closed**, a second account failing to claim a pinned row, case-insensitive matching, and both anti-lockout refusals.
- One real bug caught by these tests: `c.Context()` is already cancelled under `app.Test`, which turned every query into `context canceled` — and on an auth check that reads as a clean 403, so the deny-path tests were passing for entirely the wrong reason. Switched to `context.Background()`, the convention used everywhere else in this API.
- `npm test` green (69 passed, 11 new), `npm run build` green including the prerender and mobile-viewport guards, eslint and prettier clean.
- `scripts/migrations/check-additive.sh`: "All new migrations are additive."

## Not in this PR

The support queue (REL-263), write actions on user accounts, and any backfill of historical signup dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
