### PR TITLE
The support queue and the whole triage pipeline, read-only [REL-263]

### DIFF
--- a/api/core/server.go
+++ b/api/core/server.go
@@ -238,6 +238,16 @@ func (s *Server) setupRoutes() {
 	s.App.Post("/admin/admins", platform.LogtoAuth, admin.RequireAdmin, admin.HandleAddAdmin)
 	s.App.Delete("/admin/admins/:id", platform.LogtoAuth, admin.RequireAdmin, admin.HandleRemoveAdmin)
 
+	// The support console's read half (REL-263). Same gate as the rest of
+	// /admin, and deliberately NOT the SCROLLR_WEBHOOK_SECRET header that
+	// guards /internal/support/cases below: that secret is for
+	// machine-to-machine callers and a browser has no business holding one.
+	// The handlers live in internal/support because everything they read -
+	// the disposition vocabulary, the proven-fix walk, the hold clock - is
+	// unexported there.
+	s.App.Get("/admin/support/queue", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminQueue)
+	s.App.Get("/admin/support/case/:ticket", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminCase)
+
 	s.App.Get("/dashboard", platform.LogtoAuth, s.getDashboard)
 
 	// Support

--- a/api/internal/admin/handlers_overview.go
+++ b/api/internal/admin/handlers_overview.go
@@ -23,11 +23,11 @@ import (
 
 // Measured wraps a number with whether it means what its label says. When
 // Available is false the client renders Note instead of Value.
-type Measured struct {
-	Value     int    `json:"value"`
-	Available bool   `json:"available"`
-	Note      string `json:"note,omitempty"`
-}
+//
+// An alias rather than a declaration since REL-263: the support console needs
+// the same promise for its hold countdown, and both packages reaching for one
+// type beats two that agree by coincidence. The JSON is identical.
+type Measured = platform.Measured
 
 type OverviewResponse struct {
 	GeneratedAt  string        `json:"generated_at"`

--- a/api/internal/platform/measured.go
+++ b/api/internal/platform/measured.go
@@ -1,0 +1,25 @@
+package platform
+
+// Measured wraps a number with whether it means what its label says.
+//
+// It exists because of one specific failure: a dashboard that cannot measure
+// something and renders 0 anyway. "0 active installs" reads as a measurement
+// of zero rather than the absence of a measurement, and a reader files it
+// away as a fact. When Available is false the client renders Note and must
+// not render Value — not even as "0".
+//
+// Introduced by the staff Overview (REL-260) and lifted here when the support
+// console (REL-263) needed the same promise for a hold countdown that is
+// running against a pipeline which may be switched off. The JSON shape is
+// unchanged; internal/admin keeps `Measured` as an alias.
+type Measured struct {
+	Value     int    `json:"value"`
+	Available bool   `json:"available"`
+	Note      string `json:"note,omitempty"`
+}
+
+// Unmeasured is the "we do not have this number" answer, with the sentence
+// that says why.
+func Unmeasured(note string) Measured {
+	return Measured{Available: false, Note: note}
+}

--- a/api/internal/support/handlers_admin_console.go
+++ b/api/internal/support/handlers_admin_console.go
@@ -1,0 +1,792 @@
+package support
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+// =============================================================================
+// The staff support console, read half (REL-263)
+// =============================================================================
+//
+// Everything this serves has been in Postgres since REL-243/249. None of it has
+// ever been shown properly: Discord truncates a reply at 2000 characters,
+// splits it across posts, and has no room at all for the pipeline underneath —
+// what the classifier decided, what the drafter cited, what it admits it does
+// not know, and which rule chose the disposition. So this is not new data. It
+// is the first surface wide enough to read it.
+//
+// Read-only on purpose. Every verb is REL-261, and proving each fact is
+// visible has to come before a button can act on one.
+//
+// These handlers live in package support rather than package admin because
+// everything they need — the disposition vocabulary, the proven-fix walk, the
+// context the prompt was given, the hold clock — is here and unexported.
+// Moving them would have meant exporting a dozen internals so another package
+// could reassemble them in the same order. The staff gate is applied where the
+// routes are declared: platform.LogtoAuth + admin.RequireAdmin, and never the
+// SCROLLR_WEBHOOK_SECRET header that guards /internal/support/cases — that
+// secret is for machine-to-machine callers and a browser has no business
+// holding one.
+
+// queueLimit caps how many cases one queue read considers. The whole table is
+// in the low hundreds, so this is a ceiling rather than a pager: showing an
+// admin a partial queue and calling it the queue is the failure to avoid.
+const queueLimit = 500
+
+const (
+	queueNeedsYou = "needs_you"
+	queueWaiting  = "waiting"
+	queueHandled  = "handled"
+)
+
+// AutoSendState is the pipeline's switch position. Every countdown on the page
+// is meaningless without it: a hold running against a paused pipeline is not
+// counting down to anything.
+type AutoSendState struct {
+	Armed       bool   `json:"armed"`
+	Paused      bool   `json:"paused"`
+	Enabled     bool   `json:"enabled"`
+	HoldMinutes int    `json:"hold_minutes"`
+	Note        string `json:"note"`
+}
+
+func autoSendState(ctx context.Context) AutoSendState {
+	s := AutoSendState{
+		Enabled:     autosendEnabled(),
+		Paused:      autosendPaused(ctx),
+		HoldMinutes: int(holdDuration() / time.Minute),
+	}
+	s.Armed = s.Enabled && !s.Paused
+	switch {
+	case !s.Enabled:
+		s.Note = "Autonomous sending is off (SUPPORT_AUTOSEND). Every draft waits for a person, whatever its disposition says."
+	case s.Paused:
+		s.Note = "Autonomous sending is paused. Holds keep their deadlines and resume where they were, but nothing goes out until /resume."
+	default:
+		s.Note = fmt.Sprintf("Autonomous sending is on, with a %d-minute hold. A draft on a hold sends itself when the countdown runs out — doing nothing is what sends it.", s.HoldMinutes)
+	}
+	return s
+}
+
+// AdminHold is a live countdown, or an honest refusal to show one.
+//
+// Remaining is Measured rather than a bare number because the number is only a
+// countdown while the pipeline is armed. Printing "sends in 12 minutes" with
+// SUPPORT_AUTOSEND off is exactly the failure that type exists to stop.
+type AdminHold struct {
+	Until     time.Time         `json:"until"`
+	Remaining platform.Measured `json:"remaining_seconds"`
+	Verb      string            `json:"verb"`
+	Expired   bool              `json:"expired"`
+	Note      string            `json:"note"`
+}
+
+// draftStatus is a parameter and not an afterthought: hold_until is NEVER
+// cleared when a draft is sent, held or skipped, so a row that went out this
+// morning still carries this morning's deadline. Reading it without checking
+// the status renders a countdown for a reply that has already been sent, which
+// is the same lie as counting down against a switched-off pipeline. The
+// sweeper's own query says `status = 'pending'`; so does this.
+func buildHold(until *time.Time, draftStatus, disposition string, armed bool, now time.Time) *AdminHold {
+	if until == nil || draftStatus != "pending" {
+		return nil
+	}
+	h := &AdminHold{Until: until.UTC(), Verb: "Sending"}
+	if disposition == dispositionAutoClose {
+		h.Verb = "Sending and closing the ticket"
+	}
+	remaining := int(until.Sub(now).Round(time.Second) / time.Second)
+	h.Expired = remaining <= 0
+	switch {
+	case !armed:
+		h.Remaining = platform.Unmeasured("Autonomous sending is off or paused, so this deadline is not counting down to anything. It waits for a person.")
+		h.Note = h.Remaining.Note
+	case h.Expired:
+		h.Remaining = platform.Measured{Value: 0, Available: true}
+		h.Note = "The hold has run out. The sweeper runs once a minute and sends this on its next pass."
+	default:
+		h.Remaining = platform.Measured{Value: remaining, Available: true}
+		h.Note = "Doing nothing sends it."
+	}
+	return h
+}
+
+// AdminFix is the proven-fix answer with the reasoning that produced it.
+//
+// The reasoning is the point. "No fix on record" is the ordinary answer and
+// says nothing on its own; whether that is because nobody linked an issue,
+// because the issue is not done, or because the fix has not shipped yet
+// changes what the reader should do next.
+type AdminFix struct {
+	IssueKey   string     `json:"issue_key,omitempty"`
+	Proven     bool       `json:"proven"`
+	Version    string     `json:"version,omitempty"`
+	ReleaseURL string     `json:"release_url,omitempty"`
+	MergedAt   *time.Time `json:"merged_at,omitempty"`
+	Reason     string     `json:"reason"`
+}
+
+const noIssueLinkedReason = "No Linear issue is linked to this case, so no fix may be claimed. Linking one is a person's decision — the model never does it, because a wrong link produces a confidently wrong claim that something shipped."
+
+// queueFix is the cheap answer, for a row in a list: proven or not, with no
+// explanation of a negative. Costs one Redis-cached lookup per issue key.
+func queueFix(ctx context.Context, issueKey string) *AdminFix {
+	if issueKey == "" {
+		return nil
+	}
+	f := &AdminFix{IssueKey: issueKey}
+	pf := provenFixForIssue(ctx, issueKey)
+	if pf == nil {
+		f.Reason = "Not done and shipped — no released fix is on record for " + issueKey + "."
+		return f
+	}
+	merged := pf.MergedAt
+	f.Proven, f.Version, f.ReleaseURL, f.MergedAt = true, pf.Version, pf.ReleaseURL, &merged
+	f.Reason = fmt.Sprintf("%s is done and shipped in Scrollr %s.", issueKey, pf.Version)
+	return f
+}
+
+// explainFix is the case view's answer: it walks the same three checks
+// lookupProvenFix does and says which one failed.
+func explainFix(ctx context.Context, issueKey string) AdminFix {
+	if issueKey == "" {
+		return AdminFix{Reason: noIssueLinkedReason}
+	}
+	if f := queueFix(ctx, issueKey); f != nil && f.Proven {
+		f.Reason = fmt.Sprintf(
+			"%s is done, and the pull request that closed it merged on %s — before Scrollr %s went out. The reply is allowed to say the fix shipped in %s.",
+			issueKey, f.MergedAt.UTC().Format("2 Jan 2006"), f.Version, f.Version)
+		return *f
+	}
+
+	f := AdminFix{IssueKey: issueKey}
+	mergedAt, err := linearClosingMerge(ctx, issueKey)
+	switch {
+	case err != nil:
+		f.Reason = fmt.Sprintf("%s is linked, but Linear could not be reached to check it (%v). An unreachable Linear is a reason to say nothing, never a reason to guess.", issueKey, err)
+	case mergedAt.IsZero():
+		f.Reason = fmt.Sprintf("%s is linked but is not in a completed state with a merged pull request behind it. Nothing is proven, so the reply may not name a version as the remedy.", issueKey)
+	default:
+		f.Reason = fmt.Sprintf("%s was fixed — merged %s — but no published release has gone out since, so there is still nothing for this user to update to.", issueKey, mergedAt.UTC().Format("2 Jan 2006"))
+	}
+	return f
+}
+
+// ===== Grouping ===================================================
+
+// queueState is everything the grouping reads. Split out so the rule is a pure
+// function over it: the three groups are the shape of the whole page and they
+// deserve a test that needs no database and no clock.
+type queueState struct {
+	CaseStatus    string
+	HasDraft      bool
+	DraftStatus   string
+	Disposition   string
+	AutoSendArmed bool
+}
+
+// group answers which of the three columns a case belongs in, and why in
+// words. The reason is not decoration: "Needs you" with no explanation is the
+// Discord queue again, where thirteen drafts sat pending since May because
+// nothing ever said what was waiting on whom.
+func (q queueState) group() (string, string) {
+	if strings.EqualFold(strings.TrimSpace(q.CaseStatus), "closed") {
+		return queueHandled, "The ticket is closed."
+	}
+	if !q.HasDraft {
+		return queueNeedsYou, "No draft was ever written for this ticket, so nothing is going to answer it on its own."
+	}
+
+	switch q.DraftStatus {
+	case "pending":
+		return queueNeedsYou, q.pendingReason()
+	case "failed":
+		return queueNeedsYou, "The send failed. The draft is still here and the user has heard nothing."
+	case "asked":
+		return queueWaiting, "We asked the user for what we need to troubleshoot and are waiting on the answer."
+	case "sent", "approved", "edited":
+		return queueWaiting, "We replied. Nothing is due from us until they write back."
+	case "skipped":
+		return queueHandled, "Someone decided this needed no reply."
+	default:
+		return queueNeedsYou, fmt.Sprintf("Draft status %q is not one this console recognises, so it is being shown rather than filed away.", q.DraftStatus)
+	}
+}
+
+func (q queueState) pendingReason() string {
+	switch q.Disposition {
+	case "":
+		return "No disposition was recorded, so nothing will send this on its own."
+	case dispositionEscalate:
+		return "Escalated. No timer is running and nothing will send it."
+	case dispositionAutoAsk:
+		return "Queued to ask the user. An ask has no hold, so if it is still here the send did not go through."
+	case dispositionAutoSend, dispositionAutoClose:
+		if q.AutoSendArmed {
+			return "On a hold. Doing nothing sends it."
+		}
+		return "Would send on a hold, but autonomous sending is off or paused, so it is waiting for a person."
+	default:
+		return fmt.Sprintf("Disposition %q, still pending.", q.Disposition)
+	}
+}
+
+// ===== The queue ==================================================
+
+type AdminQueueRow struct {
+	TicketNumber string `json:"ticket_number"`
+	Subject      string `json:"subject"`
+	UserEmail    string `json:"user_email,omitempty"`
+	Category     string `json:"category,omitempty"`
+	Priority     string `json:"priority,omitempty"`
+	Status       string `json:"status"`
+	Summary      string `json:"summary,omitempty"`
+
+	Group       string `json:"group"`
+	GroupReason string `json:"group_reason"`
+
+	DraftID           int64  `json:"draft_id,omitempty"`
+	DraftStatus       string `json:"draft_status,omitempty"`
+	Disposition       string `json:"disposition,omitempty"`
+	DispositionReason string `json:"disposition_reason,omitempty"`
+
+	LastUserMessageAt *time.Time        `json:"last_user_message_at,omitempty"`
+	WaitingHours      platform.Measured `json:"waiting_hours"`
+
+	Hold *AdminHold `json:"hold,omitempty"`
+	Fix  *AdminFix  `json:"fix,omitempty"`
+
+	OpenedAt  time.Time `json:"opened_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type AdminQueueResponse struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	AutoSend    AutoSendState   `json:"autosend"`
+	Counts      map[string]int  `json:"counts"`
+	State       string          `json:"state"`
+	Rows        []AdminQueueRow `json:"rows"`
+}
+
+const queueSQL = `
+	WITH latest AS (
+		SELECT DISTINCT ON (ticket_number)
+		       ticket_number, id, status, disposition, disposition_reason, hold_until
+		  FROM support_drafts
+		 ORDER BY ticket_number, created_at DESC, id DESC
+	)
+	SELECT c.ticket_number, coalesce(c.user_email, ''), c.subject,
+	       coalesce(c.category, ''), coalesce(c.priority, ''), c.status,
+	       coalesce(c.summary, ''), coalesce(c.linear_issue_key, ''),
+	       c.opened_at, c.updated_at,
+	       (SELECT max(m.created_at) FROM support_messages m
+	         WHERE m.ticket_number = c.ticket_number AND m.kind = 'user'),
+	       d.id, d.status, d.disposition, d.disposition_reason, d.hold_until
+	  FROM support_cases c
+	  LEFT JOIN latest d ON d.ticket_number = c.ticket_number
+	 ORDER BY c.updated_at DESC
+	 LIMIT $1
+`
+
+// HandleAdminQueue - GET /admin/support/queue?state=needs_you|waiting|handled|all
+//
+// The counts are always over the whole queue and never over the filter, so
+// switching to "Handled" cannot make "Needs you" look empty.
+func HandleAdminQueue(c *fiber.Ctx) error {
+	if platform.DBPool == nil {
+		return adminSupportError(c, "The support database is not reachable from this API instance.")
+	}
+	state := strings.TrimSpace(c.Query("state", "all"))
+	if state == "" {
+		state = "all"
+	}
+	switch state {
+	case queueNeedsYou, queueWaiting, queueHandled, "all":
+	default:
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "state must be one of needs_you, waiting, handled, all",
+		})
+	}
+
+	// context.Background(), not c.Context(): Fiber's request context is
+	// already cancelled by the time a handler under app.Test reaches the
+	// database, which turns every query in a test into "context canceled".
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	autosend := autoSendState(ctx)
+	rows, err := platform.DBPool.Query(ctx, queueSQL, queueLimit)
+	if err != nil {
+		log.Printf("[AdminSupport] queue: %v", err)
+		return adminSupportError(c, "Could not read the support queue.")
+	}
+	defer rows.Close()
+
+	now := time.Now()
+	all := make([]AdminQueueRow, 0, 64)
+	counts := map[string]int{queueNeedsYou: 0, queueWaiting: 0, queueHandled: 0}
+
+	for rows.Next() {
+		var r AdminQueueRow
+		var issueKey string
+		var draftID *int64
+		var draftStatus, disposition, dispositionReason *string
+		var holdUntil, lastUser *time.Time
+
+		if err := rows.Scan(&r.TicketNumber, &r.UserEmail, &r.Subject,
+			&r.Category, &r.Priority, &r.Status, &r.Summary, &issueKey,
+			&r.OpenedAt, &r.UpdatedAt, &lastUser,
+			&draftID, &draftStatus, &disposition, &dispositionReason, &holdUntil); err != nil {
+			log.Printf("[AdminSupport] scan queue row: %v", err)
+			continue
+		}
+
+		if draftID != nil {
+			r.DraftID = *draftID
+		}
+		r.DraftStatus = deref(draftStatus)
+		r.Disposition = deref(disposition)
+		r.DispositionReason = deref(dispositionReason)
+		r.LastUserMessageAt = lastUser
+
+		// A backfilled case can have no user message on record. That is not a
+		// wait of zero hours, and rendering it as one would put a months-old
+		// ticket at the bottom of anything sorted by how long someone waited.
+		if lastUser == nil {
+			r.WaitingHours = platform.Unmeasured("No message from the user is on record for this ticket, so there is nothing to measure the wait from.")
+		} else {
+			r.WaitingHours = platform.Measured{Value: int(now.Sub(*lastUser).Hours()), Available: true}
+		}
+
+		r.Hold = buildHold(holdUntil, r.DraftStatus, r.Disposition, autosend.Armed, now)
+		r.Group, r.GroupReason = queueState{
+			CaseStatus:    r.Status,
+			HasDraft:      draftID != nil,
+			DraftStatus:   r.DraftStatus,
+			Disposition:   r.Disposition,
+			AutoSendArmed: autosend.Armed,
+		}.group()
+		counts[r.Group]++
+
+		if issueKey != "" {
+			r.Fix = &AdminFix{IssueKey: issueKey}
+		}
+		all = append(all, r)
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("[AdminSupport] queue rows: %v", err)
+	}
+
+	out := make([]AdminQueueRow, 0, len(all))
+	for _, r := range all {
+		if state == "all" || r.Group == state {
+			out = append(out, r)
+		}
+	}
+	resolveQueueFixes(ctx, out)
+
+	return c.JSON(AdminQueueResponse{
+		GeneratedAt: now.UTC(),
+		AutoSend:    autosend,
+		Counts:      counts,
+		State:       state,
+		Rows:        out,
+	})
+}
+
+// resolveQueueFixes fills in the proven-fix answer for the rows being
+// returned, once per DISTINCT issue key rather than once per row: several
+// tickets routinely point at the same bug, and each lookup is a Linear call
+// plus a GitHub call on a cold cache.
+func resolveQueueFixes(ctx context.Context, rows []AdminQueueRow) {
+	byKey := map[string][]int{}
+	for i, r := range rows {
+		if r.Fix != nil {
+			byKey[r.Fix.IssueKey] = append(byKey[r.Fix.IssueKey], i)
+		}
+	}
+	if len(byKey) == 0 {
+		return
+	}
+
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		sem    = make(chan struct{}, 4)
+		answer = map[string]*AdminFix{}
+	)
+	for key := range byKey {
+		wg.Add(1)
+		go func(key string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			f := queueFix(ctx, key)
+			mu.Lock()
+			answer[key] = f
+			mu.Unlock()
+		}(key)
+	}
+	wg.Wait()
+
+	for key, idxs := range byKey {
+		f := answer[key]
+		if f == nil {
+			continue
+		}
+		for _, i := range idxs {
+			copied := *f
+			rows[i].Fix = &copied
+		}
+	}
+}
+
+// ===== One case ===================================================
+
+type AdminMessage struct {
+	Kind       string    `json:"kind"`
+	Body       string    `json:"body"`
+	Superseded bool      `json:"superseded"`
+	DraftID    int64     `json:"draft_id,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// AdminDraft is every field the pipeline wrote about one draft. Nothing is
+// dropped for tidiness: an empty field is itself the answer, and the gap
+// between "the drafter cited nothing" and "we did not show you what it cited"
+// is exactly the gap this page exists to close.
+type AdminDraft struct {
+	ID     int64  `json:"id"`
+	Status string `json:"status"`
+	Body   string `json:"body"`
+	Edited string `json:"edited_body,omitempty"`
+
+	Summary     string `json:"summary,omitempty"`
+	Category    string `json:"category,omitempty"`
+	Priority    string `json:"priority,omitempty"`
+	Confidence  string `json:"confidence,omitempty"`
+	DuplicateOf string `json:"duplicate_of,omitempty"`
+	Sentiment   string `json:"sentiment,omitempty"`
+	// DrafterCategory is what the second model call thought this was. A
+	// disagreement with Category is itself an escalation rule.
+	DrafterCategory string `json:"drafter_category,omitempty"`
+
+	GroundedIn   string `json:"grounded_in,omitempty"`
+	Unknowns     string `json:"unknowns,omitempty"`
+	AskUserFor   string `json:"ask_user_for,omitempty"`
+	InternalNote string `json:"internal_note,omitempty"`
+	NeedsInfo    bool   `json:"needs_info"`
+	ShouldClose  bool   `json:"should_close"`
+
+	Disposition       string     `json:"disposition,omitempty"`
+	DispositionReason string     `json:"disposition_reason,omitempty"`
+	// HoldUntil is the raw deadline on the row. It survives the send, so read
+	// Hold on the case (which checks the status) rather than this.
+	HoldUntil  *time.Time `json:"hold_until,omitempty"`
+	Intervened bool       `json:"intervened"`
+	CreatedAt         time.Time  `json:"created_at"`
+	DecidedAt         *time.Time `json:"decided_at,omitempty"`
+	SentAt            *time.Time `json:"sent_at,omitempty"`
+}
+
+type AdminWidget struct {
+	Type     string `json:"type"`
+	OnTicker bool   `json:"on_ticker"`
+}
+
+// AdminUserContext is the WHO IS WRITING block the model was given, as
+// structure rather than prose. VersionState is the server's comparison and the
+// browser must not redo it — "out of date" is a diagnostic here and never
+// permission to tell the user to update, which needs Fix.
+type AdminUserContext struct {
+	Tier             string        `json:"tier"`
+	AppVersion       string        `json:"app_version,omitempty"`
+	CurrentVersion   string        `json:"current_version,omitempty"`
+	VersionState     string        `json:"version_state"` // unknown | behind | current
+	OS               string        `json:"os,omitempty"`
+	MonitorsAttached int           `json:"monitors_attached"`
+	MonitorsChosen   int           `json:"monitors_chosen"`
+	Widgets          []AdminWidget `json:"widgets"`
+	HasDiagnostics   bool          `json:"has_diagnostics"`
+	Note             string        `json:"note"`
+}
+
+type AdminSimilarCase struct {
+	TicketNumber string `json:"ticket_number"`
+	Subject      string `json:"subject"`
+	UserWrote    string `json:"user_wrote"`
+	WeSent       string `json:"we_sent"`
+}
+
+type AdminCaseDetail struct {
+	TicketNumber    string     `json:"ticket_number"`
+	Subject         string     `json:"subject"`
+	UserEmail       string     `json:"user_email,omitempty"`
+	LogtoSub        string     `json:"logto_sub,omitempty"`
+	Status          string     `json:"status"`
+	Category        string     `json:"category,omitempty"`
+	Priority        string     `json:"priority,omitempty"`
+	Summary         string     `json:"summary,omitempty"`
+	LinearIssueKey  string     `json:"linear_issue_key,omitempty"`
+	DiscordThreadID string     `json:"discord_thread_id,omitempty"`
+	DiscordURL      string     `json:"discord_url,omitempty"`
+	OpenedAt        time.Time  `json:"opened_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	ClosedAt        *time.Time `json:"closed_at,omitempty"`
+
+	Group       string `json:"group"`
+	GroupReason string `json:"group_reason"`
+
+	Messages []AdminMessage `json:"messages"`
+	Draft    *AdminDraft    `json:"draft"`
+	// DraftNote says why Draft is nil when it is. A missing draft is a fact
+	// about the pipeline, not an empty panel.
+	DraftNote string `json:"draft_note,omitempty"`
+
+	Context  AdminUserContext `json:"context"`
+	Fix      AdminFix         `json:"fix"`
+	AutoSend AutoSendState    `json:"autosend"`
+	Hold     *AdminHold       `json:"hold,omitempty"`
+
+	// StaleDays is how long the user has been waiting since they last wrote;
+	// StaleAfter is the threshold past which the policy makes a reply ask
+	// rather than tell.
+	StaleDays  int `json:"stale_days"`
+	StaleAfter int `json:"stale_after"`
+
+	Similar     []AdminSimilarCase `json:"similar"`
+	KnownIssues string             `json:"known_issues,omitempty"`
+	// EvidenceNote is the honesty line on the two blocks above: neither is
+	// stored per draft, so both are rebuilt now and can differ from what the
+	// model was actually shown.
+	EvidenceNote string `json:"evidence_note"`
+}
+
+const caseSQL = `
+	SELECT ticket_number, subject, coalesce(user_email, ''), coalesce(logto_sub, ''),
+	       status, coalesce(category, ''), coalesce(priority, ''), coalesce(summary, ''),
+	       coalesce(linear_issue_key, ''), coalesce(discord_thread_id, ''),
+	       opened_at, updated_at, closed_at
+	  FROM support_cases WHERE ticket_number = $1
+`
+
+// HandleAdminCase - GET /admin/support/case/:ticket
+func HandleAdminCase(c *fiber.Ctx) error {
+	if platform.DBPool == nil {
+		return adminSupportError(c, "The support database is not reachable from this API instance.")
+	}
+	ticket := strings.TrimSpace(c.Params("ticket"))
+	if ticket == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error", Error: "A ticket number is required",
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var d AdminCaseDetail
+	err := platform.DBPool.QueryRow(ctx, caseSQL, ticket).Scan(
+		&d.TicketNumber, &d.Subject, &d.UserEmail, &d.LogtoSub, &d.Status,
+		&d.Category, &d.Priority, &d.Summary, &d.LinearIssueKey,
+		&d.DiscordThreadID, &d.OpenedAt, &d.UpdatedAt, &d.ClosedAt)
+	if err == pgx.ErrNoRows {
+		return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "No case with that ticket number. The case database only carries tickets the API has seen or backfilled.",
+		})
+	}
+	if err != nil {
+		log.Printf("[AdminSupport] case %s: %v", ticket, err)
+		return adminSupportError(c, "Could not read that case.")
+	}
+	if d.DiscordThreadID != "" {
+		if guild := strings.TrimSpace(os.Getenv("DISCORD_GUILD_ID")); guild != "" {
+			d.DiscordURL = "https://discord.com/channels/" + guild + "/" + d.DiscordThreadID
+		}
+	}
+
+	d.Messages = adminCaseMessages(ctx, ticket)
+	d.Draft, d.DraftNote = adminCurrentDraft(ctx, ticket)
+	d.AutoSend = autoSendState(ctx)
+	if d.Draft != nil {
+		d.Hold = buildHold(d.Draft.HoldUntil, d.Draft.Status, d.Draft.Disposition, d.AutoSend.Armed, time.Now())
+	}
+	d.Group, d.GroupReason = queueState{
+		CaseStatus:    d.Status,
+		HasDraft:      d.Draft != nil,
+		DraftStatus:   draftStatusOf(d.Draft),
+		Disposition:   draftDispositionOf(d.Draft),
+		AutoSendArmed: d.AutoSend.Armed,
+	}.group()
+
+	d.Context = adminUserContext(ctx, ticket)
+	d.Fix = explainFix(ctx, d.LinearIssueKey)
+	d.StaleDays = caseStaleDays(ctx, ticket)
+	d.StaleAfter = staleTicketDays()
+
+	d.Similar = make([]AdminSimilarCase, 0, 3)
+	for _, s := range FetchSimilarCases(ctx, d.Subject+" "+d.Summary, ticket, 3) {
+		d.Similar = append(d.Similar, AdminSimilarCase{
+			TicketNumber: s.TicketNumber, Subject: s.Subject,
+			UserWrote: s.UserWrote, WeSent: s.WeSent,
+		})
+	}
+	d.KnownIssues = knownIssuesBlock(ctx)
+	d.EvidenceNote = "The similar cases and the known-issues block are rebuilt now, by the same queries the prompt uses. Neither is stored per draft, so on an older case they can differ from what the model was actually shown."
+
+	return c.JSON(d)
+}
+
+func adminCaseMessages(ctx context.Context, ticket string) []AdminMessage {
+	rows, err := platform.DBPool.Query(ctx, `
+		SELECT kind, coalesce(body_text, ''), coalesce(body_html, ''), superseded,
+		       coalesce(ai_draft_id, 0), created_at
+		  FROM support_messages WHERE ticket_number = $1
+		 ORDER BY created_at, id`, ticket)
+	if err != nil {
+		log.Printf("[AdminSupport] messages for %s: %v", ticket, err)
+		return nil
+	}
+	defer rows.Close()
+
+	out := make([]AdminMessage, 0, 8)
+	for rows.Next() {
+		var m AdminMessage
+		var text, bodyHTML string
+		if err := rows.Scan(&m.Kind, &text, &bodyHTML, &m.Superseded, &m.DraftID, &m.CreatedAt); err != nil {
+			continue
+		}
+		// Plain text, always. It is what Discord shows, what the model was
+		// given, and what a reply looks like once an email client is done with
+		// it — and it means this page never renders a stranger's HTML.
+		//
+		// htmlToPlain runs over body_text as well as over the fallback, not
+		// only over the fallback: osTicket's own thread bodies arrived in
+		// body_text WITH their markup — ticket 819835's opening message
+		// starts "<h3>Bug Report</h3>" — so trusting the column name prints
+		// tags at a reader instead of a conversation. The cost is that a
+		// message genuinely containing "a < b > c" loses that fragment; the
+		// benefit is that every backfilled ticket reads as prose.
+		if strings.TrimSpace(text) == "" {
+			text = bodyHTML
+		}
+		m.Body = strings.TrimSpace(htmlToPlain(text))
+		out = append(out, m)
+	}
+	return out
+}
+
+// adminCurrentDraft returns the newest draft on a case, or the sentence that
+// explains why there is not one.
+func adminCurrentDraft(ctx context.Context, ticket string) (*AdminDraft, string) {
+	var id int64
+	err := platform.DBPool.QueryRow(ctx, `
+		SELECT id FROM support_drafts WHERE ticket_number = $1
+		 ORDER BY created_at DESC, id DESC LIMIT 1`, ticket).Scan(&id)
+	if err == pgx.ErrNoRows {
+		return nil, "No draft was ever written for this ticket. Either triage produced no reply body, or the case was backfilled from osTicket without one — either way nothing is going to answer it on its own."
+	}
+	if err != nil {
+		log.Printf("[AdminSupport] draft id for %s: %v", ticket, err)
+		return nil, "The draft for this ticket could not be read."
+	}
+	draft, err := loadSupportDraft(ctx, id)
+	if err != nil || draft == nil {
+		log.Printf("[AdminSupport] load draft %d: %v", id, err)
+		return nil, "The draft for this ticket could not be read."
+	}
+	return &AdminDraft{
+		ID:                draft.ID,
+		Status:            draft.Status,
+		Body:              strings.TrimSpace(htmlToPlain(draft.DraftBodyHTML)),
+		Edited:            strings.TrimSpace(htmlToPlain(draft.EditedBodyHTML)),
+		Summary:           draft.AISummary,
+		Category:          draft.AICategory,
+		Priority:          draft.AIPriority,
+		Confidence:        draft.AIConfidence,
+		DuplicateOf:       draft.AIDuplicateOf,
+		Sentiment:         draft.Sentiment,
+		DrafterCategory:   draft.DrafterCategory,
+		GroundedIn:        draft.GroundedIn,
+		Unknowns:          draft.Unknowns,
+		AskUserFor:        draft.AskUserFor,
+		InternalNote:      draft.InternalNote,
+		NeedsInfo:         draft.NeedsInfo,
+		ShouldClose:       draft.ShouldClose,
+		Disposition:       draft.Disposition,
+		DispositionReason: draft.DispositionReason,
+		HoldUntil:         draft.HoldUntil,
+		Intervened:        draft.Intervened,
+		CreatedAt:         draft.CreatedAt,
+		DecidedAt:         draft.DecidedAt,
+		SentAt:            draft.SentAt,
+	}, ""
+}
+
+func adminUserContext(ctx context.Context, ticket string) AdminUserContext {
+	tc := ticketContextFromCase(ctx, ticket)
+	out := AdminUserContext{
+		Tier:             tc.Tier,
+		AppVersion:       tc.AppVersion,
+		CurrentVersion:   currentDesktopVersion(),
+		OS:               tc.OS,
+		MonitorsAttached: tc.MonitorCount,
+		MonitorsChosen:   tc.ChosenMonitors,
+		HasDiagnostics:   tc.HasDiagnostics,
+		Widgets:          make([]AdminWidget, 0, len(tc.Widgets)),
+		Note:             "Rebuilt from the case row and this account's widgets, by the same function that builds the prompt's WHO IS WRITING block. Being behind is a diagnostic and never permission to tell someone to update — that needs a fix on record.",
+	}
+	switch {
+	case tc.AppVersion == "" || out.CurrentVersion == "":
+		out.VersionState = "unknown"
+	case compareVersions(tc.AppVersion, out.CurrentVersion) < 0:
+		out.VersionState = "behind"
+	default:
+		out.VersionState = "current"
+	}
+	for _, w := range tc.Widgets {
+		out.Widgets = append(out.Widgets, AdminWidget{Type: w.Type, OnTicker: w.OnTicker})
+	}
+	return out
+}
+
+// ===== small helpers ==============================================
+
+func adminSupportError(c *fiber.Ctx, message string) error {
+	return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+		Status: "error", Error: message,
+	})
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func draftStatusOf(d *AdminDraft) string {
+	if d == nil {
+		return ""
+	}
+	return d.Status
+}
+
+func draftDispositionOf(d *AdminDraft) string {
+	if d == nil {
+		return ""
+	}
+	return d.Disposition
+}

--- a/api/internal/support/handlers_admin_console.go
+++ b/api/internal/support/handlers_admin_console.go
@@ -147,7 +147,11 @@ func queueFix(ctx context.Context, issueKey string) *AdminFix {
 	f := &AdminFix{IssueKey: issueKey}
 	pf := provenFixForIssue(ctx, issueKey)
 	if pf == nil {
-		f.Reason = "Not done and shipped — no released fix is on record for " + issueKey + "."
+		// Deliberately says only what a nil answer supports. A nil covers both
+		// "the issue is not done and shipped" and "Linear could not be
+		// reached", and the queue does not know which — the case view asks the
+		// second question and names the answer.
+		f.Reason = "No released fix is on record for " + issueKey + ". Open the case for why."
 		return f
 	}
 	merged := pf.MergedAt

--- a/api/internal/support/handlers_admin_console_test.go
+++ b/api/internal/support/handlers_admin_console_test.go
@@ -1,0 +1,456 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/admin"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+	"github.com/gofiber/fiber/v2"
+)
+
+// ===== The grouping rule, with no database and no clock ============
+
+func TestQueueGroupSaysWhoIsWaitingAndWhy(t *testing.T) {
+	cases := []struct {
+		name      string
+		state     queueState
+		wantGroup string
+		wantSaid  string
+	}{
+		{
+			name:      "a closed ticket is handled",
+			state:     queueState{CaseStatus: "closed", HasDraft: true, DraftStatus: "pending"},
+			wantGroup: queueHandled,
+			wantSaid:  "closed",
+		},
+		{
+			// The failure REL-263 exists for: triage produced nothing, so no
+			// button and no timer will ever answer this person.
+			name:      "a case with no draft at all needs a person",
+			state:     queueState{CaseStatus: "open", HasDraft: false},
+			wantGroup: queueNeedsYou,
+			wantSaid:  "No draft was ever written",
+		},
+		{
+			name:      "an escalation needs a person and says no timer is running",
+			state:     queueState{CaseStatus: "open", HasDraft: true, DraftStatus: "pending", Disposition: dispositionEscalate},
+			wantGroup: queueNeedsYou,
+			wantSaid:  "No timer is running",
+		},
+		{
+			name:      "an armed hold says doing nothing sends it",
+			state:     queueState{CaseStatus: "open", HasDraft: true, DraftStatus: "pending", Disposition: dispositionAutoSend, AutoSendArmed: true},
+			wantGroup: queueNeedsYou,
+			wantSaid:  "Doing nothing sends it",
+		},
+		{
+			// Same row, switch off. It must NOT still claim doing nothing
+			// sends it, because nothing will.
+			name:      "the same hold with sending off waits for a person",
+			state:     queueState{CaseStatus: "open", HasDraft: true, DraftStatus: "pending", Disposition: dispositionAutoSend},
+			wantGroup: queueNeedsYou,
+			wantSaid:  "waiting for a person",
+		},
+		{
+			name:      "an ask is waiting on the user",
+			state:     queueState{CaseStatus: "open", HasDraft: true, DraftStatus: "asked"},
+			wantGroup: queueWaiting,
+			wantSaid:  "waiting on the answer",
+		},
+		{
+			name:      "a sent reply is waiting on the user",
+			state:     queueState{CaseStatus: "open", HasDraft: true, DraftStatus: "sent"},
+			wantGroup: queueWaiting,
+			wantSaid:  "We replied",
+		},
+		{
+			name:      "a skipped draft is handled",
+			state:     queueState{CaseStatus: "open", HasDraft: true, DraftStatus: "skipped"},
+			wantGroup: queueHandled,
+			wantSaid:  "no reply",
+		},
+		{
+			name:      "a failed send needs a person",
+			state:     queueState{CaseStatus: "open", HasDraft: true, DraftStatus: "failed"},
+			wantGroup: queueNeedsYou,
+			wantSaid:  "send failed",
+		},
+		{
+			// A status this console does not know must surface, never vanish
+			// into "handled" where nobody looks.
+			name:      "an unrecognised status is shown rather than filed away",
+			state:     queueState{CaseStatus: "open", HasDraft: true, DraftStatus: "quantum"},
+			wantGroup: queueNeedsYou,
+			wantSaid:  "not one this console recognises",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			group, reason := tc.state.group()
+			if group != tc.wantGroup {
+				t.Errorf("group = %q, want %q (reason: %s)", group, tc.wantGroup, reason)
+			}
+			if !strings.Contains(reason, tc.wantSaid) {
+				t.Errorf("reason %q does not contain %q", reason, tc.wantSaid)
+			}
+		})
+	}
+}
+
+// The countdown is the one number on this page that can be a lie. hold_until
+// keeps ticking whether or not anything is going to collect it, so a page that
+// renders the remaining seconds while SUPPORT_AUTOSEND is off tells an admin a
+// reply is about to go out when none is.
+func TestHoldCountdownRefusesToRenderWhenNothingWillSend(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	until := now.Add(12 * time.Minute)
+
+	armed := buildHold(&until, "pending", dispositionAutoSend, true, now)
+	if !armed.Remaining.Available || armed.Remaining.Value != 720 {
+		t.Fatalf("armed hold: got %+v, want 720 available seconds", armed.Remaining)
+	}
+	if !strings.Contains(armed.Note, "Doing nothing sends it") {
+		t.Errorf("armed hold must say doing nothing sends it, got %q", armed.Note)
+	}
+
+	off := buildHold(&until, "pending", dispositionAutoSend, false, now)
+	if off.Remaining.Available {
+		t.Fatal("a hold with sending off must not render a countdown")
+	}
+	if off.Remaining.Value != 0 || off.Remaining.Note == "" {
+		t.Errorf("an unavailable countdown needs a sentence and no number, got %+v", off.Remaining)
+	}
+
+	expired := buildHold(&until, "pending", dispositionAutoClose, true, until.Add(time.Minute))
+	if !expired.Expired || expired.Remaining.Value != 0 {
+		t.Errorf("an expired hold should read as zero and expired, got %+v", expired)
+	}
+	if expired.Verb != "Sending and closing the ticket" {
+		t.Errorf("auto_close must say it closes the ticket, got %q", expired.Verb)
+	}
+
+	if buildHold(nil, "pending", dispositionEscalate, true, now) != nil {
+		t.Error("an escalation has no hold and must render none")
+	}
+
+	// hold_until is never cleared when a draft is sent, so the row that went
+	// out this morning still carries this morning's deadline. Reading it
+	// without checking the status put a live countdown on an already-sent
+	// reply in the queue — found against real production rows, ticket 143026.
+	for _, decided := range []string{"sent", "asked", "skipped", "approved", "edited", "failed"} {
+		if h := buildHold(&until, decided, dispositionAutoSend, true, now); h != nil {
+			t.Errorf("a %s draft must not report a hold, got %+v", decided, h)
+		}
+	}
+}
+
+// ===== The endpoints ===============================================
+
+// adminSupportApp wires the REAL staff gate in front of the real handlers.
+// Testing the handlers without it would prove nothing about the thing this
+// ticket is careful about: these two routes carry every user's email, ticket
+// history and diagnostics.
+func adminSupportApp(sub string, roles ...string) *fiber.App {
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("user_id", sub)
+		c.Locals("user_roles", roles)
+		return c.Next()
+	})
+	app.Get("/admin/support/queue", admin.RequireAdmin, HandleAdminQueue)
+	app.Get("/admin/support/case/:ticket", admin.RequireAdmin, HandleAdminCase)
+	return app
+}
+
+func getJSON(t *testing.T, app *fiber.App, path string) (int, string) {
+	t.Helper()
+	resp, err := app.Test(httptest.NewRequest("GET", path, nil), 30000)
+	if err != nil {
+		t.Fatalf("app.Test %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(raw)
+}
+
+// seedAdmin pins the one admin row to a sub, so RequireAdmin takes its
+// pinned-sub path and never reaches for Logto.
+func seedAdmin(t *testing.T, sub string) {
+	t.Helper()
+	testsupport.MustExec(t, `DELETE FROM admin_users`)
+	testsupport.MustExec(t,
+		`INSERT INTO admin_users (email, logto_sub, added_by) VALUES ('staff@example.com', $1, 'test')`, sub)
+}
+
+// A signed-in account that is not on the admin list gets 403 from both
+// endpoints, and the handlers do not run.
+//
+// The single admin row is already PINNED to another sub, so this holds without
+// depending on what Logto answers: the bootstrap UPDATE requires
+// `logto_sub IS NULL` and matches nothing.
+func TestAdminSupportEndpointsRejectASignedInNonAdmin(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	testsupport.MustExec(t,
+		`INSERT INTO support_cases (ticket_number, subject, status) VALUES ('900001', 'hello', 'open')`)
+
+	// A product tier is not staff. super_user exists on real accounts.
+	app := adminSupportApp("sub-someone-else", "super_user", "uplink_ultimate")
+
+	for _, path := range []string{"/admin/support/queue", "/admin/support/case/900001"} {
+		status, body := getJSON(t, app, path)
+		if status != fiber.StatusForbidden {
+			t.Errorf("%s: got %d, want 403 (body: %s)", path, status, body)
+		}
+		if strings.Contains(body, "hello") {
+			t.Errorf("%s leaked case content to a non-admin: %s", path, body)
+		}
+	}
+}
+
+// The queue puts every case in exactly one group, counts over the whole queue
+// rather than the filter, and refuses to invent a wait for a case with no user
+// message on record.
+func TestAdminQueueGroupsEveryCaseAndCountsThemAll(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	t.Setenv("SUPPORT_AUTOSEND", "off")
+
+	// One that needs a person, one waiting on the user, one handled.
+	testsupport.MustExec(t, `INSERT INTO support_cases (ticket_number, subject, status, updated_at) VALUES
+		('900010', 'escalated one', 'open',   now()),
+		('900011', 'asked one',     'open',   now() - interval '1 hour'),
+		('900012', 'closed one',    'closed', now() - interval '2 hours')`)
+	testsupport.MustExec(t, `INSERT INTO support_messages (ticket_number, kind, body_text, created_at)
+		VALUES ('900010', 'user', 'it is broken', now() - interval '5 hours')`)
+	testsupport.MustExec(t, `INSERT INTO support_drafts
+		(ticket_number, user_email, original_subject, draft_body_html, status, disposition, disposition_reason)
+		VALUES
+		('900010', 'a@example.com', 'escalated one', '<p>hi</p>', 'pending', 'escalate', 'money (refund)'),
+		('900011', 'b@example.com', 'asked one',     '<p>which OS?</p>', 'asked', 'auto_ask', 'asking the user'),
+		('900012', 'c@example.com', 'closed one',    '<p>done</p>', 'sent', 'auto_send', 'grounded')`)
+
+	app := adminSupportApp("sub-staff")
+
+	status, body := getJSON(t, app, "/admin/support/queue")
+	if status != fiber.StatusOK {
+		t.Fatalf("queue: got %d, want 200 (body: %s)", status, body)
+	}
+	var res AdminQueueResponse
+	if err := json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatalf("decode queue: %v (body: %s)", err, body)
+	}
+
+	want := map[string]string{"900010": queueNeedsYou, "900011": queueWaiting, "900012": queueHandled}
+	got := map[string]string{}
+	for _, r := range res.Rows {
+		got[r.TicketNumber] = r.Group
+		if r.GroupReason == "" {
+			t.Errorf("%s is in %q with no reason given", r.TicketNumber, r.Group)
+		}
+	}
+	for ticket, group := range want {
+		if got[ticket] != group {
+			t.Errorf("%s grouped as %q, want %q", ticket, got[ticket], group)
+		}
+	}
+	for _, group := range []string{queueNeedsYou, queueWaiting, queueHandled} {
+		if res.Counts[group] != 1 {
+			t.Errorf("counts[%s] = %d, want 1 (%v)", group, res.Counts[group], res.Counts)
+		}
+	}
+	if res.AutoSend.Armed {
+		t.Error("SUPPORT_AUTOSEND=off must report the pipeline as not armed")
+	}
+
+	// The escalation reason has to survive to the row: an escalation nobody
+	// can read is the Discord queue again.
+	for _, r := range res.Rows {
+		if r.TicketNumber != "900010" {
+			continue
+		}
+		if r.DispositionReason != "money (refund)" {
+			t.Errorf("disposition_reason = %q, want the rule that fired", r.DispositionReason)
+		}
+		if !r.WaitingHours.Available || r.WaitingHours.Value < 4 {
+			t.Errorf("waiting_hours = %+v, want a measured wait of about five hours", r.WaitingHours)
+		}
+	}
+	// 900011 has no user message; the wait is unknown, not zero.
+	for _, r := range res.Rows {
+		if r.TicketNumber == "900011" && r.WaitingHours.Available {
+			t.Errorf("a case with no user message must not report a wait: %+v", r.WaitingHours)
+		}
+	}
+
+	// Filtering narrows the rows and leaves the counts alone.
+	_, body = getJSON(t, app, "/admin/support/queue?state=needs_you")
+	if err := json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatalf("decode filtered queue: %v", err)
+	}
+	if len(res.Rows) != 1 || res.Rows[0].TicketNumber != "900010" {
+		t.Errorf("state=needs_you returned %d rows, want just 900010", len(res.Rows))
+	}
+	if res.Counts[queueHandled] != 1 {
+		t.Errorf("counts must cover the whole queue, not the filter: %v", res.Counts)
+	}
+}
+
+// The case view is the point of the ticket: everything the pipeline recorded
+// has to be reachable, or a person still has to open Discord.
+func TestAdminCaseShowsTheWholePipeline(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	// No Linear key and a stubbed release list, so nothing in this test
+	// reaches the network.
+	t.Setenv("LINEAR_API_KEY", "")
+	releases := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer releases.Close()
+	prevURL := knownIssuesReleasesURL
+	knownIssuesReleasesURL = releases.URL + "?per_page=%d"
+	defer func() { knownIssuesReleasesURL = prevURL }()
+
+	testsupport.MustExec(t, `INSERT INTO support_cases
+		(ticket_number, user_email, subject, category, priority, status, summary, app_version, os, tier_at_open)
+		VALUES ('900020', 'user@example.com', 'ticker will not scroll', 'bug', 'high', 'open',
+		        'the bar is frozen', '1.5.0', 'Windows 11', 'free')`)
+	testsupport.MustExec(t, `INSERT INTO support_messages (ticket_number, kind, body_text, created_at)
+		VALUES ('900020', 'user', 'my ticker stopped moving', now() - interval '3 days')`)
+	testsupport.MustExec(t, `INSERT INTO support_drafts
+		(ticket_number, user_email, original_subject, draft_body_html, status,
+		 ai_summary, ai_category, ai_priority, ai_confidence, sentiment, drafter_category,
+		 grounded_in, unknowns, ask_user_for, internal_note, needs_info, should_close,
+		 disposition, disposition_reason, hold_until)
+		VALUES ('900020', 'user@example.com', 'ticker will not scroll',
+		        '<p>Sorry about that. Which build are you on?</p>', 'pending',
+		        'ticker frozen', 'bug', 'high', 'medium', 'frustrated', 'feature',
+		        'KB: ticker rotation', 'whether they are on 1.6.1', 'their Scrollr version',
+		        'looks like REL-234', true, false,
+		        'escalate', 'classification and drafting disagreed (bug vs feature)',
+		        now() + interval '30 minutes')`)
+
+	app := adminSupportApp("sub-staff")
+	status, body := getJSON(t, app, "/admin/support/case/900020")
+	if status != fiber.StatusOK {
+		t.Fatalf("case: got %d, want 200 (body: %s)", status, body)
+	}
+	var d AdminCaseDetail
+	if err := json.Unmarshal([]byte(body), &d); err != nil {
+		t.Fatalf("decode case: %v (body: %s)", err, body)
+	}
+
+	if d.Draft == nil {
+		t.Fatalf("no draft on the case (note: %s)", d.DraftNote)
+	}
+	// Every pipeline field, by name. A field silently dropped from the
+	// response is invisible in exactly the way this page exists to fix.
+	for name, got := range map[string]string{
+		"grounded_in":        d.Draft.GroundedIn,
+		"unknowns":           d.Draft.Unknowns,
+		"ask_user_for":       d.Draft.AskUserFor,
+		"internal_note":      d.Draft.InternalNote,
+		"disposition":        d.Draft.Disposition,
+		"disposition_reason": d.Draft.DispositionReason,
+		"sentiment":          d.Draft.Sentiment,
+		"drafter_category":   d.Draft.DrafterCategory,
+		"confidence":         d.Draft.Confidence,
+		"body":               d.Draft.Body,
+	} {
+		if strings.TrimSpace(got) == "" {
+			t.Errorf("draft.%s is empty; it was written to the row", name)
+		}
+	}
+	if !d.Draft.NeedsInfo {
+		t.Error("needs_info was true on the row and false in the response")
+	}
+	if !strings.Contains(d.Draft.DispositionReason, "disagreed") {
+		t.Errorf("the escalation reason must be readable: %q", d.Draft.DispositionReason)
+	}
+	// The draft is stored as HTML and served as text — what Discord shows,
+	// and no stranger's markup rendered in a staff page.
+	if strings.Contains(d.Draft.Body, "<p>") {
+		t.Errorf("draft body should be plain text, got %q", d.Draft.Body)
+	}
+
+	if len(d.Messages) != 1 || d.Messages[0].Kind != "user" {
+		t.Fatalf("expected the user's message in the conversation, got %+v", d.Messages)
+	}
+	if d.Hold == nil || d.Hold.Until.IsZero() {
+		t.Fatal("a pending draft with hold_until must report its deadline")
+	}
+	if d.Group != queueNeedsYou {
+		t.Errorf("an escalated pending draft belongs in %q, got %q", queueNeedsYou, d.Group)
+	}
+	if d.Context.Tier != "free" || d.Context.OS != "Windows 11" || d.Context.AppVersion != "1.5.0" {
+		t.Errorf("the user context the model was given is wrong: %+v", d.Context)
+	}
+	if d.StaleDays < 3 {
+		t.Errorf("stale_days = %d, want at least 3", d.StaleDays)
+	}
+	// No issue is linked, so the console has to say that rather than leaving
+	// "no fix on record" to be read as "we checked and there isn't one".
+	if d.Fix.Proven || !strings.Contains(d.Fix.Reason, "No Linear issue is linked") {
+		t.Errorf("unlinked case fix reason = %q", d.Fix.Reason)
+	}
+	if d.EvidenceNote == "" {
+		t.Error("the similar-cases and known-issues blocks are recomputed and must say so")
+	}
+}
+
+// A ticket the case DB has never seen is a sentence, not a 500.
+func TestAdminCaseSaysWhenThereIsNoSuchTicket(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+
+	status, body := getJSON(t, adminSupportApp("sub-staff"), "/admin/support/case/404404")
+	if status != fiber.StatusNotFound {
+		t.Fatalf("got %d, want 404 (body: %s)", status, body)
+	}
+	if !strings.Contains(body, "No case with that ticket number") {
+		t.Errorf("the 404 should explain itself, got %s", body)
+	}
+}
+
+// explainFix has to distinguish the three ways a fix can fail to be proven.
+// "No fix on record" alone is what let ten backlog drafts want to tell people
+// to update.
+func TestExplainFixSaysWhichCheckFailed(t *testing.T) {
+	if f := explainFix(context.Background(), ""); f.Proven || !strings.Contains(f.Reason, "No Linear issue is linked") {
+		t.Errorf("unlinked: %+v", f)
+	}
+	// With no LINEAR_API_KEY the lookup cannot answer, and "we could not find
+	// out" must not read as "there is no fix".
+	t.Setenv("LINEAR_API_KEY", "")
+	// An unreachable Linear is never cached as "no fix" (see
+	// provenFixForIssue), so this holds with or without Redis. The key is one
+	// nothing else in the suite touches.
+	f := explainFix(context.Background(), "REL-000000")
+	if f.Proven {
+		t.Error("nothing may be proven when Linear cannot be reached")
+	}
+	if !strings.Contains(f.Reason, "could not be reached") {
+		t.Errorf("reason = %q, want it to say the lookup failed rather than that no fix exists", f.Reason)
+	}
+}

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -195,6 +195,158 @@ export interface AccountDetail {
   cases: Array<AccountCase>
 }
 
+// ── Support console (read-only, REL-263) ──────────────────
+
+export type QueueGroup = 'needs_you' | 'waiting' | 'handled'
+
+/** The pipeline's switch position. Every countdown is meaningless without it. */
+export interface AutoSendState {
+  armed: boolean
+  paused: boolean
+  enabled: boolean
+  hold_minutes: number
+  note: string
+}
+
+/**
+ * A hold, as the server computed it. `remaining_seconds` is Measured because
+ * the number is only a countdown while the pipeline is armed — an unavailable
+ * one must render as `note`, never as a time.
+ */
+export interface AdminHold {
+  until: string
+  remaining_seconds: Measured
+  verb: string
+  expired: boolean
+  note: string
+}
+
+/** The proven-fix answer plus the reasoning that produced it. */
+export interface AdminFix {
+  issue_key?: string
+  proven: boolean
+  version?: string
+  release_url?: string
+  merged_at?: string
+  reason: string
+}
+
+export interface QueueRow {
+  ticket_number: string
+  subject: string
+  user_email?: string
+  category?: string
+  priority?: string
+  status: string
+  summary?: string
+  group: QueueGroup
+  group_reason: string
+  draft_id?: number
+  draft_status?: string
+  disposition?: string
+  disposition_reason?: string
+  last_user_message_at?: string
+  waiting_hours: Measured
+  hold?: AdminHold
+  fix?: AdminFix
+  opened_at: string
+  updated_at: string
+}
+
+export interface SupportQueue {
+  generated_at: string
+  autosend: AutoSendState
+  counts: Record<string, number>
+  state: string
+  rows: Array<QueueRow> | null
+}
+
+export interface CaseMessage {
+  kind: 'user' | 'ai_draft' | 'sent' | 'note'
+  body: string
+  superseded: boolean
+  draft_id?: number
+  created_at: string
+}
+
+/** Every field the pipeline wrote about one draft. */
+export interface CaseDraft {
+  id: number
+  status: string
+  body: string
+  edited_body?: string
+  summary?: string
+  category?: string
+  priority?: string
+  confidence?: string
+  duplicate_of?: string
+  sentiment?: string
+  drafter_category?: string
+  grounded_in?: string
+  unknowns?: string
+  ask_user_for?: string
+  internal_note?: string
+  needs_info: boolean
+  should_close: boolean
+  disposition?: string
+  disposition_reason?: string
+  intervened: boolean
+  created_at: string
+  decided_at?: string
+  sent_at?: string
+}
+
+export interface CaseContext {
+  tier: string
+  app_version?: string
+  current_version?: string
+  version_state: 'unknown' | 'behind' | 'current'
+  os?: string
+  monitors_attached: number
+  monitors_chosen: number
+  widgets: Array<{ type: string; on_ticker: boolean }> | null
+  has_diagnostics: boolean
+  note: string
+}
+
+export interface SimilarCase {
+  ticket_number: string
+  subject: string
+  user_wrote: string
+  we_sent: string
+}
+
+export interface CaseDetail {
+  ticket_number: string
+  subject: string
+  user_email?: string
+  logto_sub?: string
+  status: string
+  category?: string
+  priority?: string
+  summary?: string
+  linear_issue_key?: string
+  discord_thread_id?: string
+  discord_url?: string
+  opened_at: string
+  updated_at: string
+  closed_at?: string
+  group: QueueGroup
+  group_reason: string
+  messages: Array<CaseMessage> | null
+  draft: CaseDraft | null
+  draft_note?: string
+  context: CaseContext
+  fix: AdminFix
+  autosend: AutoSendState
+  hold?: AdminHold
+  stale_days: number
+  stale_after: number
+  similar: Array<SimilarCase> | null
+  known_issues?: string
+  evidence_note: string
+}
+
 // ── Admins ────────────────────────────────────────────────────────
 
 export interface AdminRow {
@@ -228,6 +380,18 @@ export const adminApi = {
   account: (getToken: Token, sub: string) =>
     adminFetch<AccountDetail>(
       `/admin/accounts/${encodeURIComponent(sub)}`,
+      getToken,
+    ),
+
+  supportQueue: (getToken: Token, state: string) =>
+    adminFetch<SupportQueue>(
+      `/admin/support/queue?state=${encodeURIComponent(state)}`,
+      getToken,
+    ),
+
+  supportCase: (getToken: Token, ticket: string) =>
+    adminFetch<CaseDetail>(
+      `/admin/support/case/${encodeURIComponent(ticket)}`,
       getToken,
     ),
 

--- a/myscrollr.com/src/components/admin/SupportPage.tsx
+++ b/myscrollr.com/src/components/admin/SupportPage.tsx
@@ -1,0 +1,803 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  HelpCircle,
+  Loader2,
+  MessageSquare,
+} from 'lucide-react'
+import type {
+  AdminFix,
+  AdminHold,
+  AutoSendState,
+  CaseDetail,
+  QueueGroup,
+  QueueRow,
+  SupportQueue,
+} from '@/api/admin'
+import { adminApi } from '@/api/admin'
+import {
+  QUEUE_GROUPS,
+  dispositionTone,
+  fixBadge,
+  formatWait,
+  holdCountdown,
+} from '@/lib/supportConsole'
+import { useGetToken } from '@/hooks/useGetToken'
+
+/**
+ * The Support section: the queue on the left, one case on the right.
+ *
+ * Read-only. Every verb — send, hold, edit, ask, skip — is REL-261, and the
+ * point of shipping the read half first is to prove every fact is visible
+ * before a button can act on one.
+ *
+ * The case view is the whole reason this exists. Discord could show the draft
+ * and roughly two thousand characters of it; it could not show what the
+ * classifier decided, what the drafter says it is grounded in, what it admits
+ * it does not know, which rule chose the disposition, or what the model was
+ * told about the person writing. All of that has been in Postgres since
+ * REL-249. This is the first surface wide enough to read it.
+ *
+ * Nothing here recomputes the pipeline. Disposition, hold expiry and the
+ * proven-fix answer arrive decided; the browser formats them.
+ */
+
+// ── small shared pieces ───────────────────────────────────────────
+
+function Field({
+  label,
+  value,
+  empty,
+  mono,
+}: {
+  label: string
+  value?: string | null
+  empty: string
+  mono?: boolean
+}) {
+  const has = typeof value === 'string' && value.trim() !== ''
+  return (
+    <div className="border-b border-base-300/40 px-4 py-3 last:border-0">
+      <p className="text-xs font-semibold tracking-wide text-base-content/45 uppercase">
+        {label}
+      </p>
+      <p
+        className={`mt-1 text-sm whitespace-pre-wrap ${
+          has ? 'text-base-content/85' : 'text-base-content/45 italic'
+        } ${mono && has ? 'font-mono text-xs' : ''}`}
+      >
+        {has ? value : empty}
+      </p>
+    </div>
+  )
+}
+
+function Panel({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string
+  subtitle?: string
+  children: React.ReactNode
+}) {
+  return (
+    <section>
+      <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+        {title}
+      </h2>
+      {subtitle && (
+        <p className="mt-1 text-xs text-base-content/50">{subtitle}</p>
+      )}
+      <div className="mt-2 rounded-xl ring-1 ring-base-300/60">{children}</div>
+    </section>
+  )
+}
+
+const TONE_RING: Record<string, string> = {
+  stop: 'ring-error/40 bg-error/5',
+  clock: 'ring-warning/40 bg-warning/5',
+  ask: 'ring-info/40 bg-info/5',
+  done: 'ring-base-300/60',
+  none: 'ring-base-300/60',
+}
+
+/**
+ * The countdown. `holdCountdown` returns a null display whenever the server
+ * marked the number unavailable, and this renders the sentence instead — a
+ * hold that is not counting down to anything must never look like one that is.
+ */
+function HoldBanner({
+  hold,
+  autosend,
+}: {
+  hold: AdminHold
+  autosend: AutoSendState
+}) {
+  // One tick a second, only to re-render: holdCountdown derives the remaining
+  // time from the server's deadline, so nothing here tracks it in state.
+  const [, tick] = useState(0)
+  useEffect(() => {
+    if (!hold.remaining_seconds.available || hold.expired) return
+    const t = setInterval(() => tick((n) => n + 1), 1000)
+    return () => clearInterval(t)
+  }, [hold])
+
+  const live = holdCountdown(hold)
+
+  return (
+    <div
+      className={`rounded-xl px-4 py-3 ring-1 ${
+        live.display
+          ? 'bg-warning/10 ring-warning/40'
+          : 'bg-base-200/40 ring-base-300/60'
+      }`}
+    >
+      <div className="flex items-baseline gap-2">
+        <Clock size={16} className="translate-y-0.5 shrink-0" />
+        {live.display ? (
+          <p className="text-sm font-semibold">
+            {hold.verb} in {live.display}
+          </p>
+        ) : (
+          <p className="text-sm font-semibold">
+            {hold.verb} — on hold, not counting down
+          </p>
+        )}
+      </div>
+      <p className="mt-1 text-xs text-base-content/65">{live.note}</p>
+      {!autosend.armed && (
+        <p className="mt-1 text-xs text-base-content/50">{autosend.note}</p>
+      )}
+    </div>
+  )
+}
+
+function FixCard({ fix }: { fix: AdminFix }) {
+  return (
+    <div
+      className={`rounded-xl px-4 py-3 ring-1 ${
+        fix.proven
+          ? 'bg-success/5 ring-success/40'
+          : 'bg-base-200/40 ring-base-300/60'
+      }`}
+    >
+      <div className="flex items-baseline gap-2">
+        {fix.proven ? (
+          <CheckCircle2
+            size={16}
+            className="translate-y-0.5 shrink-0 text-success"
+          />
+        ) : (
+          <HelpCircle
+            size={16}
+            className="translate-y-0.5 shrink-0 text-base-content/40"
+          />
+        )}
+        <p className="text-sm font-semibold">
+          {fix.proven
+            ? `Fix on record — shipped in ${fix.version}`
+            : 'No fix on record'}
+        </p>
+      </div>
+      <p className="mt-1 text-xs text-base-content/65">{fix.reason}</p>
+      {fix.release_url && (
+        <a
+          href={fix.release_url}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+        >
+          The release <ExternalLink size={12} />
+        </a>
+      )}
+    </div>
+  )
+}
+
+// ── the conversation ──────────────────────────────────────────────
+
+const KIND_LABEL: Record<string, string> = {
+  user: 'They wrote',
+  sent: 'We replied',
+  ai_draft: 'Drafted, never sent',
+  note: 'Internal note',
+}
+
+function Conversation({ detail }: { detail: CaseDetail }) {
+  const messages = detail.messages ?? []
+  if (messages.length === 0) {
+    return (
+      <Panel title="The conversation">
+        <p className="p-4 text-sm text-base-content/50">
+          Nothing is on record for this ticket. The case database only carries
+          messages the API saw or backfilled from osTicket, so an older ticket
+          answered entirely inside osTicket can look empty here.
+        </p>
+      </Panel>
+    )
+  }
+  return (
+    <Panel
+      title="The conversation"
+      subtitle="Oldest first. Drafts that were never sent are shown too, marked as such — this is the record of what we wrote, not only of what they read."
+    >
+      <div className="divide-y divide-base-300/40">
+        {messages.map((m, i) => {
+          const mine = m.kind === 'sent'
+          return (
+            <div key={`${m.created_at}-${i}`} className="p-4">
+              <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span
+                  className={`text-xs font-semibold ${
+                    mine ? 'text-primary' : 'text-base-content/70'
+                  }`}
+                >
+                  {KIND_LABEL[m.kind] ?? m.kind}
+                </span>
+                <span className="text-xs text-base-content/45">
+                  {new Date(m.created_at).toLocaleString()}
+                </span>
+                {m.superseded && (
+                  <span className="rounded bg-base-300/60 px-1.5 py-0.5 text-[11px] text-base-content/60">
+                    superseded
+                  </span>
+                )}
+              </div>
+              <p
+                className={`mt-2 text-sm whitespace-pre-wrap ${
+                  m.kind === 'ai_draft'
+                    ? 'text-base-content/55 italic'
+                    : 'text-base-content/85'
+                }`}
+              >
+                {m.body || '(empty)'}
+              </p>
+            </div>
+          )
+        })}
+      </div>
+    </Panel>
+  )
+}
+
+// ── the pipeline ──────────────────────────────────────────────────
+
+function Pipeline({ detail }: { detail: CaseDetail }) {
+  const draft = detail.draft
+  if (!draft) {
+    return (
+      <Panel title="The pipeline">
+        <p className="p-4 text-sm text-base-content/60">
+          {detail.draft_note ?? 'There is no draft on this case.'}
+        </p>
+      </Panel>
+    )
+  }
+  const tone = dispositionTone(draft.disposition, draft.status)
+
+  return (
+    <div className="space-y-5">
+      <section>
+        <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+          What the server decided
+        </h2>
+        <div className={`mt-2 rounded-xl px-4 py-3 ring-1 ${TONE_RING[tone]}`}>
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            {tone === 'stop' && (
+              <AlertTriangle size={16} className="translate-y-0.5 text-error" />
+            )}
+            <span className="font-mono text-sm font-semibold">
+              {draft.disposition || 'no disposition recorded'}
+            </span>
+            <span className="text-xs text-base-content/50">
+              draft is {draft.status}
+              {draft.intervened && ' · a person intervened'}
+            </span>
+          </div>
+          {/* The rule that fired, verbatim. An escalation whose reason has to
+              be guessed at is the Discord queue again. */}
+          <p className="mt-2 text-sm text-base-content/85">
+            {draft.disposition_reason ||
+              'No reason was recorded. This draft predates the autonomous policy, so nothing will send it on its own.'}
+          </p>
+        </div>
+      </section>
+
+      {detail.hold && (
+        <HoldBanner hold={detail.hold} autosend={detail.autosend} />
+      )}
+
+      <Panel
+        title="What the drafter wrote"
+        subtitle={
+          draft.edited_body
+            ? 'The draft, and the edit that replaced it before sending.'
+            : 'Exactly as stored — plain text, which is what the user receives.'
+        }
+      >
+        <div className="p-4">
+          <p className="text-sm whitespace-pre-wrap text-base-content/85">
+            {draft.body || '(the drafting call produced no body)'}
+          </p>
+        </div>
+        {draft.edited_body && (
+          <div className="border-t border-base-300/40 p-4">
+            <p className="text-xs font-semibold tracking-wide text-base-content/45 uppercase">
+              Edited before sending
+            </p>
+            <p className="mt-1 text-sm whitespace-pre-wrap text-base-content/85">
+              {draft.edited_body}
+            </p>
+          </div>
+        )}
+      </Panel>
+
+      <Panel
+        title="What it says it knows"
+        subtitle="Empty is an answer. A draft that cites nothing is escalated on exactly that."
+      >
+        <Field
+          label="Grounded in"
+          value={draft.grounded_in}
+          empty="Cites nothing."
+        />
+        <Field
+          label="Unknowns"
+          value={draft.unknowns}
+          empty="Nothing left open."
+        />
+        <Field
+          label="Wants to ask"
+          value={draft.ask_user_for}
+          empty="Asks for nothing — this is meant as a final answer."
+        />
+        <Field
+          label="Internal note"
+          value={draft.internal_note}
+          empty="No note to us."
+        />
+      </Panel>
+
+      <Panel title="What the classifier decided">
+        <div className="grid grid-cols-2 gap-px bg-base-300/40 sm:grid-cols-3">
+          {[
+            ['Category', draft.category],
+            ['Drafter said', draft.drafter_category],
+            ['Priority', draft.priority],
+            ['Confidence', draft.confidence],
+            ['Sentiment', draft.sentiment],
+            ['Duplicate of', draft.duplicate_of],
+          ].map(([label, value]) => (
+            <div key={label} className="bg-base-100 px-4 py-3">
+              <p className="text-xs font-semibold tracking-wide text-base-content/45 uppercase">
+                {label}
+              </p>
+              <p className="mt-1 text-sm text-base-content/85">
+                {value && String(value).trim() !== '' ? (
+                  String(value)
+                ) : (
+                  <span className="text-base-content/40 italic">unset</span>
+                )}
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-base-300/40 px-4 py-3 text-xs text-base-content/60">
+          needs_info is{' '}
+          <span className="font-semibold">{String(draft.needs_info)}</span>;
+          should_close is{' '}
+          <span className="font-semibold">{String(draft.should_close)}</span>.
+          {draft.category &&
+            draft.drafter_category &&
+            draft.category !== draft.drafter_category && (
+              <>
+                {' '}
+                The two calls disagreed on the category, which is itself an
+                escalation rule.
+              </>
+            )}
+        </div>
+      </Panel>
+    </div>
+  )
+}
+
+// ── the case ──────────────────────────────────────────────────────
+
+function CaseView({ ticket }: { ticket: string }) {
+  const getToken = useGetToken()
+  const [detail, setDetail] = useState<CaseDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setDetail(null)
+    setError(null)
+    adminApi
+      .supportCase(getToken, ticket)
+      .then((res) => !cancelled && setDetail(res))
+      .catch(
+        (err: unknown) =>
+          !cancelled &&
+          setError(
+            err instanceof Error
+              ? err.message
+              : 'That case could not be loaded.',
+          ),
+      )
+    return () => {
+      cancelled = true
+    }
+  }, [getToken, ticket])
+
+  if (error) {
+    return <p className="p-4 text-sm text-error">{error}</p>
+  }
+  if (!detail) {
+    return (
+      <div className="p-4">
+        <Loader2 className="size-5 animate-spin text-base-content/40" />
+      </div>
+    )
+  }
+
+  const ctx = detail.context
+  const widgets = ctx.widgets ?? []
+  const similar = detail.similar ?? []
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h1 className="text-xl font-bold">
+            {detail.subject || '(no subject)'}
+          </h1>
+          <span className="font-mono text-xs text-base-content/50">
+            #{detail.ticket_number}
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-base-content/60">
+          {detail.user_email ?? 'no email on file'} · {detail.status}
+          {detail.category && ` · ${detail.category}`}
+          {detail.priority && ` · ${detail.priority}`} · opened{' '}
+          {new Date(detail.opened_at).toLocaleDateString()}
+        </p>
+        <p className="mt-2 text-sm text-base-content/70">
+          {detail.group_reason}
+        </p>
+        {detail.discord_url && (
+          <a
+            href={detail.discord_url}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+          >
+            <MessageSquare size={12} /> The Discord thread
+          </a>
+        )}
+      </header>
+
+      <Conversation detail={detail} />
+      <Pipeline detail={detail} />
+
+      <section>
+        <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+          Can we claim a fix?
+        </h2>
+        <div className="mt-2">
+          <FixCard fix={detail.fix} />
+        </div>
+      </section>
+
+      <Panel title="What the model was told about them" subtitle={ctx.note}>
+        <div className="grid grid-cols-2 gap-px bg-base-300/40 sm:grid-cols-3">
+          {[
+            ['Plan', ctx.tier],
+            [
+              'App version',
+              ctx.app_version
+                ? `${ctx.app_version}${
+                    ctx.version_state === 'behind'
+                      ? ` (behind ${ctx.current_version})`
+                      : ctx.version_state === 'current'
+                        ? ' (current)'
+                        : ''
+                  }`
+                : 'unknown',
+            ],
+            ['Operating system', ctx.os || 'unknown'],
+            [
+              'Monitors',
+              ctx.monitors_attached > 0
+                ? `${ctx.monitors_attached} attached, ${ctx.monitors_chosen} chosen`
+                : 'unknown',
+            ],
+            [
+              'Widgets',
+              widgets.length === 0
+                ? 'none known'
+                : `${widgets.length} added, ${
+                    widgets.filter((w) => w.on_ticker).length
+                  } on the bar`,
+            ],
+            [
+              'Waiting',
+              detail.stale_days >= detail.stale_after
+                ? `${detail.stale_days} days — past the ${detail.stale_after}-day line, so a reply must ask rather than tell`
+                : `${detail.stale_days} days since they last wrote`,
+            ],
+          ].map(([label, value]) => (
+            <div key={label} className="bg-base-100 px-4 py-3">
+              <p className="text-xs font-semibold tracking-wide text-base-content/45 uppercase">
+                {label}
+              </p>
+              <p className="mt-1 text-sm text-base-content/85">{value}</p>
+            </div>
+          ))}
+        </div>
+        {!ctx.has_diagnostics && (
+          <p className="border-t border-base-300/40 px-4 py-3 text-xs text-base-content/60">
+            No diagnostics were attached to this ticket, so the version, OS and
+            monitor counts above are whatever the case row already knew.
+          </p>
+        )}
+        {widgets.length > 0 && (
+          <p className="border-t border-base-300/40 px-4 py-3 text-xs text-base-content/60">
+            {widgets
+              .map((w) => `${w.type}${w.on_ticker ? ' (on the bar)' : ''}`)
+              .join(', ')}
+          </p>
+        )}
+      </Panel>
+
+      <Panel title="What it was shown" subtitle={detail.evidence_note}>
+        {similar.length === 0 ? (
+          <p className="p-4 text-sm text-base-content/50">
+            No past case we replied to matches this one closely enough to be a
+            precedent.
+          </p>
+        ) : (
+          <div className="divide-y divide-base-300/40">
+            {similar.map((s) => (
+              <div key={s.ticket_number} className="p-4">
+                <p className="text-sm font-medium">
+                  {s.subject}{' '}
+                  <span className="font-mono text-xs text-base-content/45">
+                    #{s.ticket_number}
+                  </span>
+                </p>
+                <p className="mt-1 line-clamp-3 text-xs text-base-content/60">
+                  <span className="font-semibold">They wrote:</span>{' '}
+                  {s.user_wrote}
+                </p>
+                <p className="mt-1 line-clamp-3 text-xs text-base-content/60">
+                  <span className="font-semibold">We sent:</span> {s.we_sent}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+        {detail.known_issues && (
+          <details className="border-t border-base-300/40 p-4">
+            <summary className="cursor-pointer text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+              The known-issues block
+            </summary>
+            <pre className="mt-2 overflow-x-auto text-xs whitespace-pre-wrap text-base-content/70">
+              {detail.known_issues}
+            </pre>
+          </details>
+        )}
+      </Panel>
+    </div>
+  )
+}
+
+// ── the queue ─────────────────────────────────────────────────────
+
+function QueueItem({
+  row,
+  active,
+  onSelect,
+}: {
+  row: QueueRow
+  active: boolean
+  onSelect: () => void
+}) {
+  const wait = formatWait(row.waiting_hours)
+  const countdown = holdCountdown(row.hold)
+  const badge = fixBadge(row.fix ?? null)
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`w-full cursor-pointer border-b border-base-300/40 px-3 py-2.5 text-left transition-colors last:border-0 ${
+        active ? 'bg-base-200' : 'hover:bg-base-200/50'
+      }`}
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="truncate text-sm font-medium">
+          {row.subject || '(no subject)'}
+        </span>
+        <span className="shrink-0 font-mono text-[11px] text-base-content/45">
+          #{row.ticket_number}
+        </span>
+      </div>
+      <p className="mt-0.5 truncate text-xs text-base-content/55">
+        {row.user_email ?? 'no email'}
+        {row.category && ` · ${row.category}`}
+        {' · '}
+        {wait ? `waiting ${wait}` : 'wait unknown'}
+      </p>
+      <p className="mt-1 line-clamp-2 text-xs text-base-content/70">
+        {row.disposition_reason || row.group_reason}
+      </p>
+      <div className="mt-1 flex flex-wrap gap-1.5">
+        {countdown.display && (
+          <span className="rounded bg-warning/15 px-1.5 py-0.5 text-[11px] font-medium text-warning-content/90 ring-1 ring-warning/30">
+            sends in {countdown.display}
+          </span>
+        )}
+        {row.disposition === 'escalate' && (
+          <span className="rounded bg-error/10 px-1.5 py-0.5 text-[11px] font-medium ring-1 ring-error/30">
+            escalated
+          </span>
+        )}
+        {badge && (
+          <span className="rounded bg-base-200 px-1.5 py-0.5 text-[11px] text-base-content/60">
+            {badge}
+          </span>
+        )}
+      </div>
+    </button>
+  )
+}
+
+export default function SupportPage() {
+  const getToken = useGetToken()
+  const [filter, setFilter] = useState<QueueGroup | 'all'>('all')
+  const [queue, setQueue] = useState<SupportQueue | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    let cancelled = false
+    adminApi
+      .supportQueue(getToken, filter)
+      .then((res) => !cancelled && setQueue(res))
+      .catch(
+        (err: unknown) =>
+          !cancelled &&
+          setError(
+            err instanceof Error
+              ? err.message
+              : 'The support queue could not be loaded.',
+          ),
+      )
+    return () => {
+      cancelled = true
+    }
+  }, [getToken, filter])
+
+  useEffect(() => load(), [load])
+
+  const rows = queue?.rows ?? []
+  const groups = QUEUE_GROUPS.filter(
+    (g) => filter === 'all' || g.key === filter,
+  )
+
+  return (
+    <div className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight">Support</h1>
+        <p className="mt-1 text-sm text-base-content/60">
+          Read-only. Send, hold, edit, ask and skip are still Discord&apos;s —
+          this side proves every fact is visible first.
+        </p>
+        {queue && (
+          <p
+            className={`mt-3 rounded-lg px-3 py-2 text-xs ring-1 ${
+              queue.autosend.armed
+                ? 'bg-warning/10 ring-warning/30'
+                : 'bg-base-200/50 ring-base-300/60'
+            }`}
+          >
+            {queue.autosend.note}
+          </p>
+        )}
+      </header>
+
+      {error && <p className="text-sm text-error">{error}</p>}
+      {!queue && !error && (
+        <Loader2 className="size-5 animate-spin text-base-content/40" />
+      )}
+
+      {queue && (
+        <div className="flex flex-col gap-6 lg:flex-row">
+          <div className="lg:w-[22rem] lg:shrink-0">
+            <div className="flex flex-wrap gap-1 pb-1">
+              {(['all', ...QUEUE_GROUPS.map((g) => g.key)] as const).map(
+                (key) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setFilter(key)}
+                    className={`cursor-pointer rounded-lg px-2.5 py-1.5 text-xs font-medium whitespace-nowrap transition-colors ${
+                      filter === key
+                        ? 'bg-base-200 text-base-content'
+                        : 'text-base-content/60 hover:bg-base-200/60'
+                    }`}
+                  >
+                    {key === 'all'
+                      ? 'Everything'
+                      : QUEUE_GROUPS.find((g) => g.key === key)?.label}
+                    {key !== 'all' && (
+                      <span className="ml-1 tabular-nums text-base-content/45">
+                        {queue.counts[key] ?? 0}
+                      </span>
+                    )}
+                  </button>
+                ),
+              )}
+            </div>
+
+            <div className="mt-3 space-y-5">
+              {groups.map((group) => {
+                const items = rows.filter((r) => r.group === group.key)
+                return (
+                  <section key={group.key}>
+                    <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+                      {group.label}{' '}
+                      <span className="tabular-nums text-base-content/40">
+                        {queue.counts[group.key] ?? 0}
+                      </span>
+                    </h2>
+                    <p className="mt-0.5 text-xs text-base-content/45">
+                      {group.blurb}
+                    </p>
+                    <div className="mt-2 overflow-hidden rounded-xl ring-1 ring-base-300/60">
+                      {items.length === 0 ? (
+                        <p className="p-4 text-sm text-base-content/50">
+                          {group.key === 'needs_you'
+                            ? 'Nothing is waiting on you.'
+                            : group.key === 'waiting'
+                              ? 'Nobody owes us a reply.'
+                              : 'Nothing has been handled yet.'}
+                        </p>
+                      ) : (
+                        items.map((row) => (
+                          <QueueItem
+                            key={row.ticket_number}
+                            row={row}
+                            active={selected === row.ticket_number}
+                            onSelect={() => setSelected(row.ticket_number)}
+                          />
+                        ))
+                      )}
+                    </div>
+                  </section>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="min-w-0 flex-1">
+            {selected ? (
+              <CaseView ticket={selected} />
+            ) : (
+              <div className="rounded-xl bg-base-200/30 px-6 py-16 text-center ring-1 ring-base-300/60">
+                <p className="text-sm text-base-content/60">
+                  Pick a case. The conversation reads top to bottom, and what
+                  the pipeline decided about it sits underneath.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/myscrollr.com/src/lib/supportConsole.test.ts
+++ b/myscrollr.com/src/lib/supportConsole.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import {
+  dispositionTone,
+  fixBadge,
+  formatDuration,
+  formatWait,
+  groupLabel,
+  holdCountdown,
+} from './supportConsole'
+import type { AdminHold } from '@/api/admin'
+
+const NOW = Date.parse('2026-09-09T12:18:00Z')
+
+function hold(over: Partial<AdminHold> = {}): AdminHold {
+  return {
+    until: '2026-09-09T12:30:00Z', // twelve minutes after NOW
+    remaining_seconds: { value: 720, available: true },
+    verb: 'Sending',
+    expired: false,
+    note: 'Doing nothing sends it.',
+    ...over,
+  }
+}
+
+describe('holdCountdown', () => {
+  it('shows the remaining time while the pipeline is armed', () => {
+    expect(holdCountdown(hold(), NOW).display).toBe('12m 00s')
+  })
+
+  // The seconds in the response were right when it was built and wrong a
+  // minute later. The deadline is the thing the sweeper actually reads, so a
+  // page left open must count down against that, not against a stale number.
+  it('counts down from the deadline, not from the seconds in the response', () => {
+    const stale = hold({ remaining_seconds: { value: 720, available: true } })
+    expect(holdCountdown(stale, NOW + 10 * 60 * 1000).display).toBe('2m 00s')
+    expect(holdCountdown(stale, NOW + 20 * 60 * 1000).display).toBe(
+      'any moment',
+    )
+  })
+
+  // The one mistake this page cannot make. hold_until keeps ticking whether or
+  // not anything is going to collect it, so with autonomous sending off the
+  // number is not a countdown and must not render as one — "sends in 12
+  // minutes" would tell an admin a reply is about to go out when none is.
+  it('refuses to render a countdown the server marked unavailable', () => {
+    const off = holdCountdown(
+      hold({
+        remaining_seconds: {
+          value: 720,
+          available: false,
+          note: 'Autonomous sending is off or paused.',
+        },
+        note: 'Autonomous sending is off or paused.',
+      }),
+      NOW,
+    )
+    expect(off.display).toBeNull()
+    expect(off.note).toContain('off or paused')
+  })
+
+  it('says an expired hold is going any moment rather than showing 0s', () => {
+    expect(holdCountdown(hold({ expired: true }), NOW).display).toBe(
+      'any moment',
+    )
+  })
+
+  it('renders nothing for a draft with no hold at all', () => {
+    expect(holdCountdown(null).display).toBeNull()
+    expect(holdCountdown(undefined).display).toBeNull()
+  })
+})
+
+describe('formatDuration', () => {
+  it('drops seconds past an hour and keeps them under one', () => {
+    expect(formatDuration(3900)).toBe('1h 05m')
+    expect(formatDuration(125)).toBe('2m 05s')
+    expect(formatDuration(44)).toBe('44s')
+  })
+
+  it('never renders a negative remainder', () => {
+    expect(formatDuration(-30)).toBe('0s')
+  })
+})
+
+describe('formatWait', () => {
+  it('scales the unit to the wait', () => {
+    expect(formatWait({ value: 0, available: true })).toBe('under an hour')
+    expect(formatWait({ value: 5, available: true })).toBe('5h')
+    expect(formatWait({ value: 24, available: true })).toBe('1 day')
+    expect(formatWait({ value: 100, available: true })).toBe('4 days')
+  })
+
+  // A case with no user message on record is not a wait of zero hours. Showing
+  // it as one would sort a months-old backfilled ticket in with the freshest.
+  it('returns null rather than zero when the wait is not measurable', () => {
+    expect(
+      formatWait({ value: 0, available: false, note: 'no user message' }),
+    ).toBeNull()
+  })
+})
+
+describe('dispositionTone', () => {
+  it('reads a pending escalation as a stop and a pending hold as a clock', () => {
+    expect(dispositionTone('escalate', 'pending')).toBe('stop')
+    expect(dispositionTone('auto_send', 'pending')).toBe('clock')
+    expect(dispositionTone('auto_close', 'pending')).toBe('clock')
+    expect(dispositionTone('auto_ask', 'pending')).toBe('ask')
+  })
+
+  // Once a draft is decided, its disposition is history. A sent reply must not
+  // still look like a running timer.
+  it('reads any decided draft as done whatever its disposition said', () => {
+    expect(dispositionTone('auto_send', 'sent')).toBe('done')
+    expect(dispositionTone('escalate', 'skipped')).toBe('done')
+  })
+
+  it('has a neutral tone for a draft with no disposition', () => {
+    expect(dispositionTone(undefined, 'pending')).toBe('none')
+  })
+})
+
+describe('fixBadge', () => {
+  it('names the version only when the fix is proven', () => {
+    expect(
+      fixBadge({ issue_key: 'REL-234', proven: true, version: '1.6.1' }),
+    ).toBe('REL-234 · shipped in 1.6.1')
+    expect(fixBadge({ issue_key: 'REL-234', proven: false })).toBe(
+      'REL-234 · not shipped',
+    )
+  })
+
+  it('shows nothing when no issue is linked', () => {
+    expect(fixBadge(null)).toBeNull()
+    expect(fixBadge({ proven: false })).toBeNull()
+  })
+})
+
+describe('groupLabel', () => {
+  it('names the three columns and passes an unknown one through', () => {
+    expect(groupLabel('needs_you')).toBe('Needs you')
+    expect(groupLabel('waiting')).toBe('Waiting on the user')
+    expect(groupLabel('handled')).toBe('Handled')
+    expect(groupLabel('something_else')).toBe('something_else')
+  })
+})

--- a/myscrollr.com/src/lib/supportConsole.ts
+++ b/myscrollr.com/src/lib/supportConsole.ts
@@ -1,0 +1,140 @@
+/**
+ * Presentation rules for the staff Support console (REL-263).
+ *
+ * Same reason adminFormat.ts exists: these encode the page's promises, and a
+ * promise is worth a test that does not need a DOM.
+ *
+ * The promise here is narrower than the Overview's and sharper. This page
+ * shows a countdown that, when it runs out, sends a real reply to a real
+ * person. So the countdown may only appear when something is actually going
+ * to collect it — the server says so with `available` on the Measured, and
+ * nothing in this file is allowed to second-guess that. Disposition, hold
+ * expiry and the proven-fix answer are all computed on the server; the browser
+ * formats them and never recomputes them.
+ */
+
+import type { AdminHold, Measured, QueueGroup } from '@/api/admin'
+
+/** The three columns, in the order a person should read them. */
+export const QUEUE_GROUPS: Array<{
+  key: QueueGroup
+  label: string
+  blurb: string
+}> = [
+  {
+    key: 'needs_you',
+    label: 'Needs you',
+    blurb:
+      'Nothing here moves on its own, or it moves on a clock you can stop.',
+  },
+  {
+    key: 'waiting',
+    label: 'Waiting on the user',
+    blurb:
+      'We answered or asked. Nothing is due from us until they write back.',
+  },
+  {
+    key: 'handled',
+    label: 'Handled',
+    blurb: 'Closed, or someone decided it needed no reply.',
+  },
+]
+
+export function groupLabel(group: string): string {
+  return QUEUE_GROUPS.find((g) => g.key === group)?.label ?? group
+}
+
+/**
+ * The countdown, or the sentence that replaces it.
+ *
+ * `display` is null whenever the server said the number is not a measurement
+ * of anything — which is what a hold looks like while autonomous sending is
+ * off or paused. Rendering "sends in 12 minutes" then would tell an admin a
+ * reply is about to go out when none is, and that is the one mistake this page
+ * cannot make.
+ */
+export function holdCountdown(
+  hold: AdminHold | null | undefined,
+  now: number = Date.now(),
+): {
+  display: string | null
+  note: string
+} {
+  if (!hold) return { display: null, note: '' }
+  // `available` is the server's word on whether this is a countdown at all,
+  // and is never second-guessed here.
+  if (!hold.remaining_seconds.available) {
+    return { display: null, note: hold.note }
+  }
+  // The remaining time is derived from `until` — the deadline the sweeper
+  // itself reads — rather than from the seconds the server happened to
+  // compute when the response was built. Those seconds go stale the moment
+  // the page sits still, and a queue that says "sends in 13m" ten minutes
+  // later is the same lie as one that counts down against a paused pipeline.
+  const left = Math.round((new Date(hold.until).getTime() - now) / 1000)
+  if (hold.expired || left <= 0) {
+    return { display: 'any moment', note: hold.note }
+  }
+  return { display: formatDuration(left), note: hold.note }
+}
+
+/** "1h 04m" / "12m 03s" / "44s". Seconds only appear under an hour. */
+export function formatDuration(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m`
+  if (m > 0) return `${m}m ${String(s).padStart(2, '0')}s`
+  return `${s}s`
+}
+
+/**
+ * How long the user has been waiting, from a Measured in hours.
+ *
+ * A case with no user message on record is not a wait of zero. The server
+ * marks it unavailable and this returns null, so the column reads as unknown
+ * rather than as the freshest ticket in the queue.
+ */
+export function formatWait(hours: Measured): string | null {
+  if (!hours.available) return null
+  const h = hours.value
+  if (h < 1) return 'under an hour'
+  if (h < 24) return `${h}h`
+  const days = Math.floor(h / 24)
+  return days === 1 ? '1 day' : `${days} days`
+}
+
+/** The tone a disposition should carry in the UI. */
+export type DispositionTone = 'stop' | 'clock' | 'ask' | 'done' | 'none'
+
+export function dispositionTone(
+  disposition: string | undefined,
+  draftStatus: string | undefined,
+): DispositionTone {
+  if (draftStatus && draftStatus !== 'pending') return 'done'
+  switch (disposition) {
+    case 'escalate':
+      return 'stop'
+    case 'auto_send':
+    case 'auto_close':
+      return 'clock'
+    case 'auto_ask':
+      return 'ask'
+    default:
+      return 'none'
+  }
+}
+
+/**
+ * The one-line version of the proven-fix rule, for a queue row. The full
+ * reasoning is a sentence the server writes and the case view prints whole;
+ * this is only the badge next to a linked issue.
+ */
+export function fixBadge(
+  fix: { issue_key?: string; proven: boolean; version?: string } | null,
+): string | null {
+  if (!fix?.issue_key) return null
+  if (!fix.proven) return `${fix.issue_key} · not shipped`
+  return `${fix.issue_key} · shipped in ${fix.version}`
+}

--- a/myscrollr.com/src/routes/admin.support.tsx
+++ b/myscrollr.com/src/routes/admin.support.tsx
@@ -1,46 +1,21 @@
 /**
- * Support — a deliberate stub.
+ * Support - the queue and the triage pipeline, read-only (REL-263).
  *
- * The support queue is REL-263. It is a large surface (the queue, the drafts,
- * the per-category intervention rates, the send/hold/skip controls) and
- * building it here would have made REL-260 unreviewable. The nav entry exists
- * now so the shell is complete and the section has somewhere to land.
- *
- * No dynamic import: there is nothing here worth a chunk.
+ * The component is behind a dynamic import so the staff console lands in its
+ * own chunk: nothing in /admin ships to a marketing visitor. The API gate
+ * (LogtoAuth + RequireAdmin) is the real boundary — this split is about bundle
+ * weight and not leaking internal UI, never about access control.
  */
 
-import { Link, createFileRoute } from '@tanstack/react-router'
-import { LifeBuoy } from 'lucide-react'
+import { createFileRoute } from '@tanstack/react-router'
+import { Suspense, lazy } from 'react'
+
+const SupportPage = lazy(() => import('@/components/admin/SupportPage'))
 
 export const Route = createFileRoute('/admin/support')({
-  component: SupportStub,
+  component: () => (
+    <Suspense fallback={<div className="min-h-[40vh]" />}>
+      <SupportPage />
+    </Suspense>
+  ),
 })
-
-function SupportStub() {
-  return (
-    <div className="space-y-5">
-      <header>
-        <h1 className="text-2xl font-bold tracking-tight">Support</h1>
-        <p className="mt-1 text-sm text-base-content/60">
-          The support queue lives here.
-        </p>
-      </header>
-
-      <div className="flex flex-col items-center rounded-xl bg-base-200/40 px-6 py-16 text-center ring-1 ring-base-300/60">
-        <LifeBuoy className="size-8 text-base-content/30" />
-        <h2 className="mt-4 text-lg font-semibold">Not built yet</h2>
-        <p className="mt-2 max-w-md text-sm text-base-content/60">
-          The queue, the AI drafts and the send controls are REL-263. Until
-          then, the Overview tile carries the numbers that already exist: open
-          cases, drafts waiting, what auto-sent, and what needed a person.
-        </p>
-        <Link
-          to="/admin"
-          className="mt-6 rounded-lg px-4 py-2 text-sm font-semibold ring-1 ring-base-300 transition-colors hover:bg-base-200"
-        >
-          Back to Overview
-        </Link>
-      </div>
-    </div>
-  )
-}


### PR DESCRIPTION
Link 2 of the admin dashboard. [REL-260](https://linear.app/relentnet/issue/REL-260) built the admin list, `RequireAdmin` and the `/admin` shell with a stubbed Support section; this fills the stub, and it is the section that replaces reading Discord.

Nothing here is new data. `support_cases`, `support_messages` and `support_drafts` have carried `disposition`, `disposition_reason`, `grounded_in`, `unknowns`, `ask_user_for`, `internal_note` and `linear_issue_key` since REL-243/249. Discord could show a draft and about two thousand characters of it; it had no room for the pipeline underneath. This is the first surface wide enough to read it.

## The case view

![the case view](https://raw.githubusercontent.com/doughknee/myscrollr/captures/rel-263/case-view.png)

Real production ticket #819835 — the Linux AppImage login report, three drafts deep, two of them superseded by re-triage. It shows the conversation as a conversation, then: the disposition and the exact rule that chose it (`account access or identity (category account)`), the drafted reply, what it cites, what it admits it does not know, what it wants to ask, its note to us, both categories side by side, the proven-fix answer *with the reason it is a no* (`REL-255 is linked but is not in a completed state with a merged pull request behind it`), the context the model was given, and how long the reporter has been waiting against the line past which a reply must ask rather than tell.

![the hold countdown](https://raw.githubusercontent.com/doughknee/myscrollr/captures/rel-263/hold-view.png)

The hold countdown, and the sentence that has to sit under it: **doing nothing sends it**. That one row is CONSTRUCTED and says so in its own subject — no production draft is on a live hold right now (the three that ever had one were all sent).

## Endpoints

`GET /admin/support/queue?state=needs_you|waiting|handled|all` and `GET /admin/support/case/:ticket`, both behind `LogtoAuth + RequireAdmin`. Not the `SCROLLR_WEBHOOK_SECRET` header that guards `/internal/support/cases` — that is machine-to-machine and a browser has no business holding one.

They live in `internal/support` rather than `internal/admin` because everything they read is unexported there: the disposition vocabulary, `linearClosingMerge`, `ticketContextFromCase`, `holdDuration`, `autosendArmed`. Moving the handlers would have meant exporting a dozen internals so another package could reassemble them in the same order. The gate is applied where the routes are declared.

Counts are always over the whole queue, never over the filter, so switching to "Handled" cannot make "Needs you" look empty.

## Two numbers that could lie, so both are `Measured`

REL-260's rule was that an unavailable value must refuse to render as a number. Two things here qualify:

- **The hold countdown.** `hold_until` keeps ticking whether or not anything is going to collect it. With `SUPPORT_AUTOSEND` off or `/pause` on, the seconds are not a countdown, and "sends in 12 minutes" would tell an admin a reply is about to go out when none is. The server marks it unavailable and the page prints the sentence instead.
- **The wait on a case with no user message on record.** Backfilled tickets have this. That is unknown, not zero hours — showing zero would sort a months-old ticket in with the freshest.

`Measured` moved to `internal/platform` with `type Measured = platform.Measured` left in `internal/admin`, so both packages share one type. The JSON is byte-identical and `handlers_overview.go` is otherwise untouched.

## Three things the real data caught

Verifying against production rows rather than fixtures found three bugs, all fixed here:

1. **The queue rendered a live countdown for an already-sent draft** (ticket 143026). `hold_until` is never cleared on send, and only the case view checked the status. `buildHold` now takes the draft status and both callers go through it, the same rule the sweeper's own query uses. Covered by a test over every decided status.
2. **osTicket's backfilled bodies arrive in `body_text` *with* their markup** — #819835's opening message starts `<h3>Bug Report</h3>` — so trusting the column name printed tags at the reader. `htmlToPlain` now runs over `body_text` as well as over the fallback. The cost is that a message genuinely containing `a < b > c` loses that fragment; the benefit is that every backfilled ticket reads as prose.
3. **The countdown was derived from the seconds in the response**, which go stale the moment a page sits still. It now derives from `until` — the deadline the sweeper actually reads — in one function both the queue chip and the case banner call.

## Verification, and what I could not click

- Go: `go build`, `go vet` and `go test ./...` clean in-cluster (Docker Desktop is still broken on this box). New tests cover the grouping rule as a pure function, the countdown's refusal to render, **403 for a signed-in non-admin on both endpoints** (with a `super_user` token, since that tier is a product tier and not staff), the queue's grouping and counts over real-shaped rows, the whole pipeline surviving into the case JSON, and the 404 sentence.
- `npm test` green in `myscrollr.com` (84 tests, 8 files), eslint and prettier clean, `npm run build` green including `tsc`.
- **Code split:** the home page's static import graph is 4 chunks and none of them is admin. The support console lands in `SupportPage-*.js` plus the `admin-*.js` API chunk, neither statically reachable from `index.html`.
- **Side by side with Discord:** I read thread `1546788068168699955` for #819835 through the bot token and compared it field by field with this page. Everything Discord shows is here — the user's message, all three drafts, category, priority, confidence, mood, app version against current, the fix line, the internal note, what it needs from the user, grounded_in, the escalation and its reason, the re-triage notices. This page additionally shows `unknowns`, the drafter's own category, the days waited against the stale line, and the *reason* the fix is not proven. Nothing was missing.

**I could not sign in as Brandon, so I have not clicked this as a real admin.** The screenshots are the real handlers' JSON rendered by the real component: two production cases were seeded into a test schema, the handlers were called through `app.Test`, and the page was pointed at that output. What that does not prove is the signed-in path — `RequireAdmin` bootstrapping through Logto, and `AdminShell`'s gate wrapping the section. Both are REL-260 code that this PR does not touch, and the 403 path is covered by tests. Worth one click after deploy.

Read-only throughout: no write actions (REL-261), nothing about disposition, proven-fix or hold expiry recomputed in the browser, the Discord code untouched, and osTicket left exactly where it is.

Closes REL-263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
