### PR TITLE
Every support verb, from the console, through one function [REL-261]

### DIFF
--- a/api/core/server.go
+++ b/api/core/server.go
@@ -248,6 +248,26 @@ func (s *Server) setupRoutes() {
 	s.App.Get("/admin/support/queue", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminQueue)
 	s.App.Get("/admin/support/case/:ticket", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminCase)
 
+	// The write half (REL-261). Every one of these is the same function the
+	// Discord button calls, behind the same gate as the read half. Send is the
+	// only irreversible one and the only one the page confirms; friction on the
+	// reversible ones is what makes people stop using a tool.
+	s.App.Post("/admin/support/draft/:draft/send", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminSend)
+	s.App.Post("/admin/support/draft/:draft/edit", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminEditAndSend)
+	s.App.Post("/admin/support/draft/:draft/ask", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminAsk)
+	s.App.Post("/admin/support/draft/:draft/skip", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminSkip)
+	s.App.Post("/admin/support/draft/:draft/hold", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminHold)
+	s.App.Post("/admin/support/draft/:draft/bug", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminFileAsBug)
+	s.App.Post("/admin/support/case/:ticket/link", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminLinkIssue)
+	s.App.Delete("/admin/support/case/:ticket/link", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminUnlinkIssue)
+	s.App.Post("/admin/support/autosend", platform.LogtoAuth, admin.RequireAdmin, support.HandleAdminAutoSend)
+
+	// The console's own SSE stream: the support topic and nothing else, so a
+	// hold counting down and a reply landing show up without a refresh. Same
+	// gate again - and the credential stays in the Authorization header, which
+	// is why the page reads this with fetch rather than EventSource.
+	s.App.Get("/admin/support/stream", platform.LogtoAuth, admin.RequireAdmin, events.StreamAdminEvents)
+
 	s.App.Get("/dashboard", platform.LogtoAuth, s.getDashboard)
 
 	// Support

--- a/api/internal/events/events.go
+++ b/api/internal/events/events.go
@@ -219,6 +219,7 @@ func (h *Hub) listenToTopics(ctx context.Context) {
 		platform.TopicPrefixPredictions+"*",
 		platform.TopicPrefixCore+"*",
 		platform.TopicSSEControlResubscribe,
+		platform.TopicSupportAdmin,
 	)
 	defer pubsub.Close()
 
@@ -598,4 +599,41 @@ func getUserFantasyLeagues(ctx context.Context, userID string) ([]string, error)
 		keys = append(keys, key)
 	}
 	return keys, nil
+}
+
+// ===== The staff console's stream (REL-261) =======================
+
+// adminClientPrefix namespaces a console connection's hub key so it cannot
+// collide with the same person's desktop connection. An admin running Scrollr
+// on the same account would otherwise get support events in their ticker and
+// ticker CDC in their console — both harmless, both nonsense.
+const adminClientPrefix = "admin-console:"
+
+// AdminClientKey is the hub key a console connection registers under.
+func AdminClientKey(sub string) string { return adminClientPrefix + sub }
+
+// RegisterAdminClient adds a staff-console SSE connection: subscribed to the
+// support topic and to nothing else.
+//
+// It goes through the same hub, registry and dispatch workers as every other
+// client — the console is not a second fan-out, it is one more subscriber to
+// one more topic. What it skips is subscribeUserToTopics, because a browser
+// reading the support queue has no widgets and wants no CDC.
+func RegisterAdminClient(sub string) *Client {
+	client := &Client{
+		UserID: AdminClientKey(sub),
+		Ch:     make(chan []byte, platform.SSEClientBufferSize),
+	}
+	globalHub.register(client)
+	globalHub.registry.subscribe(client.UserID, platform.TopicSupportAdmin)
+	return client
+}
+
+// PublishSupportEvent puts one support-pipeline event on the console topic.
+// Best-effort by design: an event that does not reach a browser costs a
+// refresh, and nothing in the pipeline may fail because Redis hiccuped.
+func PublishSupportEvent(payload []byte) {
+	if err := platform.PublishRaw(platform.TopicSupportAdmin, payload); err != nil {
+		log.Printf("[EventHub] support event publish failed: %v", err)
+	}
 }

--- a/api/internal/events/events_support_test.go
+++ b/api/internal/events/events_support_test.go
@@ -1,0 +1,74 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// The staff console is one more subscriber to one more topic on the hub that
+// already exists (REL-261), and these pin the two halves of that claim.
+
+// A console connection receives support events and nothing else. The "nothing
+// else" is the half that matters: an admin who also runs Scrollr on the same
+// account must not get their own ticker's CDC in the support page, and the
+// support page's traffic must not reach their ticker.
+func TestAdminConsoleClientGetsSupportEventsAndNoCDC(t *testing.T) {
+	h := swapHub(t)
+	client := RegisterAdminClient("sub-staff")
+	t.Cleanup(func() { UnregisterClient(client) })
+
+	// A CDC topic the same person's desktop would be on. The console is not
+	// subscribed to it, so nothing is dispatched.
+	h.handleTopicMessage(platform.TopicPrefixSports+"NFL", []byte(`{"type":"sports"}`))
+	// The desktop's own per-user channel, which targets a logto sub directly.
+	// The console registers under a namespaced key precisely so this misses.
+	h.handleTopicMessage(platform.TopicPrefixCore+"sub-staff", []byte(`{"type":"core"}`))
+	drainDispatch(t, h)
+	select {
+	case got := <-client.Ch:
+		t.Fatalf("the console received CDC traffic: %s", got)
+	default:
+	}
+
+	h.handleTopicMessage(platform.TopicSupportAdmin, []byte(`{"type":"support","event":"sent"}`))
+	drainDispatch(t, h)
+	select {
+	case got := <-client.Ch:
+		if string(got) != `{"type":"support","event":"sent"}` {
+			t.Errorf("payload = %s", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("the console received no support event")
+	}
+}
+
+// The subscription goes away with the connection, so a replica does not fan
+// out to a browser that closed hours ago.
+func TestAdminConsoleUnsubscribesOnDisconnect(t *testing.T) {
+	h := swapHub(t)
+	client := RegisterAdminClient("sub-staff")
+	if users := h.registry.getUsersForTopic(platform.TopicSupportAdmin); len(users) != 1 {
+		t.Fatalf("subscribers after connect = %d, want 1", len(users))
+	}
+	UnregisterClient(client)
+	if users := h.registry.getUsersForTopic(platform.TopicSupportAdmin); len(users) != 0 {
+		t.Errorf("subscribers after disconnect = %d, want 0", len(users))
+	}
+}
+
+// drainDispatch runs the dispatch queue synchronously. The worker pool is not
+// started in these tests, so this stands in for it and keeps the assertions
+// free of sleeps.
+func drainDispatch(t *testing.T, h *Hub) {
+	t.Helper()
+	for {
+		select {
+		case job := <-h.dispatchCh:
+			h.dispatchToUser(job.userID, job.payload)
+		default:
+			return
+		}
+	}
+}

--- a/api/internal/events/handlers_sse.go
+++ b/api/internal/events/handlers_sse.go
@@ -54,18 +54,38 @@ func StreamEvents(c *fiber.Ctx) error {
 		})
 	}
 
-	// 3. Set headers for SSE
+	log.Printf("[SSE] Client connected: user=%s ip=%s", userID, c.IP())
+	return streamToClient(c, RegisterClient(userID), userID)
+}
+
+// StreamAdminEvents handles the staff console's SSE connection — GET
+// /admin/support/stream (REL-261).
+//
+// It carries the support topic and nothing else, and the gate is the route's
+// own middleware (LogtoAuth + RequireAdmin) rather than a token in the query
+// string: this is fetched with an Authorization header from a browser that
+// already holds one, so there is no reason to put a credential in a URL.
+func StreamAdminEvents(c *fiber.Ctx) error {
+	sub := platform.GetUserID(c)
+	if sub == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(platform.ErrorResponse{
+			Status: "unauthorized",
+			Error:  "Authentication required",
+		})
+	}
+	log.Printf("[SSE] Admin console connected: ip=%s", c.IP())
+	return streamToClient(c, RegisterAdminClient(sub), AdminClientKey(sub))
+}
+
+// streamToClient writes the SSE body for an already-registered client until it
+// disconnects. Shared by the desktop stream and the console stream so the
+// heartbeat, the retry hint and the panic containment below exist once.
+func streamToClient(c *fiber.Ctx, client *Client, label string) error {
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")
 	c.Set("Connection", "keep-alive")
 	c.Set("Transfer-Encoding", "chunked")
 
-	// 4. Register this authenticated client
-	client := RegisterClient(userID)
-
-	log.Printf("[SSE] Client connected: user=%s ip=%s", userID, c.IP())
-
-	// 5. Stream events to the client
 	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
 		// This runs in a fasthttp-spawned goroutine, so a panic here crashes
 		// the whole process — Fiber's Recover middleware only wraps the request
@@ -75,7 +95,7 @@ func StreamEvents(c *fiber.Ctx) error {
 		// deferred UnregisterClient below as well.
 		defer func() {
 			if r := recover(); r != nil {
-				log.Printf("[SSE] recovered from panic in stream writer (user=%s): %v", userID, r)
+				log.Printf("[SSE] recovered from panic in stream writer (%s): %v", label, r)
 			}
 		}()
 		ticker := time.NewTicker(platform.SSEHeartbeatInterval)

--- a/api/internal/platform/constants.go
+++ b/api/internal/platform/constants.go
@@ -71,6 +71,14 @@ const (
 	// this, only the replica that served the config-change HTTP request
 	// would refresh, leaving the connection-holding replica stale.
 	TopicSSEControlResubscribe = "sse:ctl:resubscribe"
+
+	// TopicSupportAdmin carries support-pipeline events to the staff console
+	// (REL-261): a draft written, a disposition decided, a hold armed, a reply
+	// sent, an escalation. One channel, not one per ticket — the console is a
+	// queue, every admin watching it wants every event, and there are a few an
+	// hour. The payload names the ticket and the event; the page re-reads what
+	// it needs rather than trusting a copy of a case to arrive intact.
+	TopicSupportAdmin = "support:admin"
 )
 
 // =============================================================================

--- a/api/internal/support/actions.go
+++ b/api/internal/support/actions.go
@@ -1,0 +1,362 @@
+package support
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// =============================================================================
+// The support verbs — one function each, called by every surface (REL-261)
+// =============================================================================
+//
+// Send, Edit, Ask, Skip, Hold, File as bug and Link used to live inside the
+// Discord interaction handlers, which made Discord the only place they could
+// happen. This file is those flows with the Discord taken out: each one takes
+// a draft id (or a ticket number) and its inputs, does the whole thing, and
+// returns the new state.
+//
+// Both surfaces call these and neither reimplements one. That is the point:
+// while Discord and the console coexist, a rule changed in one has to change
+// in the other, and the only way to guarantee that is for there to be one of
+// it. TestEverySurfaceCallsTheSameVerb pins it.
+//
+// Nothing here is a policy decision. The escalation gates (REL-249) and the
+// proven-fix gate (REL-259) run in decideDisposition before a draft ever
+// reaches a button, and a person choosing to send is the escape hatch those
+// gates were built to require — not one they get to skip. A console click and
+// a Discord click are the same click.
+
+var (
+	// ErrDraftNotFound is a draft id that is not in the table.
+	ErrDraftNotFound = errors.New("draft not found")
+	// ErrEmptyBody is an edit or a question with nothing in it.
+	ErrEmptyBody = errors.New("body is empty")
+	// ErrNotLinked is an unlink on a case with no issue on it.
+	ErrNotLinked = errors.New("no issue is linked to this case")
+	// ErrBadIssueKey is a Linear identifier that is not shaped like one.
+	ErrBadIssueKey = errors.New("not a Linear issue key")
+)
+
+// ErrAlreadyLinked reports the key that is already on the case, so a caller
+// can say which one rather than only refusing.
+type ErrAlreadyLinked struct{ IssueKey string }
+
+func (e ErrAlreadyLinked) Error() string { return "already linked to " + e.IssueKey }
+
+// requirePendingDraft is the precondition every verb shares: the draft exists
+// and nobody has actioned it yet. Telling "gone" from "already decided" is
+// what lets a surface say which happened instead of "that failed".
+func requirePendingDraft(ctx context.Context, draftID int64) (*SupportDraft, error) {
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil {
+		return nil, fmt.Errorf("load draft %d: %w", draftID, err)
+	}
+	if draft == nil {
+		return nil, ErrDraftNotFound
+	}
+	if draft.Status != "pending" {
+		return nil, ErrAlreadyDecided
+	}
+	return draft, nil
+}
+
+// claimDraft moves a pending draft to its decided status and returns the row
+// as it now stands. The UPDATE is conditional on `status = 'pending'`, so two
+// people clicking Send at the same moment produce one send and one
+// ErrAlreadyDecided — and that is also what makes Hold, Edit, Ask and Skip
+// cancel a running countdown.
+func claimDraft(ctx context.Context, draftID int64, status, editedBodyHTML string) (*SupportDraft, error) {
+	if _, err := requirePendingDraft(ctx, draftID); err != nil {
+		return nil, err
+	}
+	if err := markDraftDecided(ctx, draftID, status, editedBodyHTML); err != nil {
+		return nil, err
+	}
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil || draft == nil {
+		return nil, ErrDraftNotFound
+	}
+	return draft, nil
+}
+
+// ActionSend sends the draft as the model wrote it.
+//
+// "Send now" and "send" are the same verb: a hold is only a deadline the
+// sweeper reads, and claiming the row is what takes it off the sweeper's
+// query. There is no separate timer to cancel.
+func ActionSend(ctx context.Context, draftID int64) (*SupportDraft, error) {
+	draft, err := claimDraft(ctx, draftID, "approved", "")
+	if err != nil {
+		return nil, err
+	}
+	if err := sendDraftReply(ctx, draft, draft.DraftBodyHTML); err != nil {
+		return draft, fmt.Errorf("send reply for ticket %s: %w", draft.TicketNumber, err)
+	}
+	applySendStateToThread(ctx, draft, draft.ShouldClose)
+	return reloadDraft(ctx, draftID, draft), nil
+}
+
+// ActionEditAndSend replaces the body and sends that instead.
+//
+// editedPlain is plain text — what the console's editor holds and what the
+// Discord modal returns — wrapped into paragraphs on the way to the email
+// path, which is the one place HTML is required. There is no length cap here:
+// Discord's 4000 characters is Discord's limit, never the reply's.
+func ActionEditAndSend(ctx context.Context, draftID int64, editedPlain string) (*SupportDraft, error) {
+	editedPlain = strings.TrimSpace(editedPlain)
+	if editedPlain == "" {
+		return nil, ErrEmptyBody
+	}
+	editedHTML := plainToHTMLParagraphs(editedPlain)
+
+	draft, err := claimDraft(ctx, draftID, "edited", editedHTML)
+	if err != nil {
+		return nil, err
+	}
+	markIntervened(ctx, draftID)
+
+	// draft.DraftBodyHTML is still the model's own body — the edit went into
+	// edited_body_html — so the diff below compares the two honestly.
+	original := draft.DraftBodyHTML
+	if err := sendDraftReply(ctx, draft, editedHTML); err != nil {
+		return draft, fmt.Errorf("send edited reply for ticket %s: %w", draft.TicketNumber, err)
+	}
+	applyEditStateToThread(ctx, draft, draft.ShouldClose)
+	postEditDiff(ctx, draft, htmlToPlain(original), editedPlain)
+	return reloadDraft(ctx, draftID, draft), nil
+}
+
+// ActionAsk sends one clarifying question in place of the drafted answer.
+//
+// The question goes out on the same reply path an approved draft takes, so the
+// user reads it as an ordinary support email and their answer comes back
+// through the thread-message webhook, which drafts afresh with it.
+func ActionAsk(ctx context.Context, draftID int64, question string) (*SupportDraft, error) {
+	question = strings.TrimSpace(question)
+	if question == "" {
+		return nil, ErrEmptyBody
+	}
+	questionHTML := plainToHTMLParagraphs(question)
+
+	draft, err := claimDraft(ctx, draftID, "asked", questionHTML)
+	if err != nil {
+		return nil, err
+	}
+	// A question never closes a ticket, whatever triage thought of the reply
+	// it stands in for.
+	draft.ShouldClose = false
+
+	if err := sendDraftReply(ctx, draft, questionHTML); err != nil {
+		return draft, fmt.Errorf("send question for ticket %s: %w", draft.TicketNumber, err)
+	}
+	applyAskStateToThread(ctx, draft)
+	return reloadDraft(ctx, draftID, draft), nil
+}
+
+// ActionSkip decides that this ticket needs no reply from us.
+func ActionSkip(ctx context.Context, draftID int64) (*SupportDraft, error) {
+	draft, err := claimDraft(ctx, draftID, "skipped", "")
+	if err != nil {
+		return nil, err
+	}
+	markIntervened(ctx, draftID)
+	applySkipStateToThread(ctx, draft)
+	publishSupportEvent(draft.TicketNumber, supportEventSkipped)
+	return draft, nil
+}
+
+// ActionHold stops a running countdown without deciding anything. The row
+// stays pending with every verb still open to it; it simply stops being
+// something that happens on its own.
+//
+// It is the cheapest thing a person can say — "not this one, not yet" — and it
+// counts as an intervention, which is what demotes a category out of autonomy.
+func ActionHold(ctx context.Context, draftID int64) (*SupportDraft, error) {
+	if _, err := requirePendingDraft(ctx, draftID); err != nil {
+		return nil, err
+	}
+	if err := holdDraft(ctx, draftID); err != nil {
+		return nil, err
+	}
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil || draft == nil {
+		return nil, ErrDraftNotFound
+	}
+	publishSupportEvent(draft.TicketNumber, supportEventHeld)
+	return draft, nil
+}
+
+// reloadDraft re-reads a row after a send so the caller renders sent_at and
+// the promoted status rather than the pre-send copy. Falls back to what it was
+// given: a reply that has already gone out is not worth failing a response
+// over.
+func reloadDraft(ctx context.Context, draftID int64, fallback *SupportDraft) *SupportDraft {
+	if fresh, err := loadSupportDraft(ctx, draftID); err == nil && fresh != nil {
+		return fresh
+	}
+	return fallback
+}
+
+// ===== Filing and linking =========================================
+
+// FileBugResult is what happened, in fields, so each surface phrases it once.
+//
+// LinkSaved false with an IssueKey set is the corner that matters: the issue
+// exists but the case does not know about it, so the next click would file a
+// duplicate. Both surfaces have to say so.
+type FileBugResult struct {
+	IssueKey  string `json:"issue_key"`
+	URL       string `json:"url"`
+	Already   bool   `json:"already_filed"`
+	LinkSaved bool   `json:"link_saved"`
+}
+
+// ActionFileAsBug turns the ticket into a Linear issue and links it.
+//
+// A second call files nothing and returns the issue that already exists — the
+// same button on the same case is how someone checks whether it was filed.
+func ActionFileAsBug(ctx context.Context, draftID int64) (FileBugResult, error) {
+	draft, err := loadSupportDraft(ctx, draftID)
+	if err != nil {
+		return FileBugResult{}, fmt.Errorf("load draft %d: %w", draftID, err)
+	}
+	if draft == nil {
+		return FileBugResult{}, ErrDraftNotFound
+	}
+
+	if existing := caseLinearIssueKey(ctx, draft.TicketNumber); existing != "" {
+		return FileBugResult{
+			IssueKey: existing, URL: linearIssueURL(existing), Already: true, LinkSaved: true,
+		}, nil
+	}
+
+	title := strings.TrimSpace(draft.AISummary)
+	if title == "" {
+		title = strings.TrimSpace(draft.OriginalSubject)
+	}
+	if title == "" {
+		title = "Support ticket #" + draft.TicketNumber
+	}
+	issue, err := linearCreateIssue(ctx, truncateRunes(title, 120), buildLinearIssueBody(ctx, draft))
+	if err != nil {
+		return FileBugResult{}, fmt.Errorf("file in Linear: %w", err)
+	}
+
+	res := FileBugResult{IssueKey: issue.Identifier, URL: issue.URL}
+	if err := setCaseLinearIssueKey(ctx, draft.TicketNumber, issue.Identifier); err != nil {
+		// The issue exists; we just cannot remember it. Say so, or the next
+		// click files a second one silently.
+		log.Printf("[Support] link %s to ticket %s: %v", issue.Identifier, draft.TicketNumber, err)
+		return res, nil
+	}
+	res.LinkSaved = true
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: draft.TicketNumber, Kind: "note",
+		BodyText: "filed as " + issue.Identifier, AIDraftID: draft.ID,
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
+	publishSupportEvent(draft.TicketNumber, supportEventLinked)
+	return res, nil
+}
+
+// issueKeyPattern is Linear's identifier shape. Checking it is not tidiness: a
+// typo'd key reads to the proven-fix walk as an issue that cannot be reached,
+// and "we could not check" looks a great deal like "not fixed yet".
+var issueKeyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9]*-[0-9]+$`)
+
+// ActionLinkIssue points a case at an issue that already exists.
+//
+// It refuses to overwrite an existing link rather than replacing it: two
+// people acting at once keep the first answer, and changing a link is unlink
+// then link — two deliberate acts instead of one silent one.
+func ActionLinkIssue(ctx context.Context, ticket, issueKey string) (string, error) {
+	ticket = strings.TrimSpace(ticket)
+	issueKey = strings.ToUpper(strings.TrimSpace(issueKey))
+	if ticket == "" || issueKey == "" {
+		return "", ErrBadIssueKey
+	}
+	if !issueKeyPattern.MatchString(issueKey) {
+		return "", fmt.Errorf("%q: %w", issueKey, ErrBadIssueKey)
+	}
+	if existing := caseLinearIssueKey(ctx, ticket); existing != "" {
+		return existing, ErrAlreadyLinked{IssueKey: existing}
+	}
+	// Ask Linear whether the issue is real before writing it down. The answer
+	// — done or not — is irrelevant here; reaching it at all is the check, and
+	// a wrong key is precisely what produces a confidently wrong claim that
+	// something shipped (REL-259).
+	if _, err := linearIssueIsDone(ctx, issueKey); err != nil {
+		return "", fmt.Errorf("%s could not be found in Linear: %w", issueKey, err)
+	}
+	if err := setCaseLinearIssueKey(ctx, ticket, issueKey); err != nil {
+		return "", fmt.Errorf("save link: %w", err)
+	}
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: ticket, Kind: "note", BodyText: "linked to " + issueKey + " by hand",
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
+	postToTicketThread(ctx, ticket, fmt.Sprintf(
+		"🔗 Linked to **%s** — %s. Drafts on this ticket may name the release that carries it once it ships.",
+		issueKey, linearIssueURL(issueKey)))
+	publishSupportEvent(ticket, supportEventLinked)
+	return issueKey, nil
+}
+
+// ActionUnlinkIssue takes the issue back off a case, so a fix stops being
+// claimable on it. The audit note stays — the link happened, and undoing it is
+// its own entry rather than an erasure.
+func ActionUnlinkIssue(ctx context.Context, ticket string) error {
+	ticket = strings.TrimSpace(ticket)
+	if ticket == "" {
+		return ErrNotLinked
+	}
+	if platform.DBPool == nil {
+		return fmt.Errorf("DB not initialized")
+	}
+	existing := caseLinearIssueKey(ctx, ticket)
+	if existing == "" {
+		return ErrNotLinked
+	}
+	if _, err := platform.DBPool.Exec(ctx,
+		`UPDATE support_cases SET linear_issue_key = NULL, updated_at = now() WHERE ticket_number = $1`,
+		ticket); err != nil {
+		return fmt.Errorf("unlink: %w", err)
+	}
+	if err := recordSupportMessage(ctx, SupportMessage{
+		TicketNumber: ticket, Kind: "note", BodyText: "unlinked from " + existing,
+	}); err != nil {
+		log.Printf("[Cases] %v", err)
+	}
+	postToTicketThread(ctx, ticket, fmt.Sprintf(
+		"🔗 Unlinked from **%s**. Drafts on this ticket may no longer name a release as the remedy.", existing))
+	publishSupportEvent(ticket, supportEventUnlinked)
+	return nil
+}
+
+// ===== The kill switch ============================================
+
+// ActionSetPaused stops, or restarts, every unattended send at once.
+//
+// Pending holds keep their deadlines rather than being cleared, so resuming
+// puts the queue back where it was instead of firing everything that expired
+// meanwhile — which is why the sweeper checks the pause and not each draft.
+func ActionSetPaused(ctx context.Context, paused bool) error {
+	if paused {
+		if err := policySet(ctx, policyPausedKey, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			return err
+		}
+	} else if err := policyDelete(ctx, policyPausedKey); err != nil {
+		return err
+	}
+	publishSupportEvent("", supportEventAutoSend)
+	return nil
+}

--- a/api/internal/support/autosend.go
+++ b/api/internal/support/autosend.go
@@ -47,6 +47,7 @@ func applyDisposition(ctx context.Context, draft *SupportDraft) {
 		return
 	}
 	draft.Disposition, draft.DispositionReason = disposition, reason
+	publishSupportEvent(draft.TicketNumber, supportEventDecided, disposition)
 	log.Printf("[Disposition] draft %d (ticket %s) -> %s (%s) armed=%t",
 		draft.ID, draft.TicketNumber, disposition, reason, armed)
 

--- a/api/internal/support/events.go
+++ b/api/internal/support/events.go
@@ -1,0 +1,66 @@
+package support
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/events"
+)
+
+// =============================================================================
+// Support events on the SSE hub (REL-261)
+// =============================================================================
+//
+// The console has to move on its own — a hold running out and a reply landing
+// are things that happen without anybody clicking, and a queue that only
+// updates when you reload is a queue you stop trusting. core-api already runs
+// an SSE hub for the desktop app, so this is one more topic on it rather than
+// a second fan-out or a poll.
+//
+// The payload deliberately does NOT carry the case. A case is thirty fields
+// wide, several of them computed against Linear and GitHub, and a copy of one
+// arriving over a socket is a copy that can disagree with the endpoint that
+// built it. The event says which ticket moved and what happened to it; the
+// page re-reads the queue (and the open case, if it is that one) from the same
+// handlers it read them from in the first place. One source of truth.
+
+const (
+	supportEventDrafted  = "drafted"
+	supportEventDecided  = "decided"
+	supportEventSent     = "sent"
+	supportEventFailed   = "failed"
+	supportEventSkipped  = "skipped"
+	supportEventHeld     = "held"
+	supportEventLinked   = "linked"
+	supportEventUnlinked = "unlinked"
+	supportEventAutoSend = "autosend"
+)
+
+// supportEvent is what a console connection receives.
+//
+// Ticket is empty for the one event that is not about a ticket — the pipeline
+// being paused or resumed — and the page treats that as "re-read everything".
+type supportEvent struct {
+	Type        string    `json:"type"`
+	Event       string    `json:"event"`
+	Ticket      string    `json:"ticket_number,omitempty"`
+	Disposition string    `json:"disposition,omitempty"`
+	At          time.Time `json:"at"`
+}
+
+// publishSupportEvent tells every open console that something moved.
+//
+// Fire-and-forget on purpose: nothing in the support pipeline may fail because
+// a browser did not hear about it. The cost of a lost event is one stale panel
+// until the next one, and the page re-reads on focus regardless.
+func publishSupportEvent(ticket, event string, disposition ...string) {
+	e := supportEvent{Type: "support", Event: event, Ticket: ticket, At: time.Now().UTC()}
+	if len(disposition) > 0 {
+		e.Disposition = disposition[0]
+	}
+	payload, err := json.Marshal(e)
+	if err != nil {
+		return
+	}
+	events.PublishSupportEvent(payload)
+}

--- a/api/internal/support/handlers_admin_actions.go
+++ b/api/internal/support/handlers_admin_actions.go
@@ -1,0 +1,315 @@
+package support
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/admin"
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+)
+
+// =============================================================================
+// The staff support console, write half (REL-261)
+// =============================================================================
+//
+// Nine endpoints, all under /admin/support and all behind the same gate as the
+// read half (platform.LogtoAuth + admin.RequireAdmin, declared with the
+// routes). Each one is a thin shell around the shared verb in actions.go: read
+// the inputs, call the function Discord calls, and answer with the case as it
+// now stands.
+//
+// "As it now stands" is the whole contract. A browser that guesses what a
+// click did is a browser that can be wrong about whether a reply went to a
+// real person, so nothing here returns "ok" — every write re-reads the case
+// through HandleAdminCase's own builder and hands back exactly what a reload
+// would have shown.
+//
+// The browser decides nothing. It cannot set a disposition, cannot declare a
+// fix proven, and cannot ask for a send that skips a gate: the gates ran in
+// decideDisposition before the draft ever reached a queue, and clicking Send
+// here is the same escape hatch as clicking Send in Discord — a person taking
+// responsibility, which is what those gates were built to require.
+
+// actionRequest is every body these endpoints accept. One struct because the
+// fields do not overlap: an edit has a body, an ask has a question, a link has
+// a key, and the rest have nothing.
+type actionRequest struct {
+	Body     string `json:"body"`
+	Question string `json:"question"`
+	IssueKey string `json:"issue_key"`
+	Paused   bool   `json:"paused"`
+}
+
+// draftIDFromPath parses :draft, which is the id the queue handed the page.
+func draftIDFromPath(c *fiber.Ctx) (int64, bool) {
+	id, err := strconv.ParseInt(strings.TrimSpace(c.Params("draft")), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}
+
+// respondWithAction answers a write with the updated case.
+//
+// The ticket number comes from the draft the verb acted on rather than from
+// the request, so a response can never describe a different case than the one
+// that moved.
+func respondWithAction(c *fiber.Ctx, ctx context.Context, draft *SupportDraft, err error, verb string) error {
+	if err != nil {
+		return actionErrorResponse(c, verb, err)
+	}
+	return respondWithCase(c, ctx, draft.TicketNumber, verb)
+}
+
+// respondWithCase re-reads the case through the read endpoint's own builder.
+// A verb that succeeded but whose case cannot be re-read is still a verb that
+// succeeded — the reply went out — so this says so rather than reporting the
+// action as failed.
+func respondWithCase(c *fiber.Ctx, ctx context.Context, ticket, verb string) error {
+	detail, err := buildAdminCase(ctx, ticket)
+	if err != nil {
+		log.Printf("[AdminSupport] %s on ticket %s succeeded but the case could not be re-read: %v", verb, ticket, err)
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{
+			"ticket_number": ticket,
+			"stale":         true,
+			"note":          "The " + verb + " went through, but this case could not be re-read. Reload to see where it stands.",
+		})
+	}
+	return c.JSON(detail)
+}
+
+// actionErrorResponse maps a shared verb's error onto a status a page can act
+// on. The two that are not failures are the ones worth telling apart: someone
+// else got there first (409), and the draft is gone (404). Everything else is
+// ours and says so.
+func actionErrorResponse(c *fiber.Ctx, verb string, err error) error {
+	var linked ErrAlreadyLinked
+	switch {
+	case errors.Is(err, ErrAlreadyDecided):
+		return c.Status(fiber.StatusConflict).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "This draft has already been actioned — reload the case to see what happened to it.",
+		})
+	case errors.Is(err, ErrDraftNotFound):
+		return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
+			Status: "error", Error: "That draft no longer exists.",
+		})
+	case errors.Is(err, ErrEmptyBody):
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error", Error: "There is nothing to send.",
+		})
+	case errors.Is(err, ErrBadIssueKey):
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error", Error: "That is not a Linear issue key. They look like REL-261.",
+		})
+	case errors.As(err, &linked):
+		return c.Status(fiber.StatusConflict).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "This case is already linked to " + linked.IssueKey + ". Unlink it first if it is wrong.",
+		})
+	case errors.Is(err, ErrNotLinked):
+		return c.Status(fiber.StatusConflict).JSON(platform.ErrorResponse{
+			Status: "error", Error: "No issue is linked to this case.",
+		})
+	}
+	log.Printf("[AdminSupport] %s by %s: %v", verb, admin.ActingAdmin(c), err)
+	return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+		Status: "error", Error: "Could not " + verb + ": " + truncate(err.Error(), 300),
+	})
+}
+
+// actionContext is context.Background() for the same reason every other
+// handler in this package uses it: Fiber's request context is already
+// cancelled by the time a handler under app.Test reaches the database, and a
+// send that fails as "context canceled" is a send nobody can debug.
+//
+// The timeout is generous because a send is two upstream round-trips (osTicket
+// and Resend) and the page is waiting on the answer rather than guessing it.
+func actionContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 60*time.Second)
+}
+
+// HandleAdminSend - POST /admin/support/draft/:draft/send
+//
+// The one irreversible verb. The confirmation step lives in the browser, which
+// is the right place for it: the server cannot tell a confirmed click from an
+// unconfirmed one, and a second endpoint pretending otherwise would only be
+// ceremony. What the server guarantees is that a second click sends nothing —
+// the claim is conditional on the row still being pending.
+func HandleAdminSend(c *fiber.Ctx) error {
+	draftID, ok := draftIDFromPath(c)
+	if !ok {
+		return badDraftID(c)
+	}
+	ctx, cancel := actionContext()
+	defer cancel()
+	draft, err := ActionSend(ctx, draftID)
+	log.Printf("[AdminSupport] send draft %d by %s (err=%v)", draftID, admin.ActingAdmin(c), err)
+	return respondWithAction(c, ctx, draft, err, "send")
+}
+
+// HandleAdminEditAndSend - POST /admin/support/draft/:draft/edit
+//
+// The body is plain text and has no length limit here. Discord's editor capped
+// a reply at 4000 characters because a Discord modal does; nothing about a
+// support email does, and a cap that exists only because of the surface it was
+// typed into is a cap that silently truncates someone's answer.
+func HandleAdminEditAndSend(c *fiber.Ctx) error {
+	draftID, ok := draftIDFromPath(c)
+	if !ok {
+		return badDraftID(c)
+	}
+	var req actionRequest
+	if err := c.BodyParser(&req); err != nil {
+		return badBody(c)
+	}
+	ctx, cancel := actionContext()
+	defer cancel()
+	draft, err := ActionEditAndSend(ctx, draftID, req.Body)
+	log.Printf("[AdminSupport] edit+send draft %d by %s (err=%v)", draftID, admin.ActingAdmin(c), err)
+	return respondWithAction(c, ctx, draft, err, "send the edit")
+}
+
+// HandleAdminAsk - POST /admin/support/draft/:draft/ask
+func HandleAdminAsk(c *fiber.Ctx) error {
+	draftID, ok := draftIDFromPath(c)
+	if !ok {
+		return badDraftID(c)
+	}
+	var req actionRequest
+	if err := c.BodyParser(&req); err != nil {
+		return badBody(c)
+	}
+	ctx, cancel := actionContext()
+	defer cancel()
+	draft, err := ActionAsk(ctx, draftID, req.Question)
+	log.Printf("[AdminSupport] ask draft %d by %s (err=%v)", draftID, admin.ActingAdmin(c), err)
+	return respondWithAction(c, ctx, draft, err, "ask")
+}
+
+// HandleAdminSkip - POST /admin/support/draft/:draft/skip
+func HandleAdminSkip(c *fiber.Ctx) error {
+	draftID, ok := draftIDFromPath(c)
+	if !ok {
+		return badDraftID(c)
+	}
+	ctx, cancel := actionContext()
+	defer cancel()
+	draft, err := ActionSkip(ctx, draftID)
+	log.Printf("[AdminSupport] skip draft %d by %s (err=%v)", draftID, admin.ActingAdmin(c), err)
+	return respondWithAction(c, ctx, draft, err, "skip")
+}
+
+// HandleAdminHold - POST /admin/support/draft/:draft/hold
+//
+// Disarms the countdown and leaves the draft pending. The console also calls
+// this when someone opens the editor, which is what Discord does when someone
+// opens the modal: typing a reply takes longer than a hold that is nearly up,
+// and "I am working on this one" has to actually stop the clock.
+func HandleAdminHold(c *fiber.Ctx) error {
+	draftID, ok := draftIDFromPath(c)
+	if !ok {
+		return badDraftID(c)
+	}
+	ctx, cancel := actionContext()
+	defer cancel()
+	draft, err := ActionHold(ctx, draftID)
+	return respondWithAction(c, ctx, draft, err, "hold")
+}
+
+// HandleAdminFileAsBug - POST /admin/support/draft/:draft/bug
+func HandleAdminFileAsBug(c *fiber.Ctx) error {
+	draftID, ok := draftIDFromPath(c)
+	if !ok {
+		return badDraftID(c)
+	}
+	ctx, cancel := actionContext()
+	defer cancel()
+	res, err := ActionFileAsBug(ctx, draftID)
+	if err != nil {
+		return actionErrorResponse(c, "file as bug", err)
+	}
+	log.Printf("[AdminSupport] filed %s for draft %d by %s", res.IssueKey, draftID, admin.ActingAdmin(c))
+
+	draft, _ := loadSupportDraft(ctx, draftID)
+	if draft == nil {
+		return actionErrorResponse(c, "file as bug", ErrDraftNotFound)
+	}
+	detail, err := buildAdminCase(ctx, draft.TicketNumber)
+	if err != nil {
+		return respondWithCase(c, ctx, draft.TicketNumber, "file as bug")
+	}
+	// The result rides alongside the case rather than replacing it: the case
+	// says the issue is linked, and `filed` says whether this click is what
+	// linked it, whether it was already there, and — the one that matters —
+	// whether the link failed to save, which is how a duplicate gets filed.
+	return c.JSON(fiber.Map{"filed": res, "case": detail})
+}
+
+// HandleAdminLinkIssue - POST /admin/support/case/:ticket/link
+func HandleAdminLinkIssue(c *fiber.Ctx) error {
+	ticket := strings.TrimSpace(c.Params("ticket"))
+	var req actionRequest
+	if err := c.BodyParser(&req); err != nil {
+		return badBody(c)
+	}
+	ctx, cancel := actionContext()
+	defer cancel()
+	key, err := ActionLinkIssue(ctx, ticket, req.IssueKey)
+	if err != nil {
+		return actionErrorResponse(c, "link that issue", err)
+	}
+	log.Printf("[AdminSupport] linked %s to ticket %s by %s", key, ticket, admin.ActingAdmin(c))
+	return respondWithCase(c, ctx, ticket, "link")
+}
+
+// HandleAdminUnlinkIssue - DELETE /admin/support/case/:ticket/link
+func HandleAdminUnlinkIssue(c *fiber.Ctx) error {
+	ticket := strings.TrimSpace(c.Params("ticket"))
+	ctx, cancel := actionContext()
+	defer cancel()
+	if err := ActionUnlinkIssue(ctx, ticket); err != nil {
+		return actionErrorResponse(c, "unlink that issue", err)
+	}
+	log.Printf("[AdminSupport] unlinked ticket %s by %s", ticket, admin.ActingAdmin(c))
+	return respondWithCase(c, ctx, ticket, "unlink")
+}
+
+// HandleAdminAutoSend - POST /admin/support/autosend
+//
+// The same switch /pause and /resume throw, and it answers with the switch
+// position rather than with a case: pausing is not about one ticket.
+//
+// Resuming here lifts the pause and nothing else. Un-demoting a category that
+// earned its way out of autonomy stays a Discord command on purpose — it is a
+// judgement about a whole class of tickets, not a button next to one of them.
+func HandleAdminAutoSend(c *fiber.Ctx) error {
+	var req actionRequest
+	if err := c.BodyParser(&req); err != nil {
+		return badBody(c)
+	}
+	ctx, cancel := actionContext()
+	defer cancel()
+	if err := ActionSetPaused(ctx, req.Paused); err != nil {
+		return actionErrorResponse(c, "change the pipeline switch", err)
+	}
+	log.Printf("[AdminSupport] autosend paused=%t by %s", req.Paused, admin.ActingAdmin(c))
+	return c.JSON(autoSendState(ctx))
+}
+
+func badDraftID(c *fiber.Ctx) error {
+	return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+		Status: "error", Error: "A numeric draft id is required.",
+	})
+}
+
+func badBody(c *fiber.Ctx) error {
+	return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+		Status: "error", Error: "Malformed request body.",
+	})
+}

--- a/api/internal/support/handlers_admin_actions_test.go
+++ b/api/internal/support/handlers_admin_actions_test.go
@@ -1,0 +1,619 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/admin"
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+	"github.com/gofiber/fiber/v2"
+)
+
+// =============================================================================
+// The write half (REL-261)
+// =============================================================================
+
+// ===== One verb, two surfaces =====================================
+
+// TestEverySurfaceCallsTheSameVerb is the test this ticket is really about.
+//
+// The console and the Discord buttons will coexist until REL-262 retires the
+// buttons, and the failure to prevent is the boring one: a rule tightened in
+// one surface and forgotten in the other, so the same case reaches two
+// different outcomes depending on where somebody clicked. The only structural
+// guarantee against that is for there to be exactly one implementation, and
+// this reads the package's own source to prove there is.
+//
+// For each verb it asserts the HTTP handler and the Discord handler both name
+// the same Action* function, and — the half that actually bites — that neither
+// surface reaches past it to the primitives underneath. A copy-pasted flow
+// would show up as markDraftDecided or sendDraftReply appearing in a handler
+// file, which is exactly what this refuses.
+func TestEverySurfaceCallsTheSameVerb(t *testing.T) {
+	const (
+		httpSurface    = "handlers_admin_actions.go"
+		discordSurface = "handlers_discord_interactions.go"
+		linkSurface    = "link_backfill.go"
+	)
+	calls := map[string]map[string]bool{}
+	for _, f := range []string{httpSurface, discordSurface, linkSurface} {
+		calls[f] = callsIn(t, f)
+	}
+
+	// The verb, and the two files that must both reach it through one name.
+	for _, v := range []struct{ verb, discordFile string }{
+		{"ActionSend", discordSurface},
+		{"ActionEditAndSend", discordSurface},
+		{"ActionAsk", discordSurface},
+		{"ActionSkip", discordSurface},
+		{"ActionHold", discordSurface},
+		{"ActionFileAsBug", discordSurface},
+		{"ActionLinkIssue", linkSurface},
+		{"ActionSetPaused", discordSurface},
+	} {
+		if !calls[httpSurface][v.verb] {
+			t.Errorf("%s does not call %s — the console has its own copy of that flow", httpSurface, v.verb)
+		}
+		if !calls[v.discordFile][v.verb] {
+			t.Errorf("%s does not call %s — Discord has its own copy of that flow", v.discordFile, v.verb)
+		}
+	}
+
+	// The primitives a re-implementation would have to reach for. A handler
+	// that calls one of these is a handler doing the verb itself.
+	for _, file := range []string{httpSurface, discordSurface, linkSurface} {
+		// policySet is deliberately absent: /resume <category> writes a
+		// DIFFERENT policy key to un-demote a category, and that stays a
+		// Discord command on purpose — it is a judgement about a whole class
+		// of tickets, not a button next to one of them.
+		for _, primitive := range []string{
+			"markDraftDecided", "sendDraftReply", "holdDraft",
+			"setCaseLinearIssueKey", "linearCreateIssue",
+		} {
+			if calls[file][primitive] {
+				t.Errorf("%s calls %s directly; that belongs behind an Action* verb so both surfaces get it", file, primitive)
+			}
+		}
+	}
+}
+
+// callsIn returns every function name called anywhere in one file of this
+// package. Method calls come back by their selector (`x.Foo` -> "Foo"), which
+// is fine: nothing here shares a name with a method.
+func callsIn(t *testing.T, filename string) map[string]bool {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), filename, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", filename, err)
+	}
+	out := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			out[fn.Name] = true
+		case *ast.SelectorExpr:
+			out[fn.Sel.Name] = true
+		}
+		return true
+	})
+	return out
+}
+
+// ===== The gate ===================================================
+
+// adminActionApp wires the real staff gate in front of the real write
+// handlers, so a 403 here is the gate refusing rather than a handler being
+// polite.
+func adminActionApp(sub string, roles ...string) *fiber.App {
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("user_id", sub)
+		c.Locals("user_roles", roles)
+		return c.Next()
+	})
+	registerAdminActionRoutes(app, admin.RequireAdmin)
+	return app
+}
+
+// anonymousActionApp is the same routes behind the real LogtoAuth, with no
+// token anywhere. Nothing under /admin may answer an unauthenticated caller.
+func anonymousActionApp() *fiber.App {
+	app := fiber.New()
+	registerAdminActionRoutes(app, platform.LogtoAuth, admin.RequireAdmin)
+	return app
+}
+
+// registerAdminActionRoutes mirrors core/server.go. Kept in one place so the
+// two deny tests and every verb test walk the same route table.
+func registerAdminActionRoutes(app *fiber.App, gate ...fiber.Handler) {
+	post := func(path string, h fiber.Handler) {
+		app.Post(path, append(append([]fiber.Handler{}, gate...), h)...)
+	}
+	post("/admin/support/draft/:draft/send", HandleAdminSend)
+	post("/admin/support/draft/:draft/edit", HandleAdminEditAndSend)
+	post("/admin/support/draft/:draft/ask", HandleAdminAsk)
+	post("/admin/support/draft/:draft/skip", HandleAdminSkip)
+	post("/admin/support/draft/:draft/hold", HandleAdminHold)
+	post("/admin/support/draft/:draft/bug", HandleAdminFileAsBug)
+	post("/admin/support/case/:ticket/link", HandleAdminLinkIssue)
+	post("/admin/support/autosend", HandleAdminAutoSend)
+	app.Delete("/admin/support/case/:ticket/link",
+		append(append([]fiber.Handler{}, gate...), HandleAdminUnlinkIssue)...)
+}
+
+// everyWriteRoute is the list both deny tests walk, so a route added later
+// without a gate cannot slip through by not being in a test.
+func everyWriteRoute(draftID string) []struct{ method, path string } {
+	return []struct{ method, path string }{
+		{"POST", "/admin/support/draft/" + draftID + "/send"},
+		{"POST", "/admin/support/draft/" + draftID + "/edit"},
+		{"POST", "/admin/support/draft/" + draftID + "/ask"},
+		{"POST", "/admin/support/draft/" + draftID + "/skip"},
+		{"POST", "/admin/support/draft/" + draftID + "/hold"},
+		{"POST", "/admin/support/draft/" + draftID + "/bug"},
+		{"POST", "/admin/support/case/900100/link"},
+		{"DELETE", "/admin/support/case/900100/link"},
+		{"POST", "/admin/support/autosend"},
+	}
+}
+
+func postJSON(t *testing.T, app *fiber.App, method, path, body string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, 30000)
+	if err != nil {
+		t.Fatalf("app.Test %s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(raw)
+}
+
+// A signed-in account that is not on the admin list gets 403 from every write
+// route, and no draft moves.
+func TestAdminActionEndpointsRejectASignedInNonAdmin(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	draft := seedPendingDraft(t, "900100", "Ticker froze")
+
+	// A product tier is not staff. super_user exists on real accounts.
+	app := adminActionApp("sub-someone-else", "super_user", "uplink_ultimate")
+	for _, r := range everyWriteRoute(itoa(draft.ID)) {
+		status, body := postJSON(t, app, r.method, r.path, `{"body":"x","question":"x","issue_key":"REL-1","paused":true}`)
+		if status != fiber.StatusForbidden {
+			t.Errorf("%s %s: got %d, want 403 (body: %s)", r.method, r.path, status, body)
+		}
+	}
+	if got := draftStatus(t, draft.ID); got != "pending" {
+		t.Errorf("a refused request still moved the draft: status=%s", got)
+	}
+}
+
+// With no credential at all, every write route is 401 before RequireAdmin is
+// even consulted.
+func TestAdminActionEndpointsRejectAnonymousCallers(t *testing.T) {
+	app := anonymousActionApp()
+	for _, r := range everyWriteRoute("1") {
+		req := httptest.NewRequest(r.method, r.path, strings.NewReader("{}"))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, 10000)
+		if err != nil {
+			t.Fatalf("app.Test: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Errorf("%s %s: got %d, want 401", r.method, r.path, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+}
+
+// ===== The verbs, end to end ======================================
+
+// seedPendingDraft puts one case and one pending draft in the database, with
+// the user's own message on the timeline so the editor has something to show.
+func seedPendingDraft(t *testing.T, ticket, subject string) *SupportDraft {
+	t.Helper()
+	ctx := context.Background()
+	recordTicketOpened(ctx, SupportCase{
+		TicketNumber: ticket, UserEmail: "u@example.com", LogtoSub: "sub-u",
+		Subject: subject, Category: "bug",
+	}, "<p>The ticker stopped scrolling after sleep</p>")
+	draft, err := createSupportDraft(ctx, &SupportDraft{
+		TicketNumber: ticket, UserEmail: "u@example.com", OriginalSubject: subject,
+		UserMessageHTML: "<p>The ticker stopped scrolling after sleep</p>",
+		DraftBodyHTML:   "<p>Try restarting the app.</p>",
+		AISummary:       "ticker freezes after sleep", AICategory: "bug", AIPriority: "high",
+		AskUserFor: "which version you are on",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return draft
+}
+
+func draftStatus(t *testing.T, id int64) string {
+	t.Helper()
+	var s string
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT status FROM support_drafts WHERE id = $1`, id).Scan(&s); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func itoa(n int64) string { return strconv.FormatInt(n, 10) }
+
+// decodeCase parses a write response as the case it must answer with. Every
+// verb returns the whole case so the page renders what happened rather than
+// guessing at it, and this is where that promise is checked.
+func decodeCase(t *testing.T, body string) AdminCaseDetail {
+	t.Helper()
+	var d AdminCaseDetail
+	if err := json.Unmarshal([]byte(body), &d); err != nil {
+		t.Fatalf("response is not a case: %v (body: %s)", err, truncate(body, 300))
+	}
+	if d.TicketNumber == "" {
+		t.Fatalf("response carries no ticket number: %s", truncate(body, 300))
+	}
+	return d
+}
+
+// Send reaches the user, records the send, and hands back the case.
+func TestAdminSendSendsTheReplyAndAnswersWithTheCase(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	srv := httptest.NewServer((&fakeOSTicket{}).handler(t))
+	defer srv.Close()
+	setOSTicketEnv(t, srv.URL)
+
+	draft := seedPendingDraft(t, "900100", "Ticker froze")
+	app := adminActionApp("sub-staff")
+
+	status, body := postJSON(t, app, "POST", "/admin/support/draft/"+itoa(draft.ID)+"/send", "{}")
+	if status != fiber.StatusOK {
+		t.Fatalf("send: got %d (%s)", status, body)
+	}
+	got := decodeCase(t, body)
+	if got.Draft == nil || got.Draft.SentAt == nil {
+		t.Fatalf("the case came back without a sent_at, so the page cannot tell the reply went out: %+v", got.Draft)
+	}
+	// REL-256: sent_at is the fact a reply reached a user, and the console
+	// path has to write it exactly like every other send path.
+	if got.Draft.Status != "sent" {
+		t.Errorf("draft status = %q, want sent", got.Draft.Status)
+	}
+	// The case history has to be identical whichever surface was used, which
+	// means the send is on the timeline as a sent message.
+	if n := countMessages(t, "900100", "sent"); n != 1 {
+		t.Errorf("sent messages on the case = %d, want 1", n)
+	}
+
+	// A second click sends nothing. The claim is conditional on the row still
+	// being pending, and the page is told which of the two happened.
+	status, body = postJSON(t, app, "POST", "/admin/support/draft/"+itoa(draft.ID)+"/send", "{}")
+	if status != fiber.StatusConflict {
+		t.Errorf("second send: got %d (%s), want 409", status, body)
+	}
+	if n := countMessages(t, "900100", "sent"); n != 1 {
+		t.Errorf("a second click sent a second reply: %d on the case", n)
+	}
+}
+
+// Edit stores the edit, sends the edit rather than the draft, and marks the
+// draft as one a person intervened on.
+func TestAdminEditSendsWhatWasTypedAndRecordsTheIntervention(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	srv := httptest.NewServer((&fakeOSTicket{}).handler(t))
+	defer srv.Close()
+	setOSTicketEnv(t, srv.URL)
+
+	draft := seedPendingDraft(t, "900100", "Ticker froze")
+	app := adminActionApp("sub-staff")
+
+	// Deliberately longer than Discord's 4000-character modal limit: the cap
+	// belonged to the modal, and nothing about a support email has it.
+	long := "Update to 1.6.2, which fixes the freeze after sleep. " + strings.Repeat("Details follow. ", 400)
+	status, body := postJSON(t, app, "POST", "/admin/support/draft/"+itoa(draft.ID)+"/edit",
+		mustJSON(t, map[string]string{"body": long}))
+	if status != fiber.StatusOK {
+		t.Fatalf("edit: got %d (%s)", status, body)
+	}
+	got := decodeCase(t, body)
+	if got.Draft == nil || got.Draft.Status != "edited" {
+		t.Fatalf("draft status = %v, want edited", got.Draft)
+	}
+	if !got.Draft.Intervened {
+		t.Error("an edit must count as an intervention — it is the numerator that demotes a category")
+	}
+	if !strings.Contains(got.Draft.Edited, "Update to 1.6.2") {
+		t.Errorf("the edit was not stored on the row: %q", truncate(got.Draft.Edited, 120))
+	}
+	if len(got.Draft.Edited) < 4000 {
+		t.Errorf("the edit was truncated to %d characters; there is no length limit here", len(got.Draft.Edited))
+	}
+	if got.Draft.SentAt == nil {
+		t.Error("an edited reply that was sent must still record sent_at (REL-256)")
+	}
+}
+
+// An empty edit is refused before anything is claimed.
+func TestAdminEditRefusesAnEmptyBody(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	draft := seedPendingDraft(t, "900100", "Ticker froze")
+
+	app := adminActionApp("sub-staff")
+	status, _ := postJSON(t, app, "POST", "/admin/support/draft/"+itoa(draft.ID)+"/edit",
+		mustJSON(t, map[string]string{"body": "   \n  "}))
+	if status != fiber.StatusBadRequest {
+		t.Errorf("empty edit: got %d, want 400", status)
+	}
+	if got := draftStatus(t, draft.ID); got != "pending" {
+		t.Errorf("a refused edit still claimed the draft: %s", got)
+	}
+}
+
+// Ask sends the question and parks the draft waiting on the user — and never
+// closes the ticket, whatever triage thought of the answer it replaced.
+func TestAdminAskParksTheCaseWaitingOnTheUser(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	// A recording osTicket rather than the shared fake: the shared one answers
+	// `closed: true` to every reply, which would hide the thing this test is
+	// for. What matters is whether the ASK asked for a close.
+	var askedToClose bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		askedToClose, _ = payload["close_ticket"].(bool)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok", "entry_id": 9002, "closed": askedToClose,
+		})
+	}))
+	defer srv.Close()
+	setOSTicketEnv(t, srv.URL)
+
+	draft := seedPendingDraft(t, "900100", "Ticker froze")
+	// Triage thought the reply it drafted was a resolution. The question that
+	// replaces it is not one, whatever triage thought.
+	testsupport.MustExec(t, `UPDATE support_drafts SET should_close = true WHERE id = $1`, draft.ID)
+
+	app := adminActionApp("sub-staff")
+	status, body := postJSON(t, app, "POST", "/admin/support/draft/"+itoa(draft.ID)+"/ask",
+		mustJSON(t, map[string]string{"question": "Which version are you on?"}))
+	if status != fiber.StatusOK {
+		t.Fatalf("ask: got %d (%s)", status, body)
+	}
+	got := decodeCase(t, body)
+	if got.Draft == nil || got.Draft.Status != "asked" {
+		t.Fatalf("draft status = %v, want asked", got.Draft)
+	}
+	if got.Group != queueWaiting {
+		t.Errorf("group = %q, want %q — an ask is waiting on the user", got.Group, queueWaiting)
+	}
+	if askedToClose {
+		t.Error("the ask asked osTicket to close the ticket; a question is never a resolution")
+	}
+	if got.Status == "closed" {
+		t.Error("asking a question closed the ticket")
+	}
+}
+
+// Skip and hold: one decides, one only stops the clock. Both count as a
+// person intervening.
+func TestAdminSkipDecidesAndHoldOnlyStopsTheClock(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	app := adminActionApp("sub-staff")
+
+	held := seedPendingDraft(t, "900100", "Held one")
+	deadline := time.Now().Add(30 * time.Minute)
+	if err := recordDisposition(context.Background(), held.ID, dispositionAutoSend, "confident", &deadline); err != nil {
+		t.Fatal(err)
+	}
+	status, body := postJSON(t, app, "POST", "/admin/support/draft/"+itoa(held.ID)+"/hold", "{}")
+	if status != fiber.StatusOK {
+		t.Fatalf("hold: got %d (%s)", status, body)
+	}
+	got := decodeCase(t, body)
+	if got.Draft == nil || got.Draft.Status != "pending" {
+		t.Fatalf("hold decided the draft: %v", got.Draft)
+	}
+	if got.Draft.HoldUntil != nil {
+		t.Errorf("hold left a deadline on the row: %v", got.Draft.HoldUntil)
+	}
+	if got.Hold != nil {
+		t.Errorf("the case still reports a countdown after a hold: %+v", got.Hold)
+	}
+	if !got.Draft.Intervened {
+		t.Error("a hold is an intervention")
+	}
+
+	skipped := seedPendingDraft(t, "900101", "Skipped one")
+	status, body = postJSON(t, app, "POST", "/admin/support/draft/"+itoa(skipped.ID)+"/skip", "{}")
+	if status != fiber.StatusOK {
+		t.Fatalf("skip: got %d (%s)", status, body)
+	}
+	got = decodeCase(t, body)
+	if got.Draft == nil || got.Draft.Status != "skipped" {
+		t.Fatalf("draft status = %v, want skipped", got.Draft)
+	}
+	if got.Group != queueHandled {
+		t.Errorf("group = %q, want %q", got.Group, queueHandled)
+	}
+	// The same audit note the Discord path writes.
+	if n := countMessages(t, "900101", "note"); n == 0 {
+		t.Error("a skip left no note on the case; the history must not depend on the surface")
+	}
+}
+
+// Link refuses anything that is not an issue key, and unlink is the only way
+// to change one.
+func TestAdminLinkRefusesNonsenseAndUnlinkClearsTheKey(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	seedPendingDraft(t, "900100", "Ticker froze")
+	app := adminActionApp("sub-staff")
+
+	// Never reaches Linear: the shape is wrong, and a typo'd key reads to the
+	// fix check as an issue it could not reach — which looks like "not fixed".
+	status, _ := postJSON(t, app, "POST", "/admin/support/case/900100/link",
+		mustJSON(t, map[string]string{"issue_key": "not a key"}))
+	if status != fiber.StatusBadRequest {
+		t.Errorf("malformed key: got %d, want 400", status)
+	}
+
+	// Unlink with nothing linked says so rather than pretending it worked.
+	status, _ = postJSON(t, app, "DELETE", "/admin/support/case/900100/link", "")
+	if status != fiber.StatusConflict {
+		t.Errorf("unlink with no link: got %d, want 409", status)
+	}
+
+	// With a link in place, unlink clears it and leaves the note behind.
+	testsupport.MustExec(t, `UPDATE support_cases SET linear_issue_key = 'REL-261' WHERE ticket_number = '900100'`)
+	status, body := postJSON(t, app, "DELETE", "/admin/support/case/900100/link", "")
+	if status != fiber.StatusOK {
+		t.Fatalf("unlink: got %d (%s)", status, body)
+	}
+	got := decodeCase(t, body)
+	if got.LinearIssueKey != "" {
+		t.Errorf("the case still carries %q after unlink", got.LinearIssueKey)
+	}
+	if !strings.Contains(got.Fix.Reason, "No Linear issue is linked") {
+		t.Errorf("the fix answer did not fall back to the unlinked reasoning: %q", got.Fix.Reason)
+	}
+	if n := countMessages(t, "900100", "note"); n == 0 {
+		t.Error("unlinking left no note; undoing a link is its own entry, not an erasure")
+	}
+}
+
+// The kill switch, from the console, is the same switch /pause throws.
+func TestAdminAutoSendPauseAndResume(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	t.Setenv("SUPPORT_AUTOSEND", "on")
+	app := adminActionApp("sub-staff")
+	ctx := context.Background()
+
+	status, body := postJSON(t, app, "POST", "/admin/support/autosend", `{"paused":true}`)
+	if status != fiber.StatusOK {
+		t.Fatalf("pause: got %d (%s)", status, body)
+	}
+	var state AutoSendState
+	if err := json.Unmarshal([]byte(body), &state); err != nil {
+		t.Fatal(err)
+	}
+	if !state.Paused || state.Armed {
+		t.Errorf("after pausing: %+v", state)
+	}
+	if !autosendPaused(ctx) {
+		t.Error("the console paused the page but not the pipeline")
+	}
+
+	status, body = postJSON(t, app, "POST", "/admin/support/autosend", `{"paused":false}`)
+	if status != fiber.StatusOK {
+		t.Fatalf("resume: got %d (%s)", status, body)
+	}
+	if err := json.Unmarshal([]byte(body), &state); err != nil {
+		t.Fatal(err)
+	}
+	if state.Paused || !state.Armed {
+		t.Errorf("after resuming: %+v", state)
+	}
+}
+
+// ===== The queue moves on its own =================================
+
+// A hold that runs out moves its case out of "Needs you" with nobody
+// clicking anything. This is the sweeper's job, and it is what the console's
+// live stream is there to show — so it has to actually happen.
+func TestTheQueueMovesWhenAHoldExpires(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	srv := httptest.NewServer((&fakeOSTicket{}).handler(t))
+	defer srv.Close()
+	setOSTicketEnv(t, srv.URL)
+	t.Setenv("SUPPORT_AUTOSEND", "on")
+
+	draft := seedPendingDraft(t, "900100", "Ticker froze")
+	past := time.Now().Add(-time.Minute)
+	if err := recordDisposition(context.Background(), draft.ID, dispositionAutoSend, "confident and cited", &past); err != nil {
+		t.Fatal(err)
+	}
+
+	app := adminSupportApp("sub-staff")
+	status, body := getJSON(t, app, "/admin/support/queue?state=needs_you")
+	if status != fiber.StatusOK {
+		t.Fatalf("queue: got %d (%s)", status, body)
+	}
+	if !strings.Contains(body, "900100") {
+		t.Fatalf("the case is not in Needs you before the sweep: %s", truncate(body, 300))
+	}
+
+	sweepExpiredHolds(context.Background())
+
+	status, body = getJSON(t, app, "/admin/support/queue?state=needs_you")
+	if status != fiber.StatusOK {
+		t.Fatalf("queue after sweep: got %d (%s)", status, body)
+	}
+	if strings.Contains(body, "900100") {
+		t.Errorf("the case is still in Needs you after its hold ran out: %s", truncate(body, 400))
+	}
+	if got := draftStatus(t, draft.ID); got != "sent" {
+		t.Errorf("draft status after the sweep = %q, want sent", got)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}

--- a/api/internal/support/handlers_admin_console.go
+++ b/api/internal/support/handlers_admin_console.go
@@ -493,15 +493,15 @@ type AdminDraft struct {
 	NeedsInfo    bool   `json:"needs_info"`
 	ShouldClose  bool   `json:"should_close"`
 
-	Disposition       string     `json:"disposition,omitempty"`
-	DispositionReason string     `json:"disposition_reason,omitempty"`
+	Disposition       string `json:"disposition,omitempty"`
+	DispositionReason string `json:"disposition_reason,omitempty"`
 	// HoldUntil is the raw deadline on the row. It survives the send, so read
 	// Hold on the case (which checks the status) rather than this.
 	HoldUntil  *time.Time `json:"hold_until,omitempty"`
 	Intervened bool       `json:"intervened"`
-	CreatedAt         time.Time  `json:"created_at"`
-	DecidedAt         *time.Time `json:"decided_at,omitempty"`
-	SentAt            *time.Time `json:"sent_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+	DecidedAt  *time.Time `json:"decided_at,omitempty"`
+	SentAt     *time.Time `json:"sent_at,omitempty"`
 }
 
 type AdminWidget struct {
@@ -600,11 +600,7 @@ func HandleAdminCase(c *fiber.Ctx) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var d AdminCaseDetail
-	err := platform.DBPool.QueryRow(ctx, caseSQL, ticket).Scan(
-		&d.TicketNumber, &d.Subject, &d.UserEmail, &d.LogtoSub, &d.Status,
-		&d.Category, &d.Priority, &d.Summary, &d.LinearIssueKey,
-		&d.DiscordThreadID, &d.OpenedAt, &d.UpdatedAt, &d.ClosedAt)
+	d, err := buildAdminCase(ctx, ticket)
 	if err == pgx.ErrNoRows {
 		return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
 			Status: "error",
@@ -612,8 +608,29 @@ func HandleAdminCase(c *fiber.Ctx) error {
 		})
 	}
 	if err != nil {
-		log.Printf("[AdminSupport] case %s: %v", ticket, err)
 		return adminSupportError(c, "Could not read that case.")
+	}
+	return c.JSON(d)
+}
+
+// buildAdminCase assembles one case exactly as the read endpoint serves it.
+//
+// Split out for REL-261: every write endpoint answers with the case as it now
+// stands, and it has to be the same case a reload would show. A second
+// assembly of the same fields is a second place for them to drift, and the
+// drift would be invisible — the page would simply be wrong about what just
+// happened.
+func buildAdminCase(ctx context.Context, ticket string) (*AdminCaseDetail, error) {
+	var d AdminCaseDetail
+	err := platform.DBPool.QueryRow(ctx, caseSQL, ticket).Scan(
+		&d.TicketNumber, &d.Subject, &d.UserEmail, &d.LogtoSub, &d.Status,
+		&d.Category, &d.Priority, &d.Summary, &d.LinearIssueKey,
+		&d.DiscordThreadID, &d.OpenedAt, &d.UpdatedAt, &d.ClosedAt)
+	if err != nil {
+		if err != pgx.ErrNoRows {
+			log.Printf("[AdminSupport] case %s: %v", ticket, err)
+		}
+		return nil, err
 	}
 	if d.DiscordThreadID != "" {
 		if guild := strings.TrimSpace(os.Getenv("DISCORD_GUILD_ID")); guild != "" {
@@ -650,7 +667,7 @@ func HandleAdminCase(c *fiber.Ctx) error {
 	d.KnownIssues = knownIssuesBlock(ctx)
 	d.EvidenceNote = "The similar cases and the known-issues block are rebuilt now, by the same queries the prompt uses. Neither is stored per draft, so on an older case they can differ from what the model was actually shown."
 
-	return c.JSON(d)
+	return &d, nil
 }
 
 func adminCaseMessages(ctx context.Context, ticket string) []AdminMessage {

--- a/api/internal/support/handlers_discord_interactions.go
+++ b/api/internal/support/handlers_discord_interactions.go
@@ -219,53 +219,49 @@ func handleDiscordButtonClick(c *fiber.Ctx, ix *discordInteraction) error {
 	}
 }
 
-// handleDiscordSendAction calls the existing approve-and-send flow.
+// handleDiscordSendAction sends the draft. Deferred, because the send is a
+// round-trip to osTicket and Resend while Discord's interaction budget is
+// three seconds — and because a confirmation posted before the send finishes
+// is a confirmation that can be wrong.
 func handleDiscordSendAction(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	draft, err := loadSupportDraft(ctx, draftID)
-	if err != nil {
-		log.Printf("[DiscordInteraction] load draft %d: %v", draftID, err)
-		return discordEphemeralResponse(c, "Could not load draft.")
-	}
-	if draft == nil {
-		return discordEphemeralResponse(c, "Draft not found (already actioned?).")
-	}
-	if draft.Status != "pending" {
-		return discordEphemeralResponse(c,
-			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
-	}
-
-	// Atomic decide → approved (no edits). Same call the email
-	// approval flow makes for the Send action.
-	if err := markDraftDecided(ctx, draftID, "approved", ""); err != nil {
-		log.Printf("[DiscordInteraction] markDraftDecided for %d: %v", draftID, err)
-		return discordEphemeralResponse(c, "Could not mark draft as approved.")
-	}
-	// Reload to get the post-mark state (status='approved').
-	draft, _ = loadSupportDraft(ctx, draftID)
-
-	// Fire-and-forget the actual reply send + thread state transition.
-	// On send success: flip thread to "sent" tag, prefix [SENT] in name.
-	// If close-flag also set: append "closed" tag, archive thread.
-	// On send failure: leave thread in "pending" so partner can retry.
-	go func() {
-		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer bgCancel()
-		if err := sendDraftReply(bgCtx, draft, draft.DraftBodyHTML); err != nil {
-			log.Printf("[DiscordInteraction] sendDraftReply for ticket %s: %v",
-				draft.TicketNumber, err)
-			return
+	return discordDeferred(c, ix, func(ctx context.Context) string {
+		draft, err := ActionSend(ctx, draftID)
+		if err != nil {
+			return discordActionError("send", draftID, err)
 		}
-		applySendStateToThread(bgCtx, draft, draft.ShouldClose)
-	}()
+		return buildSendConfirmation(draft)
+	})
+}
 
-	// Render a richer confirmation than just "✅ Sent" — give the
-	// partner the recipient + ticket-number + auto-close indicator
-	// without making them re-read the thread header.
-	confirmation := buildSendConfirmation(draft)
-	return discordVisibleResponse(c, confirmation)
+// discordDeferred answers Discord inside its three-second budget and posts
+// what actually happened once the work finishes. Every verb goes through it,
+// so each handler is the shared action plus the sentence to show for it.
+func discordDeferred(c *fiber.Ctx, ix *discordInteraction, work func(context.Context) string) error {
+	appID, token := ix.ApplicationID, ix.Token
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := discordCompleteDeferred(ctx, appID, token, work(ctx)); err != nil {
+			log.Printf("[DiscordInteraction] deferred follow-up: %v", err)
+		}
+	}()
+	return c.JSON(fiber.Map{"type": discordResponseDeferredChannelMessage})
+}
+
+// discordActionError turns a shared verb's error into the line a partner
+// reads. The three that are not failures get their own sentence: a draft
+// somebody already actioned, one that is gone, and an empty box.
+func discordActionError(verb string, draftID int64, err error) string {
+	switch {
+	case errors.Is(err, ErrAlreadyDecided):
+		return "Draft is already actioned."
+	case errors.Is(err, ErrDraftNotFound):
+		return "Draft not found (already actioned?)."
+	case errors.Is(err, ErrEmptyBody):
+		return "There was nothing to send."
+	}
+	log.Printf("[DiscordInteraction] %s draft %d: %v", verb, draftID, err)
+	return "⚠️ Could not " + verb + ": " + truncate(err.Error(), 300)
 }
 
 // buildSendConfirmation renders the post-Send message visible in the
@@ -506,44 +502,20 @@ func handleDiscordAskOpenModal(c *fiber.Ctx, ix *discordInteraction, draftID int
 func stopHoldForModal(draftID int64) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := holdDraft(ctx, draftID); err != nil && !errors.Is(err, ErrAlreadyDecided) {
+	if _, err := ActionHold(ctx, draftID); err != nil && !errors.Is(err, ErrAlreadyDecided) {
 		log.Printf("[DiscordInteraction] stop hold for draft %d: %v", draftID, err)
 	}
 }
 
-// handleDiscordSkipAction marks the draft as skipped.
+// handleDiscordSkipAction decides that this ticket needs no reply.
 func handleDiscordSkipAction(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	draft, err := loadSupportDraft(ctx, draftID)
-	if err != nil {
-		return discordEphemeralResponse(c, "Could not load draft.")
-	}
-	if draft == nil {
-		return discordEphemeralResponse(c, "Draft not found.")
-	}
-	if draft.Status != "pending" {
-		return discordEphemeralResponse(c,
-			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
-	}
-
-	if err := markDraftDecided(ctx, draftID, "skipped", ""); err != nil {
-		log.Printf("[DiscordInteraction] markDraftDecided (skipped) %d: %v", draftID, err)
-		return discordEphemeralResponse(c, "Could not skip draft.")
-	}
-
-	markIntervened(ctx, draftID)
-
-	// Update thread cosmetics fire-and-forget.
-	go func() {
-		bgCtx, bgCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer bgCancel()
-		applySkipStateToThread(bgCtx, draft)
-	}()
-
-	return discordVisibleResponse(c,
-		fmt.Sprintf("⏭️ Skipped — ticket #%s left without an AI reply.", draft.TicketNumber))
+	return discordDeferred(c, ix, func(ctx context.Context) string {
+		draft, err := ActionSkip(ctx, draftID)
+		if err != nil {
+			return discordActionError("skip", draftID, err)
+		}
+		return fmt.Sprintf("⏭️ Skipped — ticket #%s left without an AI reply.", draft.TicketNumber)
+	})
 }
 
 // handleDiscordHoldAction stops a running countdown without deciding the
@@ -554,24 +526,15 @@ func handleDiscordSkipAction(c *fiber.Ctx, ix *discordInteraction, draftID int64
 // a person saying "not this one, not yet" without having to also say what
 // should happen instead. It counts as an intervention.
 func handleDiscordHoldAction(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	draft, err := loadSupportDraft(ctx, draftID)
-	if err != nil || draft == nil {
-		return discordEphemeralResponse(c, "Draft not found.")
-	}
-	if draft.Status != "pending" {
-		return discordEphemeralResponse(c,
-			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
-	}
-	if err := holdDraft(ctx, draftID); err != nil {
-		log.Printf("[DiscordInteraction] holdDraft %d: %v", draftID, err)
-		return discordEphemeralResponse(c, "Could not hold this draft.")
-	}
-	return discordVisibleResponse(c, fmt.Sprintf(
-		"✋ Held — ticket #%s will not send by itself. Send, Edit, Ask or Skip when you are ready.",
-		draft.TicketNumber))
+	return discordDeferred(c, ix, func(ctx context.Context) string {
+		draft, err := ActionHold(ctx, draftID)
+		if err != nil {
+			return discordActionError("hold", draftID, err)
+		}
+		return fmt.Sprintf(
+			"✋ Held — ticket #%s will not send by itself. Send, Edit, Ask or Skip when you are ready.",
+			draft.TicketNumber)
+	})
 }
 
 // =============================================================================
@@ -603,52 +566,13 @@ func handleDiscordModalSubmit(c *fiber.Ctx, ix *discordInteraction) error {
 	}
 
 	editedBody := strings.TrimSpace(modalFieldValue(ix, "edited_body"))
-	if editedBody == "" {
-		return discordEphemeralResponse(c, "Edited body is empty.")
-	}
-
-	// Wrap plain-text in basic HTML so the email rendering path doesn't
-	// break. Existing pipeline expects HTML.
-	editedBodyHTML := plainToHTMLParagraphs(editedBody)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	draft, err := loadSupportDraft(ctx, draftID)
-	if err != nil || draft == nil {
-		return discordEphemeralResponse(c, "Draft not found.")
-	}
-	if draft.Status != "pending" {
-		return discordEphemeralResponse(c,
-			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
-	}
-
-	// Atomic decide → edited with the edited body persisted on the row.
-	if err := markDraftDecided(ctx, draftID, "edited", editedBodyHTML); err != nil {
-		log.Printf("[DiscordInteraction] markDraftDecided (edited) %d: %v", draftID, err)
-		return discordEphemeralResponse(c, "Could not save edits.")
-	}
-	markIntervened(ctx, draftID)
-	draft, _ = loadSupportDraft(ctx, draftID)
-
-	originalBody := draft.DraftBodyHTML
-	go func() {
-		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer bgCancel()
-		if err := sendDraftReply(bgCtx, draft, editedBodyHTML); err != nil {
-			log.Printf("[DiscordInteraction] sendDraftReply (edited) for ticket %s: %v",
-				draft.TicketNumber, err)
-			return
+	return discordDeferred(c, ix, func(ctx context.Context) string {
+		draft, err := ActionEditAndSend(ctx, draftID, editedBody)
+		if err != nil {
+			return discordActionError("send the edit", draftID, err)
 		}
-		// Edit-then-send still goes through the same thread state
-		// transitions as plain Send. Tag flips to "edited" instead of
-		// "sent" so we can distinguish them in /stats.
-		applyEditStateToThread(bgCtx, draft, draft.ShouldClose)
-		postEditDiff(bgCtx, draft, htmlToPlain(originalBody), editedBody)
-	}()
-
-	confirmation := buildEditConfirmation(draft)
-	return discordVisibleResponse(c, confirmation)
+		return buildEditConfirmation(draft)
+	})
 }
 
 // buildEditConfirmation parallels buildSendConfirmation for the
@@ -719,48 +643,14 @@ func modalFieldValue(ix *discordInteraction, customID string) string {
 // reply with the new information in it.
 func handleDiscordAskSubmit(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
 	question := strings.TrimSpace(modalFieldValue(ix, "ask_body"))
-	if question == "" {
-		return discordEphemeralResponse(c, "Question is empty.")
-	}
-	questionHTML := plainToHTMLParagraphs(question)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	draft, err := loadSupportDraft(ctx, draftID)
-	if err != nil || draft == nil {
-		return discordEphemeralResponse(c, "Draft not found.")
-	}
-	if draft.Status != "pending" {
-		return discordEphemeralResponse(c,
-			fmt.Sprintf("Draft is `%s` (already actioned).", draft.Status))
-	}
-
-	if err := markDraftDecided(ctx, draftID, "asked", questionHTML); err != nil {
-		log.Printf("[DiscordInteraction] markDraftDecided (asked) %d: %v", draftID, err)
-		return discordEphemeralResponse(c, "Could not record the question.")
-	}
-	draft, _ = loadSupportDraft(ctx, draftID)
-	if draft == nil {
-		return discordEphemeralResponse(c, "Draft vanished mid-ask.")
-	}
-	// A question never closes a ticket, whatever triage thought of the
-	// reply it replaces.
-	draft.ShouldClose = false
-
-	go func() {
-		bgCtx, bgCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer bgCancel()
-		if err := sendDraftReply(bgCtx, draft, questionHTML); err != nil {
-			log.Printf("[DiscordInteraction] send question for ticket %s: %v", draft.TicketNumber, err)
-			return
+	return discordDeferred(c, ix, func(ctx context.Context) string {
+		draft, err := ActionAsk(ctx, draftID, question)
+		if err != nil {
+			return discordActionError("ask", draftID, err)
 		}
-		applyAskStateToThread(bgCtx, draft)
-	}()
-
-	return discordVisibleResponse(c, fmt.Sprintf(
-		"❓ Asked on ticket #%s — waiting on the user:\n> %s",
-		draft.TicketNumber, strings.ReplaceAll(question, "\n", "\n> ")))
+		return fmt.Sprintf("❓ Asked on ticket #%s — waiting on the user:\n> %s",
+			draft.TicketNumber, strings.ReplaceAll(question, "\n", "\n> "))
+	})
 }
 
 // applyAskStateToThread is the Ask analog of applySendStateToThread. The
@@ -884,61 +774,28 @@ func splitLines(s string) []string {
 // duplicate — the same button on the same thread is how someone checks
 // whether it was already filed.
 func handleDiscordFileAsBug(c *fiber.Ctx, ix *discordInteraction, draftID int64) error {
-	appID, token := ix.ApplicationID, ix.Token
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-		defer cancel()
-		msg := fileDraftAsBug(ctx, draftID)
-		if err := discordCompleteDeferred(ctx, appID, token, msg); err != nil {
-			log.Printf("[DiscordInteraction] file-as-bug follow-up for draft %d: %v", draftID, err)
-		}
-	}()
-	return c.JSON(fiber.Map{"type": discordResponseDeferredChannelMessage})
+	return discordDeferred(c, ix, func(ctx context.Context) string {
+		return fileDraftAsBug(ctx, draftID)
+	})
 }
 
-// fileDraftAsBug does the work and returns the message to post in the
-// thread — success, "already filed", or why it failed. Never returns an
-// error: whatever happened, the partner needs to read it in Discord.
+// fileDraftAsBug phrases ActionFileAsBug for the thread — success, "already
+// filed", or why it failed. Never returns an error: whatever happened, the
+// partner needs to read it in Discord.
 func fileDraftAsBug(ctx context.Context, draftID int64) string {
-	draft, err := loadSupportDraft(ctx, draftID)
-	if err != nil || draft == nil {
-		return "Could not load draft."
-	}
-
-	if existing := caseLinearIssueKey(ctx, draft.TicketNumber); existing != "" {
-		return fmt.Sprintf("🐛 Already filed as **%s** — %s",
-			existing, linearIssueURL(existing))
-	}
-
-	title := strings.TrimSpace(draft.AISummary)
-	if title == "" {
-		title = strings.TrimSpace(draft.OriginalSubject)
-	}
-	if title == "" {
-		title = "Support ticket #" + draft.TicketNumber
-	}
-	title = truncateRunes(title, 120)
-
-	issue, err := linearCreateIssue(ctx, title, buildLinearIssueBody(ctx, draft))
+	res, err := ActionFileAsBug(ctx, draftID)
 	if err != nil {
-		log.Printf("[DiscordInteraction] linear create for ticket %s: %v", draft.TicketNumber, err)
-		return "⚠️ Could not file in Linear: " + err.Error()
+		return discordActionError("file as bug", draftID, err)
 	}
-
-	if err := setCaseLinearIssueKey(ctx, draft.TicketNumber, issue.Identifier); err != nil {
-		// The issue exists; we just can't remember it. Say so, or the next
-		// click files a second one silently.
-		log.Printf("[DiscordInteraction] link %s to ticket %s: %v", issue.Identifier, draft.TicketNumber, err)
-		return fmt.Sprintf("🐛 Filed **%s** (%s) — but the link back to ticket #%s did not save; a second click will file a duplicate.",
-			issue.Identifier, issue.URL, draft.TicketNumber)
+	switch {
+	case res.Already:
+		return fmt.Sprintf("🐛 Already filed as **%s** — %s", res.IssueKey, res.URL)
+	case !res.LinkSaved:
+		return fmt.Sprintf("🐛 Filed **%s** (%s) — but the link back to the ticket did not save; a second click will file a duplicate.",
+			res.IssueKey, res.URL)
+	default:
+		return fmt.Sprintf("🐛 Filed as **%s** — %s", res.IssueKey, res.URL)
 	}
-	if err := recordSupportMessage(ctx, SupportMessage{
-		TicketNumber: draft.TicketNumber, Kind: "note",
-		BodyText: "filed as " + issue.Identifier, AIDraftID: draft.ID,
-	}); err != nil {
-		log.Printf("[Cases] %v", err)
-	}
-	return fmt.Sprintf("🐛 Filed as **%s** — %s", issue.Identifier, issue.URL)
 }
 
 // buildLinearIssueBody is what an engineer needs to pick the issue up: the
@@ -1089,7 +946,7 @@ func handleDiscordSlashCommand(c *fiber.Ctx, ix *discordInteraction) error {
 func handleDiscordPauseCommand(c *fiber.Ctx) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := policySet(ctx, policyPausedKey, time.Now().UTC().Format(time.RFC3339)); err != nil {
+	if err := ActionSetPaused(ctx, true); err != nil {
 		log.Printf("[DiscordInteraction] pause: %v", err)
 		return discordEphemeralResponse(c, "Could not pause. Set SUPPORT_AUTOSEND=off if this keeps failing.")
 	}
@@ -1107,7 +964,7 @@ func handleDiscordResumeCommand(c *fiber.Ctx, ix *discordInteraction) error {
 
 	category := strings.ToLower(strings.TrimSpace(commandOption(ix, "category")))
 	if category == "" {
-		if err := policyDelete(ctx, policyPausedKey); err != nil {
+		if err := ActionSetPaused(ctx, false); err != nil {
 			log.Printf("[DiscordInteraction] resume: %v", err)
 			return discordEphemeralResponse(c, "Could not resume.")
 		}

--- a/api/internal/support/handlers_support_approval.go
+++ b/api/internal/support/handlers_support_approval.go
@@ -340,8 +340,13 @@ var sendApprovedReply = func(ctx context.Context, draft *SupportDraft, body stri
 func sendDraftReply(ctx context.Context, draft *SupportDraft, body string) error {
 	if err := sendApprovedReply(ctx, draft, body); err != nil {
 		markDraftFailed(ctx, draft.ID)
+		publishSupportEvent(draft.TicketNumber, supportEventFailed)
 		return err
 	}
 	markDraftSent(ctx, draft.ID)
+	// Every send goes through here (REL-256), which is exactly why the console
+	// event is published here and not once per verb: an Ask, an edit, a plain
+	// Send and the sweeper's unattended send all reach a person the same way.
+	publishSupportEvent(draft.TicketNumber, supportEventSent)
 	return nil
 }

--- a/api/internal/support/link_backfill.go
+++ b/api/internal/support/link_backfill.go
@@ -2,6 +2,7 @@ package support
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -228,32 +229,27 @@ func buildLinkProposals(ctx context.Context) (string, []DiscordActionRow) {
 // draft id.
 func handleDiscordLinkConfirm(c *fiber.Ctx, arg string) error {
 	ticket, issueKey, ok := strings.Cut(arg, "|")
-	ticket, issueKey = strings.TrimSpace(ticket), strings.ToUpper(strings.TrimSpace(issueKey))
-	if !ok || ticket == "" || issueKey == "" {
+	if !ok {
 		return discordEphemeralResponse(c, "malformed link target")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if existing := caseLinearIssueKey(ctx, ticket); existing != "" {
-		return discordEphemeralResponse(c,
-			fmt.Sprintf("#%s is already linked to **%s**.", ticket, existing))
-	}
-	if err := setCaseLinearIssueKey(ctx, ticket, issueKey); err != nil {
+	// ActionLinkIssue is the same function the console's link endpoint calls,
+	// so the note, the thread post and the refusal to overwrite an existing
+	// link are written once (REL-261).
+	key, err := ActionLinkIssue(ctx, ticket, issueKey)
+	if err != nil {
+		var already ErrAlreadyLinked
+		if errors.As(err, &already) {
+			return discordEphemeralResponse(c,
+				fmt.Sprintf("#%s is already linked to **%s**.", strings.TrimSpace(ticket), already.IssueKey))
+		}
 		log.Printf("[Link] %s -> %s: %v", ticket, issueKey, err)
-		return discordEphemeralResponse(c, "Could not save the link.")
+		return discordEphemeralResponse(c, "Could not save the link: "+truncate(err.Error(), 200))
 	}
-	if err := recordSupportMessage(ctx, SupportMessage{
-		TicketNumber: ticket, Kind: "note",
-		BodyText: "linked to " + issueKey + " by hand",
-	}); err != nil {
-		log.Printf("[Cases] %v", err)
-	}
-	postToTicketThread(ctx, ticket, fmt.Sprintf(
-		"🔗 Linked to **%s** — %s. Drafts on this ticket may name the release that carries it once it ships.",
-		issueKey, linearIssueURL(issueKey)))
 
 	return discordVisibleResponse(c, fmt.Sprintf("🔗 **#%s → %s.** %s",
-		ticket, issueKey, linearIssueURL(issueKey)))
+		strings.TrimSpace(ticket), key, linearIssueURL(key)))
 }

--- a/api/internal/support/support_drafts.go
+++ b/api/internal/support/support_drafts.go
@@ -160,6 +160,7 @@ func createSupportDraft(ctx context.Context, draft *SupportDraft) (*SupportDraft
 	applyTriageToCase(ctx, draft.TicketNumber, &TriageResult{
 		Category: draft.AICategory, Priority: draft.AIPriority, Summary: draft.AISummary,
 	})
+	publishSupportEvent(draft.TicketNumber, supportEventDrafted)
 	return draft, nil
 }
 

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -347,6 +347,44 @@ export interface CaseDetail {
   evidence_note: string
 }
 
+// ── Support console, the verbs (REL-261) ─────────────────────────
+
+/** What filing a bug did. `link_saved: false` is the one that matters. */
+export interface FiledBug {
+  issue_key: string
+  url: string
+  already_filed: boolean
+  link_saved: boolean
+}
+
+export interface FiledBugResult {
+  filed: FiledBug
+  case: CaseDetail
+}
+
+/**
+ * One support event off the SSE hub. It names the ticket that moved and what
+ * happened to it, and carries no case: the page re-reads from the same
+ * handlers it read the first time, so a socket can never disagree with the
+ * endpoint about what a case looks like.
+ */
+export interface SupportEvent {
+  type: 'support'
+  event:
+    | 'drafted'
+    | 'decided'
+    | 'sent'
+    | 'failed'
+    | 'skipped'
+    | 'held'
+    | 'linked'
+    | 'unlinked'
+    | 'autosend'
+  ticket_number?: string
+  disposition?: string
+  at: string
+}
+
 // ── Admins ────────────────────────────────────────────────────────
 
 export interface AdminRow {
@@ -408,4 +446,138 @@ export const adminApi = {
     adminFetch<{ status: string }>(`/admin/admins/${id}`, getToken, {
       method: 'DELETE',
     }),
+
+  // Every verb answers with the case as it now stands, so nothing below
+  // returns a status for the page to interpret — it returns the truth.
+  sendDraft: (getToken: Token, draftId: number) =>
+    draftAction<CaseDetail>(getToken, draftId, 'send'),
+
+  editAndSend: (getToken: Token, draftId: number, body: string) =>
+    draftAction<CaseDetail>(getToken, draftId, 'edit', { body }),
+
+  askUser: (getToken: Token, draftId: number, question: string) =>
+    draftAction<CaseDetail>(getToken, draftId, 'ask', { question }),
+
+  skipDraft: (getToken: Token, draftId: number) =>
+    draftAction<CaseDetail>(getToken, draftId, 'skip'),
+
+  holdDraft: (getToken: Token, draftId: number) =>
+    draftAction<CaseDetail>(getToken, draftId, 'hold'),
+
+  fileAsBug: (getToken: Token, draftId: number) =>
+    draftAction<FiledBugResult>(getToken, draftId, 'bug'),
+
+  linkIssue: (getToken: Token, ticket: string, issueKey: string) =>
+    adminFetch<CaseDetail>(
+      `/admin/support/case/${encodeURIComponent(ticket)}/link`,
+      getToken,
+      { method: 'POST', body: JSON.stringify({ issue_key: issueKey }) },
+    ),
+
+  unlinkIssue: (getToken: Token, ticket: string) =>
+    adminFetch<CaseDetail>(
+      `/admin/support/case/${encodeURIComponent(ticket)}/link`,
+      getToken,
+      { method: 'DELETE' },
+    ),
+
+  setAutoSendPaused: (getToken: Token, paused: boolean) =>
+    adminFetch<AutoSendState>('/admin/support/autosend', getToken, {
+      method: 'POST',
+      body: JSON.stringify({ paused }),
+    }),
+}
+
+function draftAction<T>(
+  getToken: Token,
+  draftId: number,
+  verb: string,
+  body?: unknown,
+): Promise<T> {
+  return adminFetch<T>(`/admin/support/draft/${draftId}/${verb}`, getToken, {
+    method: 'POST',
+    body: JSON.stringify(body ?? {}),
+  })
+}
+
+/** SSE frames are separated by a blank line; fields by a single one. */
+const FRAME_SEPARATOR = '\n\n'
+const LINE_SEPARATOR = '\n'
+
+/**
+ * Subscribe to the console's SSE stream. Returns a function that closes it.
+ *
+ * `fetch` rather than `EventSource` for one reason: EventSource cannot send an
+ * Authorization header, and the alternative is a JWT in the query string,
+ * which puts a credential in every proxy log between here and the API. The
+ * body is the same `data: {json}` frames either way, and the parsing below is
+ * the whole cost of not doing that.
+ *
+ * Reconnects with a fixed delay while the caller still wants it. This is a
+ * staff page on a fast network; anything cleverer than "try again in three
+ * seconds" would be machinery for a case that does not happen.
+ */
+export function subscribeToSupportEvents(
+  getToken: Token,
+  onEvent: (event: SupportEvent) => void,
+  onStatus?: (connected: boolean) => void,
+): () => void {
+  // The abort signal is the only "should I stop" flag. A second boolean beside
+  // it would be written from the returned closure, which control-flow analysis
+  // cannot see — so every check of it reads as dead code.
+  const controller = new AbortController()
+  // A function, not a property read: TypeScript narrows a property to false
+  // after the loop condition tests it, which makes every later check read as
+  // dead code even though abort() flips it from outside.
+  const stopped = () => controller.signal.aborted
+
+  const run = async () => {
+    while (!stopped()) {
+      try {
+        const token = await getToken()
+        const response = await fetch(`${API_BASE}/admin/support/stream`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          credentials: 'include',
+          signal: controller.signal,
+        })
+        if (!response.ok || !response.body) {
+          throw new AdminApiError('stream refused', response.status)
+        }
+        onStatus?.(true)
+
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+        for (;;) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          const frames = buffer.split(FRAME_SEPARATOR)
+          // The trailing piece is a frame still arriving, not a frame.
+          buffer = frames.pop() ?? ''
+          for (const frame of frames) {
+            for (const line of frame.split(LINE_SEPARATOR)) {
+              // Anything that is not a data line — the retry hint, the
+              // heartbeat comment — carries nothing for this page.
+              if (!line.startsWith('data:')) continue
+              try {
+                onEvent(JSON.parse(line.slice(5).trim()) as SupportEvent)
+              } catch {
+                // A frame we cannot parse is a frame we ignore; the page
+                // catches up on the next one.
+              }
+            }
+          }
+        }
+      } catch {
+        if (stopped()) return
+      }
+      onStatus?.(false)
+      if (stopped()) return
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+    }
+  }
+  void run()
+
+  return () => controller.abort()
 }

--- a/myscrollr.com/src/components/admin/CaseActions.tsx
+++ b/myscrollr.com/src/components/admin/CaseActions.tsx
@@ -1,0 +1,583 @@
+import { useEffect, useState } from 'react'
+import {
+  AlertTriangle,
+  Bug,
+  Hand,
+  Link2,
+  Link2Off,
+  Loader2,
+  MessageCircleQuestion,
+  Pencil,
+  Send,
+  SkipForward,
+} from 'lucide-react'
+import type { CaseDetail, FiledBug } from '@/api/admin'
+import { adminApi } from '@/api/admin'
+import { isUnchanged, lineDiff } from '@/lib/supportConsole'
+import { useGetToken } from '@/hooks/useGetToken'
+
+/**
+ * Every support verb, next to the case it acts on (REL-261).
+ *
+ * These are the same functions the Discord buttons call — one HTTP endpoint
+ * each, one shared function behind both — so a decision reached here and a
+ * decision reached in the thread are the same decision, with the same audit
+ * trail. Nothing here computes a disposition or decides whether a fix is
+ * proven; the server did that before this case ever reached a queue, and the
+ * only thing a person adds is responsibility for the click.
+ *
+ * Send is the one action that cannot be undone, so it is the one action that
+ * asks twice. Skip, hold, link, unlink and file go through on the first click
+ * on purpose: a tool that makes you confirm everything is a tool you stop
+ * using, and every one of those can be put back.
+ */
+
+type Panel = 'none' | 'confirm-send' | 'edit' | 'ask' | 'link'
+
+export default function CaseActions({
+  detail,
+  onCase,
+}: {
+  detail: CaseDetail
+  onCase: (next: CaseDetail) => void
+}) {
+  const getToken = useGetToken()
+  const draft = detail.draft
+  const pending = draft?.status === 'pending'
+
+  const [panel, setPanel] = useState<Panel>('none')
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const [body, setBody] = useState('')
+  const [question, setQuestion] = useState('')
+  const [issueKey, setIssueKey] = useState('')
+
+  // Reset when the case changes underneath — an open editor holding another
+  // ticket's draft is how the wrong reply gets sent to the wrong person.
+  useEffect(() => {
+    setPanel('none')
+    setError(null)
+    setNotice(null)
+    setBody(draft?.body ?? '')
+    setQuestion(draft?.ask_user_for ?? '')
+    setIssueKey('')
+  }, [detail.ticket_number, draft?.id, draft?.body, draft?.ask_user_for])
+
+  /** Runs one verb, keeps whatever case came back, and says what went wrong. */
+  const run = async (
+    name: string,
+    call: () => Promise<CaseDetail>,
+    after?: () => void,
+  ) => {
+    setBusy(name)
+    setError(null)
+    setNotice(null)
+    try {
+      onCase(await call())
+      after?.()
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'That did not go through.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const openEditor = () => {
+    setPanel('edit')
+    setError(null)
+    // Opening the editor stops the countdown, exactly as opening the Discord
+    // modal does. Typing a reply takes longer than a hold that is nearly up,
+    // and "I am working on this one" has to actually stop the clock rather
+    // than race it.
+    if (pending && detail.hold) {
+      void run('hold', () => adminApi.holdDraft(getToken, draft.id))
+    }
+  }
+
+  const fileBug = async () => {
+    if (!draft) return
+    setBusy('bug')
+    setError(null)
+    setNotice(null)
+    try {
+      const res = await adminApi.fileAsBug(getToken, draft.id)
+      onCase(res.case)
+      setNotice(describeFiling(res.filed))
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Could not file that.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const edited = body.trim()
+  const unchanged = isUnchanged(draft?.body ?? '', edited)
+
+  return (
+    <section>
+      <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+        What you can do
+      </h2>
+
+      {!pending && (
+        <p className="mt-2 rounded-xl bg-base-200/40 px-4 py-3 text-sm text-base-content/60 ring-1 ring-base-300/60">
+          {draft
+            ? `This draft is ${draft.status}, so there is nothing left to send on it. The issue link below is still yours to change.`
+            : 'There is no draft to act on. Link an issue, or answer this one in osTicket.'}
+        </p>
+      )}
+
+      <div className="mt-2 flex flex-wrap gap-2">
+        {pending && (
+          <>
+            <ActionButton
+              label="Send"
+              icon={<Send size={14} />}
+              tone="primary"
+              busy={busy === 'send'}
+              disabled={busy !== null}
+              onClick={() => {
+                setPanel('confirm-send')
+                setError(null)
+              }}
+            />
+            <ActionButton
+              label="Edit"
+              icon={<Pencil size={14} />}
+              busy={busy === 'hold' && panel === 'edit'}
+              disabled={busy !== null}
+              onClick={openEditor}
+            />
+            <ActionButton
+              label="Ask"
+              icon={<MessageCircleQuestion size={14} />}
+              disabled={busy !== null}
+              onClick={() => {
+                setPanel('ask')
+                setError(null)
+              }}
+            />
+            <ActionButton
+              label="Hold"
+              icon={<Hand size={14} />}
+              busy={busy === 'hold' && panel !== 'edit'}
+              disabled={busy !== null}
+              onClick={() =>
+                run('hold', () => adminApi.holdDraft(getToken, draft.id))
+              }
+            />
+            <ActionButton
+              label="Skip"
+              icon={<SkipForward size={14} />}
+              busy={busy === 'skip'}
+              disabled={busy !== null}
+              onClick={() =>
+                run('skip', () => adminApi.skipDraft(getToken, draft.id))
+              }
+            />
+            <ActionButton
+              label="File as bug"
+              icon={<Bug size={14} />}
+              busy={busy === 'bug'}
+              disabled={busy !== null}
+              onClick={fileBug}
+            />
+          </>
+        )}
+
+        {detail.linear_issue_key ? (
+          <ActionButton
+            label={`Unlink ${detail.linear_issue_key}`}
+            icon={<Link2Off size={14} />}
+            busy={busy === 'unlink'}
+            disabled={busy !== null}
+            onClick={() =>
+              run('unlink', () =>
+                adminApi.unlinkIssue(getToken, detail.ticket_number),
+              )
+            }
+          />
+        ) : (
+          <ActionButton
+            label="Link an issue"
+            icon={<Link2 size={14} />}
+            disabled={busy !== null}
+            onClick={() => {
+              setPanel('link')
+              setError(null)
+            }}
+          />
+        )}
+      </div>
+
+      {error && (
+        <p className="mt-2 flex items-baseline gap-2 rounded-lg bg-error/10 px-3 py-2 text-sm text-error ring-1 ring-error/30">
+          <AlertTriangle size={14} className="translate-y-0.5 shrink-0" />
+          {error}
+        </p>
+      )}
+      {notice && (
+        <p className="mt-2 rounded-lg bg-base-200/60 px-3 py-2 text-sm text-base-content/75 ring-1 ring-base-300/60">
+          {notice}
+        </p>
+      )}
+
+      {/* ── Send, confirmed ─────────────────────────────────────── */}
+      {panel === 'confirm-send' && pending && (
+        <ConfirmSend
+          who={detail.user_email}
+          closing={draft.should_close}
+          busy={busy === 'send'}
+          onCancel={() => setPanel('none')}
+          onSend={() =>
+            run(
+              'send',
+              () => adminApi.sendDraft(getToken, draft.id),
+              () => setPanel('none'),
+            )
+          }
+        />
+      )}
+
+      {/* ── The editor ──────────────────────────────────────────── */}
+      {panel === 'edit' && pending && (
+        <div className="mt-3 space-y-3 rounded-xl p-4 ring-1 ring-base-300/60">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div>
+              <label
+                htmlFor="reply-body"
+                className="text-xs font-semibold tracking-wide text-base-content/50 uppercase"
+              >
+                The reply
+              </label>
+              {/* No maxLength. Discord capped this at 4000 because a Discord
+                  modal does; a support email does not, and a limit that comes
+                  from the surface you happen to be typing into is a limit that
+                  silently cuts somebody's answer in half. */}
+              <textarea
+                id="reply-body"
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                rows={16}
+                spellCheck
+                className="mt-1 w-full resize-y rounded-lg bg-base-100 px-3 py-2 font-mono text-sm ring-1 ring-base-300/60 focus:ring-2 focus:ring-primary/50 focus:outline-none"
+              />
+              <p className="mt-1 text-xs text-base-content/45">
+                {edited.length.toLocaleString()} characters. Plain text — it is
+                wrapped into paragraphs on the way out.
+              </p>
+            </div>
+
+            <div>
+              <p className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+                What they wrote
+              </p>
+              {/* Beside the box, not behind it. The Discord modal covered the
+                  thread while it was open, so rewriting an answer meant
+                  cancelling out to re-read the question. */}
+              <div className="mt-1 max-h-[26rem] overflow-y-auto rounded-lg bg-base-200/40 px-3 py-2 text-sm whitespace-pre-wrap text-base-content/80 ring-1 ring-base-300/60">
+                {lastUserMessage(detail) ?? (
+                  <span className="text-base-content/45 italic">
+                    Nothing from the user is on record for this ticket.
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <DiffPanel before={draft.body} after={edited} />
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              disabled={busy !== null || edited === ''}
+              onClick={() =>
+                run(
+                  'edit',
+                  () => adminApi.editAndSend(getToken, draft.id, edited),
+                  () => setPanel('none'),
+                )
+              }
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-content disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy === 'edit' ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Send size={14} />
+              )}
+              Send this instead
+            </button>
+            <button
+              type="button"
+              disabled={busy !== null}
+              onClick={() => setPanel('none')}
+              className="cursor-pointer rounded-lg px-3 py-1.5 text-sm text-base-content/70 hover:bg-base-200/60"
+            >
+              Cancel
+            </button>
+            {unchanged && edited !== '' && (
+              <span className="text-xs text-base-content/50">
+                Nothing has changed yet — this would send the draft as written.
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ── Ask one question ───────────────────────────────────── */}
+      {panel === 'ask' && pending && (
+        <div className="mt-3 space-y-3 rounded-xl p-4 ring-1 ring-base-300/60">
+          <label
+            htmlFor="ask-body"
+            className="text-xs font-semibold tracking-wide text-base-content/50 uppercase"
+          >
+            One question, in place of the answer
+          </label>
+          <textarea
+            id="ask-body"
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            rows={4}
+            placeholder="Which version are you on, and does it happen on every launch?"
+            className="w-full resize-y rounded-lg bg-base-100 px-3 py-2 text-sm ring-1 ring-base-300/60 focus:ring-2 focus:ring-primary/50 focus:outline-none"
+          />
+          <p className="text-xs text-base-content/50">
+            {draft.ask_user_for
+              ? 'Pre-filled with what the drafter said it still needs. Their answer comes back through the ticket and drafts afresh with it.'
+              : 'The drafter did not say it was missing anything, so this box started empty.'}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={busy !== null || question.trim() === ''}
+              onClick={() =>
+                run(
+                  'ask',
+                  () => adminApi.askUser(getToken, draft.id, question.trim()),
+                  () => setPanel('none'),
+                )
+              }
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-content disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy === 'ask' ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Send size={14} />
+              )}
+              Send the question
+            </button>
+            <button
+              type="button"
+              disabled={busy !== null}
+              onClick={() => setPanel('none')}
+              className="cursor-pointer rounded-lg px-3 py-1.5 text-sm text-base-content/70 hover:bg-base-200/60"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Link an existing issue ─────────────────────────────── */}
+      {panel === 'link' && (
+        <div className="mt-3 space-y-3 rounded-xl p-4 ring-1 ring-base-300/60">
+          <label
+            htmlFor="issue-key"
+            className="text-xs font-semibold tracking-wide text-base-content/50 uppercase"
+          >
+            Issue key
+          </label>
+          <div className="flex flex-wrap gap-2">
+            <input
+              id="issue-key"
+              value={issueKey}
+              onChange={(e) => setIssueKey(e.target.value.toUpperCase())}
+              placeholder="REL-261"
+              className="w-40 rounded-lg bg-base-100 px-3 py-1.5 font-mono text-sm ring-1 ring-base-300/60 focus:ring-2 focus:ring-primary/50 focus:outline-none"
+            />
+            <button
+              type="button"
+              disabled={busy !== null || issueKey.trim() === ''}
+              onClick={() =>
+                run(
+                  'link',
+                  () =>
+                    adminApi.linkIssue(
+                      getToken,
+                      detail.ticket_number,
+                      issueKey.trim(),
+                    ),
+                  () => setPanel('none'),
+                )
+              }
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-base-200 px-3 py-1.5 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy === 'link' ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Link2 size={14} />
+              )}
+              Link it
+            </button>
+            <button
+              type="button"
+              disabled={busy !== null}
+              onClick={() => setPanel('none')}
+              className="cursor-pointer rounded-lg px-3 py-1.5 text-sm text-base-content/70 hover:bg-base-200/60"
+            >
+              Cancel
+            </button>
+          </div>
+          <p className="text-xs text-base-content/50">
+            Checked against Linear before it is saved. A key that does not exist
+            reads to the fix check as an issue it could not reach, which looks a
+            great deal like &ldquo;not fixed yet&rdquo;.
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}
+
+/** The one confirmation on the page, in front of the one thing you cannot undo. */
+function ConfirmSend({
+  who,
+  closing,
+  busy,
+  onSend,
+  onCancel,
+}: {
+  who?: string
+  closing: boolean
+  busy: boolean
+  onSend: () => void
+  onCancel: () => void
+}) {
+  return (
+    <div className="mt-3 rounded-xl bg-warning/5 px-4 py-3 ring-1 ring-warning/40">
+      <p className="text-sm font-semibold">
+        Send this reply to {who ?? 'the reporter'}?
+      </p>
+      <p className="mt-1 text-xs text-base-content/70">
+        It goes out as an email and is marked answered in osTicket. There is no
+        undo.
+        {closing && ' The ticket also closes — triage flagged it as resolved.'}
+      </p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onSend}
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-content disabled:opacity-50"
+        >
+          {busy ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <Send size={14} />
+          )}
+          Yes, send it
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onCancel}
+          className="cursor-pointer rounded-lg px-3 py-1.5 text-sm text-base-content/70 hover:bg-base-200/60"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/** What changed, before the click rather than after it. */
+function DiffPanel({ before, after }: { before: string; after: string }) {
+  const lines = lineDiff(before, after)
+  const changed = lines.filter((l) => l.kind !== 'kept').length
+  if (changed === 0) {
+    return (
+      <p className="text-xs text-base-content/50">
+        No changes yet. The diff appears here as soon as there are any.
+      </p>
+    )
+  }
+  return (
+    <details open>
+      <summary className="cursor-pointer text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+        What changed · {changed} {changed === 1 ? 'line' : 'lines'}
+      </summary>
+      <div className="mt-2 max-h-64 overflow-auto rounded-lg bg-base-200/40 p-2 ring-1 ring-base-300/60">
+        {lines.map((l, i) => (
+          <p
+            key={i}
+            className={`font-mono text-xs whitespace-pre-wrap ${
+              l.kind === 'removed'
+                ? 'bg-error/10 text-error'
+                : l.kind === 'added'
+                  ? 'bg-success/10 text-success'
+                  : 'text-base-content/50'
+            }`}
+          >
+            {l.kind === 'removed' ? '- ' : l.kind === 'added' ? '+ ' : '  '}
+            {l.text}
+          </p>
+        ))}
+      </div>
+    </details>
+  )
+}
+
+function ActionButton({
+  label,
+  icon,
+  tone,
+  busy,
+  disabled,
+  onClick,
+}: {
+  label: string
+  icon: React.ReactNode
+  tone?: 'primary'
+  busy?: boolean
+  disabled?: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+        tone === 'primary'
+          ? 'bg-primary text-primary-content'
+          : 'bg-base-200 text-base-content hover:bg-base-300/70'
+      }`}
+    >
+      {busy ? <Loader2 size={14} className="animate-spin" /> : icon}
+      {label}
+    </button>
+  )
+}
+
+/** The reporter's most recent words — what an answer has to answer. */
+function lastUserMessage(detail: CaseDetail): string | null {
+  const messages = detail.messages ?? []
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].kind === 'user' && messages[i].body.trim() !== '') {
+      return messages[i].body
+    }
+  }
+  return null
+}
+
+function describeFiling(filed: FiledBug): string {
+  if (filed.already_filed) {
+    return `Already filed as ${filed.issue_key} — ${filed.url}`
+  }
+  if (!filed.link_saved) {
+    return `Filed ${filed.issue_key} (${filed.url}), but the link back to this ticket did not save. Filing again would create a duplicate — link ${filed.issue_key} by hand instead.`
+  }
+  return `Filed as ${filed.issue_key} — ${filed.url}`
+}

--- a/myscrollr.com/src/components/admin/SupportPage.tsx
+++ b/myscrollr.com/src/components/admin/SupportPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   AlertTriangle,
   CheckCircle2,
@@ -7,6 +7,9 @@ import {
   HelpCircle,
   Loader2,
   MessageSquare,
+  Pause,
+  Play,
+  Radio,
 } from 'lucide-react'
 import type {
   AdminFix,
@@ -17,7 +20,8 @@ import type {
   QueueRow,
   SupportQueue,
 } from '@/api/admin'
-import { adminApi } from '@/api/admin'
+import { adminApi, subscribeToSupportEvents } from '@/api/admin'
+import CaseActions from '@/components/admin/CaseActions'
 import {
   QUEUE_GROUPS,
   dispositionTone,
@@ -30,9 +34,16 @@ import { useGetToken } from '@/hooks/useGetToken'
 /**
  * The Support section: the queue on the left, one case on the right.
  *
- * Read-only. Every verb — send, hold, edit, ask, skip — is REL-261, and the
- * point of shipping the read half first is to prove every fact is visible
- * before a button can act on one.
+ * REL-263 built the read half; REL-261 gave every fact on it a button. Each
+ * button calls the same server function the Discord button calls, so the two
+ * surfaces cannot drift while they coexist, and a case reads the same
+ * whichever one was used.
+ *
+ * The page moves on its own. A support event on the SSE hub — a draft written,
+ * a disposition decided, a reply sent — re-reads the queue and the open case
+ * from the endpoints that built them. Nothing polls, and nothing patches a
+ * case out of a socket payload: the event says which ticket moved, and the
+ * server says what it now looks like.
  *
  * The case view is the whole reason this exists. Discord could show the draft
  * and roughly two thousand characters of it; it could not show what the
@@ -408,14 +419,22 @@ function Pipeline({ detail }: { detail: CaseDetail }) {
 
 // ── the case ──────────────────────────────────────────────────────
 
-function CaseView({ ticket }: { ticket: string }) {
+function CaseView({
+  ticket,
+  reloadKey,
+}: {
+  ticket: string
+  reloadKey: number
+}) {
   const getToken = useGetToken()
   const [detail, setDetail] = useState<CaseDetail | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  // reloadKey is bumped when a support event names this ticket. The panel is
+  // NOT blanked on a re-read — only on a change of ticket — so a reply landing
+  // while you are reading does not throw the page away and start again.
   useEffect(() => {
     let cancelled = false
-    setDetail(null)
     setError(null)
     adminApi
       .supportCase(getToken, ticket)
@@ -432,7 +451,9 @@ function CaseView({ ticket }: { ticket: string }) {
     return () => {
       cancelled = true
     }
-  }, [getToken, ticket])
+  }, [getToken, ticket, reloadKey])
+
+  useEffect(() => setDetail(null), [ticket])
 
   if (error) {
     return <p className="p-4 text-sm text-error">{error}</p>
@@ -483,6 +504,7 @@ function CaseView({ ticket }: { ticket: string }) {
 
       <Conversation detail={detail} />
       <Pipeline detail={detail} />
+      <CaseActions detail={detail} onCase={setDetail} />
 
       <section>
         <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
@@ -662,6 +684,10 @@ export default function SupportPage() {
   const [queue, setQueue] = useState<SupportQueue | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
+  const [live, setLive] = useState(false)
+  const [queueKey, setQueueKey] = useState(0)
+  const [caseKey, setCaseKey] = useState(0)
+  const [switching, setSwitching] = useState(false)
 
   const load = useCallback(() => {
     let cancelled = false
@@ -680,9 +706,51 @@ export default function SupportPage() {
     return () => {
       cancelled = true
     }
-  }, [getToken, filter])
+  }, [getToken, filter, queueKey])
 
   useEffect(() => load(), [load])
+
+  // The open ticket lives in a ref so the subscription below never has to be
+  // torn down and rebuilt when the selection changes — reconnecting the stream
+  // on every click would drop events in the gap.
+  const selectedRef = useRef<string | null>(null)
+  selectedRef.current = selected
+
+  useEffect(() => {
+    return subscribeToSupportEvents(
+      getToken,
+      (event) => {
+        // Every event moves the queue: a group, a countdown or a row. The open
+        // case is re-read only when the event is about it, or about the
+        // pipeline switch, which changes what every countdown means.
+        setQueueKey((n) => n + 1)
+        if (
+          !event.ticket_number ||
+          event.ticket_number === selectedRef.current
+        ) {
+          setCaseKey((n) => n + 1)
+        }
+      },
+      setLive,
+    )
+  }, [getToken])
+
+  const toggleAutoSend = async () => {
+    if (!queue) return
+    setSwitching(true)
+    try {
+      const next = await adminApi.setAutoSendPaused(
+        getToken,
+        !queue.autosend.paused,
+      )
+      setQueue({ ...queue, autosend: next })
+      setQueueKey((n) => n + 1)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'The switch did not move.')
+    } finally {
+      setSwitching(false)
+    }
+  }
 
   const rows = queue?.rows ?? []
   const groups = QUEUE_GROUPS.filter(
@@ -694,20 +762,49 @@ export default function SupportPage() {
       <header>
         <h1 className="text-2xl font-bold tracking-tight">Support</h1>
         <p className="mt-1 text-sm text-base-content/60">
-          Read-only. Send, hold, edit, ask and skip are still Discord&apos;s —
-          this side proves every fact is visible first.
+          Every verb here is the same function the Discord buttons call. Send is
+          the only one that cannot be undone, and the only one that asks twice.
         </p>
         {queue && (
-          <p
-            className={`mt-3 rounded-lg px-3 py-2 text-xs ring-1 ${
+          <div
+            className={`mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg px-3 py-2 ring-1 ${
               queue.autosend.armed
                 ? 'bg-warning/10 ring-warning/30'
                 : 'bg-base-200/50 ring-base-300/60'
             }`}
           >
-            {queue.autosend.note}
-          </p>
+            <p className="text-xs">{queue.autosend.note}</p>
+            {/* Pause and resume, the same switch /pause and /resume throw.
+                Un-demoting a category stays a Discord command: that is a
+                judgement about a class of tickets, not a button beside one. */}
+            {queue.autosend.enabled && (
+              <button
+                type="button"
+                onClick={toggleAutoSend}
+                disabled={switching}
+                className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-base-100 px-2.5 py-1 text-xs font-medium ring-1 ring-base-300/60 hover:bg-base-200/60 disabled:opacity-50"
+              >
+                {switching ? (
+                  <Loader2 size={12} className="animate-spin" />
+                ) : queue.autosend.paused ? (
+                  <Play size={12} />
+                ) : (
+                  <Pause size={12} />
+                )}
+                {queue.autosend.paused ? 'Resume sending' : 'Pause sending'}
+              </button>
+            )}
+          </div>
         )}
+        <p className="mt-2 flex items-center gap-1.5 text-xs text-base-content/45">
+          <Radio
+            size={12}
+            className={live ? 'text-success' : 'text-base-content/40'}
+          />
+          {live
+            ? 'Live — holds and replies appear here without a refresh.'
+            : 'Not connected to the live stream; this page is showing what it last read.'}
+        </p>
       </header>
 
       {error && <p className="text-sm text-error">{error}</p>}
@@ -786,7 +883,7 @@ export default function SupportPage() {
 
           <div className="min-w-0 flex-1">
             {selected ? (
-              <CaseView ticket={selected} />
+              <CaseView ticket={selected} reloadKey={caseKey} />
             ) : (
               <div className="rounded-xl bg-base-200/30 px-6 py-16 text-center ring-1 ring-base-300/60">
                 <p className="text-sm text-base-content/60">

--- a/myscrollr.com/src/lib/supportConsole.test.ts
+++ b/myscrollr.com/src/lib/supportConsole.test.ts
@@ -6,6 +6,8 @@ import {
   formatWait,
   groupLabel,
   holdCountdown,
+  isUnchanged,
+  lineDiff,
 } from './supportConsole'
 import type { AdminHold } from '@/api/admin'
 
@@ -141,5 +143,32 @@ describe('groupLabel', () => {
     expect(groupLabel('waiting')).toBe('Waiting on the user')
     expect(groupLabel('handled')).toBe('Handled')
     expect(groupLabel('something_else')).toBe('something_else')
+  })
+})
+
+describe('lineDiff', () => {
+  it('marks what a rewrite removed and what it added', () => {
+    const got = lineDiff(
+      ['Try restarting the app.', 'If that fails, reinstall.'].join('\n'),
+      ['Try restarting the app.', 'Update to 1.6.2 first.'].join('\n'),
+    )
+    expect(got).toEqual([
+      { kind: 'kept', text: 'Try restarting the app.' },
+      { kind: 'removed', text: 'If that fails, reinstall.' },
+      { kind: 'added', text: 'Update to 1.6.2 first.' },
+    ])
+  })
+
+  it('treats blank lines as formatting, not as changes', () => {
+    expect(
+      isUnchanged(
+        ['one', '', 'two'].join('\n'),
+        ['  one  ', 'two', ''].join('\n'),
+      ),
+    ).toBe(true)
+  })
+
+  it('reports a wholly rewritten reply as changed', () => {
+    expect(isUnchanged('the draft', 'something else entirely')).toBe(false)
   })
 })

--- a/myscrollr.com/src/lib/supportConsole.ts
+++ b/myscrollr.com/src/lib/supportConsole.ts
@@ -138,3 +138,77 @@ export function fixBadge(
   if (!fix.proven) return `${fix.issue_key} · not shipped`
   return `${fix.issue_key} · shipped in ${fix.version}`
 }
+
+/** One line of a rendered diff. */
+export interface DiffLine {
+  kind: 'kept' | 'removed' | 'added'
+  text: string
+}
+
+/**
+ * A line-level diff of the draft against the edit, for the panel that opens
+ * before Send.
+ *
+ * This is the point of editing here rather than in a Discord modal: the modal
+ * was one text box and you sent whatever was in it, and half of every actioned
+ * draft in the May–September audit was rewritten with nothing left recording
+ * what had been wrong with it. Seeing what you changed, immediately before the
+ * click that reaches a person, is the cheapest version of that record — and
+ * the same diff is posted into the thread afterwards.
+ *
+ * Standard LCS over lines, matching what the server posts to Discord. Support
+ * replies are tens of lines, so the O(n·m) table is the right machinery.
+ */
+export function lineDiff(before: string, after: string): Array<DiffLine> {
+  const a = splitMeaningfulLines(before)
+  const b = splitMeaningfulLines(after)
+
+  // lcs[i][j] = length of the longest common subsequence of a[i:] and b[j:].
+  const lcs: Array<Array<number>> = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  )
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      lcs[i][j] =
+        a[i] === b[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1])
+    }
+  }
+
+  const out: Array<DiffLine> = []
+  let i = 0
+  let j = 0
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      out.push({ kind: 'kept', text: a[i] })
+      i++
+      j++
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ kind: 'removed', text: a[i] })
+      i++
+    } else {
+      out.push({ kind: 'added', text: b[j] })
+      j++
+    }
+  }
+  for (; i < a.length; i++) out.push({ kind: 'removed', text: a[i] })
+  for (; j < b.length; j++) out.push({ kind: 'added', text: b[j] })
+  return out
+}
+
+/** Splits on newlines, dropping blanks so a reflowed paragraph is not a wall. */
+function splitMeaningfulLines(s: string): Array<string> {
+  return s
+    .trim()
+    .split(NEWLINE)
+    .map((l) => l.trim())
+    .filter((l) => l !== '')
+}
+
+const NEWLINE = '\n'
+
+/** True when the edit changed nothing worth showing. */
+export function isUnchanged(before: string, after: string): boolean {
+  return lineDiff(before, after).every((l) => l.kind === 'kept')
+}


### PR DESCRIPTION
Link 3 of 4 of the admin dashboard. [REL-263](https://linear.app/relentnet/issue/REL-263) made the support pipeline readable; this gives every fact on that page a button, and every button the same function the Discord button calls.

## The extraction came first

`handlers_discord_interactions.go` held the whole of Send, Edit, Ask, Skip, Hold, File-as-bug and `/link` inside interaction handlers. They are now plain functions in `api/internal/support/actions.go` — draft id in, new state out — and both surfaces call them. Nothing is copy-pasted, and there is a test that says so rather than a comment asking nicely:

`TestEverySurfaceCallsTheSameVerb` parses the package's own source. For each verb it asserts the HTTP handler file and the Discord handler file both name the same `Action*` function, and — the half that bites — that no handler file calls `markDraftDecided`, `sendDraftReply`, `holdDraft`, `setCaseLinearIssueKey` or `linearCreateIssue` directly. A re-implemented flow shows up as one of those appearing in a handler and fails the build. It already caught two: `stopHoldForModal` still reached for `holdDraft`, and I had left `/pause` writing the policy key by hand.

Net effect on the Discord file: 317 lines changed, 285 of them deleted.

## Nine endpoints, under `/admin/support`, behind `RequireAdmin`

`POST draft/:draft/send · edit · ask · skip · hold · bug`, `POST|DELETE case/:ticket/link`, `POST autosend`.

Each answers with the updated case, built by `buildAdminCase` — the same function `GET /admin/support/case/:ticket` now calls. A second assembly of thirty fields is a second place for them to drift, and the drift would be invisible: the page would simply be wrong about what just happened.

Statuses the page can act on: 409 when someone else got there first, 404 for a draft that is gone, 400 for an empty body or a malformed issue key.

## A real editor

The draft in a textarea, the reporter's own most recent words in a pane beside it, the line diff open above the send button. No length cap — the 4000 characters was Discord's modal, not a support email, and a test sends a ~6,500-character reply to prove it. Opening the editor calls `hold`, which is exactly what opening the Discord modal does: typing takes longer than a hold that is nearly up.

## The queue moves itself

Support events go out on the existing SSE hub (`api/internal/events`) as one more topic, `support:admin`, with one more kind of subscriber. `RegisterAdminClient` registers under a namespaced hub key and subscribes to that topic and nothing else, so an admin who also runs Scrollr on the same account does not get their ticker's CDC in the console or vice versa — there is a test for both directions.

Events are published from the choke points rather than per verb: `sendDraftReply` (the one send path, [REL-256](https://linear.app/relentnet/issue/REL-256)), `applyDisposition`, `createSupportDraft`, and the verbs with no send behind them. The payload names the ticket and what happened and carries no case; the page re-reads from the endpoints. `GET /admin/support/stream` is read with `fetch` rather than `EventSource` so the credential stays in the Authorization header instead of the query string.

## Confirmation, in exactly one place

Send asks twice. Skip, hold, link, unlink and file go through on the first click, and edit's confirmation is the diff it makes you look at. Friction on the reversible ones is what stops people using a tool.

## Nothing was weakened

The [REL-249](https://linear.app/relentnet/issue/REL-249) consequence gates and the [REL-259](https://linear.app/relentnet/issue/REL-259) proven-fix rule run inside `decideDisposition`, before a draft reaches any queue. A person choosing to send is the escape hatch those gates were built to require, and a console click is the same click as a Discord one. The browser computes no disposition and declares no fix — it renders `AdminFix` and `AdminHold` as the server built them. Discord's buttons stay (that is [REL-262](https://linear.app/relentnet/issue/REL-262)). There is no bulk send. Un-demoting a category stays a Discord command on purpose: it is a judgement about a class of tickets, not a button beside one of them.

## The three traps REL-263 hit on real data

* `hold_until` is never cleared on send, so everything that reads it also checks `status = 'pending'` — the new writes go through `buildHold`, which already does, and a test asserts a held draft reports no countdown and no deadline.
* osTicket's backfilled `body_text` still carries markup, so the editor's "what they wrote" pane reads `AdminMessage.Body`, which `adminCaseMessages` has already run through `htmlToPlain` regardless of which column it came from.
* The countdown derives from `hold.until`, never from `remaining_seconds` — that was already true in `holdCountdown` and nothing new second-guesses it.

## Verification

Run in a `golang:1.25-alpine` pod with a Postgres sidecar (no Go and no working Docker on this box):

* `go vet ./...` clean; `go test ./...` green across all 11 packages.
* Per endpoint, against a fake osTicket: send writes `sent_at` and promotes the status, a second send is 409 and sends nothing, edit stores the edit and marks the intervention and is not truncated, an empty edit is 400 and does not claim the draft, ask parks the case as waiting and never asks osTicket to close (asserted on the outgoing `close_ticket` payload, because the shared fake answers `closed: true` to everything), skip decides and hold only stops the clock, link refuses a malformed key without calling Linear, unlink clears the key and leaves the note, pause and resume move the real switch.
* **403** from all nine routes for a signed-in `super_user` who is not on the admin list, with the draft still pending afterwards; **401** from all nine with no credential, behind the real `LogtoAuth`.
* **The queue moves on its own**: a case with an expired hold is in "Needs you", `sweepExpiredHolds` runs, and it is gone from "Needs you" with the draft `sent` — nobody clicked anything.
* Web: `eslint`, `prettier`, `tsc` and `vitest` (87 tests, including three new ones for the diff) all clean.

### What I could not click

I cannot sign in as Brandon, so **no part of the browser UI has been exercised against a live API** — not the buttons, not the editor, not the SSE stream reconnecting, and not the "Live" indicator. Everything above is server-side tests plus type/lint checks. The first real use should be a case you control end to end.

**No reply was sent to a real user as part of this.** Every send in these tests goes to an `httptest` server standing in for osTicket; no ticket number used here (`900100`, `900101`) exists in production.

Worth knowing before the first click: Discord's Send, Edit, Ask, Skip and Hold now defer their response the way file-as-bug already did, so the thread shows "thinking…" for a moment and then the real outcome, instead of a confirmation posted before the send finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
