### PR TITLE
The support queue is people, not tickets, and it works on a phone [REL-266]

### DIFF
--- a/api/internal/support/admin_queue_people.go
+++ b/api/internal/support/admin_queue_people.go
@@ -1,0 +1,518 @@
+package support
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// =============================================================================
+// The queue, as people rather than tickets (REL-266)
+// =============================================================================
+//
+// REL-263 shipped sixty tickets at equal visual weight, and the verdict on it
+// was "just so confusing and overwhelming". Two things were wrong, and both
+// are decided here rather than in the browser.
+//
+// A row is a PERSON. Rachel Armstrong wrote five times in one afternoon; that
+// was five rows shouting at a reader who has one human to answer. Cases are
+// grouped by `user_email`, which is also why the key is an email and not an
+// account: #819835 arrived anonymously from the marketing site, has no
+// logto_sub, and still belongs in the queue. A group carries a name and a plan
+// only when one actually exists — an invented "Anonymous User" reads exactly
+// like a real one.
+//
+// PAYING CUSTOMERS ARE A SECTION, not a sort key. Priority support was sold,
+// so no ordering a reader picks may push a paying customer below someone who
+// did not pay. The plan comes from the CURRENT subscription in
+// `stripe_customers`, never from `support_cases.tier_at_open` — that column
+// records the plan on the day the ticket opened, so someone who upgraded last
+// week would sit in the wrong section forever, and someone who lapsed would be
+// promoted for a ticket they wrote while paying. `plan = 'free'` is excluded:
+// production has three `active` stripe rows and only two of them are paying.
+
+const (
+	sectionPaying   = "paying"
+	sectionOpen     = "open"
+	sectionAnswered = "answered"
+	sectionResolved = "resolved"
+)
+
+// sectionOrder is the reading order, and it is the whole point: sorting
+// happens INSIDE a section and sections never move.
+var sectionOrder = []string{sectionPaying, sectionOpen, sectionAnswered, sectionResolved}
+
+const (
+	sortLastWrote = "last_wrote"
+	sortWaiting   = "waiting"
+	sortTickets   = "tickets"
+	sortPlan      = "plan"
+	sortName      = "name"
+)
+
+// sortFields is also the vocabulary the endpoint validates against. An
+// unrecognised sort is a 400 and never a silent fallback to some other order:
+// a list that quietly ignores what you asked it for is the reason the old page
+// needed a client-side array sort in the first place.
+var sortFields = []string{sortLastWrote, sortWaiting, sortTickets, sortPlan, sortName}
+
+// defaultDirection is what each field means when nobody says. "Longest
+// waiting, ascending" is a sentence nobody should have to think about; every
+// field's natural reading is its default and the direction button flips it.
+func defaultDirection(field string) string {
+	if field == sortName {
+		return "asc"
+	}
+	return "desc"
+}
+
+// planIsPaying is the one rule that decides the top section.
+//
+// Lifetime counts even though a lifetime row has no live subscription status —
+// the Ultimate lifetime purchase is the largest single thing anyone has paid
+// us, and reading it as unpaid because Stripe has nothing left to renew would
+// put the best customer we have in the general queue.
+func planIsPaying(plan, status string, lifetime bool) bool {
+	p := strings.ToLower(strings.TrimSpace(plan))
+	if p == "" || p == "free" {
+		return false
+	}
+	if lifetime {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(status), "active")
+}
+
+// AdminQueueAccounts is the caption under the paying section, and the reason
+// that section can be empty while two people are paying.
+//
+// It exists because production says something the mockup did not: only ONE of
+// fifty-nine cases carries a logto_sub, and it is not one of the two paying
+// accounts. Support tickets arrive from the marketing form and from osTicket,
+// neither of which has a signed-in user, so almost nothing in this table is
+// joined to an account at all. An empty paying section is therefore the
+// truthful answer — and an empty box with no sentence in it reads as a bug in
+// the page rather than as a gap in the data.
+type AdminQueueAccounts struct {
+	Paying           int    `json:"paying"`
+	CasesWithAccount int    `json:"cases_with_account"`
+	Cases            int    `json:"cases"`
+	Note             string `json:"note"`
+}
+
+// payingSectionNote says, in a sentence, what an empty paying section means.
+func payingSectionNote(a AdminQueueAccounts, inSection int) string {
+	switch {
+	case a.Paying == 0:
+		return "Nobody is on a paid plan right now, so this section has nothing to hold."
+	case inSection > 0:
+		return ""
+	default:
+		who := fmt.Sprintf("%d accounts are paying, and none of them has", a.Paying)
+		if a.Paying == 1 {
+			who = "One account is paying, and it has not"
+		}
+		return fmt.Sprintf(
+			"%s written in under an account we can see. Only %d of %d cases carry a signed-in user at all — the marketing form and osTicket both arrive without one — so a paying customer only lands here if they wrote from inside the app.",
+			who, a.CasesWithAccount, a.Cases)
+	}
+}
+
+// AdminPerson is one row of the queue: an email, everything we honestly know
+// about whoever is behind it, and the tickets they wrote.
+//
+// The tickets are referenced by number rather than embedded. The flat rows are
+// in the same response, so embedding them would ship every case twice and give
+// the two copies somewhere to disagree.
+type AdminPerson struct {
+	// Key groups the cases. It is the lowercased email; a case with no email
+	// gets a key of its own so two unrelated anonymous reports never merge
+	// into one imaginary person.
+	Key   string `json:"key"`
+	Email string `json:"email,omitempty"`
+	// Name is whatever the ticket carried. Empty means we do not know it, and
+	// the page says so rather than inventing one.
+	Name string `json:"name,omitempty"`
+	// Plan is the CURRENT subscription plan, and is empty when no Stripe row
+	// stands behind this email. Never tier_at_open.
+	Plan   string `json:"plan,omitempty"`
+	Paying bool   `json:"paying"`
+	// PlanNote explains an empty Plan, because "free" and "no account exists
+	// for this person" are different facts and only one of them is a plan.
+	PlanNote string `json:"plan_note,omitempty"`
+
+	Section string `json:"section"`
+
+	Tickets  int `json:"tickets"`
+	NeedsYou int `json:"needs_you"`
+	Waiting  int `json:"waiting"`
+	Handled  int `json:"handled"`
+
+	// Headline is the one ticket this row is about — the one a reader would
+	// open. Everything else is history underneath it.
+	Headline       string `json:"headline,omitempty"`
+	HeadlineTicket string `json:"headline_ticket,omitempty"`
+
+	// Provenance is who is responsible for the last reply that went out,
+	// decided here from the draft's status, its disposition and whether an
+	// edit replaced the body. The browser renders ProvenanceLabel and works
+	// none of it out.
+	Provenance      string `json:"provenance,omitempty"`
+	ProvenanceLabel string `json:"provenance_label,omitempty"`
+
+	LastUserMessageAt *time.Time        `json:"last_user_message_at,omitempty"`
+	WaitingHours      platform.Measured `json:"waiting_hours"`
+
+	TicketNumbers []string `json:"ticket_numbers"`
+}
+
+// ===== Provenance =================================================
+
+const (
+	provenanceBot    = "bot"
+	provenanceEdited = "edited"
+	provenancePerson = "person"
+)
+
+// replyProvenance says who is responsible for the reply that went out.
+//
+// It reads exactly the three things the row already records. `edited` is the
+// status claimDraft writes when a person rewrote the body, and edited_body_html
+// is checked as well because a draft can also be edited through the older
+// approval endpoint. Everything the autonomous sweeper sends lands as
+// `approved` or `asked` with `intervened` still false — that, and only that,
+// is the bot.
+func replyProvenance(draftStatus, disposition, draftBody, editedBody string, intervened bool) (string, string) {
+	switch draftStatus {
+	case "sent", "approved", "edited", "asked":
+	default:
+		return "", ""
+	}
+
+	edited := strings.TrimSpace(editedBody) != "" &&
+		strings.TrimSpace(editedBody) != strings.TrimSpace(draftBody)
+	if draftStatus == "edited" || edited {
+		return provenanceEdited, "you edited it"
+	}
+
+	autonomous := disposition == dispositionAutoSend ||
+		disposition == dispositionAutoClose ||
+		disposition == dispositionAutoAsk
+	if autonomous && !intervened {
+		return provenanceBot, "sent by the bot"
+	}
+	return provenancePerson, "you sent it"
+}
+
+// ===== Sections ===================================================
+
+// caseSection places one ticket. Paying wins over everything: it is the
+// promise we sold, not the state of this particular ticket.
+func caseSection(group string, paying bool) string {
+	if paying {
+		return sectionPaying
+	}
+	switch group {
+	case queueNeedsYou:
+		return sectionOpen
+	case queueWaiting:
+		return sectionAnswered
+	default:
+		return sectionResolved
+	}
+}
+
+// ===== Grouping ===================================================
+
+// groupPeople turns the flat case rows into one row per person.
+//
+// The order rows arrive in does not matter — sortPeople decides the order —
+// but the grouping is deterministic, so two reads of unchanged data produce
+// the same keys and the same headline.
+func groupPeople(rows []AdminQueueRow) []AdminPerson {
+	byKey := map[string]*AdminPerson{}
+	order := make([]string, 0, len(rows))
+
+	// best holds the winning headline candidate per key, so the choice does
+	// not depend on the order rows arrive in.
+	type candidate struct {
+		rank int
+		at   time.Time
+	}
+	best := map[string]candidate{}
+
+	for _, r := range rows {
+		key := personKey(r)
+		p := byKey[key]
+		if p == nil {
+			p = &AdminPerson{
+				Key:           key,
+				Email:         r.UserEmail,
+				TicketNumbers: make([]string, 0, 2),
+				WaitingHours: platform.Unmeasured(
+					"No message from this person is on record, so there is nothing to measure a wait from."),
+			}
+			if r.UserEmail == "" {
+				p.PlanNote = "No account is attached to this ticket — it arrived without a signed-in user, so there is no name and no plan to show."
+			}
+			byKey[key] = p
+			order = append(order, key)
+		}
+
+		p.Tickets++
+		p.TicketNumbers = append(p.TicketNumbers, r.TicketNumber)
+		switch r.Group {
+		case queueNeedsYou:
+			p.NeedsYou++
+		case queueWaiting:
+			p.Waiting++
+		default:
+			p.Handled++
+		}
+
+		// The name and the plan come from whichever ticket actually carries
+		// them. Someone who wrote once signed in and once through the
+		// marketing form is still one person, and the half of the record that
+		// knows their name is the half worth keeping.
+		if p.Name == "" && r.Name != "" {
+			p.Name = r.Name
+		}
+		if r.Paying {
+			p.Paying = true
+		}
+		if p.Plan == "" && r.Plan != "" {
+			p.Plan = r.Plan
+		}
+
+		if r.LastUserMessageAt != nil &&
+			(p.LastUserMessageAt == nil || r.LastUserMessageAt.After(*p.LastUserMessageAt)) {
+			p.LastUserMessageAt = r.LastUserMessageAt
+		}
+		// The wait shown is the LONGEST any of their tickets has waited, not
+		// the freshest. Someone with a five-day-old question and a new one has
+		// been waiting five days.
+		if r.WaitingHours.Available &&
+			(!p.WaitingHours.Available || r.WaitingHours.Value > p.WaitingHours.Value) {
+			p.WaitingHours = platform.Measured{Value: r.WaitingHours.Value, Available: true}
+		}
+
+		c := candidate{rank: headlineRank(r.Group), at: r.UpdatedAt}
+		if prev, seen := best[key]; !seen || c.rank > prev.rank ||
+			(c.rank == prev.rank && c.at.After(prev.at)) {
+			best[key] = c
+			p.Headline = r.Subject
+			p.HeadlineTicket = r.TicketNumber
+			p.Provenance, p.ProvenanceLabel = r.Provenance, r.ProvenanceLabel
+		}
+	}
+
+	out := make([]AdminPerson, 0, len(order))
+	for _, key := range order {
+		p := byKey[key]
+		p.Section = personSection(*p)
+		out = append(out, *p)
+	}
+	return out
+}
+
+// personKey groups by email, and refuses to group without one.
+func personKey(r AdminQueueRow) string {
+	email := strings.ToLower(strings.TrimSpace(r.UserEmail))
+	if email == "" {
+		// Not a shared "anonymous" bucket: two anonymous reports are two
+		// different people until something says otherwise, and merging them
+		// would put one stranger's words under another's row.
+		return "ticket:" + r.TicketNumber
+	}
+	return email
+}
+
+// headlineRank ranks the three states by how much a reader needs to see them.
+func headlineRank(group string) int {
+	switch group {
+	case queueNeedsYou:
+		return 2
+	case queueWaiting:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func personSection(p AdminPerson) string {
+	switch {
+	case p.Paying:
+		return sectionPaying
+	case p.NeedsYou > 0:
+		return sectionOpen
+	case p.Waiting > 0:
+		return sectionAnswered
+	default:
+		return sectionResolved
+	}
+}
+
+// ===== Sorting ====================================================
+
+// sortKey is the only thing either comparator reads, so a person and a single
+// ticket sort by exactly the same rules.
+type sortKey struct {
+	LastWrote *time.Time
+	Wait      platform.Measured
+	Tickets   int
+	Paying    bool
+	Plan      string
+	Name      string
+	Tie       string
+}
+
+func personSortKey(p AdminPerson) sortKey {
+	return sortKey{
+		LastWrote: p.LastUserMessageAt, Wait: p.WaitingHours, Tickets: p.Tickets,
+		Paying: p.Paying, Plan: p.Plan, Name: p.Name, Tie: p.Key,
+	}
+}
+
+func rowSortKey(r AdminQueueRow) sortKey {
+	return sortKey{
+		LastWrote: r.LastUserMessageAt, Wait: r.WaitingHours, Tickets: 1,
+		Paying: r.Paying, Plan: r.Plan, Name: r.Name, Tie: r.TicketNumber,
+	}
+}
+
+// lessBy answers "does a come before b" for one field in one direction.
+//
+// Every field puts the unknowns last in BOTH directions. A person with no
+// message on record has not been waiting zero hours, and reversing the sort
+// must not float "we do not know" to the top as though it were the extreme
+// value — that is the same lie as a countdown against a paused pipeline.
+func lessBy(a, b sortKey, field, dir string) bool {
+	asc := dir == "asc"
+	switch field {
+	case sortWaiting:
+		if a.Wait.Available != b.Wait.Available {
+			return a.Wait.Available
+		}
+		if a.Wait.Available && a.Wait.Value != b.Wait.Value {
+			return flip(a.Wait.Value < b.Wait.Value, asc)
+		}
+	case sortTickets:
+		if a.Tickets != b.Tickets {
+			return flip(a.Tickets < b.Tickets, asc)
+		}
+	case sortPlan:
+		if a.Paying != b.Paying {
+			return flip(!a.Paying, asc)
+		}
+		if (a.Plan == "") != (b.Plan == "") {
+			return a.Plan != ""
+		}
+		if !strings.EqualFold(a.Plan, b.Plan) {
+			return flip(strings.ToLower(a.Plan) < strings.ToLower(b.Plan), asc)
+		}
+	case sortName:
+		if (a.Name == "") != (b.Name == "") {
+			return a.Name != ""
+		}
+		if !strings.EqualFold(a.Name, b.Name) {
+			return flip(strings.ToLower(a.Name) < strings.ToLower(b.Name), asc)
+		}
+	default: // sortLastWrote
+		if (a.LastWrote == nil) != (b.LastWrote == nil) {
+			return a.LastWrote != nil
+		}
+		if a.LastWrote != nil && !a.LastWrote.Equal(*b.LastWrote) {
+			return flip(a.LastWrote.Before(*b.LastWrote), asc)
+		}
+	}
+	// A stable tiebreak, so the list does not shuffle between two reads of
+	// data that did not change.
+	return a.Tie < b.Tie
+}
+
+func flip(less, asc bool) bool {
+	if asc {
+		return less
+	}
+	return !less
+}
+
+// sortPeople orders rows INSIDE each section and never across them. The
+// section index is compared first, which is what makes "paying customers never
+// fall below anyone" true of every sort rather than only of the default one.
+func sortPeople(people []AdminPerson, field, dir string) {
+	rank := sectionRanks()
+	sort.SliceStable(people, func(i, j int) bool {
+		if a, b := rank[people[i].Section], rank[people[j].Section]; a != b {
+			return a < b
+		}
+		return lessBy(personSortKey(people[i]), personSortKey(people[j]), field, dir)
+	})
+}
+
+func sortRows(rows []AdminQueueRow, field, dir string) {
+	rank := sectionRanks()
+	sort.SliceStable(rows, func(i, j int) bool {
+		if a, b := rank[rows[i].Section], rank[rows[j].Section]; a != b {
+			return a < b
+		}
+		return lessBy(rowSortKey(rows[i]), rowSortKey(rows[j]), field, dir)
+	})
+}
+
+func sectionRanks() map[string]int {
+	rank := make(map[string]int, len(sectionOrder))
+	for i, s := range sectionOrder {
+		rank[s] = i
+	}
+	return rank
+}
+
+// ===== Query parameters ===========================================
+
+// normaliseSort validates the two sort parameters. Both are server-side on
+// purpose: a client-side array sort is only correct while the whole list is in
+// the browser, and the moment this queue outgrows one read it would start
+// sorting a page instead of a queue and look right doing it.
+func normaliseSort(field, dir string) (string, string, bool) {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		field = sortLastWrote
+	}
+	known := false
+	for _, f := range sortFields {
+		if f == field {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return "", "", false
+	}
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		dir = defaultDirection(field)
+	}
+	if dir != "asc" && dir != "desc" {
+		return "", "", false
+	}
+	return field, dir, true
+}
+
+// matchesSearch is the search box, decided here rather than by filtering an
+// array in the browser, for the same reason the sort is.
+func matchesSearch(r AdminQueueRow, q string) bool {
+	if q == "" {
+		return true
+	}
+	q = strings.ToLower(q)
+	for _, field := range []string{r.TicketNumber, r.Subject, r.UserEmail, r.Name, r.Summary, r.Category} {
+		if strings.Contains(strings.ToLower(field), q) {
+			return true
+		}
+	}
+	return false
+}

--- a/api/internal/support/admin_queue_people_test.go
+++ b/api/internal/support/admin_queue_people_test.go
@@ -1,0 +1,576 @@
+package support
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+	"github.com/gofiber/fiber/v2"
+)
+
+// ===== The rules, with no database and no clock ====================
+
+func at(day int) *time.Time {
+	t := time.Date(2026, 9, day, 12, 0, 0, 0, time.UTC)
+	return &t
+}
+
+func row(ticket, email, name, group string, opts ...func(*AdminQueueRow)) AdminQueueRow {
+	r := AdminQueueRow{
+		TicketNumber: ticket,
+		UserEmail:    email,
+		Name:         name,
+		Subject:      "subject " + ticket,
+		Group:        group,
+		UpdatedAt:    time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		WaitingHours: platform.Unmeasured("no message on record"),
+	}
+	for _, o := range opts {
+		o(&r)
+	}
+	r.Section = caseSection(r.Group, r.Paying)
+	r.PersonKey = personKey(r)
+	return r
+}
+
+func wrote(day, waitHours int) func(*AdminQueueRow) {
+	return func(r *AdminQueueRow) {
+		r.LastUserMessageAt = at(day)
+		r.WaitingHours = platform.Measured{Value: waitHours, Available: true}
+	}
+}
+
+func paid(plan string) func(*AdminQueueRow) {
+	return func(r *AdminQueueRow) { r.Plan, r.Paying = plan, true }
+}
+
+func freePlan(r *AdminQueueRow) { r.Plan = "free" }
+
+// The whole reason for the ticket: Rachel wrote five times in one afternoon
+// and that is one person to answer, not five rows to read.
+func TestFiveTicketsFromOnePersonAreOneRow(t *testing.T) {
+	rows := []AdminQueueRow{
+		row("752473", "r_armstrong@me.com", "Rachel Armstrong", queueNeedsYou, wrote(1, 12)),
+		row("584802", "r_armstrong@me.com", "", queueWaiting, wrote(2, 300)),
+		row("411284", "R_Armstrong@me.com", "", queueWaiting, wrote(2, 300)),
+		row("956950", "r_armstrong@me.com", "", queueHandled),
+		row("613084", "r_armstrong@me.com", "", queueHandled),
+	}
+
+	people := groupPeople(rows)
+	if len(people) != 1 {
+		t.Fatalf("got %d rows, want one person: %+v", len(people), people)
+	}
+	p := people[0]
+	if p.Tickets != 5 {
+		t.Errorf("tickets = %d, want 5", p.Tickets)
+	}
+	// The mixed case in #411284 is the same mailbox, and grouping that missed
+	// it would show Rachel twice.
+	if p.Key != "r_armstrong@me.com" {
+		t.Errorf("key = %q, want the lowercased email", p.Key)
+	}
+	if p.NeedsYou != 1 || p.Waiting != 2 || p.Handled != 2 {
+		t.Errorf("state counts = %d/%d/%d, want 1 needing a person, 2 waiting, 2 handled",
+			p.NeedsYou, p.Waiting, p.Handled)
+	}
+	// The name is on one ticket out of five. Losing it because four rows did
+	// not carry it would be the same failure as inventing one.
+	if p.Name != "Rachel Armstrong" {
+		t.Errorf("name = %q, want it carried over from the ticket that had it", p.Name)
+	}
+	// The headline is the ticket that needs a person, whatever order the rows
+	// arrived in.
+	if p.HeadlineTicket != "752473" {
+		t.Errorf("headline = %q, want the open one (#752473)", p.HeadlineTicket)
+	}
+	if p.Section != sectionOpen {
+		t.Errorf("section = %q, want %q", p.Section, sectionOpen)
+	}
+	// The wait is the longest of her tickets, not the newest one.
+	if !p.WaitingHours.Available || p.WaitingHours.Value != 300 {
+		t.Errorf("waiting_hours = %+v, want the longest wait across her tickets", p.WaitingHours)
+	}
+}
+
+// #819835 came in from the marketing site with nobody behind it. It has to
+// appear, and it has to appear without a name we made up.
+func TestACaseWithNoAccountIsGroupedWithoutInventingAPerson(t *testing.T) {
+	people := groupPeople([]AdminQueueRow{
+		row("819835", "", "", queueNeedsYou, wrote(1, 40)),
+		row("819836", "", "", queueNeedsYou, wrote(1, 40)),
+	})
+
+	if len(people) != 2 {
+		t.Fatalf("two anonymous tickets are two unknown people, got %d: %+v", len(people), people)
+	}
+	for _, p := range people {
+		if p.Name != "" || p.Email != "" || p.Plan != "" {
+			t.Errorf("an anonymous group must carry no name, email or plan: %+v", p)
+		}
+		if p.Paying {
+			t.Error("nothing is known about this person, so they are certainly not in the paying section")
+		}
+		if !strings.Contains(p.PlanNote, "No account is attached") {
+			t.Errorf("the empty plan needs a sentence saying why: %q", p.PlanNote)
+		}
+		if p.Tickets != 1 {
+			t.Errorf("tickets = %d, want 1", p.Tickets)
+		}
+	}
+}
+
+// Priority support is something we sold. No ordering a reader picks may push a
+// paying customer below somebody who did not pay.
+func TestPayingCustomersStayOnTopUnderEverySort(t *testing.T) {
+	rows := []AdminQueueRow{
+		row("1", "zoe@example.com", "Zoe Zephyr", queueNeedsYou, paid("uplink_ultimate"), wrote(1, 200)),
+		row("2", "amy@example.com", "Amy Adams", queueNeedsYou, freePlan, wrote(9, 1)),
+		row("3", "amy@example.com", "Amy Adams", queueNeedsYou, freePlan, wrote(9, 1)),
+		row("4", "bob@example.com", "Bob Brown", queueWaiting, freePlan, wrote(5, 90)),
+	}
+
+	for _, field := range sortFields {
+		for _, dir := range []string{"asc", "desc"} {
+			people := groupPeople(rows)
+			sortPeople(people, field, dir)
+			if people[0].Key != "zoe@example.com" {
+				t.Errorf("sort=%s dir=%s put %q first; the paying customer must lead every sort",
+					field, dir, people[0].Key)
+			}
+			if people[0].Section != sectionPaying {
+				t.Errorf("sort=%s dir=%s: leading row is in %q", field, dir, people[0].Section)
+			}
+			// Sections never reorder, whatever the sort is doing inside them.
+			rank := sectionRanks()
+			for i := 1; i < len(people); i++ {
+				if rank[people[i].Section] < rank[people[i-1].Section] {
+					t.Errorf("sort=%s dir=%s reordered the sections: %v",
+						field, dir, sectionsOf(people))
+					break
+				}
+			}
+		}
+	}
+}
+
+func sectionsOf(people []AdminPerson) []string {
+	out := make([]string, 0, len(people))
+	for _, p := range people {
+		out = append(out, p.Section)
+	}
+	return out
+}
+
+// Each field orders by the thing it names, and the direction button reverses
+// it — inside the section, which for these four rows is the same one.
+func TestEverySortFieldOrdersByWhatItNames(t *testing.T) {
+	rows := []AdminQueueRow{
+		row("10", "cara@example.com", "Cara", queueNeedsYou, wrote(3, 150)),
+		row("11", "cara@example.com", "Cara", queueNeedsYou, wrote(3, 150)),
+		row("12", "abe@example.com", "Abe", queueNeedsYou, wrote(8, 20)),
+		row("13", "bea@example.com", "Bea", queueNeedsYou, wrote(1, 400)),
+	}
+
+	cases := []struct {
+		field    string
+		dir      string
+		wantHead string
+		why      string
+	}{
+		{sortLastWrote, "desc", "abe@example.com", "newest first"},
+		{sortLastWrote, "asc", "bea@example.com", "oldest first"},
+		{sortWaiting, "desc", "bea@example.com", "longest waiting first"},
+		{sortWaiting, "asc", "abe@example.com", "shortest waiting first"},
+		{sortTickets, "desc", "cara@example.com", "most tickets first"},
+		{sortName, "asc", "abe@example.com", "A first"},
+		{sortName, "desc", "cara@example.com", "Z first"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field+"/"+tc.dir, func(t *testing.T) {
+			people := groupPeople(rows)
+			sortPeople(people, tc.field, tc.dir)
+			if people[0].Key != tc.wantHead {
+				t.Errorf("%s: got %q first, want %q (%s)", tc.why, people[0].Key, tc.wantHead, tc.why)
+			}
+		})
+	}
+
+	// Reversing has to be a real reversal, not a re-shuffle: same rows, same
+	// grouping, opposite order.
+	for _, field := range sortFields {
+		up, down := groupPeople(rows), groupPeople(rows)
+		sortPeople(up, field, "asc")
+		sortPeople(down, field, "desc")
+		if len(up) != len(down) {
+			t.Fatalf("%s: grouping is not stable across sorts", field)
+		}
+	}
+}
+
+// "We do not know" is not an extreme value. A person with no message on record
+// sorts last both ways rather than floating to the top when you reverse.
+func TestUnknownsSortLastInBothDirections(t *testing.T) {
+	rows := []AdminQueueRow{
+		row("20", "known@example.com", "Known", queueNeedsYou, wrote(3, 150)),
+		row("21", "silent@example.com", "", queueNeedsYou),
+	}
+	for _, field := range []string{sortLastWrote, sortWaiting, sortName} {
+		for _, dir := range []string{"asc", "desc"} {
+			people := groupPeople(rows)
+			sortPeople(people, field, dir)
+			if people[len(people)-1].Key != "silent@example.com" {
+				t.Errorf("sort=%s dir=%s floated the unknown to %d; unknowns go last both ways",
+					field, dir, indexOf(people, "silent@example.com"))
+			}
+		}
+	}
+}
+
+func indexOf(people []AdminPerson, key string) int {
+	for i, p := range people {
+		if p.Key == key {
+			return i
+		}
+	}
+	return -1
+}
+
+// The section a person lands in, from what their tickets are doing.
+func TestSectionsFollowTheWorstTicketAndThePlanBeatsBoth(t *testing.T) {
+	cases := []struct {
+		name string
+		rows []AdminQueueRow
+		want string
+	}{
+		{"anything needing a person is open",
+			[]AdminQueueRow{row("1", "a@x.com", "", queueNeedsYou), row("2", "a@x.com", "", queueHandled)},
+			sectionOpen},
+		{"replied and nothing else is answered",
+			[]AdminQueueRow{row("1", "a@x.com", "", queueWaiting), row("2", "a@x.com", "", queueHandled)},
+			sectionAnswered},
+		{"everything closed is resolved",
+			[]AdminQueueRow{row("1", "a@x.com", "", queueHandled)},
+			sectionResolved},
+		{"a paying customer with nothing open is still in the paying section",
+			[]AdminQueueRow{row("1", "a@x.com", "", queueHandled, paid("uplink"))},
+			sectionPaying},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			people := groupPeople(tc.rows)
+			if people[0].Section != tc.want {
+				t.Errorf("section = %q, want %q", people[0].Section, tc.want)
+			}
+		})
+	}
+}
+
+// Production has three `active` stripe rows and two paying customers. The
+// third is on the free plan, and reading `status = 'active'` alone would put a
+// free user in the section we sold to people who pay.
+func TestOnlyRealMoneyCountsAsPaying(t *testing.T) {
+	cases := []struct {
+		plan, status string
+		lifetime     bool
+		want         bool
+	}{
+		{"uplink_ultimate", "active", false, true},
+		{"uplink", "active", false, true},
+		{"free", "active", false, false},
+		{"", "active", false, false},
+		{"uplink", "canceled", false, false},
+		{"uplink", "past_due", false, false},
+		// The lifetime purchase has nothing left for Stripe to renew, so its
+		// status is not "active" — and it is the largest single payment anyone
+		// has made us.
+		{"uplink_ultimate", "", true, true},
+		{"free", "", true, false},
+	}
+	for _, tc := range cases {
+		if got := planIsPaying(tc.plan, tc.status, tc.lifetime); got != tc.want {
+			t.Errorf("planIsPaying(%q, %q, %v) = %v, want %v",
+				tc.plan, tc.status, tc.lifetime, got, tc.want)
+		}
+	}
+}
+
+// Who sent the last reply, from the three things the row already records.
+func TestReplyProvenanceNamesWhoIsResponsible(t *testing.T) {
+	cases := []struct {
+		name                        string
+		status, disposition         string
+		draft, edited               string
+		intervened                  bool
+		wantCode, wantLabelContains string
+	}{
+		{"the sweeper sent it unattended", "approved", dispositionAutoSend,
+			"<p>hi</p>", "", false, provenanceBot, "bot"},
+		{"the sweeper asked unattended", "asked", dispositionAutoAsk,
+			"<p>which version?</p>", "", false, provenanceBot, "bot"},
+		{"a person rewrote it", "edited", dispositionAutoSend,
+			"<p>hi</p>", "<p>hello there</p>", true, provenanceEdited, "edited"},
+		// The older approval endpoint stores an edit without moving the status
+		// to "edited"; a differing body is still an edit.
+		{"an edit stored under the old status", "approved", dispositionAutoSend,
+			"<p>hi</p>", "<p>hello there</p>", false, provenanceEdited, "edited"},
+		{"a person approved it as written", "approved", dispositionAutoSend,
+			"<p>hi</p>", "", true, provenancePerson, "you sent it"},
+		{"an escalation somebody sent by hand", "approved", dispositionEscalate,
+			"<p>hi</p>", "", false, provenancePerson, "you sent it"},
+		{"nothing has gone out yet", "pending", dispositionAutoSend,
+			"<p>hi</p>", "", false, "", ""},
+		{"a skipped draft never went out", "skipped", dispositionEscalate,
+			"<p>hi</p>", "", true, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, label := replyProvenance(tc.status, tc.disposition, tc.draft, tc.edited, tc.intervened)
+			if code != tc.wantCode {
+				t.Errorf("code = %q, want %q", code, tc.wantCode)
+			}
+			if !strings.Contains(label, tc.wantLabelContains) {
+				t.Errorf("label = %q, want it to mention %q", label, tc.wantLabelContains)
+			}
+		})
+	}
+}
+
+// An unrecognised sort is refused rather than quietly answered in some other
+// order. A list that ignores what you asked it for is how you end up sorting
+// in the browser instead.
+func TestSortParametersAreValidatedNotGuessed(t *testing.T) {
+	if f, d, ok := normaliseSort("", ""); !ok || f != sortLastWrote || d != "desc" {
+		t.Errorf("the default is last wrote, newest first; got %q/%q ok=%v", f, d, ok)
+	}
+	if _, d, ok := normaliseSort(sortName, ""); !ok || d != "asc" {
+		t.Errorf("name defaults to A-Z, got %q", d)
+	}
+	for _, bad := range [][2]string{{"oldest", ""}, {sortName, "sideways"}, {"; DROP TABLE", "asc"}} {
+		if _, _, ok := normaliseSort(bad[0], bad[1]); ok {
+			t.Errorf("normaliseSort(%q, %q) was accepted", bad[0], bad[1])
+		}
+	}
+}
+
+func TestSearchLooksAtEveryFieldAReaderCanSee(t *testing.T) {
+	r := row("752473", "r_armstrong@me.com", "Rachel Armstrong", queueNeedsYou)
+	r.Subject = "Adding an RSS feed felt risky"
+	for _, q := range []string{"", "rachel", "RACHEL", "752473", "rss feed", "armstrong@me"} {
+		if !matchesSearch(r, q) {
+			t.Errorf("search %q should have matched", q)
+		}
+	}
+	if matchesSearch(r, "kalshi") {
+		t.Error("search matched something that is not there")
+	}
+}
+
+// ===== The endpoint ================================================
+
+// The section a person lands in must follow the CURRENT subscription, not the
+// plan recorded on the ticket. Reading tier_at_open would leave somebody who
+// upgraded last week in the general queue forever, and promote somebody who
+// has since lapsed.
+func TestQueueSectionsUseTheCurrentPlanNotTierAtOpen(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	t.Setenv("SUPPORT_AUTOSEND", "off")
+	testsupport.MustExec(t, `DELETE FROM stripe_customers WHERE logto_sub LIKE 'sub-rel266%'`)
+	t.Cleanup(func() {
+		testsupport.MustExec(t, `DELETE FROM stripe_customers WHERE logto_sub LIKE 'sub-rel266%'`)
+	})
+
+	// upgraded: wrote while free, is paying now.
+	// lapsed:   wrote while paying, is on free now.
+	// nobody:   no account at all, the way #819835 arrived.
+	testsupport.MustExec(t, `INSERT INTO stripe_customers
+		(logto_sub, stripe_customer_id, plan, status, lifetime) VALUES
+		('sub-rel266-up',     'cus_up',     'uplink_ultimate', 'active', false),
+		('sub-rel266-lapsed', 'cus_lapsed', 'free',            'active', false)`)
+	testsupport.MustExec(t, `INSERT INTO support_cases
+		(ticket_number, user_email, logto_sub, subject, status, tier_at_open, os, updated_at) VALUES
+		('900100', 'up@example.com',     'sub-rel266-up',     'ticker will not scroll', 'open', 'free',            'macOS',   now()),
+		('900101', 'lapsed@example.com', 'sub-rel266-lapsed', 'feed cannot be edited',  'open', 'uplink_ultimate', 'Windows', now() - interval '1 hour'),
+		('900102', NULL,                 NULL,                'Linux sign-in',          'open', NULL,              'Linux',   now() - interval '2 hours')`)
+	testsupport.MustExec(t, `INSERT INTO support_messages (ticket_number, kind, body_text, created_at) VALUES
+		('900100', 'user', 'it will not move', now() - interval '4 hours'),
+		('900101', 'user', 'cannot edit',      now() - interval '2 days'),
+		('900102', 'user', 'no browser opens', now() - interval '100 days')`)
+
+	app := adminSupportApp("sub-staff")
+	status, body := getJSON(t, app, "/admin/support/queue")
+	if status != fiber.StatusOK {
+		t.Fatalf("queue: got %d, want 200 (body: %s)", status, body)
+	}
+	var res AdminQueueResponse
+	if err := json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatalf("decode queue: %v (body: %s)", err, body)
+	}
+
+	byKey := map[string]AdminPerson{}
+	for _, p := range res.People {
+		byKey[p.Key] = p
+	}
+	if len(res.People) != 3 {
+		t.Fatalf("got %d people, want 3: %v", len(res.People), sectionsOf(res.People))
+	}
+
+	up := byKey["up@example.com"]
+	if !up.Paying || up.Section != sectionPaying {
+		t.Errorf("a customer who upgraded since opening the ticket must be in the paying section: %+v", up)
+	}
+	if up.Plan != "uplink_ultimate" {
+		t.Errorf("plan = %q, want the current subscription rather than tier_at_open (free)", up.Plan)
+	}
+
+	lapsed := byKey["lapsed@example.com"]
+	if lapsed.Paying || lapsed.Section != sectionOpen {
+		t.Errorf("a lapsed customer must not be promoted by tier_at_open: %+v", lapsed)
+	}
+	if lapsed.Plan != "free" {
+		t.Errorf("plan = %q, want the current 'free' rather than tier_at_open (uplink_ultimate)", lapsed.Plan)
+	}
+
+	// The anonymous one: present, grouped, and with nothing invented.
+	anon := byKey["ticket:900102"]
+	if anon.Key == "" {
+		t.Fatalf("the anonymous case is missing from the queue: %v", res.People)
+	}
+	if anon.Name != "" || anon.Email != "" || anon.Plan != "" {
+		t.Errorf("the anonymous case grew a person: %+v", anon)
+	}
+	if anon.Section != sectionOpen {
+		t.Errorf("the anonymous case is open and needs a person, got section %q", anon.Section)
+	}
+
+	if res.Sections[sectionPaying] != 1 {
+		t.Errorf("sections = %v, want exactly one paying row", res.Sections)
+	}
+	// The caption under the paying section comes from the server, counted
+	// over the whole table rather than over this page.
+	if res.Accounts.Cases != 3 || res.Accounts.CasesWithAccount != 2 {
+		t.Errorf("account counts = %+v, want 3 cases of which 2 carry an account", res.Accounts)
+	}
+	if res.Accounts.Paying != 1 {
+		t.Errorf("paying accounts = %d, want the one uplink_ultimate row", res.Accounts.Paying)
+	}
+
+	if res.Sort != sortLastWrote || res.Dir != "desc" || res.RowsMode != "person" {
+		t.Errorf("the response must echo what it sorted by: sort=%q dir=%q rows=%q",
+			res.Sort, res.Dir, res.RowsMode)
+	}
+}
+
+// An empty paying section is a fact about the data, and it has to say so.
+//
+// Production is the reason this test exists: two accounts pay, and neither has
+// ever written in under an account we can see — only ONE of fifty-nine cases
+// carries a logto_sub at all. A blank box there reads as a broken query.
+func TestAnEmptyPayingSectionExplainsItself(t *testing.T) {
+	accounts := AdminQueueAccounts{Paying: 2, CasesWithAccount: 1, Cases: 59}
+
+	note := payingSectionNote(accounts, 0)
+	for _, want := range []string{"2 accounts are paying", "1 of 59"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("the empty paying section must say %q; got %q", want, note)
+		}
+	}
+	// With somebody in it there is nothing to explain.
+	if payingSectionNote(accounts, 1) != "" {
+		t.Errorf("a populated section needs no excuse: %q", payingSectionNote(accounts, 1))
+	}
+	// And nobody paying is a different sentence from nobody writing in.
+	none := payingSectionNote(AdminQueueAccounts{Cases: 59}, 0)
+	if !strings.Contains(none, "Nobody is on a paid plan") {
+		t.Errorf("no paying accounts at all: %q", none)
+	}
+	// One account is one account. "1 accounts are paying" is the kind of
+	// sentence that makes a reader distrust every other number on the page.
+	one := payingSectionNote(AdminQueueAccounts{Paying: 1, CasesWithAccount: 0, Cases: 9}, 0)
+	if !strings.Contains(one, "One account is paying") || strings.Contains(one, "1 accounts") {
+		t.Errorf("singular: %q", one)
+	}
+}
+
+// Sorting is a query parameter and the server answers it. Asking for something
+// it does not know is a 400 rather than an unannounced different order.
+func TestQueueSortsServerSideAndRefusesAnUnknownField(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	t.Setenv("SUPPORT_AUTOSEND", "off")
+
+	testsupport.MustExec(t, `INSERT INTO support_cases
+		(ticket_number, user_email, subject, status, updated_at) VALUES
+		('900110', 'cara@example.com', 'one',   'open', now()),
+		('900111', 'cara@example.com', 'two',   'open', now() - interval '1 hour'),
+		('900112', 'abe@example.com',  'three', 'open', now() - interval '2 hours')`)
+	testsupport.MustExec(t, `INSERT INTO support_messages (ticket_number, kind, body_text, created_at) VALUES
+		('900110', 'user', 'a', now() - interval '1 hour'),
+		('900111', 'user', 'b', now() - interval '9 days'),
+		('900112', 'user', 'c', now() - interval '2 hours')`)
+
+	app := adminSupportApp("sub-staff")
+
+	read := func(query string) AdminQueueResponse {
+		t.Helper()
+		status, body := getJSON(t, app, "/admin/support/queue"+query)
+		if status != fiber.StatusOK {
+			t.Fatalf("%s: got %d (body: %s)", query, status, body)
+		}
+		var res AdminQueueResponse
+		if err := json.Unmarshal([]byte(body), &res); err != nil {
+			t.Fatalf("decode %s: %v", query, err)
+		}
+		return res
+	}
+
+	if got := read("?sort=tickets&dir=desc").People[0].Key; got != "cara@example.com" {
+		t.Errorf("sort=tickets desc put %q first, want the person with two tickets", got)
+	}
+	if got := read("?sort=tickets&dir=asc").People[0].Key; got != "abe@example.com" {
+		t.Errorf("sort=tickets asc put %q first, want the person with one ticket", got)
+	}
+	if got := read("?sort=name&dir=asc").People[0].Key; got != "abe@example.com" {
+		t.Errorf("sort=name asc put %q first", got)
+	}
+	// Longest waiting is nine days, on Cara's second ticket.
+	if got := read("?sort=waiting&dir=desc").People[0].Key; got != "cara@example.com" {
+		t.Errorf("sort=waiting desc put %q first", got)
+	}
+
+	// By ticket, the raw list: three rows, still sorted by the server.
+	byTicket := read("?rows=ticket&sort=last_wrote&dir=asc")
+	if len(byTicket.Rows) != 3 || byTicket.Rows[0].TicketNumber != "900111" {
+		t.Errorf("rows=ticket asc: got %d rows starting at %q, want 3 starting at the oldest (900111)",
+			len(byTicket.Rows), firstTicket(byTicket.Rows))
+	}
+
+	// The search box is server-side too.
+	found := read("?q=abe@example.com")
+	if len(found.People) != 1 || found.People[0].Key != "abe@example.com" {
+		t.Errorf("q= narrowed to %v, want just Abe", sectionsOf(found.People))
+	}
+
+	for _, bad := range []string{"?sort=whenever", "?sort=name&dir=sideways", "?rows=whatever"} {
+		if status, _ := getJSON(t, app, "/admin/support/queue"+bad); status != fiber.StatusBadRequest {
+			t.Errorf("%s: got %d, want 400", bad, status)
+		}
+	}
+}
+
+func firstTicket(rows []AdminQueueRow) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	return rows[0].TicketNumber
+}

--- a/api/internal/support/handlers_admin_console.go
+++ b/api/internal/support/handlers_admin_console.go
@@ -255,9 +255,28 @@ type AdminQueueRow struct {
 	Priority     string `json:"priority,omitempty"`
 	Status       string `json:"status"`
 	Summary      string `json:"summary,omitempty"`
+	OS           string `json:"os,omitempty"`
+
+	// Who wrote it, as REL-266 needs it. Name is whatever the ticket carried
+	// and is empty when nothing did; Plan is the CURRENT subscription and is
+	// empty when no Stripe row stands behind this email. Neither is ever
+	// invented, and Plan is never tier_at_open.
+	Name      string `json:"name,omitempty"`
+	Plan      string `json:"plan,omitempty"`
+	Paying    bool   `json:"paying"`
+	PersonKey string `json:"person_key"`
 
 	Group       string `json:"group"`
 	GroupReason string `json:"group_reason"`
+	// Section is the reading order on the page: paying, open, answered,
+	// resolved. Group is still the pipeline's own answer about this one
+	// ticket; Section is where a person looking at the queue finds it.
+	Section string `json:"section"`
+
+	// Provenance is who sent the last reply. Decided on the server so the
+	// browser never has to diff a draft against its edit to find out.
+	Provenance      string `json:"provenance,omitempty"`
+	ProvenanceLabel string `json:"provenance_label,omitempty"`
 
 	DraftID           int64  `json:"draft_id,omitempty"`
 	DraftStatus       string `json:"draft_status,omitempty"`
@@ -275,37 +294,76 @@ type AdminQueueRow struct {
 }
 
 type AdminQueueResponse struct {
-	GeneratedAt time.Time       `json:"generated_at"`
-	AutoSend    AutoSendState   `json:"autosend"`
-	Counts      map[string]int  `json:"counts"`
-	State       string          `json:"state"`
-	Rows        []AdminQueueRow `json:"rows"`
+	GeneratedAt time.Time     `json:"generated_at"`
+	AutoSend    AutoSendState `json:"autosend"`
+	// Counts is the pipeline's three groups, over the whole queue and never
+	// over the filter. Sections is the four the page reads in.
+	Counts   map[string]int `json:"counts"`
+	Sections map[string]int `json:"sections"`
+	State    string         `json:"state"`
+	// Sort, Dir and RowsMode are echoed back so the controls can render from
+	// the answer rather than from what they hoped they asked for.
+	Sort     string `json:"sort"`
+	Dir      string `json:"dir"`
+	RowsMode string `json:"rows_mode"`
+	Search   string `json:"search,omitempty"`
+	// Accounts is the caption under the paying section, and the sentence that
+	// explains it when it is empty.
+	Accounts AdminQueueAccounts `json:"accounts"`
+	Rows     []AdminQueueRow    `json:"rows"`
+	// People is the same rows grouped by user_email — one row per human.
+	People []AdminPerson `json:"people"`
 }
 
+// queueSQL reads a case, its newest draft, and the CURRENT subscription behind
+// its account.
+//
+// The stripe_customers join is on logto_sub, so a case that arrived without a
+// signed-in user simply has no plan — which is the honest answer, and the
+// reason the page shows those without a name or a badge instead of guessing.
+// tier_at_open is deliberately not read: it is the plan on the day the ticket
+// opened, and the top section has to be about who is paying now.
 const queueSQL = `
 	WITH latest AS (
 		SELECT DISTINCT ON (ticket_number)
-		       ticket_number, id, status, disposition, disposition_reason, hold_until
+		       ticket_number, id, status, disposition, disposition_reason, hold_until,
+		       coalesce(user_name, '')        AS user_name,
+		       coalesce(draft_body_html, '')  AS draft_body_html,
+		       coalesce(edited_body_html, '') AS edited_body_html,
+		       intervened
 		  FROM support_drafts
 		 ORDER BY ticket_number, created_at DESC, id DESC
 	)
 	SELECT c.ticket_number, coalesce(c.user_email, ''), c.subject,
 	       coalesce(c.category, ''), coalesce(c.priority, ''), c.status,
-	       coalesce(c.summary, ''), coalesce(c.linear_issue_key, ''),
+	       coalesce(c.summary, ''), coalesce(c.os, ''), coalesce(c.linear_issue_key, ''),
 	       c.opened_at, c.updated_at,
 	       (SELECT max(m.created_at) FROM support_messages m
 	         WHERE m.ticket_number = c.ticket_number AND m.kind = 'user'),
-	       d.id, d.status, d.disposition, d.disposition_reason, d.hold_until
+	       d.id, d.status, d.disposition, d.disposition_reason, d.hold_until,
+	       coalesce(d.user_name, ''), coalesce(d.draft_body_html, ''),
+	       coalesce(d.edited_body_html, ''), coalesce(d.intervened, false),
+	       coalesce(s.plan, ''), coalesce(s.status, ''), coalesce(s.lifetime, false)
 	  FROM support_cases c
 	  LEFT JOIN latest d ON d.ticket_number = c.ticket_number
+	  LEFT JOIN stripe_customers s ON s.logto_sub = c.logto_sub
 	 ORDER BY c.updated_at DESC
 	 LIMIT $1
 `
 
-// HandleAdminQueue - GET /admin/support/queue?state=needs_you|waiting|handled|all
+// HandleAdminQueue - GET /admin/support/queue
+//
+//	?state=needs_you|waiting|handled|all
+//	?sort=last_wrote|waiting|tickets|plan|name  &dir=asc|desc
+//	?rows=person|ticket   &q=<search>
 //
 // The counts are always over the whole queue and never over the filter, so
 // switching to "Handled" cannot make "Needs you" look empty.
+//
+// Sort and direction are parameters here rather than an array sort in the
+// browser. That is not tidiness: queueLimit caps one read at 500 cases, and a
+// browser sorting whatever fitted would present a sorted page as a sorted
+// queue with nothing on screen admitting the difference.
 func HandleAdminQueue(c *fiber.Ctx) error {
 	if platform.DBPool == nil {
 		return adminSupportError(c, "The support database is not reachable from this API instance.")
@@ -322,6 +380,24 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 			Error:  "state must be one of needs_you, waiting, handled, all",
 		})
 	}
+
+	sortField, sortDir, ok := normaliseSort(c.Query("sort"), c.Query("dir"))
+	if !ok {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error",
+			Error:  "sort must be one of " + strings.Join(sortFields, ", ") + ", and dir one of asc, desc",
+		})
+	}
+	rowsMode := strings.TrimSpace(c.Query("rows", "person"))
+	if rowsMode == "" {
+		rowsMode = "person"
+	}
+	if rowsMode != "person" && rowsMode != "ticket" {
+		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
+			Status: "error", Error: "rows must be person or ticket",
+		})
+	}
+	search := strings.TrimSpace(c.Query("q"))
 
 	// context.Background(), not c.Context(): Fiber's request context is
 	// already cancelled by the time a handler under app.Test reaches the
@@ -347,11 +423,15 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 		var draftID *int64
 		var draftStatus, disposition, dispositionReason *string
 		var holdUntil, lastUser *time.Time
+		var draftBody, editedBody, planStatus string
+		var intervened, lifetime bool
 
 		if err := rows.Scan(&r.TicketNumber, &r.UserEmail, &r.Subject,
-			&r.Category, &r.Priority, &r.Status, &r.Summary, &issueKey,
+			&r.Category, &r.Priority, &r.Status, &r.Summary, &r.OS, &issueKey,
 			&r.OpenedAt, &r.UpdatedAt, &lastUser,
-			&draftID, &draftStatus, &disposition, &dispositionReason, &holdUntil); err != nil {
+			&draftID, &draftStatus, &disposition, &dispositionReason, &holdUntil,
+			&r.Name, &draftBody, &editedBody, &intervened,
+			&r.Plan, &planStatus, &lifetime); err != nil {
 			log.Printf("[AdminSupport] scan queue row: %v", err)
 			continue
 		}
@@ -359,6 +439,7 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 		if draftID != nil {
 			r.DraftID = *draftID
 		}
+		r.Paying = planIsPaying(r.Plan, planStatus, lifetime)
 		r.DraftStatus = deref(draftStatus)
 		r.Disposition = deref(disposition)
 		r.DispositionReason = deref(dispositionReason)
@@ -381,6 +462,10 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 			Disposition:   r.Disposition,
 			AutoSendArmed: autosend.Armed,
 		}.group()
+		r.Section = caseSection(r.Group, r.Paying)
+		r.Provenance, r.ProvenanceLabel = replyProvenance(
+			r.DraftStatus, r.Disposition, draftBody, editedBody, intervened)
+		r.PersonKey = personKey(r)
 		counts[r.Group]++
 
 		if issueKey != "" {
@@ -394,19 +479,69 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 
 	out := make([]AdminQueueRow, 0, len(all))
 	for _, r := range all {
-		if state == "all" || r.Group == state {
-			out = append(out, r)
+		if state != "all" && r.Group != state {
+			continue
 		}
+		if !matchesSearch(r, search) {
+			continue
+		}
+		out = append(out, r)
 	}
 	resolveQueueFixes(ctx, out)
+
+	// The people are grouped from the rows being returned, so a search or a
+	// state filter narrows both together and a person's ticket count always
+	// matches the tickets actually on the page.
+	people := groupPeople(out)
+	sortPeople(people, sortField, sortDir)
+	sortRows(out, sortField, sortDir)
+
+	sections := map[string]int{}
+	for _, s := range sectionOrder {
+		sections[s] = 0
+	}
+	for _, p := range people {
+		sections[p.Section]++
+	}
+
+	accounts := queueAccounts(ctx)
+	accounts.Note = payingSectionNote(accounts, sections[sectionPaying])
 
 	return c.JSON(AdminQueueResponse{
 		GeneratedAt: now.UTC(),
 		AutoSend:    autosend,
 		Counts:      counts,
+		Sections:    sections,
 		State:       state,
+		Sort:        sortField,
+		Dir:         sortDir,
+		RowsMode:    rowsMode,
+		Search:      search,
+		Accounts:    accounts,
 		Rows:        out,
+		People:      people,
 	})
+}
+
+// queueAccounts counts what the paying section is measured against: how many
+// accounts pay, and how many cases are joined to an account at all.
+//
+// The second number is the interesting one. In production it is 1 of 59:
+// almost every ticket arrives through the marketing form or osTicket with no
+// signed-in user, so there is nothing to join a subscription to. Without it an
+// empty paying section looks like a broken query.
+func queueAccounts(ctx context.Context) AdminQueueAccounts {
+	var a AdminQueueAccounts
+	if err := platform.DBPool.QueryRow(ctx, `
+		SELECT (SELECT count(*) FROM stripe_customers
+		         WHERE plan NOT IN ('', 'free') AND (lifetime OR status = 'active')),
+		       (SELECT count(*) FROM support_cases
+		         WHERE logto_sub IS NOT NULL AND logto_sub <> ''),
+		       (SELECT count(*) FROM support_cases)`).Scan(
+		&a.Paying, &a.CasesWithAccount, &a.Cases); err != nil {
+		log.Printf("[AdminSupport] account counts: %v", err)
+	}
+	return a
 }
 
 // resolveQueueFixes fills in the proven-fix answer for the rows being
@@ -552,6 +687,15 @@ type AdminCaseDetail struct {
 	Group       string `json:"group"`
 	GroupReason string `json:"group_reason"`
 
+	// Plan is the CURRENT subscription behind this account, which is a
+	// different question from Context.Tier — that one is tier_at_open, the
+	// plan the model was told about on the day the ticket opened. A header
+	// printing the old one would quietly mis-badge anybody who has since
+	// upgraded or lapsed.
+	Plan     string `json:"plan,omitempty"`
+	Paying   bool   `json:"paying"`
+	PlanNote string `json:"plan_note,omitempty"`
+
 	Messages []AdminMessage `json:"messages"`
 	Draft    *AdminDraft    `json:"draft"`
 	// DraftNote says why Draft is nil when it is. A missing draft is a fact
@@ -578,11 +722,14 @@ type AdminCaseDetail struct {
 }
 
 const caseSQL = `
-	SELECT ticket_number, subject, coalesce(user_email, ''), coalesce(logto_sub, ''),
-	       status, coalesce(category, ''), coalesce(priority, ''), coalesce(summary, ''),
-	       coalesce(linear_issue_key, ''), coalesce(discord_thread_id, ''),
-	       opened_at, updated_at, closed_at
-	  FROM support_cases WHERE ticket_number = $1
+	SELECT c.ticket_number, c.subject, coalesce(c.user_email, ''), coalesce(c.logto_sub, ''),
+	       c.status, coalesce(c.category, ''), coalesce(c.priority, ''), coalesce(c.summary, ''),
+	       coalesce(c.linear_issue_key, ''), coalesce(c.discord_thread_id, ''),
+	       c.opened_at, c.updated_at, c.closed_at,
+	       coalesce(s.plan, ''), coalesce(s.status, ''), coalesce(s.lifetime, false)
+	  FROM support_cases c
+	  LEFT JOIN stripe_customers s ON s.logto_sub = c.logto_sub
+	 WHERE c.ticket_number = $1
 `
 
 // HandleAdminCase - GET /admin/support/case/:ticket
@@ -622,15 +769,22 @@ func HandleAdminCase(c *fiber.Ctx) error {
 // happened.
 func buildAdminCase(ctx context.Context, ticket string) (*AdminCaseDetail, error) {
 	var d AdminCaseDetail
+	var planStatus string
+	var lifetime bool
 	err := platform.DBPool.QueryRow(ctx, caseSQL, ticket).Scan(
 		&d.TicketNumber, &d.Subject, &d.UserEmail, &d.LogtoSub, &d.Status,
 		&d.Category, &d.Priority, &d.Summary, &d.LinearIssueKey,
-		&d.DiscordThreadID, &d.OpenedAt, &d.UpdatedAt, &d.ClosedAt)
+		&d.DiscordThreadID, &d.OpenedAt, &d.UpdatedAt, &d.ClosedAt,
+		&d.Plan, &planStatus, &lifetime)
 	if err != nil {
 		if err != pgx.ErrNoRows {
 			log.Printf("[AdminSupport] case %s: %v", ticket, err)
 		}
 		return nil, err
+	}
+	d.Paying = planIsPaying(d.Plan, planStatus, lifetime)
+	if d.Plan == "" {
+		d.PlanNote = "No Stripe customer stands behind this ticket, so there is no current plan to show. That is normal for a case that arrived without a signed-in user."
 	}
 	if d.DiscordThreadID != "" {
 		if guild := strings.TrimSpace(os.Getenv("DISCORD_GUILD_ID")); guild != "" {

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -231,6 +231,28 @@ export interface AdminFix {
   reason: string
 }
 
+/**
+ * The four sections the page reads in, in order (REL-266).
+ *
+ * `paying` is a SECTION and not a sort key: priority support is something we
+ * sold, so nothing a reader picks in the sort controls may push a paying
+ * customer below somebody who did not pay.
+ */
+export type QueueSection = 'paying' | 'open' | 'answered' | 'resolved'
+
+export type QueueSort = 'last_wrote' | 'waiting' | 'tickets' | 'plan' | 'name'
+
+export type QueueDir = 'asc' | 'desc'
+export type QueueRowsMode = 'person' | 'ticket'
+
+export interface QueueQuery {
+  state?: string
+  sort?: QueueSort
+  dir?: QueueDir
+  rows?: QueueRowsMode
+  q?: string
+}
+
 export interface QueueRow {
   ticket_number: string
   subject: string
@@ -239,8 +261,19 @@ export interface QueueRow {
   priority?: string
   status: string
   summary?: string
+  os?: string
+  /** Empty when the ticket carried no name. Never invented. */
+  name?: string
+  /** The CURRENT subscription, empty when there is no Stripe row. */
+  plan?: string
+  paying: boolean
+  person_key: string
   group: QueueGroup
   group_reason: string
+  section: QueueSection
+  /** Who sent the last reply. The server decided this; do not re-derive it. */
+  provenance?: 'bot' | 'edited' | 'person'
+  provenance_label?: string
   draft_id?: number
   draft_status?: string
   disposition?: string
@@ -253,12 +286,59 @@ export interface QueueRow {
   updated_at: string
 }
 
+/** One row of the queue: a person, and the tickets they wrote. */
+export interface QueuePerson {
+  key: string
+  email?: string
+  name?: string
+  plan?: string
+  paying: boolean
+  plan_note?: string
+  section: QueueSection
+  tickets: number
+  needs_you: number
+  waiting: number
+  handled: number
+  headline?: string
+  headline_ticket?: string
+  provenance?: 'bot' | 'edited' | 'person'
+  provenance_label?: string
+  last_user_message_at?: string
+  waiting_hours: Measured
+  ticket_numbers: Array<string> | null
+}
+
+/**
+ * The caption under the paying section, and the sentence that explains it
+ * when it is empty. In production `cases_with_account` is 1 of 59: almost
+ * every ticket arrives with no signed-in user, so there is nothing to join a
+ * subscription to.
+ */
+export interface QueueAccounts {
+  paying: number
+  cases_with_account: number
+  cases: number
+  note: string
+}
+
 export interface SupportQueue {
   generated_at: string
   autosend: AutoSendState
-  counts: Record<string, number>
+  /**
+   * Keyed by group and by section. The values are optional because an
+   * arbitrary key is not a promise the server made — `counts.needs_you ?? 0`
+   * is how a caller says what an absent key should read as.
+   */
+  counts: Record<string, number | undefined>
+  sections: Record<string, number | undefined>
   state: string
+  sort: QueueSort
+  dir: QueueDir
+  rows_mode: QueueRowsMode
+  search?: string
+  accounts: QueueAccounts
   rows: Array<QueueRow> | null
+  people: Array<QueuePerson> | null
 }
 
 export interface CaseMessage {
@@ -333,6 +413,14 @@ export interface CaseDetail {
   closed_at?: string
   group: QueueGroup
   group_reason: string
+  /**
+   * The CURRENT subscription — a different question from `context.tier`,
+   * which is tier_at_open, the plan the model was told about on the day the
+   * ticket opened.
+   */
+  plan?: string
+  paying: boolean
+  plan_note?: string
   messages: Array<CaseMessage> | null
   draft: CaseDraft | null
   draft_note?: string
@@ -421,11 +509,26 @@ export const adminApi = {
       getToken,
     ),
 
-  supportQueue: (getToken: Token, state: string) =>
-    adminFetch<SupportQueue>(
-      `/admin/support/queue?state=${encodeURIComponent(state)}`,
+  /**
+   * The queue, sorted and searched BY THE SERVER (REL-266).
+   *
+   * Every knob here is a query parameter for the same reason: one read is
+   * capped at 500 cases, so a browser reordering whatever arrived would show a
+   * sorted page while calling it a sorted queue.
+   */
+  supportQueue: (getToken: Token, opts: QueueQuery = {}) => {
+    const params = new URLSearchParams({
+      state: opts.state ?? 'all',
+      sort: opts.sort ?? 'last_wrote',
+      dir: opts.dir ?? 'desc',
+      rows: opts.rows ?? 'person',
+    })
+    if (opts.q?.trim()) params.set('q', opts.q.trim())
+    return adminFetch<SupportQueue>(
+      `/admin/support/queue?${params.toString()}`,
       getToken,
-    ),
+    )
+  },
 
   supportCase: (getToken: Token, ticket: string) =>
     adminFetch<CaseDetail>(

--- a/myscrollr.com/src/components/admin/AdminShell.tsx
+++ b/myscrollr.com/src/components/admin/AdminShell.tsx
@@ -46,7 +46,6 @@ function Centered({ children }: { children: React.ReactNode }) {
 export default function AdminShell() {
   const { isAuthenticated, isLoading, signIn } = useScrollrAuth()
   const getToken = useGetToken()
-  const location = useLocation()
   const [gate, setGate] = useState<GateState>({ kind: 'checking' })
 
   useEffect(() => {
@@ -138,19 +137,46 @@ export default function AdminShell() {
     )
   }
 
+  return <AdminChrome email={gate.email}>{<Outlet />}</AdminChrome>
+}
+
+/**
+ * The console's chrome: the container, the nav and the slot.
+ *
+ * Split out from the gate so it can be rendered without one — the Support
+ * console cannot be signed into from a development machine, and the only
+ * honest way to check its layout at four widths is to render the real chrome
+ * around the real page.
+ */
+export function AdminChrome({
+  email,
+  children,
+}: {
+  email: string
+  children: React.ReactNode
+}) {
+  const location = useLocation()
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-10 sm:px-6 lg:flex-row lg:gap-10">
-      <nav className="lg:w-52 lg:shrink-0">
-        <p className="px-3 text-xs font-semibold tracking-wide text-base-content/40 uppercase">
+    /* Wide enough for the Support console's two panes to sit as drawn at
+       1440, and capped so an ultrawide gives the extra width to margin
+       instead of stretching a line of prose across 3440 pixels. The reading
+       measure inside each pane is capped again, at 75ch, where it matters. */
+    <div className="mx-auto flex w-full max-w-[104rem] flex-col gap-6 px-4 py-8 sm:px-6 md:flex-row md:gap-6 lg:py-10 xl:gap-10">
+      {/* Under 768px the nav is a scrolling row of full labels. From 768 to
+          1279 it collapses to an icon rail, which is where the width has to
+          come from for the queue and the case to stay side by side. From 1280
+          the labels come back. */}
+      <nav className="md:w-14 md:shrink-0 xl:w-52">
+        <p className="px-3 text-xs font-semibold tracking-wide text-base-content/40 uppercase md:hidden xl:block">
           Staff
         </p>
         <p
-          className="mt-1 truncate px-3 text-xs text-base-content/60"
-          title={gate.email}
+          className="mt-1 truncate px-3 text-xs text-base-content/60 md:hidden xl:block"
+          title={email}
         >
-          {gate.email}
+          {email}
         </p>
-        <ul className="mt-4 flex gap-1 overflow-x-auto lg:flex-col lg:overflow-visible">
+        <ul className="flex gap-1 overflow-x-auto md:mt-0 md:flex-col md:overflow-visible xl:mt-4">
           {SECTIONS.map(({ to, label, Icon, ...rest }) => {
             const exact = 'exact' in rest && rest.exact
             const active = exact
@@ -161,14 +187,16 @@ export default function AdminShell() {
               <li key={to}>
                 <Link
                   to={to}
-                  className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors ${
+                  title={label}
+                  aria-label={label}
+                  className={`flex min-h-11 items-center gap-2.5 rounded-lg px-3 text-sm font-medium whitespace-nowrap transition-colors md:justify-center md:px-0 xl:justify-start xl:px-3 ${
                     active
                       ? 'bg-base-200 text-base-content'
                       : 'text-base-content/60 hover:bg-base-200/60 hover:text-base-content'
                   }`}
                 >
-                  <Icon size={16} strokeWidth={2} />
-                  {label}
+                  <Icon size={16} strokeWidth={2} className="shrink-0" />
+                  <span className="md:hidden xl:inline">{label}</span>
                 </Link>
               </li>
             )
@@ -176,9 +204,7 @@ export default function AdminShell() {
         </ul>
       </nav>
 
-      <main className="min-w-0 flex-1">
-        <Outlet />
-      </main>
+      <main className="min-w-0 flex-1">{children}</main>
     </div>
   )
 }

--- a/myscrollr.com/src/components/admin/CaseActions.tsx
+++ b/myscrollr.com/src/components/admin/CaseActions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   AlertTriangle,
   Bug,
@@ -7,7 +7,6 @@ import {
   Link2Off,
   Loader2,
   MessageCircleQuestion,
-  Pencil,
   Send,
   SkipForward,
 } from 'lucide-react'
@@ -32,7 +31,7 @@ import { useGetToken } from '@/hooks/useGetToken'
  * using, and every one of those can be put back.
  */
 
-type Panel = 'none' | 'confirm-send' | 'edit' | 'ask' | 'link'
+type Panel = 'none' | 'confirm-send' | 'ask' | 'link'
 
 export default function CaseActions({
   detail,
@@ -84,16 +83,16 @@ export default function CaseActions({
     }
   }
 
-  const openEditor = () => {
-    setPanel('edit')
-    setError(null)
-    // Opening the editor stops the countdown, exactly as opening the Discord
-    // modal does. Typing a reply takes longer than a hold that is nearly up,
-    // and "I am working on this one" has to actually stop the clock rather
-    // than race it.
-    if (pending && detail.hold) {
-      void run('hold', () => adminApi.holdDraft(getToken, draft.id))
-    }
+  // Touching the reply box stops the countdown, exactly as opening the
+  // Discord modal used to. Typing a reply takes longer than a hold that is
+  // nearly up, and "I am working on this one" has to actually stop the clock
+  // rather than race it. Once per case: the hold is already off after the
+  // first touch, and re-holding on every refocus would be a write per click.
+  const held = useRef<number | null>(null)
+  const holdOnFirstTouch = () => {
+    if (!pending || !detail.hold || held.current === draft.id) return
+    held.current = draft.id
+    void run('hold', () => adminApi.holdDraft(getToken, draft.id))
   }
 
   const fileBug = async () => {
@@ -117,100 +116,52 @@ export default function CaseActions({
 
   return (
     <section>
-      <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
-        What you can do
-      </h2>
+      {/* ── The reply, editable where it is read ────────────────
+          The mockup's "Proposed reply · edit it here" is this box. It used to
+          sit behind an Edit button, which meant the thing you are here to do
+          was one click further away than the thing you are here to read. */}
+      {pending && (
+        <>
+          <div className="flex flex-wrap items-baseline gap-x-2">
+            <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+              Proposed reply
+            </h2>
+            <span className="text-xs text-base-content/45">edit it here</span>
+          </div>
+          <textarea
+            id="reply-body"
+            aria-label="Proposed reply"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            onFocus={holdOnFirstTouch}
+            rows={12}
+            spellCheck
+            /* No maxLength. Discord capped this at 4000 because a Discord
+               modal does; a support email does not, and a limit inherited
+               from the surface you happen to be typing into is a limit that
+               silently cuts somebody's answer in half. */
+            className="mt-2 w-full max-w-[75ch] resize-y rounded-xl bg-base-100 px-4 py-3 text-sm leading-relaxed ring-1 ring-base-300/60 focus:ring-2 focus:ring-primary/50 focus:outline-none"
+          />
+          <p className="mt-1 text-xs text-base-content/45">
+            {edited.length.toLocaleString()} characters. Plain text — it is
+            wrapped into paragraphs on the way out.
+            {!unchanged && ' Sending will send your version.'}
+          </p>
+          {!unchanged && (
+            <div className="mt-2 max-w-[75ch]">
+              <DiffPanel before={draft.body} after={edited} />
+            </div>
+          )}
+        </>
+      )}
 
       {!pending && (
-        <p className="mt-2 rounded-xl bg-base-200/40 px-4 py-3 text-sm text-base-content/60 ring-1 ring-base-300/60">
+        <p className="rounded-xl bg-base-200/40 px-4 py-3 text-sm text-base-content/60 ring-1 ring-base-300/60">
           {draft
             ? `This draft is ${draft.status}, so there is nothing left to send on it. The issue link below is still yours to change.`
             : 'There is no draft to act on. Link an issue, or answer this one in osTicket.'}
         </p>
       )}
-
-      <div className="mt-2 flex flex-wrap gap-2">
-        {pending && (
-          <>
-            <ActionButton
-              label="Send"
-              icon={<Send size={14} />}
-              tone="primary"
-              busy={busy === 'send'}
-              disabled={busy !== null}
-              onClick={() => {
-                setPanel('confirm-send')
-                setError(null)
-              }}
-            />
-            <ActionButton
-              label="Edit"
-              icon={<Pencil size={14} />}
-              busy={busy === 'hold' && panel === 'edit'}
-              disabled={busy !== null}
-              onClick={openEditor}
-            />
-            <ActionButton
-              label="Ask"
-              icon={<MessageCircleQuestion size={14} />}
-              disabled={busy !== null}
-              onClick={() => {
-                setPanel('ask')
-                setError(null)
-              }}
-            />
-            <ActionButton
-              label="Hold"
-              icon={<Hand size={14} />}
-              busy={busy === 'hold' && panel !== 'edit'}
-              disabled={busy !== null}
-              onClick={() =>
-                run('hold', () => adminApi.holdDraft(getToken, draft.id))
-              }
-            />
-            <ActionButton
-              label="Skip"
-              icon={<SkipForward size={14} />}
-              busy={busy === 'skip'}
-              disabled={busy !== null}
-              onClick={() =>
-                run('skip', () => adminApi.skipDraft(getToken, draft.id))
-              }
-            />
-            <ActionButton
-              label="File as bug"
-              icon={<Bug size={14} />}
-              busy={busy === 'bug'}
-              disabled={busy !== null}
-              onClick={fileBug}
-            />
-          </>
-        )}
-
-        {detail.linear_issue_key ? (
-          <ActionButton
-            label={`Unlink ${detail.linear_issue_key}`}
-            icon={<Link2Off size={14} />}
-            busy={busy === 'unlink'}
-            disabled={busy !== null}
-            onClick={() =>
-              run('unlink', () =>
-                adminApi.unlinkIssue(getToken, detail.ticket_number),
-              )
-            }
-          />
-        ) : (
-          <ActionButton
-            label="Link an issue"
-            icon={<Link2 size={14} />}
-            disabled={busy !== null}
-            onClick={() => {
-              setPanel('link')
-              setError(null)
-            }}
-          />
-        )}
-      </div>
 
       {error && (
         <p className="mt-2 flex items-baseline gap-2 rounded-lg bg-error/10 px-3 py-2 text-sm text-error ring-1 ring-error/30">
@@ -224,106 +175,124 @@ export default function CaseActions({
         </p>
       )}
 
-      {/* ── Send, confirmed ─────────────────────────────────────── */}
+      {/* The quieter verbs. Above the pinned bar rather than in it: on a
+          phone the bar is what a thumb reaches, and it should only hold the
+          three things you came to do. */}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {pending && (
+          <>
+            <ActionButton
+              label="Hold"
+              icon={<Hand size={14} />}
+              small
+              busy={busy === 'hold'}
+              disabled={busy !== null}
+              onClick={() =>
+                run('hold', () => adminApi.holdDraft(getToken, draft.id))
+              }
+            />
+            <ActionButton
+              label="File as bug"
+              icon={<Bug size={14} />}
+              small
+              busy={busy === 'bug'}
+              disabled={busy !== null}
+              onClick={fileBug}
+            />
+          </>
+        )}
+        {detail.linear_issue_key ? (
+          <ActionButton
+            label={`Unlink ${detail.linear_issue_key}`}
+            icon={<Link2Off size={14} />}
+            small
+            busy={busy === 'unlink'}
+            disabled={busy !== null}
+            onClick={() =>
+              run('unlink', () =>
+                adminApi.unlinkIssue(getToken, detail.ticket_number),
+              )
+            }
+          />
+        ) : (
+          <ActionButton
+            label="Link an issue"
+            icon={<Link2 size={14} />}
+            small
+            disabled={busy !== null}
+            onClick={() => {
+              setPanel('link')
+              setError(null)
+            }}
+          />
+        )}
+      </div>
+
+      {/* ── The action bar ──────────────────────────────────────
+          Pinned to the bottom of the viewport under 768px, above the safe
+          area, so the three verbs are reachable with a thumb without
+          scrolling past a reply that can run to forty lines. It rejoins the
+          flow at md, where the whole case is on screen anyway. */}
+      {pending && (
+        <div className="sticky bottom-0 z-20 mt-3 -mb-4 flex flex-wrap items-center gap-2 border-t border-base-300/60 bg-base-100/95 px-1 pt-3 pb-[calc(env(safe-area-inset-bottom,0px)+0.75rem)] backdrop-blur md:static md:mb-0 md:border-0 md:bg-transparent md:px-0 md:pt-0 md:pb-0 md:backdrop-blur-none">
+          <ActionButton
+            label="Send reply"
+            icon={<Send size={14} />}
+            tone="primary"
+            busy={busy === 'send' || busy === 'edit'}
+            disabled={busy !== null || edited === ''}
+            onClick={() => {
+              setPanel('confirm-send')
+              setError(null)
+            }}
+          />
+          <ActionButton
+            label="Ask something else"
+            icon={<MessageCircleQuestion size={14} />}
+            disabled={busy !== null}
+            onClick={() => {
+              setPanel('ask')
+              setError(null)
+            }}
+          />
+          <ActionButton
+            label="Skip"
+            icon={<SkipForward size={14} />}
+            busy={busy === 'skip'}
+            disabled={busy !== null}
+            onClick={() =>
+              run('skip', () => adminApi.skipDraft(getToken, draft.id))
+            }
+          />
+        </div>
+      )}
+
+      {/* ── Send, confirmed ───────────────────────────────────────
+          The one confirmation on the page, in front of the one thing that
+          cannot be undone. Which verb it runs depends on whether the box
+          above still holds the draft: an untouched reply goes out as the
+          draft, an edited one goes out as an edit and is recorded as one. */}
       {panel === 'confirm-send' && pending && (
         <ConfirmSend
           who={detail.user_email}
           closing={draft.should_close}
-          busy={busy === 'send'}
+          editing={!unchanged}
+          busy={busy === 'send' || busy === 'edit'}
           onCancel={() => setPanel('none')}
           onSend={() =>
-            run(
-              'send',
-              () => adminApi.sendDraft(getToken, draft.id),
-              () => setPanel('none'),
-            )
-          }
-        />
-      )}
-
-      {/* ── The editor ──────────────────────────────────────────── */}
-      {panel === 'edit' && pending && (
-        <div className="mt-3 space-y-3 rounded-xl p-4 ring-1 ring-base-300/60">
-          <div className="grid gap-4 lg:grid-cols-2">
-            <div>
-              <label
-                htmlFor="reply-body"
-                className="text-xs font-semibold tracking-wide text-base-content/50 uppercase"
-              >
-                The reply
-              </label>
-              {/* No maxLength. Discord capped this at 4000 because a Discord
-                  modal does; a support email does not, and a limit that comes
-                  from the surface you happen to be typing into is a limit that
-                  silently cuts somebody's answer in half. */}
-              <textarea
-                id="reply-body"
-                value={body}
-                onChange={(e) => setBody(e.target.value)}
-                rows={16}
-                spellCheck
-                className="mt-1 w-full resize-y rounded-lg bg-base-100 px-3 py-2 font-mono text-sm ring-1 ring-base-300/60 focus:ring-2 focus:ring-primary/50 focus:outline-none"
-              />
-              <p className="mt-1 text-xs text-base-content/45">
-                {edited.length.toLocaleString()} characters. Plain text — it is
-                wrapped into paragraphs on the way out.
-              </p>
-            </div>
-
-            <div>
-              <p className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
-                What they wrote
-              </p>
-              {/* Beside the box, not behind it. The Discord modal covered the
-                  thread while it was open, so rewriting an answer meant
-                  cancelling out to re-read the question. */}
-              <div className="mt-1 max-h-[26rem] overflow-y-auto rounded-lg bg-base-200/40 px-3 py-2 text-sm whitespace-pre-wrap text-base-content/80 ring-1 ring-base-300/60">
-                {lastUserMessage(detail) ?? (
-                  <span className="text-base-content/45 italic">
-                    Nothing from the user is on record for this ticket.
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
-
-          <DiffPanel before={draft.body} after={edited} />
-
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              disabled={busy !== null || edited === ''}
-              onClick={() =>
-                run(
+            unchanged
+              ? run(
+                  'send',
+                  () => adminApi.sendDraft(getToken, draft.id),
+                  () => setPanel('none'),
+                )
+              : run(
                   'edit',
                   () => adminApi.editAndSend(getToken, draft.id, edited),
                   () => setPanel('none'),
                 )
-              }
-              className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-content disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {busy === 'edit' ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <Send size={14} />
-              )}
-              Send this instead
-            </button>
-            <button
-              type="button"
-              disabled={busy !== null}
-              onClick={() => setPanel('none')}
-              className="cursor-pointer rounded-lg px-3 py-1.5 text-sm text-base-content/70 hover:bg-base-200/60"
-            >
-              Cancel
-            </button>
-            {unchanged && edited !== '' && (
-              <span className="text-xs text-base-content/50">
-                Nothing has changed yet — this would send the draft as written.
-              </span>
-            )}
-          </div>
-        </div>
+          }
+        />
       )}
 
       {/* ── Ask one question ───────────────────────────────────── */}
@@ -445,12 +414,14 @@ export default function CaseActions({
 function ConfirmSend({
   who,
   closing,
+  editing,
   busy,
   onSend,
   onCancel,
 }: {
   who?: string
   closing: boolean
+  editing: boolean
   busy: boolean
   onSend: () => void
   onCancel: () => void
@@ -464,6 +435,8 @@ function ConfirmSend({
         It goes out as an email and is marked answered in osTicket. There is no
         undo.
         {closing && ' The ticket also closes — triage flagged it as resolved.'}
+        {editing &&
+          ' Your version is sent, not the draft, and the diff is posted into the Discord thread.'}
       </p>
       <div className="mt-2 flex flex-wrap gap-2">
         <button
@@ -533,6 +506,7 @@ function ActionButton({
   label,
   icon,
   tone,
+  small,
   busy,
   disabled,
   onClick,
@@ -540,6 +514,8 @@ function ActionButton({
   label: string
   icon: React.ReactNode
   tone?: 'primary'
+  /** Secondary verbs. Still 44px tall on a phone; only the padding shrinks. */
+  small?: boolean
   busy?: boolean
   disabled?: boolean
   onClick: () => void
@@ -549,7 +525,9 @@ function ActionButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+      className={`inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-lg text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+        small ? 'px-2.5 py-1.5 text-xs' : 'px-4 py-2'
+      } ${
         tone === 'primary'
           ? 'bg-primary text-primary-content'
           : 'bg-base-200 text-base-content hover:bg-base-300/70'
@@ -559,17 +537,6 @@ function ActionButton({
       {label}
     </button>
   )
-}
-
-/** The reporter's most recent words — what an answer has to answer. */
-function lastUserMessage(detail: CaseDetail): string | null {
-  const messages = detail.messages ?? []
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].kind === 'user' && messages[i].body.trim() !== '') {
-      return messages[i].body
-    }
-  }
-  return null
 }
 
 function describeFiling(filed: FiledBug): string {

--- a/myscrollr.com/src/components/admin/SupportPage.tsx
+++ b/myscrollr.com/src/components/admin/SupportPage.tsx
@@ -1,7 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AlertTriangle,
+  ArrowDown,
+  ArrowLeft,
+  ArrowUp,
   CheckCircle2,
+  ChevronRight,
   Clock,
   ExternalLink,
   HelpCircle,
@@ -10,50 +14,68 @@ import {
   Pause,
   Play,
   Radio,
+  Search,
+  Star,
 } from 'lucide-react'
 import type {
   AdminFix,
   AdminHold,
   AutoSendState,
   CaseDetail,
-  QueueGroup,
+  QueueDir,
+  QueuePerson,
   QueueRow,
+  QueueRowsMode,
+  QueueSection,
+  QueueSort,
   SupportQueue,
 } from '@/api/admin'
 import { adminApi, subscribeToSupportEvents } from '@/api/admin'
 import CaseActions from '@/components/admin/CaseActions'
 import {
-  QUEUE_GROUPS,
+  QUEUE_SECTIONS,
+  SORT_FIELDS,
+  diagnosticsChips,
+  directionLabel,
   dispositionTone,
   fixBadge,
   formatWait,
   holdCountdown,
+  lastUserMessage,
+  personMeta,
+  personTitle,
+  planBadge,
 } from '@/lib/supportConsole'
 import { useGetToken } from '@/hooks/useGetToken'
 
 /**
- * The Support section: the queue on the left, one case on the right.
+ * The Support section, rebuilt around people (REL-266).
  *
- * REL-263 built the read half; REL-261 gave every fact on it a button. Each
- * button calls the same server function the Discord button calls, so the two
- * surfaces cannot drift while they coexist, and a case reads the same
- * whichever one was used.
+ * REL-263 built this page as a debugging view, because that is what its brief
+ * asked for: the whole triage pipeline under every case, sixty tickets at
+ * equal weight, eight all-caps sections expanded at once. The bot does the
+ * triage now. This page is for the exceptions, and it is built on three rules.
  *
- * The page moves on its own. A support event on the SSE hub — a draft written,
- * a disposition decided, a reply sent — re-reads the queue and the open case
- * from the endpoints that built them. Nothing polls, and nothing patches a
- * case out of a socket payload: the event says which ticket moved, and the
- * server says what it now looks like.
+ * A ROW IS A PERSON. Rachel Armstrong wrote five times in one afternoon; you
+ * answer a human, not a queue. The grouping is the server's — the browser
+ * never re-derives who is who from an email.
  *
- * The case view is the whole reason this exists. Discord could show the draft
- * and roughly two thousand characters of it; it could not show what the
- * classifier decided, what the drafter says it is grounded in, what it admits
- * it does not know, which rule chose the disposition, or what the model was
- * told about the person writing. All of that has been in Postgres since
- * REL-249. This is the first surface wide enough to read it.
+ * PAYING CUSTOMERS ARE A SECTION. Priority support is something we sold, so no
+ * sort a reader picks can push one below anybody else. The sections are fixed
+ * and the sort works inside them.
  *
- * Nothing here recomputes the pipeline. Disposition, hold expiry and the
- * proven-fix answer arrive decided; the browser formats them.
+ * NOTHING IS RECOMPUTED HERE. Disposition, hold expiry, the proven-fix answer,
+ * who sent the last reply, and which section a person belongs in all arrive
+ * decided. The browser formats them. The sort and the search are query
+ * parameters for the same reason: one queue read is capped at 500 cases, and a
+ * browser sorting whatever fitted would present a sorted page as a sorted
+ * queue.
+ *
+ * The case view stops dumping. Above the fold: their words, one sentence on
+ * why it stopped, the draft where it can be edited, and the actions.
+ * Everything else moved one level down behind "Why it decided this" — moved,
+ * not deleted, because the whole point of REL-263 was that this data had never
+ * been readable anywhere.
  */
 
 // ── small shared pieces ───────────────────────────────────────────
@@ -97,9 +119,9 @@ function Panel({
 }) {
   return (
     <section>
-      <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+      <h3 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
         {title}
-      </h2>
+      </h3>
       {subtitle && (
         <p className="mt-1 text-xs text-base-content/50">{subtitle}</p>
       )}
@@ -114,6 +136,44 @@ const TONE_RING: Record<string, string> = {
   ask: 'ring-info/40 bg-info/5',
   done: 'ring-base-300/60',
   none: 'ring-base-300/60',
+}
+
+/** A pill. One place, so the queue and the case view cannot drift apart. */
+function Pill({
+  children,
+  tone = 'neutral',
+}: {
+  children: React.ReactNode
+  tone?: 'neutral' | 'paying' | 'needs' | 'edited' | 'done'
+}) {
+  const tones: Record<string, string> = {
+    neutral: 'bg-base-200 text-base-content/65',
+    paying: 'bg-success/15 text-success',
+    needs: 'bg-error/10 text-error',
+    edited: 'bg-secondary/15 text-secondary',
+    done: 'bg-success/10 text-success',
+  }
+  return (
+    <span
+      className={`shrink-0 rounded px-1.5 py-0.5 text-[11px] font-semibold ${tones[tone]}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+/** The provenance chip: sent by the bot, or you edited it. Server's words. */
+function ProvenancePill({
+  provenance,
+  label,
+}: {
+  provenance?: string
+  label?: string
+}) {
+  if (!label) return null
+  return (
+    <Pill tone={provenance === 'edited' ? 'edited' : 'neutral'}>{label}</Pill>
+  )
 }
 
 /**
@@ -209,7 +269,7 @@ function FixCard({ fix }: { fix: AdminFix }) {
   )
 }
 
-// ── the conversation ──────────────────────────────────────────────
+// ── everything that moved one level down ──────────────────────────
 
 const KIND_LABEL: Record<string, string> = {
   user: 'They wrote',
@@ -259,7 +319,7 @@ function Conversation({ detail }: { detail: CaseDetail }) {
                 )}
               </div>
               <p
-                className={`mt-2 text-sm whitespace-pre-wrap ${
+                className={`mt-2 max-w-[75ch] text-sm whitespace-pre-wrap ${
                   m.kind === 'ai_draft'
                     ? 'text-base-content/55 italic'
                     : 'text-base-content/85'
@@ -274,8 +334,6 @@ function Conversation({ detail }: { detail: CaseDetail }) {
     </Panel>
   )
 }
-
-// ── the pipeline ──────────────────────────────────────────────────
 
 function Pipeline({ detail }: { detail: CaseDetail }) {
   const draft = detail.draft
@@ -293,9 +351,9 @@ function Pipeline({ detail }: { detail: CaseDetail }) {
   return (
     <div className="space-y-5">
       <section>
-        <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+        <h3 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
           What the server decided
-        </h2>
+        </h3>
         <div className={`mt-2 rounded-xl px-4 py-3 ring-1 ${TONE_RING[tone]}`}>
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
             {tone === 'stop' && (
@@ -311,7 +369,7 @@ function Pipeline({ detail }: { detail: CaseDetail }) {
           </div>
           {/* The rule that fired, verbatim. An escalation whose reason has to
               be guessed at is the Discord queue again. */}
-          <p className="mt-2 text-sm text-base-content/85">
+          <p className="mt-2 max-w-[75ch] text-sm text-base-content/85">
             {draft.disposition_reason ||
               'No reason was recorded. This draft predates the autonomous policy, so nothing will send it on its own.'}
           </p>
@@ -322,30 +380,21 @@ function Pipeline({ detail }: { detail: CaseDetail }) {
         <HoldBanner hold={detail.hold} autosend={detail.autosend} />
       )}
 
-      <Panel
-        title="What the drafter wrote"
-        subtitle={
-          draft.edited_body
-            ? 'The draft, and the edit that replaced it before sending.'
-            : 'Exactly as stored — plain text, which is what the user receives.'
-        }
-      >
-        <div className="p-4">
-          <p className="text-sm whitespace-pre-wrap text-base-content/85">
-            {draft.body || '(the drafting call produced no body)'}
-          </p>
-        </div>
-        {draft.edited_body && (
-          <div className="border-t border-base-300/40 p-4">
-            <p className="text-xs font-semibold tracking-wide text-base-content/45 uppercase">
-              Edited before sending
-            </p>
-            <p className="mt-1 text-sm whitespace-pre-wrap text-base-content/85">
-              {draft.edited_body}
+      {/* The draft as the model wrote it. The editable copy is above the
+          fold; this is the original, and it only earns its place once an
+          edit has replaced it. */}
+      {draft.edited_body && (
+        <Panel
+          title="What the drafter wrote"
+          subtitle="The original, before the edit that replaced it."
+        >
+          <div className="p-4">
+            <p className="max-w-[75ch] text-sm whitespace-pre-wrap text-base-content/85">
+              {draft.body || '(the drafting call produced no body)'}
             </p>
           </div>
-        )}
-      </Panel>
+        </Panel>
+      )}
 
       <Panel
         title="What it says it knows"
@@ -417,108 +466,18 @@ function Pipeline({ detail }: { detail: CaseDetail }) {
   )
 }
 
-// ── the case ──────────────────────────────────────────────────────
-
-function CaseView({
-  ticket,
-  reloadKey,
-}: {
-  ticket: string
-  reloadKey: number
-}) {
-  const getToken = useGetToken()
-  const [detail, setDetail] = useState<CaseDetail | null>(null)
-  const [error, setError] = useState<string | null>(null)
-
-  // reloadKey is bumped when a support event names this ticket. The panel is
-  // NOT blanked on a re-read — only on a change of ticket — so a reply landing
-  // while you are reading does not throw the page away and start again.
-  useEffect(() => {
-    let cancelled = false
-    setError(null)
-    adminApi
-      .supportCase(getToken, ticket)
-      .then((res) => !cancelled && setDetail(res))
-      .catch(
-        (err: unknown) =>
-          !cancelled &&
-          setError(
-            err instanceof Error
-              ? err.message
-              : 'That case could not be loaded.',
-          ),
-      )
-    return () => {
-      cancelled = true
-    }
-  }, [getToken, ticket, reloadKey])
-
-  useEffect(() => setDetail(null), [ticket])
-
-  if (error) {
-    return <p className="p-4 text-sm text-error">{error}</p>
-  }
-  if (!detail) {
-    return (
-      <div className="p-4">
-        <Loader2 className="size-5 animate-spin text-base-content/40" />
-      </div>
-    )
-  }
-
+/** What the model was told about them, plus what it was shown. */
+function TheEvidence({ detail }: { detail: CaseDetail }) {
   const ctx = detail.context
   const widgets = ctx.widgets ?? []
   const similar = detail.similar ?? []
 
   return (
-    <div className="space-y-6">
-      <header>
-        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <h1 className="text-xl font-bold">
-            {detail.subject || '(no subject)'}
-          </h1>
-          <span className="font-mono text-xs text-base-content/50">
-            #{detail.ticket_number}
-          </span>
-        </div>
-        <p className="mt-1 text-sm text-base-content/60">
-          {detail.user_email ?? 'no email on file'} · {detail.status}
-          {detail.category && ` · ${detail.category}`}
-          {detail.priority && ` · ${detail.priority}`} · opened{' '}
-          {new Date(detail.opened_at).toLocaleDateString()}
-        </p>
-        <p className="mt-2 text-sm text-base-content/70">
-          {detail.group_reason}
-        </p>
-        {detail.discord_url && (
-          <a
-            href={detail.discord_url}
-            target="_blank"
-            rel="noreferrer"
-            className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
-          >
-            <MessageSquare size={12} /> The Discord thread
-          </a>
-        )}
-      </header>
-
-      <Conversation detail={detail} />
-      <Pipeline detail={detail} />
-      <CaseActions detail={detail} onCase={setDetail} />
-
-      <section>
-        <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
-          Can we claim a fix?
-        </h2>
-        <div className="mt-2">
-          <FixCard fix={detail.fix} />
-        </div>
-      </section>
-
+    <div className="space-y-5">
       <Panel title="What the model was told about them" subtitle={ctx.note}>
         <div className="grid grid-cols-2 gap-px bg-base-300/40 sm:grid-cols-3">
           {[
-            ['Plan', ctx.tier],
+            ['Plan when it opened', ctx.tier],
             [
               'App version',
               ctx.app_version
@@ -561,6 +520,13 @@ function CaseView({
             </div>
           ))}
         </div>
+        {/* The plan above is tier_at_open — what the model was told on the day
+            — and the header carries the current one. Saying which is which is
+            the difference between a diagnostic and a contradiction. */}
+        <p className="border-t border-base-300/40 px-4 py-3 text-xs text-base-content/60">
+          This is the plan as the ticket recorded it when it opened. The badge
+          in the header is the subscription they are on now.
+        </p>
         {!ctx.has_diagnostics && (
           <p className="border-t border-base-300/40 px-4 py-3 text-xs text-base-content/60">
             No diagnostics were attached to this ticket, so the version, OS and
@@ -575,6 +541,15 @@ function CaseView({
           </p>
         )}
       </Panel>
+
+      <section>
+        <h3 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+          Can we claim a fix?
+        </h3>
+        <div className="mt-2">
+          <FixCard fix={detail.fix} />
+        </div>
+      </section>
 
       <Panel title="What it was shown" subtitle={detail.evidence_note}>
         {similar.length === 0 ? (
@@ -618,9 +593,434 @@ function CaseView({
   )
 }
 
+// ── the case ──────────────────────────────────────────────────────
+
+/**
+ * One case, above the fold.
+ *
+ * `compact` is the version that appears inside a person's history: the same
+ * case without its own header, because the person's name is already above it.
+ */
+function CaseBody({
+  detail,
+  onCase,
+  compact,
+}: {
+  detail: CaseDetail
+  onCase: (next: CaseDetail) => void
+  compact?: boolean
+}) {
+  const theirWords = lastUserMessage(detail.messages)
+  const chips = diagnosticsChips(detail.context)
+  const tone = dispositionTone(detail.draft?.disposition, detail.draft?.status)
+  const stopped = detail.draft?.disposition_reason || detail.group_reason
+
+  return (
+    <div className="space-y-5">
+      {/* Why it stopped, in one sentence, before anything else. The old page
+          made you read eight sections to find this out. */}
+      <div className={`rounded-xl px-4 py-3 ring-1 ${TONE_RING[tone]}`}>
+        <div className="flex gap-2.5">
+          {tone === 'stop' ? (
+            <AlertTriangle
+              size={17}
+              className="mt-0.5 shrink-0 text-error"
+              aria-hidden
+            />
+          ) : (
+            <HelpCircle
+              size={17}
+              className="mt-0.5 shrink-0 text-base-content/40"
+              aria-hidden
+            />
+          )}
+          <p className="max-w-[75ch] text-sm leading-relaxed">{stopped}</p>
+        </div>
+      </div>
+
+      {detail.hold && (
+        <HoldBanner hold={detail.hold} autosend={detail.autosend} />
+      )}
+
+      <section>
+        <h3 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
+          They wrote
+        </h3>
+        <p className="mt-2 max-w-[75ch] border-l-2 border-base-300 pl-4 text-sm leading-relaxed whitespace-pre-wrap text-base-content/85">
+          {theirWords ?? (
+            <span className="text-base-content/45 italic">
+              Nothing from the user is on record for this ticket. The case
+              database only carries messages the API saw or backfilled.
+            </span>
+          )}
+        </p>
+
+        {/* Three chips instead of a diagnostics blob taller than the sentence
+            above them. The blob is still here, one click down. */}
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {chips.map((chip) => (
+            <span
+              key={chip}
+              className="rounded-md bg-base-200 px-2 py-1 text-xs text-base-content/70"
+            >
+              {chip}
+            </span>
+          ))}
+          <span className="rounded-md bg-base-200 px-2 py-1 text-xs text-base-content/70">
+            Opened {new Date(detail.opened_at).toLocaleDateString()}
+          </span>
+          <details className="text-xs">
+            <summary className="min-h-11 cursor-pointer content-center px-1 text-base-content/50 hover:text-base-content">
+              Full diagnostics
+            </summary>
+            <pre className="mt-2 max-h-72 overflow-auto rounded-lg bg-base-200/50 p-3 text-xs whitespace-pre-wrap text-base-content/70 ring-1 ring-base-300/60">
+              {JSON.stringify(detail.context, null, 2)}
+            </pre>
+          </details>
+        </div>
+      </section>
+
+      <CaseActions detail={detail} onCase={onCase} />
+
+      {/* One disclosure, holding everything the old page shouted at once.
+          Nothing was removed; it moved one level down. */}
+      <details className="rounded-xl ring-1 ring-base-300/60">
+        <summary className="flex min-h-11 cursor-pointer items-center gap-2 px-4 text-sm font-medium text-base-content/70 hover:text-base-content">
+          <ChevronRight size={15} className="shrink-0" />
+          Why it decided this
+        </summary>
+        <div className="space-y-6 border-t border-base-300/40 p-4">
+          <Pipeline detail={detail} />
+          <Conversation detail={detail} />
+          <TheEvidence detail={detail} />
+          {!compact && detail.discord_url && (
+            <a
+              href={detail.discord_url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+            >
+              <MessageSquare size={12} /> The Discord thread
+            </a>
+          )}
+        </div>
+      </details>
+    </div>
+  )
+}
+
+/** Loads one case and renders it. Used by both the case and person views. */
+function useCase(ticket: string | null, reloadKey: number) {
+  const getToken = useGetToken()
+  const [detail, setDetail] = useState<CaseDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // The panel is NOT blanked on a re-read — only on a change of ticket — so a
+  // reply landing while you are reading does not throw the page away.
+  useEffect(() => setDetail(null), [ticket])
+
+  useEffect(() => {
+    if (!ticket) return
+    let cancelled = false
+    setError(null)
+    adminApi
+      .supportCase(getToken, ticket)
+      .then((res) => !cancelled && setDetail(res))
+      .catch(
+        (err: unknown) =>
+          !cancelled &&
+          setError(
+            err instanceof Error
+              ? err.message
+              : 'That case could not be loaded.',
+          ),
+      )
+    return () => {
+      cancelled = true
+    }
+  }, [getToken, ticket, reloadKey])
+
+  return { detail, error, setDetail }
+}
+
+function CaseView({
+  ticket,
+  reloadKey,
+}: {
+  ticket: string
+  reloadKey: number
+}) {
+  const { detail, error, setDetail } = useCase(ticket, reloadKey)
+
+  if (error) return <p className="p-4 text-sm text-error">{error}</p>
+  if (!detail) {
+    return (
+      <div className="p-4">
+        <Loader2 className="size-5 animate-spin text-base-content/40" />
+      </div>
+    )
+  }
+
+  const badge = planBadge(detail)
+
+  return (
+    <div className="space-y-5">
+      <header>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="font-mono text-xs text-base-content/45">
+            #{detail.ticket_number}
+          </span>
+          <span className="text-xs text-base-content/50">
+            {detail.user_email ?? 'no email on file'}
+          </span>
+          {badge ? (
+            <Pill tone={badge.paying ? 'paying' : 'neutral'}>
+              {badge.label}
+            </Pill>
+          ) : (
+            <span className="text-xs text-base-content/45 italic">
+              no account on file
+            </span>
+          )}
+        </div>
+        <h1 className="mt-1.5 text-xl font-bold tracking-tight sm:text-2xl">
+          {detail.subject || '(no subject)'}
+        </h1>
+      </header>
+      <CaseBody detail={detail} onCase={setDetail} />
+    </div>
+  )
+}
+
+// ── the person ────────────────────────────────────────────────────
+
+/**
+ * One person: who they are, then their threads newest first.
+ *
+ * The one needing action is open with its draft and buttons; the ones awaiting
+ * a reply are listed; the resolved ones are dimmed. That ordering is the whole
+ * argument for grouping — five rows shouting becomes one person with a
+ * history.
+ */
+function PersonView({
+  person,
+  rows,
+  reloadKey,
+  openTicket,
+  onOpenTicket,
+}: {
+  person: QueuePerson
+  rows: Array<QueueRow>
+  reloadKey: number
+  openTicket: string | null
+  onOpenTicket: (ticket: string | null) => void
+}) {
+  const mine = useMemo(() => {
+    const numbers = new Set(person.ticket_numbers ?? [])
+    return rows
+      .filter((r) => numbers.has(r.ticket_number))
+      .sort((a, b) => b.updated_at.localeCompare(a.updated_at))
+  }, [person, rows])
+
+  // The thread that opens by default is the one that needs a person. Anything
+  // else makes you click to find the only thing on the row that is asking for
+  // you.
+  const needsAction = mine.find((r) => r.group === 'needs_you')
+  const active = openTicket ?? needsAction?.ticket_number ?? null
+
+  const who = personTitle(person)
+  const badge = planBadge(person)
+  const firstWrote = mine.reduce<string | null>(
+    (min, r) => (min === null || r.opened_at < min ? r.opened_at : min),
+    null,
+  )
+
+  return (
+    <div className="space-y-5">
+      <header className="border-b border-base-300/50 pb-4">
+        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
+            {who.title}
+          </h1>
+          {badge ? (
+            <Pill tone={badge.paying ? 'paying' : 'neutral'}>
+              {badge.label}
+            </Pill>
+          ) : (
+            <span className="text-xs text-base-content/45 italic">
+              {person.plan_note ? 'no account' : 'no plan on file'}
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-sm text-base-content/55">
+          {[
+            who.subtitle,
+            mine.find((r) => r.os)?.os,
+            firstWrote &&
+              `first wrote ${new Date(firstWrote).toLocaleDateString()}`,
+            `${person.tickets} ${person.tickets === 1 ? 'ticket' : 'tickets'}${
+              person.handled > 0 ? `, ${person.handled} resolved` : ''
+            }`,
+          ]
+            .filter(Boolean)
+            .join(' · ')}
+        </p>
+        {person.plan_note && (
+          <p className="mt-1.5 max-w-[75ch] text-xs text-base-content/50">
+            {person.plan_note}
+          </p>
+        )}
+      </header>
+
+      <div className="divide-y divide-base-300/40">
+        {mine.map((r) => (
+          <Thread
+            key={r.ticket_number}
+            row={r}
+            open={active === r.ticket_number}
+            reloadKey={reloadKey}
+            onToggle={() =>
+              onOpenTicket(active === r.ticket_number ? null : r.ticket_number)
+            }
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** One of a person's threads. Open, it is the whole case view. */
+function Thread({
+  row,
+  open,
+  reloadKey,
+  onToggle,
+}: {
+  row: QueueRow
+  open: boolean
+  reloadKey: number
+  onToggle: () => void
+}) {
+  const { detail, error, setDetail } = useCase(
+    open ? row.ticket_number : null,
+    reloadKey,
+  )
+  const resolved = row.group === 'handled'
+
+  return (
+    <div className={`py-4 ${resolved && !open ? 'opacity-60' : ''}`}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex w-full cursor-pointer items-start gap-3 text-left"
+      >
+        <span className="w-14 shrink-0 pt-0.5 font-mono text-[11px] text-base-content/40">
+          #{row.ticket_number}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span
+              className={`text-sm ${open || row.group === 'needs_you' ? 'font-semibold' : 'font-medium'}`}
+            >
+              {row.subject || '(no subject)'}
+            </span>
+            {row.group === 'needs_you' ? (
+              <Pill tone="needs">needs you</Pill>
+            ) : resolved ? (
+              <Pill tone="done">resolved</Pill>
+            ) : (
+              <ProvenancePill
+                provenance={row.provenance}
+                label={row.provenance_label}
+              />
+            )}
+          </span>
+          <span className="mt-1 block text-xs text-base-content/50">
+            {row.group_reason}
+          </span>
+        </span>
+        <ChevronRight
+          size={15}
+          className={`mt-1 shrink-0 text-base-content/35 transition-transform ${open ? 'rotate-90' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="mt-4 pl-0 sm:pl-17">
+          {error && <p className="text-sm text-error">{error}</p>}
+          {!detail && !error && (
+            <Loader2 className="size-5 animate-spin text-base-content/40" />
+          )}
+          {detail && <CaseBody detail={detail} onCase={setDetail} compact />}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── the queue ─────────────────────────────────────────────────────
 
-function QueueItem({
+function PersonCard({
+  person,
+  active,
+  onSelect,
+}: {
+  person: QueuePerson
+  active: boolean
+  onSelect: () => void
+}) {
+  const who = personTitle(person)
+  const badge = planBadge(person)
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={active ? 'true' : undefined}
+      className={`w-full cursor-pointer rounded-xl px-3 py-2.5 text-left ring-1 transition-colors ${
+        active
+          ? 'bg-base-100 ring-2 ring-primary/60'
+          : 'bg-base-100 ring-base-300/60 hover:bg-base-200/50'
+      }`}
+    >
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span
+          className={`text-sm font-semibold ${who.known ? '' : 'text-base-content/70 italic'}`}
+        >
+          {who.title}
+        </span>
+        {badge && (
+          <Pill tone={badge.paying ? 'paying' : 'neutral'}>{badge.label}</Pill>
+        )}
+        {!badge && person.section === 'answered' && (
+          <ProvenancePill
+            provenance={person.provenance}
+            label={person.provenance_label}
+          />
+        )}
+      </div>
+      {who.subtitle && (
+        <p className="mt-0.5 truncate text-[11px] text-base-content/45">
+          {who.subtitle}
+        </p>
+      )}
+      <p className="mt-1 line-clamp-2 text-xs text-base-content/60">
+        {person.headline ?? 'No ticket on record'}
+        {person.needs_you > 0 && (
+          <>
+            {' · '}
+            <span className="font-semibold text-error">needs you</span>
+          </>
+        )}
+      </p>
+      <p className="mt-1 text-[11px] text-base-content/45">
+        {personMeta(person)}
+      </p>
+    </button>
+  )
+}
+
+function TicketCard({
   row,
   active,
   onSelect,
@@ -636,8 +1036,11 @@ function QueueItem({
     <button
       type="button"
       onClick={onSelect}
-      className={`w-full cursor-pointer border-b border-base-300/40 px-3 py-2.5 text-left transition-colors last:border-0 ${
-        active ? 'bg-base-200' : 'hover:bg-base-200/50'
+      aria-current={active ? 'true' : undefined}
+      className={`w-full cursor-pointer rounded-xl px-3 py-2.5 text-left ring-1 transition-colors ${
+        active
+          ? 'bg-base-100 ring-2 ring-primary/60'
+          : 'bg-base-100 ring-base-300/60 hover:bg-base-200/50'
       }`}
     >
       <div className="flex items-baseline justify-between gap-2">
@@ -649,8 +1052,7 @@ function QueueItem({
         </span>
       </div>
       <p className="mt-0.5 truncate text-xs text-base-content/55">
-        {row.user_email ?? 'no email'}
-        {row.category && ` · ${row.category}`}
+        {row.name || row.user_email || 'no account on this ticket'}
         {' · '}
         {wait ? `waiting ${wait}` : 'wait unknown'}
       </p>
@@ -659,40 +1061,138 @@ function QueueItem({
       </p>
       <div className="mt-1 flex flex-wrap gap-1.5">
         {countdown.display && (
-          <span className="rounded bg-warning/15 px-1.5 py-0.5 text-[11px] font-medium text-warning-content/90 ring-1 ring-warning/30">
-            sends in {countdown.display}
-          </span>
+          <Pill tone="needs">sends in {countdown.display}</Pill>
         )}
-        {row.disposition === 'escalate' && (
-          <span className="rounded bg-error/10 px-1.5 py-0.5 text-[11px] font-medium ring-1 ring-error/30">
-            escalated
-          </span>
-        )}
-        {badge && (
-          <span className="rounded bg-base-200 px-1.5 py-0.5 text-[11px] text-base-content/60">
-            {badge}
-          </span>
-        )}
+        <ProvenancePill
+          provenance={row.provenance}
+          label={row.provenance_label}
+        />
+        {badge && <Pill>{badge}</Pill>}
       </div>
     </button>
   )
 }
 
+/**
+ * The three sort controls: a field, a direction of its own, and what a row is.
+ *
+ * The direction is a button rather than another menu entry so reversing never
+ * costs a trip through a dropdown — that is the whole complaint the "one sort
+ * control" mockup was rejected over.
+ */
+function SortBar({
+  sort,
+  dir,
+  rowsMode,
+  search,
+  onSort,
+  onDir,
+  onRowsMode,
+  onSearch,
+}: {
+  sort: QueueSort
+  dir: QueueDir
+  rowsMode: QueueRowsMode
+  search: string
+  onSort: (s: QueueSort) => void
+  onDir: (d: QueueDir) => void
+  onRowsMode: (m: QueueRowsMode) => void
+  onSearch: (q: string) => void
+}) {
+  return (
+    <div className="space-y-2">
+      <label className="flex min-h-11 items-center gap-2 rounded-lg bg-base-100 px-3 ring-1 ring-base-300/60 focus-within:ring-2 focus-within:ring-primary/50">
+        <Search size={15} className="shrink-0 text-base-content/40" />
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => onSearch(e.target.value)}
+          placeholder="Search people and tickets"
+          aria-label="Search people and tickets"
+          className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+        />
+      </label>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-stretch overflow-hidden rounded-lg ring-1 ring-base-300/60">
+          <select
+            value={sort}
+            onChange={(e) => onSort(e.target.value as QueueSort)}
+            aria-label="Sort by"
+            className="min-h-11 cursor-pointer bg-base-100 px-2.5 text-xs font-medium outline-none focus:ring-2 focus:ring-primary/50"
+          >
+            {SORT_FIELDS.map((f) => (
+              <option key={f.key} value={f.key}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+          {/* Its own button. Reversing is one click, both ways. */}
+          <button
+            type="button"
+            onClick={() => onDir(dir === 'asc' ? 'desc' : 'asc')}
+            title={directionLabel(sort, dir)}
+            aria-label={`Direction: ${directionLabel(sort, dir)}`}
+            className="min-h-11 cursor-pointer border-l border-base-300/60 bg-base-100 px-2.5 hover:bg-base-200/60"
+          >
+            {dir === 'asc' ? <ArrowUp size={14} /> : <ArrowDown size={14} />}
+          </button>
+        </div>
+
+        <select
+          value={rowsMode}
+          onChange={(e) => onRowsMode(e.target.value as QueueRowsMode)}
+          aria-label="What a row is"
+          className="min-h-11 cursor-pointer rounded-lg bg-base-100 px-2.5 text-xs font-medium ring-1 ring-base-300/60 outline-none focus:ring-2 focus:ring-primary/50"
+        >
+          <option value="person">By person</option>
+          <option value="ticket">By ticket</option>
+        </select>
+      </div>
+      <p className="px-0.5 text-[11px] text-base-content/40">
+        {directionLabel(sort, dir)} — inside each section. Sections never
+        reorder.
+      </p>
+    </div>
+  )
+}
+
+const SECTION_STYLE: Record<QueueSection, string> = {
+  paying: 'text-success',
+  open: 'text-error',
+  answered: 'text-base-content/55',
+  resolved: 'text-base-content/45',
+}
+
 export default function SupportPage() {
   const getToken = useGetToken()
-  const [filter, setFilter] = useState<QueueGroup | 'all'>('all')
+  const [sort, setSort] = useState<QueueSort>('last_wrote')
+  const [dir, setDir] = useState<QueueDir>('desc')
+  const [rowsMode, setRowsMode] = useState<QueueRowsMode>('person')
+  const [search, setSearch] = useState('')
+  const [debounced, setDebounced] = useState('')
+
   const [queue, setQueue] = useState<SupportQueue | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [selected, setSelected] = useState<string | null>(null)
+  const [selectedPerson, setSelectedPerson] = useState<string | null>(null)
+  const [selectedTicket, setSelectedTicket] = useState<string | null>(null)
   const [live, setLive] = useState(false)
   const [queueKey, setQueueKey] = useState(0)
   const [caseKey, setCaseKey] = useState(0)
   const [switching, setSwitching] = useState(false)
+  const [showResolved, setShowResolved] = useState(false)
+
+  // The search is a server round trip, so it waits for a pause in typing
+  // rather than firing a query per keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search), 250)
+    return () => clearTimeout(t)
+  }, [search])
 
   const load = useCallback(() => {
     let cancelled = false
     adminApi
-      .supportQueue(getToken, filter)
+      .supportQueue(getToken, { sort, dir, rows: rowsMode, q: debounced })
       .then((res) => !cancelled && setQueue(res))
       .catch(
         (err: unknown) =>
@@ -706,27 +1206,39 @@ export default function SupportPage() {
     return () => {
       cancelled = true
     }
-  }, [getToken, filter, queueKey])
+  }, [getToken, sort, dir, rowsMode, debounced, queueKey])
 
   useEffect(() => load(), [load])
 
-  // The open ticket lives in a ref so the subscription below never has to be
-  // torn down and rebuilt when the selection changes — reconnecting the stream
-  // on every click would drop events in the gap.
-  const selectedRef = useRef<string | null>(null)
-  selectedRef.current = selected
+  // The open row lives in a ref so the subscription below never has to be torn
+  // down and rebuilt when the selection changes — reconnecting the stream on
+  // every click would drop events in the gap.
+  const openRef = useRef<Array<string>>([])
+  const rows = useMemo(() => queue?.rows ?? [], [queue])
+  const people = useMemo(() => queue?.people ?? [], [queue])
+
+  const person = useMemo(
+    () => people.find((p) => p.key === selectedPerson) ?? null,
+    [people, selectedPerson],
+  )
+  openRef.current = person
+    ? (person.ticket_numbers ?? [])
+    : selectedTicket
+      ? [selectedTicket]
+      : []
 
   useEffect(() => {
     return subscribeToSupportEvents(
       getToken,
       (event) => {
-        // Every event moves the queue: a group, a countdown or a row. The open
-        // case is re-read only when the event is about it, or about the
-        // pipeline switch, which changes what every countdown means.
+        // Every event moves the queue: a section, a countdown or a row. The
+        // open case is re-read only when the event is about something on
+        // screen, or about the pipeline switch, which changes what every
+        // countdown means.
         setQueueKey((n) => n + 1)
         if (
           !event.ticket_number ||
-          event.ticket_number === selectedRef.current
+          openRef.current.includes(event.ticket_number)
         ) {
           setCaseKey((n) => n + 1)
         }
@@ -752,19 +1264,25 @@ export default function SupportPage() {
     }
   }
 
-  const rows = queue?.rows ?? []
-  const groups = QUEUE_GROUPS.filter(
-    (g) => filter === 'all' || g.key === filter,
-  )
+  const selected = rowsMode === 'person' ? selectedPerson : selectedTicket
+  const back = () => {
+    setSelectedPerson(null)
+    setSelectedTicket(null)
+  }
+  const needsYou = queue?.counts.needs_you ?? 0
 
   return (
-    <div className="space-y-5">
-      <header>
-        <h1 className="text-2xl font-bold tracking-tight">Support</h1>
-        <p className="mt-1 text-sm text-base-content/60">
-          Every verb here is the same function the Discord buttons call. Send is
-          the only one that cannot be undone, and the only one that asks twice.
-        </p>
+    <div className="space-y-4">
+      {/* On a phone the header is the queue's header, and it steps aside once
+          a person is open so the whole viewport is the thing you came to
+          read. */}
+      <header className={selected ? 'hidden md:block' : ''}>
+        <div className="flex flex-wrap items-baseline gap-x-3">
+          <h1 className="text-2xl font-bold tracking-tight">Support</h1>
+          <span className="text-sm text-base-content/50">
+            {needsYou === 1 ? '1 needs you' : `${needsYou} need you`}
+          </span>
+        </div>
         {queue && (
           <div
             className={`mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg px-3 py-2 ring-1 ${
@@ -774,15 +1292,13 @@ export default function SupportPage() {
             }`}
           >
             <p className="text-xs">{queue.autosend.note}</p>
-            {/* Pause and resume, the same switch /pause and /resume throw.
-                Un-demoting a category stays a Discord command: that is a
-                judgement about a class of tickets, not a button beside one. */}
+            {/* Pause and resume, the same switch /pause and /resume throw. */}
             {queue.autosend.enabled && (
               <button
                 type="button"
                 onClick={toggleAutoSend}
                 disabled={switching}
-                className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-base-100 px-2.5 py-1 text-xs font-medium ring-1 ring-base-300/60 hover:bg-base-200/60 disabled:opacity-50"
+                className="inline-flex min-h-11 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-base-100 px-3 text-xs font-medium ring-1 ring-base-300/60 hover:bg-base-200/60 disabled:opacity-50"
               >
                 {switching ? (
                   <Loader2 size={12} className="animate-spin" />
@@ -813,82 +1329,147 @@ export default function SupportPage() {
       )}
 
       {queue && (
-        <div className="flex flex-col gap-6 lg:flex-row">
-          <div className="lg:w-[22rem] lg:shrink-0">
-            <div className="flex flex-wrap gap-1 pb-1">
-              {(['all', ...QUEUE_GROUPS.map((g) => g.key)] as const).map(
-                (key) => (
-                  <button
-                    key={key}
-                    type="button"
-                    onClick={() => setFilter(key)}
-                    className={`cursor-pointer rounded-lg px-2.5 py-1.5 text-xs font-medium whitespace-nowrap transition-colors ${
-                      filter === key
-                        ? 'bg-base-200 text-base-content'
-                        : 'text-base-content/60 hover:bg-base-200/60'
-                    }`}
-                  >
-                    {key === 'all'
-                      ? 'Everything'
-                      : QUEUE_GROUPS.find((g) => g.key === key)?.label}
-                    {key !== 'all' && (
-                      <span className="ml-1 tabular-nums text-base-content/45">
-                        {queue.counts[key] ?? 0}
-                      </span>
-                    )}
-                  </button>
-                ),
-              )}
-            </div>
+        <div className="flex flex-col gap-5 md:flex-row md:gap-5 lg:gap-8">
+          {/* Under 768px the queue IS the page; picking someone pushes their
+              view over it and the back control returns. From 768 up the two
+              panes sit side by side, with the queue narrowed. */}
+          <div
+            className={`min-w-0 md:w-64 md:shrink-0 lg:w-80 xl:w-96 ${
+              selected ? 'hidden md:block' : 'block'
+            }`}
+          >
+            <SortBar
+              sort={sort}
+              dir={dir}
+              rowsMode={rowsMode}
+              search={search}
+              onSort={(s) => setSort(s)}
+              onDir={(d) => setDir(d)}
+              onRowsMode={(m) => {
+                setRowsMode(m)
+                back()
+              }}
+              onSearch={setSearch}
+            />
 
-            <div className="mt-3 space-y-5">
-              {groups.map((group) => {
-                const items = rows.filter((r) => r.group === group.key)
+            <div className="mt-4 space-y-5">
+              {QUEUE_SECTIONS.map((section) => {
+                const count = queue.sections[section.key] ?? 0
+                const inSection =
+                  rowsMode === 'person'
+                    ? people.filter((p) => p.section === section.key)
+                    : rows.filter((r) => r.section === section.key)
+
+                // Resolved is a count that opens. Forty-six closed tickets are
+                // not what anybody came here to read.
+                const collapsed = section.key === 'resolved' && !showResolved
+
                 return (
-                  <section key={group.key}>
-                    <h2 className="text-xs font-semibold tracking-wide text-base-content/50 uppercase">
-                      {group.label}{' '}
-                      <span className="tabular-nums text-base-content/40">
-                        {queue.counts[group.key] ?? 0}
+                  <section key={section.key}>
+                    <div className="flex items-center gap-2 px-1 pb-2">
+                      {section.key === 'paying' && (
+                        <Star size={13} className="shrink-0 text-success" />
+                      )}
+                      <h2
+                        className={`text-[11px] font-bold tracking-wider uppercase ${SECTION_STYLE[section.key]}`}
+                      >
+                        {section.label}
+                      </h2>
+                      <span className="ml-auto text-[11px] tabular-nums text-base-content/40">
+                        {section.key === 'paying' && queue.accounts.paying > 0
+                          ? `${rowsMode === 'person' ? count : inSection.length} of ${queue.accounts.paying} paying`
+                          : rowsMode === 'person'
+                            ? count
+                            : inSection.length}
                       </span>
-                    </h2>
-                    <p className="mt-0.5 text-xs text-base-content/45">
-                      {group.blurb}
-                    </p>
-                    <div className="mt-2 overflow-hidden rounded-xl ring-1 ring-base-300/60">
-                      {items.length === 0 ? (
-                        <p className="p-4 text-sm text-base-content/50">
-                          {group.key === 'needs_you'
-                            ? 'Nothing is waiting on you.'
-                            : group.key === 'waiting'
-                              ? 'Nobody owes us a reply.'
-                              : 'Nothing has been handled yet.'}
-                        </p>
-                      ) : (
-                        items.map((row) => (
-                          <QueueItem
-                            key={row.ticket_number}
-                            row={row}
-                            active={selected === row.ticket_number}
-                            onSelect={() => setSelected(row.ticket_number)}
+                      {section.key === 'resolved' && (
+                        <button
+                          type="button"
+                          onClick={() => setShowResolved((v) => !v)}
+                          aria-expanded={showResolved}
+                          className="cursor-pointer text-base-content/40 hover:text-base-content"
+                        >
+                          <ChevronRight
+                            size={14}
+                            className={`transition-transform ${showResolved ? 'rotate-90' : ''}`}
                           />
-                        ))
+                        </button>
                       )}
                     </div>
+
+                    {!collapsed && (
+                      <div className="flex flex-col gap-2">
+                        {inSection.length === 0 ? (
+                          /* An empty paying section is a fact about the data,
+                             not a blank box: almost no ticket is joined to an
+                             account, and the server says so in a sentence. */
+                          <p className="px-1 text-xs text-base-content/45">
+                            {section.key === 'paying'
+                              ? queue.accounts.note || section.empty
+                              : section.empty}
+                          </p>
+                        ) : rowsMode === 'person' ? (
+                          (inSection as Array<QueuePerson>).map((p) => (
+                            <PersonCard
+                              key={p.key}
+                              person={p}
+                              active={selectedPerson === p.key}
+                              onSelect={() => {
+                                setSelectedPerson(p.key)
+                                setSelectedTicket(null)
+                              }}
+                            />
+                          ))
+                        ) : (
+                          (inSection as Array<QueueRow>).map((r) => (
+                            <TicketCard
+                              key={r.ticket_number}
+                              row={r}
+                              active={selectedTicket === r.ticket_number}
+                              onSelect={() => {
+                                setSelectedTicket(r.ticket_number)
+                                setSelectedPerson(null)
+                              }}
+                            />
+                          ))
+                        )}
+                      </div>
+                    )}
                   </section>
                 )
               })}
             </div>
           </div>
 
-          <div className="min-w-0 flex-1">
-            {selected ? (
-              <CaseView ticket={selected} reloadKey={caseKey} />
+          <div
+            className={`min-w-0 flex-1 ${selected ? 'block' : 'hidden md:block'}`}
+          >
+            {selected && (
+              <button
+                type="button"
+                onClick={back}
+                className="mb-3 inline-flex min-h-11 cursor-pointer items-center gap-1.5 text-sm font-medium text-base-content/70 hover:text-base-content md:hidden"
+              >
+                <ArrowLeft size={16} /> All of support
+              </button>
+            )}
+
+            {rowsMode === 'person' && person ? (
+              <PersonView
+                person={person}
+                rows={rows}
+                reloadKey={caseKey}
+                openTicket={selectedTicket}
+                onOpenTicket={setSelectedTicket}
+              />
+            ) : rowsMode === 'ticket' && selectedTicket ? (
+              <CaseView ticket={selectedTicket} reloadKey={caseKey} />
             ) : (
               <div className="rounded-xl bg-base-200/30 px-6 py-16 text-center ring-1 ring-base-300/60">
-                <p className="text-sm text-base-content/60">
-                  Pick a case. The conversation reads top to bottom, and what
-                  the pipeline decided about it sits underneath.
+                <p className="mx-auto max-w-[50ch] text-sm text-base-content/60">
+                  Pick someone. Their identity and history come first, then
+                  their threads newest first — the one needing an answer open
+                  with its draft, the rest underneath.
                 </p>
               </div>
             )}

--- a/myscrollr.com/src/lib/supportConsole.test.ts
+++ b/myscrollr.com/src/lib/supportConsole.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  QUEUE_SECTIONS,
+  diagnosticsChips,
+  directionLabel,
   dispositionTone,
   fixBadge,
   formatDuration,
@@ -7,9 +10,32 @@ import {
   groupLabel,
   holdCountdown,
   isUnchanged,
+  lastUserMessage,
   lineDiff,
+  personMeta,
+  personTitle,
+  planBadge,
+  planLabel,
+  relativeAge,
 } from './supportConsole'
-import type { AdminHold } from '@/api/admin'
+import type { AdminHold, QueuePerson } from '@/api/admin'
+
+function person(over: Partial<QueuePerson> = {}): QueuePerson {
+  return {
+    key: 'r_armstrong@me.com',
+    email: 'r_armstrong@me.com',
+    name: 'Rachel Armstrong',
+    paying: false,
+    section: 'open',
+    tickets: 5,
+    needs_you: 1,
+    waiting: 2,
+    handled: 2,
+    waiting_hours: { value: 288, available: true },
+    ticket_numbers: ['752473'],
+    ...over,
+  }
+}
 
 const NOW = Date.parse('2026-09-09T12:18:00Z')
 
@@ -170,5 +196,177 @@ describe('lineDiff', () => {
 
   it('reports a wholly rewritten reply as changed', () => {
     expect(isUnchanged('the draft', 'something else entirely')).toBe(false)
+  })
+})
+
+// ── REL-266: people, sections and the sort controls ───────────────
+
+describe('QUEUE_SECTIONS', () => {
+  // The order is the whole design. Paying customers lead because priority
+  // support is something we sold, and no sort a reader picks may move it.
+  it('reads paying, open, answered, resolved and nothing else', () => {
+    expect(QUEUE_SECTIONS.map((s) => s.key)).toEqual([
+      'paying',
+      'open',
+      'answered',
+      'resolved',
+    ])
+  })
+})
+
+describe('planBadge', () => {
+  // "Free" and "nobody is behind this ticket" are different facts. #819835
+  // arrived anonymously from the marketing site, and badging it Free would
+  // invent an account for a stranger.
+  it('is nothing at all when there is no account behind the ticket', () => {
+    expect(planBadge({ paying: false })).toBeNull()
+    expect(planBadge({ plan: '  ', paying: false })).toBeNull()
+  })
+
+  it('says which plan, and whether it is a paying one', () => {
+    expect(planBadge({ plan: 'free', paying: false })).toEqual({
+      label: 'Free',
+      paying: false,
+    })
+    expect(planBadge({ plan: 'uplink_ultimate', paying: true })).toEqual({
+      label: 'Uplink Ultimate',
+      paying: true,
+    })
+  })
+})
+
+describe('planLabel', () => {
+  it('turns a column value into something to show a person', () => {
+    expect(planLabel('uplink_ultimate')).toBe('Uplink Ultimate')
+    expect(planLabel('uplink')).toBe('Uplink')
+    // An unknown plan is title-cased rather than printed raw or dropped.
+    expect(planLabel('team_annual')).toBe('Team Annual')
+  })
+})
+
+describe('personTitle', () => {
+  it('prefers the name, falls back to the email', () => {
+    expect(
+      personTitle({ name: 'Rachel Armstrong', email: 'r@me.com' }),
+    ).toEqual({ title: 'Rachel Armstrong', subtitle: 'r@me.com', known: true })
+    expect(personTitle({ email: 'r@me.com' })).toEqual({
+      title: 'r@me.com',
+      subtitle: null,
+      known: true,
+    })
+  })
+
+  // The one that matters: an unknown person must read as an unknown person,
+  // never as somebody called "Anonymous".
+  it('says there is no account rather than inventing a name', () => {
+    const who = personTitle({})
+    expect(who.known).toBe(false)
+    expect(who.title).toBe('No account on this ticket')
+    expect(who.title.toLowerCase()).not.toContain('anonymous')
+  })
+})
+
+describe('relativeAge', () => {
+  it('is null when there is no timestamp, so never never reads as recent', () => {
+    expect(relativeAge(undefined)).toBeNull()
+    expect(relativeAge('not a date')).toBeNull()
+  })
+
+  it('scales from minutes to months', () => {
+    const now = Date.parse('2026-09-09T12:00:00Z')
+    expect(relativeAge('2026-09-09T11:56:00Z', now)).toBe('4 minutes ago')
+    expect(relativeAge('2026-09-09T08:00:00Z', now)).toBe('4 hours ago')
+    expect(relativeAge('2026-09-09T11:00:00Z', now)).toBe('1 hour ago')
+    expect(relativeAge('2026-08-27T12:00:00Z', now)).toBe('13 days ago')
+    expect(relativeAge('2026-05-29T12:00:00Z', now)).toBe('3 months ago')
+  })
+})
+
+describe('personMeta', () => {
+  it('counts one ticket without an s', () => {
+    expect(personMeta(person({ tickets: 1 }))).toContain('1 ticket ')
+    expect(personMeta(person({ tickets: 5 }))).toContain('5 tickets')
+  })
+
+  it('says nothing about a wait it does not know', () => {
+    const line = personMeta(
+      person({ waiting_hours: { value: 0, available: false } }),
+    )
+    expect(line).toContain('never wrote in')
+    expect(line).not.toContain('0h')
+  })
+
+  // The bug this test exists for: waiting_hours is the LONGEST wait across
+  // someone's tickets, which is what the "longest waiting" sort reads. Under a
+  // label saying "last wrote", it told a reader that a customer whose open
+  // ticket was four hours old had last written forty days ago.
+  it('reads "last wrote" from when they last wrote, not from the longest wait', () => {
+    const now = Date.parse('2026-09-09T12:00:00Z')
+    const line = personMeta(
+      person({
+        tickets: 2,
+        last_user_message_at: '2026-09-09T08:00:00Z',
+        waiting_hours: { value: 960, available: true },
+      }),
+      now,
+    )
+    expect(line).toContain('last wrote 4 hours ago')
+    expect(line).not.toContain('40 days')
+  })
+
+  it('notes when everything of theirs is closed', () => {
+    expect(
+      personMeta(person({ tickets: 3, needs_you: 0, waiting: 0, handled: 3 })),
+    ).toContain('all resolved')
+  })
+})
+
+describe('directionLabel', () => {
+  // "Ascending" is a word about arrays. The button says what it will do.
+  it('says what the direction means for the field chosen', () => {
+    expect(directionLabel('waiting', 'desc')).toBe('Longest waiting first')
+    expect(directionLabel('waiting', 'asc')).toBe('Shortest wait first')
+    expect(directionLabel('last_wrote', 'desc')).toBe('Newest first')
+    expect(directionLabel('name', 'asc')).toBe('A to Z')
+    expect(directionLabel('plan', 'desc')).toBe('Paying first')
+  })
+})
+
+describe('diagnosticsChips', () => {
+  it('names what it does not know instead of dropping the chip', () => {
+    expect(diagnosticsChips({ version_state: 'unknown' })).toEqual([
+      'OS unknown',
+      'Version unknown',
+    ])
+  })
+
+  it('carries the version comparison the server made', () => {
+    expect(
+      diagnosticsChips({
+        os: 'Linux · AppImage',
+        app_version: '1.5.0',
+        current_version: '1.6.1',
+        version_state: 'behind',
+      }),
+    ).toEqual(['Linux · AppImage', '1.5.0 · behind 1.6.1'])
+  })
+})
+
+describe('lastUserMessage', () => {
+  it('is their most recent words, not ours and not a draft', () => {
+    expect(
+      lastUserMessage([
+        { kind: 'user', body: 'first' },
+        { kind: 'sent', body: 'our reply' },
+        { kind: 'user', body: 'still broken' },
+        { kind: 'ai_draft', body: 'a draft nobody sent' },
+      ]),
+    ).toBe('still broken')
+  })
+
+  it('is null when they are not on record, rather than an empty quote', () => {
+    expect(lastUserMessage([])).toBeNull()
+    expect(lastUserMessage(null)).toBeNull()
+    expect(lastUserMessage([{ kind: 'user', body: '   ' }])).toBeNull()
   })
 })

--- a/myscrollr.com/src/lib/supportConsole.ts
+++ b/myscrollr.com/src/lib/supportConsole.ts
@@ -13,7 +13,15 @@
  * formats them and never recomputes them.
  */
 
-import type { AdminHold, Measured, QueueGroup } from '@/api/admin'
+import type {
+  AdminHold,
+  Measured,
+  QueueDir,
+  QueueGroup,
+  QueuePerson,
+  QueueSection,
+  QueueSort,
+} from '@/api/admin'
 
 /** The three columns, in the order a person should read them. */
 export const QUEUE_GROUPS: Array<{
@@ -42,6 +50,166 @@ export const QUEUE_GROUPS: Array<{
 
 export function groupLabel(group: string): string {
   return QUEUE_GROUPS.find((g) => g.key === group)?.label ?? group
+}
+
+/**
+ * The four sections, in the order a person reads them (REL-266).
+ *
+ * The order is fixed here and never derived from a sort. Paying customers lead
+ * because priority support is a thing we sold; letting a sort key move that
+ * section would sell it back.
+ */
+export const QUEUE_SECTIONS: Array<{
+  key: QueueSection
+  label: string
+  empty: string
+}> = [
+  {
+    key: 'paying',
+    label: 'Paying customers',
+    empty: 'No paying customer has written in.',
+  },
+  { key: 'open', label: 'Open', empty: 'Nothing is waiting on you.' },
+  {
+    key: 'answered',
+    label: 'Answered, waiting on them',
+    empty: 'Nobody owes us a reply.',
+  },
+  { key: 'resolved', label: 'Resolved', empty: 'Nothing has been closed yet.' },
+]
+
+/** The sort fields, with the words the menu shows for them. */
+export const SORT_FIELDS: Array<{ key: QueueSort; label: string }> = [
+  { key: 'last_wrote', label: 'Last wrote' },
+  { key: 'waiting', label: 'Longest waiting' },
+  { key: 'tickets', label: 'Most tickets' },
+  { key: 'plan', label: 'Plan' },
+  { key: 'name', label: 'Name' },
+]
+
+/**
+ * What the direction button means for the field currently chosen.
+ *
+ * "Ascending" is a word about arrays, not about people. Every field gets the
+ * sentence a reader would actually say, so the button can be labelled with
+ * what it will do rather than with a compass direction.
+ */
+export function directionLabel(sort: QueueSort, dir: QueueDir): string {
+  const words: Record<QueueSort, [string, string]> = {
+    last_wrote: ['Oldest first', 'Newest first'],
+    waiting: ['Shortest wait first', 'Longest waiting first'],
+    tickets: ['Fewest tickets first', 'Most tickets first'],
+    plan: ['Free first', 'Paying first'],
+    name: ['A to Z', 'Z to A'],
+  }
+  return words[sort][dir === 'asc' ? 0 : 1]
+}
+
+/**
+ * One line under a person's name: how many tickets, and when they last wrote.
+ *
+ * Deliberately says "1 ticket" rather than "1 tickets", and says nothing at
+ * all about a wait it does not know — the server marks that unavailable and a
+ * person with no message on record has not been waiting no time.
+ */
+export function personMeta(
+  person: QueuePerson,
+  now: number = Date.now(),
+): string {
+  const parts = [
+    person.tickets === 1 ? '1 ticket' : `${person.tickets} tickets`,
+  ]
+  // From the timestamp, not from `waiting_hours`. The wait is the LONGEST any
+  // of their tickets has waited, which is what "longest waiting" sorts on; it
+  // is not when they last wrote, and printing one under the other's label
+  // told a reader Dana last wrote 40 days ago while her open ticket was four
+  // hours old.
+  const wrote = relativeAge(person.last_user_message_at, now)
+  if (wrote) parts.push(`last wrote ${wrote}`)
+  else parts.push('never wrote in')
+  if (person.needs_you === 0 && person.handled === person.tickets) {
+    parts.push('all resolved')
+  }
+  return parts.join(' · ')
+}
+
+/**
+ * "4 hours ago" / "13 days ago" / "just now". Null when there is no timestamp,
+ * because "never" and "a moment ago" must not render the same.
+ */
+export function relativeAge(
+  iso: string | null | undefined,
+  now: number = Date.now(),
+): string | null {
+  if (!iso) return null
+  const then = Date.parse(iso)
+  if (Number.isNaN(then)) return null
+  const mins = Math.round((now - then) / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins} ${mins === 1 ? 'minute' : 'minutes'} ago`
+  const hours = Math.round(mins / 60)
+  if (hours < 24) return `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`
+  const days = Math.round(hours / 24)
+  if (days < 30) return `${days} ${days === 1 ? 'day' : 'days'} ago`
+  const months = Math.round(days / 30)
+  return `${months} ${months === 1 ? 'month' : 'months'} ago`
+}
+
+/**
+ * The plan badge, or nothing.
+ *
+ * Returns null rather than "Free" when there is no account behind the ticket,
+ * because "this person is on the free plan" and "nobody is behind this ticket"
+ * are different facts and a badge that conflates them invents an account.
+ */
+export function planBadge(person: {
+  plan?: string
+  paying: boolean
+}): { label: string; paying: boolean } | null {
+  const plan = person.plan?.trim()
+  if (!plan) return null
+  return { label: planLabel(plan), paying: person.paying }
+}
+
+/** `uplink_ultimate` is a column value, not something to show a person. */
+export function planLabel(plan: string): string {
+  const known: Record<string, string> = {
+    free: 'Free',
+    uplink: 'Uplink',
+    uplink_pro: 'Uplink Pro',
+    uplink_ultimate: 'Uplink Ultimate',
+  }
+  const key = plan.trim().toLowerCase()
+  return (
+    known[key] ??
+    key
+      .split(/[_\s-]+/)
+      .filter(Boolean)
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ')
+  )
+}
+
+/**
+ * How to name someone we may not know the name of.
+ *
+ * #819835 arrived from the marketing site with no account behind it. It has to
+ * read as exactly that, and never as a person called "Anonymous User".
+ */
+export function personTitle(person: { name?: string; email?: string }): {
+  title: string
+  subtitle: string | null
+  known: boolean
+} {
+  const name = person.name?.trim()
+  const email = person.email?.trim()
+  if (name) return { title: name, subtitle: email ?? null, known: true }
+  if (email) return { title: email, subtitle: null, known: true }
+  return {
+    title: 'No account on this ticket',
+    subtitle: 'it arrived without a signed-in user',
+    known: false,
+  }
 }
 
 /**
@@ -211,4 +379,47 @@ const NEWLINE = '\n'
 /** True when the edit changed nothing worth showing. */
 export function isUnchanged(before: string, after: string): boolean {
   return lineDiff(before, after).every((l) => l.kind === 'kept')
+}
+
+/**
+ * The reporter's most recent words — what an answer has to answer.
+ *
+ * This is the top of the case view now (REL-266). The old page opened with the
+ * whole conversation, the whole pipeline and a diagnostics blob taller than
+ * the sentence a person actually wrote; their words come first because they
+ * are the only part nobody can regenerate.
+ */
+export function lastUserMessage(
+  messages: Array<{ kind: string; body: string }> | null | undefined,
+): string | null {
+  const all = messages ?? []
+  for (let i = all.length - 1; i >= 0; i--) {
+    if (all[i].kind === 'user' && all[i].body.trim() !== '') return all[i].body
+  }
+  return null
+}
+
+/**
+ * The three chips that replace the diagnostics blob.
+ *
+ * Everything they summarise is still one click away under "Full diagnostics" —
+ * moved down a level, never deleted. Each chip says "unknown" out loud rather
+ * than disappearing, because a missing OS is itself a thing to know about a
+ * bug report.
+ */
+export function diagnosticsChips(ctx: {
+  os?: string
+  app_version?: string
+  current_version?: string
+  version_state: 'unknown' | 'behind' | 'current'
+}): Array<string> {
+  const version =
+    ctx.app_version && ctx.app_version.trim() !== ''
+      ? ctx.version_state === 'behind' && ctx.current_version
+        ? `${ctx.app_version} · behind ${ctx.current_version}`
+        : ctx.version_state === 'current'
+          ? `${ctx.app_version} · current`
+          : ctx.app_version
+      : 'Version unknown'
+  return [ctx.os?.trim() || 'OS unknown', version]
 }

--- a/myscrollr.com/src/routes/__root.tsx
+++ b/myscrollr.com/src/routes/__root.tsx
@@ -150,6 +150,11 @@ const DEMO_BAR_EXCLUDED = [
   '/callback',
   '/u/',
   '/business',
+  // The staff console is a tool, not a shop window. A demo ticker scrolling
+  // fake prices over it is noise at every width, and at phone widths it is
+  // worse than noise: it is fixed to the bottom of the viewport, exactly
+  // where the Support case actions live (REL-266).
+  '/admin',
 ]
 
 function showsDemoBar(pathname: string): boolean {


### PR DESCRIPTION
Brandon on the Support section as shipped: *"the support page is just so confusing and overwhelming right now."* This builds the direction he picked after four rounds of mockups — [the approved design](https://claude.ai/code/artifact/c9255628-bb69-490b-a0bf-010469944903), page "By person".

## What changed

**A row is a person.** Cases group by `support_cases.user_email` in the handler, so five tickets written in one afternoon are one human to answer. A case with no email keeps a key of its own — two anonymous reports are two strangers, not one imaginary person — and a group carries a name and a plan only when one actually exists.

**Paying customers are a section, not a sort key.** The plan comes from the current subscription in `stripe_customers`, never from `tier_at_open` (which records the plan on the day the ticket opened, so anyone who upgraded would sit in the wrong section forever and anyone who lapsed would be promoted). `plan = 'free'` is excluded; a lifetime row counts even though Stripe has nothing left to renew. The section index is compared before the sort key, which is what makes "paying customers never fall below anyone" true of *every* sort rather than just the default.

**Sorting and search are query parameters.** `?sort=last_wrote|waiting|tickets|plan|name&dir=asc|desc&rows=person|ticket&q=`. One queue read is capped at 500 cases, so a browser reordering whatever arrived would show a sorted *page* while calling it a sorted *queue*. An unrecognised field is a 400, never a quietly different order. The direction is its own button so reversing costs one click.

**The case view stops dumping.** Above the fold: their words, one sentence on why it stopped, the draft editable where it is read, and the actions. Diagnostics are three chips with the raw JSON one click away. `grounded_in`, `unknowns`, `ask_user_for`, `internal_note`, the classifier table, the conversation and what the model was shown all collapse behind one **Why it decided this**. Nothing was deleted; it moved one level down.

**Provenance is decided on the server.** `sent by the bot` / `you edited it` / `you sent it`, from `status`, `disposition` and whether `edited_body_html` differs from the draft. The browser renders the label and works none of it out.

## Two things production said that the mockup could not

**1. The paying section is empty in production, and that is correct.** The issue's acceptance criterion says it should show 2. It shows 0, because **neither paying customer has ever filed a ticket**:

```
stripe rows        annual/active 1 · ultimate_annual/active 1 · free/active 1  -> 2 paying
support_cases      59 total, 41 with no email at all, 1 with a logto_sub
paying subs appearing on any support case                                      -> 0
```

`stripe_customers` keys on `logto_sub`, and there is no email-to-account mapping anywhere else in the database. The marketing form and osTicket both arrive without a signed-in user, so almost nothing in that table can be joined to a subscription. Joining on `logto_sub` is the honest implementation of the spec; the "2" in the issue is the count of paying **accounts** (the mockup's "2 of 182 accounts" caption), not of paying people in the queue.

So rather than render a blank box that reads like a broken query, the empty section says why, from real counts — see the last screenshot. **The underlying gap (tickets are not linked to accounts) is filed separately as REL-267.**

**2. `/admin` was not excluded from the marketing demo ticker bar.** A fake scrolling price bar sat over the staff console at every width — and it is fixed to the bottom of the viewport, which at phone widths is exactly where the case actions live. One line in `__root.tsx`.

## Screenshots

⚠️ **The people in these are invented.** This repository is public; real customer emails and support text have no business in a PR screenshot. The *shape* is production's — a five-ticket person, a case with no account behind it, a plan that differs from `tier_at_open`. They are rendered by the real component against JSON dumped from the real Go handlers.

**2560** — reading measure capped at 75ch, the rest to margin
[![2560](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-2560.png?raw=true)](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-2560.png?raw=true)

**1440** — as drawn
[![1440](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-1440.png?raw=true)](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-1440.png?raw=true)

**1024** — nav collapsed to icons, both panes side by side
[![1024](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-1024.png?raw=true)](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-1024.png?raw=true)

**390** — one pane at a time; the action bar pinned to the viewport, and the queue-as-page with its back control
[![390 actions](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-390.png?raw=true)](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-390.png?raw=true)
[![390 queue](https://github.com/doughknee/myscrollr/blob/captures/rel-266/queue-390.png?raw=true)](https://github.com/doughknee/myscrollr/blob/captures/rel-266/queue-390.png?raw=true)
[![390 back](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-390-top.png?raw=true)](https://github.com/doughknee/myscrollr/blob/captures/rel-266/person-390-top.png?raw=true)

**The empty paying section, explaining itself** (production's shape)
[![no paying](https://github.com/doughknee/myscrollr/blob/captures/rel-266/nopaying-1440.png?raw=true)](https://github.com/doughknee/myscrollr/blob/captures/rel-266/nopaying-1440.png?raw=true)

`document.documentElement.scrollWidth === clientWidth` at all four widths — 2550/2550, 1430/1430, 1014/1014, 390/390. No horizontal page scroll anywhere. The sticky bar was probed at five scroll positions: at `scrollY=400` its bottom is 844 with `innerHeight` 844, so it is genuinely pinned while the case is on screen.

## Tests

- `go test ./...` green. New: grouping five tickets into one person (including a mixed-case email), an anonymous group that invents nothing, every sort field in both directions, unknowns sorting last **both ways**, paying-on-top under all ten sort/direction combinations, the paying rule across eight plan/status/lifetime combinations, provenance across eight draft states, parameter validation, and two DB-backed endpoint tests — one where the current plan differs from `tier_at_open` in both directions, one for server-side sorting and the 400s.
- `npm test` green, 104 tests. New: section order, `planBadge` returning **null** rather than "Free" when no account exists, `personTitle` never producing "Anonymous", the direction labels, the diagnostics chips, `lastUserMessage`, and a regression test for a bug this caught — `personMeta` was printing the *longest wait* under a "last wrote" label, so a customer whose open ticket was four hours old read as "last wrote 40 days ago".
- `TestEverySurfaceCallsTheSameVerb` still passes. `actions.go` untouched. No REL-249 or REL-259 gate weakened, and nothing about disposition, hold expiry, proven fixes or provenance is recomputed in the browser.

## What I could not click

I cannot sign in as Brandon, so **no write path was exercised end to end against a real ticket**. Send, edit-and-send, ask, hold, skip, file-as-bug and link/unlink were verified as rendering and wiring only — they call the same `adminApi` functions as before, and `CaseActions`' verbs are unchanged apart from where the buttons sit and Send now routing to `editAndSend` when the box differs from the draft. The queue and case *reads* were exercised against the real handlers via `app.Test`. The Discord-thread comparison in the issue's Verify list is also unrun, for the same reason.

Closes REL-266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
