### PR TITLE
The account count is the account count, and the gap is the story [REL-265]

### DIFF
--- a/api/internal/accounts/logto_admin.go
+++ b/api/internal/accounts/logto_admin.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -435,6 +436,47 @@ func DeleteLogtoUser(logtoSub string) error {
 	return nil
 }
 
+// GetLogtoUser reads one account from the Management API.
+//
+// Returns (nil, nil) when Logto has no such user - local rows can outlive a
+// deleted account, and that is not an error worth failing a page over.
+func GetLogtoUser(logtoSub string) (*LogtoUser, error) {
+	cfg := getM2MConfig()
+
+	token, err := getM2MToken()
+	if err != nil {
+		return nil, err
+	}
+
+	reqURL := fmt.Sprintf("%s/api/users/%s", cfg.Endpoint, logtoSub)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create get user request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: platform.LogtoM2MTokenTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get user request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get user returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var user LogtoUser
+	if err := json.Unmarshal(body, &user); err != nil {
+		return nil, fmt.Errorf("decode user: %w", err)
+	}
+	return &user, nil
+}
+
 // LogtoPrimaryEmail returns the Logto-verified primary email for a user.
 //
 // The access token carries an `email` claim (wired via Logto Custom JWT) but
@@ -446,38 +488,9 @@ func DeleteLogtoUser(logtoSub string) error {
 //
 // Returns ("", nil) when the user has no primary email set.
 func LogtoPrimaryEmail(logtoSub string) (string, error) {
-	cfg := getM2MConfig()
-
-	token, err := getM2MToken()
-	if err != nil {
+	user, err := GetLogtoUser(logtoSub)
+	if err != nil || user == nil {
 		return "", err
-	}
-
-	reqURL := fmt.Sprintf("%s/api/users/%s", cfg.Endpoint, logtoSub)
-	req, err := http.NewRequest("GET", reqURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("create get user request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	client := &http.Client{Timeout: platform.LogtoM2MTokenTimeout}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("get user request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("get user returned %d: %s", resp.StatusCode, string(body))
-	}
-
-	var user struct {
-		PrimaryEmail string `json:"primaryEmail"`
-		IsSuspended  bool   `json:"isSuspended"`
-	}
-	if err := json.Unmarshal(body, &user); err != nil {
-		return "", fmt.Errorf("decode user: %w", err)
 	}
 	// A suspended account keeps its primaryEmail. Treat it as having none so
 	// suspension revokes staff access too.
@@ -485,4 +498,135 @@ func LogtoPrimaryEmail(logtoSub string) (string, error) {
 		return "", nil
 	}
 	return user.PrimaryEmail, nil
+}
+
+// =============================================================================
+// Logto Management API — reading the account list
+// =============================================================================
+
+// LogtoUser is the slice of a Logto user record this product actually reads.
+//
+// Logto is the system of record for accounts. The local user_preferences table
+// only gains a row once someone gets far enough into the app to save a
+// preference, so counting it counts app setups, not accounts — see REL-265.
+//
+// CreatedAt and LastSignInAt are Unix milliseconds, which is how Logto sends
+// them. LastSignInAt is zero for an account that has never signed in.
+type LogtoUser struct {
+	ID            string `json:"id"`
+	PrimaryEmail  string `json:"primaryEmail"`
+	Name          string `json:"name"`
+	Username      string `json:"username"`
+	CreatedAt     int64  `json:"createdAt"`
+	LastSignInAt  int64  `json:"lastSignInAt"`
+	ApplicationID string `json:"applicationId"`
+	IsSuspended   bool   `json:"isSuspended"`
+}
+
+// logtoMaxPageSize is Logto's own cap. Asking for more returns
+// guard.invalid_pagination rather than a clamped page, so we clamp here.
+const logtoMaxPageSize = 100
+
+// ListLogtoUsers returns one page of accounts plus the total across all pages.
+//
+// The total comes from the `total-number` response header, so counting every
+// account costs one request with page_size=1 — no paging, no row counting.
+// page is 1-based, matching Logto.
+//
+// search, when non-empty, matches Logto's primaryEmail and username. Those are
+// the only two fields Logto can search; anything held locally (widget counts,
+// ticket counts) cannot be filtered or sorted across the whole set from here.
+func ListLogtoUsers(page, pageSize int, search string) ([]LogtoUser, int, error) {
+	cfg := getM2MConfig()
+	if cfg.Endpoint == "" {
+		return nil, 0, fmt.Errorf("LOGTO_ENDPOINT not set")
+	}
+
+	token, err := getM2MToken()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 1
+	}
+	if pageSize > logtoMaxPageSize {
+		pageSize = logtoMaxPageSize
+	}
+
+	q := url.Values{}
+	q.Set("page", strconv.Itoa(page))
+	q.Set("page_size", strconv.Itoa(pageSize))
+	if search != "" {
+		// Logto's search.<field> params are LIKE patterns; the caller passes a
+		// bare term and we widen it here so partial matches work.
+		q.Set("search.primaryEmail", "%"+search+"%")
+		q.Set("search.username", "%"+search+"%")
+		q.Set("searchMode", "or")
+	}
+
+	req, err := http.NewRequest("GET", cfg.Endpoint+"/api/users?"+q.Encode(), nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create list users request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: platform.LogtoM2MTokenTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list users request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, fmt.Errorf("list users returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var users []LogtoUser
+	if err := json.Unmarshal(body, &users); err != nil {
+		return nil, 0, fmt.Errorf("decode users: %w", err)
+	}
+
+	total, err := strconv.Atoi(resp.Header.Get("total-number"))
+	if err != nil {
+		// No header means no honest total. Refusing here is the point: a
+		// caller that got a short page and no total would otherwise report
+		// the page length as the account count.
+		return nil, 0, fmt.Errorf("missing total-number header on list users")
+	}
+	return users, total, nil
+}
+
+// logtoScanCap bounds ListAllLogtoUsers so a runaway or a much larger tenant
+// cannot turn one dashboard load into hundreds of upstream requests.
+//
+// ponytail: a full scan is fine at ~200 accounts. If this cap ever bites, the
+// fix is a cached nightly aggregate of signup dates, not a bigger cap.
+const logtoScanCap = 5000
+
+// ListAllLogtoUsers walks every page and returns every account.
+//
+// Only the Overview's signup series needs this: the per-account createdAt is
+// what makes "new this week" a fact about signups rather than about when a
+// local column was added. Anything that only needs the count should call
+// ListLogtoUsers(1, 1, "") and read the total.
+//
+// Returns the scanned users and the upstream total. When the cap truncates the
+// scan the total still reflects reality, so a caller can tell.
+func ListAllLogtoUsers() ([]LogtoUser, int, error) {
+	var all []LogtoUser
+	for page := 1; ; page++ {
+		batch, total, err := ListLogtoUsers(page, logtoMaxPageSize, "")
+		if err != nil {
+			return nil, 0, err
+		}
+		all = append(all, batch...)
+		if len(batch) < logtoMaxPageSize || len(all) >= total || len(all) >= logtoScanCap {
+			return all, total, nil
+		}
+	}
 }

--- a/api/internal/admin/handlers_accounts.go
+++ b/api/internal/admin/handlers_accounts.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/brandon-relentnet/myscrollr/api/internal/accounts"
 	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
 	"github.com/gofiber/fiber/v2"
-	"github.com/jackc/pgx/v5"
 )
 
 // The Users section: read-only, deliberately.
@@ -19,125 +19,273 @@ import (
 // separate consequences, so there is no write path here at all - not a
 // disabled button, not a guarded handler. Nothing to reach.
 //
-// The list is keyed on user_preferences because that is the account row. The
-// email is not stored locally; support_cases is the only table that has one,
-// so a user with no ticket has no email to show and the row says so rather
-// than reaching out to Logto for every row on every page.
+// The list is driven from Logto, which is the system of record for accounts
+// (REL-265). It used to be driven from user_preferences, but that table only
+// gains a row once someone gets far enough into the app to save a preference:
+// in production that was 100 rows against 183 real accounts, so 83 people were
+// structurally invisible here and in the Overview's account count.
+//
+// Logto supplies the identity half of a row - email, signup date, last sign-in
+// - and the local tables are left-joined for the product half. An account with
+// no local rows is shown with zero widgets and zero tickets, which is the
+// truth about it, rather than being dropped.
 
 const accountsPageSize = 50
 
+// listLogtoUsers is a seam, not indirection for its own sake: it lets the
+// tests drive both the healthy path and the Logto-unreachable path without a
+// network. Same pattern as lookupVerifiedEmail in auth.go.
+var (
+	listLogtoUsers = accounts.ListLogtoUsers
+	getLogtoUser   = accounts.GetLogtoUser
+)
+
 type AccountRow struct {
-	LogtoSub      string  `json:"logto_sub"`
-	Email         *string `json:"email"`
-	Plan          string  `json:"plan"`
-	Status        string  `json:"status"`
-	Lifetime      bool    `json:"lifetime"`
-	Widgets       int     `json:"widgets"`
-	OnTicker      int     `json:"on_ticker"`
-	Fantasy       bool    `json:"fantasy"`
-	Tickets       int     `json:"tickets"`
-	CreatedAt     *string `json:"created_at"`
-	UpdatedAt     string  `json:"updated_at"`
+	LogtoSub string  `json:"logto_sub"`
+	Email    *string `json:"email"`
+	Name     *string `json:"name"`
+	Plan     string  `json:"plan"`
+	Status   string  `json:"status"`
+	Lifetime bool    `json:"lifetime"`
+	Widgets  int     `json:"widgets"`
+	OnTicker int     `json:"on_ticker"`
+	Fantasy  bool    `json:"fantasy"`
+	Tickets  int     `json:"tickets"`
+
+	// SignedUpAt and LastSignInAt come from Logto and mean what they say.
+	// LastUsedApp is user_preferences.updated_at - the last time the app wrote
+	// a preference - which is a different fact and carries a different name so
+	// the two can never be read as the same thing. It is null for an account
+	// that has never set the app up.
+	SignedUpAt   *string `json:"signed_up_at"`
+	LastSignInAt *string `json:"last_sign_in_at"`
+	LastUsedApp  *string `json:"last_used_app"`
+	SetUp        bool    `json:"set_up"`
+
+	Suspended     bool    `json:"suspended"`
 	DeletionState *string `json:"deletion_state"`
 }
 
-// accountsSelect is shared by the list and the detail read so the two can
-// never drift into disagreeing about the same user.
-const accountsSelect = `
-	SELECT p.logto_sub,
-	       (SELECT c.user_email FROM support_cases c
-	         WHERE c.logto_sub = p.logto_sub AND c.user_email IS NOT NULL
-	         ORDER BY c.opened_at DESC LIMIT 1),
-	       coalesce(s.plan, 'free'),
-	       coalesce(s.status, 'none'),
-	       coalesce(s.lifetime, false),
-	       (SELECT count(*) FROM user_widgets w WHERE w.logto_sub = p.logto_sub),
-	       (SELECT count(*) FROM user_widgets w
-	         WHERE w.logto_sub = p.logto_sub AND w.ticker_enabled),
-	       EXISTS (SELECT 1 FROM yahoo_users y WHERE y.logto_sub = p.logto_sub),
-	       (SELECT count(*) FROM support_cases c WHERE c.logto_sub = p.logto_sub),
-	       p.created_at,
-	       p.updated_at,
-	       (SELECT d.status FROM user_deletion_requests d
-	         WHERE d.logto_sub = p.logto_sub ORDER BY d.requested_at DESC LIMIT 1)
-	  FROM user_preferences p
-	  LEFT JOIN stripe_customers s ON s.logto_sub = p.logto_sub`
+// localAccountRows fills the product half of each row for the given subs.
+//
+// Driving the query from unnest() rather than from user_preferences is the
+// whole fix: the sub list is the authority on which rows exist, and every
+// local table is a LEFT JOIN off it. A sub with nothing local still comes back.
+func localAccountRows(ctx context.Context, subs []string) map[string]AccountRow {
+	out := make(map[string]AccountRow, len(subs))
+	if len(subs) == 0 {
+		return out
+	}
 
-func scanAccount(row pgx.Row) (AccountRow, error) {
-	var a AccountRow
-	var created *time.Time
-	var updated time.Time
-	err := row.Scan(&a.LogtoSub, &a.Email, &a.Plan, &a.Status, &a.Lifetime,
-		&a.Widgets, &a.OnTicker, &a.Fantasy, &a.Tickets, &created, &updated,
-		&a.DeletionState)
+	rows, err := platform.DBPool.Query(ctx, `
+		SELECT u.sub,
+		       coalesce(s.plan, 'free'),
+		       coalesce(s.status, 'none'),
+		       coalesce(s.lifetime, false),
+		       (SELECT count(*) FROM user_widgets w WHERE w.logto_sub = u.sub),
+		       (SELECT count(*) FROM user_widgets w
+		         WHERE w.logto_sub = u.sub AND w.ticker_enabled),
+		       EXISTS (SELECT 1 FROM yahoo_users y WHERE y.logto_sub = u.sub),
+		       (SELECT count(*) FROM support_cases c WHERE c.logto_sub = u.sub),
+		       p.updated_at,
+		       (SELECT d.status FROM user_deletion_requests d
+		         WHERE d.logto_sub = u.sub ORDER BY d.requested_at DESC LIMIT 1)
+		  FROM unnest($1::text[]) AS u(sub)
+		  LEFT JOIN user_preferences p ON p.logto_sub = u.sub
+		  LEFT JOIN stripe_customers s ON s.logto_sub = u.sub`, subs)
 	if err != nil {
-		return a, err
+		// A local read failing must not blank the list. The identity half is
+		// already in hand; the rows go out with zeroed product columns.
+		log.Printf("[Admin] accounts local join: %v", err)
+		return out
 	}
-	if created != nil {
-		s := created.UTC().Format(time.RFC3339)
-		a.CreatedAt = &s
+	defer rows.Close()
+
+	for rows.Next() {
+		var a AccountRow
+		var lastUsed *time.Time
+		if err := rows.Scan(&a.LogtoSub, &a.Plan, &a.Status, &a.Lifetime,
+			&a.Widgets, &a.OnTicker, &a.Fantasy, &a.Tickets, &lastUsed,
+			&a.DeletionState); err != nil {
+			log.Printf("[Admin] scan account: %v", err)
+			continue
+		}
+		if lastUsed != nil {
+			s := lastUsed.UTC().Format(time.RFC3339)
+			a.LastUsedApp = &s
+			a.SetUp = true
+		}
+		out[a.LogtoSub] = a
 	}
-	a.UpdatedAt = updated.UTC().Format(time.RFC3339)
-	return a, nil
+	return out
+}
+
+// msToRFC3339 converts Logto's Unix-millisecond timestamps. Zero means the
+// event never happened, which is a fact worth keeping as null rather than
+// rendering as 1970.
+func msToRFC3339(ms int64) *string {
+	if ms <= 0 {
+		return nil
+	}
+	s := time.UnixMilli(ms).UTC().Format(time.RFC3339)
+	return &s
+}
+
+func strPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// AccountsPage is the list response.
+//
+// Total and SetUp are two different counts on purpose. Total is accounts;
+// SetUp is how many of them ever saved a preference. The gap between them was
+// invisible until REL-265 and is the most interesting number on the page, so
+// the API hands both to the client rather than picking one.
+//
+// Source says which system the list came from. When Logto is unreachable the
+// list degrades to the local table and Source says "local" - the client must
+// label the number accordingly rather than presenting a smaller number as the
+// account count.
+type AccountsPage struct {
+	Accounts []AccountRow `json:"accounts"`
+	Total    int          `json:"total"`
+	SetUp    int          `json:"set_up"`
+	Page     int          `json:"page"`
+	PageSize int          `json:"page_size"`
+	Source   string       `json:"source"`
+	Note     string       `json:"note,omitempty"`
 }
 
 // HandleListAccounts - GET /admin/accounts?q=&page=
 //
-// The search matches the Logto sub or the email on any of the user's support
-// cases. There is no other email anywhere in this database to match against.
+// Search runs against Logto and therefore matches primaryEmail and username.
+// Widget and ticket counts live locally and cannot be searched or sorted
+// across the whole set from here; the client says so rather than sorting one
+// page and letting it look global.
 func HandleListAccounts(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(context.Background(), overviewTimeout)
+	defer cancel()
+
 	query := strings.TrimSpace(c.Query("q"))
 	page, _ := strconv.Atoi(c.Query("page", "0"))
 	if page < 0 {
 		page = 0
 	}
 
-	// An empty q becomes the pattern '%', which LIKE matches against every
-	// row - so one query shape serves both browsing and searching, with no
-	// branch for "no search term".
-	pattern := "%" + strings.ToLower(query) + "%"
-
-	where := `
-		 WHERE (lower(p.logto_sub) LIKE $1
-		    OR EXISTS (SELECT 1 FROM support_cases c
-		                WHERE c.logto_sub = p.logto_sub
-		                  AND lower(c.user_email) LIKE $1))`
-
-	var total int
-	if err := platform.DBPool.QueryRow(context.Background(),
-		`SELECT count(*) FROM user_preferences p`+where, pattern).Scan(&total); err != nil {
-		log.Printf("[Admin] accounts count: %v", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
-			Status: "error", Error: "Could not read accounts",
-		})
+	// How many of these accounts ever set the app up. Independent of the
+	// list, so a failure here costs the gap number, not the page.
+	var setUp int
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT count(*) FROM user_preferences`).Scan(&setUp); err != nil {
+		log.Printf("[Admin] accounts set-up count: %v", err)
 	}
 
-	rows, err := platform.DBPool.Query(context.Background(),
-		accountsSelect+where+` ORDER BY p.updated_at DESC LIMIT $2 OFFSET $3`,
-		pattern, accountsPageSize, page*accountsPageSize)
+	// Logto's paging is 1-based; the client's is 0-based. Convert here so
+	// neither side has to know about the other's convention.
+	users, total, err := listLogtoUsers(page+1, accountsPageSize, query)
 	if err != nil {
-		log.Printf("[Admin] accounts list: %v", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
-			Status: "error", Error: "Could not read accounts",
-		})
+		log.Printf("[Admin] logto user list: %v", err)
+		return listAccountsFromLocal(ctx, c, query, page, setUp)
 	}
-	defer rows.Close()
 
-	out := make([]AccountRow, 0, accountsPageSize)
-	for rows.Next() {
-		a, err := scanAccount(rows)
-		if err != nil {
-			log.Printf("[Admin] scan account: %v", err)
-			continue
+	subs := make([]string, 0, len(users))
+	for _, u := range users {
+		subs = append(subs, u.ID)
+	}
+	local := localAccountRows(ctx, subs)
+
+	out := make([]AccountRow, 0, len(users))
+	for _, u := range users {
+		a, ok := local[u.ID]
+		if !ok {
+			// The local read failed or raced a deletion. Zeroed product
+			// columns beat dropping an account that demonstrably exists.
+			a = AccountRow{LogtoSub: u.ID, Plan: "free", Status: "none"}
 		}
+		a.Email = strPtr(u.PrimaryEmail)
+		a.Name = strPtr(firstNonEmpty(u.Name, u.Username))
+		a.SignedUpAt = msToRFC3339(u.CreatedAt)
+		a.LastSignInAt = msToRFC3339(u.LastSignInAt)
+		a.Suspended = u.IsSuspended
 		out = append(out, a)
 	}
 
-	return c.JSON(fiber.Map{
-		"accounts":  out,
-		"total":     total,
-		"page":      page,
-		"page_size": accountsPageSize,
+	return c.JSON(AccountsPage{
+		Accounts: out,
+		Total:    total,
+		SetUp:    setUp,
+		Page:     page,
+		PageSize: accountsPageSize,
+		Source:   "logto",
+	})
+}
+
+// listAccountsFromLocal is the degraded path, taken only when Logto cannot be
+// reached. It lists the accounts that have local rows - which is fewer than
+// exist - and labels itself so, because a smaller number presented without
+// that label is the exact bug REL-265 was filed about.
+func listAccountsFromLocal(ctx context.Context, c *fiber.Ctx, query string, page, setUp int) error {
+	pattern := "%" + strings.ToLower(query) + "%"
+
+	var total int
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT count(*) FROM user_preferences WHERE lower(logto_sub) LIKE $1`,
+		pattern).Scan(&total); err != nil {
+		log.Printf("[Admin] accounts local count: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read accounts",
+		})
+	}
+
+	rows, err := platform.DBPool.Query(ctx,
+		`SELECT logto_sub FROM user_preferences
+		  WHERE lower(logto_sub) LIKE $1
+		  ORDER BY updated_at DESC LIMIT $2 OFFSET $3`,
+		pattern, accountsPageSize, page*accountsPageSize)
+	if err != nil {
+		log.Printf("[Admin] accounts local list: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read accounts",
+		})
+	}
+	subs := make([]string, 0, accountsPageSize)
+	for rows.Next() {
+		var sub string
+		if err := rows.Scan(&sub); err == nil {
+			subs = append(subs, sub)
+		}
+	}
+	rows.Close()
+
+	local := localAccountRows(ctx, subs)
+	out := make([]AccountRow, 0, len(subs))
+	for _, sub := range subs {
+		if a, ok := local[sub]; ok {
+			out = append(out, a)
+		}
+	}
+
+	return c.JSON(AccountsPage{
+		Accounts: out,
+		Total:    total,
+		SetUp:    setUp,
+		Page:     page,
+		PageSize: accountsPageSize,
+		Source:   "local",
+		Note: "Logto is unreachable, so this is not the account list. It is " +
+			"the accounts that have local data, which is fewer than exist.",
 	})
 }
 
@@ -165,7 +313,14 @@ type AccountCase struct {
 }
 
 // HandleGetAccount - GET /admin/accounts/:sub
+//
+// Reachable for every account, including one with no local rows. It used to
+// 404 on those, which meant the 83 accounts the list could not show were also
+// the 83 nobody could open.
 func HandleGetAccount(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(context.Background(), overviewTimeout)
+	defer cancel()
+
 	sub := c.Params("sub")
 	if sub == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
@@ -173,17 +328,24 @@ func HandleGetAccount(c *fiber.Ctx) error {
 		})
 	}
 
-	account, err := scanAccount(platform.DBPool.QueryRow(context.Background(),
-		accountsSelect+` WHERE p.logto_sub = $1`, sub))
+	account, hasLocal := localAccountRows(ctx, []string{sub})[sub]
+	if !hasLocal {
+		account = AccountRow{LogtoSub: sub, Plan: "free", Status: "none"}
+	}
+
+	user, err := getLogtoUser(sub)
 	if err != nil {
-		if err == pgx.ErrNoRows {
-			return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
-				Status: "error", Error: "No such account",
-			})
-		}
-		log.Printf("[Admin] account detail: %v", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
-			Status: "error", Error: "Could not read that account",
+		log.Printf("[Admin] account detail logto lookup for %s: %v", sub, err)
+	} else if user != nil {
+		account.Email = strPtr(user.PrimaryEmail)
+		account.Name = strPtr(firstNonEmpty(user.Name, user.Username))
+		account.SignedUpAt = msToRFC3339(user.CreatedAt)
+		account.LastSignInAt = msToRFC3339(user.LastSignInAt)
+		account.Suspended = user.IsSuspended
+	} else if !hasLocal {
+		// Neither Logto nor the local tables know this id.
+		return c.Status(fiber.StatusNotFound).JSON(platform.ErrorResponse{
+			Status: "error", Error: "No such account",
 		})
 	}
 
@@ -193,7 +355,7 @@ func HandleGetAccount(c *fiber.Ctx) error {
 		Cases:   make([]AccountCase, 0, 4),
 	}
 
-	if rows, err := platform.DBPool.Query(context.Background(),
+	if rows, err := platform.DBPool.Query(ctx,
 		`SELECT widget_type, enabled, ticker_enabled, updated_at
 		   FROM user_widgets WHERE logto_sub = $1 ORDER BY widget_type`, sub); err != nil {
 		log.Printf("[Admin] account widgets: %v", err)
@@ -209,7 +371,7 @@ func HandleGetAccount(c *fiber.Ctx) error {
 		rows.Close()
 	}
 
-	if rows, err := platform.DBPool.Query(context.Background(),
+	if rows, err := platform.DBPool.Query(ctx,
 		`SELECT ticket_number, subject, status, category, opened_at
 		   FROM support_cases WHERE logto_sub = $1 ORDER BY opened_at DESC LIMIT 50`, sub); err != nil {
 		log.Printf("[Admin] account cases: %v", err)

--- a/api/internal/admin/handlers_accounts_test.go
+++ b/api/internal/admin/handlers_accounts_test.go
@@ -1,0 +1,301 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/accounts"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+	"github.com/gofiber/fiber/v2"
+)
+
+// These tests pin the thing REL-265 was filed about: the account count must be
+// the account count. Everything here is arranged so that a regression to
+// "count user_preferences and call it accounts" fails loudly.
+
+// withLogtoUsers swaps both Logto seams for a fixed set of accounts.
+func withLogtoUsers(t *testing.T, total int, users ...accounts.LogtoUser) {
+	t.Helper()
+	prevList, prevGet, prevAll := listLogtoUsers, getLogtoUser, listAllLogtoUsers
+
+	listLogtoUsers = func(page, pageSize int, search string) ([]accounts.LogtoUser, int, error) {
+		return users, total, nil
+	}
+	getLogtoUser = func(sub string) (*accounts.LogtoUser, error) {
+		for i := range users {
+			if users[i].ID == sub {
+				return &users[i], nil
+			}
+		}
+		return nil, nil
+	}
+	listAllLogtoUsers = func() ([]accounts.LogtoUser, int, error) {
+		return users, total, nil
+	}
+
+	t.Cleanup(func() {
+		listLogtoUsers, getLogtoUser, listAllLogtoUsers = prevList, prevGet, prevAll
+	})
+}
+
+// withLogtoDown makes every Logto read fail, which is the case the page has to
+// survive without quietly reporting a smaller number as the truth.
+func withLogtoDown(t *testing.T) {
+	t.Helper()
+	prevList, prevGet, prevAll := listLogtoUsers, getLogtoUser, listAllLogtoUsers
+	down := errors.New("logto unreachable")
+
+	listLogtoUsers = func(page, pageSize int, search string) ([]accounts.LogtoUser, int, error) {
+		return nil, 0, down
+	}
+	getLogtoUser = func(sub string) (*accounts.LogtoUser, error) { return nil, down }
+	listAllLogtoUsers = func() ([]accounts.LogtoUser, int, error) { return nil, 0, down }
+
+	t.Cleanup(func() {
+		listLogtoUsers, getLogtoUser, listAllLogtoUsers = prevList, prevGet, prevAll
+	})
+}
+
+func resetAccountTables(t *testing.T) {
+	t.Helper()
+	testsupport.MustExec(t, `DELETE FROM user_widgets`)
+	testsupport.MustExec(t, `DELETE FROM stripe_customers`)
+	testsupport.MustExec(t, `DELETE FROM user_preferences`)
+}
+
+func seedPreferences(t *testing.T, sub string) {
+	t.Helper()
+	testsupport.MustExec(t,
+		`INSERT INTO user_preferences (logto_sub) VALUES ($1)`, sub)
+}
+
+func getAccountsPage(t *testing.T, path string) AccountsPage {
+	t.Helper()
+	app := fiber.New()
+	app.Get("/admin/accounts", HandleListAccounts)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, path, nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var page AccountsPage
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return page
+}
+
+// The list is every account, and the total is Logto's, not the row count of a
+// local table that only some accounts ever write to.
+func TestListAccountsCountsLogtoNotPreferences(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAccountTables(t)
+
+	withLogtoUsers(t, 183,
+		accounts.LogtoUser{ID: "has-prefs", PrimaryEmail: "a@example.test", CreatedAt: 1_700_000_000_000, LastSignInAt: 1_700_000_500_000},
+		accounts.LogtoUser{ID: "never-set-up", PrimaryEmail: "b@example.test", CreatedAt: 1_700_000_000_000},
+	)
+	seedPreferences(t, "has-prefs")
+
+	page := getAccountsPage(t, "/admin/accounts")
+
+	if page.Source != "logto" {
+		t.Fatalf("source = %q, want logto", page.Source)
+	}
+	if page.Total != 183 {
+		t.Errorf("total = %d, want 183 (Logto's count, not the local table's)", page.Total)
+	}
+	if page.SetUp != 1 {
+		t.Errorf("set_up = %d, want 1", page.SetUp)
+	}
+	if len(page.Accounts) != 2 {
+		t.Fatalf("got %d rows, want 2", len(page.Accounts))
+	}
+}
+
+// The whole bug in one assertion: an account that exists in Logto and has no
+// local row must still be in the list, with honest zeroes.
+func TestListAccountsIncludesAccountWithNoLocalRow(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAccountTables(t)
+
+	withLogtoUsers(t, 2,
+		accounts.LogtoUser{ID: "has-prefs", CreatedAt: 1_700_000_000_000},
+		accounts.LogtoUser{ID: "never-set-up", PrimaryEmail: "b@example.test", CreatedAt: 1_700_000_000_000},
+	)
+	seedPreferences(t, "has-prefs")
+
+	page := getAccountsPage(t, "/admin/accounts")
+
+	var found *AccountRow
+	for i := range page.Accounts {
+		if page.Accounts[i].LogtoSub == "never-set-up" {
+			found = &page.Accounts[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("account with no user_preferences row is missing from the list")
+	}
+	if found.SetUp {
+		t.Error("set_up = true for an account with no preferences row")
+	}
+	if found.Widgets != 0 || found.Tickets != 0 {
+		t.Errorf("widgets/tickets = %d/%d, want 0/0", found.Widgets, found.Tickets)
+	}
+	if found.LastUsedApp != nil {
+		t.Errorf("last_used_app = %v, want null", *found.LastUsedApp)
+	}
+	if found.SignedUpAt == nil {
+		t.Error("signed_up_at is null; Logto's createdAt should have filled it")
+	}
+	if found.Email == nil || *found.Email != "b@example.test" {
+		t.Errorf("email = %v, want b@example.test", found.Email)
+	}
+}
+
+// Logto down must be visible. Reporting the smaller local number without
+// saying so is the exact failure this ticket exists to prevent.
+func TestListAccountsDegradesVisiblyWhenLogtoIsDown(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAccountTables(t)
+	seedPreferences(t, "has-prefs")
+	withLogtoDown(t)
+
+	page := getAccountsPage(t, "/admin/accounts")
+
+	if page.Source != "local" {
+		t.Fatalf("source = %q, want local", page.Source)
+	}
+	if page.Note == "" {
+		t.Error("no note explaining that this is not the account list")
+	}
+	if page.Total != 1 {
+		t.Errorf("total = %d, want the local count of 1", page.Total)
+	}
+}
+
+// The detail page has to open for an account with no local rows too, or the
+// accounts the list could not show stay unreachable by another route.
+func TestGetAccountWorksWithNoLocalRow(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAccountTables(t)
+	withLogtoUsers(t, 1,
+		accounts.LogtoUser{ID: "never-set-up", PrimaryEmail: "b@example.test", CreatedAt: 1_700_000_000_000})
+
+	app := fiber.New()
+	app.Get("/admin/accounts/:sub", HandleGetAccount)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/admin/accounts/never-set-up", nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var detail AccountDetail
+	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail.Account.SetUp {
+		t.Error("set_up = true for an account with no preferences row")
+	}
+	if detail.Account.Email == nil {
+		t.Error("email is null; Logto had one")
+	}
+}
+
+// Both numbers, and the gap, from one tile.
+func TestAccountsTileCarriesBothCounts(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAccountTables(t)
+	seedPreferences(t, "has-prefs")
+
+	withLogtoUsers(t, 3,
+		accounts.LogtoUser{ID: "has-prefs", CreatedAt: 1_700_000_000_000},
+		accounts.LogtoUser{ID: "b", CreatedAt: 1_700_000_000_000},
+		accounts.LogtoUser{ID: "c", CreatedAt: 1_700_000_000_000},
+	)
+
+	tile := accountsTile(context.Background())
+	if tile.Source != "logto" {
+		t.Fatalf("source = %q, want logto", tile.Source)
+	}
+	if tile.Total != 3 {
+		t.Errorf("total = %d, want 3", tile.Total)
+	}
+	if tile.SetUp != 1 {
+		t.Errorf("set_up = %d, want 1", tile.SetUp)
+	}
+}
+
+func TestAccountsTileDegradesVisiblyWhenLogtoIsDown(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAccountTables(t)
+	seedPreferences(t, "has-prefs")
+	withLogtoDown(t)
+
+	tile := accountsTile(context.Background())
+	if tile.Source != "local" {
+		t.Fatalf("source = %q, want local", tile.Source)
+	}
+	if tile.Note == "" {
+		t.Error("no note saying the number is not the account count")
+	}
+	if tile.Total != tile.SetUp {
+		t.Errorf("total = %d, set_up = %d; the local fallback should report the local number",
+			tile.Total, tile.SetUp)
+	}
+	if tile.New7d.Available || tile.New30d.Available {
+		t.Error("signup windows claim to be available with Logto down")
+	}
+}
+
+// A free-plan row sitting in stripe_customers is not a customer. Production
+// has three active rows and two paying people.
+func TestPayingExcludesFreePlanRows(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetAccountTables(t)
+
+	seed := func(sub, plan, status string) {
+		testsupport.MustExec(t,
+			`INSERT INTO stripe_customers (logto_sub, stripe_customer_id, plan, status)
+			 VALUES ($1, $2, $3, $4)`, sub, "cus_"+sub, plan, status)
+	}
+	seed("payer-1", "ultimate_annual", "active")
+	seed("payer-2", "annual", "active")
+	seed("freeloader", "free", "active")
+
+	if got := plansTile(context.Background()).Paying; got != 2 {
+		t.Fatalf("paying = %d, want 2 (three active rows, one on the free plan)", got)
+	}
+
+	seed("freeloader-2", "free", "active")
+	if got := plansTile(context.Background()).Paying; got != 2 {
+		t.Errorf("paying = %d after adding another free row, want 2", got)
+	}
+}

--- a/api/internal/admin/handlers_overview.go
+++ b/api/internal/admin/handlers_overview.go
@@ -3,9 +3,11 @@ package admin
 import (
 	"context"
 	"log"
+	"sort"
 	"sync"
 	"time"
 
+	"github.com/brandon-relentnet/myscrollr/api/internal/accounts"
 	"github.com/brandon-relentnet/myscrollr/api/internal/events"
 	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
 	"github.com/gofiber/fiber/v2"
@@ -20,6 +22,10 @@ import (
 // telemetry or analytics anywhere in this API - a standing decision, not an
 // oversight - so installs are NOT measurable, and the Installs tile exists
 // purely to say so and point at downloads instead.
+
+// listAllLogtoUsers is the tile's seam onto Logto, so the tests can drive
+// both the healthy path and the unreachable path without a network.
+var listAllLogtoUsers = accounts.ListAllLogtoUsers
 
 // Measured wraps a number with whether it means what its label says. When
 // Available is false the client renders Note instead of Value.
@@ -41,19 +47,33 @@ type OverviewResponse struct {
 	Ingest       []IngestRow   `json:"ingest"`
 }
 
-// AccountsTile counts rows in user_preferences - the row created the first
-// time an account reads its preferences, and therefore the account itself.
+// AccountsTile carries two counts because they answer two questions.
 //
-// created_at was only added in migration 000016 and deliberately not
-// backfilled, so accounts that predate it have no signup date. Untracked is
-// how many, and TrackingSince is when the honest series starts.
+// Total is accounts, read from Logto, which is the system of record for them.
+// SetUp is rows in user_preferences - the row written the first time the app
+// saves a preference - so it is how many of those accounts ever got far enough
+// into the product to configure anything. This tile used to report SetUp as
+// Total: 100 against 183 real accounts, a 46% undercount on the number most
+// likely to be quoted (REL-265).
+//
+// The gap between them is the point. It is 83 people who created an account
+// and never set the app up, and it dwarfs everything else on the funnel.
+//
+// Source is "logto" normally and "local" when Logto could not be reached; in
+// the local case Total falls back to SetUp and Note says why. A smaller number
+// presented without that label is the bug this tile was rebuilt to fix.
+//
+// The signup series comes from Logto's per-account createdAt, so "new this
+// week" is a fact about signups rather than about when a local column was
+// added. That retires the old untracked/tracking-since apparatus.
 type AccountsTile struct {
-	Total         int          `json:"total"`
-	New7d         Measured     `json:"new_7d"`
-	New30d        Measured     `json:"new_30d"`
-	Untracked     int          `json:"untracked"`
-	TrackingSince string       `json:"tracking_since,omitempty"`
-	Daily         []DailyCount `json:"daily"`
+	Total  int          `json:"total"`
+	SetUp  int          `json:"set_up"`
+	Source string       `json:"source"`
+	Note   string       `json:"note,omitempty"`
+	New7d  Measured     `json:"new_7d"`
+	New30d Measured     `json:"new_30d"`
+	Daily  []DailyCount `json:"daily"`
 }
 
 type DailyCount struct {
@@ -61,12 +81,17 @@ type DailyCount struct {
 	Count int    `json:"count"`
 }
 
-// PlansTile is the mix from stripe_customers. Accounts with no Stripe row
-// have never started a checkout, so they are free - counted here rather than
-// dropped, or the mix would not add up to the account total.
+// PlansTile is the mix from stripe_customers, and Paying is the count that
+// matters. It excludes plan = 'free': production carries three active Stripe
+// rows and one of them is on the free plan, so a bare row count reads 3 when
+// two people are actually paying (REL-265).
+//
+// There is no Free field. Free is every account that is not paying, and the
+// account total lives on the accounts tile - deriving it there beats keeping a
+// second count here that could disagree with it.
 type PlansTile struct {
-	Free int       `json:"free"`
-	Rows []PlanRow `json:"rows"`
+	Paying int       `json:"paying"`
+	Rows   []PlanRow `json:"rows"`
 }
 
 type PlanRow struct {
@@ -163,47 +188,53 @@ func HandleGetOverview(c *fiber.Ctx) error {
 
 func accountsTile(ctx context.Context) AccountsTile {
 	var t AccountsTile
-	var since *time.Time
-	err := platform.DBPool.QueryRow(ctx, `
-		SELECT count(*),
-		       count(*) FILTER (WHERE created_at IS NULL),
-		       count(*) FILTER (WHERE created_at >= now() - interval '7 days'),
-		       count(*) FILTER (WHERE created_at >= now() - interval '30 days'),
-		       min(created_at)
-		  FROM user_preferences`).
-		Scan(&t.Total, &t.Untracked, &t.New7d.Value, &t.New30d.Value, &since)
-	if err != nil {
-		log.Printf("[Admin] accounts tile: %v", err)
-		return t
+
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT count(*) FROM user_preferences`).Scan(&t.SetUp); err != nil {
+		log.Printf("[Admin] accounts set-up count: %v", err)
 	}
 
-	// The windows only mean anything once tracking has been running. Before
-	// the first dated row exists, "0 new this week" would read as a fact about
-	// signups when it is only a fact about the column's age.
-	if since == nil {
-		note := "No signup dates recorded yet - tracking began with this release."
+	users, total, err := listAllLogtoUsers()
+	if err != nil {
+		// Degrade loudly. The local number is real, but it is not the account
+		// count, and the tile says which one the reader is looking at.
+		log.Printf("[Admin] accounts tile logto: %v", err)
+		t.Total, t.Source = t.SetUp, "local"
+		t.Note = "Logto is unreachable, so this is not the account count. It " +
+			"is how many accounts have set the app up, which is fewer."
+		note := "Signup dates come from Logto, which is unreachable."
 		t.New7d = Measured{Available: false, Note: note}
 		t.New30d = Measured{Available: false, Note: note}
 		return t
 	}
-	t.TrackingSince = since.UTC().Format(time.RFC3339)
+
+	t.Total, t.Source = total, "logto"
 	t.New7d.Available, t.New30d.Available = true, true
 
-	rows, err := platform.DBPool.Query(ctx, `
-		SELECT to_char(date_trunc('day', created_at), 'YYYY-MM-DD'), count(*)
-		  FROM user_preferences
-		 WHERE created_at >= now() - interval '30 days'
-		 GROUP BY 1 ORDER BY 1`)
-	if err != nil {
-		log.Printf("[Admin] accounts daily: %v", err)
-		return t
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var d DailyCount
-		if err := rows.Scan(&d.Day, &d.Count); err == nil {
-			t.Daily = append(t.Daily, d)
+	now := time.Now()
+	week, month := now.AddDate(0, 0, -7), now.AddDate(0, 0, -30)
+	daily := make(map[string]int, 30)
+	for _, u := range users {
+		if u.CreatedAt <= 0 {
+			continue
 		}
+		created := time.UnixMilli(u.CreatedAt)
+		if created.After(week) {
+			t.New7d.Value++
+		}
+		if created.After(month) {
+			t.New30d.Value++
+			daily[created.UTC().Format("2006-01-02")]++
+		}
+	}
+
+	days := make([]string, 0, len(daily))
+	for day := range daily {
+		days = append(days, day)
+	}
+	sort.Strings(days)
+	for _, day := range days {
+		t.Daily = append(t.Daily, DailyCount{Day: day, Count: daily[day]})
 	}
 	return t
 }
@@ -227,11 +258,13 @@ func plansTile(ctx context.Context) PlansTile {
 		rows.Close()
 	}
 
+	// A free-plan row in stripe_customers is somebody who reached checkout
+	// and did not pay. Counting the table would call them a customer.
 	if err := platform.DBPool.QueryRow(ctx, `
-		SELECT count(*) FROM user_preferences p
-		 WHERE NOT EXISTS (SELECT 1 FROM stripe_customers s WHERE s.logto_sub = p.logto_sub)`).
-		Scan(&t.Free); err != nil {
-		log.Printf("[Admin] plans free count: %v", err)
+		SELECT count(*) FROM stripe_customers
+		 WHERE plan <> 'free' AND status IN ('active', 'trialing', 'past_due')`).
+		Scan(&t.Paying); err != nil {
+		log.Printf("[Admin] plans paying count: %v", err)
 	}
 	return t
 }

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -69,12 +69,22 @@ export interface DailyCount {
   count: number
 }
 
+/**
+ * Two counts, because they answer two questions. `total` is accounts, read
+ * from Logto. `set_up` is how many of them ever saved a preference locally.
+ * The gap between them is 83 people who signed up and never set the app up —
+ * the most interesting number on the page (REL-265).
+ *
+ * `source` is 'local' when Logto could not be reached; `total` then falls back
+ * to `set_up` and must be labelled as the local number, never as accounts.
+ */
 export interface AccountsTile {
   total: number
+  set_up: number
+  source: 'logto' | 'local'
+  note?: string
   new_7d: Measured
   new_30d: Measured
-  untracked: number
-  tracking_since?: string
   daily: Array<DailyCount> | null
 }
 
@@ -85,8 +95,9 @@ export interface PlanRow {
   count: number
 }
 
+/** `paying` excludes plan='free', so a free row in Stripe cannot inflate it. */
 export interface PlansTile {
-  free: number
+  paying: number
   rows: Array<PlanRow> | null
 }
 
@@ -155,6 +166,7 @@ export interface AdminOverview {
 export interface AccountRow {
   logto_sub: string
   email: string | null
+  name: string | null
   plan: string
   status: string
   lifetime: boolean
@@ -162,16 +174,28 @@ export interface AccountRow {
   on_ticker: number
   fantasy: boolean
   tickets: number
-  created_at: string | null
-  updated_at: string
+  /** From Logto. When they created the account. */
+  signed_up_at: string | null
+  /** From Logto. When they last authenticated. */
+  last_sign_in_at: string | null
+  /** Local. When the app last wrote a preference — not the same as last seen. */
+  last_used_app: string | null
+  /** Whether they have a user_preferences row at all. */
+  set_up: boolean
+  suspended: boolean
   deletion_state: string | null
 }
 
 export interface AccountsPage {
   accounts: Array<AccountRow>
+  /** Accounts in Logto, or — when source is 'local' — accounts with local data. */
   total: number
+  /** How many accounts have ever set the app up. Global, not per page. */
+  set_up: number
   page: number
   page_size: number
+  source: 'logto' | 'local'
+  note?: string
 }
 
 export interface AccountWidget {

--- a/myscrollr.com/src/components/admin/OverviewPage.tsx
+++ b/myscrollr.com/src/components/admin/OverviewPage.tsx
@@ -123,6 +123,10 @@ export default function OverviewPage() {
   const releases = (data.downloads.releases ?? []).slice(0, 5)
   const ingest = data.ingest ?? []
   const plans = (data.plans.rows ?? []).filter((r) => r.plan !== 'free')
+  // The gap is the point of this page: accounts that exist but never got far
+  // enough into the product to save a preference.
+  const neverSetUp = Math.max(0, data.accounts.total - data.accounts.set_up)
+  const free = Math.max(0, data.accounts.total - data.plans.paying)
   const requests = (data.demand.catalog_requests ?? []).slice(0, 5)
 
   return (
@@ -138,15 +142,35 @@ export default function OverviewPage() {
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <Tile
-          title="Accounts"
+          title={
+            data.accounts.source === 'local'
+              ? 'Accounts (local count)'
+              : 'Accounts'
+          }
           to="/admin/users"
           caveat={
-            data.accounts.untracked > 0
-              ? `${data.accounts.untracked.toLocaleString()} accounts predate signup-date tracking, so they are counted in the total but not in "new".`
-              : undefined
+            data.accounts.note ??
+            'Accounts come from Logto. "Set up the app" is a local count of who ever saved a preference.'
           }
         >
           <Big>{data.accounts.total.toLocaleString()}</Big>
+          <p className="mt-1 text-sm text-base-content/60">
+            {data.accounts.source === 'local'
+              ? 'accounts with local data — Logto unreachable'
+              : 'accounts'}
+          </p>
+          {data.accounts.source === 'logto' && (
+            <p className="mt-3 text-sm text-base-content/60">
+              <span className="font-semibold text-base-content">
+                {data.accounts.set_up.toLocaleString()}
+              </span>{' '}
+              have set up the app —{' '}
+              <span className="font-semibold text-warning">
+                {neverSetUp.toLocaleString()}
+              </span>{' '}
+              never did
+            </p>
+          )}
           <div className="mt-3">
             {newAccounts.display === null ? (
               <Unmeasurable note={newAccounts.note} />
@@ -179,11 +203,13 @@ export default function OverviewPage() {
         </Tile>
 
         <Tile
-          title="Plans"
-          caveat="From Stripe. Accounts with no Stripe record are counted as free."
+          title="Paying"
+          caveat="From Stripe, excluding rows on the free plan — one active Stripe record is a free-plan row and is not a customer. Free is every account that is not paying."
         >
-          <Big>{data.plans.free.toLocaleString()}</Big>
-          <p className="mt-1 mb-2 text-sm text-base-content/60">free</p>
+          <Big>{data.plans.paying.toLocaleString()}</Big>
+          <p className="mt-1 mb-2 text-sm text-base-content/60">
+            paying · {free.toLocaleString()} free
+          </p>
           {plans.length === 0 ? (
             <p className="text-sm text-base-content/50">
               No paid subscriptions.

--- a/myscrollr.com/src/components/admin/UsersPage.tsx
+++ b/myscrollr.com/src/components/admin/UsersPage.tsx
@@ -12,13 +12,22 @@ import { useGetToken } from '@/hooks/useGetToken'
  * separate consequences, so there is no write path here at all — no disabled
  * button, no "coming soon" affordance, nothing to reach for.
  *
- * Search matches the Logto sub or an email from the user's support cases,
- * which is the only place this database keeps one.
+ * The list is every account, from Logto. It used to be every row in
+ * user_preferences, which meant the 83 people who signed up and never set the
+ * app up were not in it at all (REL-265). Search runs against Logto and so
+ * matches email and username; widget and ticket counts are local and cannot be
+ * searched or sorted across the whole set, which the page says out loud rather
+ * than sorting one page and letting it look global.
  */
 
 function planLabel(a: AccountRow): string {
   if (a.plan === 'free' || a.status === 'none') return 'Free'
   return `${a.plan}${a.lifetime ? ' · lifetime' : ''} · ${a.status}`
+}
+
+/** A date, or an em dash when the event never happened. */
+function day(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleDateString() : '—'
 }
 
 function DetailPanel({ sub, onBack }: { sub: string; onBack: () => void }) {
@@ -63,7 +72,9 @@ function DetailPanel({ sub, onBack }: { sub: string; onBack: () => void }) {
         <>
           <header>
             <h1 className="text-xl font-bold break-all">
-              {detail.account.email ?? detail.account.logto_sub}
+              {detail.account.email ??
+                detail.account.name ??
+                detail.account.logto_sub}
             </h1>
             <p className="mt-1 font-mono text-xs break-all text-base-content/50">
               {detail.account.logto_sub}
@@ -71,13 +82,30 @@ function DetailPanel({ sub, onBack }: { sub: string; onBack: () => void }) {
             <p className="mt-2 text-sm text-base-content/60">
               {planLabel(detail.account)}
               {detail.account.fantasy && ' · fantasy connected'}
+              {detail.account.suspended && ' · suspended'}
               {detail.account.deletion_state &&
                 ` · deletion ${detail.account.deletion_state}`}
             </p>
-            {!detail.account.email && (
-              <p className="mt-2 text-xs text-base-content/45">
-                No email on file — this database only stores an address once a
-                user opens a support ticket.
+            <dl className="mt-3 grid grid-cols-3 gap-3 text-sm">
+              <div>
+                <dt className="text-xs text-base-content/50">Signed up</dt>
+                <dd>{day(detail.account.signed_up_at)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-base-content/50">Last sign-in</dt>
+                <dd>{day(detail.account.last_sign_in_at)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-base-content/50">
+                  Last used the app
+                </dt>
+                <dd>{day(detail.account.last_used_app)}</dd>
+              </div>
+            </dl>
+            {!detail.account.set_up && (
+              <p className="mt-3 text-xs text-warning">
+                This account has never set the app up — no preferences were ever
+                saved.
               </p>
             )}
           </header>
@@ -181,13 +209,45 @@ export default function UsersPage() {
   }
 
   const pageCount = data ? Math.ceil(data.total / data.page_size) : 0
+  // The gap REL-265 uncovered: accounts that exist but never saved a
+  // preference. Global counts, so they are only honest with no search term.
+  const neverSetUp = data ? Math.max(0, data.total - data.set_up) : 0
 
   return (
     <div className="space-y-5">
       <header>
         <h1 className="text-2xl font-bold tracking-tight">Users</h1>
+        {data?.source === 'local' ? (
+          <p className="mt-1 text-sm text-warning">
+            {data.note ?? 'Logto is unreachable.'} Showing{' '}
+            {data.total.toLocaleString()} accounts with local data.
+          </p>
+        ) : (
+          data && (
+            <p className="mt-1 text-sm text-base-content/60">
+              <span className="font-semibold text-base-content">
+                {data.total.toLocaleString()}
+              </span>{' '}
+              {query ? 'accounts match' : 'accounts'}
+              {/* set_up is a count of the whole database, so pairing it with a
+                  filtered total would read as a gap within the search. */}
+              {!query && (
+                <>
+                  {' · '}
+                  <span className="font-semibold text-base-content">
+                    {data.set_up.toLocaleString()}
+                  </span>{' '}
+                  have set up the app ·{' '}
+                  <span className="font-semibold text-warning">
+                    {neverSetUp.toLocaleString()}
+                  </span>{' '}
+                  never did
+                </>
+              )}
+            </p>
+          )
+        )}
         <p className="mt-1 text-sm text-base-content/60">
-          {data ? `${data.total.toLocaleString()} accounts. ` : ''}
           Read-only — this console does not edit anyone&apos;s account.
         </p>
       </header>
@@ -204,7 +264,7 @@ export default function UsersPage() {
             setQuery(e.target.value)
             setPage(0)
           }}
-          placeholder="Search by user id or support email"
+          placeholder="Search by email or username"
           className="w-full rounded-lg bg-base-200/50 py-2.5 pr-3 pl-9 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
         />
       </div>
@@ -224,14 +284,15 @@ export default function UsersPage() {
                   <th className="p-3 font-semibold">Plan</th>
                   <th className="p-3 font-semibold">Widgets</th>
                   <th className="p-3 font-semibold">Tickets</th>
-                  <th className="p-3 font-semibold">Last seen</th>
+                  <th className="p-3 font-semibold">Signed up</th>
+                  <th className="p-3 font-semibold">Last sign-in</th>
                 </tr>
               </thead>
               <tbody>
                 {data.accounts.length === 0 && (
                   <tr>
                     <td
-                      colSpan={5}
+                      colSpan={6}
                       className="p-6 text-center text-base-content/50"
                     >
                       No accounts match that search.
@@ -246,10 +307,13 @@ export default function UsersPage() {
                   >
                     <td className="max-w-[18rem] p-3">
                       <span className="block truncate font-medium">
-                        {a.email ?? '—'}
+                        {a.email ?? a.name ?? '—'}
                       </span>
                       <span className="block truncate font-mono text-xs text-base-content/45">
                         {a.logto_sub}
+                        {!a.set_up && (
+                          <span className="text-warning"> · never set up</span>
+                        )}
                       </span>
                     </td>
                     <td className="p-3 text-base-content/70">{planLabel(a)}</td>
@@ -264,13 +328,22 @@ export default function UsersPage() {
                     </td>
                     <td className="p-3 tabular-nums">{a.tickets}</td>
                     <td className="p-3 text-base-content/60">
-                      {new Date(a.updated_at).toLocaleDateString()}
+                      {day(a.signed_up_at)}
+                    </td>
+                    <td className="p-3 text-base-content/60">
+                      {day(a.last_sign_in_at)}
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
+
+          <p className="text-xs text-base-content/45">
+            Ordered by Logto; search matches email and username. Widgets and
+            tickets come from this database and cannot be sorted or searched
+            across the whole set — those columns describe only this page.
+          </p>
 
           {pageCount > 1 && (
             <div className="flex items-center justify-between text-sm">


### PR DESCRIPTION
Closes [REL-265](https://linear.app/relentnet/issue/REL-265).

## The bug

The Users page header and the Overview's Accounts tile both counted `SELECT count(*) FROM user_preferences`. That table gains a row the first time the app saves a preference, so it counts *app setups*, not accounts.

Production: **100** rows in `user_preferences`, **183** accounts in Logto. Eighty-three people were structurally invisible — not just miscounted, absent from the list entirely, and their detail pages 404'd.

## What changed

**Logto is the source for accounts.** `api/internal/accounts/logto_admin.go` gains `ListLogtoUsers(page, pageSize, search)`, `ListAllLogtoUsers()` and `GetLogtoUser(sub)`. `LogtoPrimaryEmail` becomes a four-line wrapper over `GetLogtoUser` — same behaviour, one HTTP path instead of two. No new credentials; the existing M2M client and token cache do the work.

The total comes from the `total-number` response header, so counting every account costs one request with `page_size=1`. Logto rejects `page_size > 100` with `guard.invalid_pagination` rather than clamping, so the client clamps.

**The Users list** pages `/api/users` and left-joins the local tables off the returned ids (`FROM unnest($1::text[]) AS u(sub) LEFT JOIN …`). Driving the query from the id list rather than from `user_preferences` is the whole fix: an account with no local rows comes back with honest zeroes instead of being dropped. `HandleGetAccount` works for those accounts too — it used to 404.

**Both numbers, labelled differently.** The header reads `183 accounts · 100 have set up the app · 83 never did`, and the Accounts tile carries `total`, `set_up` and the gap. The gap line is hidden while a search is active, because `set_up` is a whole-database count and pairing it with a filtered total would read as a gap within the search.

**Signup date and last sign-in** come from Logto's `createdAt` / `lastSignInAt` (Unix milliseconds). The old `user_preferences.updated_at` column stays, renamed to **"last used the app"** — it was labelled "last seen" and never meant that. Real signup dates for all 183 also retire the `untracked` / `tracking_since` apparatus and make the pending `created_at` backfill moot.

**Paying excludes `plan = 'free'`.** Three active `stripe_customers` rows, one on the free plan → the honest count is 2. `PlansTile.Free` is gone; free is derived as `accounts.total − plans.paying` so a second count can't drift from the first.

**Logto down degrades visibly.** Both surfaces fall back to the local number, set `source: "local"`, carry a note, and label the number as local. The tile title becomes "Accounts (local count)" and the signup windows report themselves unavailable. Reporting 100 as the truth is the bug this change exists to fix, so it can't be the failure mode.

## Decided, not discovered

- Search runs against Logto → matches `primaryEmail` and `username` only. Widget and ticket counts are local and **not** sortable across the whole set; the page says so in a caption rather than sorting one page and letting it look global.
- One Logto call per page view. The Overview's signup series walks all pages (2 requests at 183 accounts) because the per-account `createdAt` is what makes "new this week" a fact about signups. Capped at 5000 with a `ponytail:` note naming the upgrade path. No cache, no sync job — the two surfaces are separate page loads and neither needs the other's number.

## Verification

Exercised against production:

- `accounts.ListLogtoUsers(1, 1, "")` → **total = 183**, matching the Logto dashboard exactly. `ListAllLogtoUsers()` → scanned 183, total 183. All 183 carry a `primaryEmail`; 169 carry a `lastSignInAt`.
- Search params confirmed live: `search.primaryEmail` + `search.username` + `searchMode=or` returns 200 with a correct `total-number` (139 for `%gmail%`, 0 for a nonsense term). Worth checking because a 400 here would have silently degraded every search to the local path.
- Prod DB read-only: `user_preferences` = 100 rows; `stripe_customers` = `ultimate_annual/active`, `annual/active`, `free/active`.

Seven new integration tests in `api/internal/admin/handlers_accounts_test.go`, all passing against a real Postgres (not skipped):

- the list total is Logto's, not the local table's
- an account present in Logto with no `user_preferences` row appears, with zero widgets/tickets, null `last_used_app`, and Logto's email and signup date
- the detail page opens for such an account
- Logto down → `source: "local"` + a note + the local total
- the tile carries both counts
- the tile degrades with the signup windows marked unavailable
- **paying reads 2, and adding another free-plan row leaves it at 2**

`go build ./...`, `go vet`, `gofmt -l` and the full `go test ./...` are clean. Site: `vite build && tsc`, `vitest` (104 tests), `eslint` and `prettier --check` all pass.

**Not exercised:** the rendered page. There is no way to sign in as Brandon from here, so verification stops at the auth gate — `GET /admin/overview` and `GET /admin/accounts` on production return 401 with no token and with a junk token, unchanged. The React changes are covered by the typechecker and the build, not by a live render.

**No screenshots**, deliberately: the Users page renders 183 real email addresses and this repository is public.

---

### Reported separately, not built here

Now that `lastSignInAt` and `applicationId` are readable, the 83 split out as: 14 never signed in at all, 58 signed in once at signup and never returned, 11 sign in but have never set the app up. By signup app: 53 desktop, 15 website, 15 with no application recorded. Numbers are in the Linear comment for the home session to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
