### PR TITLE
Growth is Logto's to compute, deltas and the curve included [REL-269]

### DIFF
--- a/api/internal/accounts/logto_admin.go
+++ b/api/internal/accounts/logto_admin.go
@@ -600,33 +600,3 @@ func ListLogtoUsers(page, pageSize int, search string) ([]LogtoUser, int, error)
 	}
 	return users, total, nil
 }
-
-// logtoScanCap bounds ListAllLogtoUsers so a runaway or a much larger tenant
-// cannot turn one dashboard load into hundreds of upstream requests.
-//
-// ponytail: a full scan is fine at ~200 accounts. If this cap ever bites, the
-// fix is a cached nightly aggregate of signup dates, not a bigger cap.
-const logtoScanCap = 5000
-
-// ListAllLogtoUsers walks every page and returns every account.
-//
-// Only the Overview's signup series needs this: the per-account createdAt is
-// what makes "new this week" a fact about signups rather than about when a
-// local column was added. Anything that only needs the count should call
-// ListLogtoUsers(1, 1, "") and read the total.
-//
-// Returns the scanned users and the upstream total. When the cap truncates the
-// scan the total still reflects reality, so a caller can tell.
-func ListAllLogtoUsers() ([]LogtoUser, int, error) {
-	var all []LogtoUser
-	for page := 1; ; page++ {
-		batch, total, err := ListLogtoUsers(page, logtoMaxPageSize, "")
-		if err != nil {
-			return nil, 0, err
-		}
-		all = append(all, batch...)
-		if len(batch) < logtoMaxPageSize || len(all) >= total || len(all) >= logtoScanCap {
-			return all, total, nil
-		}
-	}
-}

--- a/api/internal/accounts/logto_stats.go
+++ b/api/internal/accounts/logto_stats.go
@@ -1,0 +1,131 @@
+package accounts
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+)
+
+// =============================================================================
+// Logto Management API — the dashboard stats endpoints
+// =============================================================================
+//
+// Logto already computes account growth and activity, with each figure's
+// change against the previous period, and a daily-active series about a month
+// deep. Reading it costs three requests and no storage: no aggregation table,
+// no nightly rollup, no cron. That is the whole reason to prefer these over
+// walking /api/users and counting rows ourselves (REL-269).
+//
+// ⚠️ SECURITY: /api/dashboard/* sits one path segment away from
+// /api/connectors, whose response body returns every connector's
+// configuration INCLUDING API TOKENS IN PLAINTEXT. It is not a dashboard data
+// source under any circumstance. Nothing in this codebase calls it, and
+// nothing should start.
+
+// LogtoTrend is a count together with Logto's own change against the previous
+// comparable period. The delta is the point: 85 monthly actives says little,
+// 85 up from 35 says the product is growing.
+type LogtoTrend struct {
+	Count int `json:"count"`
+	Delta int `json:"delta"`
+}
+
+// LogtoDayCount is one point on the daily-active curve. Date is "2006-01-02".
+type LogtoDayCount struct {
+	Date  string `json:"date"`
+	Count int    `json:"count"`
+}
+
+// LogtoStats is everything the three dashboard endpoints report.
+//
+// Total replaces the total-number header trick REL-265 used: same number, from
+// an endpoint that exists to answer exactly this.
+type LogtoStats struct {
+	Total    int
+	NewToday LogtoTrend
+	New7d    LogtoTrend
+	DAU      LogtoTrend
+	WAU      LogtoTrend
+	MAU      LogtoTrend
+	DauCurve []LogtoDayCount
+}
+
+// FetchLogtoStats reads the three dashboard endpoints.
+//
+// Sequential on purpose: the caller caches the result for minutes, so the
+// three round trips happen once per cache window and concurrency would buy
+// nothing but a fan-out to reason about. Any one failing fails the whole
+// read — a half-filled growth tile is worse than one that says Logto is down.
+func FetchLogtoStats() (LogtoStats, error) {
+	var s LogtoStats
+
+	var total struct {
+		TotalUserCount int `json:"totalUserCount"`
+	}
+	if err := logtoGetJSON("/api/dashboard/users/total", &total); err != nil {
+		return s, err
+	}
+
+	var fresh struct {
+		Today     LogtoTrend `json:"today"`
+		Last7Days LogtoTrend `json:"last7Days"`
+	}
+	if err := logtoGetJSON("/api/dashboard/users/new", &fresh); err != nil {
+		return s, err
+	}
+
+	var active struct {
+		DAU      LogtoTrend      `json:"dau"`
+		WAU      LogtoTrend      `json:"wau"`
+		MAU      LogtoTrend      `json:"mau"`
+		DauCurve []LogtoDayCount `json:"dauCurve"`
+	}
+	if err := logtoGetJSON("/api/dashboard/users/active", &active); err != nil {
+		return s, err
+	}
+
+	s.Total = total.TotalUserCount
+	s.NewToday, s.New7d = fresh.Today, fresh.Last7Days
+	s.DAU, s.WAU, s.MAU = active.DAU, active.WAU, active.MAU
+	s.DauCurve = active.DauCurve
+	return s, nil
+}
+
+// logtoGetJSON GETs a Management API path with the M2M token and decodes the
+// body into out. path starts with a slash.
+func logtoGetJSON(path string, out any) error {
+	cfg := getM2MConfig()
+	if cfg.Endpoint == "" {
+		return fmt.Errorf("LOGTO_ENDPOINT not set")
+	}
+
+	token, err := getM2MToken()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("GET", cfg.Endpoint+path, nil)
+	if err != nil {
+		return fmt.Errorf("create %s request: %w", path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: platform.LogtoM2MTokenTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s request failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned %d: %s", path, resp.StatusCode, string(body))
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+	return nil
+}

--- a/api/internal/admin/handlers_accounts_test.go
+++ b/api/internal/admin/handlers_accounts_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/brandon-relentnet/myscrollr/api/internal/accounts"
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
 	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
 	"github.com/gofiber/fiber/v2"
 )
@@ -17,10 +18,10 @@ import (
 // the account count. Everything here is arranged so that a regression to
 // "count user_preferences and call it accounts" fails loudly.
 
-// withLogtoUsers swaps both Logto seams for a fixed set of accounts.
+// withLogtoUsers swaps both Logto account seams for a fixed set of accounts.
 func withLogtoUsers(t *testing.T, total int, users ...accounts.LogtoUser) {
 	t.Helper()
-	prevList, prevGet, prevAll := listLogtoUsers, getLogtoUser, listAllLogtoUsers
+	prevList, prevGet := listLogtoUsers, getLogtoUser
 
 	listLogtoUsers = func(page, pageSize int, search string) ([]accounts.LogtoUser, int, error) {
 		return users, total, nil
@@ -33,30 +34,54 @@ func withLogtoUsers(t *testing.T, total int, users ...accounts.LogtoUser) {
 		}
 		return nil, nil
 	}
-	listAllLogtoUsers = func() ([]accounts.LogtoUser, int, error) {
-		return users, total, nil
-	}
 
 	t.Cleanup(func() {
-		listLogtoUsers, getLogtoUser, listAllLogtoUsers = prevList, prevGet, prevAll
+		listLogtoUsers, getLogtoUser = prevList, prevGet
 	})
+}
+
+// withLogtoStats swaps the dashboard-stats seam and clears the Redis copy, so
+// a case cannot be served the previous case's numbers out of the cache.
+func withLogtoStats(t *testing.T, stats accounts.LogtoStats) func() int {
+	t.Helper()
+	prev := logtoStats
+	calls := 0
+	logtoStats = func() (accounts.LogtoStats, error) {
+		calls++
+		return stats, nil
+	}
+	clearLogtoStatsCache(t)
+	t.Cleanup(func() {
+		logtoStats = prev
+		clearLogtoStatsCache(t)
+	})
+	return func() int { return calls }
+}
+
+func clearLogtoStatsCache(t *testing.T) {
+	t.Helper()
+	if platform.Rdb != nil {
+		_ = platform.Rdb.Del(context.Background(), logtoStatsCacheKey).Err()
+	}
 }
 
 // withLogtoDown makes every Logto read fail, which is the case the page has to
 // survive without quietly reporting a smaller number as the truth.
 func withLogtoDown(t *testing.T) {
 	t.Helper()
-	prevList, prevGet, prevAll := listLogtoUsers, getLogtoUser, listAllLogtoUsers
+	prevList, prevGet, prevStats := listLogtoUsers, getLogtoUser, logtoStats
 	down := errors.New("logto unreachable")
 
 	listLogtoUsers = func(page, pageSize int, search string) ([]accounts.LogtoUser, int, error) {
 		return nil, 0, down
 	}
 	getLogtoUser = func(sub string) (*accounts.LogtoUser, error) { return nil, down }
-	listAllLogtoUsers = func() ([]accounts.LogtoUser, int, error) { return nil, 0, down }
+	logtoStats = func() (accounts.LogtoStats, error) { return accounts.LogtoStats{}, down }
+	clearLogtoStatsCache(t)
 
 	t.Cleanup(func() {
-		listLogtoUsers, getLogtoUser, listAllLogtoUsers = prevList, prevGet, prevAll
+		listLogtoUsers, getLogtoUser, logtoStats = prevList, prevGet, prevStats
+		clearLogtoStatsCache(t)
 	})
 }
 
@@ -223,29 +248,95 @@ func TestGetAccountWorksWithNoLocalRow(t *testing.T) {
 	}
 }
 
-// Both numbers, and the gap, from one tile.
+// prodShapedStats mirrors what Logto returned for this tenant on 2026-09-09,
+// including the dau delta of -10: a day that went down is the case the tile
+// most has to render honestly.
+func prodShapedStats() accounts.LogtoStats {
+	return accounts.LogtoStats{
+		Total:    183,
+		NewToday: accounts.LogtoTrend{Count: 0, Delta: -2},
+		New7d:    accounts.LogtoTrend{Count: 16, Delta: 1},
+		DAU:      accounts.LogtoTrend{Count: 2, Delta: -10},
+		WAU:      accounts.LogtoTrend{Count: 31, Delta: 2},
+		MAU:      accounts.LogtoTrend{Count: 85, Delta: 50},
+		DauCurve: []accounts.LogtoDayCount{
+			{Date: "2026-08-12", Count: 4},
+			{Date: "2026-08-13", Count: 7},
+			{Date: "2026-09-09", Count: 2},
+		},
+	}
+}
+
+// Both numbers, and the gap, from one tile. The account total is Logto's;
+// set_up is local. Reporting the local number as the account total is the
+// regression REL-265 was filed for and this still guards it.
 func TestAccountsTileCarriesBothCounts(t *testing.T) {
 	if !testsupport.DBAvailable(t) {
 		return
 	}
 	resetAccountTables(t)
 	seedPreferences(t, "has-prefs")
+	withLogtoStats(t, prodShapedStats())
 
-	withLogtoUsers(t, 3,
-		accounts.LogtoUser{ID: "has-prefs", CreatedAt: 1_700_000_000_000},
-		accounts.LogtoUser{ID: "b", CreatedAt: 1_700_000_000_000},
-		accounts.LogtoUser{ID: "c", CreatedAt: 1_700_000_000_000},
-	)
-
-	tile := accountsTile(context.Background())
+	stats, err := cachedLogtoStats(context.Background())
+	tile := accountsTile(context.Background(), stats, err)
 	if tile.Source != "logto" {
 		t.Fatalf("source = %q, want logto", tile.Source)
 	}
-	if tile.Total != 3 {
-		t.Errorf("total = %d, want 3", tile.Total)
+	if tile.Total != 183 {
+		t.Errorf("total = %d, want 183", tile.Total)
 	}
 	if tile.SetUp != 1 {
 		t.Errorf("set_up = %d, want 1", tile.SetUp)
+	}
+	if tile.New7d.Value != 16 || tile.New7d.Delta != 1 || !tile.New7d.Available {
+		t.Errorf("new_7d = %+v, want 16 (+1) available", tile.New7d)
+	}
+	// A count of 0 with a delta of -2 is a real reading, not a missing one.
+	if !tile.NewToday.Available || tile.NewToday.Value != 0 || tile.NewToday.Delta != -2 {
+		t.Errorf("new_today = %+v, want 0 (-2) available", tile.NewToday)
+	}
+}
+
+// The figures are cached: a second read inside the window must not cost
+// another three round trips to Logto.
+func TestLogtoStatsAreCached(t *testing.T) {
+	if !testsupport.RedisAvailable(t) {
+		return
+	}
+	calls := withLogtoStats(t, prodShapedStats())
+
+	first, err := cachedLogtoStats(context.Background())
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	second, _ := cachedLogtoStats(context.Background())
+
+	if calls() != 1 {
+		t.Errorf("hit Logto %d times for two reads, want 1", calls())
+	}
+	if second.Total != first.Total || second.MAU != first.MAU ||
+		len(second.DauCurve) != len(first.DauCurve) {
+		t.Errorf("cached read differs: %+v vs %+v", second, first)
+	}
+}
+
+func TestActiveTileCarriesDeltasAndTheCurve(t *testing.T) {
+	tile := activeTile(prodShapedStats(), nil)
+
+	if !tile.DAU.Available || tile.DAU.Value != 2 || tile.DAU.Delta != -10 {
+		t.Errorf("dau = %+v, want 2 (-10) available", tile.DAU)
+	}
+	if tile.MAU.Delta != 50 {
+		t.Errorf("mau delta = %d, want 50", tile.MAU.Delta)
+	}
+	if len(tile.Curve) != 3 {
+		t.Fatalf("curve has %d points, want 3", len(tile.Curve))
+	}
+	// The final point is today's. Dropping or reordering it would put the
+	// chart's most-read end somewhere it did not happen.
+	if last := tile.Curve[len(tile.Curve)-1]; last.Day != "2026-09-09" || last.Count != 2 {
+		t.Errorf("last curve point = %+v, want 2026-09-09 count 2", last)
 	}
 }
 
@@ -257,7 +348,11 @@ func TestAccountsTileDegradesVisiblyWhenLogtoIsDown(t *testing.T) {
 	seedPreferences(t, "has-prefs")
 	withLogtoDown(t)
 
-	tile := accountsTile(context.Background())
+	stats, err := cachedLogtoStats(context.Background())
+	if err == nil {
+		t.Fatal("cachedLogtoStats returned no error with Logto down")
+	}
+	tile := accountsTile(context.Background(), stats, err)
 	if tile.Source != "local" {
 		t.Fatalf("source = %q, want local", tile.Source)
 	}
@@ -268,8 +363,25 @@ func TestAccountsTileDegradesVisiblyWhenLogtoIsDown(t *testing.T) {
 		t.Errorf("total = %d, set_up = %d; the local fallback should report the local number",
 			tile.Total, tile.SetUp)
 	}
-	if tile.New7d.Available || tile.New30d.Available {
+	if tile.New7d.Available || tile.NewToday.Available {
 		t.Error("signup windows claim to be available with Logto down")
+	}
+}
+
+// Activity has no local stand-in at all, so with Logto down the tile says so
+// and shows nothing - never a zero, which would read as "nobody used Scrollr
+// today".
+func TestActiveTileSaysSoWhenLogtoIsDown(t *testing.T) {
+	tile := activeTile(accounts.LogtoStats{}, errors.New("logto unreachable"))
+
+	if tile.DAU.Available || tile.WAU.Available || tile.MAU.Available {
+		t.Error("an activity figure claims to be available with Logto down")
+	}
+	if tile.Note == "" {
+		t.Error("no note where the numbers would be")
+	}
+	if len(tile.Curve) != 0 {
+		t.Errorf("curve has %d points with Logto down", len(tile.Curve))
 	}
 }
 

--- a/api/internal/admin/handlers_overview.go
+++ b/api/internal/admin/handlers_overview.go
@@ -2,8 +2,8 @@ package admin
 
 import (
 	"context"
+	"encoding/json"
 	"log"
-	"sort"
 	"sync"
 	"time"
 
@@ -23,9 +23,14 @@ import (
 // oversight - so installs are NOT measurable, and the Installs tile exists
 // purely to say so and point at downloads instead.
 
-// listAllLogtoUsers is the tile's seam onto Logto, so the tests can drive
-// both the healthy path and the unreachable path without a network.
-var listAllLogtoUsers = accounts.ListAllLogtoUsers
+// logtoStats is the tile's seam onto Logto, so the tests can drive both the
+// healthy path and the unreachable path without a network.
+var logtoStats = accounts.FetchLogtoStats
+
+const (
+	logtoStatsCacheKey = "scrollr:admin:logto_stats"
+	logtoStatsCacheTTL = 5 * time.Minute
+)
 
 // Measured wraps a number with whether it means what its label says. When
 // Available is false the client renders Note instead of Value.
@@ -38,6 +43,7 @@ type Measured = platform.Measured
 type OverviewResponse struct {
 	GeneratedAt  string        `json:"generated_at"`
 	Accounts     AccountsTile  `json:"accounts"`
+	Active       ActiveTile    `json:"active"`
 	Plans        PlansTile     `json:"plans"`
 	Downloads    DownloadsTile `json:"downloads"`
 	Installs     Measured      `json:"installs"`
@@ -63,17 +69,43 @@ type OverviewResponse struct {
 // the local case Total falls back to SetUp and Note says why. A smaller number
 // presented without that label is the bug this tile was rebuilt to fix.
 //
-// The signup series comes from Logto's per-account createdAt, so "new this
-// week" is a fact about signups rather than about when a local column was
-// added. That retires the old untracked/tracking-since apparatus.
+// The signup counts are Logto's own, each with the change against the
+// previous comparable period. REL-269 swapped them in for a walk over every
+// account's createdAt: same facts, one request, and a delta we could not have
+// computed without storing yesterday's answer somewhere.
 type AccountsTile struct {
-	Total  int          `json:"total"`
-	SetUp  int          `json:"set_up"`
-	Source string       `json:"source"`
-	Note   string       `json:"note,omitempty"`
-	New7d  Measured     `json:"new_7d"`
-	New30d Measured     `json:"new_30d"`
-	Daily  []DailyCount `json:"daily"`
+	Total    int    `json:"total"`
+	SetUp    int    `json:"set_up"`
+	Source   string `json:"source"`
+	Note     string `json:"note,omitempty"`
+	NewToday Trend  `json:"new_today"`
+	New7d    Trend  `json:"new_7d"`
+}
+
+// Trend is a figure with the change Logto reports against the previous
+// comparable period. Available is false when Logto could not be reached, and
+// then neither number may be rendered - the same promise Measured makes, with
+// a second field, since a delta of 0 is as much a claim as a count of 0.
+type Trend struct {
+	Value     int    `json:"value"`
+	Delta     int    `json:"delta"`
+	Available bool   `json:"available"`
+	Note      string `json:"note,omitempty"`
+}
+
+// ActiveTile is who actually used Scrollr, which is a different question from
+// how many accounts exist - and the only one of the two that can go down.
+//
+// Curve is Logto's daily-active series, about a month deep. It is theirs, not
+// ours: no aggregation table, no rollup job, no cron. If Logto ever stops
+// serving it the chart disappears rather than being reconstructed from
+// something that only resembles it.
+type ActiveTile struct {
+	DAU   Trend        `json:"dau"`
+	WAU   Trend        `json:"wau"`
+	MAU   Trend        `json:"mau"`
+	Curve []DailyCount `json:"curve"`
+	Note  string       `json:"note,omitempty"`
 }
 
 type DailyCount struct {
@@ -171,7 +203,13 @@ func HandleGetOverview(c *fiber.Ctx) error {
 		}()
 	}
 
-	run("accounts", func() { out.Accounts = accountsTile(ctx) })
+	// Accounts and Active come from the same cached Logto read, so they run
+	// as one section rather than racing for the same three round trips.
+	run("logto", func() {
+		stats, err := cachedLogtoStats(ctx)
+		out.Accounts = accountsTile(ctx, stats, err)
+		out.Active = activeTile(stats, err)
+	})
 	run("plans", func() { out.Plans = plansTile(ctx) })
 	run("downloads", func() { out.Downloads = downloadsTile(ctx) })
 	run("support", func() { out.Support = supportTile(ctx) })
@@ -186,15 +224,50 @@ func HandleGetOverview(c *fiber.Ctx) error {
 	return c.JSON(out)
 }
 
-func accountsTile(ctx context.Context) AccountsTile {
-	var t AccountsTile
-
-	if err := platform.DBPool.QueryRow(ctx,
-		`SELECT count(*) FROM user_preferences`).Scan(&t.SetUp); err != nil {
-		log.Printf("[Admin] accounts set-up count: %v", err)
+// cachedLogtoStats reads the growth figures through Redis. They are a
+// dashboard's numbers, not per-request data: without the cache every Overview
+// load - and every refresh of it - would cost three upstream round trips to
+// tell the reader the same thing.
+//
+// There is deliberately no stale-copy fallback like the downloads tile's. A
+// download count that is fifteen minutes old is still a download count; "2
+// people were active today" from an hour ago is a different claim than it
+// looks. When Logto is unreachable the tiles say so.
+func cachedLogtoStats(ctx context.Context) (accounts.LogtoStats, error) {
+	var s accounts.LogtoStats
+	if platform.Rdb != nil {
+		if raw, err := platform.Rdb.Get(ctx, logtoStatsCacheKey).Result(); err == nil && raw != "" {
+			if json.Unmarshal([]byte(raw), &s) == nil {
+				return s, nil
+			}
+		}
 	}
 
-	users, total, err := listAllLogtoUsers()
+	s, err := logtoStats()
+	if err != nil {
+		return accounts.LogtoStats{}, err
+	}
+
+	if platform.Rdb != nil {
+		if raw, err := json.Marshal(s); err == nil {
+			_ = platform.Rdb.Set(ctx, logtoStatsCacheKey, raw, logtoStatsCacheTTL).Err()
+		}
+	}
+	return s, nil
+}
+
+// logtoDownNote is the one sentence both tiles use when the read failed. It
+// says which number is missing and why, and never a number in its place.
+const logtoDownNote = "Logto is unreachable, so this is not measurable right now."
+
+func accountsTile(ctx context.Context, stats accounts.LogtoStats, err error) AccountsTile {
+	var t AccountsTile
+
+	if dbErr := platform.DBPool.QueryRow(ctx,
+		`SELECT count(*) FROM user_preferences`).Scan(&t.SetUp); dbErr != nil {
+		log.Printf("[Admin] accounts set-up count: %v", dbErr)
+	}
+
 	if err != nil {
 		// Degrade loudly. The local number is real, but it is not the account
 		// count, and the tile says which one the reader is looking at.
@@ -202,39 +275,29 @@ func accountsTile(ctx context.Context) AccountsTile {
 		t.Total, t.Source = t.SetUp, "local"
 		t.Note = "Logto is unreachable, so this is not the account count. It " +
 			"is how many accounts have set the app up, which is fewer."
-		note := "Signup dates come from Logto, which is unreachable."
-		t.New7d = Measured{Available: false, Note: note}
-		t.New30d = Measured{Available: false, Note: note}
+		t.NewToday = Trend{Note: "Signup counts come from Logto, which is unreachable."}
+		t.New7d = t.NewToday
 		return t
 	}
 
-	t.Total, t.Source = total, "logto"
-	t.New7d.Available, t.New30d.Available = true, true
+	t.Total, t.Source = stats.Total, "logto"
+	t.NewToday = Trend{Value: stats.NewToday.Count, Delta: stats.NewToday.Delta, Available: true}
+	t.New7d = Trend{Value: stats.New7d.Count, Delta: stats.New7d.Delta, Available: true}
+	return t
+}
 
-	now := time.Now()
-	week, month := now.AddDate(0, 0, -7), now.AddDate(0, 0, -30)
-	daily := make(map[string]int, 30)
-	for _, u := range users {
-		if u.CreatedAt <= 0 {
-			continue
-		}
-		created := time.UnixMilli(u.CreatedAt)
-		if created.After(week) {
-			t.New7d.Value++
-		}
-		if created.After(month) {
-			t.New30d.Value++
-			daily[created.UTC().Format("2006-01-02")]++
-		}
+func activeTile(stats accounts.LogtoStats, err error) ActiveTile {
+	if err != nil {
+		return ActiveTile{Note: logtoDownNote}
 	}
 
-	days := make([]string, 0, len(daily))
-	for day := range daily {
-		days = append(days, day)
+	t := ActiveTile{
+		DAU: Trend{Value: stats.DAU.Count, Delta: stats.DAU.Delta, Available: true},
+		WAU: Trend{Value: stats.WAU.Count, Delta: stats.WAU.Delta, Available: true},
+		MAU: Trend{Value: stats.MAU.Count, Delta: stats.MAU.Delta, Available: true},
 	}
-	sort.Strings(days)
-	for _, day := range days {
-		t.Daily = append(t.Daily, DailyCount{Day: day, Count: daily[day]})
+	for _, p := range stats.DauCurve {
+		t.Curve = append(t.Curve, DailyCount{Day: p.Date, Count: p.Count})
 	}
 	return t
 }

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -70,6 +70,19 @@ export interface DailyCount {
 }
 
 /**
+ * A figure with Logto's own change against the previous comparable period.
+ * `available: false` means Logto could not be reached — neither number may be
+ * rendered then, the same promise `Measured` makes. A delta of 0 is as much a
+ * claim as a count of 0 (REL-269).
+ */
+export interface Trend {
+  value: number
+  delta: number
+  available: boolean
+  note?: string
+}
+
+/**
  * Two counts, because they answer two questions. `total` is accounts, read
  * from Logto. `set_up` is how many of them ever saved a preference locally.
  * The gap between them is 83 people who signed up and never set the app up —
@@ -83,9 +96,24 @@ export interface AccountsTile {
   set_up: number
   source: 'logto' | 'local'
   note?: string
-  new_7d: Measured
-  new_30d: Measured
-  daily: Array<DailyCount> | null
+  new_today: Trend
+  new_7d: Trend
+}
+
+/**
+ * Who actually used Scrollr, which is a different question from how many
+ * accounts exist — and the only one of the two that can go down.
+ *
+ * `curve` is Logto's daily-active series, about a month deep, computed by
+ * Logto rather than stored here. With Logto unreachable it is empty and `note`
+ * says so; it is never reconstructed from something that only resembles it.
+ */
+export interface ActiveTile {
+  dau: Trend
+  wau: Trend
+  mau: Trend
+  curve: Array<DailyCount> | null
+  note?: string
 }
 
 export interface PlanRow {
@@ -152,6 +180,7 @@ export interface IngestRow {
 export interface AdminOverview {
   generated_at: string
   accounts: AccountsTile
+  active: ActiveTile
   plans: PlansTile
   downloads: DownloadsTile
   installs: Measured

--- a/myscrollr.com/src/components/admin/OverviewPage.tsx
+++ b/myscrollr.com/src/components/admin/OverviewPage.tsx
@@ -1,8 +1,9 @@
 import { Link } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
-import { AlertTriangle, Loader2 } from 'lucide-react'
+import { AlertTriangle, ArrowDown, ArrowUp, Loader2 } from 'lucide-react'
 import type { ReactNode } from 'react'
-import type { AdminOverview } from '@/api/admin'
+import type { AdminOverview, DailyCount, Trend } from '@/api/admin'
+import type { TrendDisplay } from '@/lib/adminFormat'
 import { adminApi } from '@/api/admin'
 import { useGetToken } from '@/hooks/useGetToken'
 import {
@@ -11,6 +12,8 @@ import {
   formatAge,
   ingestHealth,
   measuredValue,
+  sparkline,
+  trendValue,
 } from '@/lib/adminFormat'
 
 /**
@@ -72,6 +75,110 @@ function Unmeasurable({ note }: { note?: string }) {
   )
 }
 
+/**
+ * A change against the previous period, with the direction readable without
+ * reading the number. Up is coloured as good because every figure that carries
+ * one here (signups, daily/weekly/monthly actives) is one where up is good —
+ * a fall is a dip, not a decoration, so it gets the warning colour and its own
+ * arrow rather than a smaller green number.
+ */
+function Delta({ trend }: { trend: TrendDisplay }) {
+  if (trend.delta === null) {
+    return <span className="text-xs text-base-content/40">no change</span>
+  }
+  const up = trend.direction === 'up'
+  return (
+    <span
+      title="Change against the previous period, from Logto"
+      className={`inline-flex items-center gap-0.5 font-mono text-xs font-semibold tabular-nums ${
+        up ? 'text-success' : 'text-warning'
+      }`}
+    >
+      {up ? <ArrowUp size={12} /> : <ArrowDown size={12} />}
+      {trend.delta}
+    </span>
+  )
+}
+
+/** A figure and its delta on one line, or a plain admission it is missing. */
+function TrendRow({ label, trend }: { label: string; trend: Trend }) {
+  const t = trendValue(trend)
+  return (
+    <Row
+      label={label}
+      value={
+        t.value === null ? (
+          <span className="text-xs font-normal text-base-content/50">
+            unavailable
+          </span>
+        ) : (
+          <span className="inline-flex items-baseline gap-2">
+            {t.value}
+            <Delta trend={t} />
+          </span>
+        )
+      }
+    />
+  )
+}
+
+/**
+ * Logto's daily-active curve, drawn as two SVG paths. No charting library:
+ * the site ships none, and thirty points do not justify the first one.
+ *
+ * `preserveAspectRatio="none"` lets the box stretch to whatever width the tile
+ * gives it; `vector-effect` then keeps the stroke a hairline instead of
+ * stretching with it, and the marker is a tick rather than a dot for the same
+ * reason.
+ */
+const SPARK_W = 160
+const SPARK_H = 44
+
+function Sparkline({ points }: { points: Array<DailyCount> | null }) {
+  const chart = sparkline(points, SPARK_W, SPARK_H)
+  if (!chart || !points || points.length === 0) return null
+
+  const from = points[0].day
+  const to = points[points.length - 1].day
+
+  return (
+    <figure className="min-w-0 flex-1">
+      <svg
+        viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+        preserveAspectRatio="none"
+        className="h-11 w-full text-primary"
+        role="img"
+        aria-label={`Daily active users from ${from} to ${to}, peak ${chart.peak}`}
+      >
+        <path d={chart.area} fill="currentColor" opacity={0.15} />
+        <path
+          d={chart.line}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+        {/* Today, marked. The helper's padding is what keeps it on screen. */}
+        <line
+          x1={chart.last.x}
+          y1={chart.last.y}
+          x2={chart.last.x}
+          y2={SPARK_H - 3}
+          stroke="currentColor"
+          strokeWidth={1.5}
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      <figcaption className="mt-1 flex justify-between gap-2 font-mono text-[10px] text-base-content/45">
+        <span>{from}</span>
+        <span>peak {chart.peak.toLocaleString()}</span>
+        <span>{to}</span>
+      </figcaption>
+    </figure>
+  )
+}
+
 function Row({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="flex items-baseline justify-between gap-3 py-1 text-sm">
@@ -118,8 +225,8 @@ export default function OverviewPage() {
     )
   }
 
-  const newAccounts = measuredValue(data.accounts.new_30d)
   const installs = measuredValue(data.installs)
+  const dau = trendValue(data.active.dau)
   const releases = (data.downloads.releases ?? []).slice(0, 5)
   const ingest = data.ingest ?? []
   const plans = (data.plans.rows ?? []).filter((r) => r.plan !== 'free')
@@ -171,18 +278,36 @@ export default function OverviewPage() {
               never did
             </p>
           )}
-          <div className="mt-3">
-            {newAccounts.display === null ? (
-              <Unmeasurable note={newAccounts.note} />
-            ) : (
-              <p className="text-sm text-base-content/60">
-                <span className="font-semibold text-base-content">
-                  {newAccounts.display}
-                </span>{' '}
-                new in the last 30 days
-              </p>
-            )}
+          <div className="mt-3 border-t border-base-300/60 pt-2">
+            <TrendRow label="New today" trend={data.accounts.new_today} />
+            <TrendRow label="New this week" trend={data.accounts.new_7d} />
           </div>
+        </Tile>
+
+        <Tile
+          title="Active users"
+          caveat="From Logto: accounts that actually authenticated in the window. Someone using Scrollr without signing in again does not appear here, so these are floors, not ceilings."
+        >
+          {dau.value === null ? (
+            <Unmeasurable note={data.active.note} />
+          ) : (
+            <>
+              <div className="flex items-end gap-4">
+                <div className="shrink-0">
+                  <Big>{dau.value}</Big>
+                  <p className="mt-1 flex items-baseline gap-2 text-sm text-base-content/60">
+                    today
+                    <Delta trend={dau} />
+                  </p>
+                </div>
+                <Sparkline points={data.active.curve} />
+              </div>
+              <div className="mt-3 border-t border-base-300/60 pt-2">
+                <TrendRow label="This week" trend={data.active.wau} />
+                <TrendRow label="This month" trend={data.active.mau} />
+              </div>
+            </>
+          )}
         </Tile>
 
         <Tile

--- a/myscrollr.com/src/lib/adminFormat.test.ts
+++ b/myscrollr.com/src/lib/adminFormat.test.ts
@@ -5,6 +5,8 @@ import {
   formatAge,
   ingestHealth,
   measuredValue,
+  sparkline,
+  trendValue,
 } from './adminFormat'
 
 describe('measuredValue', () => {
@@ -76,5 +78,100 @@ describe('ingestHealth', () => {
     expect(
       ingestHealth({ table: 'trades', age_seconds: 7 * 3600, has_data: true }),
     ).toBe('stale')
+  })
+})
+
+describe('trendValue', () => {
+  it('keeps the sign and the direction of a fall', () => {
+    const t = trendValue({ value: 2, delta: -10, available: true })
+    expect(t.value).toBe('2')
+    expect(t.delta).toBe('-10')
+    expect(t.direction).toBe('down')
+  })
+
+  it('marks a rise', () => {
+    const t = trendValue({ value: 85, delta: 50, available: true })
+    expect(t.delta).toBe('+50')
+    expect(t.direction).toBe('up')
+  })
+
+  // A count of 0 that fell by 2 is a reading, not a missing number: the tile
+  // has to show "0" and "-2", not fall through to "not measurable".
+  it('renders a real zero with its delta', () => {
+    const t = trendValue({ value: 0, delta: -2, available: true })
+    expect(t.value).toBe('0')
+    expect(t.delta).toBe('-2')
+    expect(t.direction).toBe('down')
+  })
+
+  it('shows no delta when nothing moved', () => {
+    expect(
+      trendValue({ value: 31, delta: 0, available: true }).delta,
+    ).toBeNull()
+  })
+
+  // Same promise as measuredValue: unavailable never renders as a number, and
+  // that includes the delta.
+  it('hides both numbers when Logto is unreachable', () => {
+    const t = trendValue({
+      value: 0,
+      delta: 0,
+      available: false,
+      note: 'Logto is unreachable.',
+    })
+    expect(t.value).toBeNull()
+    expect(t.delta).toBeNull()
+    expect(t.note).toContain('unreachable')
+  })
+})
+
+describe('sparkline', () => {
+  const month = Array.from({ length: 30 }, (_, i) => ({
+    day: `2026-08-${String(i + 1).padStart(2, '0')}`,
+    count: i,
+  }))
+
+  // The bug this guards: the newest point is the one everybody reads, and at
+  // x = width it loses half its stroke and all of its dot to the viewBox edge.
+  it('keeps the final point inside the box', () => {
+    const s = sparkline(month, 120, 36)!
+    expect(s.last.x).toBe(120 - 3)
+    expect(s.last.y).toBeGreaterThanOrEqual(3)
+    expect(s.last.y).toBeLessThanOrEqual(36 - 3)
+  })
+
+  it('puts the peak at the top and the trough at the baseline', () => {
+    const s = sparkline(
+      [
+        { day: 'a', count: 0 },
+        { day: 'b', count: 10 },
+      ],
+      100,
+      40,
+    )!
+    expect(s.peak).toBe(10)
+    expect(s.line).toContain('M3,37')
+    expect(s.last.y).toBe(3)
+  })
+
+  // A month where nobody was active is a fact. It must draw flat along the
+  // baseline rather than divide by a peak of zero.
+  it('draws an all-zero month flat instead of dividing by zero', () => {
+    const s = sparkline(
+      [
+        { day: 'a', count: 0 },
+        { day: 'b', count: 0 },
+      ],
+      100,
+      40,
+    )!
+    expect(s.peak).toBe(0)
+    expect(s.last.y).toBe(37)
+    expect(s.line).not.toContain('NaN')
+  })
+
+  it('has nothing to draw with no points', () => {
+    expect(sparkline([], 100, 40)).toBeNull()
+    expect(sparkline(null, 100, 40)).toBeNull()
   })
 })

--- a/myscrollr.com/src/lib/adminFormat.ts
+++ b/myscrollr.com/src/lib/adminFormat.ts
@@ -6,7 +6,13 @@
  * promise is worth a test that does not need a DOM.
  */
 
-import type { ConnectedTile, IngestRow, Measured } from '@/api/admin'
+import type {
+  ConnectedTile,
+  DailyCount,
+  IngestRow,
+  Measured,
+  Trend,
+} from '@/api/admin'
 
 /** What a tile should actually render for a Measured value. */
 export interface TileValue {
@@ -77,3 +83,108 @@ export function ingestHealth(row: IngestRow): IngestHealth {
  */
 export const DOWNLOADS_CAVEAT =
   'Downloads, not installs. One person upgrading through five releases is five downloads, and nothing reports back whether the app was kept or opened.'
+
+/**
+ * A Trend ready to render: the figure, the signed change, and which way it
+ * went. `value: null` carries the same promise as `measuredValue` — with Logto
+ * unreachable neither the count nor the delta may appear as a number.
+ *
+ * Direction is reported, not judged. Every figure on the Overview that carries
+ * a Trend today (signups, DAU, WAU, MAU) is one where up is good, so the page
+ * colours `up` positively; a figure where down is the good outcome would need
+ * that decision made at its own tile, not baked in here.
+ */
+export type TrendDirection = 'up' | 'down' | 'flat'
+
+export interface TrendDisplay {
+  value: string | null
+  /** The signed change, e.g. "+50" or "-10". Null when it did not move. */
+  delta: string | null
+  direction: TrendDirection
+  note?: string
+}
+
+export function trendValue(t: Trend | undefined): TrendDisplay {
+  if (!t || !t.available) {
+    return {
+      value: null,
+      delta: null,
+      direction: 'flat',
+      note: t?.note ?? 'Not measurable.',
+    }
+  }
+  return {
+    value: t.value.toLocaleString(),
+    delta:
+      t.delta === 0
+        ? null
+        : t.delta.toLocaleString(undefined, { signDisplay: 'exceptZero' }),
+    direction: t.delta > 0 ? 'up' : t.delta < 0 ? 'down' : 'flat',
+    note: t.note,
+  }
+}
+
+/**
+ * A sparkline as two SVG paths, so the chart needs no charting library —
+ * the site ships none and thirty points do not justify the first one.
+ *
+ * The padding is not decoration: without it the newest point, which is the one
+ * everybody reads, sits exactly on the viewBox edge and loses half its stroke
+ * and all of its dot. Every returned coordinate is inside [pad, size - pad].
+ *
+ * The baseline is zero rather than the minimum, so a flat month looks flat
+ * instead of being stretched into drama.
+ */
+export interface Sparkline {
+  /** The line through the points. */
+  line: string
+  /** The same line closed down to the baseline, for the area fill. */
+  area: string
+  /** The highest count in the series — the chart's top axis value. */
+  peak: number
+  /** The newest point, for the dot that marks today. */
+  last: { x: number; y: number }
+}
+
+export function sparkline(
+  points: Array<DailyCount> | null | undefined,
+  width: number,
+  height: number,
+  pad = 3,
+): Sparkline | null {
+  if (!points || points.length === 0) return null
+
+  const innerW = width - pad * 2
+  const innerH = height - pad * 2
+  const peak = Math.max(...points.map((p) => p.count))
+  // An all-zero month is a real reading; dividing by it is not.
+  const scale = peak > 0 ? peak : 1
+
+  const round = (n: number) => Math.round(n * 100) / 100
+  const x = (i: number) =>
+    round(
+      points.length === 1
+        ? pad + innerW
+        : pad + (i / (points.length - 1)) * innerW,
+    )
+  const y = (v: number) => round(pad + innerH - (v / scale) * innerH)
+
+  const coords = points.map((p, i) => ({ x: x(i), y: y(p.count) }))
+  // One point has no line to draw, so hold its value across the whole width
+  // rather than inventing a slope.
+  const line =
+    coords.length === 1
+      ? `M${pad},${coords[0].y} L${coords[0].x},${coords[0].y}`
+      : coords.map((c, i) => `${i === 0 ? 'M' : 'L'}${c.x},${c.y}`).join(' ')
+
+  const base = round(height - pad)
+  const first = coords.length === 1 ? pad : coords[0].x
+  const last = coords[coords.length - 1]
+
+  return {
+    line,
+    area: `${line} L${last.x},${base} L${first},${base} Z`,
+    peak,
+    last,
+  }
+}


### PR DESCRIPTION
Closes REL-269.

REL-265 got the account total right by reading the `total-number` header off a `/api/users` page. It works, but Logto has a purpose-built stats API that answers the same question and three more for the same effort.

The Overview now reads `/api/dashboard/users/{total,new,active}`, cached in Redis for five minutes.

## What changed

**Accounts tile.** The total comes from `/api/dashboard/users/total` instead of the header trick — same number, from an endpoint that exists to answer exactly this. The "N accounts vs N have set up the app" pairing REL-265 shipped is untouched; that gap is still the story. Below it, two new rows: **New today** and **New this week**, each with Logto's own delta.

**A new "Active users" tile**, sitting between Accounts and "Active installs" on purpose — the measurable one next to the one that says it cannot be measured. Big DAU number and its delta on the left, the thirty-point daily-active sparkline filling the space to its right, WAU and MAU as rows underneath. Under the chart, a mono caption: first date · `peak N` · last date.

**Deltas are legible, not decorative.** A fall gets the warning colour, a down arrow and an explicit sign, so `dau -10` reads as a dip. Up is coloured as good because every figure carrying a delta here (signups, DAU/WAU/MAU) is one where up is good; a down-is-good figure would need that decision made at its own tile, and the helper's doc comment says so.

**No charting library.** Two SVG paths from a pure function in `adminFormat.ts`. The site ships no charting dependency and thirty points do not justify the first one. The padding is load-bearing rather than cosmetic: without it the newest point — the one everybody reads — sits exactly on the viewBox edge and loses half its stroke and all of its marker. A test pins that.

## What went away

`ListAllLogtoUsers` and its page walk, and with it the 30-day signup count and the daily *signup* series (which the page never rendered). Logto's `new` endpoint answers the same question in one request and carries a delta we could not have computed without storing yesterday's answer somewhere. If a 30-day signup count is wanted back it is a separate figure, not a reason to keep the scan.

## Degrading honestly

REL-265's rule holds. With Logto unreachable:

* the accounts tile falls back to the local set-up count **and labels it** — never the smaller number presented as the account count;
* the activity tile shows nothing at all. There is no local stand-in for "who used Scrollr today", and a `0` there would read as "nobody did".

There is deliberately **no stale-copy fallback** like the downloads tile's. A download count from fifteen minutes ago is still a download count; "2 people were active today" from an hour ago is a different claim than it looks.

## ⚠️ One security note in the code

`/api/dashboard/*` sits one path segment from `/api/connectors`, whose response body returns every connector's configuration **including API tokens in plaintext**. `logto_stats.go` carries that warning at the top, where someone extending it will read it. Nothing here calls it.

## Verified

* **The live endpoints, through this code.** `accounts.FetchLogtoStats()` was run from a pod against production Logto (M2M creds from `scrollr-secrets`, `LOGTO_ENDPOINT` from the `core-config` ConfigMap — both are needed or the token call fails silently). Every field decoded: total, both `new` windows with deltas, DAU/WAU/MAU with deltas, and a 30-point curve whose final point is today and matches the DAU figure exactly. Numbers withheld here; the repo is public.
* **Go**: `go build ./...`, `go vet`, and the full `go test ./...` green against a real Postgres + miniredis. New cases cover both counts on one tile, a real zero with a negative delta staying available, the deltas and curve surviving the tile, the cache costing one upstream read for two page loads, and both degradation paths.
* **Web**: all 113 vitest tests pass; `tsc` clean on every touched file; eslint clean. New cases cover the sign and direction of a fall, a real `0` with a `-2` delta not falling through to "not measurable", the unavailable case hiding *both* numbers, the final curve point staying inside the box, and an all-zero month drawing flat instead of dividing by its peak.
* **The chart's geometry** was rendered from the real helper output and looked at: sensible zero baseline, readable axis caption, final point and its marker fully inside the frame.

**Not verified:** the `/admin` page itself in a browser. I cannot sign in as an admin, so nothing past the auth gate was clicked — the component is covered by types, the pure-function tests, and the standalone render of its chart, not by an end-to-end load. Per the issue, no screenshots of pages carrying real user data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
