### PR TITLE
Count what every request already tells us, and nothing else [REL-271]

### DIFF
--- a/api/core/server.go
+++ b/api/core/server.go
@@ -81,6 +81,14 @@ func (s *Server) setupMiddleware() {
 		}))
 	}
 
+	// Request counters (REL-271). Placed above everything below it so it sees
+	// the rate limiter's 429s and the security-header path too — an error rate
+	// that silently excludes the errors is worse than none. It records four
+	// bounded dimensions (app version, platform, route pattern, status class)
+	// and folds them in memory; see internal/platform/usage.go for the line it
+	// must not cross.
+	s.App.Use(platform.RecordUsage)
+
 	// Security Headers
 	s.App.Use(func(c *fiber.Ctx) error {
 		c.Set("X-XSS-Protection", "1; mode=block")
@@ -234,6 +242,11 @@ func (s *Server) setupRoutes() {
 	s.App.Get("/admin/overview", platform.LogtoAuth, admin.RequireAdmin, admin.HandleGetOverview)
 	s.App.Get("/admin/accounts", platform.LogtoAuth, admin.RequireAdmin, admin.HandleListAccounts)
 	s.App.Get("/admin/accounts/:sub", platform.LogtoAuth, admin.RequireAdmin, admin.HandleGetAccount)
+	// Version adoption, platform mix and error rate by version, all read from
+	// the per-day request counters (REL-271). Its own endpoint and its own
+	// page: the Overview is tiles about the business, this is one question
+	// about the fleet.
+	s.App.Get("/admin/versions", platform.LogtoAuth, admin.RequireAdmin, admin.HandleGetVersions)
 	s.App.Get("/admin/admins", platform.LogtoAuth, admin.RequireAdmin, admin.HandleListAdmins)
 	s.App.Post("/admin/admins", platform.LogtoAuth, admin.RequireAdmin, admin.HandleAddAdmin)
 	s.App.Delete("/admin/admins/:id", platform.LogtoAuth, admin.RequireAdmin, admin.HandleRemoveAdmin)

--- a/api/internal/admin/handlers_versions.go
+++ b/api/internal/admin/handlers_versions.go
@@ -1,0 +1,237 @@
+package admin
+
+import (
+	"context"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/gofiber/fiber/v2"
+)
+
+// The Versions page (REL-271) — three questions the counters can answer, and
+// one they cannot.
+//
+// Everything here is built from `api_usage_daily`, which holds request counts
+// keyed by (day, app version, platform, route pattern, status class) and
+// nothing else. That bounds what this page is allowed to claim, and the
+// Overview's honesty rule applies: a number that is a proxy says so in its
+// own label rather than borrowing the authority of a headcount.
+//
+// The proxy that matters: these are REQUESTS, not installs. We deliberately
+// store no user id, so "40% of installs are on 1.6.1" is not measurable here.
+// What is measurable is "40% of desktop API traffic comes from 1.6.1", and
+// since every install polls the dashboard on the same timer, that tracks
+// adoption closely enough to answer "is anyone still on 1.4.0". The client
+// labels it as traffic share. It must never be relabelled as installs.
+
+// VersionRow is one build's share of desktop traffic, and how much of it went
+// wrong. The error rate is the whole point of the page: it is what turns
+// "some users report X" into "X is 1.5.x on Windows".
+type VersionRow struct {
+	Version      string  `json:"version"`
+	Requests     int64   `json:"requests"`
+	Share        float64 `json:"share"`         // of desktop traffic, 0..1
+	ClientErrors int64   `json:"client_errors"` // 4xx
+	ServerErrors int64   `json:"server_errors"` // 5xx
+	ErrorRate    float64 `json:"error_rate"`    // (4xx+5xx)/requests, 0..1
+}
+
+// PlatformRow is the OS mix, over the same desktop traffic.
+type PlatformRow struct {
+	Platform string  `json:"platform"`
+	Requests int64   `json:"requests"`
+	Share    float64 `json:"share"`
+}
+
+type VersionsResponse struct {
+	GeneratedAt string `json:"generated_at"`
+	Days        int    `json:"days"`
+	// The newest build that has actually called the API in the window. Derived
+	// from the counters, not from GitHub — this is "what is out there", and a
+	// release nobody has installed yet correctly does not appear.
+	CurrentRelease string        `json:"current_release"`
+	CurrentShare   float64       `json:"current_share"`
+	Versions       []VersionRow  `json:"versions"`
+	Platforms      []PlatformRow `json:"platforms"`
+	DesktopTotal   int64         `json:"desktop_total"`
+	// Requests whose user agent was not a recognisable Scrollr build: the
+	// website, the extension, curl, k8s probes. Kept visible on purpose — if
+	// desktop traffic ever stops being recognised, this is where it shows up,
+	// and a silently empty adoption chart is exactly the failure this issue
+	// exists to prevent.
+	Unrecognized int64 `json:"unrecognized"`
+}
+
+// usageAgg is one grouped row out of the counters table.
+type usageAgg struct {
+	version     string
+	platform    string
+	statusClass string
+	requests    int64
+}
+
+// HandleGetVersions — GET /admin/versions?days=N
+func HandleGetVersions(c *fiber.Ctx) error {
+	days := 30
+	if raw := c.Query("days"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 1 && n <= 365 {
+			days = n
+		}
+	}
+	since := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -(days - 1))
+
+	rows, err := platform.DBPool.Query(context.Background(),
+		`SELECT app_version, platform, status_class, SUM(requests)
+		   FROM api_usage_daily
+		  WHERE day >= $1
+		  GROUP BY app_version, platform, status_class`, since)
+	if err != nil {
+		log.Printf("[Admin] versions query: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(platform.ErrorResponse{
+			Status: "error", Error: "Could not read the request counters",
+		})
+	}
+	defer rows.Close()
+
+	aggs := make([]usageAgg, 0, 256)
+	for rows.Next() {
+		var a usageAgg
+		if err := rows.Scan(&a.version, &a.platform, &a.statusClass, &a.requests); err != nil {
+			log.Printf("[Admin] versions scan: %v", err)
+			continue
+		}
+		aggs = append(aggs, a)
+	}
+
+	return c.JSON(buildVersionsResponse(aggs, days))
+}
+
+// buildVersionsResponse folds the grouped counters into the three views. Split
+// out from the handler so the shares and the error rates are testable without
+// a database.
+func buildVersionsResponse(aggs []usageAgg, days int) VersionsResponse {
+	res := VersionsResponse{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Days:        days,
+		Versions:    []VersionRow{},
+		Platforms:   []PlatformRow{},
+	}
+
+	byVersion := map[string]*VersionRow{}
+	byPlatform := map[string]int64{}
+
+	for _, a := range aggs {
+		// "unknown" is everything that is not a Scrollr desktop build. It is
+		// counted and shown, but it is not part of any adoption denominator —
+		// a browser has no app version to adopt.
+		if a.version == "unknown" {
+			res.Unrecognized += a.requests
+			continue
+		}
+
+		v, ok := byVersion[a.version]
+		if !ok {
+			v = &VersionRow{Version: a.version}
+			byVersion[a.version] = v
+		}
+		v.Requests += a.requests
+		switch a.statusClass {
+		case "4xx":
+			v.ClientErrors += a.requests
+		case "5xx":
+			v.ServerErrors += a.requests
+		}
+
+		byPlatform[a.platform] += a.requests
+		res.DesktopTotal += a.requests
+	}
+
+	for _, v := range byVersion {
+		if res.DesktopTotal > 0 {
+			v.Share = float64(v.Requests) / float64(res.DesktopTotal)
+		}
+		if v.Requests > 0 {
+			v.ErrorRate = float64(v.ClientErrors+v.ServerErrors) / float64(v.Requests)
+		}
+		res.Versions = append(res.Versions, *v)
+	}
+	// Newest build first: the question is almost always "how much of the fleet
+	// has moved up", which reads top-down.
+	sort.Slice(res.Versions, func(i, j int) bool {
+		return compareVersions(res.Versions[i].Version, res.Versions[j].Version) > 0
+	})
+	if len(res.Versions) > 0 {
+		res.CurrentRelease = res.Versions[0].Version
+		res.CurrentShare = res.Versions[0].Share
+	}
+
+	for p, n := range byPlatform {
+		row := PlatformRow{Platform: p, Requests: n}
+		if res.DesktopTotal > 0 {
+			row.Share = float64(n) / float64(res.DesktopTotal)
+		}
+		res.Platforms = append(res.Platforms, row)
+	}
+	sort.Slice(res.Platforms, func(i, j int) bool {
+		return res.Platforms[i].Requests > res.Platforms[j].Requests
+	})
+
+	return res
+}
+
+// compareVersions orders dotted numeric versions numerically, so 1.10.0 sorts
+// above 1.9.0 where a string compare would not. A pre-release suffix
+// ("1.7.0-beta.1") sorts below the same release without one, per semver.
+// Returns -1, 0 or 1.
+//
+// Only identical strings return 0. Two spellings that tie numerically ("1.6"
+// and "1.6.0") fall back to a string compare, because sort.Slice is not
+// stable and a list that reorders itself between reads is worse than an
+// arbitrary but fixed order.
+func compareVersions(a, b string) int {
+	aNum, aPre := splitPrerelease(a)
+	bNum, bPre := splitPrerelease(b)
+	for i := 0; i < len(aNum) || i < len(bNum); i++ {
+		x, y := 0, 0
+		if i < len(aNum) {
+			x = aNum[i]
+		}
+		if i < len(bNum) {
+			y = bNum[i]
+		}
+		if x != y {
+			if x < y {
+				return -1
+			}
+			return 1
+		}
+	}
+	switch {
+	case aPre == bPre:
+		return strings.Compare(a, b)
+	case aPre == "":
+		return 1
+	case bPre == "":
+		return -1
+	}
+	return strings.Compare(aPre, bPre)
+}
+
+func splitPrerelease(v string) ([]int, string) {
+	pre := ""
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		pre = v[i+1:]
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	nums := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, _ := strconv.Atoi(p)
+		nums = append(nums, n)
+	}
+	return nums, pre
+}

--- a/api/internal/admin/handlers_versions_db_test.go
+++ b/api/internal/admin/handlers_versions_db_test.go
@@ -1,0 +1,144 @@
+package admin
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/brandon-relentnet/myscrollr/api/internal/platform"
+	"github.com/brandon-relentnet/myscrollr/api/internal/testsupport"
+	"github.com/gofiber/fiber/v2"
+)
+
+// The whole path, end to end and against a real database: requests go through
+// the middleware, the counters flush, and the page reads them back.
+//
+// It exists to hold two claims that are only true if the storage actually
+// behaves as designed, and that a unit test on the in-memory buffer cannot
+// prove:
+//
+//  1. The table gains rows per DAY, not per request. 1,200 requests here
+//     become three rows.
+//  2. An endpoint returning 500 shows up as error rate against the build that
+//     called it — the thing that turns a vague report into a targeted one.
+func TestUsageCountersRoundTrip(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	ctx := context.Background()
+	if _, err := platform.DBPool.Exec(ctx, `DELETE FROM api_usage_daily`); err != nil {
+		t.Fatalf("clear counters: %v", err)
+	}
+
+	app := fiber.New()
+	app.Use(platform.RecordUsage)
+	app.Get("/dashboard", func(c *fiber.Ctx) error { return c.SendString("ok") })
+	app.Get("/broken", func(c *fiber.Ctx) error {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "boom"})
+	})
+
+	drive := func(path, ua string, n int) {
+		t.Helper()
+		for i := 0; i < n; i++ {
+			req := httptest.NewRequest("GET", path, nil)
+			req.Header.Set("User-Agent", ua)
+			if _, err := app.Test(req); err != nil {
+				t.Fatalf("%s: %v", path, err)
+			}
+		}
+	}
+
+	// A healthy fleet on the current build, and a smaller unhappy one on the
+	// build people are complaining about.
+	drive("/dashboard", "Scrollr/1.6.1 (windows)", 900)
+	drive("/dashboard", "Scrollr/1.5.0 (windows)", 200)
+	drive("/broken", "Scrollr/1.5.0 (windows)", 100)
+
+	platform.FlushUsage(ctx)
+
+	// (1) Aggregated, not accumulated.
+	var rows, total int64
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT count(*), coalesce(sum(requests), 0) FROM api_usage_daily`).Scan(&rows, &total); err != nil {
+		t.Fatalf("count counters: %v", err)
+	}
+	if total != 1200 {
+		t.Errorf("counters total %d requests, want 1200", total)
+	}
+	if rows != 3 {
+		t.Errorf("1200 requests produced %d rows, want 3 — the table must grow per day, not per request", rows)
+	}
+
+	// A second flush of the same traffic adds to the same rows rather than
+	// inserting new ones. This is what lets every replica flush its own
+	// buffer into one shared count.
+	drive("/dashboard", "Scrollr/1.6.1 (windows)", 100)
+	platform.FlushUsage(ctx)
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT count(*), coalesce(sum(requests), 0) FROM api_usage_daily`).Scan(&rows, &total); err != nil {
+		t.Fatalf("recount counters: %v", err)
+	}
+	if rows != 3 || total != 1300 {
+		t.Errorf("after a second flush: %d rows / %d requests, want 3 / 1300", rows, total)
+	}
+
+	// (2) The page reads it back, and the 500s land on 1.5.0.
+	aggs := readAggs(t, ctx)
+	res := buildVersionsResponse(aggs, 30)
+
+	if res.CurrentRelease != "1.6.1" {
+		t.Fatalf("current release = %q, want 1.6.1", res.CurrentRelease)
+	}
+	if !closeTo(res.CurrentShare, 1000.0/1300.0) {
+		t.Errorf("current share = %v, want ~0.769", res.CurrentShare)
+	}
+	newest := findVersion(t, res, "1.6.1")
+	if newest.ServerErrors != 0 || !closeTo(newest.ErrorRate, 0) {
+		t.Errorf("1.6.1 = %+v, want a clean build", newest)
+	}
+	old := findVersion(t, res, "1.5.0")
+	if old.ServerErrors != 100 || !closeTo(old.ErrorRate, 100.0/300.0) {
+		t.Errorf("1.5.0 = %+v, want 100 server errors at a ~0.33 rate", old)
+	}
+
+	// And nothing personal reached the table. The unit test asserts this on
+	// the in-memory key; this asserts it on what was actually written.
+	stored, err := platform.DBPool.Query(ctx,
+		`SELECT app_version, platform, endpoint, status_class FROM api_usage_daily`)
+	if err != nil {
+		t.Fatalf("read counters: %v", err)
+	}
+	defer stored.Close()
+	for stored.Next() {
+		var v, p, e, s string
+		if err := stored.Scan(&v, &p, &e, &s); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if e != "/dashboard" && e != "/broken" {
+			t.Errorf("stored endpoint %q is not a registered route pattern", e)
+		}
+		if v != "1.6.1" && v != "1.5.0" {
+			t.Errorf("stored app_version %q was not one of the two builds driven", v)
+		}
+	}
+}
+
+func readAggs(t *testing.T, ctx context.Context) []usageAgg {
+	t.Helper()
+	rows, err := platform.DBPool.Query(ctx,
+		`SELECT app_version, platform, status_class, SUM(requests)
+		   FROM api_usage_daily GROUP BY app_version, platform, status_class`)
+	if err != nil {
+		t.Fatalf("aggregate counters: %v", err)
+	}
+	defer rows.Close()
+	var out []usageAgg
+	for rows.Next() {
+		var a usageAgg
+		if err := rows.Scan(&a.version, &a.platform, &a.statusClass, &a.requests); err != nil {
+			t.Fatalf("scan agg: %v", err)
+		}
+		out = append(out, a)
+	}
+	return out
+}

--- a/api/internal/admin/handlers_versions_test.go
+++ b/api/internal/admin/handlers_versions_test.go
@@ -1,0 +1,132 @@
+package admin
+
+import (
+	"math"
+	"testing"
+)
+
+func findVersion(t *testing.T, res VersionsResponse, version string) VersionRow {
+	t.Helper()
+	for _, v := range res.Versions {
+		if v.Version == version {
+			return v
+		}
+	}
+	t.Fatalf("version %q missing from %+v", version, res.Versions)
+	return VersionRow{}
+}
+
+func closeTo(a, b float64) bool { return math.Abs(a-b) < 0.0001 }
+
+// The three surfaces the page exists for, off one set of counters: adoption
+// share, platform mix, and error rate by version.
+func TestBuildVersionsResponse(t *testing.T) {
+	aggs := []usageAgg{
+		// 1.6.1 on Windows: 800 good, no errors.
+		{"1.6.1", "windows", "2xx", 800},
+		// 1.6.1 on macOS: 200 good.
+		{"1.6.1", "macos", "2xx", 200},
+		// 1.5.0 on Windows: 600 good, 300 server errors, 100 client errors.
+		// This is the shape REL-253 would have shown as.
+		{"1.5.0", "windows", "2xx", 600},
+		{"1.5.0", "windows", "5xx", 300},
+		{"1.5.0", "windows", "4xx", 100},
+		// The website and the k8s probes.
+		{"unknown", "unknown", "2xx", 5000},
+	}
+
+	res := buildVersionsResponse(aggs, 30)
+
+	if res.DesktopTotal != 2000 {
+		t.Errorf("desktop total = %d, want 2000 (browser traffic must not be in the denominator)", res.DesktopTotal)
+	}
+	if res.Unrecognized != 5000 {
+		t.Errorf("unrecognized = %d, want 5000", res.Unrecognized)
+	}
+
+	// Adoption: newest build first, and its share is over desktop traffic only.
+	if res.CurrentRelease != "1.6.1" {
+		t.Errorf("current release = %q, want 1.6.1", res.CurrentRelease)
+	}
+	if !closeTo(res.CurrentShare, 0.5) {
+		t.Errorf("current share = %v, want 0.5", res.CurrentShare)
+	}
+
+	// Error rate by version — the number that scopes a bug report.
+	newest := findVersion(t, res, "1.6.1")
+	if !closeTo(newest.ErrorRate, 0) {
+		t.Errorf("1.6.1 error rate = %v, want 0", newest.ErrorRate)
+	}
+	old := findVersion(t, res, "1.5.0")
+	if old.Requests != 1000 || old.ServerErrors != 300 || old.ClientErrors != 100 {
+		t.Errorf("1.5.0 = %+v, want 1000 requests / 300 5xx / 100 4xx", old)
+	}
+	if !closeTo(old.ErrorRate, 0.4) {
+		t.Errorf("1.5.0 error rate = %v, want 0.4", old.ErrorRate)
+	}
+
+	// Platform mix, biggest first.
+	if len(res.Platforms) != 2 {
+		t.Fatalf("platforms = %+v, want windows and macos only", res.Platforms)
+	}
+	if res.Platforms[0].Platform != "windows" || res.Platforms[0].Requests != 1800 {
+		t.Errorf("platforms[0] = %+v, want windows/1800", res.Platforms[0])
+	}
+	if !closeTo(res.Platforms[0].Share, 0.9) {
+		t.Errorf("windows share = %v, want 0.9", res.Platforms[0].Share)
+	}
+}
+
+// Nothing has called the API yet: empty lists and zeroes, never a divide by
+// zero and never a fabricated "100% on the latest".
+func TestBuildVersionsResponseEmpty(t *testing.T) {
+	res := buildVersionsResponse(nil, 30)
+	if res.CurrentRelease != "" || res.CurrentShare != 0 {
+		t.Errorf("empty counters produced current release %q at %v", res.CurrentRelease, res.CurrentShare)
+	}
+	if len(res.Versions) != 0 || len(res.Platforms) != 0 {
+		t.Errorf("empty counters produced rows: %+v %+v", res.Versions, res.Platforms)
+	}
+}
+
+// Only the website has traffic. Every install is on nothing, so there is no
+// adoption to report — and crucially the page must not divide by zero or
+// claim the browser bucket as a build.
+func TestBuildVersionsResponseUnknownOnly(t *testing.T) {
+	res := buildVersionsResponse([]usageAgg{{"unknown", "unknown", "2xx", 42}}, 7)
+	if res.DesktopTotal != 0 || len(res.Versions) != 0 {
+		t.Errorf("unknown traffic leaked into the desktop views: %+v", res)
+	}
+	if res.Unrecognized != 42 {
+		t.Errorf("unrecognized = %d, want 42", res.Unrecognized)
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.6.1", "1.6.0", 1},
+		{"1.6.0", "1.6.1", -1},
+		{"1.6.1", "1.6.1", 0},
+		// The whole reason this is not strings.Compare.
+		{"1.10.0", "1.9.0", 1},
+		{"2.0.0", "1.99.99", 1},
+		// Missing trailing parts count as zero, so these tie numerically. The
+		// string tie-break then orders them anyway: two spellings of the same
+		// version would otherwise sort arbitrarily against each other.
+		{"1.6", "1.6.0", -1},
+		{"1.6.0", "1.6", 1},
+		{"1.6.1", "1.6", 1},
+		// Semver: a prerelease sorts below its release.
+		{"1.7.0-beta.1", "1.7.0", -1},
+		{"1.7.0", "1.7.0-beta.1", 1},
+		{"1.7.0-beta.2", "1.7.0-beta.1", 1},
+	}
+	for _, tt := range tests {
+		if got := compareVersions(tt.a, tt.b); got != tt.want {
+			t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/api/internal/platform/usage.go
+++ b/api/internal/platform/usage.go
@@ -1,0 +1,208 @@
+package platform
+
+import (
+	"context"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+// Request counters, and nothing else (REL-271).
+//
+// Every desktop install calls this API several times an hour and its user
+// agent says which build and which OS it is. We used to throw that away on
+// every request, which is why "is REL-253 still happening on 1.5.x?" had to
+// be asked of users by email. This keeps the answer.
+//
+// ⚠️ THE LINE, and it is the reason this file is short: nothing about what a
+// user WATCHES may leave their machine. No symbols, no teams, no feed URLs,
+// no widget contents, no query strings, no user id, no IP. The only four
+// dimensions below are app version, platform, route pattern and status class,
+// and `usageKey` is deliberately the whole vocabulary — a field that does not
+// exist cannot be filled in later by accident. TestUsageStoresNothingPersonal
+// asserts it.
+//
+// Aggregate, never accumulate: requests fold into an in-memory map keyed by
+// day and those four dimensions, and a timer upserts the counters. There is
+// no per-request row written anywhere, so there is nothing to leak and
+// nothing to purge beyond a yearly prune.
+
+// usageKey is one counter's identity — and the complete list of everything
+// this subsystem is allowed to know about a request.
+type usageKey struct {
+	Day         time.Time // UTC midnight
+	AppVersion  string
+	Platform    string
+	Endpoint    string // registered route pattern, never the request path
+	StatusClass string
+}
+
+var (
+	usageMu     sync.Mutex
+	usageCounts = make(map[usageKey]int64)
+)
+
+// usageMaxKeys caps the in-memory map. Route patterns and status classes are
+// finite, but `app_version` comes off a header, and a caller sending a fresh
+// well-formed version string on every request would otherwise grow this map
+// (and the table) without limit. Past the cap we drop rather than grow: a
+// slightly short count beats an unbounded one.
+const usageMaxKeys = 20000
+
+// usageRetention is how long daily aggregates are kept. A year is enough to
+// answer "did anyone ever update off that build" and short enough that the
+// table stays trivially small.
+const usageRetention = 365 * 24 * time.Hour
+
+// clientUARe is BOTH the parser and the cardinality guard, which is why it is
+// this strict. It matches only the user agent the desktop app sends —
+// `Scrollr/1.6.1 (windows)` — with a bounded version shape and a closed set
+// of platforms. Anything else (a browser, curl, a probe, a hostile string)
+// falls through to "unknown", so no caller can mint new dimension values.
+var clientUARe = regexp.MustCompile(`^Scrollr/(\d{1,3}(?:\.\d{1,4}){0,3}(?:-[A-Za-z0-9.]{1,16})?) \((windows|macos|linux)\)`)
+
+// ParseClientUA extracts the app version and platform from a Scrollr desktop
+// user agent. Both are "unknown" for anything it does not recognise — which
+// is the honest answer for a browser hitting the same API, and the canary
+// that tells us if the desktop header ever stops arriving.
+//
+// ⚠️ The results are CLONED, and they have to be. Fiber's c.Get hands back a
+// string pointing straight into fasthttp's request buffer, which is pooled and
+// reused by the next request on that worker; FindStringSubmatch then returns
+// substrings of it. Keeping one as a map key means the key's bytes change
+// under the map once the buffer is recycled — traffic silently reattributed to
+// whatever build happened to come next, which is worse than no data at all.
+func ParseClientUA(ua string) (version, platform string) {
+	m := clientUARe.FindStringSubmatch(ua)
+	if m == nil {
+		return "unknown", "unknown"
+	}
+	return strings.Clone(m[1]), strings.Clone(m[2])
+}
+
+// RecordUsage is the Fiber middleware. It runs the request, then folds one
+// count into memory. No I/O on the request path.
+func RecordUsage(c *fiber.Ctx) error {
+	err := c.Next()
+
+	status := c.Response().StatusCode()
+	// c.Next() returning an error means an error handler will still set the
+	// status, so read the class from the error where Fiber gives us one.
+	if e, ok := err.(*fiber.Error); ok && e != nil {
+		status = e.Code
+	}
+
+	version, plat := ParseClientUA(c.Get(fiber.HeaderUserAgent))
+
+	// The REGISTERED PATTERN, not c.Path(). "/users/:username" is a bounded
+	// dimension; "/users/alice" is a username in a metrics table.
+	endpoint := "/"
+	if r := c.Route(); r != nil && r.Path != "" {
+		endpoint = r.Path
+	}
+
+	countUsage(usageKey{
+		Day:         time.Now().UTC().Truncate(24 * time.Hour),
+		AppVersion:  version,
+		Platform:    plat,
+		Endpoint:    endpoint,
+		StatusClass: strconv.Itoa(status/100) + "xx",
+	})
+
+	return err
+}
+
+func countUsage(k usageKey) {
+	usageMu.Lock()
+	defer usageMu.Unlock()
+	if _, seen := usageCounts[k]; !seen && len(usageCounts) >= usageMaxKeys {
+		return
+	}
+	usageCounts[k]++
+}
+
+// FlushUsage writes the pending counters and empties the buffer. Exported so
+// tests can force the write without waiting on the ticker.
+func FlushUsage(ctx context.Context) {
+	usageMu.Lock()
+	pending := usageCounts
+	usageCounts = make(map[usageKey]int64, len(pending))
+	usageMu.Unlock()
+
+	if len(pending) == 0 || DBPool == nil {
+		return
+	}
+
+	batch := &pgx.Batch{}
+	for k, n := range pending {
+		batch.Queue(
+			`INSERT INTO api_usage_daily (day, app_version, platform, endpoint, status_class, requests)
+			 VALUES ($1, $2, $3, $4, $5, $6)
+			 ON CONFLICT (day, app_version, platform, endpoint, status_class)
+			 DO UPDATE SET requests = api_usage_daily.requests + EXCLUDED.requests`,
+			k.Day, k.AppVersion, k.Platform, k.Endpoint, k.StatusClass, n)
+	}
+
+	res := DBPool.SendBatch(ctx, batch)
+	defer res.Close()
+	for range pending {
+		if _, err := res.Exec(); err != nil {
+			log.Printf("[Usage] flush: %v", err)
+			return
+		}
+	}
+}
+
+// pruneUsage drops aggregates past the retention window.
+func pruneUsage(ctx context.Context) {
+	if DBPool == nil {
+		return
+	}
+	cutoff := time.Now().UTC().Add(-usageRetention)
+	tag, err := DBPool.Exec(ctx, `DELETE FROM api_usage_daily WHERE day < $1`, cutoff)
+	if err != nil {
+		log.Printf("[Usage] prune: %v", err)
+		return
+	}
+	if n := tag.RowsAffected(); n > 0 {
+		log.Printf("[Usage] pruned %d aggregate rows older than %d days", n, int(usageRetention.Hours()/24))
+	}
+}
+
+// StartUsageFlusher writes the counters every minute for the lifetime of ctx,
+// prunes once a day, and flushes once more on the way out so a rolling deploy
+// does not drop the last minute.
+//
+// Every replica flushes its own buffer into the same rows; the upsert adds,
+// so the counts are the fleet's, not one pod's. No leader election needed —
+// unlike the janitors, this is commutative.
+func StartUsageFlusher(ctx context.Context) {
+	go func() {
+		flush := time.NewTicker(time.Minute)
+		prune := time.NewTicker(24 * time.Hour)
+		defer flush.Stop()
+		defer prune.Stop()
+		pruneUsage(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				// ctx is already cancelled, so the final write needs its own.
+				final, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				FlushUsage(final)
+				cancel()
+				return
+			case <-flush.C:
+				FlushUsage(ctx)
+			case <-prune.C:
+				pruneUsage(ctx)
+			}
+		}
+	}()
+	log.Println("[Usage] request counters started (1m flush, 365d retention)")
+}

--- a/api/internal/platform/usage_test.go
+++ b/api/internal/platform/usage_test.go
@@ -1,0 +1,246 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func resetUsage() {
+	usageMu.Lock()
+	usageCounts = make(map[usageKey]int64)
+	usageMu.Unlock()
+}
+
+func snapshotUsage() map[usageKey]int64 {
+	usageMu.Lock()
+	defer usageMu.Unlock()
+	out := make(map[usageKey]int64, len(usageCounts))
+	for k, v := range usageCounts {
+		out[k] = v
+	}
+	return out
+}
+
+func TestParseClientUA(t *testing.T) {
+	tests := []struct {
+		name, ua, version, platform string
+	}{
+		{"windows release", "Scrollr/1.6.1 (windows)", "1.6.1", "windows"},
+		{"macos release", "Scrollr/1.6.1 (macos)", "1.6.1", "macos"},
+		{"linux release", "Scrollr/2.0.0 (linux)", "2.0.0", "linux"},
+		{"two-part version", "Scrollr/1.6 (linux)", "1.6", "linux"},
+		{"four-part version", "Scrollr/1.6.1.2 (linux)", "1.6.1.2", "linux"},
+		{"prerelease", "Scrollr/1.7.0-beta.1 (macos)", "1.7.0-beta.1", "macos"},
+		{"trailing junk ignored", "Scrollr/1.6.1 (windows) extra/1", "1.6.1", "windows"},
+
+		{"empty", "", "unknown", "unknown"},
+		{"a browser", "Mozilla/5.0 (Windows NT 10.0) Chrome/140", "unknown", "unknown"},
+		{"curl", "curl/8.4.0", "unknown", "unknown"},
+		{"kube probe", "kube-probe/1.29", "unknown", "unknown"},
+		{"unknown platform", "Scrollr/1.6.1 (freebsd)", "unknown", "unknown"},
+		{"no platform", "Scrollr/1.6.1", "unknown", "unknown"},
+		{"not anchored at start", "x Scrollr/1.6.1 (windows)", "unknown", "unknown"},
+		{"letters in version", "Scrollr/abc (windows)", "unknown", "unknown"},
+		{"absurd version length", "Scrollr/" + strings.Repeat("1", 40) + " (linux)", "unknown", "unknown"},
+		{"too many segments", "Scrollr/1.2.3.4.5 (linux)", "unknown", "unknown"},
+		// The closing paren has to follow the platform immediately, so an
+		// attempt to smuggle a field into the user agent is rejected whole
+		// rather than half-accepted.
+		{"platform injection", "Scrollr/1.6.1 (windows; user=alice)", "unknown", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, p := ParseClientUA(tt.ua)
+			if v != tt.version || p != tt.platform {
+				t.Errorf("ParseClientUA(%q) = (%q, %q), want (%q, %q)", tt.ua, v, p, tt.version, tt.platform)
+			}
+		})
+	}
+}
+
+// TestUsageKeyHasNoPersonalFields is the erosion guard.
+//
+// The privacy promise for REL-271 is not a policy sentence, it is the absence
+// of fields: a counter keyed by four bounded dimensions cannot carry what a
+// user watches even if someone later wants it to. This test fails the moment
+// a field is added to usageKey, so adding one is a deliberate act with a code
+// review attached rather than a quiet afternoon of convenience.
+func TestUsageKeyHasNoPersonalFields(t *testing.T) {
+	want := []string{"Day", "AppVersion", "Platform", "Endpoint", "StatusClass"}
+	typ := reflect.TypeOf(usageKey{})
+	var got []string
+	for i := 0; i < typ.NumField(); i++ {
+		got = append(got, typ.Field(i).Name)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("usageKey fields = %v, want exactly %v.\n"+
+			"A new dimension on the request counters is a privacy decision: it must not be able to\n"+
+			"carry a user id, an IP, a symbol, a team, a feed URL or anything else off a user's screen.\n"+
+			"See api/internal/platform/usage.go and REL-271 before changing this.", got, want)
+	}
+}
+
+// TestUsageStoresNothingPersonal drives real requests carrying every kind of
+// thing that must never be kept — a username in the path, a ticker symbol and
+// a feed URL in the query string, a bearer token, a client IP — and asserts
+// none of it survives into a counter.
+func TestUsageStoresNothingPersonal(t *testing.T) {
+	resetUsage()
+
+	app := fiber.New()
+	app.Use(RecordUsage)
+	app.Get("/users/:username", func(c *fiber.Ctx) error { return c.SendString("ok") })
+	app.Get("/public/feed", func(c *fiber.Ctx) error { return c.SendString("ok") })
+
+	req := httptest.NewRequest("GET", "/users/alice-secret?symbol=NVDA&team=packers&feed=https://example.com/rss.xml", nil)
+	req.Header.Set("User-Agent", "Scrollr/1.6.1 (windows)")
+	req.Header.Set("Authorization", "Bearer tok_supersecret")
+	req.Header.Set("X-Forwarded-For", "203.0.113.42")
+	if _, err := app.Test(req); err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	req2 := httptest.NewRequest("GET", "/public/feed?symbols=AAPL,TSLA", nil)
+	req2.Header.Set("User-Agent", "Scrollr/1.6.1 (windows)")
+	if _, err := app.Test(req2); err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	forbidden := []string{
+		"alice-secret", "NVDA", "AAPL", "TSLA", "packers",
+		"example.com", "rss.xml", "tok_supersecret", "203.0.113.42", "?",
+	}
+
+	keys := snapshotUsage()
+	if len(keys) != 2 {
+		t.Fatalf("got %d counters, want 2 (one per route)", len(keys))
+	}
+	for k := range keys {
+		v := reflect.ValueOf(k)
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if f.Kind() != reflect.String {
+				continue
+			}
+			for _, bad := range forbidden {
+				if strings.Contains(f.String(), bad) {
+					t.Errorf("counter field %s = %q contains %q — nothing about what a user watches may be stored",
+						v.Type().Field(i).Name, f.String(), bad)
+				}
+			}
+		}
+		if k.Endpoint != "/users/:username" && k.Endpoint != "/public/feed" {
+			t.Errorf("endpoint %q is not a registered route pattern", k.Endpoint)
+		}
+	}
+}
+
+// TestUsageAggregatesNotAccumulates is the "a day is a few hundred rows"
+// promise: a thousand requests to the same route are one counter, not a
+// thousand records.
+func TestUsageAggregatesNotAccumulates(t *testing.T) {
+	resetUsage()
+
+	app := fiber.New()
+	app.Use(RecordUsage)
+	app.Get("/dashboard", func(c *fiber.Ctx) error { return c.SendString("ok") })
+
+	for i := 0; i < 1000; i++ {
+		req := httptest.NewRequest("GET", "/dashboard", nil)
+		req.Header.Set("User-Agent", "Scrollr/1.6.1 (windows)")
+		if _, err := app.Test(req); err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+	}
+
+	keys := snapshotUsage()
+	if len(keys) != 1 {
+		t.Fatalf("got %d counters for 1000 identical requests, want 1", len(keys))
+	}
+	for k, n := range keys {
+		if n != 1000 {
+			t.Errorf("counter = %d, want 1000", n)
+		}
+		if k.AppVersion != "1.6.1" || k.Platform != "windows" || k.Endpoint != "/dashboard" || k.StatusClass != "2xx" {
+			t.Errorf("unexpected key %+v", k)
+		}
+	}
+}
+
+// TestUsageStatusClasses is what makes error rate by version work: a failing
+// endpoint has to land in its own bucket, separate from the same endpoint's
+// successes and from other builds.
+func TestUsageStatusClasses(t *testing.T) {
+	resetUsage()
+
+	app := fiber.New()
+	app.Use(RecordUsage)
+	app.Get("/dashboard", func(c *fiber.Ctx) error { return c.SendString("ok") })
+	app.Get("/boom", func(c *fiber.Ctx) error {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "boom"})
+	})
+	app.Get("/upstream", func(c *fiber.Ctx) error {
+		return fiber.NewError(fiber.StatusBadGateway, "upstream")
+	})
+
+	for _, tc := range []struct{ path, ua string }{
+		{"/dashboard", "Scrollr/1.6.1 (windows)"},
+		{"/boom", "Scrollr/1.5.0 (windows)"},
+		{"/upstream", "Scrollr/1.5.0 (windows)"},
+		{"/nope", "Scrollr/1.5.0 (windows)"},
+	} {
+		req := httptest.NewRequest("GET", tc.path, nil)
+		req.Header.Set("User-Agent", tc.ua)
+		if _, err := app.Test(req); err != nil {
+			t.Fatalf("%s: %v", tc.path, err)
+		}
+	}
+
+	classes := map[string]string{}
+	for k := range snapshotUsage() {
+		classes[k.Endpoint] = k.StatusClass
+	}
+	for endpoint, want := range map[string]string{
+		"/dashboard": "2xx", "/boom": "5xx", "/upstream": "5xx",
+	} {
+		if got := classes[endpoint]; got != want {
+			t.Errorf("%s status class = %q, want %q", endpoint, got, want)
+		}
+	}
+	// The 404 matched no route, so it is counted against "/" rather than
+	// inventing a dimension value out of an unrouted path.
+	if got := classes["/"]; got != "4xx" {
+		t.Errorf("unrouted request status class = %q, want 4xx", got)
+	}
+}
+
+// TestUsageKeyCap: a caller minting a fresh well-formed version on every
+// request must not be able to grow the buffer, or the table, without limit.
+func TestUsageKeyCap(t *testing.T) {
+	resetUsage()
+	defer resetUsage()
+
+	for i := 0; i < usageMaxKeys+500; i++ {
+		countUsage(usageKey{AppVersion: fmt.Sprintf("9.9.%d", i), Endpoint: "/dashboard"})
+	}
+	if n := len(snapshotUsage()); n != usageMaxKeys {
+		t.Errorf("buffer holds %d keys, want it capped at %d", n, usageMaxKeys)
+	}
+}
+
+// FlushUsage must be a no-op without a database rather than a panic — the
+// unit-test runs and any pod that serves before the pool is up both hit it.
+func TestFlushUsageWithoutDB(t *testing.T) {
+	resetUsage()
+	countUsage(usageKey{AppVersion: "1.6.1", Endpoint: "/dashboard"})
+	FlushUsage(context.Background())
+	if n := len(snapshotUsage()); n != 0 {
+		t.Errorf("buffer still holds %d keys after flush, want 0", n)
+	}
+}

--- a/api/main.go
+++ b/api/main.go
@@ -89,6 +89,10 @@ func main() {
 	// delete across local DB + Logto.
 	accounts.StartGDPRPurgeWorker(ctx)
 
+	// Writes the per-day request counters the middleware folds in memory, and
+	// prunes them past a year (REL-271). Nothing per-request is ever stored.
+	platform.StartUsageFlusher(ctx)
+
 	// Periodic prune of the Stripe webhook idempotency table. Long-lived
 	// pods otherwise grow this table unboundedly between restarts.
 	platform.StartWebhookEventsPruner(ctx)

--- a/api/migrations/000017_api_usage_daily.down.sql
+++ b/api/migrations/000017_api_usage_daily.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS api_usage_daily;

--- a/api/migrations/000017_api_usage_daily.up.sql
+++ b/api/migrations/000017_api_usage_daily.up.sql
@@ -1,0 +1,32 @@
+-- What every request already told us, kept as counts (REL-271).
+--
+-- Until now core-api discarded the app version and platform on every request,
+-- so a bug report like REL-253 ("ticker never scrolls, 1.4.0 and 1.5.0,
+-- Windows") could not be scoped: nobody could say whether anyone was still on
+-- those builds. The fix is not an event log. It is this table.
+--
+-- ONE ROW PER (day, version, platform, endpoint, status class). A day of real
+-- traffic is a few hundred rows, not a few hundred thousand. There is no
+-- per-request table anywhere and none is ever written — the middleware
+-- aggregates in memory and upserts these counters on a timer.
+--
+-- ⚠️ THE LINE. Nothing about what a user watches may ever be stored here, and
+-- the schema is the enforcement: there is no column for a symbol, a team, a
+-- feed URL, a widget, a query string, a user id or an IP address. `endpoint`
+-- is the REGISTERED ROUTE PATTERN ("/users/:username"), never the request
+-- path, so a username cannot arrive through it either. Adding a column to
+-- this table is the moment to re-read that sentence.
+CREATE TABLE api_usage_daily (
+    day          date   NOT NULL,
+    app_version  text   NOT NULL,
+    platform     text   NOT NULL,
+    endpoint     text   NOT NULL,
+    status_class text   NOT NULL,
+    requests     bigint NOT NULL DEFAULT 0,
+    PRIMARY KEY (day, app_version, platform, endpoint, status_class)
+);
+
+-- Every read on the admin console is "the last N days", so the range scan
+-- wants the day leading. The primary key already leads with day; this index
+-- exists for the pruner, which deletes by day alone.
+CREATE INDEX api_usage_daily_day_idx ON api_usage_daily (day);

--- a/desktop/src/api/fetchOverride.test.ts
+++ b/desktop/src/api/fetchOverride.test.ts
@@ -1,0 +1,75 @@
+/**
+ * REL-271 — the app has to say which build it is.
+ *
+ * Until this landed, core-api discarded the user agent on every request, so
+ * "the ticker never scrolls on 1.4.0 and 1.5.0" could not be scoped: nobody
+ * could say how many installs were still on those builds. The server counts
+ * per-day totals keyed by app version and OS, which only works if the client
+ * actually sends `Scrollr/<version> (<os>)`.
+ *
+ * These assert the client half: the header is set on API calls, it does not
+ * trample what callers already send, and it never leaks onto non-API fetches.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const tauriFetchMock = vi.fn();
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: (...args: unknown[]) => tauriFetchMock(...args),
+}));
+
+vi.stubGlobal("__APP_VERSION__", "1.6.1");
+
+const nativeFetch = vi.fn();
+window.fetch = nativeFetch as unknown as typeof window.fetch;
+
+const { API_BASE } = await import("../config");
+await import("./fetchOverride");
+
+/** The headers the override actually handed to plugin-http. */
+function sentHeaders(): Headers {
+  const init = tauriFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+  return new Headers(init?.headers);
+}
+
+describe("fetchOverride user agent", () => {
+  beforeEach(() => {
+    tauriFetchMock.mockReset();
+    nativeFetch.mockReset();
+  });
+
+  it("sends Scrollr/<version> (<os>) on API calls", async () => {
+    await window.fetch(`${API_BASE}/dashboard`);
+    expect(tauriFetchMock).toHaveBeenCalledTimes(1);
+    // jsdom reports a Linux-ish platform; the OS token is whichever of the
+    // three the server knows, and the shape is what matters here.
+    expect(sentHeaders().get("User-Agent")).toMatch(
+      /^Scrollr\/1\.6\.1 \((windows|macos|linux)\)$/,
+    );
+  });
+
+  it("keeps the caller's own headers", async () => {
+    await window.fetch(`${API_BASE}/users/me/widgets`, {
+      method: "POST",
+      headers: { Authorization: "Bearer tok", "Content-Type": "application/json" },
+    });
+    const headers = sentHeaders();
+    expect(headers.get("Authorization")).toBe("Bearer tok");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("User-Agent")).toContain("Scrollr/1.6.1");
+  });
+
+  it("does not overwrite a User-Agent the caller set", async () => {
+    await window.fetch(`${API_BASE}/dashboard`, {
+      headers: { "User-Agent": "Scrollr-Updater/1.0" },
+    });
+    expect(sentHeaders().get("User-Agent")).toBe("Scrollr-Updater/1.0");
+  });
+
+  it("leaves non-API fetches on the native path, with no header added", async () => {
+    await window.fetch("https://example.com/somewhere");
+    expect(tauriFetchMock).not.toHaveBeenCalled();
+    expect(nativeFetch).toHaveBeenCalledTimes(1);
+    const init = nativeFetch.mock.calls[0][1] as RequestInit | undefined;
+    expect(new Headers(init?.headers).has("User-Agent")).toBe(false);
+  });
+});

--- a/desktop/src/api/fetchOverride.ts
+++ b/desktop/src/api/fetchOverride.ts
@@ -10,6 +10,33 @@ import { API_HOST } from "../config";
 
 const nativeFetch = window.fetch.bind(window);
 
+/**
+ * The user agent every API call carries: `Scrollr/1.6.1 (windows)`.
+ *
+ * This is the only thing the app tells us about itself, and until REL-271 it
+ * told us nothing: the API discarded the user agent on every request, so a
+ * report like "the ticker never scrolls on 1.5.0" could not be scoped to how
+ * many installs were still on that build. The server parses exactly this
+ * shape into per-day counters — app version, platform, endpoint, status class
+ * — and stores nothing else. Nothing about what is on the ticker is sent.
+ *
+ * Version is the build-time constant (same one Sentry releases use), so there
+ * is no async lookup on the request path. Platform comes from the webview's
+ * own UA data, which is what WindowControls already reads to decide whether
+ * to draw window buttons. Keep the three platform names in step with the
+ * server's `clientUARe` in api/internal/platform/usage.go — anything else it
+ * does not recognise is counted as "unknown".
+ */
+const UA_PLATFORM =
+  (navigator as { userAgentData?: { platform?: string } }).userAgentData
+    ?.platform ?? navigator.platform;
+const OS = /Mac/.test(UA_PLATFORM)
+  ? "macos"
+  : /Win/.test(UA_PLATFORM)
+    ? "windows"
+    : "linux";
+export const CLIENT_USER_AGENT = `Scrollr/${__APP_VERSION__} (${OS})`;
+
 window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
   let url: string;
   if (typeof input === "string") {
@@ -22,7 +49,18 @@ window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
 
   try {
     if (new URL(url).host === API_HOST) {
-      return tauriFetch(input, init);
+      // Merge rather than replace. Passing a fresh header set alongside a
+      // Request would drop that Request's own Authorization, so seed from
+      // whichever the caller used, then let init override it — the same
+      // precedence fetch itself applies. An explicit User-Agent wins.
+      const headers = new Headers(
+        input instanceof Request ? input.headers : undefined,
+      );
+      new Headers(init?.headers).forEach((v, k) => headers.set(k, v));
+      if (!headers.has("User-Agent")) {
+        headers.set("User-Agent", CLIENT_USER_AGENT);
+      }
+      return tauriFetch(input, { ...init, headers });
     }
   } catch {
     // Invalid URL — fall through to native fetch

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -541,6 +541,51 @@ export interface AdminRow {
   self: boolean
 }
 
+// ── Versions (REL-271) ─────────────────────────────────────
+
+/**
+ * One build's slice of desktop API traffic, and how much of it failed.
+ *
+ * `share` is a share of REQUESTS, not of installs. Nothing per-user is stored
+ * — that is the point of the counters — so an install count is not available
+ * here and must never be implied by a label. Every install polls on the same
+ * timer, so traffic share tracks adoption closely; it is still a proxy and the
+ * page says so.
+ */
+export interface VersionRow {
+  version: string
+  requests: number
+  /** 0..1, over desktop traffic only. */
+  share: number
+  client_errors: number
+  server_errors: number
+  /** 0..1. The number that scopes a bug report to a build. */
+  error_rate: number
+}
+
+export interface PlatformRow {
+  platform: string
+  requests: number
+  share: number
+}
+
+export interface AdminVersions {
+  generated_at: string
+  days: number
+  /** Newest build seen calling the API in the window, not the newest tagged. */
+  current_release: string
+  current_share: number
+  versions: Array<VersionRow>
+  platforms: Array<PlatformRow>
+  desktop_total: number
+  /**
+   * Requests whose user agent was not a Scrollr build: the website, curl, k8s
+   * probes. Shown rather than hidden — if the desktop header ever stops
+   * arriving, this is the only place it would be visible.
+   */
+  unrecognized: number
+}
+
 type Token = () => Promise<string | null>
 
 export const adminApi = {
@@ -549,6 +594,10 @@ export const adminApi = {
 
   overview: (getToken: Token) =>
     adminFetch<AdminOverview>('/admin/overview', getToken),
+
+  /** Version adoption, platform mix and error rate by version (REL-271). */
+  versions: (getToken: Token, days: number) =>
+    adminFetch<AdminVersions>(`/admin/versions?days=${days}`, getToken),
 
   accounts: (getToken: Token, query: string, page: number) =>
     adminFetch<AccountsPage>(

--- a/myscrollr.com/src/components/admin/AdminShell.tsx
+++ b/myscrollr.com/src/components/admin/AdminShell.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet, useLocation } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
 import {
   BarChart3,
+  Layers,
   LifeBuoy,
   Loader2,
   Lock,
@@ -24,6 +25,7 @@ import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 const SECTIONS = [
   { to: '/admin', label: 'Overview', Icon: BarChart3, exact: true },
   { to: '/admin/support', label: 'Support', Icon: LifeBuoy },
+  { to: '/admin/versions', label: 'Versions', Icon: Layers },
   { to: '/admin/users', label: 'Users', Icon: Users },
   { to: '/admin/admins', label: 'Admins', Icon: ShieldCheck },
 ] as const

--- a/myscrollr.com/src/components/admin/VersionsPage.tsx
+++ b/myscrollr.com/src/components/admin/VersionsPage.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import type { AdminVersions } from '@/api/admin'
+import { adminApi } from '@/api/admin'
+import { useGetToken } from '@/hooks/useGetToken'
+
+/**
+ * Versions — what the fleet is actually running, and which builds are failing.
+ *
+ * Built entirely from per-day request counters (REL-271). Until those existed,
+ * a report like "the ticker never scrolls, 1.4.0 and 1.5.0, Windows" could not
+ * be scoped at all: nobody could say whether anyone was still on those builds,
+ * so every follow-up was an email and a week of waiting.
+ *
+ * The honesty rule from the Overview applies here and is load-bearing. These
+ * are REQUESTS, not installs. No user id is stored anywhere in the counters —
+ * deliberately, that is the privacy design — so an install headcount does not
+ * exist and no label on this page may imply one. Every install polls the
+ * dashboard on the same timer, so traffic share tracks adoption closely enough
+ * to answer the question that matters; it is a proxy and it is labelled as
+ * one, every time.
+ */
+
+const WINDOWS = [7, 30, 90] as const
+
+// A decimal only below 1%, so a real-but-tiny share never rounds to a flat
+// “0%” that reads as “nobody”.
+const pct = (n: number) => `${(n * 100).toFixed(n === 0 || n >= 0.01 ? 0 : 1)}%`
+const num = (n: number) => n.toLocaleString()
+
+/** Anything at or above this is worth a second look rather than a shrug. */
+const ERROR_RATE_WARN = 0.02
+
+function Bar({ share, tone }: { share: number; tone: string }) {
+  return (
+    <div className="h-1.5 w-full overflow-hidden rounded-full bg-base-300/60">
+      <div
+        className={`h-full rounded-full ${tone}`}
+        style={{ width: `${Math.max(share * 100, share > 0 ? 1 : 0)}%` }}
+      />
+    </div>
+  )
+}
+
+export default function VersionsPage() {
+  const getToken = useGetToken()
+  const [days, setDays] = useState<number>(30)
+  const [data, setData] = useState<AdminVersions | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    setData(null)
+    setError(null)
+    adminApi
+      .versions(getToken, days)
+      .then(setData)
+      .catch((err: unknown) =>
+        setError(
+          err instanceof Error ? err.message : 'Could not load the counters',
+        ),
+      )
+  }, [getToken, days])
+
+  useEffect(load, [load])
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Versions</h1>
+          <p className="mt-1 max-w-2xl text-sm text-base-content/60">
+            What the fleet is running, and which builds are erroring. Counted
+            from the app version and OS every request already carries — never
+            from anything on a user's ticker.
+          </p>
+        </div>
+        <div
+          role="group"
+          aria-label="Time window"
+          className="flex shrink-0 rounded-lg ring-1 ring-base-300"
+        >
+          {WINDOWS.map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => setDays(d)}
+              aria-pressed={days === d}
+              className={`min-h-9 cursor-pointer px-3 text-sm font-medium first:rounded-l-lg last:rounded-r-lg transition-colors ${
+                days === d
+                  ? 'bg-base-200 text-base-content'
+                  : 'text-base-content/60 hover:bg-base-200/60'
+              }`}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {error && (
+        <p className="rounded-lg bg-error/5 p-3 text-sm text-error ring-1 ring-error/20">
+          {error}
+        </p>
+      )}
+
+      {!data && !error && (
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Loader2 className="size-6 animate-spin text-base-content/40" />
+        </div>
+      )}
+
+      {data && data.desktop_total === 0 && (
+        <p className="rounded-xl bg-base-200/40 p-4 text-sm text-base-content/70 ring-1 ring-base-300/60">
+          No desktop requests in the last {data.days} days carried a recognisable
+          Scrollr user agent
+          {data.unrecognized > 0 && (
+            <> (though {num(data.unrecognized)} other requests arrived)</>
+          )}
+          . Installs only start reporting once they have updated to a build that
+          sends one — before then this page is correctly empty rather than
+          wrong.
+        </p>
+      )}
+
+      {data && data.desktop_total > 0 && (
+        <>
+          {/* Adoption. The headline is the share on the newest build seen. */}
+          <section className="rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <h2 className="text-sm font-semibold">Version adoption</h2>
+              <p className="text-xs text-base-content/50">
+                Share of desktop API requests, not of installs — no per-user
+                data is stored.
+              </p>
+            </div>
+            <p className="mt-3 text-3xl font-bold tabular-nums">
+              {pct(data.current_share)}
+            </p>
+            <p className="text-sm text-base-content/60">
+              on {data.current_release}, the newest build calling the API
+            </p>
+
+            <ul className="mt-5 space-y-3">
+              {data.versions.map((v) => (
+                <li key={v.version}>
+                  <div className="flex items-baseline justify-between gap-3 text-sm">
+                    <span className="font-medium tabular-nums">{v.version}</span>
+                    <span className="text-base-content/50 tabular-nums">
+                      {pct(v.share)} · {num(v.requests)} req
+                    </span>
+                  </div>
+                  <div className="mt-1.5">
+                    <Bar share={v.share} tone="bg-primary" />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            {/* Platform mix. */}
+            <section className="rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60">
+              <h2 className="text-sm font-semibold">Platform mix</h2>
+              <ul className="mt-4 space-y-3">
+                {data.platforms.map((p) => (
+                  <li key={p.platform}>
+                    <div className="flex items-baseline justify-between gap-3 text-sm">
+                      <span className="font-medium capitalize">
+                        {p.platform}
+                      </span>
+                      <span className="text-base-content/50 tabular-nums">
+                        {pct(p.share)} · {num(p.requests)} req
+                      </span>
+                    </div>
+                    <div className="mt-1.5">
+                      <Bar share={p.share} tone="bg-secondary" />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            {/* Error rate by version — the reason the page exists. */}
+            <section className="rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <h2 className="text-sm font-semibold">Error rate by version</h2>
+                <p className="text-xs text-base-content/50">4xx + 5xx</p>
+              </div>
+              <table className="mt-4 w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-base-content/50">
+                    <th className="pb-2 font-medium">Build</th>
+                    <th className="pb-2 text-right font-medium">4xx</th>
+                    <th className="pb-2 text-right font-medium">5xx</th>
+                    <th className="pb-2 text-right font-medium">Rate</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.versions.map((v) => {
+                    const hot = v.error_rate >= ERROR_RATE_WARN
+                    return (
+                      <tr key={v.version} className="border-t border-base-300/50">
+                        <td className="py-2 font-medium tabular-nums">
+                          {v.version}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-base-content/60">
+                          {num(v.client_errors)}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-base-content/60">
+                          {num(v.server_errors)}
+                        </td>
+                        <td
+                          className={`py-2 text-right font-semibold tabular-nums ${
+                            hot ? 'text-error' : 'text-base-content/70'
+                          }`}
+                        >
+                          {hot && (
+                            <AlertTriangle
+                              size={13}
+                              className="mr-1 inline-block align-[-1px]"
+                              aria-hidden
+                            />
+                          )}
+                          {pct(v.error_rate)}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+              <p className="mt-3 text-xs text-base-content/50">
+                A build erroring well above the others is a build to reproduce
+                on — this is what scopes "some users report X" to a version and
+                an OS.
+              </p>
+            </section>
+          </div>
+
+          <p className="text-xs text-base-content/50">
+            {num(data.unrecognized)} request
+            {data.unrecognized === 1 ? '' : 's'} in this window came from
+            something other than a Scrollr build — the website, the extension,
+            uptime probes. Counted separately and excluded from every share
+            above. If this number swallows desktop traffic, the app has stopped
+            sending its user agent.
+          </p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/myscrollr.com/src/components/legal/documents.ts
+++ b/myscrollr.com/src/components/legal/documents.ts
@@ -160,7 +160,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
           'Channel Configuration: We store which data channels you have enabled (finance, sports, RSS, fantasy) and their configuration settings.',
           'Yahoo Fantasy Data: If you connect your Yahoo Fantasy account, we store an encrypted refresh token (AES-256-GCM encryption) to maintain your connection. We also store your Yahoo user identifier, league data, standings, rosters, and matchup information that Yahoo provides through their API.',
           "Kalshi Account Connection: If you connect your own Kalshi account in the desktop application (an optional feature for viewing your positions), your Kalshi API key ID and private key are stored ONLY in your device's operating-system keychain or credential store. They are never transmitted to our servers, never included in our database, and are used solely for read-only portfolio requests made directly from your device to Kalshi.",
-          'Usage Data: We collect basic usage metrics including active SSE connection counts. We do not track individual page visits, browsing history, or behavioral analytics.',
+          'Usage Data: We keep anonymous operational counts — how many requests reach our API each day, which app version and operating system they came from, and how many of them failed. These are totals only: they carry no account identifier, no IP address, and nothing about the content you follow — no symbols, teams, feeds, or widget settings. We use them to tell which builds are affected by a bug and whether a fix reached people. We also count active SSE connections. We do not track individual page visits, browsing history, or behavioral analytics.',
         ],
       },
       {
@@ -257,7 +257,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         heading: 'Network Communication',
         content: [
           "The desktop application communicates with Scrollr API servers (api.myscrollr.com) to retrieve real-time data via Server-Sent Events (SSE) and to synchronize your configuration. If you optionally connect your own Kalshi account, the application additionally communicates directly with Kalshi's API from your device (see Third-Party Services below).",
-          'All network communication uses HTTPS encryption. The application sends your authentication token and subscription tier with each request. It does not transmit any data about other applications, files, or activity on your device.',
+          'All network communication uses HTTPS encryption. The application sends your authentication token, subscription tier, and its own version and operating system with each request; we keep the last two only as daily totals, to tell which builds a bug affects. It does not transmit any data about other applications, files, or activity on your device, or about which symbols, teams, or feeds you follow.',
         ],
       },
       {

--- a/myscrollr.com/src/routeTree.gen.ts
+++ b/myscrollr.com/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as AdminIndexRouteImport } from './routes/admin.index'
 import { Route as UplinkLifetimeRouteImport } from './routes/uplink_.lifetime'
 import { Route as UUsernameRouteImport } from './routes/u.$username'
 import { Route as DownloadOsRouteImport } from './routes/download_.$os'
+import { Route as AdminVersionsRouteImport } from './routes/admin.versions'
 import { Route as AdminUsersRouteImport } from './routes/admin.users'
 import { Route as AdminSupportRouteImport } from './routes/admin.support'
 import { Route as AdminAdminsRouteImport } from './routes/admin.admins'
@@ -139,6 +140,11 @@ const DownloadOsRoute = DownloadOsRouteImport.update({
   path: '/download/$os',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminVersionsRoute = AdminVersionsRouteImport.update({
+  id: '/versions',
+  path: '/versions',
+  getParentRoute: () => AdminRoute,
+} as any)
 const AdminUsersRoute = AdminUsersRouteImport.update({
   id: '/users',
   path: '/users',
@@ -176,6 +182,7 @@ export interface FileRoutesByFullPath {
   '/admin/admins': typeof AdminAdminsRoute
   '/admin/support': typeof AdminSupportRoute
   '/admin/users': typeof AdminUsersRoute
+  '/admin/versions': typeof AdminVersionsRoute
   '/download/$os': typeof DownloadOsRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink/lifetime': typeof UplinkLifetimeRoute
@@ -201,6 +208,7 @@ export interface FileRoutesByTo {
   '/admin/admins': typeof AdminAdminsRoute
   '/admin/support': typeof AdminSupportRoute
   '/admin/users': typeof AdminUsersRoute
+  '/admin/versions': typeof AdminVersionsRoute
   '/download/$os': typeof DownloadOsRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink/lifetime': typeof UplinkLifetimeRoute
@@ -228,6 +236,7 @@ export interface FileRoutesById {
   '/admin/admins': typeof AdminAdminsRoute
   '/admin/support': typeof AdminSupportRoute
   '/admin/users': typeof AdminUsersRoute
+  '/admin/versions': typeof AdminVersionsRoute
   '/download_/$os': typeof DownloadOsRoute
   '/u/$username': typeof UUsernameRoute
   '/uplink_/lifetime': typeof UplinkLifetimeRoute
@@ -256,6 +265,7 @@ export interface FileRouteTypes {
     | '/admin/admins'
     | '/admin/support'
     | '/admin/users'
+    | '/admin/versions'
     | '/download/$os'
     | '/u/$username'
     | '/uplink/lifetime'
@@ -281,6 +291,7 @@ export interface FileRouteTypes {
     | '/admin/admins'
     | '/admin/support'
     | '/admin/users'
+    | '/admin/versions'
     | '/download/$os'
     | '/u/$username'
     | '/uplink/lifetime'
@@ -307,6 +318,7 @@ export interface FileRouteTypes {
     | '/admin/admins'
     | '/admin/support'
     | '/admin/users'
+    | '/admin/versions'
     | '/download_/$os'
     | '/u/$username'
     | '/uplink_/lifetime'
@@ -485,6 +497,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DownloadOsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/versions': {
+      id: '/admin/versions'
+      path: '/versions'
+      fullPath: '/admin/versions'
+      preLoaderRoute: typeof AdminVersionsRouteImport
+      parentRoute: typeof AdminRoute
+    }
     '/admin/users': {
       id: '/admin/users'
       path: '/users'
@@ -513,6 +532,7 @@ interface AdminRouteChildren {
   AdminAdminsRoute: typeof AdminAdminsRoute
   AdminSupportRoute: typeof AdminSupportRoute
   AdminUsersRoute: typeof AdminUsersRoute
+  AdminVersionsRoute: typeof AdminVersionsRoute
   AdminIndexRoute: typeof AdminIndexRoute
 }
 
@@ -520,6 +540,7 @@ const AdminRouteChildren: AdminRouteChildren = {
   AdminAdminsRoute: AdminAdminsRoute,
   AdminSupportRoute: AdminSupportRoute,
   AdminUsersRoute: AdminUsersRoute,
+  AdminVersionsRoute: AdminVersionsRoute,
   AdminIndexRoute: AdminIndexRoute,
 }
 

--- a/myscrollr.com/src/routes/admin.versions.tsx
+++ b/myscrollr.com/src/routes/admin.versions.tsx
@@ -1,0 +1,20 @@
+/**
+ * Versions — version adoption, platform mix and error rate by version.
+ *
+ * Same lazy-import shape as the other console sections: nothing in /admin
+ * ships to a marketing visitor. The API gate (LogtoAuth + RequireAdmin) is the
+ * real boundary; this split is about bundle weight.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import { Suspense, lazy } from 'react'
+
+const VersionsPage = lazy(() => import('@/components/admin/VersionsPage'))
+
+export const Route = createFileRoute('/admin/versions')({
+  component: () => (
+    <Suspense fallback={<div className="min-h-[40vh]" />}>
+      <VersionsPage />
+    </Suspense>
+  ),
+})


### PR DESCRIPTION
Every desktop install calls core-api several times an hour, and its user agent says which build and which OS it is. We discarded that on every request. There was no request-logging or metrics middleware anywhere in `api/` — that is why [REL-253](https://linear.app/relentnet/issue/REL-253) ("ticker never scrolls, reported on 1.4.0 and 1.5.0, Windows") could not be scoped: nobody could say whether anyone was still on those builds, so every follow-up was an email and a week of waiting.

## Counters, not histories

A middleware folds each request into an in-memory map keyed by **(day, app version, platform, route pattern, status class)**, and a timer upserts the totals into `api_usage_daily`. **No per-request row is ever written**, so there is nothing to purge beyond a yearly prune and nothing to leak. The round-trip test drives 1,200 requests and asserts they become **three rows**. A real day is a few hundred; retention is a year.

Every replica flushes its own buffer into the same rows — the upsert adds, so the counts are the fleet's, not one pod's. No leader election needed; unlike the janitors this is commutative.

## ⚠️ The line

Nothing about what a user watches leaves the machine, and **the schema is the enforcement**: there is no column for a symbol, a team, a feed URL, a widget, a query string, a user id or an IP. `endpoint` is the **registered route pattern** (`/users/:username`), never the request path, so a username cannot arrive through it either.

Two tests hold it, and the first is aimed squarely at erosion:

- `TestUsageKeyHasNoPersonalFields` asserts the counter key's field list is **exactly** those five. Adding a dimension fails the build, so it becomes a deliberate act with a review attached rather than a quiet afternoon's convenience.
- `TestUsageStoresNothingPersonal` drives real requests carrying a username in the path, a ticker symbol and a feed URL in the query string, a bearer token and a client IP, and asserts none of it survives into a counter. The DB round-trip test re-asserts it against what was actually written.

The UA regexp doubles as the **cardinality guard**: an unrecognised agent is `unknown`, so no caller can mint dimension values, and the buffer is capped so a caller sending a fresh well-formed version on every request cannot grow the table without limit.

## The client did not already send a usable user agent

It sent reqwest's default, via `plugin-http`. `fetchOverride.ts` now sends `Scrollr/<version> (<os>)` — on API-host calls only, merged so a caller's own `Authorization` and `Content-Type` survive, and never added to non-API fetches. That is the entire client change.

**So existing installs report nothing until they update.** The page shows an `unrecognized` count for exactly this reason: if desktop traffic ever stops being recognised, it shows up there instead of as a silently empty chart. A silently empty chart is the failure mode this issue exists to prevent.

## Two bugs the round-trip test caught that a unit test could not

- **Fiber's `c.Get` returns a string aliasing fasthttp's pooled request buffer**, and `FindStringSubmatch` returns substrings of it. Held as a map key, the key's bytes changed under the map once the buffer was recycled — 900 requests from 1.6.1 were attributed to 1.5.0. The parsed values are cloned now. This would have silently corrupted the data in production while looking fine.
- Ordering needed a numeric compare, not `strings.Compare`: 1.10.0 must sort above 1.9.0.

## The page

A new **Versions** section in the staff console: version adoption, platform mix, and **error rate by version** — the last is the point, since it turns "some users report X" into "X is 1.5.x on Windows".

Deliberately **its own endpoint and its own page** rather than new Overview tiles, to stay out of REL-269's way; the only shared touchpoints are one nav entry, one route line and an append to `api/admin.ts`. Rebased on `main` before merge.

Labels say **requests, never installs**. No user id is stored — that is the privacy design — so an install headcount does not exist and nothing on the page may imply one. Every install polls on the same timer, so traffic share tracks adoption closely; it is a proxy and it is labelled as one.

Privacy policy gets **one plain paragraph**, categorical, no field-by-field public listing (Brandon, 2026-09-09).

## Verification

- `go vet ./...` and `go test ./...` green (Go via a `golang:1.25-alpine` k8s pod with a Postgres sidecar — Docker Desktop is still failing to start).
- Round-trip against a real Postgres: 1,200 requests → 3 rows → 1,300 requests → still 3 rows; a 500 on one endpoint shows as a ~33% error rate against the build that called it, and 0% against the clean one.
- Desktop: `tsc --noEmit` clean, 770 tests pass, 4 new for the user agent.
- Website: build, `tsc`, eslint and 104 tests green.
- The page was rendered against a fixture through the real `AdminChrome` and checked at desktop width; the preview route was removed before commit. **No screenshots here — the repo is public.** Nothing on the page is user data, but the counters table is empty in prod until this deploys and installs update, so there was nothing real to show anyway.

**Never clicked:** the page signed in as a real admin against real counters — that cannot happen until this deploys and installs update to a build that sends the user agent.

Out of scope, flagged separately for Brandon's call: the site footer still says "ZERO ADS · ZERO TELEMETRY", and the desktop privacy doc says the app includes no "crash reporters" although Sentry has shipped in the desktop build for a while (independent of this change).

Fixes REL-271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
