### PR TITLE
Say what we actually collect, in the five places we said we didn't [REL-272]

### DIFF
--- a/desktop/src/components/support/support-content.ts
+++ b/desktop/src/components/support/support-content.ts
@@ -21,7 +21,7 @@ export const FAQ_ITEMS: FAQItem[] = [
   {
     question: "Is my data private?",
     answer:
-      "Scrollr contains zero analytics, zero tracking pixels, and zero telemetry. Your widget configurations and preferences are stored on your device. The only server-side data is your account profile and subscription status.",
+      "No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines, and Scrollr's servers hold your account profile and subscription status. We also count app versions and error rates so we can find bugs without waiting for someone to report them.",
   },
   {
     question: "What platforms are supported?",

--- a/myscrollr.com/README.md
+++ b/myscrollr.com/README.md
@@ -72,9 +72,10 @@ Permissions-Policy are configured in the image's nginx.conf.
   `useTheme`).
 - **Fonts** are self-hosted in `public/fonts/` via `@font-face` so we
   can ship a tight CSP.
-- **Analytics:** none. Zero tracking pixels, zero telemetry — this is
-  a public product promise. Don't add any without a conversation
-  first.
+- **Analytics:** none. No tracking pixels and no third-party
+  analytics — this is a public product promise. The API counts app
+  versions and error rates server-side; nothing beyond that. Don't
+  add any without a conversation first.
 
 ## Structure
 

--- a/myscrollr.com/public/llms-full.txt
+++ b/myscrollr.com/public/llms-full.txt
@@ -102,7 +102,7 @@ Not noticeably. All data flows through a single lightweight connection. The tick
 
 #### Is my data private?
 
-Scrollr contains zero analytics, zero tracking pixels, and zero telemetry. Your channel configurations and preferences are stored on your device. The only server-side data is your account profile and subscription status.
+No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines, and Scrollr's servers hold your account profile and subscription status. We also count app versions and error rates so we can find bugs without waiting for someone to report them.
 
 #### What platforms are supported?
 

--- a/myscrollr.com/scripts/check-prerender.mjs
+++ b/myscrollr.com/scripts/check-prerender.mjs
@@ -209,7 +209,7 @@ if (!existsSync(shell)) {
   // this assertion fails.
   const shellHtml = readFileSync(shell, 'utf8')
   const shellBody = shellHtml.replace(/<head[\s\S]*?<\/head>/i, '')
-  const expectedShellChrome = 'ZERO ADS'
+  const expectedShellChrome = 'ZERO ADS · ZERO TRACKING'
   if (!shellBody.includes(expectedShellChrome)) {
     console.error(
       `✗ _shell.html missing expected chrome "${expectedShellChrome}" ` +

--- a/myscrollr.com/src/components/Footer.tsx
+++ b/myscrollr.com/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { LATEST_DESKTOP_VERSION } from '@/lib/latestVersion.generated'
 
 /**
  * Terminal-editorial footer (design_handoff_marketing_site/README.md):
- * wordmark left, mono uppercase link rows, `ZERO ADS · ZERO TELEMETRY`
+ * wordmark left, mono uppercase link rows, `ZERO ADS · ZERO TRACKING`
  * right. Keeps the full sitemap (status/architecture/releases/legal
  * docs) that the mockup's minimal footer omitted — existing site wins
  * on navigation/SEO.
@@ -93,7 +93,7 @@ export default function Footer() {
             in both themes (/60 measured 4.41:1 in light) while staying
             visibly de-emphasized. */}
         <div className="font-mono text-[11px] tracking-[0.1em] text-base-content/65">
-          ZERO ADS · ZERO TELEMETRY
+          ZERO ADS · ZERO TRACKING
         </div>
       </div>
 

--- a/myscrollr.com/src/components/legal/documents.ts
+++ b/myscrollr.com/src/components/legal/documents.ts
@@ -278,7 +278,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         content: [
           'Yahoo Fantasy Sports: If you connect your Yahoo account, the desktop application opens your default browser for the OAuth authorization flow. The application stores an encrypted refresh token locally and on our servers to maintain the connection. See our Privacy Policy for details on Yahoo data handling.',
           "Kalshi (optional): If you connect your own Kalshi account, the application communicates directly from your device to Kalshi's API using your credentials for READ-ONLY portfolio and position data. These requests do not pass through Scrollr servers. The application cannot place, modify, or cancel orders on your Kalshi account.",
-          'The application does not include any analytics SDKs, telemetry services, crash reporters, or advertising frameworks.',
+          'Scrollr includes no advertising frameworks and no third-party analytics. The application sends crash reports, which you can turn off with the "Send crash reports" setting. Scrollr\'s servers record counts of application versions, platforms and error rates; these counts contain no account identifier and nothing about the content of your ticker.',
         ],
       },
       {


### PR DESCRIPTION
Closes REL-272.

[REL-271](https://github.com/doughknee/myscrollr/pull/367) started counting app version, platform, route and status class per request. That is telemetry by any reasonable reading, and it made `ZERO TELEMETRY` false in every place we print it. Two further claims were already false before that.

Ships the wording approved on the issue (2026-09-10), verbatim — this PR is copy only, no product behaviour changes.

## What changed

| File | Change |
| -- | -- |
| `myscrollr.com/src/components/Footer.tsx` | `ZERO ADS · ZERO TELEMETRY` → `ZERO ADS · ZERO TRACKING` (rendered chrome + the doc comment that repeats it) |
| `myscrollr.com/scripts/check-prerender.mjs` | guards the full new string instead of the bare `'ZERO ADS'` both footers share |
| `desktop/src/components/support/support-content.ts` | "Is my data private?" answer replaced |
| `myscrollr.com/src/components/legal/documents.ts` | Third-Party Services paragraph replaced |
| `myscrollr.com/README.md`, `myscrollr.com/public/llms-full.txt` | brought in line with the in-app answer |

`llms-full.txt` is hand-maintained — nothing generates it (no build script references it), so the file itself is the source.

## The trap this deliberately avoids

An earlier draft of this copy said *"nothing about what's on your ticker ever leaves your machine."* That is false, and would have been a worse claim than the one being fixed, because it concerns real user content rather than a crash reporter. `user_widgets.config` holds `symbols`, `favoriteTeams` and `feeds` in Postgres keyed to `logto_sub` — the server needs your symbols to build your feed, and syncing is why a setup follows you to another machine. The shipped copy says the setup **syncs**, which is the true version.

The narrow promise that *is* true is scoped to the REL-271 counters only: they carry no account identifier and nothing about ticker content, enforced by the schema and a dimension-list test. That is what the legal paragraph claims, and nothing wider.

The legal doc also stops denying a crash reporter that ships (`desktop/src/sentry.tsx`) and has its own **Send crash reports** toggle at `desktop/src/components/settings/rows.ts:227`.

## Verification

- `myscrollr.com`: 113 tests pass. `desktop`: 770 tests pass.
- `npm run build` green, including `check-prerender.mjs`.
- **The guard fails on the old string** — patched the built `_shell.html` back to `ZERO ADS · ZERO TELEMETRY` and re-ran the check:
  ```
  ✗ _shell.html missing expected chrome "ZERO ADS · ZERO TRACKING"
  1 prerender check(s) failed.     (exit 1)
  ```
  Restored, it passes again. The old `'ZERO ADS'` substring would have passed both.
- Desktop support answer and `llms-full.txt` are byte-identical to each other.
- No stale "zero telemetry" remains in any of the six files.

## Not fixed here — listed, not rewritten

`git grep -i "zero telemetry"` still returns hits. The issue scoped this to five strings and one legal paragraph, and says not to rewrite marketing or legal copy on judgement, so these are reported rather than changed. Each still claims no telemetry, or that data stays on the device:

- `myscrollr.com/src/components/landing/FAQSection.tsx:47,49` — **"No analytics, no tracking pixels, and no telemetry. Period."** plus "stored locally on your device and never transmitted anywhere". The most prominent one, and the strongest wording on the site.
- `myscrollr.com/src/components/landing/PromiseSection.tsx:52` — "Scrollr ships zero telemetry… Tests block any deploy that breaks this."
- `myscrollr.com/src/routes/fantasy.tsx:119` — same claim, "no anonymous usage data".
- `myscrollr.com/src/components/support/support-content.ts:29` — website support answer (distinct from the desktop one).
- `myscrollr.com/src/lib/structured-data.ts:183` — served as schema.org FAQ markup to search engines.
- `myscrollr.com/public/llms-full.txt:84-85` — a summary bullet list earlier in the same file I edited.
- `README.md:7,165` and `docs/VISION.md:10,15,184` — repo-level "Zero ads. Zero telemetry." and "No telemetry, ever".
- `api/internal/support/kb/kb.generated.md:99,104` — **generated from `docs/VISION.md`**, so it inherits the claim and the AI support bot answers from it.
- `.github/CONTRIBUTING.md:64-65` — tells contributors "zero telemetry" is a public promise.
- `api/internal/admin/handlers_overview.go:186` — internal admin note, not user-facing.

The claim was in more places than anyone remembered, which was the point of the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
