### PR TITLE
Retire the telemetry promise everywhere it still stands [REL-274]

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,8 +61,9 @@ ports).
 - Changes to billing, Stripe webhook handling, or invite tokens
   without a clear threat-model review — these are load-bearing for
   revenue and account security.
-- Analytics, tracking pixels, or telemetry of any kind — "zero
-  telemetry" is a public product promise (see the Privacy Policy).
+- Tracking pixels or third-party analytics of any kind — "no ads, no
+  tracking pixels, no third-party analytics" is a public product
+  promise (see the Privacy Policy).
 - Dependencies under licenses incompatible with AGPL-3.0-or-later.
 
 When in doubt, **open an issue first** and check with a maintainer

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Live market quotes, fantasy matchups, game scores, and RSS feeds —
 streaming into a compact bar that floats on top of whatever you're
-working on. Multi-monitor aware. Zero ads. Zero telemetry.
+working on. Multi-monitor aware. No ads, no tracking pixels, no third-party analytics.
 
 ![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue)
 ![Desktop](https://img.shields.io/badge/desktop-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey)
@@ -162,8 +162,10 @@ unreleased; `deploy.yml` ships the API and website to production.
   so change the Go and regenerate. `desktop/src/tierLimits.ts` is a
   **hand-kept mirror** — there is no generator; edit it and the Go map
   together, as its header comment lists.
-- **No analytics, tracking pixels, or telemetry.** This is a public
-  product promise, documented in the Privacy Policy. Don't add them.
+- **No ads, tracking pixels, or third-party analytics.** This is a
+  public product promise, documented in the Privacy Policy. The API
+  counts app versions and error rates server-side; nothing beyond
+  that. Don't add more.
 - **Only core migrates.** All schema lives in `api/migrations/`; the
   ingesters are pure writers. A failed migration crashes the container.
 - **Rollbacks via rolling forward.** We prefer forward-only migrations

--- a/api/internal/admin/handlers_overview.go
+++ b/api/internal/admin/handlers_overview.go
@@ -19,9 +19,9 @@ import (
 // measurement.
 //
 // The number people always want here is active installs. There is no
-// telemetry or analytics anywhere in this API - a standing decision, not an
-// oversight - so installs are NOT measurable, and the Installs tile exists
-// purely to say so and point at downloads instead.
+// third-party analytics and no install identifier anywhere in this API - a
+// standing decision, not an oversight - so installs are NOT measurable, and
+// the Installs tile exists purely to say so and point at downloads instead.
 
 // logtoStats is the tile's seam onto Logto, so the tests can drive both the
 // healthy path and the unreachable path without a network.
@@ -183,9 +183,9 @@ func HandleGetOverview(c *fiber.Ctx) error {
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		Installs: Measured{
 			Available: false,
-			Note: "Not measurable. Scrollr ships no telemetry or analytics, by " +
-				"decision - nothing reports back that an install exists or is " +
-				"running. Downloads per release is the honest proxy.",
+			Note: "Not measurable. Scrollr ships no third-party analytics and no " +
+				"install identifier, by decision - nothing reports back that a given " +
+				"install exists or is running. Downloads per release is the honest proxy.",
 		},
 	}
 

--- a/api/internal/support/kb/kb.generated.md
+++ b/api/internal/support/kb/kb.generated.md
@@ -93,15 +93,15 @@ and leave program details to the partner.
 
 ## What Scrollr is
 
-<!-- source: docs/VISION.md @ 11e839bac266 -->
+<!-- source: docs/VISION.md @ 87cefee845b1 -->
 ### 1. What Scrollr is
 
-> **A pinned, always-on-top desktop ticker for the things you actually care about.** Live finance quotes, sports scores, fantasy matchups, prediction markets, and news stream into a compact bar floating over whatever you're working on. You pick **widgets** from a catalog; you pay for **how many you can run at once (slots)**. Multi-monitor aware. **Zero ads. Zero telemetry.**
+> **A pinned, always-on-top desktop ticker for the things you actually care about.** Live finance quotes, sports scores, fantasy matchups, prediction markets, and news stream into a compact bar floating over whatever you're working on. You pick **widgets** from a catalog; you pay for **how many you can run at once (slots)**. Multi-monitor aware. **No ads, no tracking pixels, no third-party analytics.**
 
 Three load-bearing commitments, true at every layer:
 
 1. **The desktop app is the product** (Tauri v2 + React). The website is *marketing, auth, and billing only*.
-2. **No telemetry, ever** — a public promise, enforced by per-service Sentry-scrubbing tests that block deploy.
+2. **No third-party analytics, and no personal data in crash reports** — enforced by per-service Sentry-scrubbing tests that block deploy. First-party counts of app versions and error rates carry no account identifier and nothing about ticker content.
 3. **One user-facing primitive (the widget), one price lever (the slot).** Every widget costs exactly one slot; a plan card's headline is a widget count.
 
 ## Plans and limits

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -7,12 +7,12 @@
 
 ## 1. What Scrollr is
 
-> **A pinned, always-on-top desktop ticker for the things you actually care about.** Live finance quotes, sports scores, fantasy matchups, prediction markets, and news stream into a compact bar floating over whatever you're working on. You pick **widgets** from a catalog; you pay for **how many you can run at once (slots)**. Multi-monitor aware. **Zero ads. Zero telemetry.**
+> **A pinned, always-on-top desktop ticker for the things you actually care about.** Live finance quotes, sports scores, fantasy matchups, prediction markets, and news stream into a compact bar floating over whatever you're working on. You pick **widgets** from a catalog; you pay for **how many you can run at once (slots)**. Multi-monitor aware. **No ads, no tracking pixels, no third-party analytics.**
 
 Three load-bearing commitments, true at every layer:
 
 1. **The desktop app is the product** (Tauri v2 + React). The website is *marketing, auth, and billing only*.
-2. **No telemetry, ever** — a public promise, enforced by per-service Sentry-scrubbing tests that block deploy.
+2. **No third-party analytics, and no personal data in crash reports** — enforced by per-service Sentry-scrubbing tests that block deploy. First-party counts of app versions and error rates carry no account identifier and nothing about ticker content.
 3. **One user-facing primitive (the widget), one price lever (the slot).** Every widget costs exactly one slot; a plan card's headline is a widget count.
 
 ---
@@ -181,7 +181,7 @@ Codegen TS types from the Go API's OpenAPI contract so web and desktop **cannot 
 ## 6. Non-negotiables (the spine — no decision may break these)
 
 - Desktop is the product; website stays marketing/auth/billing only.
-- Zero telemetry (public promise + enforced by tests).
+- No third-party analytics, and no personal data in crash reports (public promise + enforced by tests).
 - Slots-only monetization; one price lever.
 - **Wire-compat — *activates at first real user, suspended until then.*** Scrollr currently has **no users**, so breaking changes are free and should be taken now to establish clean names. Once you ship to real users, this becomes a hard rule: every rename/contract change goes behind a compat seam, never a breaking change (`MIN_DESKTOP_VERSION` gates retirement).
 - The CDC → Redis → SSE realtime pipeline works and is replica-safe; keep it.

--- a/myscrollr.com/public/llms-full.txt
+++ b/myscrollr.com/public/llms-full.txt
@@ -81,9 +81,9 @@ Branded desktop deployments for teams. Custom branding, multi-display, self-host
 
 ## Privacy
 
-- No analytics, no tracking pixels, no telemetry.
-- Channel configurations and preferences stored locally on your device.
-- Only server-side data is your account profile and subscription status.
+- No ads, no tracking pixels, no third-party analytics.
+- Your widget setup syncs to your account so it follows you between machines; Scrollr's servers also hold your account profile and subscription status.
+- We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.
 - Source code is publicly available on GitHub under GNU AGPL v3.0.
 
 ## FAQ

--- a/myscrollr.com/src/components/admin/OverviewPage.tsx
+++ b/myscrollr.com/src/components/admin/OverviewPage.tsx
@@ -21,9 +21,9 @@ import {
  *
  * Every tile is either a number we hold or an explicit admission that we do
  * not. The Installs tile is the second kind on purpose: Scrollr ships no
- * telemetry, by decision, so active installs cannot be measured and the page
- * says exactly that instead of substituting downloads and hoping nobody
- * notices the difference.
+ * install identifier, by decision, so active installs cannot be measured and
+ * the page says exactly that instead of substituting downloads and hoping
+ * nobody notices the difference.
  */
 
 function Tile({

--- a/myscrollr.com/src/components/landing/FAQSection.tsx
+++ b/myscrollr.com/src/components/landing/FAQSection.tsx
@@ -44,9 +44,9 @@ const FAQ_ITEMS: Array<FAQItem> = [
   {
     icon: ShieldCheck,
     question: 'Is my data private?',
-    highlight: 'No analytics, no tracking pixels, and no telemetry. Period.',
+    highlight: 'No ads, no tracking pixels, no third-party analytics.',
     answer:
-      'Scrollr contains zero analytics, zero tracking pixels, and zero telemetry. Your preferences are stored locally on your device and never transmitted anywhere. The only network requests go to the Scrollr API to fetch your feed data.',
+      'No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines. We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.',
     accent: 'sky',
   },
   {

--- a/myscrollr.com/src/components/landing/PromiseSection.tsx
+++ b/myscrollr.com/src/components/landing/PromiseSection.tsx
@@ -1,5 +1,5 @@
 /**
- * SEC 05 ／ THE PROMISE — zero telemetry, the refusals ledger, and the
+ * SEC 05 ／ THE PROMISE — the privacy promise, the refusals ledger, and the
  * live GitHub stat line (stars · forks · last commit).
  */
 
@@ -49,7 +49,7 @@ export function PromiseSection({
             </h2>
             <p className="m-0 mb-7 max-w-[460px] leading-relaxed text-base-content/60 [text-wrap:pretty]">
               {
-                'Scrollr ships zero telemetry: no analytics, no tracking pixels, no "anonymous usage data." Tests block any deploy that breaks this. You don\'t have to take our word for it.'
+                'No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines. We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.'
               }
             </p>
             <a

--- a/myscrollr.com/src/components/support/support-content.ts
+++ b/myscrollr.com/src/components/support/support-content.ts
@@ -26,7 +26,7 @@ export const FAQ_ITEMS: Array<FAQItem> = [
   {
     question: 'Is my data private?',
     answer:
-      'Scrollr ships zero telemetry: no analytics, no tracking. Enforced by tests that block deploys; the source is public.',
+      'No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines. We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.',
   },
   {
     question: 'Do I need an account?',

--- a/myscrollr.com/src/lib/adminFormat.test.ts
+++ b/myscrollr.com/src/lib/adminFormat.test.ts
@@ -22,7 +22,7 @@ describe('measuredValue', () => {
     const tile = measuredValue({
       value: 0,
       available: false,
-      note: 'Not measurable. Scrollr ships no telemetry.',
+      note: 'Not measurable. Scrollr ships no third-party analytics.',
     })
     expect(tile.display).toBeNull()
     expect(tile.note).toContain('Not measurable')

--- a/myscrollr.com/src/lib/structured-data.ts
+++ b/myscrollr.com/src/lib/structured-data.ts
@@ -180,7 +180,7 @@ export const HOMEPAGE_FAQ_ITEMS: ReadonlyArray<{
   {
     question: 'What does Scrollr collect about me?',
     answer:
-      'Nothing. Zero telemetry is a shipped promise, enforced by tests that block deploys, and the source is public.',
+      'No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines. We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.',
   },
   {
     question: 'Which platforms?',

--- a/myscrollr.com/src/routes/fantasy.tsx
+++ b/myscrollr.com/src/routes/fantasy.tsx
@@ -29,8 +29,8 @@ import { EASE } from '@/lib/animations'
 //   2. Give us an audience-level read on traffic from ingress logs
 //      alone. The distinct URL IS the instrument: hits on /fantasy vs
 //      /, and the Referer on /download/$os telling us which page
-//      sourced an install. No client telemetry, so this costs nothing
-//      against the zero-telemetry promise.
+//      sourced an install. No client analytics, so this costs
+//      nothing against the privacy promise.
 //
 // Section order is a narrative, not a copy of the homepage's:
 //   01 what you see  ->  02 proof it does FANTASY  ->  03 the ritual
@@ -116,7 +116,7 @@ const FANTASY_FAQ_ITEMS: ReadonlyArray<{ question: string; answer: string }> = [
   {
     question: 'What do you collect about me?',
     answer:
-      'Nothing. Scrollr ships zero telemetry: no analytics, no tracking pixels, no anonymous usage data. Tests block any deploy that breaks that promise, and the whole codebase is public under AGPL-3.0 if you would rather check than trust.',
+      'No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines. We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.',
   },
 ]
 


### PR DESCRIPTION
Closes REL-274. Follows REL-272 (#368), which fixed the five strings it was scoped to and correctly left the rest rather than rewriting marketing copy on its own judgement.

Ships the wording Brandon approved 2026-09-10, verbatim. Copy and docs only — no behaviour change.

## The one that was actually answering users

`api/internal/support/kb/kb.generated.md` is generated from `docs/VISION.md` and sits in the cached system prompt for every ticket the drafter answers. Until this PR, a user asking about privacy got told there is no telemetry, with a cited enforcement mechanism. Fixed at the source and regenerated with `make kb`; the regen diff is the two VISION lines plus their provenance hash and nothing else:

```
-<!-- source: docs/VISION.md @ 11e839bac266 -->
+<!-- source: docs/VISION.md @ 87cefee845b1 -->
-... Multi-monitor aware. **Zero ads. Zero telemetry.**
+... Multi-monitor aware. **No ads, no tracking pixels, no third-party analytics.**
-2. **No telemetry, ever** — a public promise, enforced by per-service Sentry-scrubbing tests that block deploy.
+2. **No third-party analytics, and no personal data in crash reports** — enforced by per-service Sentry-scrubbing tests that block deploy. First-party counts of app versions and error rates carry no account identifier and nothing about ticker content.
```

## The rest

- **`structured-data.ts`** — schema.org FAQPage, served to search engines and eligible for rich results, so the hardest one to retract.
- **`landing/FAQSection.tsx`** — the loudest version, and the only one that also said preferences are *"never transmitted anywhere"*. `user_widgets.config` holds symbols, favourite teams and feed URLs keyed to `logto_sub`, so the approved copy says the setup syncs.
- **`landing/PromiseSection.tsx`**, **`support/support-content.ts`** (the website's, distinct from the desktop file #368 fixed), **`llms-full.txt`**, **`README.md`**, **`.github/CONTRIBUTING.md`**.
- **`admin/handlers_overview.go`** + **`adminFormat.test.ts`** + the two doc comments above them. What makes installs unmeasurable is the absence of an *install identifier*, not the absence of telemetry — that is still true, so the tile's honesty rule survives with a claim that holds.

**Not on the issue's list, found by the grep:** `myscrollr.com/src/routes/fantasy.tsx:33,119`. The `/fantasy` landing FAQ answered *"What do you collect about me?"* with *"Nothing. Scrollr ships zero telemetry…"* — the most absolute phrasing anywhere on the site. Fixed with the same approved copy; the line-33 comment about ingress logs being the only instrument now says "no client analytics" instead of naming the promise.

## The enforcement claim is kept, not deleted

Several places said the promise was test-enforced. `TestScrubSentryEventRemovesPII` (in `api/internal/platform` and `channels/fantasy/api`) does exist — but it asserts Sentry events are *stripped of PII*, which presupposes Sentry ships and sends. It is evidence for "crash reports carry no personal data" and evidence **against** "no telemetry". The approved wording reattaches the enforcement claim to the thing the tests actually prove, so the site keeps a specific, checkable commitment instead of a slogan.

## ⚠️ Kalshi claims: untouched, and here's the proof

A grep for `never transmitted` hits them. They are true — verified 2026-09-10, no Kalshi credential column exists anywhere in `api/migrations` — and they are the on-device read-only key rule. Every one is byte-identical to `main`:

```
$ for f in ...; do [ "$(git rev-parse origin/main:$f)" = "$(git hash-object $f)" ] ...
  IDENTICAL myscrollr.com/src/components/legal/documents.ts
  IDENTICAL desktop/src-tauri/Cargo.toml
  IDENTICAL desktop/src-tauri/src/kalshi/mod.rs
  IDENTICAL desktop/src-tauri/src/kalshi/sign.rs
  IDENTICAL desktop/src-tauri/src/kalshi/store.rs
  IDENTICAL desktop/src-tauri/src/commands/kalshi.rs
  IDENTICAL channels/predictions/LOCAL_DEV.md
```

## Verification

- `git grep -in "zero telemetry\|no telemetry"` → **no hits.** (The single surviving `telemetry` in prose is `desktop/src/components/settings/rows.ts:230`, a *search keyword* for the Sentry crash-report toggle — the word users type to find that setting.)
- `make kb` regenerated (Docker Desktop's WSL distro is still Stopped, so kbgen ran via the in-cluster `golang:1.25-alpine` pod); `support-kb` diffs clean.
- Go: `gofmt` clean on the touched file, `go build ./...`, `go vet ./internal/admin/`, `go test ./internal/admin/ ./internal/support/... ./internal/platform/` all pass.
- Website: `vitest` 113/113, `tsc --noEmit` clean, `eslint` clean on touched files, `npm run build` + `check-prerender.mjs` all green (all 14 routes, JSON-LD counts unchanged, mobile viewport checks pass).
- New copy confirmed present in the prerendered `/`, `/fantasy` and `/support` HTML.
- Website and desktop support content now agree: both say no ads/pixels/third-party analytics, that the widget setup syncs to the account, and that app versions and error rates are counted.

## Note for REL-273

REL-273 seeds its CI guard from whatever is on `main` after this lands. Four absolute-sounding claims remain that are **not** telemetry claims and so were outside this issue's approved wording — flagging them so they aren't registered as reviewed-and-true:

- `landing/TrustSection.tsx:330` — *"Open source, zero analytics, no accounts."* **"no accounts" is false** (Logto holds 183).
- `landing/HowItWorks.tsx:205` — badge *"No tracking / Zero analytics"*.
- `landing/CallToAction.tsx:186` and `routes/fantasy.tsx:164` — *"Zero tracking"* / *"Zero ads, zero tracking"*.

`ZERO ADS · ZERO TRACKING` itself is #368's approved footer chrome, so "zero tracking" is settled; "zero analytics" and "no accounts" are not, and want Brandon's wording rather than mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
