### PR TITLE
Fix support queue status freshness [REL-278]

### DIFF
--- a/api/internal/support/handlers_admin_console.go
+++ b/api/internal/support/handlers_admin_console.go
@@ -197,6 +197,9 @@ type queueState struct {
 	DraftStatus   string
 	Disposition   string
 	AutoSendArmed bool
+	LastUser      *time.Time
+	LastSent      *time.Time
+	DraftCreated  *time.Time
 }
 
 // group answers which of the three columns a case belongs in, and why in
@@ -206,6 +209,14 @@ type queueState struct {
 func (q queueState) group() (string, string) {
 	if strings.EqualFold(strings.TrimSpace(q.CaseStatus), "closed") {
 		return queueHandled, "The ticket is closed."
+	}
+	if q.LastUser != nil && q.LastSent != nil && !q.LastSent.Before(*q.LastUser) &&
+		(q.DraftCreated == nil || !q.DraftCreated.After(*q.LastSent)) {
+		return queueWaiting, "We replied. Nothing is due from us until they write back."
+	}
+	if q.LastUser != nil && (q.LastSent == nil || q.LastUser.After(*q.LastSent)) &&
+		(q.DraftCreated == nil || q.LastUser.After(*q.DraftCreated)) {
+		return queueNeedsYou, "The user wrote after the latest reply or draft, so this needs a new answer."
 	}
 	if !q.HasDraft {
 		return queueNeedsYou, "No draft was ever written for this ticket, so nothing is going to answer it on its own."
@@ -326,7 +337,7 @@ type AdminQueueResponse struct {
 const queueSQL = `
 	WITH latest AS (
 		SELECT DISTINCT ON (ticket_number)
-		       ticket_number, id, status, disposition, disposition_reason, hold_until,
+		       ticket_number, id, status, disposition, disposition_reason, hold_until, created_at,
 		       coalesce(user_name, '')        AS user_name,
 		       coalesce(draft_body_html, '')  AS draft_body_html,
 		       coalesce(edited_body_html, '') AS edited_body_html,
@@ -340,7 +351,9 @@ const queueSQL = `
 	       c.opened_at, c.updated_at,
 	       (SELECT max(m.created_at) FROM support_messages m
 	         WHERE m.ticket_number = c.ticket_number AND m.kind = 'user'),
-	       d.id, d.status, d.disposition, d.disposition_reason, d.hold_until,
+	       (SELECT max(m.created_at) FROM support_messages m
+	         WHERE m.ticket_number = c.ticket_number AND m.kind = 'sent'),
+	       d.id, d.status, d.disposition, d.disposition_reason, d.hold_until, d.created_at,
 	       coalesce(d.user_name, ''), coalesce(d.draft_body_html, ''),
 	       coalesce(d.edited_body_html, ''), coalesce(d.intervened, false),
 	       coalesce(s.plan, ''), coalesce(s.status, ''), coalesce(s.lifetime, false)
@@ -422,14 +435,14 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 		var issueKey string
 		var draftID *int64
 		var draftStatus, disposition, dispositionReason *string
-		var holdUntil, lastUser *time.Time
+		var holdUntil, lastUser, lastSent, draftCreated *time.Time
 		var draftBody, editedBody, planStatus string
 		var intervened, lifetime bool
 
 		if err := rows.Scan(&r.TicketNumber, &r.UserEmail, &r.Subject,
 			&r.Category, &r.Priority, &r.Status, &r.Summary, &r.OS, &issueKey,
-			&r.OpenedAt, &r.UpdatedAt, &lastUser,
-			&draftID, &draftStatus, &disposition, &dispositionReason, &holdUntil,
+			&r.OpenedAt, &r.UpdatedAt, &lastUser, &lastSent,
+			&draftID, &draftStatus, &disposition, &dispositionReason, &holdUntil, &draftCreated,
 			&r.Name, &draftBody, &editedBody, &intervened,
 			&r.Plan, &planStatus, &lifetime); err != nil {
 			log.Printf("[AdminSupport] scan queue row: %v", err)
@@ -461,6 +474,9 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 			DraftStatus:   r.DraftStatus,
 			Disposition:   r.Disposition,
 			AutoSendArmed: autosend.Armed,
+			LastUser:      lastUser,
+			LastSent:      lastSent,
+			DraftCreated:  draftCreated,
 		}.group()
 		r.Section = caseSection(r.Group, r.Paying)
 		r.Provenance, r.ProvenanceLabel = replyProvenance(
@@ -795,8 +811,24 @@ func buildAdminCase(ctx context.Context, ticket string) (*AdminCaseDetail, error
 	d.Messages = adminCaseMessages(ctx, ticket)
 	d.Draft, d.DraftNote = adminCurrentDraft(ctx, ticket)
 	d.AutoSend = autoSendState(ctx)
+	var lastUser, lastSent *time.Time
+	for i := range d.Messages {
+		message := &d.Messages[i]
+		switch message.Kind {
+		case "user":
+			if lastUser == nil || message.CreatedAt.After(*lastUser) {
+				lastUser = &message.CreatedAt
+			}
+		case "sent":
+			if lastSent == nil || message.CreatedAt.After(*lastSent) {
+				lastSent = &message.CreatedAt
+			}
+		}
+	}
+	var draftCreated *time.Time
 	if d.Draft != nil {
 		d.Hold = buildHold(d.Draft.HoldUntil, d.Draft.Status, d.Draft.Disposition, d.AutoSend.Armed, time.Now())
+		draftCreated = &d.Draft.CreatedAt
 	}
 	d.Group, d.GroupReason = queueState{
 		CaseStatus:    d.Status,
@@ -804,6 +836,9 @@ func buildAdminCase(ctx context.Context, ticket string) (*AdminCaseDetail, error
 		DraftStatus:   draftStatusOf(d.Draft),
 		Disposition:   draftDispositionOf(d.Draft),
 		AutoSendArmed: d.AutoSend.Armed,
+		LastUser:      lastUser,
+		LastSent:      lastSent,
+		DraftCreated:  draftCreated,
 	}.group()
 
 	d.Context = adminUserContext(ctx, ticket)

--- a/api/internal/support/handlers_admin_console_test.go
+++ b/api/internal/support/handlers_admin_console_test.go
@@ -105,6 +105,59 @@ func TestQueueGroupSaysWhoIsWaitingAndWhy(t *testing.T) {
 	}
 }
 
+func TestQueueUsesTheActualConversationWhenDraftStateIsStaleOrMissing(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-conversation")
+	t.Setenv("SUPPORT_AUTOSEND", "off")
+	testsupport.MustExec(t, `INSERT INTO support_cases
+		(ticket_number, user_email, subject, status, updated_at) VALUES
+		('answered-no-draft', 'one@example.com', 'synthetic one', 'open', now()),
+		('new-reply', 'two@example.com', 'synthetic two', 'open', now())`)
+	testsupport.MustExec(t, `INSERT INTO support_messages (ticket_number, kind, body_text, created_at) VALUES
+		('answered-no-draft', 'user', 'question', now() - interval '3 hours'),
+		('answered-no-draft', 'sent', 'answer', now() - interval '2 hours'),
+		('new-reply', 'user', 'first question', now() - interval '4 hours'),
+		('new-reply', 'sent', 'old answer', now() - interval '3 hours'),
+		('new-reply', 'user', 'new reply', now() - interval '1 hour')`)
+	testsupport.MustExec(t, `INSERT INTO support_drafts
+		(ticket_number, user_email, original_subject, draft_body_html, status, created_at)
+		VALUES ('new-reply', 'two@example.com', 'synthetic two', '<p>old answer</p>', 'sent', now() - interval '3 hours')`)
+
+	app := adminSupportApp("sub-conversation")
+	status, body := getJSON(t, app, "/admin/support/queue")
+	if status != fiber.StatusOK {
+		t.Fatalf("queue: status=%d body=%s", status, body)
+	}
+	var response AdminQueueResponse
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		t.Fatal(err)
+	}
+	groups := map[string]string{}
+	for _, row := range response.Rows {
+		groups[row.TicketNumber] = row.Group
+	}
+	if groups["answered-no-draft"] != queueWaiting {
+		t.Errorf("answered-no-draft=%q, want waiting because staff answered", groups["answered-no-draft"])
+	}
+	if groups["new-reply"] != queueNeedsYou {
+		t.Errorf("new-reply=%q, want needs_you because inbound is newer than sent", groups["new-reply"])
+	}
+	status, body = getJSON(t, app, "/admin/support/case/new-reply")
+	if status != fiber.StatusOK {
+		t.Fatalf("case: status=%d body=%s", status, body)
+	}
+	var detail AdminCaseDetail
+	if err := json.Unmarshal([]byte(body), &detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail.Group != queueNeedsYou {
+		t.Errorf("case detail group=%q, want needs_you like the queue", detail.Group)
+	}
+}
+
 // The countdown is the one number on this page that can be a lie. hold_until
 // keeps ticking whether or not anything is going to collect it, so a page that
 // renders the remaining seconds while SUPPORT_AUTOSEND is off tells an admin a

--- a/api/internal/support/handlers_osticket_webhook.go
+++ b/api/internal/support/handlers_osticket_webhook.go
@@ -95,7 +95,7 @@ func HandleOSTicketThreadMessage(c *fiber.Ctx) error {
 		log.Printf("[OSTicketWebhook] ignoring unknown event=%q", ev.Event)
 		return c.JSON(fiber.Map{"status": "ignored", "reason": "unknown event"})
 	}
-	if ev.TicketNumber == "" || ev.MessageHTML == "" {
+	if ev.TicketNumber == "" || ev.MessageHTML == "" || parseISO(&ev.Created).IsZero() {
 		log.Printf("[OSTicketWebhook] missing required fields (ticket=%q body_len=%d)", ev.TicketNumber, len(ev.MessageHTML))
 		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{
 			Status: "error",
@@ -152,15 +152,17 @@ func processReplyTriageAsync(ev osTicketThreadMessageEvent) {
 	// Case DB first: the user's follow-up is an event whether or not
 	// triage produces a draft. A user reply reopens the ticket in osTicket,
 	// so the case goes back to open too.
+	eventTime := parseISO(&ev.Created)
 	if platform.DBPool != nil {
 		if err := upsertSupportCase(ctx, SupportCase{
 			TicketNumber: ev.TicketNumber, UserEmail: ev.UserEmail, Subject: ev.Subject, Status: "open",
+			UpdatedAt: eventTime, StatusObservedAt: eventTime,
 		}); err != nil {
 			log.Printf("[Cases] %v", err)
 		}
 		if err := recordSupportMessage(ctx, SupportMessage{
 			TicketNumber: ev.TicketNumber, Kind: "user", BodyHTML: ev.MessageHTML,
-			OSTicketEntryID: ev.ThreadEntryID,
+			OSTicketEntryID: ev.ThreadEntryID, CreatedAt: eventTime,
 		}); err != nil {
 			log.Printf("[Cases] %v", err)
 		}

--- a/api/internal/support/support.go
+++ b/api/internal/support/support.go
@@ -453,6 +453,7 @@ func recordTicketOpened(ctx context.Context, sc SupportCase, userBodyHTML string
 		return
 	}
 	sc.Status = "open"
+	sc.StatusObservedAt = time.Now()
 	if err := upsertSupportCase(ctx, sc); err != nil {
 		log.Printf("[Cases] %v", err)
 		return

--- a/api/internal/support/support_backfill.go
+++ b/api/internal/support/support_backfill.go
@@ -63,7 +63,7 @@ type osTicketDetail struct {
 	Priority    string  `json:"priority"`
 	Created     *string `json:"created"`
 	Updated     *string `json:"updated"`
-	Closed      bool    `json:"closed"`
+	Closed      *bool   `json:"closed"`
 	UserEmail   string  `json:"user_email"`
 	Thread      []struct {
 		ID        int64   `json:"id"`
@@ -204,16 +204,18 @@ func syncTicket(ctx context.Context, number string, st *BackfillStats) error {
 	if err := json.Unmarshal(body, &d); err != nil {
 		return fmt.Errorf("decode detail: %w", err)
 	}
-	caseStatus := "open"
-	if d.Closed || (d.StatusState != nil && *d.StatusState != "open") {
-		caseStatus = "closed"
-	}
+	caseStatus, statusKnown := importedCaseStatus(d)
 	sc := SupportCase{
 		TicketNumber: number, UserEmail: d.UserEmail, Subject: d.Subject,
 		Category: categoryFromTopic(d.Topic), Priority: d.Priority, Status: caseStatus,
 		OpenedAt: parseISO(d.Created), UpdatedAt: parseISO(d.Updated),
 	}
-	if caseStatus == "closed" {
+	if statusKnown && !sc.UpdatedAt.IsZero() {
+		sc.StatusObservedAt = sc.UpdatedAt
+	} else {
+		sc.Status = ""
+	}
+	if sc.Status == "closed" {
 		closed := sc.UpdatedAt
 		if closed.IsZero() {
 			closed = time.Now()
@@ -256,6 +258,21 @@ func syncTicket(ctx context.Context, number string, st *BackfillStats) error {
 		st.Messages++
 	}
 	return nil
+}
+
+func importedCaseStatus(d osTicketDetail) (string, bool) {
+	if d.Closed == nil || d.StatusState == nil {
+		return "", false
+	}
+	state := strings.ToLower(strings.TrimSpace(*d.StatusState))
+	closedState := state == "closed" || state == "archived" || state == "deleted"
+	if state != "open" && !closedState || *d.Closed != closedState {
+		return "", false
+	}
+	if closedState {
+		return "closed", true
+	}
+	return "open", true
 }
 
 // categoryFromTopic maps an osTicket help-topic name onto the category

--- a/api/internal/support/support_cases.go
+++ b/api/internal/support/support_cases.go
@@ -28,22 +28,23 @@ import (
 // times mean "unknown" on write and are never used to blank a stored
 // value — see upsertSupportCase.
 type SupportCase struct {
-	TicketNumber    string     `json:"ticket_number"`
-	UserEmail       string     `json:"-"`
-	LogtoSub        string     `json:"-"`
-	Subject         string     `json:"subject"`
-	Category        string     `json:"category,omitempty"`
-	Priority        string     `json:"priority,omitempty"`
-	Status          string     `json:"status"`
-	Summary         string     `json:"summary,omitempty"`
-	AppVersion      string     `json:"app_version,omitempty"`
-	OS              string     `json:"os,omitempty"`
-	TierAtOpen      string     `json:"tier_at_open,omitempty"`
-	LinearIssueKey  string     `json:"linear_issue_key,omitempty"`
-	DiscordThreadID string     `json:"discord_thread_id,omitempty"`
-	OpenedAt        time.Time  `json:"opened_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
-	ClosedAt        *time.Time `json:"closed_at,omitempty"`
+	TicketNumber     string     `json:"ticket_number"`
+	UserEmail        string     `json:"-"`
+	LogtoSub         string     `json:"-"`
+	Subject          string     `json:"subject"`
+	Category         string     `json:"category,omitempty"`
+	Priority         string     `json:"priority,omitempty"`
+	Status           string     `json:"status"`
+	StatusObservedAt time.Time  `json:"-"`
+	Summary          string     `json:"summary,omitempty"`
+	AppVersion       string     `json:"app_version,omitempty"`
+	OS               string     `json:"os,omitempty"`
+	TierAtOpen       string     `json:"tier_at_open,omitempty"`
+	LinearIssueKey   string     `json:"linear_issue_key,omitempty"`
+	DiscordThreadID  string     `json:"discord_thread_id,omitempty"`
+	OpenedAt         time.Time  `json:"opened_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	ClosedAt         *time.Time `json:"closed_at,omitempty"`
 }
 
 // SupportMessage mirrors one support_messages row.
@@ -68,39 +69,49 @@ func upsertSupportCase(ctx context.Context, sc SupportCase) error {
 	if platform.DBPool == nil {
 		return fmt.Errorf("DB not initialized")
 	}
-	var opened, updated *time.Time
+	var opened, updated, statusObserved *time.Time
 	if !sc.OpenedAt.IsZero() {
 		opened = &sc.OpenedAt
 	}
 	if !sc.UpdatedAt.IsZero() {
 		updated = &sc.UpdatedAt
 	}
+	if !sc.StatusObservedAt.IsZero() {
+		statusObserved = &sc.StatusObservedAt
+	}
 	const q = `
 		INSERT INTO support_cases
 			(ticket_number, user_email, logto_sub, subject, category, priority, status,
-			 summary, app_version, os, tier_at_open, opened_at, updated_at, closed_at)
+			 summary, app_version, os, tier_at_open, opened_at, updated_at, closed_at, status_observed_at)
 		VALUES ($1, NULLIF($2,''), NULLIF($3,''), $4, NULLIF($5,''), NULLIF($6,''),
-			COALESCE(NULLIF($7,''), 'open'), NULLIF($8,''), NULLIF($9,''), NULLIF($10,''),
-			NULLIF($11,''), COALESCE($12, now()), COALESCE($13, now()), $14)
+			COALESCE(NULLIF($7,''), 'unknown'), NULLIF($8,''), NULLIF($9,''), NULLIF($10,''),
+			NULLIF($11,''), COALESCE($12, now()), COALESCE($13, now()), $14, $15)
 		ON CONFLICT (ticket_number) DO UPDATE SET
 			user_email   = COALESCE(EXCLUDED.user_email, support_cases.user_email),
 			logto_sub    = COALESCE(support_cases.logto_sub, EXCLUDED.logto_sub),
 			subject      = CASE WHEN EXCLUDED.subject <> '' THEN EXCLUDED.subject ELSE support_cases.subject END,
 			category     = COALESCE(support_cases.category, EXCLUDED.category),
 			priority     = COALESCE(support_cases.priority, EXCLUDED.priority),
-			status       = COALESCE(NULLIF($7,''), support_cases.status),
+			status       = CASE WHEN NULLIF($7,'') IS NOT NULL AND ($15 IS NULL
+				OR $15 >= COALESCE(support_cases.status_observed_at, support_cases.closed_at, '-infinity'))
+				THEN COALESCE(NULLIF($7,''), support_cases.status) ELSE support_cases.status END,
 			summary      = COALESCE(support_cases.summary, EXCLUDED.summary),
 			app_version  = COALESCE(support_cases.app_version, EXCLUDED.app_version),
 			os           = COALESCE(support_cases.os, EXCLUDED.os),
 			tier_at_open = COALESCE(support_cases.tier_at_open, EXCLUDED.tier_at_open),
 			opened_at    = LEAST(support_cases.opened_at, EXCLUDED.opened_at),
 			updated_at   = GREATEST(support_cases.updated_at, EXCLUDED.updated_at),
-			closed_at    = CASE WHEN $7 = '' THEN support_cases.closed_at ELSE EXCLUDED.closed_at END
+			closed_at    = CASE WHEN NULLIF($7,'') IS NOT NULL AND ($15 IS NULL
+				OR $15 >= COALESCE(support_cases.status_observed_at, support_cases.closed_at, '-infinity'))
+				THEN EXCLUDED.closed_at ELSE support_cases.closed_at END,
+			status_observed_at = CASE WHEN $15 IS NOT NULL
+				AND $15 >= COALESCE(support_cases.status_observed_at, support_cases.closed_at, '-infinity')
+				THEN $15 ELSE support_cases.status_observed_at END
 	`
 	_, err := platform.DBPool.Exec(ctx, q,
 		sc.TicketNumber, sc.UserEmail, sc.LogtoSub, sc.Subject, sc.Category,
 		strings.ToLower(sc.Priority), sc.Status, sc.Summary, sc.AppVersion, sc.OS,
-		sc.TierAtOpen, opened, updated, sc.ClosedAt)
+		sc.TierAtOpen, opened, updated, sc.ClosedAt, statusObserved)
 	if err != nil {
 		return fmt.Errorf("upsertSupportCase %s: %w", sc.TicketNumber, err)
 	}
@@ -176,6 +187,7 @@ func setCaseStatus(ctx context.Context, ticketNumber, status string) {
 		UPDATE support_cases SET
 			status     = $2,
 			closed_at  = CASE WHEN $2 = 'closed' THEN now() ELSE NULL END,
+			status_observed_at = now(),
 			updated_at = now()
 		WHERE ticket_number = $1
 	`

--- a/api/internal/support/support_cases_test.go
+++ b/api/internal/support/support_cases_test.go
@@ -120,10 +120,12 @@ func TestCases_IngestOnEveryEvent(t *testing.T) {
 	processReplyTriageAsync(osTicketThreadMessageEvent{
 		Event: "thread.message", TicketNumber: "100", ThreadEntryID: 555,
 		UserEmail: "u@example.com", Subject: "Ticker froze", MessageHTML: "<p>Restart did not help</p>",
+		Created: "2026-06-01T10:00:00Z",
 	})
 	processReplyTriageAsync(osTicketThreadMessageEvent{ // same entry twice = one row
 		Event: "thread.message", TicketNumber: "100", ThreadEntryID: 555,
 		UserEmail: "u@example.com", Subject: "Ticker froze", MessageHTML: "<p>Restart did not help</p>",
+		Created: "2026-06-01T10:00:00Z",
 	})
 
 	if err := markDraftDecided(ctx, draft.ID, "edited", "<p>Edited: update to 1.6.2</p>"); err != nil {
@@ -287,6 +289,146 @@ func TestBackfill_Idempotent(t *testing.T) {
 	_ = json.NewDecoder(resp.Body).Decode(&body)
 	if resp.StatusCode != 200 || body.Count != 1 || body.Cases[0].TicketNumber != "201" {
 		t.Fatalf("handler: %d %+v", resp.StatusCode, body)
+	}
+}
+
+func TestBackfillDoesNotReplaceNewerOrKnownStatus(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+	newer := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	older := "2026-06-01T10:00:00Z"
+	testsupport.MustExec(t, `INSERT INTO support_cases
+		(ticket_number, subject, status, opened_at, updated_at, closed_at, status_observed_at)
+		VALUES ('stale', 'stale snapshot', 'closed', $1, $1, $1, $1),
+		       ('missing', 'missing status', 'closed', $1, $1, $1, $1),
+		       ('no-time', 'missing time', 'closed', $1, $1, $1, $1),
+		       ('fresh', 'newer reopen', 'closed', $2, $2, $2, $2)`, newer,
+		newer.Add(-24*time.Hour))
+	fresh := "2026-09-10T13:00:00Z"
+
+	fake := &fakeOSTicket{tickets: map[string]map[string]interface{}{
+		"stale": {
+			"number": "stale", "subject": "stale snapshot", "status": "Open",
+			"status_state": "open", "closed": false, "updated": older,
+		},
+		"missing": {
+			"number": "missing", "subject": "missing status", "updated": older,
+		},
+		"no-time": {
+			"number": "no-time", "subject": "missing time", "status": "Open",
+			"status_state": "open", "closed": false,
+		},
+		"fresh": {
+			"number": "fresh", "subject": "newer reopen", "status": "Open",
+			"status_state": "open", "closed": false, "updated": fresh,
+		},
+		"new-missing": {"number": "new-missing", "subject": "incomplete new case"},
+	}}
+	srv := httptest.NewServer(fake.handler(t))
+	defer srv.Close()
+	setOSTicketEnv(t, srv.URL)
+
+	if _, err := BackfillFromOSTicket(ctx, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, ticket := range []string{"stale", "missing", "no-time"} {
+		var status string
+		var closedAt *time.Time
+		if err := platform.DBPool.QueryRow(ctx,
+			`SELECT status, closed_at FROM support_cases WHERE ticket_number=$1`, ticket).
+			Scan(&status, &closedAt); err != nil {
+			t.Fatal(err)
+		}
+		if status != "closed" || closedAt == nil {
+			t.Errorf("%s: status=%q closed_at=%v, want known newer close preserved", ticket, status, closedAt)
+		}
+	}
+	var freshStatus string
+	var freshClosed *time.Time
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT status, closed_at FROM support_cases WHERE ticket_number='fresh'`).
+		Scan(&freshStatus, &freshClosed); err != nil {
+		t.Fatal(err)
+	}
+	if freshStatus != "open" || freshClosed != nil {
+		t.Errorf("fresh explicit reopen: status=%q closed_at=%v", freshStatus, freshClosed)
+	}
+	var unknownStatus string
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT status FROM support_cases WHERE ticket_number='new-missing'`).Scan(&unknownStatus); err != nil {
+		t.Fatal(err)
+	}
+	if unknownStatus != "unknown" {
+		t.Errorf("new incomplete case status=%q, want unknown", unknownStatus)
+	}
+}
+
+func TestReplyWebhookPreservesUpstreamEventTime(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	created := "2026-09-09T08:07:06Z"
+	processReplyTriageAsync(osTicketThreadMessageEvent{
+		Event: "thread.message", TicketNumber: "event-time", ThreadEntryID: 987,
+		UserEmail: "user@example.com", Subject: "synthetic", MessageHTML: "<p>Still broken</p>",
+		Created: created,
+	})
+
+	var got time.Time
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT created_at FROM support_messages WHERE osticket_entry_id=987`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	want, _ := time.Parse(time.RFC3339, created)
+	if !got.Equal(want) {
+		t.Fatalf("created_at=%s, want upstream event time %s", got, want)
+	}
+}
+
+func TestReplyWebhookRejectsMissingEventTime(t *testing.T) {
+	t.Setenv("SCROLLR_WEBHOOK_SECRET", "s3cret")
+	app := fiber.New()
+	app.Post("/webhook", HandleOSTicketThreadMessage)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(`{
+		"event":"thread.message",
+		"ticket_number":"event-time",
+		"thread_entry_id":988,
+		"user_email":"user@example.com",
+		"message_html":"<p>Still broken</p>"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scrollr-Webhook-Secret", "s3cret")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("status=%d, want 400 for missing upstream event time", resp.StatusCode)
+	}
+}
+
+func TestMessageOnlyCaseDoesNotInventAnUpstreamOpenStatus(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	if err := recordSupportMessage(context.Background(), SupportMessage{
+		TicketNumber: "message-only", Kind: "note", BodyText: "synthetic note",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var status string
+	if err := platform.DBPool.QueryRow(context.Background(),
+		`SELECT status FROM support_cases WHERE ticket_number='message-only'`).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "unknown" {
+		t.Fatalf("message-only status=%q, want unknown until an authoritative source is observed", status)
 	}
 }
 

--- a/api/migrations/000018_support_status_freshness.down.sql
+++ b/api/migrations/000018_support_status_freshness.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE support_cases ALTER COLUMN status SET DEFAULT 'open';
+ALTER TABLE support_cases DROP COLUMN status_observed_at;

--- a/api/migrations/000018_support_status_freshness.up.sql
+++ b/api/migrations/000018_support_status_freshness.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE support_cases ADD COLUMN status_observed_at timestamp with time zone;
+ALTER TABLE support_cases ALTER COLUMN status SET DEFAULT 'unknown';


### PR DESCRIPTION
Older or incomplete osTicket snapshots could overwrite a newer local close/reopen, and stale draft state could misclassify a case even when the conversation showed who replied last. This change records when status was actually observed, applies status only when upstream metadata is present and fresh, preserves webhook event time, and derives the queue from inbound/outbound chronology plus a relevant draft.

This is REL-278 Step A correctness only. Historical timeline retention, reset/cutoff controls, and operational history UX remain follow-up work.

Validation:
- `docker compose -f docker/compose.yml exec -T -e TEST_DATABASE_URL=postgres://scrollr:scrollr@postgres:5432/scrollr_test?sslmode=disable core-api go test ./... -count=1`
- `scripts/migrations/check-additive.sh origin/main`
- `git diff --check origin/main...HEAD`
