### PR TITLE
Group support cases by trusted identity [REL-279]

### DIFF
--- a/api/internal/support/admin_queue_people.go
+++ b/api/internal/support/admin_queue_people.go
@@ -19,11 +19,10 @@ import (
 //
 // A row is a PERSON. Rachel Armstrong wrote five times in one afternoon; that
 // was five rows shouting at a reader who has one human to answer. Cases are
-// grouped by `user_email`, which is also why the key is an email and not an
-// account: #819835 arrived anonymously from the marketing site, has no
-// logto_sub, and still belongs in the queue. A group carries a name and a plan
-// only when one actually exists — an invented "Anonymous User" reads exactly
-// like a real one.
+// grouped by authenticated account subject when that provenance is recorded,
+// then by contact email. A case with neither gets its own ticket key. A group
+// carries a name and a plan only when one actually exists — an invented
+// "Anonymous User" reads exactly like a real one.
 //
 // PAYING CUSTOMERS ARE A SECTION, not a sort key. Priority support was sold,
 // so no ordering a reader picks may push a paying customer below someone who
@@ -39,6 +38,13 @@ const (
 	sectionOpen     = "open"
 	sectionAnswered = "answered"
 	sectionResolved = "resolved"
+)
+
+const (
+	identityUnknownContact       = "unknown_contact"
+	identityContactOnly          = "contact_only"
+	identityConfirmedAccount     = "confirmed_account"
+	identityAmbiguousAssociation = "ambiguous_association"
 )
 
 // sectionOrder is the reading order, and it is the whole point: sorting
@@ -121,16 +127,15 @@ func payingSectionNote(a AdminQueueAccounts, inSection int) string {
 	}
 }
 
-// AdminPerson is one row of the queue: an email, everything we honestly know
-// about whoever is behind it, and the tickets they wrote.
+// AdminPerson is one row of the queue: an established account or unverified
+// contact, everything we honestly know about it, and its tickets.
 //
 // The tickets are referenced by number rather than embedded. The flat rows are
 // in the same response, so embedding them would ship every case twice and give
 // the two copies somewhere to disagree.
 type AdminPerson struct {
-	// Key groups the cases. It is the lowercased email; a case with no email
-	// gets a key of its own so two unrelated anonymous reports never merge
-	// into one imaginary person.
+	// Key groups by established account, then normalized contact email. A case
+	// with neither gets a key of its own so unrelated reports never merge.
 	Key   string `json:"key"`
 	Email string `json:"email,omitempty"`
 	// Name is whatever the ticket carried. Empty means we do not know it, and
@@ -142,7 +147,11 @@ type AdminPerson struct {
 	Paying bool   `json:"paying"`
 	// PlanNote explains an empty Plan, because "free" and "no account exists
 	// for this person" are different facts and only one of them is a plan.
-	PlanNote string `json:"plan_note,omitempty"`
+	PlanNote            string `json:"plan_note,omitempty"`
+	ContactSource       string `json:"contact_source,omitempty"`
+	IdentityState       string `json:"identity_state"`
+	AccountEstablished  bool   `json:"account_established"`
+	SubscriptionPresent bool   `json:"subscription_present"`
 
 	Section string `json:"section"`
 
@@ -243,27 +252,35 @@ func groupPeople(rows []AdminQueueRow) []AdminPerson {
 		at   time.Time
 	}
 	best := map[string]candidate{}
+	nameAt := map[string]time.Time{}
+	emailAt := map[string]time.Time{}
 
 	for _, r := range rows {
 		key := personKey(r)
 		p := byKey[key]
 		if p == nil {
+			identityState := rowIdentityState(r)
 			p = &AdminPerson{
-				Key:           key,
-				Email:         r.UserEmail,
-				TicketNumbers: make([]string, 0, 2),
+				Key:                 key,
+				ContactSource:       r.ContactSource,
+				IdentityState:       identityState,
+				AccountEstablished:  r.AccountEstablished,
+				SubscriptionPresent: r.SubscriptionPresent,
+				TicketNumbers:       make([]string, 0, 2),
 				WaitingHours: platform.Unmeasured(
 					"No message from this person is on record, so there is nothing to measure a wait from."),
 			}
-			if r.UserEmail == "" {
-				p.PlanNote = "No account is attached to this ticket — it arrived without a signed-in user, so there is no name and no plan to show."
-			}
+			p.PlanNote = identityPlanNote(identityState, r.SubscriptionPresent)
 			byKey[key] = p
 			order = append(order, key)
 		}
 
 		p.Tickets++
 		p.TicketNumbers = append(p.TicketNumbers, r.TicketNumber)
+		if rowIdentityState(r) == identityAmbiguousAssociation && !p.AccountEstablished {
+			p.IdentityState = identityAmbiguousAssociation
+		}
+		p.SubscriptionPresent = p.SubscriptionPresent || r.SubscriptionPresent
 		switch r.Group {
 		case queueNeedsYou:
 			p.NeedsYou++
@@ -273,12 +290,17 @@ func groupPeople(rows []AdminQueueRow) []AdminPerson {
 			p.Handled++
 		}
 
-		// The name and the plan come from whichever ticket actually carries
-		// them. Someone who wrote once signed in and once through the
-		// marketing form is still one person, and the half of the record that
-		// knows their name is the half worth keeping.
-		if p.Name == "" && r.Name != "" {
+		// Keep the freshest known display contact within this already-safe
+		// group. Account and contact groups never merge merely by email.
+		if strings.TrimSpace(r.Name) != "" && (p.Name == "" || r.UpdatedAt.After(nameAt[key])) {
 			p.Name = r.Name
+			p.ContactSource = r.ContactSource
+			nameAt[key] = r.UpdatedAt
+		}
+		if email := contactEmail(r.UserEmail); email != "" && (p.Email == "" || r.UpdatedAt.After(emailAt[key])) {
+			p.Email = r.UserEmail
+			p.ContactSource = r.ContactSource
+			emailAt[key] = r.UpdatedAt
 		}
 		if r.Paying {
 			p.Paying = true
@@ -312,22 +334,75 @@ func groupPeople(rows []AdminQueueRow) []AdminPerson {
 	out := make([]AdminPerson, 0, len(order))
 	for _, key := range order {
 		p := byKey[key]
+		p.PlanNote = identityPlanNote(p.IdentityState, p.SubscriptionPresent)
 		p.Section = personSection(*p)
 		out = append(out, *p)
 	}
 	return out
 }
 
-// personKey groups by email, and refuses to group without one.
+// personKey groups only authenticated account ownership; everything else is
+// an unverified contact or an individual ticket.
 func personKey(r AdminQueueRow) string {
-	email := strings.ToLower(strings.TrimSpace(r.UserEmail))
+	if r.AccountEstablished && strings.TrimSpace(r.AccountSubject) != "" {
+		return "account:" + strings.TrimSpace(r.AccountSubject)
+	}
+	email := contactEmail(r.UserEmail)
 	if email == "" {
 		// Not a shared "anonymous" bucket: two anonymous reports are two
 		// different people until something says otherwise, and merging them
 		// would put one stranger's words under another's row.
 		return "ticket:" + r.TicketNumber
 	}
+	return "contact:" + email
+}
+
+func contactEmail(email string) string {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "anonymous@scrollr.user" {
+		return ""
+	}
 	return email
+}
+
+func rowIdentityState(r AdminQueueRow) string {
+	if r.IdentityState != "" {
+		return r.IdentityState
+	}
+	state, _ := requesterIdentity(r.AccountSubject, "", r.UserEmail, r.Name)
+	if r.AccountEstablished && strings.TrimSpace(r.AccountSubject) != "" {
+		state = identityConfirmedAccount
+	}
+	return state
+}
+
+func requesterIdentity(subject, accountSource, email, name string) (string, bool) {
+	if strings.TrimSpace(subject) != "" && accountSource == accountSourceAuthenticated {
+		return identityConfirmedAccount, true
+	}
+	if strings.TrimSpace(subject) != "" {
+		return identityAmbiguousAssociation, false
+	}
+	if contactEmail(email) != "" || strings.TrimSpace(name) != "" {
+		return identityContactOnly, false
+	}
+	return identityUnknownContact, false
+}
+
+func identityPlanNote(state string, subscriptionPresent bool) string {
+	switch state {
+	case identityConfirmedAccount:
+		if !subscriptionPresent {
+			return "A confirmed account is attached, but no subscription record is available."
+		}
+	case identityAmbiguousAssociation:
+		return "A legacy account association exists, but its provenance is unavailable. It is not used for grouping or subscription context."
+	case identityContactOnly:
+		return "Contact details are available, but no signed-in account association is established."
+	default:
+		return "Requester contact and account association are unknown."
+	}
+	return ""
 }
 
 // headlineRank ranks the three states by how much a reader needs to see them.

--- a/api/internal/support/admin_queue_people_test.go
+++ b/api/internal/support/admin_queue_people_test.go
@@ -44,10 +44,60 @@ func wrote(day, waitHours int) func(*AdminQueueRow) {
 }
 
 func paid(plan string) func(*AdminQueueRow) {
-	return func(r *AdminQueueRow) { r.Plan, r.Paying = plan, true }
+	return func(r *AdminQueueRow) {
+		r.Plan, r.Paying = plan, true
+		r.AccountSubject, r.AccountEstablished = "sub-"+strings.SplitN(r.UserEmail, "@", 2)[0], true
+	}
 }
 
-func freePlan(r *AdminQueueRow) { r.Plan = "free" }
+func freePlan(r *AdminQueueRow) {
+	r.Plan = "free"
+	r.AccountSubject, r.AccountEstablished = "sub-"+strings.SplitN(r.UserEmail, "@", 2)[0], true
+}
+
+func account(sub string) func(*AdminQueueRow) {
+	return func(r *AdminQueueRow) {
+		r.AccountSubject = sub
+		r.AccountEstablished = true
+		r.IdentityState = identityConfirmedAccount
+	}
+}
+
+func TestGroupingUsesEstablishedAccountsWithoutTrustingMatchingContactEmail(t *testing.T) {
+	people := groupPeople([]AdminQueueRow{
+		row("1", "old@example.com", "Pat", queueNeedsYou, account("sub-pat")),
+		row("2", "new@example.com", "Pat", queueWaiting, account("sub-pat")),
+		row("3", "shared@example.com", "One", queueNeedsYou, account("sub-one")),
+		row("4", "shared@example.com", "Two", queueNeedsYou, account("sub-two")),
+		row("5", "shared@example.com", "Contact", queueNeedsYou),
+	})
+
+	byKey := map[string]AdminPerson{}
+	for _, person := range people {
+		byKey[person.Key] = person
+	}
+	if len(people) != 4 || byKey["account:sub-pat"].Tickets != 2 {
+		t.Fatalf("established account grouping = %+v", people)
+	}
+	for _, key := range []string{"account:sub-one", "account:sub-two", "contact:shared@example.com"} {
+		if byKey[key].Tickets != 1 {
+			t.Errorf("%s tickets=%d, want 1", key, byKey[key].Tickets)
+		}
+	}
+	if byKey["contact:shared@example.com"].Plan != "" || byKey["contact:shared@example.com"].Paying {
+		t.Errorf("matching unverified contact inherited account data: %+v", byKey["contact:shared@example.com"])
+	}
+}
+
+func TestPlaceholderContactNeverGroupsUnrelatedTickets(t *testing.T) {
+	people := groupPeople([]AdminQueueRow{
+		row("1", "anonymous@scrollr.user", "", queueNeedsYou),
+		row("2", "anonymous@scrollr.user", "", queueNeedsYou),
+	})
+	if len(people) != 2 || people[0].Key == people[1].Key {
+		t.Fatalf("placeholder contacts must remain separate: %+v", people)
+	}
+}
 
 // The whole reason for the ticket: Rachel wrote five times in one afternoon
 // and that is one person to answer, not five rows to read.
@@ -70,7 +120,7 @@ func TestFiveTicketsFromOnePersonAreOneRow(t *testing.T) {
 	}
 	// The mixed case in #411284 is the same mailbox, and grouping that missed
 	// it would show Rachel twice.
-	if p.Key != "r_armstrong@me.com" {
+	if p.Key != "contact:r_armstrong@me.com" {
 		t.Errorf("key = %q, want the lowercased email", p.Key)
 	}
 	if p.NeedsYou != 1 || p.Waiting != 2 || p.Handled != 2 {
@@ -114,7 +164,7 @@ func TestACaseWithNoAccountIsGroupedWithoutInventingAPerson(t *testing.T) {
 		if p.Paying {
 			t.Error("nothing is known about this person, so they are certainly not in the paying section")
 		}
-		if !strings.Contains(p.PlanNote, "No account is attached") {
+		if !strings.Contains(p.PlanNote, "unknown") {
 			t.Errorf("the empty plan needs a sentence saying why: %q", p.PlanNote)
 		}
 		if p.Tickets != 1 {
@@ -137,7 +187,7 @@ func TestPayingCustomersStayOnTopUnderEverySort(t *testing.T) {
 		for _, dir := range []string{"asc", "desc"} {
 			people := groupPeople(rows)
 			sortPeople(people, field, dir)
-			if people[0].Key != "zoe@example.com" {
+			if people[0].Key != "account:sub-zoe" {
 				t.Errorf("sort=%s dir=%s put %q first; the paying customer must lead every sort",
 					field, dir, people[0].Key)
 			}
@@ -181,13 +231,13 @@ func TestEverySortFieldOrdersByWhatItNames(t *testing.T) {
 		wantHead string
 		why      string
 	}{
-		{sortLastWrote, "desc", "abe@example.com", "newest first"},
-		{sortLastWrote, "asc", "bea@example.com", "oldest first"},
-		{sortWaiting, "desc", "bea@example.com", "longest waiting first"},
-		{sortWaiting, "asc", "abe@example.com", "shortest waiting first"},
-		{sortTickets, "desc", "cara@example.com", "most tickets first"},
-		{sortName, "asc", "abe@example.com", "A first"},
-		{sortName, "desc", "cara@example.com", "Z first"},
+		{sortLastWrote, "desc", "contact:abe@example.com", "newest first"},
+		{sortLastWrote, "asc", "contact:bea@example.com", "oldest first"},
+		{sortWaiting, "desc", "contact:bea@example.com", "longest waiting first"},
+		{sortWaiting, "asc", "contact:abe@example.com", "shortest waiting first"},
+		{sortTickets, "desc", "contact:cara@example.com", "most tickets first"},
+		{sortName, "asc", "contact:abe@example.com", "A first"},
+		{sortName, "desc", "contact:cara@example.com", "Z first"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.field+"/"+tc.dir, func(t *testing.T) {
@@ -222,9 +272,9 @@ func TestUnknownsSortLastInBothDirections(t *testing.T) {
 		for _, dir := range []string{"asc", "desc"} {
 			people := groupPeople(rows)
 			sortPeople(people, field, dir)
-			if people[len(people)-1].Key != "silent@example.com" {
+			if people[len(people)-1].Key != "contact:silent@example.com" {
 				t.Errorf("sort=%s dir=%s floated the unknown to %d; unknowns go last both ways",
-					field, dir, indexOf(people, "silent@example.com"))
+					field, dir, indexOf(people, "contact:silent@example.com"))
 			}
 		}
 	}
@@ -395,10 +445,10 @@ func TestQueueSectionsUseTheCurrentPlanNotTierAtOpen(t *testing.T) {
 		('sub-rel266-up',     'cus_up',     'uplink_ultimate', 'active', false),
 		('sub-rel266-lapsed', 'cus_lapsed', 'free',            'active', false)`)
 	testsupport.MustExec(t, `INSERT INTO support_cases
-		(ticket_number, user_email, logto_sub, subject, status, tier_at_open, os, updated_at) VALUES
-		('900100', 'up@example.com',     'sub-rel266-up',     'ticker will not scroll', 'open', 'free',            'macOS',   now()),
-		('900101', 'lapsed@example.com', 'sub-rel266-lapsed', 'feed cannot be edited',  'open', 'uplink_ultimate', 'Windows', now() - interval '1 hour'),
-		('900102', NULL,                 NULL,                'Linux sign-in',          'open', NULL,              'Linux',   now() - interval '2 hours')`)
+		(ticket_number, user_email, logto_sub, account_source, subject, status, tier_at_open, os, updated_at) VALUES
+		('900100', 'up@example.com',     'sub-rel266-up',     'authenticated', 'ticker will not scroll', 'open', 'free',            'macOS',   now()),
+		('900101', 'lapsed@example.com', 'sub-rel266-lapsed', 'authenticated', 'feed cannot be edited',  'open', 'uplink_ultimate', 'Windows', now() - interval '1 hour'),
+		('900102', NULL,                 NULL,                NULL,            'Linux sign-in',          'open', NULL,              'Linux',   now() - interval '2 hours')`)
 	testsupport.MustExec(t, `INSERT INTO support_messages (ticket_number, kind, body_text, created_at) VALUES
 		('900100', 'user', 'it will not move', now() - interval '4 hours'),
 		('900101', 'user', 'cannot edit',      now() - interval '2 days'),
@@ -422,7 +472,7 @@ func TestQueueSectionsUseTheCurrentPlanNotTierAtOpen(t *testing.T) {
 		t.Fatalf("got %d people, want 3: %v", len(res.People), sectionsOf(res.People))
 	}
 
-	up := byKey["up@example.com"]
+	up := byKey["account:sub-rel266-up"]
 	if !up.Paying || up.Section != sectionPaying {
 		t.Errorf("a customer who upgraded since opening the ticket must be in the paying section: %+v", up)
 	}
@@ -430,7 +480,7 @@ func TestQueueSectionsUseTheCurrentPlanNotTierAtOpen(t *testing.T) {
 		t.Errorf("plan = %q, want the current subscription rather than tier_at_open (free)", up.Plan)
 	}
 
-	lapsed := byKey["lapsed@example.com"]
+	lapsed := byKey["account:sub-rel266-lapsed"]
 	if lapsed.Paying || lapsed.Section != sectionOpen {
 		t.Errorf("a lapsed customer must not be promoted by tier_at_open: %+v", lapsed)
 	}
@@ -465,6 +515,59 @@ func TestQueueSectionsUseTheCurrentPlanNotTierAtOpen(t *testing.T) {
 	if res.Sort != sortLastWrote || res.Dir != "desc" || res.RowsMode != "person" {
 		t.Errorf("the response must echo what it sorted by: sort=%q dir=%q rows=%q",
 			res.Sort, res.Dir, res.RowsMode)
+	}
+}
+
+func TestQueueKeepsRequesterIdentityIndependentOfDraftsAndAccountPlans(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	seedAdmin(t, "sub-staff")
+	t.Setenv("SUPPORT_AUTOSEND", "off")
+	testsupport.MustExec(t, `DELETE FROM stripe_customers WHERE logto_sub LIKE 'sub-rel279%'`)
+	t.Cleanup(func() {
+		testsupport.MustExec(t, `DELETE FROM stripe_customers WHERE logto_sub LIKE 'sub-rel279%'`)
+	})
+	testsupport.MustExec(t, `INSERT INTO stripe_customers
+		(logto_sub, stripe_customer_id, plan, status, lifetime) VALUES
+		('sub-rel279-account', 'cus_rel279', 'uplink_pro', 'active', false)`)
+	testsupport.MustExec(t, `INSERT INTO support_cases
+		(ticket_number, user_email, user_name, contact_source, logto_sub, account_source, subject, status, updated_at) VALUES
+		('279001', 'old@example.com', 'Case Name', 'authenticated', 'sub-rel279-account', 'authenticated', 'first',  'open', now() - interval '2 hours'),
+		('279002', 'new@example.com', NULL,        'authenticated', 'sub-rel279-account', 'authenticated', 'second', 'open', now() - interval '1 hour'),
+		('279003', 'new@example.com', 'Contact',   'public',        NULL,                 NULL,            'third',  'open', now()),
+		('279004', 'legacy@example.com', 'Legacy', 'osticket',     'sub-rel279-account', NULL,             'fourth', 'open', now()),
+		('279005', 'known@example.com', 'Known',   'authenticated', 'sub-rel279-no-sub', 'authenticated',  'fifth',  'open', now())`)
+
+	app := adminSupportApp("sub-staff")
+	status, body := getJSON(t, app, "/admin/support/queue")
+	if status != fiber.StatusOK {
+		t.Fatalf("queue: %d %s", status, body)
+	}
+	var res AdminQueueResponse
+	if err := json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatal(err)
+	}
+	byKey := map[string]AdminPerson{}
+	for _, person := range res.People {
+		byKey[person.Key] = person
+	}
+	confirmed := byKey["account:sub-rel279-account"]
+	if confirmed.Tickets != 2 || confirmed.Name != "Case Name" || confirmed.Plan != "uplink_pro" || !confirmed.SubscriptionPresent {
+		t.Errorf("confirmed account=%+v", confirmed)
+	}
+	contact := byKey["contact:new@example.com"]
+	if contact.Tickets != 1 || contact.IdentityState != identityContactOnly || contact.Plan != "" {
+		t.Errorf("unverified matching contact=%+v", contact)
+	}
+	legacy := byKey["contact:legacy@example.com"]
+	if legacy.IdentityState != identityAmbiguousAssociation || legacy.Plan != "" || legacy.Paying {
+		t.Errorf("legacy association=%+v", legacy)
+	}
+	withoutSubscription := byKey["account:sub-rel279-no-sub"]
+	if withoutSubscription.SubscriptionPresent || !strings.Contains(withoutSubscription.PlanNote, "no subscription record") {
+		t.Errorf("confirmed account without subscription=%+v", withoutSubscription)
 	}
 }
 
@@ -534,17 +637,17 @@ func TestQueueSortsServerSideAndRefusesAnUnknownField(t *testing.T) {
 		return res
 	}
 
-	if got := read("?sort=tickets&dir=desc").People[0].Key; got != "cara@example.com" {
+	if got := read("?sort=tickets&dir=desc").People[0].Key; got != "contact:cara@example.com" {
 		t.Errorf("sort=tickets desc put %q first, want the person with two tickets", got)
 	}
-	if got := read("?sort=tickets&dir=asc").People[0].Key; got != "abe@example.com" {
+	if got := read("?sort=tickets&dir=asc").People[0].Key; got != "contact:abe@example.com" {
 		t.Errorf("sort=tickets asc put %q first, want the person with one ticket", got)
 	}
-	if got := read("?sort=name&dir=asc").People[0].Key; got != "abe@example.com" {
+	if got := read("?sort=name&dir=asc").People[0].Key; got != "contact:abe@example.com" {
 		t.Errorf("sort=name asc put %q first", got)
 	}
 	// Longest waiting is nine days, on Cara's second ticket.
-	if got := read("?sort=waiting&dir=desc").People[0].Key; got != "cara@example.com" {
+	if got := read("?sort=waiting&dir=desc").People[0].Key; got != "contact:cara@example.com" {
 		t.Errorf("sort=waiting desc put %q first", got)
 	}
 
@@ -557,7 +660,7 @@ func TestQueueSortsServerSideAndRefusesAnUnknownField(t *testing.T) {
 
 	// The search box is server-side too.
 	found := read("?q=abe@example.com")
-	if len(found.People) != 1 || found.People[0].Key != "abe@example.com" {
+	if len(found.People) != 1 || found.People[0].Key != "contact:abe@example.com" {
 		t.Errorf("q= narrowed to %v, want just Abe", sectionsOf(found.People))
 	}
 

--- a/api/internal/support/handlers_admin_console.go
+++ b/api/internal/support/handlers_admin_console.go
@@ -262,20 +262,23 @@ type AdminQueueRow struct {
 	TicketNumber string `json:"ticket_number"`
 	Subject      string `json:"subject"`
 	UserEmail    string `json:"user_email,omitempty"`
+	Name         string `json:"name,omitempty"`
 	Category     string `json:"category,omitempty"`
 	Priority     string `json:"priority,omitempty"`
 	Status       string `json:"status"`
 	Summary      string `json:"summary,omitempty"`
 	OS           string `json:"os,omitempty"`
 
-	// Who wrote it, as REL-266 needs it. Name is whatever the ticket carried
-	// and is empty when nothing did; Plan is the CURRENT subscription and is
-	// empty when no Stripe row stands behind this email. Neither is ever
-	// invented, and Plan is never tier_at_open.
-	Name      string `json:"name,omitempty"`
-	Plan      string `json:"plan,omitempty"`
-	Paying    bool   `json:"paying"`
-	PersonKey string `json:"person_key"`
+	// Name is the case contact, independent of any draft. Plan is the current
+	// subscription only when authenticated account provenance is recorded.
+	Plan                string `json:"plan,omitempty"`
+	Paying              bool   `json:"paying"`
+	PersonKey           string `json:"person_key"`
+	ContactSource       string `json:"contact_source,omitempty"`
+	IdentityState       string `json:"identity_state"`
+	AccountEstablished  bool   `json:"account_established"`
+	SubscriptionPresent bool   `json:"subscription_present"`
+	AccountSubject      string `json:"-"`
 
 	Group       string `json:"group"`
 	GroupReason string `json:"group_reason"`
@@ -322,16 +325,15 @@ type AdminQueueResponse struct {
 	// explains it when it is empty.
 	Accounts AdminQueueAccounts `json:"accounts"`
 	Rows     []AdminQueueRow    `json:"rows"`
-	// People is the same rows grouped by user_email — one row per human.
+	// People is the same rows grouped by established account or contact.
 	People []AdminPerson `json:"people"`
 }
 
 // queueSQL reads a case, its newest draft, and the CURRENT subscription behind
 // its account.
 //
-// The stripe_customers join is on logto_sub, so a case that arrived without a
-// signed-in user simply has no plan — which is the honest answer, and the
-// reason the page shows those without a name or a badge instead of guessing.
+// The stripe_customers join requires both logto_sub and authenticated account
+// provenance. A supplied email never inherits an account's plan.
 // tier_at_open is deliberately not read: it is the plan on the day the ticket
 // opened, and the top section has to be about who is paying now.
 const queueSQL = `
@@ -345,7 +347,8 @@ const queueSQL = `
 		  FROM support_drafts
 		 ORDER BY ticket_number, created_at DESC, id DESC
 	)
-	SELECT c.ticket_number, coalesce(c.user_email, ''), c.subject,
+	SELECT c.ticket_number, coalesce(c.user_email, ''), coalesce(c.user_name, ''),
+	       coalesce(c.contact_source, ''), coalesce(c.logto_sub, ''), coalesce(c.account_source, ''), c.subject,
 	       coalesce(c.category, ''), coalesce(c.priority, ''), c.status,
 	       coalesce(c.summary, ''), coalesce(c.os, ''), coalesce(c.linear_issue_key, ''),
 	       c.opened_at, c.updated_at,
@@ -354,12 +357,13 @@ const queueSQL = `
 	       (SELECT max(m.created_at) FROM support_messages m
 	         WHERE m.ticket_number = c.ticket_number AND m.kind = 'sent'),
 	       d.id, d.status, d.disposition, d.disposition_reason, d.hold_until, d.created_at,
-	       coalesce(d.user_name, ''), coalesce(d.draft_body_html, ''),
+	       coalesce(d.draft_body_html, ''),
 	       coalesce(d.edited_body_html, ''), coalesce(d.intervened, false),
-	       coalesce(s.plan, ''), coalesce(s.status, ''), coalesce(s.lifetime, false)
+	       coalesce(s.plan, ''), coalesce(s.status, ''), coalesce(s.lifetime, false),
+	       (s.logto_sub IS NOT NULL)
 	  FROM support_cases c
 	  LEFT JOIN latest d ON d.ticket_number = c.ticket_number
-	  LEFT JOIN stripe_customers s ON s.logto_sub = c.logto_sub
+	  LEFT JOIN stripe_customers s ON s.logto_sub = c.logto_sub AND c.account_source = 'authenticated'
 	 ORDER BY c.updated_at DESC
 	 LIMIT $1
 `
@@ -437,14 +441,16 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 		var draftStatus, disposition, dispositionReason *string
 		var holdUntil, lastUser, lastSent, draftCreated *time.Time
 		var draftBody, editedBody, planStatus string
+		var accountSource string
 		var intervened, lifetime bool
 
-		if err := rows.Scan(&r.TicketNumber, &r.UserEmail, &r.Subject,
+		if err := rows.Scan(&r.TicketNumber, &r.UserEmail, &r.Name,
+			&r.ContactSource, &r.AccountSubject, &accountSource, &r.Subject,
 			&r.Category, &r.Priority, &r.Status, &r.Summary, &r.OS, &issueKey,
 			&r.OpenedAt, &r.UpdatedAt, &lastUser, &lastSent,
 			&draftID, &draftStatus, &disposition, &dispositionReason, &holdUntil, &draftCreated,
-			&r.Name, &draftBody, &editedBody, &intervened,
-			&r.Plan, &planStatus, &lifetime); err != nil {
+			&draftBody, &editedBody, &intervened,
+			&r.Plan, &planStatus, &lifetime, &r.SubscriptionPresent); err != nil {
 			log.Printf("[AdminSupport] scan queue row: %v", err)
 			continue
 		}
@@ -452,6 +458,8 @@ func HandleAdminQueue(c *fiber.Ctx) error {
 		if draftID != nil {
 			r.DraftID = *draftID
 		}
+		r.IdentityState, r.AccountEstablished = requesterIdentity(
+			r.AccountSubject, accountSource, r.UserEmail, r.Name)
 		r.Paying = planIsPaying(r.Plan, planStatus, lifetime)
 		r.DraftStatus = deref(draftStatus)
 		r.Disposition = deref(disposition)
@@ -552,7 +560,7 @@ func queueAccounts(ctx context.Context) AdminQueueAccounts {
 		SELECT (SELECT count(*) FROM stripe_customers
 		         WHERE plan NOT IN ('', 'free') AND (lifetime OR status = 'active')),
 		       (SELECT count(*) FROM support_cases
-		         WHERE logto_sub IS NOT NULL AND logto_sub <> ''),
+		         WHERE logto_sub IS NOT NULL AND logto_sub <> '' AND account_source = 'authenticated'),
 		       (SELECT count(*) FROM support_cases)`).Scan(
 		&a.Paying, &a.CasesWithAccount, &a.Cases); err != nil {
 		log.Printf("[AdminSupport] account counts: %v", err)
@@ -685,20 +693,25 @@ type AdminSimilarCase struct {
 }
 
 type AdminCaseDetail struct {
-	TicketNumber    string     `json:"ticket_number"`
-	Subject         string     `json:"subject"`
-	UserEmail       string     `json:"user_email,omitempty"`
-	LogtoSub        string     `json:"logto_sub,omitempty"`
-	Status          string     `json:"status"`
-	Category        string     `json:"category,omitempty"`
-	Priority        string     `json:"priority,omitempty"`
-	Summary         string     `json:"summary,omitempty"`
-	LinearIssueKey  string     `json:"linear_issue_key,omitempty"`
-	DiscordThreadID string     `json:"discord_thread_id,omitempty"`
-	DiscordURL      string     `json:"discord_url,omitempty"`
-	OpenedAt        time.Time  `json:"opened_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
-	ClosedAt        *time.Time `json:"closed_at,omitempty"`
+	TicketNumber        string     `json:"ticket_number"`
+	Subject             string     `json:"subject"`
+	UserEmail           string     `json:"user_email,omitempty"`
+	UserName            string     `json:"user_name,omitempty"`
+	LogtoSub            string     `json:"logto_sub,omitempty"`
+	ContactSource       string     `json:"contact_source,omitempty"`
+	IdentityState       string     `json:"identity_state"`
+	AccountEstablished  bool       `json:"account_established"`
+	SubscriptionPresent bool       `json:"subscription_present"`
+	Status              string     `json:"status"`
+	Category            string     `json:"category,omitempty"`
+	Priority            string     `json:"priority,omitempty"`
+	Summary             string     `json:"summary,omitempty"`
+	LinearIssueKey      string     `json:"linear_issue_key,omitempty"`
+	DiscordThreadID     string     `json:"discord_thread_id,omitempty"`
+	DiscordURL          string     `json:"discord_url,omitempty"`
+	OpenedAt            time.Time  `json:"opened_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+	ClosedAt            *time.Time `json:"closed_at,omitempty"`
 
 	Group       string `json:"group"`
 	GroupReason string `json:"group_reason"`
@@ -738,13 +751,15 @@ type AdminCaseDetail struct {
 }
 
 const caseSQL = `
-	SELECT c.ticket_number, c.subject, coalesce(c.user_email, ''), coalesce(c.logto_sub, ''),
+	SELECT c.ticket_number, c.subject, coalesce(c.user_email, ''), coalesce(c.user_name, ''),
+	       coalesce(c.contact_source, ''), coalesce(c.logto_sub, ''), coalesce(c.account_source, ''),
 	       c.status, coalesce(c.category, ''), coalesce(c.priority, ''), coalesce(c.summary, ''),
 	       coalesce(c.linear_issue_key, ''), coalesce(c.discord_thread_id, ''),
 	       c.opened_at, c.updated_at, c.closed_at,
-	       coalesce(s.plan, ''), coalesce(s.status, ''), coalesce(s.lifetime, false)
+	       coalesce(s.plan, ''), coalesce(s.status, ''), coalesce(s.lifetime, false),
+	       (s.logto_sub IS NOT NULL)
 	  FROM support_cases c
-	  LEFT JOIN stripe_customers s ON s.logto_sub = c.logto_sub
+	  LEFT JOIN stripe_customers s ON s.logto_sub = c.logto_sub AND c.account_source = 'authenticated'
 	 WHERE c.ticket_number = $1
 `
 
@@ -786,22 +801,24 @@ func HandleAdminCase(c *fiber.Ctx) error {
 func buildAdminCase(ctx context.Context, ticket string) (*AdminCaseDetail, error) {
 	var d AdminCaseDetail
 	var planStatus string
+	var accountSource string
 	var lifetime bool
 	err := platform.DBPool.QueryRow(ctx, caseSQL, ticket).Scan(
-		&d.TicketNumber, &d.Subject, &d.UserEmail, &d.LogtoSub, &d.Status,
+		&d.TicketNumber, &d.Subject, &d.UserEmail, &d.UserName, &d.ContactSource,
+		&d.LogtoSub, &accountSource, &d.Status,
 		&d.Category, &d.Priority, &d.Summary, &d.LinearIssueKey,
 		&d.DiscordThreadID, &d.OpenedAt, &d.UpdatedAt, &d.ClosedAt,
-		&d.Plan, &planStatus, &lifetime)
+		&d.Plan, &planStatus, &lifetime, &d.SubscriptionPresent)
 	if err != nil {
 		if err != pgx.ErrNoRows {
 			log.Printf("[AdminSupport] case %s: %v", ticket, err)
 		}
 		return nil, err
 	}
+	d.IdentityState, d.AccountEstablished = requesterIdentity(
+		d.LogtoSub, accountSource, d.UserEmail, d.UserName)
 	d.Paying = planIsPaying(d.Plan, planStatus, lifetime)
-	if d.Plan == "" {
-		d.PlanNote = "No Stripe customer stands behind this ticket, so there is no current plan to show. That is normal for a case that arrived without a signed-in user."
-	}
+	d.PlanNote = identityPlanNote(d.IdentityState, d.SubscriptionPresent)
 	if d.DiscordThreadID != "" {
 		if guild := strings.TrimSpace(os.Getenv("DISCORD_GUILD_ID")); guild != "" {
 			d.DiscordURL = "https://discord.com/channels/" + guild + "/" + d.DiscordThreadID

--- a/api/internal/support/handlers_osticket_webhook.go
+++ b/api/internal/support/handlers_osticket_webhook.go
@@ -155,8 +155,9 @@ func processReplyTriageAsync(ev osTicketThreadMessageEvent) {
 	eventTime := parseISO(&ev.Created)
 	if platform.DBPool != nil {
 		if err := upsertSupportCase(ctx, SupportCase{
-			TicketNumber: ev.TicketNumber, UserEmail: ev.UserEmail, Subject: ev.Subject, Status: "open",
-			UpdatedAt: eventTime, StatusObservedAt: eventTime,
+			TicketNumber: ev.TicketNumber, UserEmail: ev.UserEmail, UserName: strings.TrimSpace(ev.UserName),
+			ContactSource: contactSourceOSTicketWebhook, ContactObservedAt: eventTime,
+			Subject: ev.Subject, Status: "open", UpdatedAt: eventTime, StatusObservedAt: eventTime,
 		}); err != nil {
 			log.Printf("[Cases] %v", err)
 		}

--- a/api/internal/support/handlers_support_public.go
+++ b/api/internal/support/handlers_support_public.go
@@ -180,10 +180,12 @@ func HandleSubmitPublicSupportTicket(c *fiber.Ctx) error {
 		redactIP(ip), redactEmail(req.Email), req.Category, ticketNumber)
 
 	recordTicketOpened(c.Context(), SupportCase{
-		TicketNumber: ticketNumber,
-		UserEmail:    req.Email,
-		Subject:      subjectFull,
-		Category:     effectiveCategory,
+		TicketNumber:  ticketNumber,
+		UserEmail:     req.Email,
+		UserName:      req.Name,
+		ContactSource: contactSourcePublic,
+		Subject:       subjectFull,
+		Category:      effectiveCategory,
 	}, originalBody)
 
 	if triage != nil && ticketNumber != "" {

--- a/api/internal/support/support.go
+++ b/api/internal/support/support.go
@@ -326,14 +326,17 @@ func HandleSubmitSupportTicket(c *fiber.Ctx) error {
 	// triage side effects so the draft has a case to attach to.
 	appVersion, osName := caseFieldsFromDiagnostics(req.Diagnostics)
 	recordTicketOpened(c.Context(), SupportCase{
-		TicketNumber: ticketNumber,
-		UserEmail:    email,
-		LogtoSub:     userID,
-		Subject:      subject,
-		Category:     effectiveCategory,
-		AppVersion:   appVersion,
-		OS:           osName,
-		TierAtOpen:   platform.TierFromRoles(platform.GetUserRoles(c)),
+		TicketNumber:  ticketNumber,
+		UserEmail:     email,
+		UserName:      strings.TrimSpace(req.Name),
+		ContactSource: contactSourceAuthenticated,
+		LogtoSub:      userID,
+		AccountSource: accountSourceAuthenticated,
+		Subject:       subject,
+		Category:      effectiveCategory,
+		AppVersion:    appVersion,
+		OS:            osName,
+		TierAtOpen:    platform.TierFromRoles(platform.GetUserRoles(c)),
 	}, originalBody)
 
 	// Side effects after successful ticket creation: persist the AI
@@ -454,6 +457,7 @@ func recordTicketOpened(ctx context.Context, sc SupportCase, userBodyHTML string
 	}
 	sc.Status = "open"
 	sc.StatusObservedAt = time.Now()
+	sc.ContactObservedAt = sc.StatusObservedAt
 	if err := upsertSupportCase(ctx, sc); err != nil {
 		log.Printf("[Cases] %v", err)
 		return

--- a/api/internal/support/support_backfill.go
+++ b/api/internal/support/support_backfill.go
@@ -65,6 +65,7 @@ type osTicketDetail struct {
 	Updated     *string `json:"updated"`
 	Closed      *bool   `json:"closed"`
 	UserEmail   string  `json:"user_email"`
+	UserName    string  `json:"user_name"`
 	Thread      []struct {
 		ID        int64   `json:"id"`
 		Type      string  `json:"type"`
@@ -114,7 +115,7 @@ func BackfillFromOSTicket(ctx context.Context, since time.Time) (BackfillStats, 
 // linkDrafts is pass 1. Returns (drafts seen, errors).
 func linkDrafts(ctx context.Context) (int, int) {
 	rows, err := platform.DBPool.Query(ctx, `
-		SELECT id, ticket_number, user_email, original_subject,
+		SELECT id, ticket_number, user_email, COALESCE(user_name,''), original_subject,
 			   COALESCE(user_message_html,''), draft_body_html, COALESCE(edited_body_html,''),
 			   COALESCE(ai_summary,''), COALESCE(ai_category,''), COALESCE(ai_priority,''),
 			   status, COALESCE(osticket_thread_entry_id,0), decided_at, sent_at, created_at
@@ -128,7 +129,7 @@ func linkDrafts(ctx context.Context) (int, int) {
 	for rows.Next() {
 		var d SupportDraft
 		var summary, category, priority string
-		if err := rows.Scan(&d.ID, &d.TicketNumber, &d.UserEmail, &d.OriginalSubject,
+		if err := rows.Scan(&d.ID, &d.TicketNumber, &d.UserEmail, &d.UserName, &d.OriginalSubject,
 			&d.UserMessageHTML, &d.DraftBodyHTML, &d.EditedBodyHTML, &summary, &category, &priority,
 			&d.Status, &d.OSTicketThreadEntryID, &d.DecidedAt, &d.SentAt, &d.CreatedAt); err != nil {
 			errs++
@@ -136,7 +137,8 @@ func linkDrafts(ctx context.Context) (int, int) {
 		}
 		n++
 		if err := upsertSupportCase(ctx, SupportCase{
-			TicketNumber: d.TicketNumber, UserEmail: d.UserEmail, Subject: d.OriginalSubject,
+			TicketNumber: d.TicketNumber, UserEmail: d.UserEmail, UserName: d.UserName,
+			ContactSource: contactSourceDraft, Subject: d.OriginalSubject,
 			Category: category, Priority: priority, Summary: summary,
 			OpenedAt: d.CreatedAt, UpdatedAt: d.CreatedAt,
 		}); err != nil {
@@ -206,7 +208,8 @@ func syncTicket(ctx context.Context, number string, st *BackfillStats) error {
 	}
 	caseStatus, statusKnown := importedCaseStatus(d)
 	sc := SupportCase{
-		TicketNumber: number, UserEmail: d.UserEmail, Subject: d.Subject,
+		TicketNumber: number, UserEmail: d.UserEmail, UserName: strings.TrimSpace(d.UserName),
+		ContactSource: contactSourceOSTicket, ContactObservedAt: parseISO(d.Updated), Subject: d.Subject,
 		Category: categoryFromTopic(d.Topic), Priority: d.Priority, Status: caseStatus,
 		OpenedAt: parseISO(d.Created), UpdatedAt: parseISO(d.Updated),
 	}

--- a/api/internal/support/support_cases.go
+++ b/api/internal/support/support_cases.go
@@ -28,24 +28,37 @@ import (
 // times mean "unknown" on write and are never used to blank a stored
 // value — see upsertSupportCase.
 type SupportCase struct {
-	TicketNumber     string     `json:"ticket_number"`
-	UserEmail        string     `json:"-"`
-	LogtoSub         string     `json:"-"`
-	Subject          string     `json:"subject"`
-	Category         string     `json:"category,omitempty"`
-	Priority         string     `json:"priority,omitempty"`
-	Status           string     `json:"status"`
-	StatusObservedAt time.Time  `json:"-"`
-	Summary          string     `json:"summary,omitempty"`
-	AppVersion       string     `json:"app_version,omitempty"`
-	OS               string     `json:"os,omitempty"`
-	TierAtOpen       string     `json:"tier_at_open,omitempty"`
-	LinearIssueKey   string     `json:"linear_issue_key,omitempty"`
-	DiscordThreadID  string     `json:"discord_thread_id,omitempty"`
-	OpenedAt         time.Time  `json:"opened_at"`
-	UpdatedAt        time.Time  `json:"updated_at"`
-	ClosedAt         *time.Time `json:"closed_at,omitempty"`
+	TicketNumber      string     `json:"ticket_number"`
+	UserEmail         string     `json:"-"`
+	UserName          string     `json:"-"`
+	ContactSource     string     `json:"-"`
+	ContactObservedAt time.Time  `json:"-"`
+	LogtoSub          string     `json:"-"`
+	AccountSource     string     `json:"-"`
+	Subject           string     `json:"subject"`
+	Category          string     `json:"category,omitempty"`
+	Priority          string     `json:"priority,omitempty"`
+	Status            string     `json:"status"`
+	StatusObservedAt  time.Time  `json:"-"`
+	Summary           string     `json:"summary,omitempty"`
+	AppVersion        string     `json:"app_version,omitempty"`
+	OS                string     `json:"os,omitempty"`
+	TierAtOpen        string     `json:"tier_at_open,omitempty"`
+	LinearIssueKey    string     `json:"linear_issue_key,omitempty"`
+	DiscordThreadID   string     `json:"discord_thread_id,omitempty"`
+	OpenedAt          time.Time  `json:"opened_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+	ClosedAt          *time.Time `json:"closed_at,omitempty"`
 }
+
+const (
+	contactSourceAuthenticated   = "authenticated"
+	contactSourcePublic          = "public"
+	contactSourceOSTicket        = "osticket"
+	contactSourceOSTicketWebhook = "osticket_webhook"
+	contactSourceDraft           = "draft"
+	accountSourceAuthenticated   = "authenticated"
+)
 
 // SupportMessage mirrors one support_messages row.
 type SupportMessage struct {
@@ -69,7 +82,14 @@ func upsertSupportCase(ctx context.Context, sc SupportCase) error {
 	if platform.DBPool == nil {
 		return fmt.Errorf("DB not initialized")
 	}
-	var opened, updated, statusObserved *time.Time
+	hasContact := strings.TrimSpace(sc.UserEmail) != "" || strings.TrimSpace(sc.UserName) != ""
+	if !hasContact {
+		sc.ContactSource = ""
+	}
+	if strings.TrimSpace(sc.LogtoSub) == "" {
+		sc.AccountSource = ""
+	}
+	var opened, updated, statusObserved, contactObserved *time.Time
 	if !sc.OpenedAt.IsZero() {
 		opened = &sc.OpenedAt
 	}
@@ -79,16 +99,46 @@ func upsertSupportCase(ctx context.Context, sc SupportCase) error {
 	if !sc.StatusObservedAt.IsZero() {
 		statusObserved = &sc.StatusObservedAt
 	}
+	if hasContact && !sc.ContactObservedAt.IsZero() {
+		contactObserved = &sc.ContactObservedAt
+	}
 	const q = `
 		INSERT INTO support_cases
 			(ticket_number, user_email, logto_sub, subject, category, priority, status,
-			 summary, app_version, os, tier_at_open, opened_at, updated_at, closed_at, status_observed_at)
+			 summary, app_version, os, tier_at_open, opened_at, updated_at, closed_at, status_observed_at,
+			 user_name, contact_source, contact_observed_at, account_source)
 		VALUES ($1, NULLIF($2,''), NULLIF($3,''), $4, NULLIF($5,''), NULLIF($6,''),
 			COALESCE(NULLIF($7,''), 'unknown'), NULLIF($8,''), NULLIF($9,''), NULLIF($10,''),
-			NULLIF($11,''), COALESCE($12, now()), COALESCE($13, now()), $14, $15)
+			NULLIF($11,''), COALESCE($12, now()), COALESCE($13, now()), $14, $15,
+			NULLIF($16,''), NULLIF($17,''), $18, NULLIF($19,''))
 		ON CONFLICT (ticket_number) DO UPDATE SET
-			user_email   = COALESCE(EXCLUDED.user_email, support_cases.user_email),
+			user_email   = CASE
+				WHEN $18 IS NOT NULL AND $18 >= COALESCE(support_cases.contact_observed_at, '-infinity')
+					THEN COALESCE(EXCLUDED.user_email, support_cases.user_email)
+				WHEN support_cases.contact_observed_at IS NULL
+					THEN COALESCE(support_cases.user_email, EXCLUDED.user_email)
+				ELSE support_cases.user_email END,
+			user_name    = CASE
+				WHEN $18 IS NOT NULL AND $18 >= COALESCE(support_cases.contact_observed_at, '-infinity')
+					THEN COALESCE(EXCLUDED.user_name, support_cases.user_name)
+				WHEN support_cases.contact_observed_at IS NULL
+					THEN COALESCE(support_cases.user_name, EXCLUDED.user_name)
+				ELSE support_cases.user_name END,
+			contact_source = CASE
+				WHEN $18 IS NOT NULL AND (EXCLUDED.user_email IS NOT NULL OR EXCLUDED.user_name IS NOT NULL)
+					AND $18 >= COALESCE(support_cases.contact_observed_at, '-infinity') THEN EXCLUDED.contact_source
+				WHEN support_cases.contact_source IS NULL AND (EXCLUDED.user_email IS NOT NULL OR EXCLUDED.user_name IS NOT NULL)
+					THEN EXCLUDED.contact_source ELSE support_cases.contact_source END,
+			contact_observed_at = CASE
+				WHEN $18 IS NOT NULL AND (EXCLUDED.user_email IS NOT NULL OR EXCLUDED.user_name IS NOT NULL)
+					AND $18 >= COALESCE(support_cases.contact_observed_at, '-infinity') THEN $18
+				ELSE support_cases.contact_observed_at END,
 			logto_sub    = COALESCE(support_cases.logto_sub, EXCLUDED.logto_sub),
+			account_source = CASE
+				WHEN support_cases.logto_sub IS NULL AND EXCLUDED.logto_sub IS NOT NULL THEN EXCLUDED.account_source
+				WHEN support_cases.logto_sub = EXCLUDED.logto_sub AND support_cases.account_source IS NULL
+					AND EXCLUDED.account_source = 'authenticated' THEN EXCLUDED.account_source
+				ELSE support_cases.account_source END,
 			subject      = CASE WHEN EXCLUDED.subject <> '' THEN EXCLUDED.subject ELSE support_cases.subject END,
 			category     = COALESCE(support_cases.category, EXCLUDED.category),
 			priority     = COALESCE(support_cases.priority, EXCLUDED.priority),
@@ -111,7 +161,8 @@ func upsertSupportCase(ctx context.Context, sc SupportCase) error {
 	_, err := platform.DBPool.Exec(ctx, q,
 		sc.TicketNumber, sc.UserEmail, sc.LogtoSub, sc.Subject, sc.Category,
 		strings.ToLower(sc.Priority), sc.Status, sc.Summary, sc.AppVersion, sc.OS,
-		sc.TierAtOpen, opened, updated, sc.ClosedAt, statusObserved)
+		sc.TierAtOpen, opened, updated, sc.ClosedAt, statusObserved,
+		sc.UserName, sc.ContactSource, contactObserved, sc.AccountSource)
 	if err != nil {
 		return fmt.Errorf("upsertSupportCase %s: %w", sc.TicketNumber, err)
 	}

--- a/api/internal/support/support_cases_test.go
+++ b/api/internal/support/support_cases_test.go
@@ -194,7 +194,7 @@ func TestBackfill_Idempotent(t *testing.T) {
 		"200": {
 			"number": "200", "subject": "Cannot log in", "topic": "Account & Login", "status": "Closed",
 			"status_state": "closed", "priority": "Normal", "created": "2026-06-01T10:00:00Z",
-			"updated": "2026-06-02T10:00:00Z", "closed": true, "user_email": "a@example.com",
+			"updated": "2026-06-02T10:00:00Z", "closed": true, "user_email": "a@example.com", "user_name": "A Person",
 			"thread": []map[string]interface{}{
 				entry(1, "M", "Login loops"), entry(2, "R", "Human: we shipped a fix in 1.6.1"), entry(3, "N", "internal note"),
 			},
@@ -202,7 +202,7 @@ func TestBackfill_Idempotent(t *testing.T) {
 		"201": { // never seen by this API (IMAP-only ticket)
 			"number": "201", "subject": "Weather widget shows nothing", "topic": "Bug Report", "status": "Open",
 			"status_state": "open", "priority": "High", "created": "2026-06-03T10:00:00Z",
-			"updated": "2026-06-03T10:00:00Z", "closed": false, "user_email": "b@example.com",
+			"updated": "2026-06-03T10:00:00Z", "closed": false, "user_email": "b@example.com", "user_name": "B Person",
 			"thread": []map[string]interface{}{entry(10, "M", "Weather widget is blank since the update")},
 		},
 	}}
@@ -226,6 +226,15 @@ func TestBackfill_Idempotent(t *testing.T) {
 	_ = platform.DBPool.QueryRow(ctx, `SELECT count(*) FROM support_cases`).Scan(&cases)
 	if cases != 2 {
 		t.Fatalf("cases: %d", cases)
+	}
+	var importedName, importedSource string
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT user_name, contact_source FROM support_cases WHERE ticket_number='201'`).Scan(
+		&importedName, &importedSource); err != nil {
+		t.Fatal(err)
+	}
+	if importedName != "B Person" || importedSource != contactSourceOSTicket {
+		t.Errorf("imported requester=%q source=%q", importedName, importedSource)
 	}
 	if got := countMessages(t, "200", ""); got != 4 { // user, ai_draft, sent, note
 		t.Fatalf("ticket 200 messages: %d", got)
@@ -429,6 +438,74 @@ func TestMessageOnlyCaseDoesNotInventAnUpstreamOpenStatus(t *testing.T) {
 	}
 	if status != "unknown" {
 		t.Fatalf("message-only status=%q, want unknown until an authoritative source is observed", status)
+	}
+}
+
+func TestRequesterContactFreshnessDoesNotChangeAccountOwnership(t *testing.T) {
+	if !testsupport.DBAvailable(t) {
+		return
+	}
+	resetCases(t)
+	ctx := context.Background()
+	opened := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: "identity", UserEmail: "signed-in@example.com", UserName: "Signed In",
+		LogtoSub: "sub-confirmed", AccountSource: accountSourceAuthenticated,
+		ContactSource: contactSourceAuthenticated, ContactObservedAt: opened,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: "identity", UserEmail: "stale@example.com", UserName: "Stale",
+		ContactSource: contactSourceOSTicket, ContactObservedAt: opened.Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: "identity", UserEmail: "current@example.com", UserName: "Current Contact",
+		ContactSource: contactSourceOSTicketWebhook, ContactObservedAt: opened.Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: "identity", UserEmail: "draft@example.com", UserName: "Draft Fallback",
+		ContactSource: contactSourceDraft,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var email, name, contactSource, sub, accountSource string
+	if err := platform.DBPool.QueryRow(ctx, `SELECT user_email, user_name, contact_source,
+		logto_sub, account_source FROM support_cases WHERE ticket_number='identity'`).Scan(
+		&email, &name, &contactSource, &sub, &accountSource); err != nil {
+		t.Fatal(err)
+	}
+	if email != "current@example.com" || name != "Current Contact" || contactSource != contactSourceOSTicketWebhook {
+		t.Errorf("contact=%q %q source=%q", email, name, contactSource)
+	}
+	if sub != "sub-confirmed" || accountSource != accountSourceAuthenticated {
+		t.Errorf("ownership=%q source=%q", sub, accountSource)
+	}
+
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: "identity-missing", ContactSource: contactSourceOSTicket,
+		ContactObservedAt: opened,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertSupportCase(ctx, SupportCase{
+		TicketNumber: "identity-missing", UserEmail: "draft-only@example.com",
+		UserName: "Draft Only", ContactSource: contactSourceDraft,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := platform.DBPool.QueryRow(ctx,
+		`SELECT user_name, contact_source FROM support_cases WHERE ticket_number='identity-missing'`).Scan(
+		&name, &contactSource); err != nil {
+		t.Fatal(err)
+	}
+	if name != "Draft Only" || contactSource != contactSourceDraft {
+		t.Errorf("missing contact fallback=%q source=%q", name, contactSource)
 	}
 }
 

--- a/api/migrations/000019_support_requester_identity.down.sql
+++ b/api/migrations/000019_support_requester_identity.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE support_cases
+    DROP COLUMN account_source,
+    DROP COLUMN contact_observed_at,
+    DROP COLUMN contact_source,
+    DROP COLUMN user_name;

--- a/api/migrations/000019_support_requester_identity.up.sql
+++ b/api/migrations/000019_support_requester_identity.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE support_cases
+    ADD COLUMN user_name text,
+    ADD COLUMN contact_source text,
+    ADD COLUMN contact_observed_at timestamptz,
+    ADD COLUMN account_source text;

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -297,6 +297,11 @@ export type QueueSort = 'last_wrote' | 'waiting' | 'tickets' | 'plan' | 'name'
 
 export type QueueDir = 'asc' | 'desc'
 export type QueueRowsMode = 'person' | 'ticket'
+export type RequesterIdentityState =
+  | 'unknown_contact'
+  | 'contact_only'
+  | 'confirmed_account'
+  | 'ambiguous_association'
 
 export interface QueueQuery {
   state?: string
@@ -317,6 +322,10 @@ export interface QueueRow {
   os?: string
   /** Empty when the ticket carried no name. Never invented. */
   name?: string
+  contact_source?: string
+  identity_state: RequesterIdentityState
+  account_established: boolean
+  subscription_present: boolean
   /** The CURRENT subscription, empty when there is no Stripe row. */
   plan?: string
   paying: boolean
@@ -347,6 +356,10 @@ export interface QueuePerson {
   plan?: string
   paying: boolean
   plan_note?: string
+  contact_source?: string
+  identity_state: RequesterIdentityState
+  account_established: boolean
+  subscription_present: boolean
   section: QueueSection
   tickets: number
   needs_you: number
@@ -453,7 +466,12 @@ export interface CaseDetail {
   ticket_number: string
   subject: string
   user_email?: string
+  user_name?: string
   logto_sub?: string
+  contact_source?: string
+  identity_state: RequesterIdentityState
+  account_established: boolean
+  subscription_present: boolean
   status: string
   category?: string
   priority?: string

--- a/myscrollr.com/src/components/admin/SupportPage.tsx
+++ b/myscrollr.com/src/components/admin/SupportPage.tsx
@@ -41,6 +41,7 @@ import {
   fixBadge,
   formatWait,
   holdCountdown,
+  identityLabel,
   lastUserMessage,
   personMeta,
   personTitle,
@@ -771,7 +772,9 @@ function CaseView({
             #{detail.ticket_number}
           </span>
           <span className="text-xs text-base-content/50">
-            {detail.user_email ?? 'no email on file'}
+            {[detail.user_name, detail.user_email]
+              .filter(Boolean)
+              .join(' · ') || 'requester unknown'}
           </span>
           {badge ? (
             <Pill tone={badge.paying ? 'paying' : 'neutral'}>
@@ -779,13 +782,18 @@ function CaseView({
             </Pill>
           ) : (
             <span className="text-xs text-base-content/45 italic">
-              no account on file
+              {identityLabel(detail.identity_state)}
             </span>
           )}
         </div>
         <h1 className="mt-1.5 text-xl font-bold tracking-tight sm:text-2xl">
           {detail.subject || '(no subject)'}
         </h1>
+        {detail.plan_note && (
+          <p className="mt-1.5 max-w-[75ch] text-xs text-base-content/50">
+            {detail.plan_note}
+          </p>
+        )}
       </header>
       <CaseBody detail={detail} onCase={setDetail} />
     </div>
@@ -848,7 +856,7 @@ function PersonView({
             </Pill>
           ) : (
             <span className="text-xs text-base-content/45 italic">
-              {person.plan_note ? 'no account' : 'no plan on file'}
+              {identityLabel(person.identity_state)}
             </span>
           )}
         </div>
@@ -1052,7 +1060,7 @@ function TicketCard({
         </span>
       </div>
       <p className="mt-0.5 truncate text-xs text-base-content/55">
-        {row.name || row.user_email || 'no account on this ticket'}
+        {row.name || row.user_email || 'requester unknown'}
         {' · '}
         {wait ? `waiting ${wait}` : 'wait unknown'}
       </p>

--- a/myscrollr.com/src/lib/supportConsole.test.ts
+++ b/myscrollr.com/src/lib/supportConsole.test.ts
@@ -9,6 +9,7 @@ import {
   formatWait,
   groupLabel,
   holdCountdown,
+  identityLabel,
   isUnchanged,
   lastUserMessage,
   lineDiff,
@@ -25,6 +26,9 @@ function person(over: Partial<QueuePerson> = {}): QueuePerson {
     key: 'r_armstrong@me.com',
     email: 'r_armstrong@me.com',
     name: 'Rachel Armstrong',
+    identity_state: 'contact_only',
+    account_established: false,
+    subscription_present: false,
     paying: false,
     section: 'open',
     tickets: 5,
@@ -258,11 +262,22 @@ describe('personTitle', () => {
 
   // The one that matters: an unknown person must read as an unknown person,
   // never as somebody called "Anonymous".
-  it('says there is no account rather than inventing a name', () => {
+  it('says the requester is unknown rather than making an account claim', () => {
     const who = personTitle({})
     expect(who.known).toBe(false)
-    expect(who.title).toBe('No account on this ticket')
+    expect(who.title).toBe('Requester unknown')
     expect(who.title.toLowerCase()).not.toContain('anonymous')
+  })
+})
+
+describe('identityLabel', () => {
+  it('keeps contact, ownership, and missing identity distinct', () => {
+    expect(identityLabel('confirmed_account')).toBe('Confirmed account')
+    expect(identityLabel('contact_only')).toBe('Contact only')
+    expect(identityLabel('ambiguous_association')).toBe(
+      'Account association unverified',
+    )
+    expect(identityLabel('unknown_contact')).toBe('Requester unknown')
   })
 })
 

--- a/myscrollr.com/src/lib/supportConsole.ts
+++ b/myscrollr.com/src/lib/supportConsole.ts
@@ -206,10 +206,20 @@ export function personTitle(person: { name?: string; email?: string }): {
   if (name) return { title: name, subtitle: email ?? null, known: true }
   if (email) return { title: email, subtitle: null, known: true }
   return {
-    title: 'No account on this ticket',
-    subtitle: 'it arrived without a signed-in user',
+    title: 'Requester unknown',
+    subtitle: 'no requester name or email was stored',
     known: false,
   }
+}
+
+export function identityLabel(state: string): string {
+  const labels: Record<string, string> = {
+    confirmed_account: 'Confirmed account',
+    contact_only: 'Contact only',
+    ambiguous_association: 'Account association unverified',
+    unknown_contact: 'Requester unknown',
+  }
+  return labels[state] ?? 'Requester identity unknown'
 }
 
 /**


### PR DESCRIPTION
Requester names previously depended on the newest AI draft, email grouped cases even when ownership was unverified, and a missing Stripe row was presented as a missing account. This change stores requester contact with source/time independently of drafts, records authenticated account provenance separately, groups confirmed subjects across email changes, and keeps email-only or placeholder contacts isolated from account plan and history context.

Legacy account associations without recorded provenance remain explicitly unverified and do not receive account grouping or subscription context. This PR does not add email-based ownership inference, bulk linking, account creation, or per-row Logto lookups.

This is stacked on REL-278 / PR #371 and should merge after it.

Validation:
- Complete API suite: `docker compose -f docker/compose.yml exec -T -e TEST_DATABASE_URL=postgres://scrollr:scrollr@postgres:5432/scrollr_test?sslmode=disable core-api go test ./... -count=1`
- Website: `npm test` (116 tests), `npm run lint`, `npm run build`
- Targeted Prettier check for the four changed website files
- Additive migration guard against the REL-278 branch
- `git diff --check` against the REL-278 branch
