### PR TITLE
fix: bound signup analytics loading

### DIFF
--- a/api/internal/accounts/logto_admin.go
+++ b/api/internal/accounts/logto_admin.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -84,7 +85,7 @@ func readCachedM2MToken() string {
 // refreshM2MToken performs the actual HTTP call to Logto's token endpoint
 // and swaps the new token into the cache under a write lock. Returns the
 // fresh token on success.
-func refreshM2MToken() (string, error) {
+func refreshM2MToken(ctx context.Context) (string, error) {
 	cfg := getM2MConfig()
 	if cfg.AppID == "" || cfg.AppSecret == "" {
 		return "", fmt.Errorf("LOGTO_M2M_APP_ID and LOGTO_M2M_APP_SECRET must be set")
@@ -95,7 +96,7 @@ func refreshM2MToken() (string, error) {
 	data.Set("resource", cfg.Resource)
 	data.Set("scope", "all")
 
-	req, err := http.NewRequest("POST", cfg.Endpoint+"/oidc/token", strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.Endpoint+"/oidc/token", strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("create M2M token request: %w", err)
 	}
@@ -146,6 +147,13 @@ func ResetM2MTokenCache() {
 }
 
 func getM2MToken() (string, error) {
+	return getM2MTokenContext(context.Background())
+}
+
+func getM2MTokenContext(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	// Fast path: cache hit under read lock.
 	if token := readCachedM2MToken(); token != "" {
 		return token, nil
@@ -153,19 +161,26 @@ func getM2MToken() (string, error) {
 
 	// Slow path: coalesce concurrent refreshes. All callers that miss the
 	// cache at the same time share one HTTP request and the same result.
-	v, err, _ := m2mGroup.Do("m2m", func() (interface{}, error) {
+	result := m2mGroup.DoChan("m2m", func() (interface{}, error) {
 		// Re-check under the read lock: another goroutine's refresh may
 		// have completed between our fast-path check and our singleflight
 		// entry.
 		if token := readCachedM2MToken(); token != "" {
 			return token, nil
 		}
-		return refreshM2MToken()
+		refreshCtx, cancel := context.WithTimeout(context.Background(), platform.LogtoM2MTokenTimeout)
+		defer cancel()
+		return refreshM2MToken(refreshCtx)
 	})
-	if err != nil {
-		return "", err
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case response := <-result:
+		if response.Err != nil {
+			return "", response.Err
+		}
+		return response.Val.(string), nil
 	}
-	return v.(string), nil
 }
 
 // AssignUplinkRole assigns the "uplink" role to a Logto user via Management API.

--- a/api/internal/accounts/logto_analytics.go
+++ b/api/internal/accounts/logto_analytics.go
@@ -214,7 +214,7 @@ func fetchSignupAnalyticsPage(ctx context.Context, appID string, page int) ([]lo
 	if cfg.Endpoint == "" {
 		return nil, fmt.Errorf("Logto endpoint is not configured")
 	}
-	token, err := getM2MToken()
+	token, err := getM2MTokenContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get Logto management token: %w", err)
 	}

--- a/api/internal/accounts/logto_analytics_test.go
+++ b/api/internal/accounts/logto_analytics_test.go
@@ -3,6 +3,7 @@ package accounts
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -208,5 +209,33 @@ func TestFetchSignupAnalyticsReturnsEmptyReasonArray(t *testing.T) {
 	raw, _ := json.Marshal(report)
 	if !strings.Contains(string(raw), `"error_reasons":[]`) {
 		t.Fatalf("empty reasons must be an array for the UI, got %s", raw)
+	}
+}
+
+func TestFetchSignupAnalyticsStopsWaitingForTokenWhenContextExpires(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oidc/token" {
+			t.Fatalf("unexpected Logto path %s", r.URL.Path)
+		}
+		time.Sleep(100 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "late-token", "expires_in": 3600})
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("LOGTO_ENDPOINT", server.URL)
+	t.Setenv("LOGTO_M2M_APP_ID", "m2m")
+	t.Setenv("LOGTO_M2M_APP_SECRET", "secret")
+	t.Setenv("LOGTO_WEB_APP_ID", "web-app")
+	ResetM2MTokenCache()
+	t.Cleanup(ResetM2MTokenCache)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err := FetchSignupAnalytics(ctx, "website", 7, time.Now())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > 200*time.Millisecond {
+		t.Fatalf("analytics token wait took %v, want bounded response", elapsed)
 	}
 }

--- a/api/internal/admin/handlers_analytics.go
+++ b/api/internal/admin/handlers_analytics.go
@@ -16,8 +16,9 @@ import (
 const signupAnalyticsCacheTTL = 5 * time.Minute
 
 var (
-	fetchSignupAnalytics = accounts.FetchSignupAnalytics
-	signupAnalyticsGroup singleflight.Group
+	fetchSignupAnalytics   = accounts.FetchSignupAnalytics
+	signupAnalyticsGroup   singleflight.Group
+	signupAnalyticsTimeout = 25 * time.Second
 )
 
 type cachedAnalyticsResult struct {
@@ -35,7 +36,9 @@ func HandleGetAnalytics(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(platform.ErrorResponse{Error: "days must be 7 or 30"})
 	}
 
-	report, hit, err := cachedSignupAnalytics(c.Context(), application, days)
+	ctx, cancel := context.WithTimeout(c.Context(), signupAnalyticsTimeout)
+	defer cancel()
+	report, hit, err := cachedSignupAnalytics(ctx, application, days)
 	if err != nil {
 		log.Print("[Admin] signup analytics unavailable")
 		return c.Status(fiber.StatusServiceUnavailable).JSON(platform.ErrorResponse{Error: "Signup analytics are unavailable."})
@@ -53,27 +56,37 @@ func cachedSignupAnalytics(ctx context.Context, application string, days int) (a
 	if report, ok := readSignupAnalyticsCache(ctx, key); ok {
 		return report, true, nil
 	}
+	if err := ctx.Err(); err != nil {
+		return accounts.SignupAnalytics{}, false, err
+	}
 
-	value, err, _ := signupAnalyticsGroup.Do(key, func() (any, error) {
-		if report, ok := readSignupAnalyticsCache(ctx, key); ok {
+	result := signupAnalyticsGroup.DoChan(key, func() (any, error) {
+		scanCtx, cancel := context.WithTimeout(context.Background(), signupAnalyticsTimeout)
+		defer cancel()
+		if report, ok := readSignupAnalyticsCache(scanCtx, key); ok {
 			return cachedAnalyticsResult{Report: report, Hit: true}, nil
 		}
-		report, err := fetchSignupAnalytics(ctx, application, days, time.Now())
+		report, err := fetchSignupAnalytics(scanCtx, application, days, time.Now())
 		if err != nil {
 			return cachedAnalyticsResult{}, err
 		}
 		if platform.Rdb != nil {
 			if raw, err := json.Marshal(report); err == nil {
-				_ = platform.Rdb.Set(ctx, key, raw, signupAnalyticsCacheTTL).Err()
+				_ = platform.Rdb.Set(scanCtx, key, raw, signupAnalyticsCacheTTL).Err()
 			}
 		}
 		return cachedAnalyticsResult{Report: report}, nil
 	})
-	if err != nil {
-		return accounts.SignupAnalytics{}, false, err
+	select {
+	case <-ctx.Done():
+		return accounts.SignupAnalytics{}, false, ctx.Err()
+	case response := <-result:
+		if response.Err != nil {
+			return accounts.SignupAnalytics{}, false, response.Err
+		}
+		value := response.Val.(cachedAnalyticsResult)
+		return value.Report, value.Hit, nil
 	}
-	result := value.(cachedAnalyticsResult)
-	return result.Report, result.Hit, nil
 }
 
 func readSignupAnalyticsCache(ctx context.Context, key string) (accounts.SignupAnalytics, bool) {

--- a/api/internal/admin/handlers_analytics_test.go
+++ b/api/internal/admin/handlers_analytics_test.go
@@ -143,3 +143,65 @@ func TestCachedSignupAnalyticsCoalescesConcurrentColdReads(t *testing.T) {
 		t.Fatalf("concurrent cold reads fetched %d times, want 1", calls.Load())
 	}
 }
+
+func TestHandleGetAnalyticsTimesOutStalledColdRead(t *testing.T) {
+	previousFetch := fetchSignupAnalytics
+	previousTimeout := signupAnalyticsTimeout
+	signupAnalyticsTimeout = 20 * time.Millisecond
+	fetchSignupAnalytics = func(ctx context.Context, _ string, _ int, _ time.Time) (accounts.SignupAnalytics, error) {
+		<-ctx.Done()
+		return accounts.SignupAnalytics{}, ctx.Err()
+	}
+	t.Cleanup(func() {
+		fetchSignupAnalytics = previousFetch
+		signupAnalyticsTimeout = previousTimeout
+	})
+	_, cleanup := testsupport.MiniRedis(t)
+	defer cleanup()
+
+	app := fiber.New()
+	app.Get("/admin/analytics", HandleGetAnalytics)
+	started := time.Now()
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/admin/analytics?application=website&days=30", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if elapsed := time.Since(started); elapsed > 200*time.Millisecond {
+		t.Fatalf("handler took %v, want bounded response", elapsed)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestCachedSignupAnalyticsStopsWaitingWhenCallerCancels(t *testing.T) {
+	_, cleanup := testsupport.MiniRedis(t)
+	defer cleanup()
+	previous := fetchSignupAnalytics
+	release := make(chan struct{})
+	called := make(chan struct{}, 1)
+	fetchSignupAnalytics = func(_ context.Context, _ string, _ int, _ time.Time) (accounts.SignupAnalytics, error) {
+		called <- struct{}{}
+		<-release
+		return analyticsReport("website", 7), nil
+	}
+	t.Cleanup(func() { fetchSignupAnalytics = previous })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	_, _, err := cachedSignupAnalytics(ctx, "website", 7)
+	close(release)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled", err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("canceled cache wait took %v", elapsed)
+	}
+	select {
+	case <-called:
+		t.Fatal("canceled caller started a cold fetch")
+	case <-time.After(20 * time.Millisecond):
+	}
+}

--- a/myscrollr.com/src/api/adminAnalytics.test.ts
+++ b/myscrollr.com/src/api/adminAnalytics.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { loadSignupAnalytics } from './adminAnalytics'
+import type { SignupAnalytics } from './adminAnalytics'
 
-afterEach(() => vi.unstubAllGlobals())
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
 
 describe('loadSignupAnalytics', () => {
   it('sends only the selected application and supported time window', async () => {
@@ -64,7 +68,7 @@ describe('loadSignupAnalytics', () => {
     ).rejects.toThrow('Signup analytics are unavailable.')
   })
 
-  it('forwards cancellation so superseded filter requests cannot win', async () => {
+  it('settles a pre-aborted request without fetching', async () => {
     const controller = new AbortController()
     const fetchMock = vi
       .fn()
@@ -80,9 +84,141 @@ describe('loadSignupAnalytics', () => {
         controller.signal,
       ),
     ).rejects.toMatchObject({ name: 'AbortError' })
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ signal: controller.signal }),
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('times out when token acquisition never settles', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn())
+
+    const request = loadSignupAnalytics(
+      () => new Promise(() => undefined),
+      'website',
+      30,
     )
+    const assertion = expect(request).rejects.toThrow(
+      'Signup analytics took too long. Please retry.',
+    )
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await assertion
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('settles cancellation while token acquisition is stalled and never fetches later', async () => {
+    let resolveToken!: (token: string) => void
+    const token = new Promise<string>((resolve) => {
+      resolveToken = resolve
+    })
+    const controller = new AbortController()
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const request = loadSignupAnalytics(
+      () => token,
+      'desktop',
+      7,
+      controller.signal,
+    )
+    controller.abort()
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+    resolveToken('late-token')
+    await Promise.resolve()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when token resolution and cancellation happen together', async () => {
+    let resolveToken!: (token: string) => void
+    const token = new Promise<string>((resolve) => {
+      resolveToken = resolve
+    })
+    const controller = new AbortController()
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const request = loadSignupAnalytics(
+      () => token,
+      'website',
+      30,
+      controller.signal,
+    )
+    resolveToken('late-token')
+    controller.abort()
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('times out while a successful response body is still stalled', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => new Promise(() => undefined),
+      }),
+    )
+
+    const request = loadSignupAnalytics(
+      () => Promise.resolve(null),
+      'website',
+      7,
+    )
+    const assertion = expect(request).rejects.toThrow(
+      'Signup analytics took too long. Please retry.',
+    )
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await assertion
+  })
+
+  it('rejects an older body even when it resolves after a newer selection', async () => {
+    let resolveOldBody!: (report: SignupAnalytics) => void
+    let markOldFetchStarted!: () => void
+    const oldBody = new Promise<SignupAnalytics>((resolve) => {
+      resolveOldBody = resolve
+    })
+    const oldFetchStarted = new Promise<void>((resolve) => {
+      markOldFetchStarted = resolve
+    })
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        markOldFetchStarted()
+        return Promise.resolve({ ok: true, json: () => oldBody })
+      })
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ application: 'desktop', window_days: 30 }),
+          { status: 200 },
+        ),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+    const oldController = new AbortController()
+
+    const oldRequest = loadSignupAnalytics(
+      () => Promise.resolve(null),
+      'website',
+      7,
+      oldController.signal,
+    )
+    const oldAssertion = expect(oldRequest).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+    await oldFetchStarted
+    oldController.abort()
+    const current = await loadSignupAnalytics(
+      () => Promise.resolve(null),
+      'desktop',
+      30,
+    )
+    resolveOldBody({
+      application: 'website',
+      window_days: 7,
+    } as SignupAnalytics)
+
+    await oldAssertion
+    expect(current).toMatchObject({ application: 'desktop', window_days: 30 })
   })
 })

--- a/myscrollr.com/src/api/adminAnalytics.ts
+++ b/myscrollr.com/src/api/adminAnalytics.ts
@@ -28,26 +28,69 @@ export interface SignupAnalytics {
   attempt_conversion: { available: false; note: string }
 }
 
+const signupAnalyticsTimeout = 30_000
+
+function abortFailure(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('Aborted', 'AbortError')
+}
+
+function waitForAbort(signal: AbortSignal): Promise<never> {
+  if (signal.aborted) return Promise.reject(abortFailure(signal))
+  return new Promise((_, reject) => {
+    signal.addEventListener('abort', () => reject(abortFailure(signal)), {
+      once: true,
+    })
+  })
+}
+
 export async function loadSignupAnalytics(
   getToken: () => Promise<string | null>,
   application: AnalyticsApplication,
   days: AnalyticsWindow,
   signal?: AbortSignal,
 ): Promise<SignupAnalytics> {
-  const token = await getToken()
-  const response = await fetch(
-    `${API_BASE}/admin/analytics?application=${application}&days=${days}`,
-    {
-      credentials: 'include',
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-      signal,
-    },
-  )
-  if (!response.ok) {
-    const body = (await response.json().catch(() => null)) as {
-      error?: string
-    } | null
-    throw new Error(body?.error ?? 'Could not load signup analytics')
+  const controller = new AbortController()
+  const forwardAbort = () => controller.abort(signal?.reason)
+  if (signal?.aborted) forwardAbort()
+  else signal?.addEventListener('abort', forwardAbort, { once: true })
+  let timedOut = false
+  const didTimeOut = () => timedOut
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, signupAnalyticsTimeout)
+  const aborted = waitForAbort(controller.signal)
+
+  try {
+    const token = await Promise.race([getToken(), aborted])
+    if (controller.signal.aborted) throw abortFailure(controller.signal)
+    const response = await Promise.race([
+      fetch(
+        `${API_BASE}/admin/analytics?application=${application}&days=${days}`,
+        {
+          credentials: 'include',
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          signal: controller.signal,
+        },
+      ),
+      aborted,
+    ])
+    if (!response.ok) {
+      const body = (await Promise.race([
+        response.json().catch(() => null),
+        aborted,
+      ])) as { error?: string } | null
+      throw new Error(body?.error ?? 'Could not load signup analytics')
+    }
+    return (await Promise.race([response.json(), aborted])) as SignupAnalytics
+  } catch (error) {
+    if (didTimeOut()) {
+      throw new Error('Signup analytics took too long. Please retry.')
+    }
+    throw error
+  } finally {
+    clearTimeout(timer)
+    signal?.removeEventListener('abort', forwardAbort)
+    controller.abort()
   }
-  return response.json() as Promise<SignupAnalytics>
 }

--- a/myscrollr.com/src/components/admin/AnalyticsPage.tsx
+++ b/myscrollr.com/src/components/admin/AnalyticsPage.tsx
@@ -83,6 +83,7 @@ export default function AnalyticsPage() {
   const [data, setData] = useState<SignupAnalytics | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [stale, setStale] = useState(false)
+  const [slow, setSlow] = useState(false)
   const request = useRef<AbortController | null>(null)
 
   const load = useCallback(() => {
@@ -92,24 +93,37 @@ export default function AnalyticsPage() {
     setData(null)
     setError(null)
     setStale(false)
+    setSlow(false)
+    const slowTimer = window.setTimeout(() => {
+      if (!controller.signal.aborted) setSlow(true)
+    }, 3_000)
     loadSignupAnalytics(getToken, application, days, controller.signal)
       .then((report) => {
         if (controller.signal.aborted) return
+        setSlow(false)
         setData(report)
         setStale(Date.now() - Date.parse(report.generated_at) > 10 * 60_000)
       })
       .catch((err: unknown) => {
         if (controller.signal.aborted) return
+        setSlow(false)
         setError(
           err instanceof Error ? err.message : 'Could not load analytics',
         )
       })
+      .finally(() => window.clearTimeout(slowTimer))
   }, [application, days, getToken])
 
   useEffect(() => {
     load()
     return () => request.current?.abort()
   }, [load])
+
+  const cancel = () => {
+    request.current?.abort()
+    setSlow(false)
+    setError('Loading canceled. You can retry.')
+  }
 
   const eventTotal = data
     ? Object.values(data.stages).reduce((sum, stage) => sum + stage.events, 0)
@@ -165,11 +179,25 @@ export default function AnalyticsPage() {
 
       {!data && !error && (
         <div
-          className="flex min-h-[40vh] items-center justify-center gap-2 text-sm text-base-content/50"
+          className="flex min-h-[40vh] flex-col items-center justify-center gap-3 text-sm text-base-content/50"
           role="status"
         >
-          <Loader2 className="size-5 animate-spin" aria-hidden /> Loading signup
-          events
+          <span className="flex items-center gap-2">
+            <Loader2 className="size-5 animate-spin" aria-hidden /> Loading
+            signup events
+          </span>
+          {slow && (
+            <>
+              <span>This range is taking longer than usual.</span>
+              <button
+                type="button"
+                onClick={cancel}
+                className="min-h-10 cursor-pointer rounded-lg px-3 font-semibold ring-1 ring-base-300 hover:bg-base-200"
+              >
+                Cancel
+              </button>
+            </>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- bound the complete signup analytics browser operation to 30 seconds, including token acquisition and response parsing
- show slow-loading feedback after 3 seconds with Cancel, plus recoverable canceled/timeout Retry states
- bound backend handler waits and cold scans to 25 seconds without letting a canceled caller poison shared Logto token refreshes
- preserve selector isolation, late-response guards, cache keys, privacy filtering, and partial/unknown coverage semantics

## Root cause and timing

The client previously awaited token acquisition outside cancellation and had no overall deadline. A cold cache miss could then scan up to 20 Logto pages serially, each with a 10-second HTTP timeout: roughly 200 seconds worst-case after token acquisition. The production observation only bounded the reported 30-day load below 19 seconds; it was not a measured request duration.

Now the UI reports slow loading at 3 seconds, the backend returns by 25 seconds, and the browser settles by 30 seconds. Caller waits and scans are context-aware. A shared M2M token refresh is independently bounded to 10 seconds, so it may finish after a caller cancels but cannot be canceled by one analytics request or proceed into a canceled analytics page fetch.

## Verification

- website ESLint: pass
- website Vitest: 10 files, 123 tests passed
- website production build and postbuild prerender/mobile checks: pass
- core API Go test ./...: pass
- independent code review: no Critical or Important findings

No production deployment is included.

Closes SCROLLR-185