### PR TITLE
SCROLLR-189: improve platform download guidance and search readiness

### DIFF
--- a/myscrollr.com/DEPLOY.md
+++ b/myscrollr.com/DEPLOY.md
@@ -16,12 +16,22 @@ The following routes are prerendered at build time and ship as static HTML with 
 - `/` (`index.html`)
 - `/channels` (`channels/index.html`)
 - `/download` (`download/index.html`)
+- `/download/mac` (`download/mac/index.html`)
+- `/download/windows` (`download/windows/index.html`)
+- `/download/linux` (`download/linux/index.html`)
+- `/widgets` (`widgets/index.html`)
+- `/fantasy` (`fantasy/index.html`)
+- `/sports` (`sports/index.html`)
+- `/markets` (`markets/index.html`)
+- `/news` (`news/index.html`)
+- `/releases` (`releases/index.html`)
 - `/business` (`business/index.html`)
 - `/architecture` (`architecture/index.html`)
 - `/support` (`support/index.html`)
 - `/legal` (`legal/index.html`)
 - `/uplink` (`uplink/index.html`)
 - `/uplink/lifetime` (`uplink/lifetime/index.html`)
+- `/status` (`status/index.html`; live values populate after hydration)
 
 ## Dynamic / auth routes (SPA fallback)
 
@@ -30,18 +40,27 @@ These routes are NOT prerendered. They require nginx's SPA fallback to serve `in
 - `/account` — Logto-gated user account page
 - `/callback` — Logto OAuth callback
 - `/invite` — invite-code redemption flow
-- `/status` — live system status
 - `/u/<username>` — public profile pages (dynamic param)
 
-The nginx config in `Dockerfile` uses `try_files $uri $uri/ /index.html;` to handle this. Any path that doesn't match a prerendered file or directory falls back to `index.html`, which boots the SPA and lets the router resolve the actual route from `window.location`.
+The nginx config in `Dockerfile` uses `try_files $uri $uri/index.html /_shell.html;` to handle this. Any path that doesn't match a prerendered file or route falls back to `_shell.html`, which boots the SPA and lets the router resolve the actual route from `window.location`.
 
 ### About `_shell.html`
 
-TanStack Start emits `dist/client/_shell.html` as the SPA shell — it's the HTML rendered by fetching `/` during prerender, so it contains the home route's `head()` output. A small `copyShellToIndex()` Vite plugin (in `vite.config.ts`) copies `_shell.html` to `index.html` after Start's post-build step, because Start's internal post-build always claims `index.html` for itself and would otherwise overwrite our home prerender.
+TanStack Start emits `dist/client/_shell.html` from the synthetic `/tss-spa-shell` mask path. It contains the shared application chrome but cannot collide with the separately prerendered homepage at `dist/client/index.html`. nginx uses `_shell.html` only as the fallback for dynamic routes.
 
-Both files exist in `dist/client/`; they are currently byte-identical. The SPA fallback target is `index.html` — equivalent to `_shell.html` for now.
+Dynamic routes briefly carry the shell metadata until the client router updates the document after hydration. The current dynamic routes are blocked in `public/robots.txt`, so crawlers are directed to the substantive prerendered pages instead.
 
-**Known limitation:** because `_shell.html` is rendered from `/`, dynamic routes that fall back to `index.html` briefly carry the home page's `<title>`, canonical, and JSON-LD until the client router updates document metadata after hydration. This affects crawlers that don't execute JS and the very first moments of the browser tab title. Most dynamic routes (`/account`, `/invite`, `/callback`, `/u/*`) are already blocked in `public/robots.txt`, so the impact is mainly on `/status` and any future non-disallowed dynamic routes. This is a known artifact of Start's current shell behavior and is acceptable for the current set of dynamic routes.
+## IndexNow activation (not enabled)
+
+IndexNow is intentionally not wired yet: this repository has no owner-approved key, and deployment must not make external search submissions implicitly. To activate it later:
+
+1. Generate an IndexNow key with 8–128 supported characters and store it as the GitHub Actions secret `INDEXNOW_KEY`; do not commit the key.
+2. In the website build job, write the secret value to `myscrollr.com/public/<key>.txt` immediately before `docker build`. The file name and its UTF-8 contents must both be the key.
+3. Deploy the website and verify `https://myscrollr.com/<key>.txt` returns only that key before submitting anything.
+4. After the production smoke test succeeds, POST only the canonical URLs changed by that deployment to `https://api.indexnow.org/indexnow` with `host`, `key`, `keyLocation`, and `urlList`. Keep the current sitemap as the full crawl inventory; IndexNow is only a change notification.
+5. Treat HTTP 200 or 202 as receipt, not proof of crawling or indexing. Failures should warn, not roll back an otherwise healthy website deployment.
+
+The official protocol documentation defines the key-file ownership check, request payload, and response meanings. Do not add the submission step until the owner authorizes the key and outbound notification.
 
 ## nginx fallback (alternative web servers)
 
@@ -49,7 +68,7 @@ Other static hosts use equivalent SPA fallback config. The config baked into the
 
 ```nginx
 location / {
-  try_files $uri $uri/ /index.html;
+  try_files $uri $uri/index.html /_shell.html;
 }
 ```
 
@@ -58,7 +77,7 @@ For Caddy (minimal site block):
 ```caddyfile
 myscrollr.com {
   root * /srv
-  try_files {path} {path}/index.html /index.html
+  try_files {path} {path}/index.html /_shell.html
   file_server
 }
 ```

--- a/myscrollr.com/DEPLOY.md
+++ b/myscrollr.com/DEPLOY.md
@@ -35,7 +35,7 @@ The following routes are prerendered at build time and ship as static HTML with 
 
 ## Dynamic / auth routes (SPA fallback)
 
-These routes are NOT prerendered. They require nginx's SPA fallback to serve `index.html`, after which the client-side TanStack Router takes over:
+These routes are NOT prerendered. They require nginx's SPA fallback to serve `_shell.html`, after which the client-side TanStack Router takes over:
 
 - `/account` — Logto-gated user account page
 - `/callback` — Logto OAuth callback
@@ -104,7 +104,7 @@ Runs:
    checkout and are rebuilt every time. `predev` runs `fetch-latest-version`
    alone, so `npm run dev` works without the rest.
 
-2. `vite build` — builds the client + SSR bundles, runs the Start prerender phase, then runs the `copyShellToIndex()` plugin.
+2. `vite build` — builds the client + SSR bundles and runs the Start prerender phase, producing the homepage and SPA shell separately.
 3. `tsc` — final type check.
 4. `postbuild` — three gates that fail the build: `check-sentry-tunnel.mjs`,
    `check-prerender.mjs`, `check-mobile-viewport.mjs`.

--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -151,7 +151,7 @@ server {\n\
     #                          and a mismatch with our canonical URLs\n\
     #                          (sitemap + <link rel=canonical> declare\n\
     #                          /uplink, not /uplink/).\n\
-    #   3. /index.html       — SPA fallback for dynamic routes\n\
+    #   3. /_shell.html      — SPA fallback for dynamic routes\n\
     #                          (/account, /callback, /u/$username, etc.)\n\
     # Canonical marketing pages are slashless. Keep this list narrow so\n\
     # assets, auth callbacks, API paths, and the SPA fallback are untouched.\n\
@@ -163,7 +163,7 @@ server {\n\
     location / {\n\
         include /etc/nginx/security-headers.conf;\n\
         add_header Cache-Control "no-cache";\n\
-        try_files $uri $uri/index.html /index.html;\n\
+        try_files $uri $uri/index.html /_shell.html;\n\
     }\n\
 \n\
     # ── Hashed static assets: cache forever ─────────────────────\n\

--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -78,7 +78,7 @@ FROM nginx:alpine
 # Copy built assets to nginx
 COPY --from=builder /app/myscrollr.com/dist/client /usr/share/nginx/html
 
-# SPA fallback: route all paths to index.html for client-side routing
+# SPA fallback: route dynamic paths to _shell.html for client-side routing
 # Includes security headers, gzip compression, and proper caching
 RUN printf 'server {\n\
     listen 3000;\n\

--- a/myscrollr.com/scripts/check-mobile-viewport.mjs
+++ b/myscrollr.com/scripts/check-mobile-viewport.mjs
@@ -52,6 +52,9 @@ const ROUTES = [
   { path: '/markets', file: 'markets/index.html' },
   { path: '/news', file: 'news/index.html' },
   { path: '/download', file: 'download/index.html' },
+  { path: '/download/mac', file: 'download/mac/index.html' },
+  { path: '/download/windows', file: 'download/windows/index.html' },
+  { path: '/download/linux', file: 'download/linux/index.html' },
   { path: '/business', file: 'business/index.html' },
   { path: '/architecture', file: 'architecture/index.html' },
   { path: '/support', file: 'support/index.html' },
@@ -134,7 +137,7 @@ function resolveStaticFile(urlPath) {
   }
 
   // SPA fallback: anything not found returns the prerendered shell.
-  // This mirrors the nginx `try_files $uri $uri/ /index.html;` rule
+  // This mirrors the nginx `try_files $uri $uri/index.html /_shell.html;` rule
   // so the browser doesn't 404 on dynamic routes during the test
   // (not currently needed for the prerendered routes, but cheap).
   const shell = join(clientDir, '_shell.html')

--- a/myscrollr.com/scripts/check-prerender.mjs
+++ b/myscrollr.com/scripts/check-prerender.mjs
@@ -91,19 +91,22 @@ const ROUTES = [
     path: '/download/mac',
     file: 'download/mac/index.html',
     minJsonLd: 3, // organization + softwareApp + breadcrumbs
-    expectedBody: 'Download for macOS',
+    expectedBody: 'Requires Apple Silicon and macOS 10.15 or later.',
+    expectedH1: 'Get Scrollr for macOS. Free. No sign-up.',
   },
   {
     path: '/download/windows',
     file: 'download/windows/index.html',
     minJsonLd: 3,
-    expectedBody: 'Download for Windows',
+    expectedBody: 'Built for Windows 10 or 11 on x64 hardware.',
+    expectedH1: 'Get Scrollr for Windows. Free. No sign-up.',
   },
   {
     path: '/download/linux',
     file: 'download/linux/index.html',
     minJsonLd: 3,
-    expectedBody: 'Download for Linux',
+    expectedBody: 'Choose the package that matches your x86_64 distribution.',
+    expectedH1: 'Get Scrollr for Linux. Free. No sign-up.',
   },
   {
     path: '/business',
@@ -316,6 +319,14 @@ if (!existsSync(shell)) {
   } else {
     console.log('✓ _shell.html present with Header chrome')
   }
+}
+
+const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
+if (!dockerfile.includes('try_files $uri $uri/index.html /_shell.html;')) {
+  console.error('✗ nginx must use _shell.html for dynamic-route fallback')
+  failures += 1
+} else {
+  console.log('✓ nginx uses _shell.html for dynamic-route fallback')
 }
 
 // Guard: the client entry bundle must wrap StartClient in our auth providers.

--- a/myscrollr.com/scripts/check-prerender.mjs
+++ b/myscrollr.com/scripts/check-prerender.mjs
@@ -98,7 +98,7 @@ const ROUTES = [
     path: '/download/windows',
     file: 'download/windows/index.html',
     minJsonLd: 3,
-    expectedBody: 'Built for Windows 10 or 11 on x64 hardware.',
+    expectedBody: 'Built as an x64 Windows setup executable.',
     expectedH1: 'Get Scrollr for Windows. Free. No sign-up.',
   },
   {

--- a/myscrollr.com/src/routes/download.tsx
+++ b/myscrollr.com/src/routes/download.tsx
@@ -99,7 +99,7 @@ const PLATFORM_GUIDES: Record<
   },
   windows: {
     label: 'Windows',
-    requirements: 'Built for Windows 10 or 11 on x64 hardware.',
+    requirements: 'Built as an x64 Windows setup executable.',
     steps: [
       'Open the downloaded setup .exe file.',
       'Follow the installer, then launch Scrollr from the Start menu.',

--- a/myscrollr.com/src/routes/download.tsx
+++ b/myscrollr.com/src/routes/download.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { Link, createFileRoute } from '@tanstack/react-router'
 import { motion } from 'motion/react'
 import type { DesktopPlatform, LinuxFormat } from '@/lib/getDownloadInfo'
 import { seo } from '@/lib/seo'
@@ -84,6 +84,39 @@ const STEPS = [
   },
 ]
 
+const PLATFORM_GUIDES: Record<
+  DesktopPlatform,
+  { label: string; requirements: string; steps: ReadonlyArray<string> }
+> = {
+  macos: {
+    label: 'macOS',
+    requirements: 'Requires Apple Silicon and macOS 10.15 or later.',
+    steps: [
+      'Open the downloaded .dmg file.',
+      'Drag Scrollr into the Applications folder.',
+      'Open Scrollr from Applications. Release builds are signed and notarized in the project workflow.',
+    ],
+  },
+  windows: {
+    label: 'Windows',
+    requirements: 'Built for Windows 10 or 11 on x64 hardware.',
+    steps: [
+      'Open the downloaded setup .exe file.',
+      'Follow the installer, then launch Scrollr from the Start menu.',
+      'Use Settings inside Scrollr to choose the monitor and pin the ticker to the top or bottom edge.',
+    ],
+  },
+  linux: {
+    label: 'Linux',
+    requirements: 'Choose the package that matches your x86_64 distribution.',
+    steps: [
+      'Use .deb for Debian or Ubuntu, .rpm for Fedora, RHEL, or openSUSE, or AppImage for a portable build.',
+      'For AppImage, mark the file executable before opening it.',
+      'Launch Scrollr, then choose your ticker position and widgets in Settings.',
+    ],
+  },
+}
+
 const CTA_BUTTON_CLASS =
   'inline-flex cursor-pointer items-center gap-3 rounded-[4px] bg-primary px-[34px] py-[17px] text-[17px] font-bold text-[#101018] shadow-[0_0_60px_color-mix(in_srgb,var(--color-primary)_18%,transparent)] transition-colors hover:bg-[#6ee7b7]'
 
@@ -117,13 +150,18 @@ export function DownloadPage({
 }: { forcedPlatform?: DesktopPlatform } = {}) {
   const detected = useDetectedPlatform(forcedPlatform)
   const version = LATEST_DESKTOP_VERSION
+  const platformGuide = forcedPlatform ? PLATFORM_GUIDES[forcedPlatform] : null
 
   return (
     <div>
       <PageHeader
         eyebrowLeft={`DOWNLOAD ／ DESKTOP V${version}`}
         eyebrowRight="SERVED FROM GITHUB RELEASES · BUILT FROM PUBLIC SOURCE"
-        line1="Get Scrollr."
+        line1={
+          platformGuide
+            ? `Get Scrollr for ${platformGuide.label}.`
+            : 'Get Scrollr.'
+        }
         line2="Free. No sign-up."
         sub="One small native app. Three widgets free forever, no account between you and a running bar."
         actions={
@@ -257,6 +295,62 @@ export function DownloadPage({
           </div>
         </TerminalContainer>
       </section>
+
+      {platformGuide && (
+        <section className="border-b border-hairline">
+          <TerminalContainer>
+            <SectionRow tag={`PLATFORM GUIDE ／ ${platformGuide.label}`} />
+            <div className="grid gap-10 py-12 lg:grid-cols-[0.75fr_1.25fr]">
+              <div>
+                <h2 className="type-display text-[clamp(32px,4vw,52px)]">
+                  Install Scrollr
+                  <br />
+                  <span className="text-primary">
+                    on {platformGuide.label}.
+                  </span>
+                </h2>
+                <p className="mt-5 leading-relaxed text-base-content/60">
+                  {platformGuide.requirements}
+                </p>
+              </div>
+              <div>
+                <ol className="m-0 space-y-5 p-0">
+                  {platformGuide.steps.map((step, index) => (
+                    <li
+                      key={step}
+                      className="flex gap-4 border-b border-hairline-minor pb-5"
+                    >
+                      <span className="font-mono text-xs text-primary">
+                        {String(index + 1).padStart(2, '0')}
+                      </span>
+                      <span className="leading-relaxed text-base-content/70">
+                        {step}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+                <nav
+                  aria-label="Explore Scrollr use cases"
+                  className="mt-8 flex flex-wrap gap-x-5 gap-y-3 font-mono text-xs"
+                >
+                  <Link to="/sports" className="text-primary">
+                    SPORTS →
+                  </Link>
+                  <Link to="/markets" className="text-primary">
+                    MARKETS →
+                  </Link>
+                  <Link to="/news" className="text-primary">
+                    NEWS & RSS →
+                  </Link>
+                  <Link to="/fantasy" className="text-primary">
+                    YAHOO FANTASY →
+                  </Link>
+                </nav>
+              </div>
+            </div>
+          </TerminalContainer>
+        </section>
+      )}
 
       {/* ── SEC 02 ／ YOUR FIRST SIXTY SECONDS ───────────────── */}
       <section className="border-b border-hairline">

--- a/myscrollr.com/src/routes/download_.$os.tsx
+++ b/myscrollr.com/src/routes/download_.$os.tsx
@@ -39,7 +39,7 @@ const META: Record<
     os: 'Windows',
     title: 'Download Scrollr for Windows',
     description:
-      'Free download of Scrollr for Windows 10/11 (x64). A quiet desktop ticker for live finance, sports, news, and fantasy data. Open source.',
+      'Free download of Scrollr for x64 Windows. A quiet desktop ticker for live finance, sports, news, and fantasy data. Open source.',
     arch: 'x64',
   },
   linux: {


### PR DESCRIPTION
## Summary
- add truthful, platform-specific install guidance for macOS, Windows, and Linux
- verify distinct prerendered H1 and body content for each platform route
- fix the production SPA fallback to use the generated shell and document owner-gated IndexNow activation

## Verification
- npm test: 118 passed
- npm run lint: passed
- npm run build: passed, including 23 prerender checks and 56 responsive viewport checks
- manual browser QA: desktop and mobile, light and dark, no console warnings or errors
- independent code review: approved after Windows compatibility and deployment documentation corrections

## Boundaries
- no merge or deployment
- no IndexNow key, hook, or external submission enabled
- no privacy or legal policy wording changed

Linear: SCROLLR-189