### PR TITLE
SCROLLR-191: Verify and refine public SEO surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,8 @@ and how to add one.
 ## Quick start — just run the desktop app
 
 Head to <https://myscrollr.com/download> and grab the build for your
-OS. Macs and PCs will flag it as "from an unidentified developer" until
-code signing lands in v1.0.1 — the download page explains how to allow
-it.
+OS. macOS builds are signed and notarized. Windows signing is tracked
+separately; the download page carries the current installation guidance.
 
 ## Quick start — local development
 

--- a/audit/CONSISTENCY.md
+++ b/audit/CONSISTENCY.md
@@ -1,0 +1,271 @@
+# SCROLLR-191 consistency and factual-claim audit
+
+## Scope and method
+
+This report audits only crawler-visible marketing metadata, JSON-LD, public
+copy, `llms*.txt`, canonical links, download/platform guidance, and the
+implementation facts needed to verify those claims. It does not treat general
+monorepo style debt as an SEO defect.
+
+Reference checks used for every finding included exact-string searches across
+`myscrollr.com`, the desktop client, core API, release workflow, and the
+server-authoritative widget catalog. Import searches were also run before
+calling any file dead. No production code was changed.
+
+## Findings
+
+### C-01 — P1 — SoftwareApplication publishes the website version as the desktop version
+
+- **Locations:** `myscrollr.com/src/lib/structured-data.ts:12,44-55`;
+  `myscrollr.com/vite.config.ts:19-24,115-116`;
+  `myscrollr.com/package.json:3`; `desktop/src-tauri/tauri.conf.json:2-4`.
+- **Defect:** `softwareApplication.softwareVersion` uses `__APP_VERSION__`, but
+  Vite defines that value from the marketing site's package (`2.1.0`), not the
+  desktop release (`1.6.3`). Every page that emits `softwareApplication`
+  therefore tells crawlers that the desktop app is version 2.1.0.
+- **Verification:** compare `package.json` and `tauri.conf.json`, then inspect
+  the homepage's prerendered JSON-LD for `"softwareVersion":"2.1.0"`.
+- **Suggested fix:** feed the already resolved latest desktop release version
+  into `softwareApplication` and add one build assertion that it matches the
+  download version.
+
+### C-02 — P1 — The crawler-visible catalog snapshot is 15 widgets behind the server authority
+
+- **Locations:** `myscrollr.com/src/lib/catalog.ts:4-13,21-70`;
+  `api/internal/platform/widgets.go:119-644`;
+  `myscrollr.com/src/routes/widgets.tsx:5,59-60`;
+  `myscrollr.com/src/components/landing/CatalogPicker.tsx:53-58,73`.
+- **Defect:** the marketing fallback contains 35 widgets and 14 sports league
+  widgets, while the server authority contains 50 widgets and 28 sports league
+  widgets. The live API can correct the hydrated page, but prerendered HTML and
+  no-JS crawlers see the stale snapshot and stale counts.
+- **Verification:** `rg '^\s*ID:\s+"' api/internal/platform/widgets.go`
+  returns 50 entries and `rg '^\s*\[''[a-z]'
+  myscrollr.com/src/lib/catalog.ts` returns 35; the equivalent sports counts
+  are 28 and 14. Build `/widgets` and inspect the server HTML before hydration.
+- **Suggested fix:** refresh or generate the marketing snapshot from the
+  server catalog and keep one small sync test so crawler HTML cannot drift
+  again.
+
+### C-03 — P1 — The full LLM digest advertises retired or absent paid features
+
+- **Locations:** `myscrollr.com/public/llms-full.txt:35-40,62-72,165-179,185-187`;
+  `myscrollr.com/src/routes/uplink.tsx:105-130,224-271`;
+  `AGENTS.md:53-59`.
+- **Defect:** the AI digest advertises custom alerts, feed profiles, advanced
+  controls, whitelist filtering, outbound webhooks, historical data export,
+  personal API access, and a full web dashboard that configures channels.
+  The current pricing page says all tiers have the same features and its
+  comparison table contains only widget count, live updates, early access,
+  and priority support. The project overview says the website is marketing,
+  auth, and billing only. Repository searches found no corresponding end-user
+  implementations for the advertised alert/profile/outbound-webhook features.
+- **Verification:** compare the cited digest sections with the active
+  `STATIC_FAQ` and `buildComparison`; search the desktop/API for the named
+  features (excluding Stripe/Sequin/Discord infrastructure webhooks).
+- **Suggested fix:** remove retired feature promises from the digest and make
+  the active pricing source, rather than a hand-maintained second feature
+  matrix, the factual authority.
+
+### C-04 — P1 — “Zero tracking/analytics” promises contradict operational diagnostics
+
+- **Locations:** `myscrollr.com/public/llms.txt:7`;
+  `myscrollr.com/public/llms-full.txt:15`;
+  `myscrollr.com/src/components/landing/PromiseSection.tsx:52,140`;
+  `myscrollr.com/src/sentry.ts:22-45`;
+  `desktop/src/preferences.ts:203-209,561-563`;
+  `api/internal/platform/usage.go:23-44`;
+  `myscrollr.com/src/components/legal/documents.ts:158-163,281`.
+- **Defect:** two AI-facing files and a visible homepage label say “zero
+  tracking,” while the product initializes Sentry in production, defaults
+  desktop crash reporting on, stores aggregate API request/version/platform/
+  error counts, and relies on Logto account records. The longer nearby privacy
+  prose is materially more accurate, making the short absolute claim the
+  inconsistency.
+- **Verification:** enable a production DSN and inspect `initSentry`; inspect
+  `DEFAULT_PRIVACY`; compare those paths and the legal policy to the exact
+  “zero tracking” strings.
+- **Suggested fix:** use one precise public formulation everywhere: no
+  advertising trackers; operational diagnostics and authentication logs exist;
+  optional product analytics, when enabled, is opt-in, coarse, account-linked,
+  desktop-only, and described in the Privacy Policy.
+
+### C-05 — P1 — Public FAQs disagree on whether an account is required
+
+- **Locations:** `myscrollr.com/src/lib/structured-data.ts:174-178`;
+  `myscrollr.com/src/components/support/support-content.ts:15-20,31-35,105-113`;
+  `desktop/src/components/support/support-content.ts:32-35`;
+  `desktop/src/components/marketplace/WidgetPanel.tsx:249-257`.
+- **Defect:** the homepage's visible/schema FAQ promises three widget slots
+  “forever, no account,” and public support says an account is unnecessary for
+  the free tier and exists only for Uplink sync. The same public support page
+  later tells users to create a free account, while the desktop's canonical
+  help and add-widget UI require sign-in to add data widgets.
+- **Verification:** open the public support FAQ and its Getting Started section,
+  then open the desktop catalog signed out; the action is “Sign in to add.”
+- **Suggested fix:** distinguish “download/browse without an account” from
+  “sign in to add live data widgets and sync settings,” using that same
+  distinction in visible FAQ text and FAQ JSON-LD.
+
+### C-06 — P1 — AI-facing league and source counts contradict both each other and the catalog
+
+- **Locations:** `myscrollr.com/public/llms-full.txt:19-24,115-117,157-159`;
+  `myscrollr.com/src/lib/catalog.ts:21-52`;
+  `api/internal/platform/widgets.go:158-426`.
+- **Defect:** the digest says Sports has 14 league widgets, later says “20+,”
+  and calls the product a four-channel system even though its own overview
+  names five data sources. The current server catalog has 28 sports widgets.
+  It also calls 10 named publishers plus Custom RSS “11 outlets,” although the
+  custom-feed widget is not a publisher.
+- **Verification:** count the server catalog's `sports_*` IDs and compare the
+  cited paragraphs in one file; count the ten curated publishers in the
+  marketing snapshot separately from `rss_custom`.
+- **Suggested fix:** avoid volatile hard-coded totals in prose; state the
+  stable capability and link to the live catalog, or generate counts from the
+  server authority at build time.
+
+### C-07 — P1 — “Instant/as they happen” delivery claims override the site's own upstream caveats
+
+- **Locations:** `myscrollr.com/src/routes/uplink.tsx:112-115`;
+  `myscrollr.com/src/routes/fantasy.tsx:112-115`;
+  `myscrollr.com/public/llms-full.txt:11,131-143`;
+  `myscrollr.com/src/routes/sports.tsx:33-35`;
+  `myscrollr.com/src/routes/markets.tsx:33-35`.
+- **Defect:** pricing, fantasy, and AI copy promise that changes appear
+  “instant” or “as they happen.” The dedicated sports and markets pages
+  correctly explain that upstream delays, corrections, availability, outages,
+  and connectivity affect arrival time. SSE removes the client's polling wait;
+  it cannot guarantee source latency.
+- **Verification:** compare the quoted FAQs; interrupt an upstream ingester or
+  observe a delayed/corrected source event—the transport cannot deliver data it
+  has not received.
+- **Suggested fix:** retain the live-streaming benefit but say updates appear
+  automatically when Scrollr receives them, with upstream timing caveats.
+
+### C-08 — P1 — The legacy `/channels` path is linked as current and lacks a direct server redirect
+
+- **Locations:** `myscrollr.com/public/llms.txt:12`;
+  `myscrollr.com/src/routes/channels.tsx:1-20,25-38`;
+  `myscrollr.com/Dockerfile:143-166`;
+  `myscrollr.com/scripts/generate-sitemap.mjs:26`.
+- **Defect:** the sitemap declares `/widgets`, but `llms.txt` directs answer
+  engines to `/channels`. That legacy route returns a prerendered page with a
+  meta refresh/client navigation rather than a permanent HTTP redirect. It is
+  also absent from nginx's slash-normalization/redirect rule, so directory
+  handling can add `/channels/` before the meta redirect.
+- **Verification:** request `/channels` and `/channels/` without following
+  redirects and compare the response chain with `/widgets`; inspect the
+  crawler-visible `http-equiv=refresh` rather than only the hydrated route.
+- **Suggested fix:** link `/widgets` everywhere and add one narrow nginx 301
+  from both legacy channel variants to `/widgets`, preserving the query string.
+
+### C-09 — P1 — Platform guidance conflicts on Intel macOS and signing status
+
+- **Locations:** `desktop/src/components/support/support-content.ts:27-30`;
+  `myscrollr.com/src/routes/download_.$os.tsx:31-50`;
+  `.github/workflows/desktop-release.yml:88-101,263-305,337-374`;
+  `README.md:97-102`; `desktop/src-tauri/tauri.conf.json:2-4,22-23`.
+- **Defect:** desktop help says macOS supports Apple Silicon **and Intel**, but
+  the release matrix produces only `aarch64-apple-darwin` and the public
+  download page correctly says Apple Silicon. Separately, the README still
+  says Macs and PCs are unidentified until signing lands in v1.0.1, despite
+  the current 1.6.3 macOS signing/notarization workflow. Windows signing is not
+  established by that workflow and must not be implied.
+- **Verification:** compare the support strings and README to the release
+  matrix target and Apple notarization steps; inspect current release asset
+  architectures rather than inferring from Tauri's cross-platform support.
+- **Suggested fix:** remove Intel until an x64 macOS artifact exists, and
+  replace the obsolete README promise with separate, current macOS and Windows
+  guidance.
+
+### C-10 — P1 — UNCERTAIN: business copy makes contract-level guarantees not evidenced in the repository
+
+- **Locations:** `myscrollr.com/src/routes/business.tsx:165-187`;
+  `myscrollr.com/public/llms-full.txt:78-80`.
+- **Defect:** the page guarantees per-display scheduling, programmatic
+  read/write API access, P1 response under one hour, uptime targets, a direct
+  Slack channel, commercial licensing that removes AGPL distribution duties,
+  standard NDAs, perpetual licensing, and fixed 2–4/6–12 week delivery ranges.
+  Full-stack self-hosting is supported by repository deployment material, but
+  searches found no public commercial license, SLA, NDA, or delivery contract
+  that substantiates the rest. This is marked **UNCERTAIN** because private
+  commercial documents may exist outside the repository.
+- **Verification:** search outside `business.tsx`/`llms-full.txt` for each
+  quoted promise and review any actual current sales templates or executed
+  standard terms before publishing them as guarantees.
+- **Suggested fix:** confirm each promise against the real commercial offer;
+  otherwise qualify it as scoped/available by agreement and remove numeric
+  guarantees from crawler-facing copy.
+
+### C-11 — P2 — Public entity links use a superseded GitHub owner
+
+- **Locations:** `myscrollr.com/src/lib/structured-data.ts:23-26`;
+  `myscrollr.com/src/components/Footer.tsx:34`;
+  `myscrollr.com/public/llms.txt:28`;
+  `myscrollr.com/src/lib/getDownloadInfo.ts:36`;
+  `myscrollr.com/package.json:12-16`.
+- **Defect:** public links and Organization `sameAs` use
+  `brandon-relentnet/myscrollr`, while the repository's configured origin is
+  `doughknee/myscrollr`. GitHub currently redirects renamed repositories, but
+  emitting the redirecting identity adds avoidable hops and entity ambiguity.
+- **Verification:** run `git remote get-url origin`, then compare every public
+  GitHub URL; request both repository URLs without following redirects.
+- **Suggested fix:** choose the current repository URL as one shared constant
+  and update visible links, package metadata, release fetches, and `sameAs`
+  together after confirming GitHub's canonical owner.
+
+### C-12 — P2 — Hand-maintained AI/FAQ copies and orphaned landing sections preserve stale claims
+
+- **Locations:** `myscrollr.com/public/llms-full.txt:91-187`;
+  `myscrollr.com/src/components/landing/FAQSection.tsx:26-90,420-425`;
+  `myscrollr.com/src/components/landing/TrustSection.tsx:24,308-330`;
+  `myscrollr.com/src/lib/structured-data.ts:163-193`;
+  `myscrollr.com/src/components/support/support-content.ts:15-56`.
+- **Defect:** the digest says it is aggregated from canonical live FAQs but is
+  manually duplicated and already diverges. `FAQSection.tsx` and
+  `TrustSection.tsx` are no longer imported by any route yet retain additional
+  “no tracking,” “zero analytics,” and account claims, making repository-wide
+  factual audits noisier and inviting accidental reintroduction.
+- **Verification:** `rg -l 'FAQSection|TrustSection' myscrollr.com/src` finds
+  their definitions/comments but no route import; compare the digest to active
+  `STATIC_FAQ`, `HOMEPAGE_FAQ_ITEMS`, and support content.
+- **Suggested fix:** delete the orphaned sections and either generate the
+  digest from canonical content or keep it concise enough that facts are not
+  copied into a second feature matrix.
+
+## Verified-consistent areas
+
+- `https://myscrollr.com` is consistently used by `BASE_URL`, sitemap URLs,
+  robots sitemap declaration, route canonicals, Open Graph URLs, JSON-LD IDs,
+  and the nginx `www` redirect.
+- Active `/sports`, `/markets`, `/news`, and `/fantasy` pages accurately scope
+  their core providers/capabilities: Yahoo only for fantasy, no trading on the
+  markets page, and public RSS/Atom feeds with source-delay caveats.
+- macOS 10.15+, Windows x64, and Linux x86_64 package formats in the public
+  download guide match `tauri.conf.json`, the build matrix, and release asset
+  naming. The public page does not claim that the pending Windows signing work
+  is already shipped.
+- The central `seo()` helper is live and used by route heads; searches found no
+  competing `usePageMeta`/runtime-title helper. Generated HTML sampled from
+  `/sports` contained one description, one canonical, and one `og:url`.
+
+## Highest-value cleanups per effort
+
+1. **C-01:** publish the desktop release version in app schema; one wrong value
+   currently contaminates every SoftwareApplication block.
+2. **C-03:** delete retired paid-feature claims from `llms-full.txt`; this is a
+   small copy fix with high trust impact.
+3. **C-04:** replace absolute “zero tracking” labels with the agreed precise
+   privacy story across visible and AI-facing copy.
+4. **C-05:** state the account boundary once and reuse it in homepage/support
+   FAQ content and schema.
+5. **C-02:** sync the marketing catalog fallback to the server authority and
+   leave one automated drift check.
+6. **C-06:** remove volatile league/channel totals from the AI digest or derive
+   them from the catalog.
+7. **C-08:** make `/channels` one permanent HTTP redirect and stop linking it.
+8. **C-07:** change “instant” to truthful live-delivery language that preserves
+   the benefit without overriding upstream-delay caveats.
+9. **C-09:** align Intel/signing guidance with the actual release matrix.
+10. **C-10:** validate or qualify contract-level business promises before they
+    remain searchable guarantees.

--- a/audit/INVENTORY.md
+++ b/audit/INVENTORY.md
@@ -1,0 +1,76 @@
+# SCROLLR-191 website audit inventory
+
+## Scope and severity calibration
+
+This audit is limited to the public `myscrollr.com` marketing, documentation,
+pricing, support, status, and download surfaces plus the routing/deployment
+configuration that controls their crawler delivery. Authenticated application
+behavior is inspected only to verify that it is excluded from indexing. A P0
+blocks the requested SEO QA PR; a P1 is a factual, indexability, accessibility,
+or crawler-delivery defect that should be fixed in this PR; a P2 is a safe
+follow-up that does not justify expanding this refinement pass.
+
+## Stack and runtime
+
+- React 19 + TanStack Router/Start static prerender, Vite 7, TypeScript 5.9,
+  Tailwind 4; route source is `myscrollr.com/src/routes/`.
+- `seo()` in `myscrollr.com/src/lib/seo.ts` owns per-route canonical, Open
+  Graph, Twitter, robots, and JSON-LD tags.
+- `myscrollr.com/src/lib/structured-data.ts` owns Organization, WebSite,
+  SoftwareApplication, Product/Offer, FAQPage, and BreadcrumbList objects.
+- `myscrollr.com/scripts/generate-sitemap.mjs` writes a hand-curated sitemap;
+  `myscrollr.com/public/robots.txt` is shipped as a static file.
+- Production serves `dist/client` from nginx configured in
+  `myscrollr.com/Dockerfile`; `k8s/ingress.yaml` terminates TLS and routes apex,
+  www, and API hostnames.
+
+## Public surfaces
+
+- Product: `/`, `/widgets`, `/sports`, `/markets`, `/news`, `/fantasy`.
+- Downloads: `/download`, `/download/mac`, `/download/windows`,
+  `/download/linux`.
+- Commercial: `/uplink`, `/uplink/lifetime`, `/business`.
+- Documentation/support: `/architecture`, `/releases`, `/support`, `/legal`,
+  `/status`.
+- Legacy public redirect: `/channels` -> `/widgets`.
+- Dynamic/private or non-indexable: `/account`, `/admin/**`, `/callback`,
+  `/invite`, `/u/$username`, `/tss-spa-shell`.
+
+## External data and links
+
+- GitHub releases and repository links supply published version/download
+  information (`scripts/fetch-latest-version.mjs`,
+  `scripts/fetch-releases.mjs`, route CTAs).
+- Logto supplies website authentication (`@logto/react`).
+- Stripe supplies checkout and billing (`@stripe/*`).
+- The public status page requests core API health data.
+- Sentry receives scrubbed operational errors through the same-origin
+  `/api/sentry-envelope` nginx tunnel.
+- Public outbound links include GitHub and Discord.
+
+## Sensitive machinery and indexing boundaries
+
+- Authenticated account and staff routes use Logto and API authorization; they
+  must remain `noindex` and excluded from the sitemap/robots crawl surface.
+- Stripe checkout and the Sentry tunnel are present but are not modified by
+  this task.
+- CSP and security headers are generated in the website Dockerfile.
+- No native bridge, filesystem access, inbound webhook, or server-side
+  user-controlled fetch exists in the scoped static marketing runtime.
+
+## Long-running behavior
+
+- Static marketing content has decorative motion and client hydration.
+- `/status`, account, admin, support form, checkout, and release/version helpers
+  have network-driven states. Only public SEO delivery and crawler-visible
+  fallback content are in scope.
+
+## Project constraints
+
+- Preserve the current brand/design and the already shipped SCROLLR-187-189
+  work; fix only evidenced defects.
+- Do not change telemetry behavior, signing integration, support deployment, or
+  analytics policy/VISION files owned by other active tasks.
+- No new dependency, generic blog, doorway page, fabricated schema field, or
+  external search/CDN/DNS mutation.
+- Finish at an independently reviewed PR; do not merge or deploy.

--- a/audit/PERFORMANCE.md
+++ b/audit/PERFORMANCE.md
@@ -1,0 +1,134 @@
+# Performance audit — SCROLLR-191
+
+## Calibration
+
+This lens is calibrated to the statically prerendered `myscrollr.com` marketing
+site, where crawler-visible HTML and cold-load cost matter more than sustained
+desktop-ticker behavior. The persistent demo bar and `/status` polling are
+included because they run after hydration on public pages; authenticated admin
+and desktop-app hot paths are outside this inventory.
+
+## Measurement notes
+
+- A production-mode Vite build emitted 2,829 transformed client modules. Its
+  shared client chunk was 667,377 bytes raw / 216,950 bytes gzip and its shared
+  stylesheet was 177,846 bytes raw / 24,920 bytes gzip. The build was stopped
+  after client, SSR, and 23-page prerender output because another audit process
+  needed exclusive ownership of the shared `dist` directory; this lens does not
+  claim the interrupted `tsc`/postbuild stages passed.
+- A fresh headless Chromium load of
+  `https://myscrollr.com/?audit=performance` at 1440x900, with no CPU or network
+  throttling, returned HTTP 200. Navigation response end was 118.8 ms,
+  `DOMContentLoaded` was 211.4 ms, and load was 304.9 ms. A second cold process
+  measured first contentful paint at 316 ms and largest contentful paint at
+  1,176 ms (the `H1`, 573,945 px²). These are diagnostic single-run numbers,
+  not field Core Web Vitals.
+- During a five-second settled-page sample, 301 animation frames averaged
+  16.64 ms; p95 was 16.70 ms and maximum was 16.80 ms. No frame-time finding
+  was reproduced during that unthrottled sample.
+- Chromium reported a 10,000,000-byte used JS heap after the cold homepage
+  load. The lens's 0/5/15-minute heap series was not run: there is no defined
+  representative 15-minute activity for this static marketing surface, and it
+  would profile the wrong product (the long-running desktop ticker is explicitly
+  outside the audit inventory). Timer cleanup and hidden-page behavior were
+  inspected directly instead.
+
+## Findings
+
+### PERF-1 — P1: a non-LCP, below-fold screenshot consumes two cold-load image transfers
+
+**Location:** `myscrollr.com/src/routes/index.tsx:65-79`,
+`myscrollr.com/src/routes/index.tsx:97-112`,
+`myscrollr.com/src/routes/index.tsx:118-127`, and
+`myscrollr.com/src/components/landing/DesktopProof.tsx:91-99`.
+
+**Evidence/reproduction:** The route marks the light and dark desktop screenshot
+preloads `fetchpriority="high"`, although `DesktopProof` is the third homepage
+section after `TerminalHero` and `CatalogPicker`, and the image itself is
+`loading="lazy"`. The measured page was 5,233 px tall with a 900 px viewport;
+its LCP was the hero `H1` at 1,176 ms, not this image. Nevertheless, the cold
+production request transferred both
+`desktop-home-light@1x.webp` (69,854 encoded bytes, initiated by `link`) and
+`desktop-home-dark@1x.webp` (70,624 encoded bytes, initiated by `img`): 140,478
+encoded bytes before any scroll. The SSR snapshot renders the dark source and
+hydration can switch it to the visitor's light theme, while the light preload
+has already run.
+
+**Suggested fix:** Remove the route-level high-priority image preloads and let
+the existing lazy image load near the section. If early discovery is later
+proven necessary, render a theme-selecting `<picture>` whose media sources are
+stable across SSR and hydration, then validate that one—not two—renditions load.
+
+### PERF-2 — P2: every public route hydrates through a 667 KB shared client chunk
+
+**Location:** `myscrollr.com/src/client.tsx:4-15` and
+`myscrollr.com/src/client.tsx:48-58`.
+
+**Evidence/reproduction:** The production build emitted a 667,377-byte raw /
+216,950-byte gzip common chunk, above the lens's 100 KB threshold. The current
+production homepage transferred a 240,670-byte encoded common chunk. Generated
+HTML module-preloads that chunk on each sampled prerender: `/` referenced
+865,028 raw bytes of CSS/JS assets, `/sports` 851,027, `/download` 845,223,
+`/status` 856,853, and `/releases` 961,505. Source-map attribution for the local
+common chunk included 545,403 source bytes from `react-dom`, 337,368 from
+`motion-dom`, 165,013 from `@tanstack/router-core`, 157,443 from `framer-motion`,
+105,319 from `@sentry/core`, and the globally imported Logto/Jose code. The same
+build also emitted two other assets above 100 KB raw: shared CSS at 177,846
+bytes (24,920 gzip) and the `/releases` route chunk at 116,282 bytes (40,940
+gzip).
+
+**Suggested fix:** Treat this as a measured follow-up, not scope for the SEO-copy
+refinement. Split authenticated Logto/provider code and route-only libraries
+from the public bootstrap while preserving operational Sentry coverage; then
+use a bundle visualizer/metafile to pick the next split. Do not add manual
+chunks blindly—the common bundle needs attribution first.
+
+### PERF-3 — P2: public recurring work continues while the document is hidden
+
+**Location:** `myscrollr.com/src/hooks/useDemoTicker.ts:683-693`,
+`myscrollr.com/src/components/DemoTickerBar.tsx:85-90`,
+`myscrollr.com/src/routes/widgets.tsx:66-78`,
+`myscrollr.com/src/routes/business.tsx:877-885`, and
+`myscrollr.com/src/routes/status.tsx:108,155-193`.
+
+**Evidence/reproduction:** The shared demo ticker schedules a React state update
+every 3,000 ms on nearly every public route and a clock update every 30,000 ms.
+`/widgets` and `/business` each add another 3,000 ms interval. `/status` issues
+three requests (`/health`, `/events/count`, `/channels`) immediately and every
+30,000 ms, or 360 requests/hour while left open. All intervals clean up on
+unmount, but none checks `document.visibilityState`; therefore their callbacks
+(and status requests) remain scheduled for background tabs. Browser RAF-based
+visual motion is automatically throttled/paused by the browser and is not part
+of this finding.
+
+**Suggested fix:** Pause the 3-second demo updates and `/status` polling on
+`visibilitychange`, resuming with one immediate refresh when visible. The
+30-second display clock can use the same shared visibility gate if profiling
+shows it matters.
+
+## Timer, listener, and background-work inventory
+
+| Surface | Recurring work | Cleanup | Hidden behavior |
+|---|---:|---|---|
+| Shared demo ticker | 3 s chip update; 30 s clock update | Both intervals clear on unmount (`useDemoTicker.ts:687-694`, `DemoTickerBar.tsx:85-90`) | No visibility gate |
+| `/widgets` | 3 s sample-chip update | Clears on unmount (`widgets.tsx:71-78`) | No visibility gate |
+| `/business` | 3 s branded-chip update | Clears on unmount (`business.tsx:881-885`) | No visibility gate |
+| `/status` | 3 fetches immediately and every 30 s | Clears interval on unmount (`status.tsx:188-194`) | No visibility gate |
+| Theme media query | `change` listener | Removed on cleanup (`useTheme.ts:108-120`) | Event-driven only |
+| Header and dialogs | Keyboard/pointer listeners | Removed on cleanup (`Header.tsx:67-76`, `DownloadButton.tsx:176-195`) | Event-driven only |
+| FAQ | Resize and keyboard listeners | Removed on cleanup (`FAQSection.tsx:434-476`) | Event-driven only |
+| Demo store | One module-lifetime `storage` listener | No component cleanup (`useDemoTicker.ts:255-266`) | One listener per loaded module, not per subscription; no accumulating leak found |
+| Business copy feedback | One 2 s timeout after click | No explicit cancellation (`business.tsx:627`) | Bounded single timeout; no material growth reproduced |
+
+## SEO-change risk summary
+
+- Fix PERF-1 in this refinement: it is directly evidenced on production, is
+  localized, and removes an unnecessary high-priority transfer without changing
+  crawler content.
+- Keep PERF-2 and PERF-3 as separate measured follow-ups unless this task is
+  explicitly expanded. Neither requires a new dependency, and neither should
+  block factual/canonical/schema corrections.
+- No render-blocking synchronous external script was found. The generated entry
+  script is `type="module" async`; the 177,846-byte stylesheet is the only
+  render-blocking asset class observed, and the two self-hosted font preloads are
+  90,096 bytes (Archivo variable) and 25,336 bytes (IBM Plex Mono 400).

--- a/audit/REPORT.md
+++ b/audit/REPORT.md
@@ -1,0 +1,39 @@
+# SCROLLR-191 final audit report
+
+## Outcome
+
+The public marketing surface is crawler-accessible and internally coherent after the fixes in this branch. The audit found no evidence that a new `/open-source-desktop-ticker` route would add distinct value beyond the existing homepage, architecture page, widget catalog, downloads, and GitHub repository, so no duplicate landing page was added.
+
+## Fixed here
+
+| Finding | Resolution |
+| --- | --- |
+| Private SPA routes and unknown paths returned an indexable homepage shell | The nginx fallback is limited to known account, callback, invite, admin, and public-profile routes; those responses carry `X-Robots-Tag: noindex, nofollow`; unknown and case-variant paths return 404. `/admin` was added to `robots.txt`. |
+| `/channels`, trailing slashes, and direct `index.html` URLs created duplicates | Narrow, query-preserving 301 redirects now lead to the slashless canonical URL and `/widgets`. |
+| Software schema published the website package version | `SoftwareApplication.softwareVersion` now uses the fetched desktop release version, with a postbuild assertion. |
+| Breadcrumb schema had no visible breadcrumb UI | Breadcrumb JSON-LD was removed instead of adding redundant navigation. |
+| Crawler-visible widget snapshot was 15 entries behind the server catalog | The snapshot now matches all 50 server entries in server order; a source-level drift test prevents recurrence. |
+| AI digests contained retired features, volatile counts, old URLs, and unsupported business promises | Both `llms` files were reduced to stable, canonical facts and current URLs. Business claims now require a written scope instead of promising price, SLA, licensing, or delivery terms. |
+| “Zero tracking” and account-free absolutes conflicted with the product | Public copy now distinguishes no advertising trackers from operational diagnostics and opt-in product analytics, and distinguishes downloading/browsing from signing in to add live data. |
+| Live delivery copy implied guaranteed source latency | Copy now states that updates appear when Scrollr receives them and names upstream and connectivity caveats. |
+| Mobile navigation allowed keyboard focus to escape | The existing dialog now traps Tab and Shift+Tab using native focus APIs; Escape and focus return remain intact. |
+| `/support` nested `<main>` and skipped from H1 to H3 | The route wrapper is now a `div` and FAQ questions are H2 headings. |
+| Homepage preloaded both below-fold theme screenshots | The route-level high-priority preloads were removed; the existing lazy image behavior remains. |
+| The responsive checker silently served directory requests as its own 500 page | Its local server now resolves route directories to `index.html`, so all viewport checks exercise the real pages. |
+| Public GitHub links used the superseded owner | Active website, download, release, package, schema, and README links now use `doughknee/myscrollr`. |
+
+## Verified
+
+- Production baseline: 18 public routes returned 200 to Googlebot, Bingbot, and OAI-SearchBot; all had one H1, self-canonicals, matching Open Graph metadata, and parseable JSON-LD. No broken internal links were found.
+- Local production build: 18 route contracts, sitemap, SPA-shell, Sentry tunnel, hydration-provider, structured-version, and 56 responsive checks passed.
+- Exact nginx configuration in a stock Alpine nginx container: public route 200; canonical and legacy redirects 301 with query preservation; private routes 200 with `noindex, nofollow`; unknown, case-variant, and synthetic shell paths 404.
+- Unit suite: 125 tests passed, including the new catalog drift guard.
+
+## Deferred, not blockers
+
+- The apex HTTP → HTTPS → apex behavior for `www` can take two hops because TLS/host normalization is split between ingress and nginx. Both paths converge correctly; changing ingress was outside this PR.
+- The shared client chunk remains about 667 kB raw / 217 kB gzip. Route-level splitting is a broader performance task.
+- Some public demo/status timers continue while their tab is hidden. Pausing them is a broader runtime optimization.
+- The CSP still permits inline scripts/styles required by the current stack. No injection path was found; nonce/hash migration is a separate security project.
+- Four orphaned legacy landing components retain old copy but are not imported, built, or crawler-visible. They can be deleted in a dedicated dead-code cleanup if desired.
+- The released desktop help still mentions Intel macOS even though current public assets are Apple Silicon only. Correcting the already released binary belongs to a future desktop release; this PR does not imply that release or Windows signing has shipped.

--- a/audit/SECURITY.md
+++ b/audit/SECURITY.md
@@ -1,0 +1,139 @@
+# SCROLLR-191 security and crawler-boundary audit
+
+Scope: public `myscrollr.com` crawler delivery, private-route indexing controls,
+nginx/ingress host handling, and the security headers that affect those
+surfaces. This is an audit only; no production code was changed.
+
+## Findings
+
+### SEC-01 — P1 — Private SPA routes are served indexable homepage HTML
+
+**References:** `myscrollr.com/Dockerfile:154`, `myscrollr.com/Dockerfile:163`,
+`myscrollr.com/Dockerfile:166`, `myscrollr.com/public/robots.txt:10`,
+`myscrollr.com/public/robots.txt:11`, `myscrollr.com/public/robots.txt:17`,
+`myscrollr.com/vite.config.ts:71`, `myscrollr.com/vite.config.ts:78`,
+`myscrollr.com/src/routes/account.tsx:29`,
+`myscrollr.com/src/routes/admin.tsx:16`,
+`myscrollr.com/src/routes/callback.tsx:4`,
+`myscrollr.com/src/routes/invite.tsx:8`,
+`myscrollr.com/src/routes/u.$username.tsx:16`.
+
+The source-level `noindex` declarations on `/account`, `/admin`, and `/u/*`
+only run after client routing. Those routes are excluded from prerendering and
+nginx answers them with `_shell.html`; that raw response has the homepage title
+and neither a robots meta tag nor an `X-Robots-Tag` header. `/callback` and
+`/invite` do not declare route-level `noindex` at all. The wildcard robots group
+also omits `/admin`. More fundamentally, a `Disallow` does not guarantee that a
+known URL stays out of an index, and it prevents compliant crawlers from
+fetching the page-level `noindex` directive.
+
+**Reproduction/evidence:** Fetching `/admin`, `/account`,
+`/callback?code=redacted`, `/invite?token=redacted`, and `/u/example` with a
+`Googlebot` user agent returned `200`, the homepage title, no canonical, no
+robots meta, and no `X-Robots-Tag`. Each response was the same 18,697-byte SPA
+shell. Fetching `robots.txt` as Googlebot, Bingbot, GPTBot, ClaudeBot,
+PerplexityBot, and CCBot returned the same wildcard rules; all included the
+account rule and all omitted an admin rule.
+
+**Suggested fix:** Give every known private/dynamic route an explicit nginx
+location that serves the SPA shell with `X-Robots-Tag: noindex, nofollow`, add
+the missing route heads for defense in depth, and make the robots policy
+consistent with the chosen crawl-versus-noindex strategy.
+
+### SEC-02 — P1 — Arbitrary paths return a 200 homepage shell (soft 404)
+
+**References:** `myscrollr.com/Dockerfile:154`,
+`myscrollr.com/Dockerfile:163`, `myscrollr.com/Dockerfile:166`.
+
+The catch-all `try_files` sends every nonexistent path to `_shell.html` with a
+successful status. This lets crawlers discover unlimited 200 responses with
+homepage metadata at arbitrary URLs, wasting crawl budget and creating soft-404
+or duplicate-content signals.
+
+**Reproduction/evidence:** A Googlebot request to
+`https://myscrollr.com/does-not-exist` returned `200`, an 18,697-byte body, and
+the title `Scrollr — Live Desktop Ticker for Sports, Stocks & News`, with no
+robots tag or canonical. It was byte-identical in size to the five private SPA
+route responses above.
+
+**Suggested fix:** Restrict SPA fallback handling to the finite authenticated
+and dynamic route patterns and return a real `404` for all other missing paths.
+
+### SEC-03 — P2 — CSP permits all inline scripts on public and authenticated pages
+
+**References:** `myscrollr.com/Dockerfile:184`,
+`myscrollr.com/Dockerfile:187`, `myscrollr.com/src/routes/__root.tsx:126`.
+
+The site has a useful CSP, but `script-src 'unsafe-inline'` removes most of its
+protection against an injected inline script on every route, including account
+and staff routes. The current static shell legitimately contains inline
+bootstrap code, so removing the directive is not a one-line change; no
+exploitable injection source was demonstrated in this scoped audit.
+
+**Reproduction/evidence:** The live `Content-Security-Policy` header contains
+`script-src 'self' 'unsafe-inline' https://js.stripe.com`; the built
+`dist/client/_shell.html` contains four inline script elements with bodies of
+695, 919, 739, and 35 bytes.
+
+**Suggested fix:** Move the inline theme/bootstrap code behind CSP hashes or
+per-response nonces, then remove `'unsafe-inline'` from `script-src`.
+
+### SEC-04 — P2 UNCERTAIN — An external origin may frame every site route
+
+**References:** `myscrollr.com/Dockerfile:187`.
+
+`frame-ancestors` allows `https://relentnet.com` to embed public, account, and
+staff routes. A repository-wide search found no other reference documenting an
+embed integration, so this may be a stale permission; if it is intentional,
+the external dependency is not represented in this repository.
+
+**Reproduction/evidence:** The live CSP is `frame-ancestors 'self'
+https://relentnet.com`, and `rg "relentnet.com|frame-ancestors"` found only the
+Dockerfile directive.
+
+**Suggested fix:** Confirm the embed owner and remove
+`https://relentnet.com` from `frame-ancestors` unless an active integration
+requires it.
+
+## Verified controls and non-findings
+
+| Boundary | Evidence | Verdict |
+|---|---|---|
+| Crawler user agents | `robots.txt:10` uses one `User-agent: *` group; live requests from Googlebot, Bingbot, GPTBot, ClaudeBot, PerplexityBot, and CCBot received the same rules. | Correct wildcard coverage; the private-route omissions are captured in SEC-01. |
+| Sitemap | `scripts/generate-sitemap.mjs:18-37` and `public/sitemap.xml:3-92` contain only the 18 intended public routes; no account, admin, callback, invite, profile, or shell URL is listed. | Pass. |
+| Canonical host | `Dockerfile:83-88` redirects www to apex. Live `https://www.myscrollr.com/sports/?probe=security` returned `301` to `https://myscrollr.com/sports/?probe=security`. | Pass; query string preserved. |
+| Trailing slash | `Dockerfile:158-160` narrows redirects to public marketing routes. Live `/sports/?probe=security` returned `301` to `/sports?probe=security`. | Pass; query string preserved. |
+| Host routing | `k8s/ingress.yaml:27-74` declares only apex, www, and API hosts. A TLS request sent to the apex address with `Host: evil.example` returned `404`; apex returned `200`, and www returned the intended `301`. | Pass at the public ingress. The Docker default server's broad `_` name is not publicly reachable through the tested ingress. |
+| HTTPS/HSTS | The live HTTP endpoint returned `308` to the same HTTPS URL with its query intact; HTTPS responses carry `Strict-Transport-Security: max-age=31536000; includeSubDomains`. | Pass, but both controls are supplied by the ingress/controller rather than this website manifest and therefore require deployment-level regression checks. |
+| Response headers | `Dockerfile:184-187` supplies nosniff, referrer, permissions, CSP, `base-uri`, `form-action`, and `frame-ancestors`; live apex, www redirect, public, and private-shell responses carried them. | Pass except SEC-03 and the uncertain exception in SEC-04. |
+| Injection search | `releases.tsx:76-77` sanitizes rendered release markdown with DOMPurify; `CustomizationShowcase.tsx:173-176` injects only module-owned constant copy; `__root.tsx:126` injects a module-owned theme script. | No crawler-boundary injection finding. |
+| Native/IPC | The scoped website is a static React/nginx runtime and the inventory identifies no native bridge or IPC entry point. | Not applicable. |
+| Webhooks/server-side fetch | The scoped static marketing runtime has no inbound webhook or user-controlled server-side fetch. | Not applicable. |
+| Secrets | `Dockerfile:49-68` distinguishes public `VITE_*` values from builder-only Sentry credentials, and the final image starts from a fresh nginx stage at `Dockerfile:75-79`. | No client-secret finding in scope. |
+
+## Dependency audit
+
+`npm audit --omit=dev --json` reported 33 advisories (11 high, 16 moderate,
+6 low, 0 critical). The high chains are Vite/build tooling and its transitive
+packages (`@babel/core`, Browserslist, js-yaml, nanoid, picomatch, PostCSS,
+Rollup, and Undici). They are used during build/dev, do not ship in the fresh
+nginx runtime image (`Dockerfile:75-79`), and their advisory preconditions
+require a dev server, untrusted build input/config, proxy/cache APIs, or direct
+parser/generator calls that the static production site does not expose. The
+runtime DOMPurify advisory is moderate/low and requires
+`CUSTOM_ELEMENT_HANDLING` or the `IN_PLACE` hook; `releases.tsx:76-77` uses only
+`USE_PROFILES: { html: true }`. No high/critical advisory was found reachable
+through the scoped production crawler surface.
+
+## Summary
+
+| Severity | Count | Findings |
+|---|---:|---|
+| P0 | 0 | — |
+| P1 | 2 | SEC-01 private routes lack effective raw-response noindex; SEC-02 arbitrary paths are soft 404s |
+| P2 | 2 | SEC-03 inline-script CSP weakening; SEC-04 uncertain external framing exception |
+
+The SEO QA PR is blocked on the two shared nginx fallback defects. The existing
+sitemap, wildcard crawler coverage, canonical host redirects, query
+preservation, public ingress host rejection, and edge-managed HTTPS/HSTS all
+passed direct verification.

--- a/audit/UI-STATES.md
+++ b/audit/UI-STATES.md
@@ -1,0 +1,136 @@
+# UI states audit — SCROLLR-191
+
+Audit date: 2026-09-10
+
+Scope: the public website surfaces listed in `audit/INVENTORY.md`. This was a
+read-only audit; no production code or external data was changed.
+
+## Method
+
+- Inspected the public production site in a fresh Codex in-app browser tab.
+- Visited every inventory route at desktop, 320 px, 390 px, and 768 px viewport
+  overrides. The live DOM was checked for horizontal overflow, landmark counts,
+  heading order, unnamed links/buttons, and images without `alt` attributes.
+- Ran the existing `scripts/check-mobile-viewport.mjs` against the current local
+  build. Its 56 route/viewport checks passed at 320, 390, 412, and 768 px.
+- Exercised keyboard entry, the skip link, the mobile navigation dialog, Escape,
+  and focus return. The status API was temporarily delayed and then blocked in
+  the isolated QA tab to verify loading and error states; normal networking was
+  restored and the healthy state reverified.
+- Filtered `/widgets` with a 204-character unbroken query to exercise its empty
+  and maximal-input state. It showed a named empty result and did not overflow.
+- Read warning/error console entries after the live public-route pass. None were
+  recorded, including no hydration warning on these public loads.
+
+Screenshots were not created. Each failure below is a DOM/accessibility-state
+defect (landmark nesting, heading level, or focus containment) that a still image
+would not materially evidence; the exact runtime observations are included.
+
+## Findings
+
+### UI-1 — P1 — Support nests a second `main` landmark
+
+- **Location:** `myscrollr.com/src/routes/support.tsx:58` (inside the shared
+  `main#main-content` in `myscrollr.com/src/routes/__root.tsx:236`).
+- **Reproduction/evidence:** Load `/support` and evaluate
+  `document.querySelectorAll('main')`. Production returns `2`; the outer element
+  is `main#main-content` and its first child route landmark begins `<main>...`.
+  Every other public inventory route returned exactly one `main`.
+- **Impact:** Nested main landmarks make screen-reader landmark navigation
+  ambiguous and violate the page's otherwise consistent one-main document
+  structure.
+- **Suggested fix:** Change the route wrapper at line 58 (and closing tag at
+  line 125) to a neutral `div`; keep the shared root `main` as the sole landmark.
+
+### UI-2 — P1 — Support jumps from its H1 directly to FAQ H3 headings
+
+- **Location:** `myscrollr.com/src/components/support/SupportFAQ.tsx:35`.
+- **Reproduction/evidence:** On production `/support`, the rendered heading list
+  is one H1 (`STUCK? PROBABLY NOT FOR LONG.`) followed directly by eight H3 FAQ
+  questions. No H2 is rendered anywhere on the page. The section labels are
+  styled text, not headings.
+- **Impact:** The document outline implies missing parent sections and makes the
+  FAQ hierarchy less useful to crawlers and heading-based assistive navigation.
+- **Suggested fix:** Make the FAQ question headings H2, or add a real visible or
+  visually-hidden H2 that owns the FAQ group before retaining H3 questions. The
+  former is the smallest correct change for the current flat page structure.
+
+### UI-3 — P1 — Keyboard focus escapes the modal mobile navigation
+
+- **Location:** `myscrollr.com/src/components/Header.tsx:129-190`, especially the
+  `aria-modal="true"` dialog at lines 142-153.
+- **Reproduction/evidence:** At the 390 px production viewport, open **Open
+  menu**, then press Tab through its controls. Focus begins on the dialog and
+  traverses its wordmark, Close, four navigation links, account link, and
+  Download. The next Tab lands on the page's background **Download for Windows**
+  button (`insideDialog === false`), followed by **See the widgets**. The
+  background is not inert. Escape does close the drawer and correctly returns
+  focus to **Open menu**.
+- **Impact:** The control declares a modal dialog but permits keyboard users to
+  interact with obscured background content.
+- **Suggested fix:** While open, trap Tab/Shift+Tab within the drawer and make
+  the background inert. Reuse the existing first/last focusable elements; no
+  dependency is needed. Preserve the already-correct Escape and focus-return
+  behavior.
+
+## Verified positives
+
+- Every route rendered exactly one H1, one footer, descriptive names for all
+  rendered links/buttons, and no image missing an `alt` attribute.
+- All routes except `/support` rendered exactly one `main`; navigation landmarks
+  were named where multiple navigation regions need disambiguation.
+- Heading order on all non-Support pages followed the rendered H1/H2/H3 section
+  structure without a skipped level.
+- The first Tab on mobile reveals **Skip to main content**; activating it moves
+  focus to `main#main-content` and updates the fragment to `#main-content`.
+- A global `:focus-visible` ring exists in `src/styles.css:1117-1118`, and the
+  skip link has a visible focused treatment.
+- Current content produced no horizontal overflow on any inventory route at the
+  tested desktop, 320, 390, or 768 px browser sizes. The existing local check
+  also passed all 56 checks at 320, 390, 412, and 768 px.
+- `/status` showed stable **CHECKING** / **Waiting on first health check** content
+  under a delayed API and styled **API UNREACHABLE** / channel fallback content
+  under blocked API requests, with no horizontal overflow. It automatically
+  retries on the existing 30-second polling interval. Normal networking was
+  restored and **ALL SYSTEMS OPERATIONAL** was reverified.
+- `/widgets` showed a descriptive no-match state for a long client-side search
+  query and remained within the viewport.
+- `/channels` resolved to `/widgets` as intended and inherited its responsive,
+  semantic, and empty-state results.
+
+## State coverage
+
+Legend: **U-S** = VERIFIED UNREACHABLE because the surface is statically
+rendered and has no runtime loading/empty/error branch; **U-R** = VERIFIED
+UNREACHABLE because `/channels` immediately redirects to `/widgets`; **PASS-S**
+= source-verified fallback not triggerable from the populated static production
+artifact. “Constrained” includes the 320/390/768 px layout and basic keyboard
+checks.
+
+| Surface | Loading | Empty | Error | Overflow / maximal content | Constrained / keyboard |
+|---|---|---|---|---|---|
+| `/` | U-S | U-S | U-S | PASS | **FAIL UI-3** |
+| `/widgets` | U-S | PASS (long no-match query) | U-S | PASS | PASS |
+| `/sports` | U-S | U-S | U-S | PASS | PASS |
+| `/markets` | U-S | U-S | U-S | PASS | PASS |
+| `/news` | U-S | U-S | U-S | PASS | PASS |
+| `/fantasy` | U-S | U-S | U-S | PASS | PASS |
+| `/download` | U-S | U-S | U-S | PASS | PASS |
+| `/download/mac` | U-S | U-S | U-S | PASS | PASS |
+| `/download/windows` | U-S | U-S | U-S | PASS | PASS |
+| `/download/linux` | U-S | U-S | U-S | PASS | PASS |
+| `/uplink` | U-S | U-S | U-S | PASS | PASS |
+| `/uplink/lifetime` | U-S | U-S | U-S | PASS | PASS |
+| `/business` | U-S | U-S | U-S | PASS | PASS |
+| `/architecture` | U-S | U-S | U-S | PASS | PASS |
+| `/releases` | U-S | PASS-S (`EmptyState`) | U-S | PASS | PASS |
+| `/support` | U-S | U-S | U-S | PASS | **FAIL UI-1, UI-2** |
+| `/legal` | U-S | U-S | U-S | PASS | PASS |
+| `/status` | PASS | PASS (service fallback) | PASS | PASS | PASS |
+| `/channels` | U-R | U-R | U-R | PASS after redirect | PASS after redirect |
+
+The authenticated account/admin routes were not opened or modified; they are
+outside this public-surface lens and the QA tab did not touch existing preview
+or authenticated admin tabs. Checkout and support-form submission states were
+not forced because doing so would create external side effects and belongs to
+their owning workstreams, not this read-only SEO audit.

--- a/audit/inspect-built.mjs
+++ b/audit/inspect-built.mjs
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = new URL('../myscrollr.com/dist/client/', import.meta.url)
+const routes = [
+  '/',
+  '/widgets',
+  '/fantasy',
+  '/sports',
+  '/markets',
+  '/news',
+  '/releases',
+  '/download',
+  '/download/mac',
+  '/download/windows',
+  '/download/linux',
+  '/business',
+  '/architecture',
+  '/support',
+  '/legal',
+  '/uplink',
+  '/uplink/lifetime',
+  '/status',
+]
+
+function decode(value = '') {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&#x27;', "'")
+    .replaceAll('&quot;', '"')
+}
+
+function match(html, pattern) {
+  return decode(html.match(pattern)?.[1])
+}
+
+const results = routes.map((route) => {
+  const path = route === '/' ? 'index.html' : join(route.slice(1), 'index.html')
+  const html = readFileSync(new URL(path.replaceAll('\\', '/'), root), 'utf8')
+  const title = match(html, /<title>(.*?)<\/title>/s)
+  const description = match(
+    html,
+    /<meta name="description" content="([^"]*)"/,
+  )
+  const canonical = match(html, /<link rel="canonical" href="([^"]+)"/)
+  const ogTitle = match(html, /<meta property="og:title" content="([^"]*)"/)
+  const ogDescription = match(
+    html,
+    /<meta property="og:description" content="([^"]*)"/,
+  )
+  const ogUrl = match(html, /<meta property="og:url" content="([^"]*)"/)
+  const ogImage = match(html, /<meta property="og:image" content="([^"]*)"/)
+  const robots = match(html, /<meta name="robots" content="([^"]*)"/)
+  const headings = [...html.matchAll(/<h([1-6])\b/gi)].map((item) => item[1])
+  const schema = [...html.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/gs)].map(
+    (item) => JSON.parse(item[1])['@type'],
+  )
+
+  return {
+    route,
+    title,
+    descriptionLength: description.length,
+    canonical,
+    metadataMatches:
+      ogTitle === title &&
+      ogDescription === description &&
+      ogUrl === canonical &&
+      ogImage.startsWith('https://myscrollr.com/og/'),
+    robots,
+    headingSequence: headings.join(''),
+    h1Count: headings.filter((level) => level === '1').length,
+    schema,
+  }
+})
+
+console.log(JSON.stringify(results, null, 2))
+
+for (const field of ['title']) {
+  const grouped = Map.groupBy(results, (row) => row[field])
+  for (const [value, rows] of grouped) {
+    if (rows.length > 1) {
+      console.error(`duplicate ${field}: ${value}: ${rows.map((row) => row.route)}`)
+      process.exitCode = 1
+    }
+  }
+}

--- a/audit/inspect-live.mjs
+++ b/audit/inspect-live.mjs
@@ -1,0 +1,138 @@
+const base = process.env.SCROLLR_AUDIT_BASE_URL ?? 'https://myscrollr.com'
+const routes = [
+  '/',
+  '/widgets',
+  '/fantasy',
+  '/sports',
+  '/markets',
+  '/news',
+  '/releases',
+  '/download',
+  '/download/mac',
+  '/download/windows',
+  '/download/linux',
+  '/business',
+  '/architecture',
+  '/support',
+  '/legal',
+  '/uplink',
+  '/uplink/lifetime',
+  '/status',
+]
+
+function value(html, pattern) {
+  return html.match(pattern)?.[1] ?? ''
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(new URL(path, base), {
+    redirect: 'manual',
+    ...options,
+  })
+  return {
+    response,
+    body: options.method === 'HEAD' ? '' : await response.text(),
+  }
+}
+
+const pages = []
+const internalLinks = new Set()
+for (const route of routes) {
+  const { response, body } = await request(route, {
+    headers: { 'user-agent': 'Googlebot' },
+  })
+  const canonical = value(body, /<link rel="canonical" href="([^"]+)"/)
+  const schemas = [...body.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/gs)].map(
+    (item) => JSON.parse(item[1])['@type'],
+  )
+  for (const item of body.matchAll(/href="(\/[^"#?]*)/g)) {
+    internalLinks.add(item[1])
+  }
+  pages.push({
+    route,
+    status: response.status,
+    canonical,
+    selfCanonical: canonical === `${base}${route}`,
+    h1Count: [...body.matchAll(/<h1\b/gi)].length,
+    noindex: /<meta name="robots" content="[^"]*noindex/i.test(body),
+    schemas,
+  })
+}
+
+const variants = []
+for (const url of [
+  ...(base === 'https://myscrollr.com'
+    ? [
+        'http://myscrollr.com/sports?probe=seo',
+        'http://www.myscrollr.com/sports?probe=seo',
+        'https://www.myscrollr.com/sports?probe=seo',
+      ]
+    : []),
+  `${base}/sports/?probe=seo`,
+  `${base}/sports/index.html?probe=seo`,
+  `${base}/Sports?probe=seo`,
+  `${base}/channels?probe=seo`,
+]) {
+  const response = await fetch(url, { redirect: 'manual' })
+  variants.push({
+    url,
+    status: response.status,
+    location: response.headers.get('location'),
+  })
+}
+
+const privateRoutes = []
+for (const path of ['/account', '/admin', '/callback', '/invite', '/u/example', '/not-a-real-route']) {
+  const { response, body } = await request(path, {
+    headers: { 'user-agent': 'Googlebot' },
+  })
+  privateRoutes.push({
+    path,
+    status: response.status,
+    xRobotsTag: response.headers.get('x-robots-tag'),
+    robotsMeta: value(body, /<meta name="robots" content="([^"]+)"/),
+    title: value(body, /<title>(.*?)<\/title>/s),
+  })
+}
+
+const linkChecks = []
+for (const path of [...internalLinks].sort()) {
+  const response = await fetch(new URL(path, base), {
+    method: 'HEAD',
+    redirect: 'manual',
+  })
+  linkChecks.push({ path, status: response.status })
+}
+
+const robots = await request('/robots.txt')
+const sitemap = await request('/sitemap.xml')
+for (const agent of ['Googlebot', 'Bingbot', 'OAI-SearchBot']) {
+  const response = await fetch(`${base}/sports`, {
+    headers: { 'user-agent': agent },
+  })
+  if (response.status !== 200) throw new Error(`${agent} received ${response.status}`)
+}
+
+console.log(
+  JSON.stringify(
+    {
+      pages,
+      variants,
+      privateRoutes,
+      brokenInternalLinks: linkChecks.filter(
+        ({ status }) => status !== 200 && status !== 301 && status !== 302,
+      ),
+      robots: {
+        status: robots.response.status,
+        body: robots.body,
+      },
+      sitemap: {
+        status: sitemap.response.status,
+        urlCount: [...sitemap.body.matchAll(/<loc>/g)].length,
+        hasLastmod: sitemap.body.includes('<lastmod>'),
+      },
+    },
+    null,
+    2,
+  ),
+)

--- a/audit/test-nginx.mjs
+++ b/audit/test-nginx.mjs
@@ -1,0 +1,121 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const dockerfile = readFileSync(
+  resolve(root, "myscrollr.com/Dockerfile"),
+  "utf8",
+);
+const blocks = [
+  ...dockerfile.matchAll(/printf '([\s\S]*?)' > (\/etc\/nginx\/[^\s]+)/g),
+];
+
+function decode(block) {
+  return block
+    .replaceAll(`'"'"'`, "'")
+    .replace(/\\n\\\r?\n/g, "\n")
+    .replaceAll("\\n", "\n");
+}
+
+const configs = Object.fromEntries(
+  blocks.map(([, body, path]) => [path, decode(body)]),
+);
+const main = configs["/etc/nginx/conf.d/default.conf"];
+const headers = configs["/etc/nginx/security-headers.conf"];
+if (!main || !headers) throw new Error("Could not extract nginx configuration");
+
+const name = `scrollr-seo-${process.pid}`;
+const docker = (...args) =>
+  execFileSync("docker", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+
+try {
+  docker(
+    "create",
+    "--name",
+    name,
+    "-e",
+    `MAIN_CONFIG=${Buffer.from(main).toString("base64")}`,
+    "-e",
+    `HEADERS_CONFIG=${Buffer.from(headers).toString("base64")}`,
+    "nginx:alpine",
+    "sh",
+    "-c",
+    'echo "$MAIN_CONFIG" | base64 -d > /etc/nginx/conf.d/default.conf && echo "$HEADERS_CONFIG" | base64 -d > /etc/nginx/security-headers.conf && nginx -g "daemon off;"',
+  );
+  docker(
+    "cp",
+    `${resolve(root, "myscrollr.com/dist/client")}/.`,
+    `${name}:/usr/share/nginx/html`,
+  );
+  docker("start", name);
+
+  let ready = false;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      docker("exec", name, "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3000/");
+      ready = true;
+      break;
+    } catch {
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+    }
+  }
+  if (!ready) {
+    const logs = spawnSync("docker", ["logs", name], { encoding: "utf8" });
+    throw new Error(
+      `${docker("inspect", "-f", "{{json .State}}", name)}\n${logs.stdout}${logs.stderr}`,
+    );
+  }
+
+  const cases = [
+    ["/sports", 200, null, null],
+    ["/sports/?probe=seo", 301, "/sports?probe=seo", null],
+    ["/sports/index.html?probe=seo", 301, "/sports?probe=seo", null],
+    ["/channels?probe=seo", 301, "/widgets?probe=seo", null],
+    ["/index.html?probe=seo", 301, "/?probe=seo", null],
+    ["/channels/index.html?probe=seo", 301, "/widgets?probe=seo", null],
+    ["/account", 200, null, "noindex, nofollow"],
+    ["/admin/support", 200, null, "noindex, nofollow"],
+    ["/u/example", 200, null, "noindex, nofollow"],
+    ["/not-a-real-route", 404, null, null],
+    ["/Sports", 404, null, null],
+    ["/tss-spa-shell", 404, null, null],
+  ];
+
+  for (const [path, status, location, robots] of cases) {
+    const result = spawnSync(
+      "docker",
+      [
+        "exec",
+        name,
+        "sh",
+        "-c",
+        `printf 'GET ${path} HTTP/1.1\r\nHost: myscrollr.com\r\nConnection: close\r\n\r\n' | nc 127.0.0.1 3000`,
+      ],
+      { encoding: "utf8" },
+    );
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    const actualStatus = Number(output.match(/HTTP\/1\.1 (\d+)/)?.[1] ?? 200);
+    const actualLocation = output.match(/^\s*Location:\s*(.+)$/im)?.[1]?.trim() ?? null;
+    const actualRobots = output.match(/^\s*X-Robots-Tag:\s*(.+)$/im)?.[1]?.trim() ?? null;
+    if (
+      actualStatus !== status ||
+      actualLocation !== location ||
+      actualRobots !== robots
+    ) {
+      throw new Error(
+        `${path}: status=${actualStatus}, location=${actualLocation}, x-robots-tag=${actualRobots}\n${output}`,
+      );
+    }
+    console.log(`✓ ${path}: ${status}`);
+  }
+} finally {
+  try {
+    docker("rm", "-f", name);
+  } catch {
+    // Container may have exited after a syntax error.
+  }
+}

--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -151,8 +151,6 @@ server {\n\
     #                          and a mismatch with our canonical URLs\n\
     #                          (sitemap + <link rel=canonical> declare\n\
     #                          /uplink, not /uplink/).\n\
-    #   3. /_shell.html      — SPA fallback for dynamic routes\n\
-    #                          (/account, /callback, /u/$username, etc.)\n\
     # Canonical marketing pages are slashless. Keep this list narrow so\n\
     # assets, auth callbacks, API paths, and the SPA fallback are untouched.\n\
     location ~ ^/(download(?:/(?:mac|windows|linux))?|uplink(?:/lifetime)?|widgets|sports|markets|news|fantasy|releases|architecture|business|support|legal|status)/$ {\n\
@@ -160,10 +158,36 @@ server {\n\
         return 301 /$1$is_args$args;\n\
     }\n\
 \n\
+    # Retired marketing route and direct index-file duplicates.\n\
+    location = /index.html {\n\
+        include /etc/nginx/security-headers.conf;\n\
+        return 301 /$is_args$args;\n\
+    }\n\
+    location = /channels/index.html {\n\
+        include /etc/nginx/security-headers.conf;\n\
+        return 301 /widgets$is_args$args;\n\
+    }\n\
+    location ~ ^/channels/?$ {\n\
+        include /etc/nginx/security-headers.conf;\n\
+        return 301 /widgets$is_args$args;\n\
+    }\n\
+    location ~ ^/(download(?:/(?:mac|windows|linux))?|uplink(?:/lifetime)?|widgets|sports|markets|news|fantasy|releases|architecture|business|support|legal|status)/index\.html$ {\n\
+        include /etc/nginx/security-headers.conf;\n\
+        return 301 /$1$is_args$args;\n\
+    }\n\
+\n\
+    # Only known client-rendered routes receive the SPA shell.\n\
+    location ~ ^/(?:account|callback|invite)/?$|^/admin(?:/.*)?$|^/u/[^/]+/?$ {\n\
+        include /etc/nginx/security-headers.conf;\n\
+        add_header X-Robots-Tag "noindex, nofollow" always;\n\
+        add_header Cache-Control "no-cache";\n\
+        try_files /_shell.html =404;\n\
+    }\n\
+\n\
     location / {\n\
         include /etc/nginx/security-headers.conf;\n\
         add_header Cache-Control "no-cache";\n\
-        try_files $uri $uri/index.html /_shell.html;\n\
+        try_files $uri $uri/index.html =404;\n\
     }\n\
 \n\
     # ── Hashed static assets: cache forever ─────────────────────\n\

--- a/myscrollr.com/package.json
+++ b/myscrollr.com/package.json
@@ -7,7 +7,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/brandon-relentnet/myscrollr.git",
+    "url": "git+https://github.com/doughknee/myscrollr.git",
     "directory": "myscrollr.com"
   },
   "homepage": "https://myscrollr.com",

--- a/myscrollr.com/public/llms-full.txt
+++ b/myscrollr.com/public/llms-full.txt
@@ -1,187 +1,58 @@
 # Scrollr — Full LLM Digest
 
-Scrollr is a quiet desktop ticker for live finance, sports, news, and fantasy data. Open source, privacy-first, and free. Available for macOS, Windows, and Linux.
+Scrollr is a quiet, source-available desktop ticker for live finance, sports, news, prediction-market, fantasy, weather, and system data. The desktop app is the primary product; myscrollr.com provides marketing, account, billing, support, and download pages.
 
-This digest contains the product overview, pricing details, and consolidated FAQ for AI crawler consumption. The desktop app is the primary product; myscrollr.com serves marketing, account management, and billing.
+## Product
 
----
+Scrollr runs as a thin always-on-top bar at the top or bottom of a chosen monitor, plus a separate desktop window for browsing widgets and configuring the ticker. It supports multiple monitors.
 
-## What Scrollr Is
+Server data is delivered to the desktop over a live Server-Sent Events connection. Changes appear automatically when Scrollr receives them. Upstream source timing, corrections, availability, outages, and the user's connection can affect arrival time.
 
-Scrollr is a quiet ticker at the edge of your screen with live sports, markets, news, and fantasy data. It runs as a thin always-on-top bar (top or bottom of any screen), plus a full dashboard for configuration. Five data sources — Finance, Sports, News, Predictions and Fantasy — stream from source APIs through a Change-Data-Capture PubSub pipeline to your desktop. Real-time streaming over Server-Sent Events is available on every tier, including Free.
+The current catalog is maintained at https://myscrollr.com/widgets and includes:
 
-Built with: Go (one gateway API serving every widget route), Rust (ingestion services, Tauri desktop core), React (web + Tauri webview), PostgreSQL (state), Redis (PubSub fan-out), Logto (auth), Stripe (billing).
+- individual widgets for supported sports leagues;
+- separate stock and crypto watchlists;
+- curated news publishers;
+- Yahoo Fantasy leagues, matchups, and standings;
+- Kalshi prediction-market data; and
+- local utilities such as Clock, Timer, Weather, System Monitor, Uptime, and GitHub Actions status.
 
-Core principles: zero tracking, no ads, no data brokers, source available under GNU AGPL v3.0, runs locally.
+The public source is licensed under GNU AGPL v3.0 at https://github.com/doughknee/myscrollr.
 
-## Channels
+## Platforms and downloads
 
-Live data channels:
+- macOS 10.15 or newer on Apple Silicon: DMG.
+- Windows 10 or newer on x64: setup EXE or MSI.
+- Linux on x86_64: AppImage, DEB, or RPM.
 
-- Finance: real-time stock and crypto prices from TwelveData.
-- Sports: live scores across 14 leagues — NFL, NBA, MLB, NHL, F1, UFC, AFL, World Cup, Champions League, Premier League, La Liga, MLS, NCAAF and NCAAM. All available on every tier.
-- News: articles from any RSS feed — a built-in catalog of 11 outlets plus your own URLs, on every tier.
-- Fantasy: Yahoo Fantasy Sports league standings, matchups, and roster updates.
+Current files and installation guidance are at https://myscrollr.com/download. The macOS release workflow includes signing and notarization. Do not infer Windows code-signing status from that macOS workflow.
 
-Utility widgets (no API costs, included on every tier):
+## Accounts and privacy
 
-- Clock
-- Timer
-- Weather
-- System Monitor (CPU, RAM, disk, network)
+You can download and browse Scrollr without an account. Sign-in is required to add live data widgets and sync settings. Account and subscription records are held by Scrollr's authentication and billing systems.
 
-## Pricing
+Scrollr has no advertising trackers and does not sell data to brokers. Operational diagnostics and authentication logs are used to run and secure the service. Optional product analytics, when enabled by the user, is opt-in, coarse, account-linked, desktop-only, and described in the Privacy Policy. See https://myscrollr.com/legal?doc=privacy for the current policy.
 
-All tiers include the full dashboard at myscrollr.com.
+## Plans
 
-Every tier gets every widget, real-time streaming, and unlimited depth inside
-each widget (as many symbols, feeds, leagues or fantasy teams as you like).
-Plans differ by how many widgets you can run at once — a slot — and how many
-ticker rows you get.
+Every tier uses the same app, widgets, and live-delivery path. Plans differ by how many widgets can run at once; paid plans also include priority support and situational early access. Current prices, annual options, widget limits, and lifetime availability are maintained at https://myscrollr.com/uplink and https://myscrollr.com/uplink/lifetime.
 
-### Free
+## Business inquiries
 
-- 3 widget slots
-- 1 ticker row
-- Real-time streaming (Server-Sent Events); 60s polling fallback
-- Every widget in the catalog, including college sports and Yahoo Fantasy
-- Site filtering: blacklist only
+Scrollr can discuss custom-branded deployments and evaluate branding, data-source, integration, multi-display, hosting, licensing, and support requirements. No public price, SLA, delivery timeline, alternative license, or feature commitment applies automatically. Those details require a written proposal for the specific engagement. See https://myscrollr.com/business.
 
-### Uplink — $9.99/month or $79.99/year
+## Canonical pages
 
-- 6 widget slots
-- 2 ticker rows
-- 30s polling fallback
-- Early access to new features
-
-### Uplink Pro — $24.99/month or $199.99/year
-
-- 12 widget slots
-- 3 ticker rows
-- 10s polling fallback
-- Custom alerts (price targets, score thresholds, keyword triggers)
-- Feed profiles, advanced controls, site filtering: blacklist + whitelist
-
-### Uplink Ultimate — $49.99/month or $399.99/year
-
-- Unlimited widget slots
-- 3 ticker rows, with per-row scroll speed, direction and mode
-
-- Webhooks push alerts to Discord, Slack, or any URL
-- Data export (CSV / JSON)
-- API access for personal dashboards or automation
-
-### Lifetime
-
-One-time payment for permanent Uplink access. 128 founding member slots available.
-
-### Business
-
-Branded desktop deployments for teams. Custom branding, multi-display, self-hosted, dedicated support. From $500/mo. See https://myscrollr.com/business.
-
-## Privacy
-
-- No ads, no tracking pixels, no third-party analytics.
-- Your widget setup syncs to your account so it follows you between machines; Scrollr's servers also hold your account profile and subscription status.
-- We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.
-- Source code is publicly available on GitHub under GNU AGPL v3.0.
-
-## FAQ
-
-The questions and answers below are aggregated from the live FAQ sections on myscrollr.com/support and myscrollr.com/uplink. They reflect the canonical Scrollr help content.
-
-### General
-
-#### Is Scrollr free?
-
-Yes. The free tier gives you real-time streaming across every source, three widget slots, and no ads. Paid tiers add slots and ticker rows; they do not unlock data, widgets, or streaming.
-
-#### Does it affect my computer's performance?
-
-Not noticeably. All data flows through a single lightweight connection. The ticker uses minimal CPU and memory. You can check resource usage anytime with the built-in System Monitor widget.
-
-#### Is my data private?
-
-No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines, and Scrollr's servers hold your account profile and subscription status. We also count app versions and error rates so we can find bugs without waiting for someone to report them.
-
-#### What platforms are supported?
-
-Scrollr runs natively on macOS (Apple Silicon), Windows (x64), and Linux (x64). Each platform gets a dedicated build optimized for that OS.
-
-#### Do I need an account?
-
-You can browse widgets and explore the desktop app without signing in. An account is needed to add channels (Finance, Sports, News, Fantasy) and to sync your setup across devices.
-
-#### What data does Scrollr show?
-
-Four channels: live stock and crypto prices (Finance), scores across 20+ leagues (Sports), articles from RSS feeds (News), and Yahoo Fantasy Sports leagues (Fantasy). Plus utility widgets for weather, clocks, system monitoring, uptime, and GitHub Actions.
-
-#### Can I customize the feed?
-
-Extensively. Move the ticker to the top or bottom of the screen by right-clicking it (or using the up/down chevron in the hover toolbar). In Settings > Ticker you can change the detail level (Compact / Detailed), add ticker rows, and adjust speed. Within each channel you can filter, sort, and toggle individual data points on or off under Options > Display preferences.
-
-#### Is Scrollr open source?
-
-Yes. Every line of code is publicly available on GitHub under the GNU AGPL v3.0 license. You can inspect, fork, or contribute.
-
-#### How do I update the app?
-
-Scrollr checks for updates automatically on launch. When an update is available, you'll see a notification prompting you to install. Updates are downloaded in the background and applied on next restart.
-
-#### How does live data work vs. polling?
-
-Every tier gets the same persistent Server-Sent Events connection, so updates arrive the instant data changes on the server. Polling is the fallback for when that connection drops, and its interval does vary by plan: 60s on Free, 30s on Uplink, 10s on Uplink Pro. Ultimate polls at 30s because SSE carries it.
-
-#### What's the difference between Uplink tiers?
-
-Free: 3 widget slots, 1 ticker row. Uplink: 6 slots, 2 rows. Uplink Pro: 12 slots, 3 rows. Uplink Ultimate: unlimited slots, 3 rows with per-row customisation. Every tier gets every widget, real-time streaming, and unlimited depth inside each widget.
-
-### Uplink pricing
-
-#### What does "data delivery" mean?
-
-Data arrives the instant it changes via Server-Sent Events (SSE), the same technology used by stock trading platforms — on every tier, including Free. Polling only matters when that connection drops, and paid plans fall back faster: 60s on Free, 30s on Uplink, 10s on Uplink Pro.
-
-#### How many symbols can I track?
-
-Tracked symbols are the stocks, ETFs, and crypto tickers that appear in your finance feed. There is no cap on any tier — add every ticker you care about and they all stream in real time. What a plan limits is how many widgets you run at once, not how much you put in one.
-
-#### How many RSS feeds can I follow?
-
-RSS feeds power the news widgets. Subscribe to as many as you want on any tier, from the built-in catalog or your own URLs.
-
-#### What are custom RSS feeds?
-
-Beyond the built-in catalog, custom feeds let you paste any RSS or Atom URL. Available on every tier, with no cap.
-
-#### What sports leagues are included?
-
-Every tier includes live scores from all 14 league widgets — NFL, NBA, MLB, NHL, F1, UFC, AFL, World Cup, Champions League, Premier League, La Liga, MLS, and college football and basketball. No league is behind a paid tier.
-
-#### How many fantasy leagues can I connect?
-
-Scrollr syncs with Yahoo Fantasy Sports to show your standings, matchups, and roster updates. Available on every tier, with no cap on leagues.
-
-#### What are custom alerts?
-
-Custom alerts let you define conditions that trigger notifications: a stock hitting a target price, a game entering the 4th quarter, or an RSS item matching a keyword. Alerts are evaluated in the app background — no server round-trip needed. Available on Pro and Ultimate tiers.
-
-#### What are feed profiles and advanced controls?
-
-Feed profiles let you save different configurations — like "Work" showing only finance and RSS, or "Weekend" with sports and fantasy. Advanced controls add pinning, custom sort rules, and per-channel filtering within the feed. Both features are exclusive to Pro and Ultimate tiers.
-
-#### What is site filtering?
-
-Site filtering controls where the feed bar appears. Every tier includes blacklist filtering — hide the bar on specific displays. Pro and Ultimate add whitelist mode on top, so you can restrict the bar to only the displays you choose.
-
-#### What about webhooks, data export, and API access?
-
-Webhooks push your alerts to Discord, Slack, or any URL. Data export lets you download tracked symbols, historical prices, and game results as CSV or JSON. API access gives you programmatic read access to your MyScrollr data for personal dashboards or automation. All three are exclusive to Ultimate.
-
-#### What does early access include?
-
-Every paid tier unlocks early access to new features, channels, and UI updates before they roll out to free users. This includes beta channels, experimental feed modes, and new dashboard widgets. You get to try everything first and provide feedback that shapes the final release.
-
-#### Does every tier get the full dashboard?
-
-Every user gets complete access to the web dashboard at myscrollr.com. You can view all your channels, manage your watchlists, configure feeds, and adjust preferences regardless of your subscription tier. Paid tiers enhance the data flowing into the dashboard, not the dashboard itself.
+- Product overview: https://myscrollr.com/
+- Widget catalog: https://myscrollr.com/widgets
+- Sports: https://myscrollr.com/sports
+- Markets: https://myscrollr.com/markets
+- News and RSS: https://myscrollr.com/news
+- Yahoo Fantasy: https://myscrollr.com/fantasy
+- Downloads: https://myscrollr.com/download
+- Pricing: https://myscrollr.com/uplink
+- Architecture: https://myscrollr.com/architecture
+- Releases: https://myscrollr.com/releases
+- Status: https://myscrollr.com/status
+- Support: https://myscrollr.com/support
+- Legal: https://myscrollr.com/legal

--- a/myscrollr.com/public/llms.txt
+++ b/myscrollr.com/public/llms.txt
@@ -1,28 +1,23 @@
 # Scrollr
 
-> Scrollr is a quiet desktop ticker for live finance, sports, news, and fantasy data. Open source, privacy-first, and free. Available for macOS, Windows, and Linux.
+> Scrollr is a quiet desktop ticker for live finance, sports, news, prediction-market, fantasy, weather, and system data. It is source available under GNU AGPL v3.0 and runs on macOS Apple Silicon, Windows x64, and Linux x86_64.
 
-Scrollr displays a thin always-on-top bar at the edge of your screen showing real-time market prices, sports scores, news headlines, and fantasy league updates. The desktop app is the primary product; this website serves marketing, account management, and billing.
+The always-on-top ticker can sit at the top or bottom of a chosen monitor. A separate desktop window is used to browse widgets and configure the ticker. The website provides marketing, account, billing, support, and download pages.
 
-Core principles: zero tracking, no ads, no data brokers, source available, runs locally.
+Privacy: no advertising trackers or data brokers. Operational diagnostics and authentication logs are used to run and secure the service. Optional product analytics is opt-in, coarse, account-linked, desktop-only, and described in the Privacy Policy.
 
 ## Product
 
-- [Download](https://myscrollr.com/download): Get the Scrollr desktop app for macOS, Windows, or Linux. Free.
-- [Channels](https://myscrollr.com/channels): The widgets Scrollr offers — individual leagues (NFL, NBA, MLB…), Stocks and Crypto, news outlets, Kalshi prediction markets and Yahoo Fantasy, plus local widgets like Clock, Timer, Weather and System Monitor.
-- [Architecture](https://myscrollr.com/architecture): How Scrollr works under the hood — source APIs through CDC PubSub to your desktop.
+- [Download](https://myscrollr.com/download): Current packages and platform requirements.
+- [Widgets](https://myscrollr.com/widgets): The current widget catalog, including individual sports leagues, stocks, crypto, curated news, Yahoo Fantasy, Kalshi, and local utilities.
+- [Architecture](https://myscrollr.com/architecture): How source data reaches the desktop ticker.
+- [Uplink](https://myscrollr.com/uplink): Current plan prices and widget-slot limits.
+- [Business](https://myscrollr.com/business): Discuss a custom deployment; capabilities, price, timing, support, and terms require a written scope.
 
-## Pricing
-
-- [Uplink](https://myscrollr.com/uplink): Premium subscription tiers — Uplink ($9.99/mo), Pro ($24.99/mo), Ultimate ($49.99/mo). Annual plans available with savings.
-- [Lifetime](https://myscrollr.com/uplink/lifetime): One-time payment for forever access. 128 founding member slots.
-- [Business](https://myscrollr.com/business): Branded desktop deployments for teams. From $500/mo.
+You can download and browse without an account. Sign-in is required to add live data widgets and sync settings. Live updates appear automatically when Scrollr receives them; upstream timing, corrections, outages, and the user's connection can affect arrival time.
 
 ## Support
 
-- [Support](https://myscrollr.com/support): FAQs, troubleshooting, billing help, contact form.
-- [Legal](https://myscrollr.com/legal): Terms, Privacy, License, Cookies.
-
-## Optional
-
-- [GitHub](https://github.com/brandon-relentnet/myscrollr): Source code.
+- [Support](https://myscrollr.com/support): FAQs, troubleshooting, billing help, and contact form.
+- [Legal](https://myscrollr.com/legal): Terms, Privacy, License, and Cookies.
+- [GitHub](https://github.com/doughknee/myscrollr): Source code.

--- a/myscrollr.com/public/robots.txt
+++ b/myscrollr.com/public/robots.txt
@@ -9,6 +9,7 @@
 
 User-agent: *
 Disallow: /account
+Disallow: /admin
 Disallow: /invite
 Disallow: /callback
 Disallow: /u/

--- a/myscrollr.com/scripts/check-mobile-viewport.mjs
+++ b/myscrollr.com/scripts/check-mobile-viewport.mjs
@@ -17,7 +17,7 @@
 // always runs it).
 
 import { createServer } from 'node:http'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, extname, join } from 'node:path'
 
@@ -121,8 +121,7 @@ function resolveStaticFile(urlPath) {
 
   const direct = join(clientDir, pathname)
   if (existsSync(direct)) {
-    // If it's a directory request (`/foo/`), serve `index.html`.
-    if (pathname.endsWith('/')) {
+    if (statSync(direct).isDirectory()) {
       const indexPath = join(direct, 'index.html')
       return existsSync(indexPath) ? indexPath : null
     }
@@ -235,7 +234,15 @@ try {
             }
           }
         }
-        return { scrollWidth, clientWidth, offender }
+        return {
+          scrollWidth,
+          clientWidth,
+          offender,
+          mainCount: document.querySelectorAll('main').length,
+          headings: Array.from(document.querySelectorAll('h1, h2, h3')).map(
+            (heading) => heading.tagName,
+          ),
+        }
       })
 
       // Subpixel rendering at 2× DSR can produce off-by-1 scrollWidth
@@ -250,6 +257,18 @@ try {
         failures += 1
       } else {
         console.log(`✓ ${route.path} @ ${viewport.name} (${viewport.width}px)`)
+      }
+
+      if (
+        route.path === '/support' &&
+        (result.mainCount !== 1 ||
+          result.headings[0] !== 'H1' ||
+          result.headings[1] !== 'H2')
+      ) {
+        console.error(
+          `✗ /support semantics: mainCount=${result.mainCount}, headings=${result.headings.join('→')}`,
+        )
+        failures += 1
       }
 
       if (route.path === '/' && viewport.width < 768) {
@@ -320,6 +339,25 @@ try {
             )
             failures += 1
           }
+        }
+
+        await page.getByRole('button', { name: 'Open menu' }).click()
+        await page.locator('#mobile-nav-drawer').waitFor()
+        let focusEscaped = false
+        for (let i = 0; i < 12; i += 1) {
+          await page.keyboard.press('Tab')
+          focusEscaped ||= !(await page.evaluate(() =>
+            document
+              .querySelector('#mobile-nav-drawer')
+              ?.contains(document.activeElement),
+          ))
+        }
+        await page.keyboard.press('Escape')
+        if (focusEscaped) {
+          console.error(
+            `✗ ${route.path} @ ${viewport.name}: focus escaped mobile navigation`,
+          )
+          failures += 1
         }
       }
     }

--- a/myscrollr.com/scripts/check-prerender.mjs
+++ b/myscrollr.com/scripts/check-prerender.mjs
@@ -18,6 +18,14 @@ import { dirname, join } from 'node:path'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const clientDir = join(__dirname, '..', 'dist', 'client')
+const versionSource = readFileSync(
+  join(__dirname, '..', 'src', 'lib', 'latestVersion.generated.ts'),
+  'utf8',
+)
+const latestDesktopVersion = versionSource.match(
+  /LATEST_DESKTOP_VERSION = '([^']+)'/,
+)?.[1]
+if (!latestDesktopVersion) throw new Error('Latest desktop version is missing')
 
 // Per-route expected contract.
 // - `minJsonLd`: minimum <script type="application/ld+json"> blocks
@@ -42,7 +50,7 @@ const ROUTES = [
   {
     path: '/widgets',
     file: 'widgets/index.html',
-    minJsonLd: 2, // organization + breadcrumbs
+    minJsonLd: 1, // organization
     expectedBody: 'Every widget streams live',
   },
   {
@@ -50,104 +58,104 @@ const ROUTES = [
     // vite.config's `pages` — this assertion catches its removal.
     path: '/fantasy',
     file: 'fantasy/index.html',
-    minJsonLd: 4, // organization + softwareApp + FAQPage + breadcrumbs
+    minJsonLd: 3, // organization + softwareApp + FAQPage
     expectedBody: 'The go-ahead touchdown',
   },
   {
     path: '/sports',
     file: 'sports/index.html',
-    minJsonLd: 4,
+    minJsonLd: 3,
     expectedBody: 'Follow the leagues and teams you care about',
     expectedH1: 'Live sports scores on your desktop',
   },
   {
     path: '/markets',
     file: 'markets/index.html',
-    minJsonLd: 4,
+    minJsonLd: 3,
     expectedBody: 'Build separate stock and crypto watchlists',
     expectedH1: 'Live stocks and crypto on your desktop',
   },
   {
     path: '/news',
     file: 'news/index.html',
-    minJsonLd: 4,
+    minJsonLd: 3,
     expectedBody: 'Choose from the built-in source catalog',
     expectedH1: 'Live news and RSS feeds on your desktop',
   },
   {
     path: '/releases',
     file: 'releases/index.html',
-    minJsonLd: 2,
+    minJsonLd: 1,
     expectedBody: 'No commit-log archaeology.',
     expectedH1: 'Every build, dated and signed.',
   },
   {
     path: '/download',
     file: 'download/index.html',
-    minJsonLd: 3, // organization + softwareApp + breadcrumbs
+    minJsonLd: 2, // organization + softwareApp
     expectedBody: 'One small native app',
   },
   {
     path: '/download/mac',
     file: 'download/mac/index.html',
-    minJsonLd: 3, // organization + softwareApp + breadcrumbs
+    minJsonLd: 2, // organization + softwareApp
     expectedBody: 'Requires Apple Silicon and macOS 10.15 or later.',
     expectedH1: 'Get Scrollr for macOS. Free. No sign-up.',
   },
   {
     path: '/download/windows',
     file: 'download/windows/index.html',
-    minJsonLd: 3,
+    minJsonLd: 2,
     expectedBody: 'Built as an x64 Windows setup executable.',
     expectedH1: 'Get Scrollr for Windows. Free. No sign-up.',
   },
   {
     path: '/download/linux',
     file: 'download/linux/index.html',
-    minJsonLd: 3,
+    minJsonLd: 2,
     expectedBody: 'Choose the package that matches your x86_64 distribution.',
     expectedH1: 'Get Scrollr for Linux. Free. No sign-up.',
   },
   {
     path: '/business',
     file: 'business/index.html',
-    minJsonLd: 2, // organization + breadcrumbs
+    minJsonLd: 1, // organization
     expectedBody: 'Sports bars',
   },
   {
     path: '/architecture',
     file: 'architecture/index.html',
-    minJsonLd: 3, // organization + TechArticle + breadcrumbs
+    minJsonLd: 2, // organization + TechArticle
     expectedBody: 'Per-user Redis',
   },
   {
     path: '/support',
     file: 'support/index.html',
-    minJsonLd: 3, // organization + FAQ + breadcrumbs
+    minJsonLd: 2, // organization + FAQ
     expectedBody: 'Most answers are a scroll away',
   },
   {
     path: '/legal',
     file: 'legal/index.html',
-    minJsonLd: 2, // organization + breadcrumbs
+    minJsonLd: 1, // organization
     expectedBody: 'Terms of Service',
   },
   {
     path: '/uplink',
     file: 'uplink/index.html',
-    minJsonLd: 4,
+    minJsonLd: 3,
     expectedBody: 'Plans for more widgets at once',
-  }, // org + productOffers + faq + breadcrumbs
+  }, // org + productOffers + faq
   {
     path: '/uplink/lifetime',
     file: 'uplink/lifetime/index.html',
-    minJsonLd: 2, // organization + breadcrumbs
+    minJsonLd: 1, // organization
     expectedBody: 'One payment. Permanent access.',
   },
   {
     path: '/status',
     file: 'status/index.html',
-    minJsonLd: 2, // organization + breadcrumbs
+    minJsonLd: 1, // organization
     // No body assertion: status body renders live data via useEffect,
     // so the prerendered HTML body is intentionally minimal.
   },
@@ -155,7 +163,13 @@ const ROUTES = [
 
 const SITE_ORIGIN = 'https://myscrollr.com'
 const PRERENDERED_PATHS = new Set(ROUTES.map((route) => route.path))
-const DYNAMIC_PATH_PREFIXES = ['/account', '/callback', '/invite', '/u/']
+const DYNAMIC_PATH_PREFIXES = [
+  '/account',
+  '/admin',
+  '/callback',
+  '/invite',
+  '/u/',
+]
 const SERVICE_PATHS = new Set(['/health', '/swagger/index.html'])
 
 let failures = 0
@@ -219,12 +233,22 @@ for (const route of ROUTES) {
       /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/g,
     ),
   ]
+  const schemas = []
   for (const script of jsonLdScripts) {
     try {
-      JSON.parse(script[1])
+      schemas.push(JSON.parse(script[1]))
     } catch (error) {
       fail(route, `invalid JSON-LD: ${error.message}`)
     }
+  }
+  const software = schemas.find(
+    (schema) => schema['@type'] === 'SoftwareApplication',
+  )
+  if (software && software.softwareVersion !== latestDesktopVersion) {
+    fail(
+      route,
+      `softwareVersion=${software.softwareVersion} expected=${latestDesktopVersion}`,
+    )
   }
 
   {
@@ -302,18 +326,18 @@ if (!existsSync(shell)) {
   console.error('✗ _shell.html missing (SPA fallback target)')
   failures += 1
 } else {
-  // Assert the shell body has real Header chrome so nginx never serves
-  // a blank page for unknown routes. The shell is rendered by fetching
+  // Assert the shell body has real Header chrome for known dynamic routes.
+  // The shell is rendered by fetching
   // the synthetic `/tss-spa-shell` route; if that route or the layout
   // ever ships an empty body again (e.g. a fresh <ClientOnly> wrap),
   // this assertion fails.
   const shellHtml = readFileSync(shell, 'utf8')
   const shellBody = shellHtml.replace(/<head[\s\S]*?<\/head>/i, '')
-  const expectedShellChrome = 'ZERO ADS · ZERO TRACKING'
+  const expectedShellChrome = 'NO ADS · ANALYTICS OPT-IN'
   if (!shellBody.includes(expectedShellChrome)) {
     console.error(
       `✗ _shell.html missing expected chrome "${expectedShellChrome}" ` +
-        `— the SPA fallback would render a blank page for unknown routes`,
+        `— known dynamic routes would render a blank page`,
     )
     failures += 1
   } else {
@@ -322,11 +346,17 @@ if (!existsSync(shell)) {
 }
 
 const dockerfile = readFileSync(join(__dirname, '..', 'Dockerfile'), 'utf8')
-if (!dockerfile.includes('try_files $uri $uri/index.html /_shell.html;')) {
-  console.error('✗ nginx must use _shell.html for dynamic-route fallback')
+if (
+  !dockerfile.includes('try_files /_shell.html =404;') ||
+  !dockerfile.includes('add_header X-Robots-Tag "noindex, nofollow" always;') ||
+  !dockerfile.includes('try_files $uri $uri/index.html =404;')
+) {
+  console.error(
+    '✗ nginx dynamic-route noindex or unknown-route 404 guard missing',
+  )
   failures += 1
 } else {
-  console.log('✓ nginx uses _shell.html for dynamic-route fallback')
+  console.log('✓ nginx limits its noindex SPA fallback to known dynamic routes')
 }
 
 // Guard: the client entry bundle must wrap StartClient in our auth providers.

--- a/myscrollr.com/scripts/fetch-latest-version.mjs
+++ b/myscrollr.com/scripts/fetch-latest-version.mjs
@@ -35,7 +35,7 @@ import { writeFile, mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const REPO = 'brandon-relentnet/myscrollr'
+const REPO = 'doughknee/myscrollr'
 // Updated whenever we bump in production. Used only as a last-resort
 // fallback for local dev when the network is unavailable; CI builds
 // hard-fail instead of falling back.

--- a/myscrollr.com/scripts/fetch-releases.mjs
+++ b/myscrollr.com/scripts/fetch-releases.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url'
 // Canonical repo path — GitHub 301-redirects to the renamed repo
 // (doughknee/myscrollr) and fetch follows redirects by default.
 const RELEASES_API_URL =
-  'https://api.github.com/repos/brandon-relentnet/myscrollr/releases?per_page=50'
+  'https://api.github.com/repos/doughknee/myscrollr/releases?per_page=50'
 const OUTPUT_PATH = fileURLToPath(
   new URL('../src/lib/releases.generated.ts', import.meta.url),
 )
@@ -71,7 +71,7 @@ function mapGitHubRelease(raw) {
     url:
       typeof raw.html_url === 'string'
         ? raw.html_url
-        : 'https://github.com/brandon-relentnet/myscrollr/releases',
+        : 'https://github.com/doughknee/myscrollr/releases',
     prerelease: raw.prerelease === true,
   }
 }

--- a/myscrollr.com/src/components/Footer.tsx
+++ b/myscrollr.com/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { LATEST_DESKTOP_VERSION } from '@/lib/latestVersion.generated'
 
 /**
  * Terminal-editorial footer (design_handoff_marketing_site/README.md):
- * wordmark left, mono uppercase link rows, `ZERO ADS · ZERO TRACKING`
+ * wordmark left, mono uppercase link rows, privacy summary
  * right. Keeps the full sitemap (status/architecture/releases/legal
  * docs) that the mockup's minimal footer omitted — existing site wins
  * on navigation/SEO.
@@ -31,7 +31,7 @@ const SECONDARY_LINKS: Array<{ label: string; to?: string; href?: string }> = [
   { label: 'TERMS', to: '/legal?doc=terms' },
   { label: 'PRIVACY', to: '/legal?doc=privacy' },
   { label: 'LICENSE', to: '/legal?doc=license' },
-  { label: 'GITHUB', href: 'https://github.com/brandon-relentnet/myscrollr' },
+  { label: 'GITHUB', href: 'https://github.com/doughknee/myscrollr' },
 ]
 
 function FooterLink({
@@ -97,7 +97,7 @@ export default function Footer() {
             in both themes (/60 measured 4.41:1 in light) while staying
             visibly de-emphasized. */}
         <div className="font-mono text-[11px] tracking-[0.1em] text-base-content/65">
-          ZERO ADS · ZERO TRACKING
+          NO ADS · ANALYTICS OPT-IN
         </div>
       </div>
 

--- a/myscrollr.com/src/components/Header.tsx
+++ b/myscrollr.com/src/components/Header.tsx
@@ -70,6 +70,26 @@ export default function Header({
       if (e.key === 'Escape') {
         e.stopPropagation()
         closeDrawer()
+        return
+      }
+      if (e.key === 'Tab' && drawerRef.current) {
+        const focusable = drawerRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        )
+        if (focusable.length === 0) return
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+        if (
+          e.shiftKey &&
+          (document.activeElement === first ||
+            document.activeElement === drawerRef.current)
+        ) {
+          e.preventDefault()
+          last.focus()
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
       }
     }
     document.addEventListener('keydown', handleKeyDown)

--- a/myscrollr.com/src/components/landing/PromiseSection.tsx
+++ b/myscrollr.com/src/components/landing/PromiseSection.tsx
@@ -9,12 +9,12 @@ import { EASE } from '@/lib/animations'
 import { SectionRow, TerminalContainer } from '@/components/terminal'
 import { useGitHubStats } from '@/hooks/useGitHubStats'
 
-const REPO = 'brandon-relentnet/myscrollr'
+const REPO = 'doughknee/myscrollr'
 const GITHUB_URL = `https://github.com/${REPO}`
 
 const REFUSALS = [
   'Read your other apps',
-  'Collect personal data',
+  'Build advertising profiles',
   'Show you ads',
   'Sell to data brokers',
 ]
@@ -49,7 +49,7 @@ export function PromiseSection({
             </h2>
             <p className="m-0 mb-7 max-w-[460px] leading-relaxed text-base-content/60 [text-wrap:pretty]">
               {
-                'No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines. We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.'
+                'No advertising trackers. Operational diagnostics and authentication logs are used to run and secure the service. Optional product analytics is opt-in, coarse, account-linked, desktop-only, and described in the Privacy Policy.'
               }
             </p>
             <a
@@ -137,7 +137,7 @@ export function PromiseSection({
               vectorEffect: 'non-scaling-stroke',
             }}
           >
-            ZERO TRACKING
+            NO AD TRACKING
           </text>
         </svg>
       </div>

--- a/myscrollr.com/src/components/landing/StepsSection.tsx
+++ b/myscrollr.com/src/components/landing/StepsSection.tsx
@@ -17,7 +17,7 @@ export function StepsSection() {
             {
               num: '01',
               title: 'Download',
-              body: 'One small native app for macOS, Windows, and Linux. Installed before your coffee cools, no account required.',
+              body: 'One small native app for macOS, Windows, and Linux. No account is required to download it or try local utility widgets; sign in to add live data.',
             },
             {
               num: '02',

--- a/myscrollr.com/src/components/support/SupportFAQ.tsx
+++ b/myscrollr.com/src/components/support/SupportFAQ.tsx
@@ -32,12 +32,12 @@ export function SupportFAQ() {
               >
                 {String(i + 1).padStart(2, '0')}
               </div>
-              <h3 className="type-display relative m-0 mb-3 max-w-[86%] text-[clamp(17px,1.4vw,21px)]">
+              <h2 className="type-display relative m-0 mb-3 max-w-[86%] text-[clamp(17px,1.4vw,21px)]">
                 <span className="mr-3 font-mono text-xs font-normal tracking-[0.1em] text-primary">
                   Q.{String(i + 1).padStart(2, '0')}
                 </span>
                 {f.question}
-              </h3>
+              </h2>
               <p className="relative m-0 text-[14.5px] leading-[1.65] text-base-content/60 [text-wrap:pretty]">
                 {f.answer}
               </p>

--- a/myscrollr.com/src/components/support/support-content.ts
+++ b/myscrollr.com/src/components/support/support-content.ts
@@ -16,7 +16,7 @@ export const FAQ_ITEMS: Array<FAQItem> = [
   {
     question: 'Is Scrollr free?',
     answer:
-      'Yes. Three widgets at once, forever, no account. Uplink plans add more concurrent widgets from $6.67/mo.',
+      'Yes. The free tier lets three widgets run at once. No account is required to download or look around; sign in to add live data widgets and sync settings. Uplink plans add more concurrent widgets from $6.67/mo.',
   },
   {
     question: "Does it affect my computer's performance?",
@@ -31,7 +31,7 @@ export const FAQ_ITEMS: Array<FAQItem> = [
   {
     question: 'Do I need an account?',
     answer:
-      'Not to use the free tier. An account only exists to sync an Uplink subscription across machines.',
+      'Not to download Scrollr or explore local utility widgets. Sign in to add live data widgets, sync settings across machines, or use an Uplink subscription.',
   },
   {
     question: 'What platforms are supported?',

--- a/myscrollr.com/src/lib/catalog.test.ts
+++ b/myscrollr.com/src/lib/catalog.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('catalog snapshot', () => {
+  it('contains every server catalog widget in server order', () => {
+    const server = readFileSync(
+      new URL('../../../api/internal/platform/widgets.go', import.meta.url),
+      'utf8',
+    )
+    const serverIds = [...server.matchAll(/\bID:\s*"([^"]+)"/g)].map(
+      ([, id]) => id,
+    )
+    const marketing = readFileSync(
+      new URL('./catalog.ts', import.meta.url),
+      'utf8',
+    )
+    const snapshotStart = marketing.indexOf('export const CATALOG_SNAPSHOT')
+    const snapshotEnd = marketing.indexOf('export const CATEGORY_ACCENT')
+    if (snapshotStart < 0 || snapshotEnd < 0) {
+      throw new Error('CATALOG_SNAPSHOT block not found')
+    }
+    const snapshot = marketing.slice(snapshotStart, snapshotEnd)
+    const marketingIds = [...snapshot.matchAll(/\['([^']+)'/g)].map(
+      ([, id]) => id,
+    )
+    expect(marketingIds).toEqual(serverIds)
+  })
+})

--- a/myscrollr.com/src/lib/catalog.ts
+++ b/myscrollr.com/src/lib/catalog.ts
@@ -4,9 +4,8 @@
  * `useCatalog()` fetches GET /catalog (the single authority — see
  * api/internal/widgets/catalog.go) with a sessionStorage cache, and falls
  * back to CATALOG_SNAPSHOT so the pages render offline and during SSR.
- * The snapshot mirrors api/internal/platform/widgets.go; drift is
- * harmless (the live response wins as soon as it arrives) but keep it
- * roughly in sync when the server catalog changes.
+ * The snapshot mirrors api/internal/platform/widgets.go. Keep it exact:
+ * prerendered HTML and offline clients render it before the live response.
  *
  * Widget counts and category counts must always be COMPUTED from the
  * widget list — never hardcode "35" in page copy.
@@ -37,6 +36,20 @@ export const CATALOG_SNAPSHOT: Array<CatalogWidget> = [
     ['sports_championsleague', 'Champions League', 'sports', '#0e1e5b', 'Live UEFA Champions League scores.'],
     ['sports_ufc', 'UFC', 'sports', '#d20a0a', 'UFC fight cards and results.'],
     ['sports_afl', 'AFL', 'sports', '#003da5', 'Live Australian Football League scores.'],
+    ['sports_bundesliga', 'Bundesliga', 'sports', '#d20515', "Live scores from Germany's Bundesliga."],
+    ['sports_seriea', 'Serie A', 'sports', '#0473ff', "Live scores from Italy's Serie A."],
+    ['sports_ligue1', 'Ligue 1', 'sports', '#085fff', "Live scores from France's Ligue 1."],
+    ['sports_euroleague', 'EuroLeague', 'sports', '#fa5500', 'Live EuroLeague basketball scores.'],
+    ['sports_khl', 'KHL', 'sports', '#17272c', 'Live Kontinental Hockey League scores.'],
+    ['sports_npb', 'NPB', 'sports', '#0091db', 'Live Nippon Professional Baseball scores.'],
+    ['sports_sixnations', 'Six Nations', 'sports', '#0d1c1c', 'Live Six Nations rugby scores.'],
+    ['sports_superrugby', 'Super Rugby', 'sports', '#00245d', 'Live Super Rugby Pacific scores.'],
+    ['sports_premrugby', 'Premiership Rugby', 'sports', '#2a2b6b', "Live scores from England's Premiership Rugby."],
+    ['sports_handballcl', 'Handball Champions League', 'sports', '#001432', 'Live EHF Champions League handball scores.'],
+    ['sports_hbl', 'Handball Bundesliga', 'sports', '#1d2f56', "Live scores from Germany's Handball-Bundesliga."],
+    ['sports_starligue', 'Starligue', 'sports', '#e42027', "Live scores from France's Starligue."],
+    ['sports_volleyballcl', 'Volleyball Champions League', 'sports', '#0000ff', 'Live CEV Champions League volleyball scores.'],
+    ['sports_vnl', 'Volleyball Nations League', 'sports', '#bbeb00', 'Live Volleyball Nations League scores.'],
     ['news_bbc', 'BBC News', 'news', '#b80000', 'World, UK and breaking news from the BBC.'],
     ['news_npr', 'NPR', 'news', '#4667de', 'US and world news, analysis and reporting from NPR.'],
     ['news_guardian', 'The Guardian', 'news', '#052962', 'Independent world news, opinion and reporting.'],
@@ -47,6 +60,7 @@ export const CATALOG_SNAPSHOT: Array<CatalogWidget> = [
     ['news_nasa', 'NASA', 'news', '#0b3d91', 'Space, science and mission news from NASA.'],
     ['news_hackernews', 'Hacker News', 'news', '#ff6600', 'Top stories from the Hacker News front page.'],
     ['news_theverge', 'The Verge', 'news', '#5200ff', 'Technology, science, art and culture.'],
+    ['news_drudge', 'Drudge Report', 'news', '#4b5563', "The Drudge Report's headline links, as they post."],
     ['rss_custom', 'Custom RSS', 'news', '#ee802f', 'Follow any RSS or Atom feed by pasting its URL.'],
     ['fantasy_yahoo', 'Yahoo Fantasy', 'fantasy', '#6001d2', 'Your Yahoo Fantasy leagues, matchups, and standings.'],
     ['predictions', 'Kalshi', 'predictions', '#1fc9a0', 'Live odds from the Kalshi prediction market.'],
@@ -104,6 +118,20 @@ export const WIDGET_ABBR: Record<string, string> = {
   sports_championsleague: 'SPT—UCL',
   sports_ufc: 'SPT—UFC',
   sports_afl: 'SPT—AFL',
+  sports_bundesliga: 'SPT—BUN',
+  sports_seriea: 'SPT—SA',
+  sports_ligue1: 'SPT—L1',
+  sports_euroleague: 'SPT—EL',
+  sports_khl: 'SPT—KHL',
+  sports_npb: 'SPT—NPB',
+  sports_sixnations: 'SPT—6N',
+  sports_superrugby: 'SPT—SR',
+  sports_premrugby: 'SPT—PR',
+  sports_handballcl: 'SPT—HCL',
+  sports_hbl: 'SPT—HBL',
+  sports_starligue: 'SPT—STAR',
+  sports_volleyballcl: 'SPT—VCL',
+  sports_vnl: 'SPT—VNL',
   news_bbc: 'RSS—BBC',
   news_npr: 'RSS—NPR',
   news_guardian: 'RSS—GDN',
@@ -114,6 +142,7 @@ export const WIDGET_ABBR: Record<string, string> = {
   news_nasa: 'RSS—NASA',
   news_hackernews: 'RSS—HN',
   news_theverge: 'RSS—TV',
+  news_drudge: 'RSS—DRG',
   rss_custom: 'RSS—YOU',
   fantasy_yahoo: 'FAN—YH',
   predictions: 'PRD—KL',

--- a/myscrollr.com/src/lib/getDownloadInfo.test.ts
+++ b/myscrollr.com/src/lib/getDownloadInfo.test.ts
@@ -15,7 +15,7 @@ vi.mock('./latestVersion.generated', () => ({
 }))
 
 const RELEASE_BASE =
-  'https://github.com/brandon-relentnet/myscrollr/releases/download/desktop-v1.2.3'
+  'https://github.com/doughknee/myscrollr/releases/download/desktop-v1.2.3'
 
 describe('getDownloadInfo', () => {
   it('resolves the macOS DMG (Apple Silicon naming)', () => {
@@ -70,7 +70,7 @@ describe('getDownloadInfo', () => {
 
   it('keeps the releases-page fallback pointed at the repo', () => {
     expect(FALLBACK_RELEASES_URL).toBe(
-      'https://github.com/brandon-relentnet/myscrollr/releases/latest',
+      'https://github.com/doughknee/myscrollr/releases/latest',
     )
   })
 })

--- a/myscrollr.com/src/lib/getDownloadInfo.ts
+++ b/myscrollr.com/src/lib/getDownloadInfo.ts
@@ -33,7 +33,7 @@ import {
   LATEST_DESKTOP_VERSION,
 } from './latestVersion.generated'
 
-const REPO_URL = 'https://github.com/brandon-relentnet/myscrollr'
+const REPO_URL = 'https://github.com/doughknee/myscrollr'
 export const FALLBACK_RELEASES_URL = `${REPO_URL}/releases/latest`
 
 export type DesktopPlatform = 'macos' | 'windows' | 'linux'

--- a/myscrollr.com/src/lib/releases.test.ts
+++ b/myscrollr.com/src/lib/releases.test.ts
@@ -14,7 +14,7 @@ const entry = (overrides: Partial<ReleaseEntry>): ReleaseEntry => ({
   headline: '',
   date: '2026-01-01T00:00:00Z',
   body: '',
-  url: 'https://github.com/brandon-relentnet/myscrollr/releases',
+  url: 'https://github.com/doughknee/myscrollr/releases',
   prerelease: false,
   ...overrides,
 })

--- a/myscrollr.com/src/lib/releases.ts
+++ b/myscrollr.com/src/lib/releases.ts
@@ -40,11 +40,11 @@ export interface ReleaseEntry {
 
 /** Canonical API constant — GitHub follows the rename redirect. */
 export const RELEASES_API_URL =
-  'https://api.github.com/repos/brandon-relentnet/myscrollr/releases?per_page=50'
+  'https://api.github.com/repos/doughknee/myscrollr/releases?per_page=50'
 
 /** Human fallback link when no data is available. */
 export const RELEASES_PAGE_URL =
-  'https://github.com/brandon-relentnet/myscrollr/releases'
+  'https://github.com/doughknee/myscrollr/releases'
 
 const DESKTOP_TAG_PREFIX = 'desktop-v'
 

--- a/myscrollr.com/src/lib/seo.ts
+++ b/myscrollr.com/src/lib/seo.ts
@@ -9,12 +9,7 @@ type SeoInput = {
   jsonLd?: object | Array<object>
   /**
    * Extra `<link>` tags to inject into the route's `<head>`. Used by the
-   * home route to add a responsive `rel="preload"` for the LCP product
-   * screenshot so the browser can fetch it in parallel with the JS
-   * bundle (the image URL is otherwise only discoverable after React
-   * mounts `HeroProductShowcase`). The wider type covers preload
-   * attributes that aren't on the default `<link>` shape — `as`,
-   * `imagesrcset`, `imagesizes`, `fetchpriority`, `media`, etc.
+   * fantasy route to add a responsive `rel="preload"` for its hero image.
    */
   extraLinks?: Array<LinkTag>
 }
@@ -25,10 +20,7 @@ type MetaTag =
   | { title: string }
   | { name: string; content: string }
   | { property: string; content: string }
-// Wide link shape so consumers can emit any well-formed `<link>` tag,
-// including `rel="preload"` variants with responsive image hints. The
-// keys mirror the HTML attribute names (lowercase) because TanStack
-// Start serializes them verbatim into the prerendered HTML.
+// Wide enough for responsive image preload attributes.
 type LinkTag = {
   rel: string
   href?: string

--- a/myscrollr.com/src/lib/structured-data.ts
+++ b/myscrollr.com/src/lib/structured-data.ts
@@ -9,7 +9,7 @@
 
 import { BASE_URL } from '@/lib/seo'
 
-declare const __APP_VERSION__: string
+import { LATEST_DESKTOP_VERSION } from '@/lib/latestVersion.generated'
 
 export const organization = {
   '@context': 'https://schema.org',
@@ -21,7 +21,7 @@ export const organization = {
   description:
     'Scrollr is a quiet desktop ticker for live finance, sports, news, and fantasy data. Open source and privacy-first.',
   sameAs: [
-    'https://github.com/brandon-relentnet/myscrollr',
+    'https://github.com/doughknee/myscrollr',
     'https://discord.gg/85b49TcGJa',
   ],
 }
@@ -52,7 +52,7 @@ export const softwareApplication = {
     'A quiet desktop ticker for live finance, sports, news, and fantasy data. Open source and privacy-first.',
   url: BASE_URL,
   downloadUrl: `${BASE_URL}/download`,
-  softwareVersion: __APP_VERSION__,
+  softwareVersion: LATEST_DESKTOP_VERSION,
   publisher: { '@id': `${BASE_URL}/#organization` },
   author: { '@id': `${BASE_URL}/#organization` },
   screenshot: [
@@ -174,7 +174,7 @@ export const HOMEPAGE_FAQ_ITEMS: ReadonlyArray<{
   {
     question: 'Is it really free?',
     answer:
-      "Yes. Three widget slots, forever, no account. Uplink exists if you outgrow them. Most people don't.",
+      'Yes. The free tier includes three widget slots forever. You can download and browse without an account; sign in to add live data widgets and sync settings. Uplink exists if you outgrow three slots.',
   },
   {
     question: 'Will it slow my computer down?',
@@ -184,25 +184,10 @@ export const HOMEPAGE_FAQ_ITEMS: ReadonlyArray<{
   {
     question: 'What does Scrollr collect about me?',
     answer:
-      'No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines. We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.',
+      'No advertising trackers. Operational diagnostics and authentication logs are used to run and secure the service. Optional product analytics is opt-in, coarse, account-linked, desktop-only, and described in the Privacy Policy.',
   },
   {
     question: 'Which platforms?',
     answer: 'macOS, Windows, and Linux. Multi-monitor aware on all three.',
   },
 ] as const
-
-type BreadcrumbItem = { name: string; path: string }
-
-export function breadcrumbs(items: Array<BreadcrumbItem>) {
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: items.map((item, idx) => ({
-      '@type': 'ListItem',
-      position: idx + 1,
-      name: item.name,
-      item: `${BASE_URL}${item.path}`,
-    })),
-  }
-}

--- a/myscrollr.com/src/routes/architecture.tsx
+++ b/myscrollr.com/src/routes/architecture.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { motion } from 'motion/react'
 
 import { BASE_URL, seo } from '@/lib/seo'
-import { breadcrumbs, organization } from '@/lib/structured-data'
+import { organization } from '@/lib/structured-data'
 import { EASE } from '@/lib/animations'
 import {
   DeparturesRow,
@@ -43,14 +43,7 @@ export const Route = createFileRoute('/architecture')({
       path: '/architecture',
       image: 'https://myscrollr.com/og/architecture.png',
       type: 'article',
-      jsonLd: [
-        organization,
-        ARCHITECTURE_TECH_ARTICLE,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Architecture', path: '/architecture' },
-        ]),
-      ],
+      jsonLd: [organization, ARCHITECTURE_TECH_ARTICLE],
     }),
   component: ArchitecturePage,
 })

--- a/myscrollr.com/src/routes/business.tsx
+++ b/myscrollr.com/src/routes/business.tsx
@@ -24,7 +24,7 @@ import {
 import { EASE } from '@/lib/animations'
 import { seededRandom } from '@/lib/seededRandom'
 import { seo } from '@/lib/seo'
-import { breadcrumbs, organization } from '@/lib/structured-data'
+import { organization } from '@/lib/structured-data'
 
 // ── Constants ───────────────────────────────────────────────────
 
@@ -45,16 +45,10 @@ export const Route = createFileRoute('/business')({
     seo({
       title: 'White-Label Desktop Ticker for Business | Scrollr',
       description:
-        'Custom-branded Scrollr deployments for brokerages, sports venues, fantasy platforms, crypto exchanges, and news publishers. From $500/mo.',
+        'Discuss a custom-branded Scrollr desktop ticker for teams, venues, publishers, and financial platforms. Scope, pricing, and terms are agreed in writing.',
       path: '/business',
       image: 'https://myscrollr.com/og/business.png',
-      jsonLd: [
-        organization,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Business', path: '/business' },
-        ]),
-      ],
+      jsonLd: organization,
     }),
   component: BusinessPage,
 })
@@ -152,39 +146,39 @@ function brandChips(brand: BrandId, tick: number): Array<DemoChip> {
 
 // prettier-ignore
 const AUDIENCES = [
-  { tag: 'VENUE', color: '#fbbf24', name: 'Sports bars & restaurants', copy: 'Every TV in the room runs live scores, news, and your branding. Better than ESPN scrollers, fully under your control.' },
-  { tag: 'FIN', color: '#00d4ff', name: 'Brokerages & advisors', copy: 'A branded desktop ticker for clients. Real-time quotes, custom watchlists, your logo, your colors, your domain.' },
-  { tag: 'FAN', color: '#ff4757', name: 'Fantasy sports platforms', copy: "White-label the desktop app as your platform's companion. Native ticker, your branding, your standings." },
-  { tag: 'ODDS', color: '#a855f7', name: 'Sportsbooks & betting affiliates', copy: "Stay on a user's desktop without a tab open. Odds, scores, and your offers, visible the moment they matter." },
-  { tag: 'CRYPTO', color: '#34d399', name: 'Crypto exchanges', copy: "A native desktop price ticker for power users. Custom symbol list, your exchange's pairs, your branding." },
-  { tag: 'NEWS', color: '#0ea5e9', name: 'News publishers', copy: "Your headlines on readers' desktops all day: a quiet, branded channel that doesn't depend on the algorithm." },
+  { tag: 'VENUE', color: '#fbbf24', name: 'Sports bars & restaurants', copy: 'Explore a branded ticker for scores, news, and venue messages across one or more displays.' },
+  { tag: 'FIN', color: '#00d4ff', name: 'Brokerages & advisors', copy: 'Explore a branded desktop ticker for client watchlists, market data, and company updates.' },
+  { tag: 'FAN', color: '#ff4757', name: 'Fantasy sports platforms', copy: "Explore a desktop companion for your platform's matchups, standings, and brand." },
+  { tag: 'ODDS', color: '#a855f7', name: 'Sportsbooks & betting affiliates', copy: 'Explore a desktop ticker for approved odds, scores, and timely account messages.' },
+  { tag: 'CRYPTO', color: '#34d399', name: 'Crypto exchanges', copy: 'Explore a branded price ticker for selected pairs and market updates.' },
+  { tag: 'NEWS', color: '#0ea5e9', name: 'News publishers', copy: "Explore a quiet desktop channel for your publication's headlines and alerts." },
 ]
 
 // prettier-ignore
 const CAPABILITIES = [
-  { num: 'CAP—01', title: 'Full white-label', body: 'Logo, colors, fonts, app name, app icon, install bundle identity, custom domain on the API. Your customers see your brand, not ours.' },
-  { num: 'CAP—02', title: 'Multi-display deployment', body: 'Venue mode: one config, every screen in the building. Per-display content and scheduling included.' },
-  { num: 'CAP—03', title: 'API access', body: 'Programmatic read/write to your deployment. Push your own data into the bar, pull state into your stack.' },
-  { num: 'CAP—04', title: 'Custom data sources', body: 'Your odds feed, your CMS, your internal metrics: we build the ingester and it streams like everything else.' },
-  { num: 'CAP—05', title: 'A real SLA', body: 'Defined response times in writing (typically P1 < 1hr), uptime targets, maintenance windows, and a direct Slack channel with the engineers.' },
-  { num: 'CAP—06', title: 'Self-host option', body: 'The full stack runs in your environment. We hand you the keys (deploy scripts, Compose files, runbooks) and stay reachable after.' },
+  { num: 'CAP—01', title: 'Branding scope', body: 'Logo, colors, app identity, and distribution requirements can be evaluated for a written proposal.' },
+  { num: 'CAP—02', title: 'Multi-display planning', body: 'Scrollr supports multiple monitors. Venue-wide configuration and scheduling requirements are scoped separately.' },
+  { num: 'CAP—03', title: 'Integration review', body: 'We review the data and system boundaries you need before promising API or write access.' },
+  { num: 'CAP—04', title: 'Data-source review', body: 'Bring the feed or system you need connected. Feasibility, licensing, and implementation are evaluated first.' },
+  { num: 'CAP—05', title: 'Support terms', body: 'Response targets, support channels, and maintenance expectations belong in the written proposal.' },
+  { num: 'CAP—06', title: 'Hosting options', body: 'The repository includes deployment tooling. Managed or self-hosted delivery depends on the agreed scope.' },
 ]
 
 // prettier-ignore
 const STEPS = [
-  { num: '01', title: 'Scope', body: 'Mutual NDA first, then a scoping call. You get a written scope with a committed timeline and price before you pay anything.' },
-  { num: '02', title: 'Build & brand', body: 'We build on the production Scrollr platform, the same pipeline running the public app, with your brand and data wired in.' },
-  { num: '03', title: 'Deploy', body: 'Most deployments go live in 2-4 weeks. We stay engaged for support, changes, and whatever breaks at 5pm on a Friday.' },
+  { num: '01', title: 'Discuss', body: 'Tell us the audience, data, branding, distribution, and support requirements.' },
+  { num: '02', title: 'Scope', body: 'We confirm feasibility and put deliverables, terms, pricing, and timing in a written proposal.' },
+  { num: '03', title: 'Build & deploy', body: 'Work starts only after agreement, with acceptance and support terms defined for that engagement.' },
 ]
 
 // prettier-ignore
 const FAQS = [
-  { num: 'B.01', q: 'Can we self-host?', a: 'Yes. Desktop app, Go API, Rust ingesters, Postgres, Redis: all of it runs in your environment, with deployment scripts, runbooks, and a hand-off call.' },
-  { num: 'B.02', q: 'Can we fully white-label?', a: 'Completely. The codebase is AGPL-3.0; white-label builds ship under a commercial license that removes the copyleft requirement for distribution.' },
-  { num: 'B.03', q: 'Do you sign NDAs?', a: 'Before the scoping call, so you can speak freely. Our standard one-pager or yours, with no legal back-and-forth before the first conversation.' },
-  { num: 'B.04', q: "What's the SLA?", a: 'Written, not implied: incident response times (often P1 < 1hr), monthly uptime targets, maintenance windows, and a direct Slack channel.' },
-  { num: 'B.05', q: 'How long does deployment take?', a: 'Custom branding, two data sources, basic integrations: 2-4 weeks. Heavy customization (new sources, custom UI, SSO): 6-12 weeks. Committed in the scope doc.' },
-  { num: 'B.06', q: 'Perpetual or one-time licensing?', a: 'For self-hosted, yes: perpetual licenses with optional annual maintenance. Managed deployments default to monthly. Bring us your procurement constraints.' },
+  { num: 'B.01', q: 'Can we self-host?', a: 'The public repository includes Docker, Compose, Kubernetes manifests, and runbooks. A supported self-hosted engagement still needs a written scope.' },
+  { num: 'B.02', q: 'Can we fully white-label?', a: 'Branding and distribution requirements can be discussed. The public code is AGPL-3.0; any different commercial terms must be agreed in writing.' },
+  { num: 'B.03', q: 'Do you sign NDAs?', a: 'We can review your NDA or discuss confidentiality requirements before sensitive details are shared.' },
+  { num: 'B.04', q: "What's the SLA?", a: 'There is no default public SLA. Any response targets, uptime commitments, or support channels are defined in the proposal.' },
+  { num: 'B.05', q: 'How long does deployment take?', a: 'Timing depends on branding, data licensing, integrations, hosting, and acceptance requirements. The proposal defines the schedule.' },
+  { num: 'B.06', q: 'What licensing is available?', a: 'The public code is available under AGPL-3.0. Alternative commercial terms, if offered, must be agreed for the specific engagement.' },
 ]
 
 const USE_CASE_OPTIONS = [
@@ -504,8 +498,8 @@ function CtaSection() {
       <TerminalContainer>
         <DeparturesRow
           index="01"
-          label="Starts at $500/mo."
-          meta="Timeline and scope committed in writing before you pay anything."
+          label="Custom scope. Written proposal."
+          meta="Deliverables, pricing, timing, and terms are agreed before work starts."
           action="START THE CONVERSATION →"
           onClick={scrollToForm}
           labelClassName="text-left text-[26px]"
@@ -651,8 +645,7 @@ function LeadForm() {
             <span className="font-medium text-base-content/85">
               {submittedEmail}
             </span>{' '}
-            with what to expect next. A real human will reply within one
-            business day.
+            with what to expect next. A real human will follow up.
           </p>
         </div>
 

--- a/myscrollr.com/src/routes/callback.tsx
+++ b/myscrollr.com/src/routes/callback.tsx
@@ -1,7 +1,15 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useHandleSignInCallback } from '@logto/react'
+import { seo } from '@/lib/seo'
 
 export const Route = createFileRoute('/callback')({
+  head: () =>
+    seo({
+      title: 'Signing In | Scrollr',
+      description: 'Completing your secure Scrollr sign-in.',
+      path: '/callback',
+      noindex: true,
+    }),
   component: Callback,
 })
 

--- a/myscrollr.com/src/routes/download.tsx
+++ b/myscrollr.com/src/routes/download.tsx
@@ -3,11 +3,7 @@ import { Link, createFileRoute } from '@tanstack/react-router'
 import { motion } from 'motion/react'
 import type { DesktopPlatform, LinuxFormat } from '@/lib/getDownloadInfo'
 import { seo } from '@/lib/seo'
-import {
-  breadcrumbs,
-  organization,
-  softwareApplication,
-} from '@/lib/structured-data'
+import { organization, softwareApplication } from '@/lib/structured-data'
 import { LATEST_DESKTOP_VERSION } from '@/lib/latestVersion.generated'
 import { detectPlatform } from '@/lib/detectPlatform'
 import {
@@ -32,21 +28,14 @@ export const Route = createFileRoute('/download')({
         'Free download of Scrollr, the quiet desktop ticker for live finance, sports, news, and fantasy data. Native builds for macOS, Windows, and Linux.',
       path: '/download',
       image: 'https://myscrollr.com/og/download.png',
-      jsonLd: [
-        organization,
-        softwareApplication,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Download', path: '/download' },
-        ]),
-      ],
+      jsonLd: [organization, softwareApplication],
     }),
   component: DownloadPage,
 })
 
 // ── Constants ──────────────────────────────────────────────────
 
-const RELEASES_URL = 'https://github.com/brandon-relentnet/myscrollr/releases'
+const RELEASES_URL = 'https://github.com/doughknee/myscrollr/releases'
 
 const CTA: Record<DesktopPlatform, string> = {
   macos: 'Download for macOS',
@@ -70,7 +59,7 @@ const STEPS = [
   {
     num: '01',
     title: 'Install & open',
-    body: 'No account wall, no onboarding tour. The bar appears with zero-setup starters already scrolling.',
+    body: 'The download has no account wall or onboarding tour. The bar opens with local starter widgets; sign in when you add live data.',
   },
   {
     num: '02',
@@ -163,7 +152,7 @@ export function DownloadPage({
             : 'Get Scrollr.'
         }
         line2="Free. No sign-up."
-        sub="One small native app. Three widgets free forever, no account between you and a running bar."
+        sub="One small native app. No sign-up to download or look around; sign in when you add live data widgets."
         actions={
           <div className="flex flex-col items-end gap-3">
             {detected ? (

--- a/myscrollr.com/src/routes/download_.$os.tsx
+++ b/myscrollr.com/src/routes/download_.$os.tsx
@@ -1,11 +1,7 @@
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { DownloadPage } from '@/routes/download'
 import { seo } from '@/lib/seo'
-import {
-  breadcrumbs,
-  organization,
-  softwareApplication,
-} from '@/lib/structured-data'
+import { organization, softwareApplication } from '@/lib/structured-data'
 
 // ── Per-OS deep links ────────────────────────────────────────────
 //
@@ -79,15 +75,7 @@ export const Route = createFileRoute('/download_/$os')({
       description: m.description,
       path: `/download/${params.os}`,
       image: 'https://myscrollr.com/og/download.png',
-      jsonLd: [
-        organization,
-        softwareApplication,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Download', path: '/download' },
-          { name: m.os, path: `/download/${params.os}` },
-        ]),
-      ],
+      jsonLd: [organization, softwareApplication],
     })
   },
   component: PerOsDownloadPage,

--- a/myscrollr.com/src/routes/fantasy.tsx
+++ b/myscrollr.com/src/routes/fantasy.tsx
@@ -4,7 +4,6 @@ import { motion } from 'motion/react'
 import type { PlatformInfo } from '@/lib/detectPlatform'
 import { seo } from '@/lib/seo'
 import {
-  breadcrumbs,
   faqPage,
   organization,
   softwareApplication,
@@ -111,12 +110,12 @@ const FANTASY_FAQ_ITEMS: ReadonlyArray<{ question: string; answer: string }> = [
   {
     question: 'How fast are the scores?',
     answer:
-      'Live. Scores stream over a single push connection rather than a polling loop, so plays land on the bar as they happen instead of on somebody else’s refresh timer. Stat corrections flow through the same way.',
+      'Live updates stream over a single push connection rather than waiting on a client polling loop. Changes appear automatically when Scrollr receives them; upstream timing, corrections, outages, and your connection can affect arrival time.',
   },
   {
     question: 'What do you collect about me?',
     answer:
-      'No ads, no tracking pixels, no third-party analytics. Your widget setup syncs to your account so it follows you between machines. We count app versions and error rates to find bugs, and crash reports are stripped of personal data before they are sent, which tests enforce on every deploy.',
+      'No advertising trackers. Operational diagnostics and authentication logs are used to run and secure the service. Optional product analytics is opt-in, coarse, account-linked, desktop-only, and described in the Privacy Policy.',
   },
 ]
 
@@ -166,15 +165,7 @@ export const Route = createFileRoute('/fantasy')({
       image: 'https://myscrollr.com/og/home.png',
       imageAlt:
         'Scrollr desktop ticker showing live fantasy matchups and NFL scores.',
-      jsonLd: [
-        organization,
-        softwareApplication,
-        faqPage(FANTASY_FAQ_ITEMS),
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Fantasy', path: '/fantasy' },
-        ]),
-      ],
+      jsonLd: [organization, softwareApplication, faqPage(FANTASY_FAQ_ITEMS)],
       extraLinks: [
         {
           rel: 'preload',

--- a/myscrollr.com/src/routes/index.tsx
+++ b/myscrollr.com/src/routes/index.tsx
@@ -61,23 +61,6 @@ const ClosingCta = lazy(() =>
   })),
 )
 
-// Page-image preload. The SEC 02 screenshot is the page's main image
-// and its <img> only renders after React mounts the lazy chunk, so the
-// browser can't discover the URL from the initial HTML. Preloading from
-// the head lets the fetch run in parallel with the JS bundle. The image
-// is theme-independent (one rendition pair for dark and light), so no
-// per-scheme media queries are needed.
-//
-// Keep both constants in sync with components/landing/DesktopProof.tsx
-// so the preloaded rendition is the one the <img> actually requests.
-// Light/dark variants of the SEC 02 desktop screenshot. Preloads are
-// scoped per OS color scheme; users whose stored theme contradicts
-// their OS eat one wasted preload (same trade-off as the original
-// hero preloads — see useTheme for the rationale).
-const pageImageSrcset = (theme: 'dark' | 'light') =>
-  `/marketing/desktop-home-${theme}@1x.webp 1600w, /marketing/desktop-home-${theme}@2x.webp 2940w`
-const PAGE_IMAGE_SIZES = '(max-width: 1023px) 100vw, 990px'
-
 export const Route = createFileRoute('/')({
   component: HomePage,
   head: () =>
@@ -93,24 +76,6 @@ export const Route = createFileRoute('/')({
         website,
         softwareApplication,
         faqPage(HOMEPAGE_FAQ_ITEMS),
-      ],
-      extraLinks: [
-        {
-          rel: 'preload',
-          as: 'image',
-          imagesrcset: pageImageSrcset('dark'),
-          imagesizes: PAGE_IMAGE_SIZES,
-          fetchpriority: 'high',
-          media: '(prefers-color-scheme: dark)',
-        },
-        {
-          rel: 'preload',
-          as: 'image',
-          imagesrcset: pageImageSrcset('light'),
-          imagesizes: PAGE_IMAGE_SIZES,
-          fetchpriority: 'high',
-          media: '(prefers-color-scheme: light)',
-        },
       ],
     }),
 })

--- a/myscrollr.com/src/routes/invite.tsx
+++ b/myscrollr.com/src/routes/invite.tsx
@@ -4,8 +4,16 @@ import { Check, Eye, EyeOff, Loader2, Shield, X } from 'lucide-react'
 import { useLogto } from '@logto/react'
 import type { FormEvent } from 'react'
 import { inviteApi } from '@/api/client'
+import { seo } from '@/lib/seo'
 
 export const Route = createFileRoute('/invite')({
+  head: () =>
+    seo({
+      title: 'Accept Invitation | Scrollr',
+      description: 'Accept a private invitation to Scrollr.',
+      path: '/invite',
+      noindex: true,
+    }),
   validateSearch: (search: Record<string, unknown>) => ({
     token: (search.token as string) || '',
     email: (search.email as string) || '',

--- a/myscrollr.com/src/routes/legal.tsx
+++ b/myscrollr.com/src/routes/legal.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, Info } from 'lucide-react'
 
 import type { LegalDocument, LegalSection } from '@/components/legal/documents'
 import { seo } from '@/lib/seo'
-import { breadcrumbs, organization } from '@/lib/structured-data'
+import { organization } from '@/lib/structured-data'
 import { EASE, riseIn } from '@/lib/animations'
 import {
   LEGAL_DOCUMENTS,
@@ -29,13 +29,7 @@ export const Route = createFileRoute('/legal')({
       description:
         'Terms of Service, Privacy Policy, License, and Cookie Policy for the Scrollr desktop app and myscrollr.com.',
       path: '/legal',
-      jsonLd: [
-        organization,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Legal', path: '/legal' },
-        ]),
-      ],
+      jsonLd: organization,
     }),
   validateSearch: (search: Record<string, unknown>): LegalSearch => ({
     doc: typeof search.doc === 'string' ? search.doc : undefined,

--- a/myscrollr.com/src/routes/markets.tsx
+++ b/myscrollr.com/src/routes/markets.tsx
@@ -12,7 +12,6 @@ import {
 import { EASE } from '@/lib/animations'
 import { seo } from '@/lib/seo'
 import {
-  breadcrumbs,
   faqPage,
   organization,
   softwareApplication,
@@ -45,15 +44,7 @@ export const Route = createFileRoute('/markets')({
       path: '/markets',
       image: 'https://myscrollr.com/og/home.png',
       imageAlt: 'Scrollr desktop ticker showing stock and crypto prices.',
-      jsonLd: [
-        organization,
-        softwareApplication,
-        faqPage(MARKETS_FAQ),
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Markets', path: '/markets' },
-        ]),
-      ],
+      jsonLd: [organization, softwareApplication, faqPage(MARKETS_FAQ)],
     }),
   component: MarketsPage,
 })

--- a/myscrollr.com/src/routes/news.tsx
+++ b/myscrollr.com/src/routes/news.tsx
@@ -12,7 +12,6 @@ import {
 import { EASE } from '@/lib/animations'
 import { seo } from '@/lib/seo'
 import {
-  breadcrumbs,
   faqPage,
   organization,
   softwareApplication,
@@ -45,15 +44,7 @@ export const Route = createFileRoute('/news')({
       path: '/news',
       image: 'https://myscrollr.com/og/home.png',
       imageAlt: 'Scrollr desktop ticker showing news and RSS headlines.',
-      jsonLd: [
-        organization,
-        softwareApplication,
-        faqPage(NEWS_FAQ),
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'News and RSS', path: '/news' },
-        ]),
-      ],
+      jsonLd: [organization, softwareApplication, faqPage(NEWS_FAQ)],
     }),
   component: NewsPage,
 })

--- a/myscrollr.com/src/routes/releases.tsx
+++ b/myscrollr.com/src/routes/releases.tsx
@@ -14,7 +14,7 @@ import { AnimatePresence, motion } from 'motion/react'
 import { marked } from 'marked'
 import type { ReleaseEntry, SortDir, SortKey } from '@/lib/releases'
 import { seo } from '@/lib/seo'
-import { breadcrumbs, organization } from '@/lib/structured-data'
+import { organization } from '@/lib/structured-data'
 import {
   BUILD_TIME_RELEASES,
   RELEASES_PAGE_URL,
@@ -36,13 +36,7 @@ export const Route = createFileRoute('/releases')({
       description:
         'Human-readable release notes for the Scrollr desktop app: every version, what shipped, and why it matters. No commit-log archaeology required.',
       path: '/releases',
-      jsonLd: [
-        organization,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Releases', path: '/releases' },
-        ]),
-      ],
+      jsonLd: organization,
     }),
   component: ReleasesPage,
 })

--- a/myscrollr.com/src/routes/sports.tsx
+++ b/myscrollr.com/src/routes/sports.tsx
@@ -12,7 +12,6 @@ import {
 import { EASE } from '@/lib/animations'
 import { seo } from '@/lib/seo'
 import {
-  breadcrumbs,
   faqPage,
   organization,
   softwareApplication,
@@ -63,15 +62,7 @@ export const Route = createFileRoute('/sports')({
       path: '/sports',
       image: 'https://myscrollr.com/og/home.png',
       imageAlt: 'Scrollr showing live sports scores in a desktop ticker.',
-      jsonLd: [
-        organization,
-        softwareApplication,
-        faqPage(SPORTS_FAQ),
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Sports', path: '/sports' },
-        ]),
-      ],
+      jsonLd: [organization, softwareApplication, faqPage(SPORTS_FAQ)],
     }),
   component: SportsPage,
 })

--- a/myscrollr.com/src/routes/status.tsx
+++ b/myscrollr.com/src/routes/status.tsx
@@ -12,7 +12,7 @@ import { motion } from 'motion/react'
 import { AnimateNumber } from 'motion-plus/react'
 import type { ReactNode } from 'react'
 import { seo } from '@/lib/seo'
-import { breadcrumbs, organization } from '@/lib/structured-data'
+import { organization } from '@/lib/structured-data'
 import { API_BASE } from '@/api/client'
 import { EASE } from '@/lib/animations'
 import {
@@ -29,13 +29,7 @@ export const Route = createFileRoute('/status')({
       description:
         'Live system status for the Scrollr platform. Real-time health of infrastructure, ingestion workers, and channel APIs.',
       path: '/status',
-      jsonLd: [
-        organization,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Status', path: '/status' },
-        ]),
-      ],
+      jsonLd: organization,
     }),
   component: StatusPage,
 })

--- a/myscrollr.com/src/routes/support.tsx
+++ b/myscrollr.com/src/routes/support.tsx
@@ -1,7 +1,7 @@
 import { ClientOnly, createFileRoute } from '@tanstack/react-router'
 import { motion } from 'motion/react'
 import { seo } from '@/lib/seo'
-import { breadcrumbs, faqPage, organization } from '@/lib/structured-data'
+import { faqPage, organization } from '@/lib/structured-data'
 import { FAQ_ITEMS } from '@/components/support/support-content'
 import { SupportFAQ } from '@/components/support/SupportFAQ'
 import { SupportTroubleshooting } from '@/components/support/SupportTroubleshooting'
@@ -20,14 +20,7 @@ export const Route = createFileRoute('/support')({
       description:
         'Get help with Scrollr. FAQs, troubleshooting articles, billing help, and a direct contact form. Real humans, no chatbots.',
       path: '/support',
-      jsonLd: [
-        organization,
-        faqPage(FAQ_ITEMS),
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Support', path: '/support' },
-        ]),
-      ],
+      jsonLd: [organization, faqPage(FAQ_ITEMS)],
     }),
   component: SupportPage,
 })
@@ -49,13 +42,13 @@ const ESCALATION_CHANNELS = [
     tag: 'BUGS & REQUESTS',
     title: 'GitHub issues',
     body: "Found a real bug or want a widget that doesn't exist? File it where the code lives.",
-    href: 'https://github.com/brandon-relentnet/myscrollr/issues',
+    href: 'https://github.com/doughknee/myscrollr/issues',
   },
 ]
 
 function SupportPage() {
   return (
-    <main>
+    <div>
       <PageHeader
         eyebrowLeft="SUPPORT ／ HELP DESK"
         eyebrowRight="ANSWERED BY THE PEOPLE WHO WROTE THE CODE"
@@ -122,6 +115,6 @@ function SupportPage() {
       <ClientOnly>
         <SupportContactForm />
       </ClientOnly>
-    </main>
+    </div>
   )
 }

--- a/myscrollr.com/src/routes/uplink.tsx
+++ b/myscrollr.com/src/routes/uplink.tsx
@@ -6,12 +6,7 @@ import { AlertTriangle, CheckCircle2, Loader2, ShieldAlert } from 'lucide-react'
 
 import type { SubscriptionStatus, TierLimitsResponse } from '@/api/client'
 import { seo } from '@/lib/seo'
-import {
-  breadcrumbs,
-  faqPage,
-  organization,
-  productOffers,
-} from '@/lib/structured-data'
+import { faqPage, organization, productOffers } from '@/lib/structured-data'
 import { EASE } from '@/lib/animations'
 import { FALLBACK_LIMITS } from '@/lib/fallbackTierLimits'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
@@ -111,7 +106,7 @@ const STATIC_FAQ = [
   {
     question: 'How fast are live updates?',
     answer:
-      'Instant, on every plan. The moment a price ticks or a score changes, it appears in your ticker over a live streaming connection. There is no faster tier to buy — everyone gets the same speed.',
+      'Every plan uses the same live streaming connection, so changes appear automatically when Scrollr receives them. Upstream timing, corrections, outages, and your connection can affect arrival time; there is no faster tier to buy.',
   },
   {
     question: 'Are there limits inside a widget?',
@@ -185,15 +180,7 @@ export const Route = createFileRoute('/uplink')({
       path: '/uplink',
       image: 'https://myscrollr.com/og/uplink.png',
       type: 'product',
-      jsonLd: [
-        organization,
-        productOffers(STATIC_TIERS),
-        faqPage(STATIC_FAQ),
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Uplink', path: '/uplink' },
-        ]),
-      ],
+      jsonLd: [organization, productOffers(STATIC_TIERS), faqPage(STATIC_FAQ)],
     }),
   component: () => (
     <ClientOnly fallback={<UplinkPrerender />}>

--- a/myscrollr.com/src/routes/uplink_.lifetime.tsx
+++ b/myscrollr.com/src/routes/uplink_.lifetime.tsx
@@ -5,7 +5,7 @@ import { Check, CheckCircle2, Loader2 } from 'lucide-react'
 
 import type { SubscriptionStatus } from '@/api/client'
 import { seo } from '@/lib/seo'
-import { breadcrumbs, organization } from '@/lib/structured-data'
+import { organization } from '@/lib/structured-data'
 import { EASE, riseIn } from '@/lib/animations'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import { useGetToken } from '@/hooks/useGetToken'
@@ -55,14 +55,7 @@ export const Route = createFileRoute('/uplink_/lifetime')({
       path: '/uplink/lifetime',
       image: 'https://myscrollr.com/og/uplink.png',
       type: 'product',
-      jsonLd: [
-        organization,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Uplink', path: '/uplink' },
-          { name: 'Lifetime', path: '/uplink/lifetime' },
-        ]),
-      ],
+      jsonLd: organization,
     }),
   component: () => (
     <ClientOnly fallback={<LifetimePrerender />}>

--- a/myscrollr.com/src/routes/widgets.tsx
+++ b/myscrollr.com/src/routes/widgets.tsx
@@ -12,7 +12,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { AnimatePresence, motion } from 'motion/react'
 import type { CatalogWidget } from '@/lib/catalog'
 import { seo } from '@/lib/seo'
-import { breadcrumbs, organization } from '@/lib/structured-data'
+import { organization } from '@/lib/structured-data'
 import { EASE } from '@/lib/animations'
 import {
   CATEGORY_ORDER,
@@ -36,13 +36,7 @@ export const Route = createFileRoute('/widgets')({
       description:
         'Browse the full Scrollr widget catalog: live sports leagues, stocks and crypto, curated news and custom RSS, Yahoo Fantasy, prediction markets, and utilities. Every widget streams live.',
       path: '/widgets',
-      jsonLd: [
-        organization,
-        breadcrumbs([
-          { name: 'Home', path: '/' },
-          { name: 'Widgets', path: '/widgets' },
-        ]),
-      ],
+      jsonLd: organization,
     }),
   component: ChannelsPage,
 })
@@ -230,7 +224,7 @@ function ChannelsPage() {
                 labelClassName="text-xl"
                 meta="Widgets ship server-side. A good request can be live for everyone in days."
                 action="REQUEST A WIDGET ↗"
-                href="https://github.com/brandon-relentnet/myscrollr/issues/new"
+                href="https://github.com/doughknee/myscrollr/issues/new"
               />
             </div>
           </motion.div>


### PR DESCRIPTION
## Summary
- harden canonical redirects, noindex dynamic routes, and real 404 behavior in the production nginx config
- align public copy, structured data, widget catalog, release metadata, privacy wording, and GitHub references with shipped behavior
- fix support semantics and mobile navigation focus containment
- add repeatable built-site, live-site, viewport, catalog-drift, and exact-nginx audit checks plus the consolidated audit report

## Verification
- 
pm test — 13 files, 135 tests passed
- 
pm run lint — passed
- 
pm run build — passed with GitHub release metadata (desktop 1.6.3), 18 prerender route checks, and 56 mobile viewport checks
- 
ode audit/test-nginx.mjs — 12 production-routing cases passed
- independent review — no remaining blocking findings

## Deliberately deferred
- www apex redirect remains an ingress concern
- shared 667 kB JS chunk, inline-script CSP tightening, hidden background timers, and orphaned landing components need separate scoped work
- no new /open-source-desktop-ticker page: existing home, architecture, widgets, download, and GitHub surfaces already cover that intent without a thin duplicate

PR-only handoff for SCROLLR-191. Do not merge or deploy as part of this task.