### PR TITLE
Release desktop 1.6.5 with app analytics controls [SCROLLR-205]

### DIFF
--- a/api/internal/support/kb/kb.generated.md
+++ b/api/internal/support/kb/kb.generated.md
@@ -4,9 +4,9 @@
 
 This is the authoritative product reference for support replies. Anything stated here is ground truth; the Policies section says what may and may not be repeated to a user.
 
-Current desktop version: **1.6.4**.
+Current desktop version: **1.6.5**.
 
-<!-- source: desktop/package.json @ c8be19c4e544 -->
+<!-- source: desktop/package.json @ d31c0fdb0783 -->
 
 ## Policies
 
@@ -566,7 +566,7 @@ Order matters here. Today the page opens with *Scroll mode*, which is the fourth
 
 ## Release history
 
-<!-- source: docs/ROADMAP.md @ 94e42b073db2 -->
+<!-- source: docs/ROADMAP.md @ 88b41ac3a60c -->
 | Version | Codename | Theme | Size |
 |---|---|---|---|
 | v1.1.1 | Paper Cuts | ✅ **Shipped 2026-07-02** — grew into the catalog redesign (absorbed half of The Library) | S→M |
@@ -591,7 +591,7 @@ Order matters here. Today the page opens with *Scroll mode*, which is the fourth
 | v1.6.1 | Under your eyes | ✅ **Shipped 2026-09-07** — a chip on the bar keeps what it is showing until it has scrolled off screen; a data refresh no longer swaps the game you are reading for another one. Baseball innings read "8th" and "10th" rather than the raw feed code, finals read "Final" in every sport, a postponed game reads "PPD". Server side, fourteen more leagues in the catalog and a sports feed that polls every 15 s without stalling on games that already ended | S |
 | v1.6.2 | Pin what matters | ✅ **Shipped 2026-09-08** — a pin is one chip that stays put: pin a team, a symbol, a feed, a market or a clock and the fixed zone shows its current chip, up to two, never rotating and never doubled on the tape; new widgets no longer pin themselves to the corner; the pin control moved off the moving chip to right-click, the widget page and the sidebar. With several monitors selected the app keeps one live connection instead of one per bar, so "Live updates paused" stops appearing and the tray toggle works with two bars. A session that has died now says so and one click signs you back in, instead of every change failing until a reinstall | S |
 | v1.6.3 | The whole matchday | ✅ **Shipped 2026-09-08** — when a league's next games are further out than a day, the bar used to show exactly one of them, so a full slate of fixtures the next evening looked like a broken ticker. It now shows that whole matchday and takes turns through it. A league whose next fixture really is a lone event, a Formula 1 race for instance, still shows the one chip it always did | S |
-| v1.6.4 | Signed and transparent | ✅ **Shipped 2026-09-10** — Windows downloads identify Scrollr, LLC as their verified publisher and carry trusted timestamps; product activity measurement is off by default and can be enabled from Data & privacy while signed in | S |
+| v1.6.4 | Signed and transparent | ✅ **Shipped 2026-09-10** — Windows downloads identify Scrollr, LLC as their verified publisher and carry trusted timestamps | S |
 
 ## Recent release notes
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.1.15",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.1.15",
+      "version": "1.6.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4622,7 +4622,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2021"
 # std::env::home_dir (Sentry path scrubber) is only correct on Windows from 1.85+
 rust-version = "1.85"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/components/settings/pages/DataPrivacyPage.test.tsx
+++ b/desktop/src/components/settings/pages/DataPrivacyPage.test.tsx
@@ -1,6 +1,8 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import DataPrivacyPage from "./DataPrivacyPage";
+import type { PrivacyPrefs } from "../../../preferences";
 
 const setConsent = vi.fn();
 const setPostHogConsent = vi.fn();
@@ -90,5 +92,34 @@ describe("DataPrivacyPage product activity consent", () => {
       shareProductAnalytics: false,
       postHogAnalyticsDecision: "enabled",
     });
+  });
+
+  it("preserves a newer crash-report change when PostHog consent finishes", async () => {
+    let resolve!: (value: { decision: "declined" }) => void;
+    setPostHogConsent.mockReturnValue(new Promise((done) => { resolve = done; }));
+
+    function Harness() {
+      const [privacy, setPrivacy] = useState<PrivacyPrefs>({
+        sendCrashReports: true,
+        shareProductAnalytics: false,
+        postHogAnalyticsDecision: "enabled",
+      });
+      return (
+        <DataPrivacyPage
+          authenticated
+          privacy={privacy}
+          onPrivacyChange={setPrivacy}
+          onResetAll={vi.fn()}
+        />
+      );
+    }
+
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("switch", { name: /share app analytics/i }));
+    fireEvent.click(screen.getByRole("switch", { name: /send crash reports/i }));
+    await act(async () => resolve({ decision: "declined" }));
+
+    expect(screen.getByRole("switch", { name: /share app analytics/i })).not.toBeChecked();
+    expect(screen.getByRole("switch", { name: /send crash reports/i })).not.toBeChecked();
   });
 });

--- a/desktop/src/components/settings/pages/DataPrivacyPage.tsx
+++ b/desktop/src/components/settings/pages/DataPrivacyPage.tsx
@@ -6,7 +6,7 @@
  * gating it behind auth would remove the only way to do that. Export is
  * hidden signed-out because there is no account to export.
  */
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { exportUserData, setProductAnalyticsConsent } from "../../../api/client";
 import { signalProductAnalyticsConsentMutation } from "../../../lib/productAnalyticsConsent";
@@ -36,6 +36,8 @@ export default function DataPrivacyPage({
   const [confirmResetAll, setConfirmResetAll] = useState(false);
   const [savingAnalytics, setSavingAnalytics] = useState(false);
   const [savingPostHog, setSavingPostHog] = useState(false);
+  const currentPrivacy = useRef(privacy);
+  currentPrivacy.current = privacy;
 
   const handleExport = useCallback(async () => {
     if (exportState === "loading") return;
@@ -93,7 +95,10 @@ export default function DataPrivacyPage({
                   signalProductAnalyticsConsentMutation();
                   try {
                     const saved = await setProductAnalyticsConsent(enabled);
-                    onPrivacyChange({ ...privacy, shareProductAnalytics: saved.enabled });
+                    onPrivacyChange({
+                      ...currentPrivacy.current,
+                      shareProductAnalytics: saved.enabled,
+                    });
                   } catch (err) {
                     toast.error(err instanceof Error ? err.message : "Could not update product activity sharing");
                   } finally {
@@ -118,7 +123,7 @@ export default function DataPrivacyPage({
                       enabled ? "enabled" : "declined",
                     );
                     onPrivacyChange({
-                      ...privacy,
+                      ...currentPrivacy.current,
                       postHogAnalyticsDecision: saved.decision,
                     });
                   } catch (err) {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,8 +10,8 @@ surface actually behave like it.
 v1.1.1–v1.1.9 were all non-breaking, with `MIN_DESKTOP_VERSION` pinned at 1.1.0.
 **v1.1.10 broke that.** The unification renamed the wire with no compat seam, so
 every older install is force-updated — it has to be, since older builds cannot
-talk to the API at all. The gate has moved twice since, once per client-visible
-server change: it currently sits at **1.1.12** (`k8s/configmap-core.yaml`), which
+talk to the API at all. The gate has moved since, once per client-visible server
+change: it currently sits at **1.6.4** (`k8s/configmap-core.yaml`), which
 is the live value to check rather than anything written here.
 
 > **Where the record lives.** Detailed per-release sections below stop at v1.1.6.
@@ -44,7 +44,8 @@ is the live value to check rather than anything written here.
 | ~~v1.6.1~~ | Under your eyes | ✅ **Shipped 2026-09-07** — a chip on the bar keeps what it is showing until it has scrolled off screen; a data refresh no longer swaps the game you are reading for another one. Baseball innings read "8th" and "10th" rather than the raw feed code, finals read "Final" in every sport, a postponed game reads "PPD". Server side, fourteen more leagues in the catalog and a sports feed that polls every 15 s without stalling on games that already ended | S |
 | ~~v1.6.2~~ | Pin what matters | ✅ **Shipped 2026-09-08** — a pin is one chip that stays put: pin a team, a symbol, a feed, a market or a clock and the fixed zone shows its current chip, up to two, never rotating and never doubled on the tape; new widgets no longer pin themselves to the corner; the pin control moved off the moving chip to right-click, the widget page and the sidebar. With several monitors selected the app keeps one live connection instead of one per bar, so "Live updates paused" stops appearing and the tray toggle works with two bars. A session that has died now says so and one click signs you back in, instead of every change failing until a reinstall | S |
 | ~~v1.6.3~~ | The whole matchday | ✅ **Shipped 2026-09-08** — when a league's next games are further out than a day, the bar used to show exactly one of them, so a full slate of fixtures the next evening looked like a broken ticker. It now shows that whole matchday and takes turns through it. A league whose next fixture really is a lone event, a Formula 1 race for instance, still shows the one chip it always did | S |
-| ~~v1.6.4~~ | Signed and transparent | ✅ **Shipped 2026-09-10** — Windows downloads identify Scrollr, LLC as their verified publisher and carry trusted timestamps; product activity measurement is off by default and can be enabled from Data & privacy while signed in | S |
+| ~~v1.6.4~~ | Signed and transparent | ✅ **Shipped 2026-09-10** — Windows downloads identify Scrollr, LLC as their verified publisher and carry trusted timestamps | S |
+| v1.6.5 | App analytics, under your control | Signed-in desktop accounts get a separate Share app analytics switch in Data & privacy. It is on by default, announced after sign-in, and can be turned off anytime; only app opens, a 30-second running signal and broad feature categories are eligible, never ticker contents, symbols, teams or feeds | S |
 | v1.2.0 | Double-Decker 2.0 | Multi-row ticker rebuilt around widgets | L |
 | — | Website rides along | Pricing rewrite shipped with v1.1.2–3; screenshots now unblocked (post-v1.1.4) | S–M |
 


### PR DESCRIPTION
Prepares the signed desktop 1.6.5 release with the merged app analytics integration. Signed-in users get default-on app analytics and a separate opt-out in Data & privacy. Delayed analytics setting saves now preserve other privacy preferences changed while the request was pending.

Synchronizes package and Tauri versions at 1.6.5 and refreshes support release content. The minimum supported version remains 1.6.4. This release is based on deployed API work and has no dependency on the pending website changes.

Validation: 787 desktop tests, mounted delayed-response regression, production frontend build and TypeScript check, 32 Rust tests, Windows signing checks, support KB tests, and independent release review passed. Final signed artifacts and updater manifest will be verified before the draft release is published.

Refs SCROLLR-205; resolves the stale package-lock version tracked in SCROLLR-34.
