### PR TITLE
Fix website analytics delivery and download coverage [SCROLLR-193]

### DIFF
--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -212,7 +212,7 @@ server {\n\
 printf 'add_header X-Content-Type-Options "nosniff" always;\n\
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;\n\
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;\n\
-add_header Content-Security-Policy "default-src '"'"'self'"'"'; frame-ancestors '"'"'self'"'"' https://relentnet.com; script-src '"'"'self'"'"' '"'"'unsafe-inline'"'"' https://js.stripe.com; style-src '"'"'self'"'"' '"'"'unsafe-inline'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"'; connect-src '"'"'self'"'"' https://api.myscrollr.com https://auth.myscrollr.com https://api.stripe.com https://api.github.com; frame-src https://js.stripe.com https://hooks.stripe.com; base-uri '"'"'self'"'"'; form-action '"'"'self'"'"';" always;\n\
+add_header Content-Security-Policy "default-src '"'"'self'"'"'; frame-ancestors '"'"'self'"'"' https://relentnet.com; script-src '"'"'self'"'"' '"'"'unsafe-inline'"'"' https://js.stripe.com; style-src '"'"'self'"'"' '"'"'unsafe-inline'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"'; connect-src '"'"'self'"'"' https://api.myscrollr.com https://auth.myscrollr.com https://api.stripe.com https://api.github.com https://us.i.posthog.com; frame-src https://js.stripe.com https://hooks.stripe.com; base-uri '"'"'self'"'"'; form-action '"'"'self'"'"';" always;\n\
 ' > /etc/nginx/security-headers.conf
 
 EXPOSE 3000

--- a/myscrollr.com/src/components/DownloadButton.tsx
+++ b/myscrollr.com/src/components/DownloadButton.tsx
@@ -5,7 +5,6 @@ import type { LinuxFormat } from '@/lib/getDownloadInfo'
 import type { PlatformInfo } from '@/lib/detectPlatform'
 import { detectIsIntelMac, detectPlatform } from '@/lib/detectPlatform'
 import { FALLBACK_RELEASES_URL, triggerDownload } from '@/lib/getDownloadInfo'
-import { captureWebsiteEvent } from '@/lib/posthog'
 
 // SSR baseline. Must match what `detectPlatform()` returns when
 // `navigator` is undefined — see `lib/detectPlatform.ts`. The initial
@@ -146,7 +145,6 @@ interface SingleDownloadButtonProps {
 
 function SingleDownloadButton({ platform, label }: SingleDownloadButtonProps) {
   const handleClick = useCallback(() => {
-    captureWebsiteEvent('download_selected', { platform })
     triggerDownload(platform)
   }, [platform])
 
@@ -199,7 +197,6 @@ function LinuxDownloadButton() {
 
   const handleSelect = useCallback((format: LinuxFormat) => {
     setOpen(false)
-    captureWebsiteEvent('download_selected', { platform: 'linux' })
     triggerDownload('linux', format)
   }, [])
 

--- a/myscrollr.com/src/lib/getDownloadInfo.test.ts
+++ b/myscrollr.com/src/lib/getDownloadInfo.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
-import { FALLBACK_RELEASES_URL, getDownloadInfo } from './getDownloadInfo'
+import {
+  FALLBACK_RELEASES_URL,
+  getDownloadInfo,
+  triggerDownload,
+} from './getDownloadInfo'
+import { captureWebsiteEvent } from './posthog'
+
+vi.mock('./posthog', () => ({ captureWebsiteEvent: vi.fn() }))
 
 // latestVersion.generated.ts is written at build time by
 // scripts/fetch-latest-version.mjs and is gitignored — mock it so tests
@@ -18,6 +25,28 @@ const RELEASE_BASE =
   'https://github.com/doughknee/myscrollr/releases/download/desktop-v1.2.3'
 
 describe('getDownloadInfo', () => {
+  it('records one download selection through the shared helper without blocking downloads on analytics failure', () => {
+    const location = { href: '' }
+    vi.stubGlobal('window', { location })
+    try {
+      vi.mocked(captureWebsiteEvent).mockClear()
+      triggerDownload('windows')
+      expect(captureWebsiteEvent).toHaveBeenCalledExactlyOnceWith(
+        'download_selected',
+        { platform: 'windows' },
+      )
+      expect(location.href).toBe(`${RELEASE_BASE}/Scrollr_1.2.3_x64-setup.exe`)
+
+      vi.mocked(captureWebsiteEvent).mockImplementationOnce(() => {
+        throw new Error('Storage unavailable')
+      })
+      expect(() => triggerDownload('macos')).not.toThrow()
+      expect(location.href).toBe(`${RELEASE_BASE}/Scrollr_1.2.3_aarch64.dmg`)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('resolves the macOS DMG (Apple Silicon naming)', () => {
     expect(getDownloadInfo('macos')).toEqual({
       version: '1.2.3',

--- a/myscrollr.com/src/lib/getDownloadInfo.ts
+++ b/myscrollr.com/src/lib/getDownloadInfo.ts
@@ -32,6 +32,7 @@ import {
   DESKTOP_ASSET_SIZES,
   LATEST_DESKTOP_VERSION,
 } from './latestVersion.generated'
+import { captureWebsiteEvent } from './posthog'
 
 const REPO_URL = 'https://github.com/doughknee/myscrollr'
 export const FALLBACK_RELEASES_URL = `${REPO_URL}/releases/latest`
@@ -110,6 +111,11 @@ export function triggerDownload(
   linuxFormat: LinuxFormat = LINUX_DEFAULT,
 ): DownloadInfo {
   const info = getDownloadInfo(platform, linuxFormat)
+  try {
+    captureWebsiteEvent('download_selected', { platform })
+  } catch {
+    // Analytics must never prevent an installer download.
+  }
   // `window.location.href = url` triggers a same-tab navigation that
   // the browser recognizes as a download because the URL serves
   // content with `Content-Disposition: attachment`. Using location


### PR DESCRIPTION
The website's security policy blocked its configured PostHog ingestion origin, and current landing/download pages bypassed the old button-only instrumentation. Allow the exact ingestion origin and capture download selections once in the existing shared download helper. Analytics errors cannot prevent downloading; all existing consent and privacy gates still apply.

Validation: reproduced the CSP refusal in a production browser, confirmed pageviews arrive when the corrected header is applied in the isolated QA browser, and added a regression that failed before the shared-helper fix and passed afterward. All 27 focused analytics/download tests and targeted lint pass. Independent review found no blockers. Production pageview/download/opt-out acceptance runs after deployment.
