### PR TITLE
Keep release website refreshes current and rollback-safe [SCROLLR-206]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,8 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
+      checkout-sha: ${{ steps.revision.outputs.sha }}
+      image-tag: ${{ steps.revision.outputs.image-tag }}
       core-api: ${{ steps.manual.outputs.core-api || steps.changes.outputs.core-api }}
       website: ${{ steps.manual.outputs.website || steps.changes.outputs.website }}
       finance-service: ${{ steps.manual.outputs.finance-service || steps.changes.outputs.finance-service }}
@@ -44,6 +46,18 @@ jobs:
       k8s: ${{ steps.manual.outputs.k8s || steps.changes.outputs.k8s }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          # A desktop tag may predate website fixes already deployed from main.
+          ref: ${{ github.event_name == 'release' && 'main' || github.sha }}
+
+      - name: Pin the deployment revision
+        id: revision
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "image-tag=sha-$(git rev-parse --short=7 HEAD)-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
+      - name: Check deployment revision tagging
+        run: node scripts/check-deploy-revision.mjs
 
       - name: Resolve manual service selection
         id: manual
@@ -165,6 +179,8 @@ jobs:
 
       - uses: actions/checkout@v6
         if: matrix.changed == 'true'
+        with:
+          ref: ${{ needs.detect-changes.outputs.checkout-sha }}
 
       - name: Install doctl
         if: matrix.changed == 'true'
@@ -276,7 +292,7 @@ jobs:
           GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IMAGE="${REGISTRY}/${{ matrix.service }}"
-          SHA_TAG="sha-${GITHUB_SHA::7}"
+          SHA_TAG="${{ needs.detect-changes.outputs.image-tag }}"
 
           BUILD_ARGS=""
           if [ "${{ matrix.service }}" = "website" ]; then
@@ -320,6 +336,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.detect-changes.outputs.checkout-sha }}
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
@@ -394,7 +412,7 @@ jobs:
       # service rollout always sees the right SHA.
       - name: Update GIT_SHA in scrollr-secrets
         run: |
-          SHA="${GITHUB_SHA::7}"
+          SHA="$(git rev-parse --short=7 HEAD)"
           SHA_B64=$(printf '%s' "$SHA" | base64)
           kubectl patch secret scrollr-secrets -n scrollr \
             --type='json' \
@@ -406,7 +424,7 @@ jobs:
 
       - name: Roll out updated images
         run: |
-          SHA_TAG="sha-${GITHUB_SHA::7}"
+          SHA_TAG="${{ needs.detect-changes.outputs.image-tag }}"
           K8S_CHANGED="${{ needs.detect-changes.outputs.k8s }}"
 
           rollout_timeout_for() {

--- a/api/internal/support/kb/kb.generated.md
+++ b/api/internal/support/kb/kb.generated.md
@@ -594,8 +594,22 @@ Order matters here. Today the page opens with *Scroll mode*, which is the fourth
 
 ## Recent release notes
 
-<!-- source: github.com/doughknee/myscrollr/releases @ desktop-v1.6.5 -->
+<!-- source: github.com/doughknee/myscrollr/releases @ desktop-v1.6.6 -->
 The last 8 published releases, newest first, as users read them.
+
+### Scrollr 1.6.6 — One analytics setting (`desktop-v1.6.6`, 2026-09-11)
+
+#### Improvements
+
+- **One analytics setting.** Settings → Data & privacy now has a single **Share usage analytics** switch. It controls Scrollr and PostHog usage measurement together; crash reporting stays separate.
+- **Clear setting status.** Loading or a failed connection no longer looks like an opt-out. If the setting cannot be checked, you can retry from the same page.
+
+#### Fixes
+
+- Analytics is on by default for accounts without a saved choice. Recorded opt-outs remain off, and resetting local settings preserves your account's analytics choice.
+- Fixed analytics delivery for internal testing without counting that activity as customer usage, and fixed daily usage counting for apps left running overnight.
+
+Your ticker contents, tracked symbols, teams, feeds and other apps' activity remain excluded. Existing settings and widgets are preserved when updating.
 
 ### Scrollr 1.6.5 — App analytics, under your control (`desktop-v1.6.5`, 2026-09-11)
 
@@ -747,32 +761,3 @@ A small release about one question: what is on my bar right now? It used to have
 #### 🐛 Fixes
 
 - College football standings could come up empty on the bar when the new season's table had not been posted yet. The bar now shows the newest season that actually has one.
-
-### v1.5.1 — The bar just works (`desktop-v1.5.1`, 2026-09-04)
-
-The last five chips were redrawn to match the rest of the bar, and the bar itself learned to hold still: no matter how much a widget has to say, it takes the same amount of room, and everything still comes round.
-
-#### ✨ The bar just works
-
-**Busy widgets no longer flood the rail.** A full MLB night used to put thirty game chips on the bar and bury everything else behind them. Each league now holds a fixed number of places, and the day's games rotate through them one lap at a time. Your favourite team's game is always pinned on top. Every game still comes round, and the bar looks the same on a quiet Tuesday as on a busy Saturday.
-
-**Headlines, stocks, crypto, prediction markets and monitors do the same.** A wire that posts thirty articles in an hour is still three chips. A watchlist of three shows three, and a watchlist of thirty shows four at a time, cycling. Nothing needs configuring — there is no setting for any of this, on purpose.
-
-**A chip never changes while you're reading it.** Rotation only happens once a chip has fully left the screen, and a chip keeps its exact width when its content swaps, so the rail never jumps.
-
-**The ticker is independent of every widget page.** How you sort or filter a list is about reading the list; it no longer rearranges the bar.
-
-#### 💄 The chips
-
-**Clock, timer, weather, sysmon and uptime** join the chip language the rest of the bar took in 1.5.0: a named tab, cells divided by clear rules, compact as the chip itself and detailed adding exactly one row underneath.
-
-**Each one's detailed row is what you'd otherwise open the app to find.** A clock shows the date and offset, so you can see that Tokyo is already tomorrow. A timer shows a draining bar, red in its last minute. Weather shows today's range, and a storm watch sits under its own city. Sysmon draws a real trend, edge to edge, so a GPU climbing reads differently from one holding steady. Uptime gives its whole row to the heartbeat history.
-
-**Weather's compact row is just the city, the icon and the temperature.** The range bar used to sit beside the temperature and made the widest cell on the rail out of the chip with the least to say.
-
-**Cell dividers are visible now**, drawn in each widget's own colour, so four system metrics read as four things instead of one long line.
-
-#### 🐛 Fixes
-
-- The clock's detail row named the zone twice.
-- The news bar's article-limit control was the one control in the bar that didn't look like the others.

--- a/scripts/check-deploy-revision.mjs
+++ b/scripts/check-deploy-revision.mjs
@@ -1,0 +1,36 @@
+// Execute the workflow's real revision step: rebuilt release metadata must
+// produce a new image tag without changing the source revision or rollback image.
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, rmdirSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = fileURLToPath(new URL('../', import.meta.url))
+const workflow = readFileSync(join(root, '.github/workflows/deploy.yml'), 'utf8')
+const step = workflow.match(/id: revision\r?\n\s+run: \|\r?\n((?: {10}[^\r\n]*\r?\n)+)/)?.[1]
+assert.ok(step, 'Deployment revision step is missing')
+const source = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim()
+const directory = mkdtempSync(join(tmpdir(), 'scrollr-deploy-revision-'))
+const bash = process.platform === 'win32' ? 'C:/Program Files/Git/bin/bash.exe' : 'bash'
+try {
+  const tags = []
+  for (const [run, attempt] of [['100', '1'], ['100', '2'], ['101', '1']]) {
+    const output = join(directory, 'output')
+    execFileSync(bash, ['-c', step], {
+      cwd: root,
+      env: { ...process.env, GITHUB_OUTPUT: output, GITHUB_RUN_ID: run, GITHUB_RUN_ATTEMPT: attempt },
+    })
+    const values = Object.fromEntries(readFileSync(output, 'utf8').trim().split('\n').map(line => line.trim().split('=')))
+    unlinkSync(output)
+    assert.equal(values.sha, source)
+    assert.match(values['image-tag'], /^sha-[0-9a-f]+-/)
+    tags.push(values['image-tag'])
+  }
+  assert.equal(new Set(tags).size, 3, 'Rebuilds and retries must not overwrite earlier images')
+  console.log('Deployment revision and immutable rebuild tags verified')
+} finally {
+  rmSync(join(directory, 'output'), { force: true })
+  rmdirSync(directory)
+}


### PR DESCRIPTION
Publishing desktop 1.6.6 started a website refresh from the older desktop tag, which would overwrite fixes already deployed from main. Resolve current main once for release events, pin that source across build and deployment, and give every build/retry a unique image tag so rebuilt release metadata rolls out without overwriting rollback images. Push and manual runs retain their requested source revision.

Also regenerate the support knowledge base from the now-published 1.6.6 notes so the next backend change starts with a current generated file.

Validation: actionlint passes; the stdlib regression executes the real revision step and verifies stable source plus distinct run/retry tags. It runs in the deployment workflow. Production website analytics and an actual Windows 1.6.5-to-1.6.6 upgrade already pass; the stale refresh was canceled during build before deployment. Final deployment will verify the website retains analytics delivery and advertises 1.6.6.
