### PR TITLE
fix: deliver website analytics through Scrollr [SCROLLR-207]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,7 +203,6 @@ jobs:
           VITE_STRIPE_PRICE_ULTIMATE_MONTHLY: ${{ secrets.VITE_STRIPE_PRICE_ULTIMATE_MONTHLY }}
           VITE_STRIPE_PRICE_ULTIMATE_ANNUAL: ${{ secrets.VITE_STRIPE_PRICE_ULTIMATE_ANNUAL }}
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
-          VITE_POSTHOG_HOST: https://us.i.posthog.com
         run: |
           trim_var() {
             printf '%s' "$1" | xargs
@@ -221,8 +220,7 @@ jobs:
             VITE_STRIPE_PRICE_PRO_ANNUAL \
             VITE_STRIPE_PRICE_ULTIMATE_MONTHLY \
             VITE_STRIPE_PRICE_ULTIMATE_ANNUAL \
-            VITE_POSTHOG_KEY \
-            VITE_POSTHOG_HOST; do
+            VITE_POSTHOG_KEY; do
             value="$(trim_var "${!var}")"
             if [ -z "$value" ]; then
               echo "Missing required website build value: $var" >&2
@@ -270,7 +268,6 @@ jobs:
           VITE_STRIPE_PRICE_ULTIMATE_MONTHLY: ${{ secrets.VITE_STRIPE_PRICE_ULTIMATE_MONTHLY }}
           VITE_STRIPE_PRICE_ULTIMATE_ANNUAL: ${{ secrets.VITE_STRIPE_PRICE_ULTIMATE_ANNUAL }}
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
-          VITE_POSTHOG_HOST: https://us.i.posthog.com
           # Sentry — used at WEBSITE BUILD TIME so the Vite plugin can
           # upload source maps. VITE_SENTRY_DSN is baked into the bundle.
           # SENTRY_AUTH_TOKEN + SENTRY_ORG let @sentry/vite-plugin upload
@@ -309,7 +306,6 @@ jobs:
               "VITE_STRIPE_PRICE_ULTIMATE_MONTHLY=$VITE_STRIPE_PRICE_ULTIMATE_MONTHLY" \
               "VITE_STRIPE_PRICE_ULTIMATE_ANNUAL=$VITE_STRIPE_PRICE_ULTIMATE_ANNUAL" \
               "VITE_POSTHOG_KEY=$VITE_POSTHOG_KEY" \
-              "VITE_POSTHOG_HOST=$VITE_POSTHOG_HOST" \
               "VITE_SENTRY_DSN=$VITE_SENTRY_DSN" \
               "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" \
               "SENTRY_ORG=$SENTRY_ORG" \

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -54,3 +54,7 @@ jobs:
       - run: npm ci
 
       - run: npm test
+
+      - name: Verify website event proxy
+        if: matrix.dir == 'myscrollr.com'
+        run: node scripts/test-posthog-proxy.mjs

--- a/myscrollr.com/.env.example
+++ b/myscrollr.com/.env.example
@@ -32,10 +32,9 @@ VITE_STRIPE_PRICE_ULTIMATE_ANNUAL=price_1TMyBVFk6czwHVgr9ntOrMXf
 # DSN is safe to expose client-side (Sentry's design).
 VITE_SENTRY_DSN=
 
-# Optional PostHog website analytics. Both values are required, and the SDK
-# still waits for an explicit visitor opt-in before initializing.
+# Optional PostHog website analytics. Production events use the same-origin
+# /ingest proxy and remain subject to regional policy and visitor choices.
 VITE_POSTHOG_KEY=
-VITE_POSTHOG_HOST=https://us.i.posthog.com
 
 # CI-only — used by @sentry/vite-plugin for source map upload.
 # NEVER commit a real value. Leave empty for local builds.

--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -47,7 +47,6 @@ ARG VITE_STRIPE_PRICE_PRO_ANNUAL
 ARG VITE_STRIPE_PRICE_ULTIMATE_MONTHLY
 ARG VITE_STRIPE_PRICE_ULTIMATE_ANNUAL
 ARG VITE_POSTHOG_KEY
-ARG VITE_POSTHOG_HOST
 # Sentry — VITE_SENTRY_DSN is baked into the bundle. SENTRY_AUTH_TOKEN
 # and SENTRY_ORG are read by @sentry/vite-plugin to upload source maps
 # during the build. If unset, the plugin disables itself (no upload).
@@ -66,7 +65,6 @@ ENV VITE_STRIPE_PRICE_PRO_ANNUAL=${VITE_STRIPE_PRICE_PRO_ANNUAL}
 ENV VITE_STRIPE_PRICE_ULTIMATE_MONTHLY=${VITE_STRIPE_PRICE_ULTIMATE_MONTHLY}
 ENV VITE_STRIPE_PRICE_ULTIMATE_ANNUAL=${VITE_STRIPE_PRICE_ULTIMATE_ANNUAL}
 ENV VITE_POSTHOG_KEY=${VITE_POSTHOG_KEY}
-ENV VITE_POSTHOG_HOST=${VITE_POSTHOG_HOST}
 ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN}
 ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
 ENV SENTRY_ORG=${SENTRY_ORG}
@@ -141,6 +139,32 @@ server {\n\
         proxy_set_header Host o4511384091033600.ingest.us.sentry.io;\n\
         proxy_set_header Content-Type $content_type;\n\
         proxy_set_header Content-Length $content_length;\n\
+    }\n\
+\n\
+    # Fixed event-only PostHog proxy. Browser credentials and IP headers\n\
+    # never reach the provider. Consent is enforced before SDK capture.\n\
+    location = /ingest/i/v0/e/ {\n\
+        if ($request_method != POST) { return 405; }\n\
+        resolver 1.1.1.1 8.8.8.8 valid=300s ipv6=off;\n\
+        set $posthog_ingest us.i.posthog.com;\n\
+        proxy_pass https://$posthog_ingest/i/v0/e/$is_args$args;\n\
+        proxy_ssl_server_name on;\n\
+        proxy_ssl_name us.i.posthog.com;\n\
+        proxy_ssl_verify on;\n\
+        proxy_ssl_trusted_certificate /etc/ssl/cert.pem;\n\
+        proxy_pass_request_headers off;\n\
+        proxy_set_header Host us.i.posthog.com;\n\
+        proxy_set_header Content-Type $content_type;\n\
+        proxy_set_header Content-Encoding $http_content_encoding;\n\
+        proxy_set_header Content-Length $content_length;\n\
+        proxy_hide_header Set-Cookie;\n\
+        proxy_hide_header Cache-Control;\n\
+        proxy_connect_timeout 5s;\n\
+        proxy_read_timeout 10s;\n\
+        client_max_body_size 256k;\n\
+        access_log off;\n\
+        include /etc/nginx/security-headers.conf;\n\
+        add_header Cache-Control "no-store" always;\n\
     }\n\
 \n\
     # ── HTML: no-cache so users always get latest deploy ────────\n\

--- a/myscrollr.com/Dockerfile
+++ b/myscrollr.com/Dockerfile
@@ -143,11 +143,11 @@ server {\n\
 \n\
     # Fixed event-only PostHog proxy. Browser credentials and IP headers\n\
     # never reach the provider. Consent is enforced before SDK capture.\n\
-    location = /ingest/i/v0/e/ {\n\
+    location = /ingest/e/ {\n\
         if ($request_method != POST) { return 405; }\n\
         resolver 1.1.1.1 8.8.8.8 valid=300s ipv6=off;\n\
         set $posthog_ingest us.i.posthog.com;\n\
-        proxy_pass https://$posthog_ingest/i/v0/e/$is_args$args;\n\
+        proxy_pass https://$posthog_ingest/e/$is_args$args;\n\
         proxy_ssl_server_name on;\n\
         proxy_ssl_name us.i.posthog.com;\n\
         proxy_ssl_verify on;\n\

--- a/myscrollr.com/scripts/test-posthog-proxy.mjs
+++ b/myscrollr.com/scripts/test-posthog-proxy.mjs
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { gzipSync } from 'node:zlib'
+
+// Exercise the production nginx configuration, changing only the destination
+// to a local receiver. No test event is sent to a real analytics project.
+const dockerfile = readFileSync(
+  new URL('../Dockerfile', import.meta.url),
+  'utf8',
+)
+const configs = Object.fromEntries(
+  [...dockerfile.matchAll(/printf '([\s\S]*?)' > (\/etc\/nginx\/[^\s]+)/g)].map(
+    ([, body, path]) => [
+      path,
+      body
+        .replaceAll(`'"'"'`, "'")
+        .replace(/\\n\\\r?\n/g, '\n')
+        .replaceAll('\\n', '\n'),
+    ],
+  ),
+)
+const production = configs['/etc/nginx/conf.d/default.conf']
+const headers = configs['/etc/nginx/security-headers.conf']
+assert.ok(
+  production && headers,
+  'Production nginx configuration must be extracted',
+)
+const received = []
+const upstream = createServer(async (request, response) => {
+  const chunks = []
+  for await (const chunk of request) chunks.push(chunk)
+  received.push({
+    url: request.url,
+    headers: request.headers,
+    body: Buffer.concat(chunks),
+  })
+  response.writeHead(200, {
+    'Set-Cookie': 'provider-cookie=must-not-escape',
+    'Cache-Control': 'public',
+  })
+  response.end('accepted')
+})
+await new Promise((resolve) => upstream.listen(0, '0.0.0.0', resolve))
+const port = upstream.address().port
+const proxyDirective =
+  'proxy_pass https://$posthog_ingest/i/v0/e/$is_args$args;'
+assert.ok(
+  production.includes(proxyDirective),
+  'Proxy must have a fixed ingestion destination',
+)
+const mocked = production.replace(
+  proxyDirective,
+  `proxy_pass http://host.docker.internal:${port}/i/v0/e/;`,
+)
+const name = `scrollr-posthog-test-${process.pid}`
+const docker = (...args) =>
+  execFileSync('docker', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+try {
+  docker(
+    'run',
+    '-d',
+    '--name',
+    name,
+    '-p',
+    '127.0.0.1::3000',
+    ...(process.platform === 'linux'
+      ? ['--add-host=host.docker.internal:host-gateway']
+      : []),
+    '-e',
+    `PRODUCTION=${Buffer.from(production).toString('base64')}`,
+    '-e',
+    `MOCKED=${Buffer.from(mocked).toString('base64')}`,
+    '-e',
+    `HEADERS=${Buffer.from(headers).toString('base64')}`,
+    'nginx:alpine',
+    'sh',
+    '-c',
+    'echo "$HEADERS" | base64 -d > /etc/nginx/security-headers.conf && echo "$PRODUCTION" | base64 -d > /etc/nginx/conf.d/default.conf && nginx -t && echo "$MOCKED" | base64 -d > /etc/nginx/conf.d/default.conf && nginx -g "daemon off;"',
+  )
+  const address = docker('port', name, '3000/tcp')
+  const base = `http://${address}`
+  let ready = false
+  for (let attempt = 0; attempt < 40; attempt++) {
+    try {
+      await fetch(base)
+      ready = true
+      break
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+  }
+  assert.ok(ready, 'Proxy must start')
+  for (const body of [
+    Buffer.from('{"event":"test"}'),
+    gzipSync('{"event":"test"}'),
+  ]) {
+    const compressed = body[0] === 31
+    const response = await fetch(
+      `${base}/ingest/i/v0/e/?compression=${compressed ? 'gzip-js' : 'none'}`,
+      {
+        method: 'POST',
+        body,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(compressed ? { 'Content-Encoding': 'gzip' } : {}),
+          Cookie: 'scrollr-auth=private-test-cookie',
+          Authorization: 'Bearer private-test-token',
+          'X-Forwarded-For': '192.0.2.1',
+          'X-Real-IP': '192.0.2.2',
+          Forwarded: 'for=192.0.2.3',
+          'User-Agent': 'private-test-browser',
+          Referer: 'https://myscrollr.com/callback?code=private',
+        },
+      },
+    )
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'accepted')
+    assert.equal(response.headers.get('set-cookie'), null)
+    assert.equal(response.headers.get('cache-control'), 'no-store')
+    const event = received.at(-1)
+    assert.equal(
+      event.url,
+      `/i/v0/e/?compression=${compressed ? 'gzip-js' : 'none'}`,
+    )
+    assert.deepEqual(event.body, body)
+    assert.equal(event.headers.host, 'us.i.posthog.com')
+    assert.equal(event.headers['content-type'], 'application/json')
+    assert.equal(
+      event.headers['content-encoding'],
+      compressed ? 'gzip' : undefined,
+    )
+    for (const header of [
+      'cookie',
+      'authorization',
+      'x-forwarded-for',
+      'x-real-ip',
+      'forwarded',
+      'user-agent',
+      'referer',
+    ]) {
+      assert.equal(
+        event.headers[header],
+        undefined,
+        `${header} must not reach PostHog`,
+      )
+    }
+  }
+  for (const [path, method, status] of [
+    ['/ingest/i/v0/e/', 'GET', 405],
+    ['/ingest/i/v0/e/', 'DELETE', 405],
+    ['/ingest/api/projects/', 'POST', 404],
+    ['/ingest/s/', 'POST', 404],
+  ]) {
+    assert.equal((await fetch(`${base}${path}`, { method })).status, status)
+  }
+  assert.equal(
+    (
+      await fetch(`${base}/ingest/i/v0/e/`, {
+        method: 'POST',
+        body: 'x'.repeat(256 * 1024 + 1),
+      })
+    ).status,
+    413,
+  )
+  assert.equal(
+    received.length,
+    2,
+    'Rejected requests must not reach the provider',
+  )
+  console.log(
+    'PostHog proxy passed: production nginx syntax, event bodies, header isolation, no cookies/cache, method/path/body limits',
+  )
+} finally {
+  try {
+    docker('rm', '-f', name)
+  } catch {
+    /* May not have started. */
+  }
+  upstream.closeAllConnections()
+  await new Promise((resolve) => upstream.close(resolve))
+}

--- a/myscrollr.com/scripts/test-posthog-proxy.mjs
+++ b/myscrollr.com/scripts/test-posthog-proxy.mjs
@@ -44,15 +44,14 @@ const upstream = createServer(async (request, response) => {
 })
 await new Promise((resolve) => upstream.listen(0, '0.0.0.0', resolve))
 const port = upstream.address().port
-const proxyDirective =
-  'proxy_pass https://$posthog_ingest/i/v0/e/$is_args$args;'
+const proxyDirective = 'proxy_pass https://$posthog_ingest/e/$is_args$args;'
 assert.ok(
   production.includes(proxyDirective),
   'Proxy must have a fixed ingestion destination',
 )
 const mocked = production.replace(
   proxyDirective,
-  `proxy_pass http://host.docker.internal:${port}/i/v0/e/;`,
+  `proxy_pass http://host.docker.internal:${port}/e/;`,
 )
 const name = `scrollr-posthog-test-${process.pid}`
 const docker = (...args) =>
@@ -101,7 +100,7 @@ try {
   ]) {
     const compressed = body[0] === 31
     const response = await fetch(
-      `${base}/ingest/i/v0/e/?compression=${compressed ? 'gzip-js' : 'none'}`,
+      `${base}/ingest/e/?compression=${compressed ? 'gzip-js' : 'none'}`,
       {
         method: 'POST',
         body,
@@ -125,7 +124,7 @@ try {
     const event = received.at(-1)
     assert.equal(
       event.url,
-      `/i/v0/e/?compression=${compressed ? 'gzip-js' : 'none'}`,
+      `/e/?compression=${compressed ? 'gzip-js' : 'none'}`,
     )
     assert.deepEqual(event.body, body)
     assert.equal(event.headers.host, 'us.i.posthog.com')
@@ -151,8 +150,8 @@ try {
     }
   }
   for (const [path, method, status] of [
-    ['/ingest/i/v0/e/', 'GET', 405],
-    ['/ingest/i/v0/e/', 'DELETE', 405],
+    ['/ingest/e/', 'GET', 405],
+    ['/ingest/e/', 'DELETE', 405],
     ['/ingest/api/projects/', 'POST', 404],
     ['/ingest/s/', 'POST', 404],
   ]) {
@@ -160,7 +159,7 @@ try {
   }
   assert.equal(
     (
-      await fetch(`${base}/ingest/i/v0/e/`, {
+      await fetch(`${base}/ingest/e/`, {
         method: 'POST',
         body: 'x'.repeat(256 * 1024 + 1),
       })

--- a/myscrollr.com/src/lib/posthog.proxy.test.ts
+++ b/myscrollr.com/src/lib/posthog.proxy.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs'
+import { expect, it, vi } from 'vitest'
+import {
+  captureWebsitePageview,
+  setWebsiteAnalyticsDecision,
+  setWebsiteAnalyticsPolicy,
+  setWebsiteAnalyticsSuppressed,
+} from './posthog'
+
+const send = vi.hoisted(() => {
+  vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+    'Mozilla/5.0 Chrome/145.0.0.0 Safari/537.36',
+  )
+  const fetch = vi.fn(
+    (_url: string | URL | Request, _options?: RequestInit) =>
+      Promise.resolve(new Response('{}', { status: 200 })),
+  )
+  vi.stubGlobal('fetch', fetch)
+  vi.stubGlobal('CompressionStream', undefined)
+  return fetch
+})
+
+it('sends real slim SDK events to the exact nginx route and stops on decline', async () => {
+  vi.useFakeTimers()
+  vi.stubEnv('PROD', true)
+  vi.stubEnv('VITE_POSTHOG_KEY', 'test-key')
+  try {
+    localStorage.clear()
+    setWebsiteAnalyticsPolicy('default-on')
+    setWebsiteAnalyticsSuppressed(false)
+    captureWebsitePageview('/download')
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(send).toHaveBeenCalled()
+    expect(
+      send.mock.calls.map(
+        ([url]) => new URL(String(url), window.location.origin).pathname,
+      ),
+    ).toEqual(['/ingest/e/'])
+    expect(readFileSync('Dockerfile', 'utf8')).toContain(
+      'location = /ingest/e/ {',
+    )
+
+    setWebsiteAnalyticsDecision('declined')
+    send.mockClear()
+    captureWebsitePageview('/widgets')
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(send).not.toHaveBeenCalled()
+  } finally {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  }
+})

--- a/myscrollr.com/src/lib/posthog.test.ts
+++ b/myscrollr.com/src/lib/posthog.test.ts
@@ -62,7 +62,6 @@ describe('website PostHog privacy boundary', () => {
     sdk.get_distinct_id.mockReturnValue('anonymous-id')
     vi.stubEnv('PROD', true)
     vi.stubEnv('VITE_POSTHOG_KEY', 'test-key')
-    vi.stubEnv('VITE_POSTHOG_HOST', 'https://example.test')
     window.location.pathname = '/'
     browserPrivacy.doNotTrack = null
     delete browserPrivacy.globalPrivacyControl
@@ -77,6 +76,8 @@ describe('website PostHog privacy boundary', () => {
     expect(sdk.init).toHaveBeenCalledWith(
       'test-key',
       expect.objectContaining({
+        api_host: '/ingest',
+        ui_host: 'https://us.posthog.com',
         advanced_disable_flags: true,
         opt_out_capturing_by_default: true,
         opt_out_persistence_by_default: true,

--- a/myscrollr.com/src/lib/posthog.ts
+++ b/myscrollr.com/src/lib/posthog.ts
@@ -98,18 +98,15 @@ export function sanitizeWebsiteCapture(
 }
 
 function configured(): boolean {
-  return Boolean(
-    import.meta.env.PROD &&
-      import.meta.env.VITE_POSTHOG_KEY &&
-      import.meta.env.VITE_POSTHOG_HOST?.startsWith('https://'),
-  )
+  return Boolean(import.meta.env.PROD && import.meta.env.VITE_POSTHOG_KEY)
 }
 
 function initialize(): boolean {
   if (!configured()) return false
   if (!initialized) {
     posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
-      api_host: import.meta.env.VITE_POSTHOG_HOST,
+      api_host: '/ingest',
+      ui_host: 'https://us.posthog.com',
       advanced_disable_flags: true,
       autocapture: false,
       before_send: sanitizeWebsiteCapture,


### PR DESCRIPTION
Website analytics currently sends requests directly to PostHog. Route the existing limited events through `myscrollr.com/ingest` so delivery uses Scrollr's domain, while retaining regional consent, saved declines, GPC/DNT handling, and payload scrubbing.

The event-only nginx proxy verifies upstream TLS, refreshes DNS, strips browser credentials and IP headers, suppresses provider cookies and caching, and limits request methods, paths and body size. Remove the obsolete website ingestion-host build setting. Desktop analytics already travels through Scrollr's API and needs no release.

Validation: all 158 website tests, typecheck, targeted lint, full website build and all mobile viewport checks pass. A regression test uses the actual slim SDK to verify its request path matches nginx and that decline stops capture. The Docker integration check passes in frontend CI, exercising production nginx syntax, compressed/plain body forwarding, header isolation and rejection paths. Production upstream DNS and CA bundle availability were checked. Independent review found no remaining blockers; live event-arrival and opt-out verification follow deployment.

The proposed GPC policy change is deferred until Scrollr's PostHog DPA is completed and provider secondary-use settings are verified; this PR does not change that behavior.

Refs SCROLLR-207.
