### PR TITLE
fix: honor regional analytics choices with browser signals [SCROLLR-207]

### DIFF
--- a/myscrollr.com/src/components/AnalyticsConsent.test.tsx
+++ b/myscrollr.com/src/components/AnalyticsConsent.test.tsx
@@ -11,6 +11,7 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
 describe('AnalyticsConsent', () => {
   afterEach(() => {
+    localStorage.clear()
     setWebsiteAnalyticsPolicy('unknown')
     vi.unstubAllGlobals()
   })
@@ -29,24 +30,35 @@ describe('AnalyticsConsent', () => {
     expect(html).not.toContain('role="dialog"')
   })
 
-  it('honors a browser privacy signal and disables manual opt-in', async () => {
+  it('allows an explicit choice with browser signals in consent-required regions', async () => {
     setWebsiteAnalyticsPolicy('consent-required')
-    vi.stubGlobal('navigator', { globalPrivacyControl: true })
-    expect(renderToStaticMarkup(<AnalyticsConsent />)).toBe('')
+    vi.stubGlobal('navigator', { globalPrivacyControl: true, doNotTrack: '1' })
 
     const container = document.createElement('div')
     const root = createRoot(container)
     await act(() => root.render(<AnalyticsConsent />))
+    const allow = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Allow',
+    )!
+    expect(allow).toBeDefined()
+    expect(allow.disabled).toBe(false)
+    expect(localStorage.getItem('scrollr-analytics-consent-v1')).toBeNull()
+    await act(() => allow.click())
+    expect(localStorage.getItem('scrollr-analytics-consent-v1')).toBe('enabled')
+    expect(container.textContent).toBe('')
+
     await act(() =>
       window.dispatchEvent(new CustomEvent('scrollr:manage-analytics')),
     )
-
-    expect(container.textContent).toContain(
-      'Your browser privacy signal keeps analytics off.',
+    const decline = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Decline',
+    )!
+    await act(() => decline.click())
+    await act(() => setWebsiteAnalyticsPolicy('default-on'))
+    expect(localStorage.getItem('scrollr-analytics-consent-v1')).toBe(
+      'declined',
     )
-    expect(container.innerHTML).toMatch(
-      /<button[^>]*disabled=""[^>]*>Allow<\/button>/,
-    )
+    expect(container.textContent).toBe('')
     await act(() => root.unmount())
   })
 

--- a/myscrollr.com/src/components/AnalyticsConsent.tsx
+++ b/myscrollr.com/src/components/AnalyticsConsent.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import {
   getWebsiteAnalyticsDecision,
   getWebsiteAnalyticsPolicy,
-  hasWebsiteAnalyticsOptOutSignal,
   setWebsiteAnalyticsDecision,
 } from '@/lib/posthog'
 
@@ -42,9 +41,8 @@ export default function AnalyticsConsent() {
     setManaging(false)
   }
 
-  const browserOptedOut = hasWebsiteAnalyticsOptOutSignal()
   const buttonClass =
-    'rounded-lg border border-base-300 px-4 py-2 text-sm font-semibold hover:bg-base-200 disabled:cursor-not-allowed disabled:opacity-50'
+    'rounded-lg border border-base-300 px-4 py-2 text-sm font-semibold hover:bg-base-200'
 
   return (
     <section
@@ -62,11 +60,6 @@ export default function AnalyticsConsent() {
         </a>
         .
       </p>
-      {browserOptedOut && (
-        <p className="mt-1 text-xs text-base-content/65">
-          Your browser privacy signal keeps analytics off.
-        </p>
-      )}
       <div className="mt-4 grid grid-cols-2 gap-3">
         <button
           type="button"
@@ -78,7 +71,6 @@ export default function AnalyticsConsent() {
         <button
           type="button"
           className={buttonClass}
-          disabled={browserOptedOut}
           onClick={() => choose('enabled')}
         >
           Allow

--- a/myscrollr.com/src/components/legal/documents.ts
+++ b/myscrollr.com/src/components/legal/documents.ts
@@ -170,6 +170,7 @@ export const LEGAL_DOCUMENTS: Array<LegalDocument> = [
         content: [
           'We use your information to provide and operate the Platform, including delivering real-time data to your desktop application and web dashboard, synchronizing your preferences across devices, and maintaining your third-party account connections.',
           'We do not sell, rent, or share your personal information with third parties for marketing purposes. We do not serve advertisements.',
+          'Browser privacy signals: Scrollr does not sell personal information or share it for cross-context behavioral advertising, including when Global Privacy Control (GPC) is enabled. GPC and Do Not Track do not automatically disable our limited product analytics, which PostHog processes on our behalf under a data processing agreement. The regional consent rules above still apply, and you can always decline through Analytics settings in the footer.',
         ],
       },
       {

--- a/myscrollr.com/src/lib/posthog.proxy.test.ts
+++ b/myscrollr.com/src/lib/posthog.proxy.test.ts
@@ -10,19 +10,22 @@ import {
 } from './posthog'
 
 const send = vi.hoisted(() => {
+  Object.defineProperties(navigator, {
+    globalPrivacyControl: { configurable: true, value: true },
+    doNotTrack: { configurable: true, value: '1' },
+  })
   vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
     'Mozilla/5.0 Chrome/145.0.0.0 Safari/537.36',
   )
-  const fetch = vi.fn(
-    (_url: string | URL | Request, _options?: RequestInit) =>
-      Promise.resolve(new Response('{}', { status: 200 })),
+  const fetch = vi.fn((_url: string | URL | Request, _options?: RequestInit) =>
+    Promise.resolve(new Response('{}', { status: 200 })),
   )
   vi.stubGlobal('fetch', fetch)
   vi.stubGlobal('CompressionStream', undefined)
   return fetch
 })
 
-it('sends real slim SDK events to the exact nginx route and stops on decline', async () => {
+it('sends real SDK events with browser signals through nginx and stops on explicit decline', async () => {
   vi.useFakeTimers()
   vi.stubEnv('PROD', true)
   vi.stubEnv('VITE_POSTHOG_KEY', 'test-key')

--- a/myscrollr.com/src/lib/posthog.test.ts
+++ b/myscrollr.com/src/lib/posthog.test.ts
@@ -5,7 +5,6 @@ import {
   captureWebsiteEvent,
   captureWebsitePageview,
   getWebsiteAnalyticsDecision,
-  hasWebsiteAnalyticsOptOutSignal,
   normalizeWebsiteAnalyticsPolicy,
   resetWebsiteAnalyticsIdentity,
   sanitizeWebsiteCapture,
@@ -81,6 +80,7 @@ describe('website PostHog privacy boundary', () => {
         advanced_disable_flags: true,
         opt_out_capturing_by_default: true,
         opt_out_persistence_by_default: true,
+        respect_dnt: false,
       }),
     )
     expect(sdk.opt_out_capturing).toHaveBeenCalledOnce()
@@ -122,7 +122,7 @@ describe('website PostHog privacy boundary', () => {
     expect(sdk.capture).not.toHaveBeenCalled()
   })
 
-  it('honors GPC and DNT before initialization, identity, or capture', () => {
+  it('uses regional consent and explicit choices with GPC or DNT enabled', () => {
     for (const signal of ['gpc', 'dnt'] as const) {
       localStorage.clear()
       vi.clearAllMocks()
@@ -132,13 +132,32 @@ describe('website PostHog privacy boundary', () => {
         browserPrivacy.doNotTrack = '1'
       }
 
-      expect(hasWebsiteAnalyticsOptOutSignal()).toBe(true)
-      setWebsiteAnalyticsDecision('enabled')
-      captureWebsitePageview('/download')
+      for (const policy of ['unknown', 'consent-required'] as const) {
+        setWebsiteAnalyticsPolicy(policy)
+        expect(getWebsiteAnalyticsDecision()).toBe('unknown')
+        captureWebsiteEvent('download_selected')
+        expect(sdk.capture).not.toHaveBeenCalled()
+      }
+
+      setWebsiteAnalyticsPolicy('default-on')
+      expect(getWebsiteAnalyticsDecision()).toBe('enabled')
+      expect(localStorage.getItem('scrollr-analytics-consent-v1')).toBeNull()
+      captureWebsiteEvent('download_selected')
+      expect(sdk.capture).toHaveBeenCalledOnce()
+
+      setWebsiteAnalyticsDecision('declined')
+      sdk.capture.mockClear()
+      captureWebsiteEvent('download_selected')
       expect(getWebsiteAnalyticsDecision()).toBe('declined')
-      expect(sdk.init).not.toHaveBeenCalled()
       expect(sdk.identify).not.toHaveBeenCalled()
       expect(sdk.capture).not.toHaveBeenCalled()
+
+      setWebsiteAnalyticsPolicy('consent-required')
+      expect(getWebsiteAnalyticsDecision()).toBe('declined')
+      setWebsiteAnalyticsDecision('enabled')
+      expect(getWebsiteAnalyticsDecision()).toBe('enabled')
+      captureWebsiteEvent('download_selected')
+      expect(sdk.capture).toHaveBeenCalledOnce()
 
       browserPrivacy.doNotTrack = null
       delete browserPrivacy.globalPrivacyControl

--- a/myscrollr.com/src/lib/posthog.ts
+++ b/myscrollr.com/src/lib/posthog.ts
@@ -119,7 +119,8 @@ function initialize(): boolean {
       opt_out_capturing_by_default: true,
       opt_out_persistence_by_default: true,
       persistence: 'localStorage',
-      respect_dnt: true,
+      // Limited service-provider analytics use the regional policy and Scrollr choice below.
+      respect_dnt: false,
     })
     initialized = true
   }
@@ -128,7 +129,6 @@ function initialize(): boolean {
 
 export function getWebsiteAnalyticsDecision(): WebsiteAnalyticsDecision {
   if (typeof window === 'undefined') return 'unknown'
-  if (hasWebsiteAnalyticsOptOutSignal()) return 'declined'
   const value = localStorage.getItem(STORAGE_KEY)
   if (value === 'enabled' || value === 'declined') return value
   return analyticsPolicy === 'default-on' ? 'enabled' : 'unknown'
@@ -153,28 +153,13 @@ export function setWebsiteAnalyticsPolicy(
   }
 }
 
-export function hasWebsiteAnalyticsOptOutSignal(): boolean {
-  if (typeof navigator === 'undefined') return false
-  const globalPrivacyControl = (
-    navigator as Navigator & { globalPrivacyControl?: boolean }
-  ).globalPrivacyControl
-  const doNotTrack =
-    navigator.doNotTrack ??
-    (typeof window === 'undefined'
-      ? null
-      : (window as Window & { doNotTrack?: string }).doNotTrack)
-  return (
-    globalPrivacyControl === true || doNotTrack === '1' || doNotTrack === 'yes'
-  )
-}
-
 export function setWebsiteAnalyticsDecision(
   decision: Exclude<WebsiteAnalyticsDecision, 'unknown'>,
 ): void {
   if (typeof window === 'undefined') return
   localStorage.setItem(STORAGE_KEY, decision)
   if (decision === 'enabled') {
-    if (!hasWebsiteAnalyticsOptOutSignal() && initialize()) {
+    if (initialize()) {
       posthog.reset()
       posthog.opt_in_capturing({ captureEventName: false })
     }


### PR DESCRIPTION
Website visitors with GPC or DNT enabled were treated as having declined Scrollr analytics, and the Allow button was disabled. Limited service-provider analytics now follow the existing US default-on policy or an explicit visitor choice; other and unresolved regions still require Allow. A saved Scrollr decline continues to stop capture and clear the browser identity.

Removes the blanket browser-signal veto, sets the SDK to use Scrollr's consent policy, enables the Allow button, and explains the behavior in the privacy policy. The signed DPA and organization AI-training opt-out were verified before release. No desktop changes or version bump.

Validation: 158 website tests passed, including actual slim-SDK delivery with GPC/DNT and no delivery after decline; typecheck, targeted ESLint, and production/prerender build passed. Existing marketing viewport sweep was skipped locally because layouts are unchanged; the changed consent controls will receive focused mobile QA. Independent review found no ship blockers. CI also checks the deployed nginx proxy configuration. Production verification will confirm event arrival, persistent opt-out, and consent-required behavior.

SCROLLR-207
