### PR TITLE
Fix website session loops, theme restoration, and account access

### DIFF
--- a/myscrollr.com/scripts/check-mobile-viewport.mjs
+++ b/myscrollr.com/scripts/check-mobile-viewport.mjs
@@ -45,6 +45,8 @@ const VIEWPORTS = [
 // Running the check against an empty <main> would silently pass and
 // hide real bugs.
 const ROUTES = [
+  { path: '/account', file: '_shell.html', authShell: true },
+  { path: '/admin', file: '_shell.html', authShell: true },
   { path: '/', file: 'index.html' },
   { path: '/widgets', file: 'widgets/index.html' },
   { path: '/fantasy', file: 'fantasy/index.html' },
@@ -191,9 +193,19 @@ try {
       isMobile: viewport.width < 768,
       hasTouch: viewport.width < 768,
     })
+    const theme = viewport.width < 400 ? 'dark' : 'light'
+    await context.addInitScript((preference) => {
+      localStorage.setItem('theme', preference)
+      localStorage.setItem('scrollr-analytics-consent-v1', 'declined')
+    }, theme)
     const page = await context.newPage()
+    const pageErrors = []
+    page.on('pageerror', (error) => pageErrors.push(error.message))
 
-    for (const route of ROUTES) {
+    for (const route of ROUTES.filter(
+      (item) => !process.argv.includes('--auth-only') || item.authShell,
+    )) {
+      pageErrors.length = 0
       try {
         await page.goto(`${baseUrl}${route.path}`, {
           waitUntil: 'networkidle',
@@ -209,6 +221,42 @@ try {
 
       // Brief settle so any in-flight layout work finishes.
       await page.waitForTimeout(250)
+
+      if (route.authShell) {
+        const actualTheme = await page.evaluate(() =>
+          document.documentElement.classList.contains('dark')
+            ? 'dark'
+            : 'light',
+        )
+        const heading = await page.locator('h1').textContent()
+        if (
+          pageErrors.length ||
+          actualTheme !== theme ||
+          !heading?.includes(
+            route.path === '/admin'
+              ? 'Sign in to continue'
+              : 'Your Scrollr account',
+          )
+        ) {
+          console.error(
+            `✗ ${route.path}: theme=${actualTheme}, expected=${theme}, heading=${heading}, errors=${pageErrors.join('; ')}`,
+          )
+          failures += 1
+        }
+        await page
+          .getByRole('button', { name: 'Open menu', exact: true })
+          .click()
+        if (
+          !(await page
+            .getByRole('dialog', { name: 'Mobile navigation' })
+            .getByRole('button', { name: 'SIGN IN', exact: true })
+            .isVisible())
+        )
+          failures += 1
+        await page
+          .getByRole('button', { name: 'Close menu', exact: true })
+          .click()
+      }
 
       const result = await page.evaluate(() => {
         const doc = document.documentElement

--- a/myscrollr.com/src/client.tsx
+++ b/myscrollr.com/src/client.tsx
@@ -1,25 +1,15 @@
 // Sentry must initialize before any other module imports so the SDK can
 // attach to browser globals before React/Logto/etc start running.
 
-import { StrictMode, useEffect, useRef, useState } from 'react'
+import { StrictMode } from 'react'
 import * as Sentry from '@sentry/react'
 import { StartClient } from '@tanstack/react-start/client'
 import { hydrateRoot } from 'react-dom/client'
 import { LogtoProvider } from '@logto/react'
 import { initSentry } from './sentry'
 import type { LogtoConfig } from '@logto/react'
-import type { WebsiteAnalyticsContext } from '@/lib/posthog'
-import { ScrollrAuthProvider, useScrollrAuth } from '@/hooks/useScrollrAuth'
-import { analyticsPolicyApi, authenticatedFetch } from '@/api/client'
-import {
-  applyWebsiteAnalyticsContext,
-  captureWebsitePageview,
-  getWebsiteAnalyticsDecision,
-  normalizeWebsiteAnalyticsPolicy,
-  resetWebsiteAnalyticsIdentity,
-  setWebsiteAnalyticsPolicy,
-  setWebsiteAnalyticsSuppressed,
-} from '@/lib/posthog'
+import { ScrollrAuthProvider } from '@/hooks/useScrollrAuth'
+import { WebsiteAnalyticsGate } from '@/components/WebsiteAnalyticsGate'
 
 import '@/styles.css'
 
@@ -54,117 +44,6 @@ function SentryFallback() {
       </button>
     </div>
   )
-}
-
-function WebsiteAnalyticsGate() {
-  const { getAccessToken, isAuthenticated, isLoading } = useScrollrAuth()
-  const checkedUser = useRef(false)
-  const retriedUser = useRef(false)
-  const wasAuthenticated = useRef(false)
-  const [consentRevision, setConsentRevision] = useState(0)
-  const [policyReady, setPolicyReady] = useState(false)
-  const [policyRevision, setPolicyRevision] = useState(0)
-
-  useEffect(() => {
-    let current = true
-    setPolicyReady(false)
-    void analyticsPolicyApi
-      .get()
-      .then(({ policy }) => {
-        if (!current) return
-        setWebsiteAnalyticsPolicy(normalizeWebsiteAnalyticsPolicy(policy))
-      })
-      .catch(() => {
-        if (current) setWebsiteAnalyticsPolicy('consent-required')
-      })
-      .finally(() => {
-        if (current) setPolicyReady(true)
-      })
-    return () => {
-      current = false
-    }
-  }, [policyRevision])
-
-  useEffect(() => {
-    const refresh = () => setPolicyRevision((value) => value + 1)
-    const refreshWhenVisible = () => {
-      if (document.visibilityState === 'visible') refresh()
-    }
-    const timer = window.setInterval(refresh, 15 * 60 * 1000)
-    window.addEventListener('focus', refresh)
-    document.addEventListener('visibilitychange', refreshWhenVisible)
-    return () => {
-      window.clearInterval(timer)
-      window.removeEventListener('focus', refresh)
-      document.removeEventListener('visibilitychange', refreshWhenVisible)
-    }
-  }, [])
-
-  useEffect(() => {
-    const changed = () => setConsentRevision((value) => value + 1)
-    window.addEventListener('scrollr:analytics-consent-changed', changed)
-    return () =>
-      window.removeEventListener('scrollr:analytics-consent-changed', changed)
-  }, [])
-
-  useEffect(() => {
-    if (!policyReady) {
-      setWebsiteAnalyticsSuppressed(true)
-      return
-    }
-    if (isLoading) {
-      setWebsiteAnalyticsSuppressed(true)
-      return
-    }
-    if (!isAuthenticated) {
-      if (wasAuthenticated.current) resetWebsiteAnalyticsIdentity()
-      wasAuthenticated.current = false
-      checkedUser.current = false
-      retriedUser.current = false
-      setWebsiteAnalyticsSuppressed(false)
-      captureWebsitePageview(window.location.pathname)
-      return
-    }
-    wasAuthenticated.current = true
-    setWebsiteAnalyticsSuppressed(true)
-    if (getWebsiteAnalyticsDecision() !== 'enabled') {
-      checkedUser.current = false
-      retriedUser.current = false
-      return
-    }
-    if (checkedUser.current) return
-    checkedUser.current = true
-    let current = true
-    let retryTimer: number | undefined
-    void authenticatedFetch<WebsiteAnalyticsContext>(
-      '/users/me/verify-website-signup',
-      { method: 'POST' },
-      getAccessToken,
-    )
-      .then((context) => {
-        if (!current) return
-        if (!applyWebsiteAnalyticsContext(context)) return
-        retriedUser.current = false
-        setWebsiteAnalyticsSuppressed(false)
-        captureWebsitePageview(window.location.pathname)
-      })
-      .catch(() => {
-        if (!current || retriedUser.current) return
-        checkedUser.current = false
-        retriedUser.current = true
-        retryTimer = window.setTimeout(
-          () => setConsentRevision((value) => value + 1),
-          2000,
-        )
-      })
-    return () => {
-      current = false
-      checkedUser.current = false
-      if (retryTimer !== undefined) window.clearTimeout(retryTimer)
-    }
-  }, [consentRevision, getAccessToken, isAuthenticated, isLoading, policyReady])
-
-  return null
 }
 
 hydrateRoot(

--- a/myscrollr.com/src/components/Header.tsx
+++ b/myscrollr.com/src/components/Header.tsx
@@ -2,7 +2,6 @@ import { ClientOnly, Link, useLocation } from '@tanstack/react-router'
 import { Menu, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
-import type { IdTokenClaims } from '@logto/react'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { useDemoTicker } from '@/hooks/useDemoTicker'
@@ -110,7 +109,7 @@ export default function Header({
         <Wordmark />
 
         {/* Desktop navigation */}
-        <nav className="hidden items-center gap-8 font-mono text-xs tracking-[0.08em] lg:flex">
+        <nav className="hidden items-center gap-6 font-mono text-xs tracking-[0.08em] lg:flex">
           {NAV_LINKS.map((l) => (
             <NavLink key={l.to} to={l.to}>
               {l.label}
@@ -236,44 +235,59 @@ function Wordmark() {
 // Each of these calls `useScrollrAuth()` and therefore must render
 // only on the client (wrapped in <ClientOnly> at the call site).
 
-function useUserClaims(): IdTokenClaims | undefined {
-  const { isAuthenticated, getIdTokenClaims } = useScrollrAuth()
-  const [userClaims, setUserClaims] = useState<IdTokenClaims>()
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      getIdTokenClaims().then(setUserClaims)
-    } else {
-      setUserClaims(undefined)
-    }
-  }, [isAuthenticated, getIdTokenClaims])
-
-  return userClaims
-}
-
 function DesktopAccountLink() {
-  const { isAuthenticated } = useScrollrAuth()
-  const userClaims = useUserClaims()
-
-  if (!isAuthenticated) return null
-
+  const { isAuthenticated, isLoading, signIn, signOut } = useScrollrAuth()
+  if (isLoading) return null
+  if (!isAuthenticated)
+    return (
+      <button
+        type="button"
+        onClick={() => signIn('/account')}
+        className="font-semibold text-primary hover:underline"
+      >
+        SIGN IN
+      </button>
+    )
   return (
-    <NavLink to="/account">
-      {(userClaims?.username || userClaims?.name || 'ACCOUNT').toUpperCase()}
-    </NavLink>
+    <div className="flex items-center gap-4">
+      <NavLink to="/account">ACCOUNT</NavLink>
+      <button
+        type="button"
+        onClick={() => signOut(window.location.origin)}
+        className="text-base-content/60 hover:text-primary"
+      >
+        SIGN OUT
+      </button>
+    </div>
   )
 }
 
 function MobileAccountLink({ onNavigate }: { onNavigate: () => void }) {
-  const { isAuthenticated } = useScrollrAuth()
-  const userClaims = useUserClaims()
-
-  if (!isAuthenticated) return null
-
+  const { isAuthenticated, isLoading, signIn, signOut } = useScrollrAuth()
+  if (isLoading) return null
+  if (!isAuthenticated)
+    return (
+      <button
+        type="button"
+        onClick={() => signIn('/account')}
+        className="block w-full rounded px-4 py-3 text-left font-semibold text-primary"
+      >
+        SIGN IN
+      </button>
+    )
   return (
-    <MobileNavLink to="/account" onClick={onNavigate}>
-      {(userClaims?.username || userClaims?.name || 'ACCOUNT').toUpperCase()}
-    </MobileNavLink>
+    <>
+      <MobileNavLink to="/account" onClick={onNavigate}>
+        ACCOUNT
+      </MobileNavLink>
+      <button
+        type="button"
+        onClick={() => signOut(window.location.origin)}
+        className="block w-full rounded px-4 py-3 text-left text-base-content/70 hover:bg-base-200"
+      >
+        SIGN OUT
+      </button>
+    </>
   )
 }
 

--- a/myscrollr.com/src/components/WebsiteAnalyticsGate.test.tsx
+++ b/myscrollr.com/src/components/WebsiteAnalyticsGate.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { act, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { expect, it, vi } from 'vitest'
+import { WebsiteAnalyticsGate } from './WebsiteAnalyticsGate'
+import { ScrollrAuthProvider } from '@/hooks/useScrollrAuth'
+
+const calls = vi.hoisted(() => ({
+  token: vi.fn(),
+  verify: vi.fn(),
+  capture: vi.fn(),
+}))
+vi.mock('@logto/react', () => ({
+  useLogto: () => {
+    const [isLoading, setLoading] = useState(false)
+    return {
+      isAuthenticated: true,
+      isLoading,
+      getAccessToken: async () => {
+        calls.token()
+        setLoading(true)
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        setLoading(false)
+        return 'test-token'
+      },
+    }
+  },
+}))
+vi.mock('@/api/client', () => ({
+  analyticsPolicyApi: { get: () => Promise.resolve({ policy: 'default-on' }) },
+  authenticatedFetch: async (
+    _path: string,
+    _options: unknown,
+    getToken: () => Promise<string>,
+  ) => {
+    await getToken()
+    calls.verify()
+    return { eligible: true, verified: false }
+  },
+}))
+vi.mock('@/lib/posthog', () => ({
+  getWebsiteAnalyticsDecision: () => 'enabled',
+  normalizeWebsiteAnalyticsPolicy: (policy: string) => policy,
+  setWebsiteAnalyticsPolicy: vi.fn(),
+  setWebsiteAnalyticsSuppressed: vi.fn(),
+  resetWebsiteAnalyticsIdentity: vi.fn(),
+  applyWebsiteAnalyticsContext: () => true,
+  captureWebsitePageview: calls.capture,
+}))
+
+it.each([false, true])(
+  'bounds verification despite SDK loading and failed=%s',
+  async (failed) => {
+    vi.clearAllMocks()
+    calls.verify.mockImplementation(() => {
+      if (failed) throw new Error('Rate limited')
+    })
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+    vi.useFakeTimers()
+    const root = createRoot(document.createElement('div'))
+    try {
+      await act(() =>
+        root.render(
+          <ScrollrAuthProvider>
+            <WebsiteAnalyticsGate />
+          </ScrollrAuthProvider>,
+        ),
+      )
+      for (let i = 0; i < 8; i++)
+        await act(() => vi.advanceTimersByTimeAsync(20))
+      await act(() =>
+        root.render(
+          <ScrollrAuthProvider>
+            <WebsiteAnalyticsGate />
+          </ScrollrAuthProvider>,
+        ),
+      )
+      await act(() => vi.advanceTimersByTimeAsync(3000))
+      await act(() => vi.advanceTimersByTimeAsync(3000))
+      expect(calls.verify).toHaveBeenCalledTimes(failed ? 2 : 1)
+      expect(calls.token).toHaveBeenCalledTimes(failed ? 2 : 1)
+      expect(calls.capture).toHaveBeenCalledTimes(failed ? 0 : 1)
+    } finally {
+      await act(() => root.unmount())
+      vi.useRealTimers()
+    }
+  },
+)

--- a/myscrollr.com/src/components/WebsiteAnalyticsGate.tsx
+++ b/myscrollr.com/src/components/WebsiteAnalyticsGate.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from 'react'
+import type { WebsiteAnalyticsContext } from '@/lib/posthog'
+import { useScrollrAuth } from '@/hooks/useScrollrAuth'
+import { analyticsPolicyApi, authenticatedFetch } from '@/api/client'
+import {
+  applyWebsiteAnalyticsContext,
+  captureWebsitePageview,
+  getWebsiteAnalyticsDecision,
+  normalizeWebsiteAnalyticsPolicy,
+  resetWebsiteAnalyticsIdentity,
+  setWebsiteAnalyticsPolicy,
+  setWebsiteAnalyticsSuppressed,
+} from '@/lib/posthog'
+
+export function WebsiteAnalyticsGate() {
+  const { getAccessToken, isAuthenticated, isLoading } = useScrollrAuth()
+  const checkedUser = useRef(false)
+  const retriedUser = useRef(false)
+  const wasAuthenticated = useRef(false)
+  const [consentRevision, setConsentRevision] = useState(0)
+  const [policyReady, setPolicyReady] = useState(false)
+  const [policyRevision, setPolicyRevision] = useState(0)
+
+  useEffect(() => {
+    let current = true
+    setPolicyReady(false)
+    void analyticsPolicyApi
+      .get()
+      .then(({ policy }) => {
+        if (!current) return
+        setWebsiteAnalyticsPolicy(normalizeWebsiteAnalyticsPolicy(policy))
+      })
+      .catch(() => {
+        if (current) setWebsiteAnalyticsPolicy('consent-required')
+      })
+      .finally(() => {
+        if (current) setPolicyReady(true)
+      })
+    return () => {
+      current = false
+    }
+  }, [policyRevision])
+
+  useEffect(() => {
+    const refresh = () => setPolicyRevision((value) => value + 1)
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === 'visible') refresh()
+    }
+    const timer = window.setInterval(refresh, 15 * 60 * 1000)
+    window.addEventListener('focus', refresh)
+    document.addEventListener('visibilitychange', refreshWhenVisible)
+    return () => {
+      window.clearInterval(timer)
+      window.removeEventListener('focus', refresh)
+      document.removeEventListener('visibilitychange', refreshWhenVisible)
+    }
+  }, [])
+
+  useEffect(() => {
+    const changed = () => setConsentRevision((value) => value + 1)
+    window.addEventListener('scrollr:analytics-consent-changed', changed)
+    return () =>
+      window.removeEventListener('scrollr:analytics-consent-changed', changed)
+  }, [])
+
+  useEffect(() => {
+    if (!policyReady) {
+      setWebsiteAnalyticsSuppressed(true)
+      return
+    }
+    if (isLoading) {
+      setWebsiteAnalyticsSuppressed(true)
+      return
+    }
+    if (!isAuthenticated) {
+      if (wasAuthenticated.current) resetWebsiteAnalyticsIdentity()
+      wasAuthenticated.current = false
+      checkedUser.current = false
+      retriedUser.current = false
+      setWebsiteAnalyticsSuppressed(false)
+      captureWebsitePageview(window.location.pathname)
+      return
+    }
+    wasAuthenticated.current = true
+    setWebsiteAnalyticsSuppressed(true)
+    if (getWebsiteAnalyticsDecision() !== 'enabled') {
+      checkedUser.current = false
+      retriedUser.current = false
+      return
+    }
+    if (checkedUser.current) return
+    checkedUser.current = true
+    let current = true
+    let retryTimer: number | undefined
+    void authenticatedFetch<WebsiteAnalyticsContext>(
+      '/users/me/verify-website-signup',
+      { method: 'POST' },
+      getAccessToken,
+    )
+      .then((context) => {
+        if (!current) return
+        if (!applyWebsiteAnalyticsContext(context)) return
+        retriedUser.current = false
+        setWebsiteAnalyticsSuppressed(false)
+        captureWebsitePageview(window.location.pathname)
+      })
+      .catch(() => {
+        if (!current || retriedUser.current) return
+        checkedUser.current = false
+        retriedUser.current = true
+        retryTimer = window.setTimeout(
+          () => setConsentRevision((value) => value + 1),
+          2000,
+        )
+      })
+    return () => {
+      current = false
+      checkedUser.current = false
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer)
+    }
+  }, [consentRevision, getAccessToken, isAuthenticated, isLoading, policyReady])
+
+  return null
+}

--- a/myscrollr.com/src/components/account/AccountHub.test.tsx
+++ b/myscrollr.com/src/components/account/AccountHub.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { AccountHub } from '@/routes/account'
+
+const mocks = vi.hoisted(() => ({
+  overview: vi.fn(),
+  token: vi.fn(),
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  authenticated: true,
+}))
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => () => ({}),
+  Link: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}))
+vi.mock('@/hooks/useScrollrAuth', () => ({
+  useScrollrAuth: () => ({
+    isAuthenticated: mocks.authenticated,
+    isLoading: false,
+    signIn: mocks.signIn,
+    signOut: mocks.signOut,
+  }),
+}))
+vi.mock('@/hooks/useGetToken', () => ({ useGetToken: () => mocks.token }))
+vi.mock('@/api/client', () => ({ userApi: { overview: mocks.overview } }))
+vi.mock('@/components/billing/SubscriptionStatus', () => ({
+  default: () => <p>Subscription details</p>,
+}))
+vi.mock('@/components/account/AccountDangerZone', () => ({
+  default: () => <p>Your data controls</p>,
+}))
+
+it('recovers account loading errors and provides a real signed-out entry point', async () => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+  mocks.overview
+    .mockRejectedValueOnce(new Error('Request failed'))
+    .mockResolvedValue({
+      identity: {
+        name: 'Test customer',
+        username: 'test',
+        email: 'test@example.test',
+      },
+      tier: { current: 'free' },
+      links: { logto_account: 'https://example.test/security' },
+      gdpr: { deletion_status: 'none', purge_at: null },
+    })
+  const container = document.createElement('div'),
+    root = createRoot(container)
+  try {
+    await act(() => root.render(<AccountHub />))
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Could not load your account',
+    )
+    expect(container.textContent).not.toContain('Profile & security')
+    const retry = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Try again',
+    )!
+    await act(() => retry.click())
+    expect(mocks.overview).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(container.textContent).toContain('Profile & security')
+    expect(container.textContent).toContain('Plan & billing')
+    expect(container.textContent).toContain('Website privacy')
+    mocks.authenticated = false
+    await act(() => root.render(<AccountHub />))
+    expect(container.textContent).not.toContain('Test customer')
+    const signIn = container.querySelector('button')!
+    await act(() => signIn.click())
+    expect(mocks.signIn).toHaveBeenCalledWith('/account')
+  } finally {
+    await act(() => root.unmount())
+  }
+})

--- a/myscrollr.com/src/components/admin/AdminShell.tsx
+++ b/myscrollr.com/src/components/admin/AdminShell.tsx
@@ -51,6 +51,7 @@ export default function AdminShell() {
   const { isAuthenticated, isLoading, signIn } = useScrollrAuth()
   const getToken = useGetToken()
   const [gate, setGate] = useState<GateState>({ kind: 'checking' })
+  const [attempt, setAttempt] = useState(0)
 
   useEffect(() => {
     if (isLoading) return
@@ -59,6 +60,7 @@ export default function AdminShell() {
       return
     }
     let cancelled = false
+    setGate({ kind: 'checking' })
     adminApi
       .me(getToken)
       .then((res) => {
@@ -72,6 +74,10 @@ export default function AdminShell() {
           setGate({ kind: 'denied' })
           return
         }
+        if (err instanceof AdminApiError && err.status === 401) {
+          setGate({ kind: 'signed-out' })
+          return
+        }
         setGate({
           kind: 'error',
           message:
@@ -81,7 +87,7 @@ export default function AdminShell() {
     return () => {
       cancelled = true
     }
-  }, [isAuthenticated, isLoading, getToken])
+  }, [isAuthenticated, isLoading, getToken, attempt])
 
   if (isLoading || gate.kind === 'checking') {
     return (
@@ -137,6 +143,13 @@ export default function AdminShell() {
         <p className="mt-2 max-w-md text-sm text-base-content/60">
           {gate.message}
         </p>
+        <button
+          type="button"
+          onClick={() => setAttempt((value) => value + 1)}
+          className="mt-6 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-content"
+        >
+          Retry access check
+        </button>
       </Centered>
     )
   }

--- a/myscrollr.com/src/hooks/useScrollrAuth.tsx
+++ b/myscrollr.com/src/hooks/useScrollrAuth.tsx
@@ -99,7 +99,9 @@ export function ScrollrAuthProvider({ children }: { children: ReactNode }) {
 
   const value: ScrollrAuthContextValue = {
     isAuthenticated: logto.isAuthenticated,
-    isLoading: logto.isLoading,
+    // Logto also sets loading during token/claims reads. Those must not
+    // restart signed-in effects or unmount account/admin screens.
+    isLoading: logto.isLoading && !logto.isAuthenticated,
     signIn,
     signOut,
     getAccessToken,

--- a/myscrollr.com/src/routes/__root.tsx
+++ b/myscrollr.com/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import {
+  ClientOnly,
   HeadContent,
   Link,
   Outlet,
@@ -147,6 +148,8 @@ function RootErrorDocument(props: { error: Error }) {
 // (account, invite, auth callback, public profiles) and /business,
 // which renders its own white-label variant of the bar.
 const DEMO_BAR_EXCLUDED = [
+  // The fallback shell must match the private routes that consume it.
+  '/tss-spa-shell',
   '/account',
   '/invite',
   '/callback',
@@ -250,7 +253,9 @@ function RootLayout() {
 
           {/* Footer */}
           <Footer />
-          <AnalyticsConsent />
+          <ClientOnly>
+            <AnalyticsConsent />
+          </ClientOnly>
 
           {/* Persistent demo ticker bar — the brand's connective tissue.
               /business mounts its own white-label variant instead. */}

--- a/myscrollr.com/src/routes/account.tsx
+++ b/myscrollr.com/src/routes/account.tsx
@@ -1,25 +1,9 @@
-import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import {
-  ArrowRight,
-  BarChart3,
-  Check,
-  Crown,
-  Globe,
-  KeyRound,
-  Loader2,
-  Lock,
-  Pencil,
-  Settings,
-  User,
-  X,
-} from 'lucide-react'
-import { motion } from 'motion/react'
-import type { ComponentType } from 'react'
+import { Link, createFileRoute } from '@tanstack/react-router'
+import { useCallback, useEffect, useState } from 'react'
+import { Check, KeyRound, Loader2, Pencil, X } from 'lucide-react'
 import type { UserOverview } from '@/api/client'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
 import LoadingSpinner from '@/components/LoadingSpinner'
-import { pageVariants, sectionVariants } from '@/lib/animations'
 import { userApi } from '@/api/client'
 import { useGetToken } from '@/hooks/useGetToken'
 import SubscriptionStatus from '@/components/billing/SubscriptionStatus'
@@ -38,435 +22,209 @@ export const Route = createFileRoute('/account')({
   component: AccountHub,
 })
 
-// ── Signature easing (matches homepage) ────────────────────────
-const EASE = [0.22, 1, 0.36, 1] as const
-
-// ── Hex colors ─────────────────────────────────────────────────
-const HEX = {
-  primary: '#34d399',
-  secondary: '#ff4757',
-  info: '#00b8db',
-  accent: '#a855f7',
-} as const
-
-// ── Hub card definitions ───────────────────────────────────────
-interface HubCardDef {
-  title: string
-  desc: string
-  to?: string
-  params?: Record<string, string>
-  search?: Record<string, unknown>
-  href?: string
-  Icon: ComponentType<{
-    size?: number
-    strokeWidth?: number
-    className?: string
-  }>
-  hex: string
-  WatermarkIcon: ComponentType<{
-    size?: number
-    strokeWidth?: number
-    className?: string
-  }>
-}
-
-const HUB_CARDS: Array<HubCardDef> = [
-  {
-    title: 'Desktop App',
-    desc: 'Download the Scrollr desktop app',
-    to: '/download',
-    Icon: BarChart3,
-    hex: HEX.primary,
-    WatermarkIcon: BarChart3,
-  },
-  {
-    title: 'Public Profile',
-    desc: 'View your public presence',
-    to: '/u/$username',
-    params: { username: 'me' },
-    Icon: Globe,
-    hex: HEX.info,
-    WatermarkIcon: Globe,
-  },
-  {
-    title: 'Security Node',
-    desc: 'Manage password, MFA & linked accounts',
-    // href is injected at render time from overview.links.logto_account
-    Icon: Lock,
-    hex: HEX.secondary,
-    WatermarkIcon: Lock,
-  },
-  {
-    title: 'Uplink',
-    desc: 'Manage your subscription tier',
-    to: '/uplink',
-    search: { session_id: undefined },
-    Icon: Crown,
-    hex: HEX.accent,
-    WatermarkIcon: Crown,
-  },
-]
-
-function AccountHub() {
-  const { isAuthenticated, isLoading } = useScrollrAuth()
-  const navigate = useNavigate()
+export function AccountHub() {
+  const { isAuthenticated, isLoading, signIn, signOut } = useScrollrAuth()
   const getToken = useGetToken()
-
-  // ── Prevent remount/re-animation on token refresh ──────────────
-  const hasLoaded = useRef(false)
-  const autoRedirectTriggered = useRef(false)
-
-  // ── Unified overview state ────────────────────────────────────
-  // One round-trip replaces the previous claims + channels +
-  // deletion-status fan-out. SubscriptionStatus and the GDPR mutating
-  // actions still use their dedicated endpoints.
   const [overview, setOverview] = useState<UserOverview | null>(null)
-
+  const [error, setError] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
   const fetchOverview = useCallback(async () => {
+    setRefreshing(true)
+    setError(null)
     try {
-      const data = await userApi.overview(getToken)
-      setOverview(data)
+      setOverview(await userApi.overview(getToken))
     } catch (err) {
-      if (import.meta.env.DEV) {
-        console.warn('Failed to load account overview', err)
-      }
+      setError(
+        err instanceof Error ? err.message : 'Could not load your account.',
+      )
+    } finally {
+      setRefreshing(false)
     }
   }, [getToken])
-
-  // ── Redirect if not authenticated ────────────────────────────
   useEffect(() => {
-    if (!isLoading && !isAuthenticated && !autoRedirectTriggered.current) {
-      autoRedirectTriggered.current = true
-      navigate({ to: '/' })
-    }
-  }, [isLoading, isAuthenticated, navigate])
-
-  // ── Fetch data when authenticated ─────────────────────────────
-  useEffect(() => {
-    if (isAuthenticated) {
-      fetchOverview()
-    }
+    if (isAuthenticated) void fetchOverview()
+    else setOverview(null)
   }, [isAuthenticated, fetchOverview])
-
-  // ── Loading / auth guards ─────────────────────────────────────
-  if (isLoading && !hasLoaded.current) {
-    return <LoadingSpinner variant="spin" label="" />
-  }
-
-  if (!isAuthenticated) {
-    return <LoadingSpinner variant="spin" label="" />
-  }
-
-  hasLoaded.current = true
-
-  return (
-    <motion.main
-      className="min-h-dvh pt-20"
-      variants={pageVariants}
-      initial="hidden"
-      animate="visible"
-    >
-      {/* ── Personalized Hero ── */}
-      <section className="relative pt-24 pb-20 overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-base-200/20 to-transparent pointer-events-none" />
-        <div className="container relative z-10">
-          <motion.div className="text-center" variants={sectionVariants}>
-            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-4">
-              Welcome back,{' '}
-              <span className="text-gradient-primary">
-                {overview?.identity.name ||
-                  overview?.identity.username ||
-                  'User'}
-              </span>
-            </h1>
-            <p className="text-base text-base-content/45 leading-relaxed max-w-lg mx-auto">
-              Your personal data widgets are ready for orchestration. Sync your
-              leagues, track your assets, and stay in the flow.
-            </p>
-          </motion.div>
-        </div>
+  if (isLoading)
+    return <LoadingSpinner variant="spin" label="Checking your session" />
+  if (!isAuthenticated)
+    return (
+      <section className="mx-auto max-w-lg px-6 py-20 text-center">
+        <h1 className="text-3xl font-bold">Your Scrollr account</h1>
+        <p className="mt-3 text-base-content/65">
+          Sign in to manage your profile, subscription, and privacy settings.
+        </p>
+        <button
+          type="button"
+          onClick={() => signIn('/account')}
+          className="mt-6 rounded-lg bg-primary px-5 py-3 font-semibold text-primary-content"
+        >
+          Sign in
+        </button>
       </section>
-
-      {/* ── Stats & Status ── */}
-      <section className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-base-200/20 to-transparent pointer-events-none" />
-        <div className="container py-16 lg:py-24">
-          <motion.div
-            className="text-center mb-12 sm:mb-16"
-            style={{ opacity: 0 }}
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: '-80px' }}
-            transition={{ duration: 0.7, ease: EASE }}
-          >
-            <h2 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight leading-[0.95] mb-4">
-              Your <span className="text-gradient-primary">Dashboard</span>
-            </h2>
-            <p className="text-base text-base-content/45 leading-relaxed max-w-lg mx-auto">
-              Subscription, widgets, and system health at a glance
-            </p>
-          </motion.div>
-
-          <div className="flex flex-col gap-6">
-            {/* Identity & Security Card */}
-            <motion.div
-              className="relative bg-base-200/40 border border-base-300/25 rounded-xl p-8 overflow-hidden"
-              style={{ opacity: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, margin: '-80px' }}
-              transition={{ duration: 0.6, ease: EASE }}
+    )
+  const card = 'rounded-xl border border-hairline bg-base-100 p-5 sm:p-6'
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-12">
+      <header className="mb-8 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-widest text-primary">
+            Account
+          </p>
+          <h1 className="mt-2 text-3xl font-bold tracking-tight">
+            {overview?.identity.name ||
+              overview?.identity.username ||
+              'Your account'}
+          </h1>
+          <p className="mt-2 text-sm text-base-content/65">
+            Your profile, plan, and privacy controls in one place.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => signOut(window.location.origin)}
+          className="rounded-lg border border-hairline px-4 py-2 text-sm font-semibold hover:bg-base-200"
+        >
+          Sign out
+        </button>
+      </header>
+      {error && (
+        <div
+          role="alert"
+          className="mb-6 rounded-lg border border-error/30 bg-error/5 p-4"
+        >
+          <p className="font-semibold">Could not load your account</p>
+          <p className="mt-1 text-sm text-base-content/65">{error}</p>
+          <div className="mt-3 flex gap-4">
+            <button
+              type="button"
+              disabled={refreshing}
+              onClick={() => void fetchOverview()}
+              className="text-sm font-semibold text-primary"
             >
-              <div
-                className="absolute top-0 left-0 right-0 h-px"
-                style={{
-                  background: `linear-gradient(90deg, transparent, ${HEX.info} 50%, transparent)`,
-                }}
-              />
-              <div
-                className="absolute top-0 right-0 w-20 h-20 opacity-[0.04] text-base-content"
-                style={{
-                  backgroundImage:
-                    'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                  backgroundSize: '8px 8px',
-                }}
-              />
-
-              <div className="flex items-center gap-3 mb-6">
-                <div
-                  className="w-11 h-11 rounded-xl flex items-center justify-center"
-                  style={{
-                    background: `${HEX.info}15`,
-                    boxShadow: `0 0 20px ${HEX.info}15, 0 0 0 1px ${HEX.info}20`,
-                  }}
-                >
-                  <User size={20} className="text-base-content/80" />
-                </div>
-                <h3 className="text-lg font-black tracking-tight text-base-content">
-                  Identity &amp; Security
-                </h3>
-              </div>
-
+              Try again
+            </button>
+            <button
+              type="button"
+              onClick={() => signIn('/account')}
+              className="text-sm font-semibold underline"
+            >
+              Sign in again
+            </button>
+          </div>
+        </div>
+      )}
+      {!overview && !error && (
+        <LoadingSpinner variant="spin" label="Loading your account" />
+      )}
+      {overview && (
+        <>
+          <div className="grid items-start gap-6 lg:grid-cols-2">
+            <section className={card} aria-labelledby="account-profile-heading">
+              <h2
+                id="account-profile-heading"
+                className="mb-5 text-lg font-bold"
+              >
+                Profile & security
+              </h2>
               <IdentityEditor
                 getToken={getToken}
                 overview={overview}
                 onUpdated={fetchOverview}
               />
-
-              <Lock
-                size={130}
-                strokeWidth={0.4}
-                className="absolute -bottom-4 -right-4 text-base-content/[0.025] pointer-events-none"
-              />
-            </motion.div>
-
-            {/* System Status Link Card */}
-            <motion.div
-              style={{ opacity: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, margin: '-80px' }}
-              transition={{ duration: 0.6, ease: EASE }}
-            >
-              <Link
-                to="/status"
-                className="relative bg-base-200/40 border border-base-300/25 rounded-xl p-8 overflow-hidden group block h-full hover:border-base-300/50 transition-colors"
-              >
-                {/* Accent top line */}
-                <div
-                  className="absolute top-0 left-0 right-0 h-px"
-                  style={{
-                    background: `linear-gradient(90deg, transparent, ${HEX.primary} 50%, transparent)`,
-                  }}
-                />
-                {/* Corner dot grid */}
-                <div
-                  className="absolute top-0 right-0 w-20 h-20 opacity-[0.04] text-base-content"
-                  style={{
-                    backgroundImage:
-                      'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                    backgroundSize: '8px 8px',
-                  }}
-                />
-                {/* Hover glow orb */}
-                <div
-                  className="absolute -top-10 -right-10 w-32 h-32 rounded-full pointer-events-none blur-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"
-                  style={{ background: `${HEX.primary}10` }}
-                />
-
-                <div className="flex items-center gap-3 mb-6">
-                  <div
-                    className="w-11 h-11 rounded-xl flex items-center justify-center"
-                    style={{
-                      background: `${HEX.primary}15`,
-                      boxShadow: `0 0 20px ${HEX.primary}15, 0 0 0 1px ${HEX.primary}20`,
-                    }}
-                  >
-                    <Settings size={20} className="text-base-content/80" />
-                  </div>
-                  <h3 className="text-lg font-black tracking-tight text-base-content">
-                    System Status
-                  </h3>
-                </div>
-                <p className="text-sm text-base-content/45 mb-6 leading-relaxed">
-                  Monitor infrastructure health, ingestion workers, and live
-                  connection status.
-                </p>
-                <div className="flex items-center gap-2 text-xs font-semibold text-base-content/40 group-hover:text-base-content/70 transition-colors">
-                  View Status Dashboard
-                  <ArrowRight size={14} />
-                </div>
-
-                {/* Watermark */}
-                <Settings
-                  size={130}
-                  strokeWidth={0.4}
-                  className="absolute -bottom-4 -right-4 text-base-content/[0.025] pointer-events-none"
-                />
-              </Link>
-            </motion.div>
-
-            {/* Subscription Status Card */}
-            <motion.div
-              className="relative bg-base-200/40 border border-base-300/25 rounded-xl p-8 overflow-hidden group"
-              style={{ opacity: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, margin: '-80px' }}
-              transition={{ duration: 0.6, ease: EASE, delay: 0.2 }}
-            >
-              {/* Accent top line */}
-              <div
-                className="absolute top-0 left-0 right-0 h-px"
-                style={{
-                  background: `linear-gradient(90deg, transparent, ${HEX.accent} 50%, transparent)`,
-                }}
-              />
-              {/* Corner dot grid */}
-              <div
-                className="absolute top-0 right-0 w-20 h-20 opacity-[0.04] text-base-content"
-                style={{
-                  backgroundImage:
-                    'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                  backgroundSize: '8px 8px',
-                }}
-              />
-              {/* Hover glow orb */}
-              <div
-                className="absolute -top-10 -right-10 w-32 h-32 rounded-full pointer-events-none blur-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"
-                style={{ background: `${HEX.accent}10` }}
-              />
-
-              <div className="flex items-center gap-3 mb-6">
-                <div
-                  className="w-11 h-11 rounded-xl flex items-center justify-center"
-                  style={{
-                    background: `${HEX.accent}15`,
-                    boxShadow: `0 0 20px ${HEX.accent}15, 0 0 0 1px ${HEX.accent}20`,
-                  }}
+              {overview.links.logto_account && (
+                <a
+                  href={overview.links.logto_account}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-5 inline-flex text-sm font-semibold text-primary"
                 >
-                  <Crown size={20} className="text-base-content/80" />
+                  Password, two-step verification & linked accounts ↗
+                </a>
+              )}
+              {overview.identity.username && (
+                <Link
+                  to="/u/$username"
+                  params={{ username: overview.identity.username }}
+                  className="mt-4 block text-sm text-base-content/65 underline"
+                >
+                  View public profile
+                </Link>
+              )}
+            </section>
+            <div className="space-y-6">
+              <section className={card} aria-labelledby="account-plan-heading">
+                <h2
+                  id="account-plan-heading"
+                  className="mb-5 text-lg font-bold"
+                >
+                  Plan & billing
+                </h2>
+                <SubscriptionStatus
+                  getToken={getToken}
+                  tier={overview.tier.current}
+                />
+                <Link
+                  to="/uplink"
+                  search={{ session_id: undefined }}
+                  className="mt-5 inline-flex text-sm font-semibold text-primary"
+                >
+                  Compare plans →
+                </Link>
+              </section>
+              <section className={card} aria-labelledby="account-app-heading">
+                <h2 id="account-app-heading" className="text-lg font-bold">
+                  Desktop app
+                </h2>
+                <p className="mt-2 text-sm text-base-content/65">
+                  Manage your ticker, widgets, and app analytics preferences in
+                  Scrollr.
+                </p>
+                <div className="mt-4 flex flex-wrap gap-4 text-sm font-semibold">
+                  <Link to="/download" className="text-primary">
+                    Download Scrollr →
+                  </Link>
+                  <Link to="/support" className="text-base-content/65">
+                    Get help
+                  </Link>
+                  <Link to="/status" className="text-base-content/65">
+                    Service status
+                  </Link>
                 </div>
-                <h3 className="text-lg font-black tracking-tight text-base-content">
-                  Subscription
-                </h3>
-              </div>
-
-              <SubscriptionStatus
-                getToken={getToken}
-                tier={overview?.tier.current}
-              />
-
-              <Link
-                to="/uplink"
-                search={{ session_id: undefined }}
-                className="mt-6 inline-flex items-center gap-2 text-xs font-semibold text-base-content/40 hover:text-base-content/70 transition-colors"
+              </section>
+              <section
+                className={card}
+                aria-labelledby="account-privacy-heading"
               >
-                View Plans <ArrowRight size={14} />
-              </Link>
-
-              {/* Watermark */}
-              <Crown
-                size={130}
-                strokeWidth={0.4}
-                className="absolute -bottom-4 -right-4 text-base-content/[0.025] pointer-events-none"
-              />
-            </motion.div>
+                <h2 id="account-privacy-heading" className="text-lg font-bold">
+                  Website privacy
+                </h2>
+                <p className="mt-2 text-sm text-base-content/65">
+                  Choose whether this browser shares usage analytics.
+                </p>
+                <button
+                  type="button"
+                  onClick={() =>
+                    window.dispatchEvent(
+                      new CustomEvent('scrollr:manage-analytics'),
+                    )
+                  }
+                  className="mt-4 text-sm font-semibold text-primary"
+                >
+                  Analytics settings
+                </button>
+              </section>
+            </div>
           </div>
-        </div>
-      </section>
-
-      {/* ── Quick Links (relocated from top — secondary affordances) ── */}
-      <section className="relative overflow-hidden">
-        <div className="container py-10 lg:py-14">
-          <motion.div
-            className="text-center mb-8"
-            style={{ opacity: 0 }}
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: '-40px' }}
-            transition={{ duration: 0.5, ease: EASE }}
-          >
-            <h2 className="text-xl sm:text-2xl font-bold tracking-tight text-base-content/70 mb-2">
-              Quick Links
-            </h2>
-          </motion.div>
-
-          {(() => {
-            const visibleCards = HUB_CARDS.filter((card) => {
-              if (card.title === 'Public Profile') {
-                return Boolean(overview?.identity.username)
-              }
-              if (card.title === 'Security Node') {
-                return Boolean(overview?.links.logto_account)
-              }
-              return true
-            }).map((card) => {
-              if (
-                card.title === 'Public Profile' &&
-                overview?.identity.username
-              ) {
-                return {
-                  ...card,
-                  params: { username: overview.identity.username },
-                }
-              }
-              if (
-                card.title === 'Security Node' &&
-                overview?.links.logto_account
-              ) {
-                return {
-                  ...card,
-                  href: overview.links.logto_account,
-                }
-              }
-              return card
-            })
-
-            return (
-              <div className="flex flex-wrap items-stretch justify-center gap-4 max-w-5xl mx-auto">
-                {visibleCards.map((card, i) => (
-                  <div
-                    key={card.title}
-                    className="flex-1 min-w-[220px] max-w-sm"
-                  >
-                    <HubCard card={card} index={i} />
-                  </div>
-                ))}
-              </div>
-            )
-          })()}
-        </div>
-      </section>
-
-      {/* ── GDPR: Export + Delete ── */}
-      <AccountDangerZone
-        getToken={getToken}
-        deletionStatus={overview?.gdpr.deletion_status ?? 'none'}
-        purgeAt={overview?.gdpr.purge_at ?? null}
-        onDeletionChange={fetchOverview}
-      />
-    </motion.main>
+          <AccountDangerZone
+            getToken={getToken}
+            deletionStatus={overview.gdpr.deletion_status}
+            purgeAt={overview.gdpr.purge_at}
+            onDeletionChange={fetchOverview}
+          />
+        </>
+      )}
+    </div>
   )
 }
 
@@ -546,7 +304,7 @@ function IdentityEditor({
           </div>
         </div>
         <span className="text-[10px] uppercase tracking-wider text-base-content/30 px-2 py-1 rounded-md bg-base-content/5 shrink-0">
-          Immutable
+          Cannot be changed
         </span>
       </div>
 
@@ -697,119 +455,5 @@ function EditableField({
       )}
       {error && <p className="mt-1.5 text-xs text-error/80">{error}</p>}
     </div>
-  )
-}
-
-// ── Hub Card ───────────────────────────────────────────────────
-
-function HubCard({ card, index }: { card: HubCardDef; index: number }) {
-  const { title, desc, to, params, search, href, Icon, hex, WatermarkIcon } =
-    card
-  const isInteractive = Boolean(href || to)
-
-  const inner = (
-    <motion.div
-      className={`relative bg-base-200/40 border border-base-300/25 rounded-xl p-6 overflow-hidden group h-full flex flex-col justify-between transition-colors ${
-        isInteractive
-          ? 'cursor-pointer hover:border-base-300/50'
-          : 'cursor-default opacity-75'
-      }`}
-      style={{ opacity: 0 }}
-      initial={{ opacity: 0, y: 30 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: '-80px' }}
-      transition={{ duration: 0.6, ease: EASE, delay: index * 0.1 }}
-      whileHover={
-        isInteractive
-          ? { y: -3, transition: { type: 'tween', duration: 0.2 } }
-          : undefined
-      }
-    >
-      {/* Accent top line */}
-      <div
-        className="absolute top-0 left-0 right-0 h-px"
-        style={{
-          background: `linear-gradient(90deg, transparent, ${hex} 50%, transparent)`,
-        }}
-      />
-      {/* Corner dot grid */}
-      <div
-        className="absolute top-0 right-0 w-16 h-16 opacity-[0.04] text-base-content"
-        style={{
-          backgroundImage:
-            'radial-gradient(circle, currentColor 1px, transparent 1px)',
-          backgroundSize: '8px 8px',
-        }}
-      />
-      {/* Hover glow orb */}
-      <div
-        className="absolute -top-8 -right-8 w-24 h-24 rounded-full pointer-events-none blur-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"
-        style={{ background: `${hex}10` }}
-      />
-
-      {/* Arrow indicator */}
-      {isInteractive ? (
-        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity">
-          <ArrowRight size={16} className="text-base-content/40" />
-        </div>
-      ) : null}
-
-      <div className="space-y-5">
-        {/* Icon badge */}
-        <div
-          className="w-11 h-11 rounded-xl flex items-center justify-center"
-          style={{
-            background: `${hex}15`,
-            boxShadow: `0 0 20px ${hex}15, 0 0 0 1px ${hex}20`,
-          }}
-        >
-          <Icon size={20} className="text-base-content/80" />
-        </div>
-        <div>
-          <h3 className="text-lg font-black tracking-tight text-base-content group-hover:text-base-content/80 transition-colors">
-            {title}
-          </h3>
-          <p className="text-xs text-base-content/40 mt-2 leading-relaxed">
-            {desc}
-          </p>
-        </div>
-      </div>
-
-      {/* Watermark */}
-      <WatermarkIcon
-        size={80}
-        strokeWidth={0.4}
-        className="absolute -bottom-2 -right-2 text-base-content/[0.025] pointer-events-none"
-      />
-    </motion.div>
-  )
-
-  // External link (e.g. Logto Account Center)
-  if (href) {
-    return (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block h-full"
-      >
-        {inner}
-      </a>
-    )
-  }
-
-  if (!to) {
-    return <div className="block h-full">{inner}</div>
-  }
-
-  return (
-    <Link
-      to={to}
-      params={params as Record<string, string>}
-      search={search as Record<string, unknown>}
-      className="block h-full"
-    >
-      {inner}
-    </Link>
   )
 }


### PR DESCRIPTION
Signed-in token reads were repeatedly restarting the signup-verification effect, causing a request storm and 429s that broke admin access. Keep authenticated token activity out of startup loading, add bounded regression coverage, and provide retry/reauthentication controls.

Match the private-route prerender shell to its hydrated layout so cold loads retain the saved theme. Add visible sign-in/account/sign-out navigation and simplify the account page while retaining profile editing, billing, security, privacy, export, and deletion actions.

Validation: 161 tests passed; TypeScript and production prerender passed; all 64 route/viewport checks passed; independent review found no blockers. Authenticated production verification follows deployment.

Resolves SCROLLR-208 and SCROLLR-190 after live verification.
