### PR TITLE
Keep the website footer below loading content

### DIFF
--- a/myscrollr.com/scripts/check-mobile-viewport.mjs
+++ b/myscrollr.com/scripts/check-mobile-viewport.mjs
@@ -187,6 +187,27 @@ let failures = 0
 
 try {
   for (const viewport of VIEWPORTS) {
+    // Before route JavaScript arrives, the shared shell must reserve the
+    // content area instead of pulling the footer up beneath the header.
+    const pendingContext = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      javaScriptEnabled: false,
+    })
+    const pendingPage = await pendingContext.newPage()
+    await pendingPage.goto(`${baseUrl}/account`)
+    const footerTop = await pendingPage
+      .locator('footer')
+      .evaluate((footer) => footer.getBoundingClientRect().top)
+    if (footerTop < viewport.height - 1) {
+      console.error(
+        `✗ Pending shell @ ${viewport.name}: footer starts at ${footerTop}px, expected at least ${viewport.height}px`,
+      )
+      failures += 1
+    } else {
+      console.log(`✓ Pending shell @ ${viewport.name}: footer below viewport`)
+    }
+    await pendingContext.close()
+
     const context = await browser.newContext({
       viewport: { width: viewport.width, height: viewport.height },
       deviceScaleFactor: 2,

--- a/myscrollr.com/src/components/account/AccountHub.test.tsx
+++ b/myscrollr.com/src/components/account/AccountHub.test.tsx
@@ -63,7 +63,6 @@ it('recovers account loading errors and provides a real signed-out entry point',
     expect(container.querySelector('[role="alert"]')).toBeNull()
     expect(container.textContent).toContain('Profile & security')
     expect(container.textContent).toContain('Plan & billing')
-    expect(container.textContent).toContain('Website privacy')
     mocks.authenticated = false
     await act(() => root.render(<AccountHub />))
     expect(container.textContent).not.toContain('Test customer')

--- a/myscrollr.com/src/routes/__root.tsx
+++ b/myscrollr.com/src/routes/__root.tsx
@@ -241,11 +241,11 @@ function RootLayout() {
           {/* Navigation */}
           <Header hasBar={hasAnyBar} />
 
-          {/* Main Content */}
+          {/* Reserve the viewport below the 60px header, even while Outlet is empty. */}
           <main
             ref={mainRef}
             id="main-content"
-            className="relative"
+            className="relative min-h-[calc(100dvh-60px)]"
             tabIndex={-1}
           >
             <Outlet />

--- a/myscrollr.com/src/routes/account.tsx
+++ b/myscrollr.com/src/routes/account.tsx
@@ -192,28 +192,6 @@ export function AccountHub() {
                   </Link>
                 </div>
               </section>
-              <section
-                className={card}
-                aria-labelledby="account-privacy-heading"
-              >
-                <h2 id="account-privacy-heading" className="text-lg font-bold">
-                  Website privacy
-                </h2>
-                <p className="mt-2 text-sm text-base-content/65">
-                  Choose whether this browser shares usage analytics.
-                </p>
-                <button
-                  type="button"
-                  onClick={() =>
-                    window.dispatchEvent(
-                      new CustomEvent('scrollr:manage-analytics'),
-                    )
-                  }
-                  className="mt-4 text-sm font-semibold text-primary"
-                >
-                  Analytics settings
-                </button>
-              </section>
             </div>
           </div>
           <AccountDangerZone


### PR DESCRIPTION
Before route JavaScript loaded, the shared main area had zero height and placed the footer directly beneath the 60px header. Reserve the remaining viewport height in main so the footer stays below the initial screen while content loads. Taller pages still grow naturally.

Remove the requested Website privacy card from the account page; the existing footer analytics settings remain available.

Validation: a no-JavaScript browser check reproduced the footer at 60px on all four viewport sizes before the fix. The new check verifies actual footer geometry using the production shell. 161 tests, targeted lint, TypeScript, production build/prerender and independent review passed. Full viewport sweep and CI must pass before merge; live verification follows deployment.

SCROLLR-209
