### PR TITLE
feat(desktop): macOS and Linux presence signals; cut 1.6.7 [SCROLLR-211]

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -254,13 +254,23 @@ jobs:
   # the webkit dev headers to link and needs no Postgres — the crate
   # never touches the database.
   #
+  # Matrix over Linux and macOS (SCROLLR-211): the presence reporter's
+  # macOS and Linux signal modules are cfg-gated per-OS, and without a
+  # macOS leg the objc2 code in presence_mac.rs would not compile anywhere
+  # until the post-merge release build. Windows stays out: the Windows
+  # test binary aborts with STATUS_ENTRYPOINT_NOT_FOUND on this toolchain.
+  #
   # No frontend build step: tauri.conf.json points frontendDist at
   # ../dist, which is gitignored and absent on a fresh checkout, but
   # tauri_build::build() compiles fine without it (verified). Adding
   # `npm ci && npm run build` here would just duplicate the vitest job
   # for no gain.
   desktop-rust-tests:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: desktop/src-tauri
@@ -270,16 +280,33 @@ jobs:
 
       # Same package set desktop-release.yml installs for its Linux build.
       - name: Install Linux dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # GitHub's macOS runners ship a Homebrew rustup-init stub at
+      # /opt/homebrew/bin/cargo which shadows the real cargo that
+      # dtolnay/rust-toolchain installs. Prepending $CARGO_HOME/bin fixes
+      # resolution for the cargo invocations below. Same workaround as
+      # desktop-release.yml, where the failure was first seen.
+      - name: Prefer $CARGO_HOME/bin on PATH (macOS Homebrew rustup workaround)
+        if: runner.os == 'macOS'
+        shell: bash
+        working-directory: .
+        run: echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
+
       - uses: Swatinem/rust-cache@v2
         with:
           # Not at the repo root, so point the cache at the crate.
           workspaces: desktop/src-tauri
           cache-on-failure: "true"
+          # Do not restore ~/.cargo/bin on macOS: a poisoned cache can
+          # replace cargo with rustup-init. Same setting as the release
+          # workflow.
+          prefix-key: "v1-rust-no-bin"
+          cache-bin: "false"
 
       - run: cargo test --quiet

--- a/api/internal/support/kb/kb.generated.md
+++ b/api/internal/support/kb/kb.generated.md
@@ -4,9 +4,9 @@
 
 This is the authoritative product reference for support replies. Anything stated here is ground truth; the Policies section says what may and may not be repeated to a user.
 
-Current desktop version: **1.6.6**.
+Current desktop version: **1.6.7**.
 
-<!-- source: desktop/package.json @ f089d1370505 -->
+<!-- source: desktop/package.json @ d1abbf3ca712 -->
 
 ## Policies
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollr-desktop",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrollr-desktop",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "private": true,
   "description": "Scrollr desktop app — pinned always-on-top ticker for sports, finance, RSS, and Yahoo Fantasy. Tauri + React.",
   "author": "Brandon Ruth <brandon@myscrollr.com>",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4622,7 +4622,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrollr-desktop"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4631,6 +4631,7 @@ dependencies = [
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "rsa",
@@ -4655,6 +4656,7 @@ dependencies = [
  "url",
  "windows-sys 0.59.0",
  "wmi",
+ "zbus",
 ]
 
 [[package]]
@@ -5997,6 +5999,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -7625,6 +7628,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrollr-desktop"
-version = "1.6.6"
+version = "1.6.7"
 edition = "2021"
 # std::env::home_dir (Sentry path scrubber) is only correct on Windows from 1.85+
 rust-version = "1.85"
@@ -108,10 +108,23 @@ objc2-app-kit = { version = "0.3", features = [
     "NSControl",
     "NSResponder",
     "NSToolbar",
+    # presence_mac.rs: workspace sleep/wake + display notifications
+    "NSWorkspace",
+] }
+# presence_mac.rs: notification centers and names. Same objc2 generation
+# as objc2-app-kit (0.3.x pairs with objc2 0.6).
+objc2-foundation = { version = "0.3", features = [
+    "NSObject",
+    "NSString",
+    "NSNotification",
+    "NSDistributedNotificationCenter",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service"] }
+# presence_linux.rs: logind + screensaver over D-Bus (SCROLLR-211). One
+# crate, on the tokio runtime Tauri already runs.
+zbus = { version = "5", default-features = false, features = ["tokio"] }
 
 [target.'cfg(windows)'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,10 @@ mod commands;
 mod compositor;
 mod kalshi;
 mod presence;
+#[cfg(target_os = "linux")]
+mod presence_linux;
+#[cfg(target_os = "macos")]
+mod presence_mac;
 #[cfg(target_os = "windows")]
 mod presence_win;
 mod state;

--- a/desktop/src-tauri/src/presence.rs
+++ b/desktop/src-tauri/src/presence.rs
@@ -222,6 +222,10 @@ pub fn report_screen_state(
 pub fn start(app: AppHandle) {
     #[cfg(target_os = "windows")]
     crate::presence_win::install(app.clone());
+    #[cfg(target_os = "macos")]
+    crate::presence_mac::install(app.clone());
+    #[cfg(target_os = "linux")]
+    crate::presence_linux::install(app.clone());
 
     tauri::async_runtime::spawn(async move {
         let client = match reqwest::Client::builder().timeout(Duration::from_secs(10)).build() {
@@ -415,13 +419,23 @@ fn now_ms() -> i64 {
 }
 
 /// Seconds since the last keyboard or mouse input, where the platform can
-/// say. Windows: GetLastInputInfo. Elsewhere: unknown for now.
+/// say. Windows: GetLastInputInfo. macOS: CGEventSourceSecondsSinceLastEventType.
+/// Linux: the desktop's screensaver idle time, or unknown where no
+/// interface provides it.
 fn idle_for() -> Option<Duration> {
     #[cfg(target_os = "windows")]
     {
         crate::presence_win::idle_for()
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        crate::presence_mac::idle_for()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        crate::presence_linux::idle_for()
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     {
         None
     }

--- a/desktop/src-tauri/src/presence_linux.rs
+++ b/desktop/src-tauri/src/presence_linux.rs
@@ -1,0 +1,320 @@
+//! Linux signals for the presence reporter (SCROLLR-211).
+//!
+//! Everything goes over D-Bus, and everything is best-effort: a machine
+//! without systemd/logind, without a session bus, or with a desktop that
+//! implements none of the freedesktop interfaces reports `unknown` for the
+//! fields it cannot read. Nothing is guessed.
+//!
+//! * Session lock / unlock — logind's `LockedHint` on the current session
+//!   object (resolved once via `GetSessionByPID`), read at startup and then
+//!   watched through `PropertiesChanged` on the session interface. Watching
+//!   the property rather than the Lock/Unlock signals means a transition
+//!   that happened while the watcher was down still shows up in the next
+//!   read.
+//! * Suspend / resume — the `PrepareForSleep(bool)` signal on
+//!   `org.freedesktop.login1.Manager`: `true` sends the final `ended`
+//!   check-in before the machine goes down; `false` lets the loop start a
+//!   fresh interval.
+//! * Idle — the desktop's reported idle time, polled every few seconds:
+//!   `org.freedesktop.ScreenSaver.GetActiveTime` (KDE, Xfce, Cinnamon; at
+//!   either well-known path) or GNOME's `org.gnome.Mutter.IdleMonitor`
+//!   `Idletime` property. The first source that answers is kept; one that
+//!   stops answering (a restarted screen locker) is re-probed. The value is
+//!   elapsed time since the last input, never what the input was, and its
+//!   staleness is bounded by the poll interval. Desktops exposing neither
+//!   interface report `unknown`.
+//! * Display sleep has no reliable cross-desktop signal and stays
+//!   `unknown`.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use anyhow::Context;
+use futures_util::StreamExt;
+use tauri::AppHandle;
+
+use crate::presence::{SESSION_LOCKED, SESSION_STATE, SESSION_UNLOCKED};
+
+/// How often the desktop's idle time is re-read. The idle threshold is
+/// five minutes; a few seconds of staleness does not move it.
+const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+const LOGIN1_SERVICE: &str = "org.freedesktop.login1";
+const LOGIN1_MANAGER_PATH: &str = "/org/freedesktop/login1";
+const LOGIN1_SESSION_INTERFACE: &str = "org.freedesktop.login1.Session";
+
+/// Cached idle reading in whole seconds; `u64::MAX` = the platform cannot
+/// say (the sentinel never collides with a real reading).
+static IDLE_SECONDS: AtomicU64 = AtomicU64::new(u64::MAX);
+
+/// Seconds since the last input as last read by the poller, or None where
+/// no desktop interface provides it.
+pub fn idle_for() -> Option<Duration> {
+    idle_duration_for_cached(IDLE_SECONDS.load(Ordering::Relaxed))
+}
+
+/// Map the cached reading to a Duration; the sentinel is not an answer.
+pub fn idle_duration_for_cached(cached_seconds: u64) -> Option<Duration> {
+    match cached_seconds {
+        u64::MAX => None,
+        secs => Some(Duration::from_secs(secs)),
+    }
+}
+
+/// Map logind's `LockedHint` to the reporter's session state.
+pub fn session_state_for_locked_hint(locked: bool) -> u8 {
+    if locked { SESSION_LOCKED } else { SESSION_UNLOCKED }
+}
+
+/// What a `PrepareForSleep` signal tells the reporter to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SleepAction {
+    /// Going down: send the final `ended` check-in now.
+    SendEnded,
+    /// Back up: clear the ended flag so the next tick starts fresh.
+    Resumed,
+}
+
+pub fn sleep_action_for(prepare_for_sleep: bool) -> SleepAction {
+    if prepare_for_sleep { SleepAction::SendEnded } else { SleepAction::Resumed }
+}
+
+/// Extract `LockedHint` from a `PropertiesChanged` payload: only the
+/// session interface's own key, only when it is a boolean.
+pub fn locked_hint_from_changed(
+    interface: &str,
+    changed: &HashMap<String, zbus::zvariant::OwnedValue>,
+) -> Option<bool> {
+    if interface != LOGIN1_SESSION_INTERFACE {
+        return None;
+    }
+    let value = changed.get("LockedHint")?;
+    bool::try_from(value.clone()).ok()
+}
+
+/// Install every watcher. Called once from `presence::start`. Each source
+/// fails independently into `unknown`; none of them is fatal.
+pub fn install(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = watch_login1(&app).await {
+            log::info!("[presence] linux: logind signals unavailable ({e:#}); session and suspend stay unknown");
+        }
+    });
+    tauri::async_runtime::spawn(async move {
+        poll_idle_time().await;
+    });
+}
+
+/// Session lock and suspend/resume both come from logind on the system
+/// bus. One connection serves both; the lock watcher is a child task so a
+/// session that logind does not know (containers, SSH) does not take the
+/// suspend signal down with it.
+async fn watch_login1(app: &AppHandle) -> anyhow::Result<()> {
+    let conn = zbus::Connection::system().await.context("connect to the system bus")?;
+    let manager = zbus::Proxy::new(&conn, LOGIN1_SERVICE, LOGIN1_MANAGER_PATH, "org.freedesktop.login1.Manager")
+        .await
+        .context("logind manager proxy")?;
+
+    {
+        let conn = conn.clone();
+        let manager = manager.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(e) = watch_locked_hint(&conn, &manager).await {
+                log::info!("[presence] linux: session lock watch unavailable ({e:#}); session reports unknown");
+            }
+        });
+    }
+
+    let mut stream = manager
+        .receive_signal("PrepareForSleep")
+        .await
+        .context("subscribe to PrepareForSleep")?;
+    while let Some(msg) = stream.next().await {
+        let flag: bool = match msg.body().deserialize() {
+            Ok(flag) => flag,
+            Err(e) => {
+                log::debug!("[presence] linux: PrepareForSleep body unreadable: {e}");
+                continue;
+            }
+        };
+        match sleep_action_for(flag) {
+            SleepAction::SendEnded => {
+                log::info!("[presence] suspend: sending ended check-in");
+                crate::presence::send_ended_blocking(app);
+            }
+            SleepAction::Resumed => {
+                log::info!("[presence] resume");
+                crate::presence::resumed(app);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read the current session's `LockedHint` once, then follow its changes.
+async fn watch_locked_hint(conn: &zbus::Connection, manager: &zbus::Proxy<'_>) -> anyhow::Result<()> {
+    let path: zbus::zvariant::OwnedObjectPath = manager
+        .call("GetSessionByPID", &std::process::id())
+        .await
+        .context("resolve this session via GetSessionByPID")?;
+    let session = zbus::Proxy::new(conn, LOGIN1_SERVICE, path.as_str(), LOGIN1_SESSION_INTERFACE)
+        .await
+        .context("session proxy")?;
+    if let Ok(locked) = session.get_property::<bool>("LockedHint").await {
+        let state = session_state_for_locked_hint(locked);
+        SESSION_STATE.store(state, Ordering::Relaxed);
+        log::info!("[presence] session {}", crate::presence::session_word(state));
+    }
+    let props = zbus::Proxy::new(conn, LOGIN1_SERVICE, path.as_str(), "org.freedesktop.DBus.Properties")
+        .await
+        .context("session properties proxy")?;
+    let mut stream = props
+        .receive_signal("PropertiesChanged")
+        .await
+        .context("subscribe to PropertiesChanged")?;
+    while let Some(msg) = stream.next().await {
+        let body = msg.body();
+        let parsed = body.deserialize::<(String, HashMap<String, zbus::zvariant::OwnedValue>, Vec<String>)>();
+        let Ok((interface, changed, _invalidated)) = parsed else {
+            continue;
+        };
+        if let Some(locked) = locked_hint_from_changed(&interface, &changed) {
+            let state = session_state_for_locked_hint(locked);
+            SESSION_STATE.store(state, Ordering::Relaxed);
+            log::info!("[presence] session {}", crate::presence::session_word(state));
+        }
+    }
+    Ok(())
+}
+
+/// The desktop idle source that answered a probe, with its proxy kept for
+/// polling. Proxies are cheap handles; the connection outlives them.
+enum IdleSource {
+    /// org.freedesktop.ScreenSaver, GetActiveTime -> seconds.
+    ScreenSaver(zbus::Proxy<'static>),
+    /// org.gnome.Mutter.IdleMonitor, Idletime -> milliseconds.
+    MutterIdleMonitor(zbus::Proxy<'static>),
+}
+
+impl IdleSource {
+    async fn read_seconds(&self) -> Option<u64> {
+        match self {
+            IdleSource::ScreenSaver(proxy) => {
+                let secs: u32 = proxy.call("GetActiveTime", &()).await.ok()?;
+                Some(u64::from(secs))
+            }
+            IdleSource::MutterIdleMonitor(proxy) => {
+                let millis: u64 = proxy.get_property("Idletime").await.ok()?;
+                Some(millis / 1000)
+            }
+        }
+    }
+}
+
+/// Try the known idle interfaces, most standard first. A proxy is only
+/// kept when an actual read succeeds — creating one never touches the bus,
+/// so the read is what proves the service exists.
+async fn probe_idle_source(conn: &zbus::Connection) -> Option<IdleSource> {
+    for path in ["/org/freedesktop/ScreenSaver", "/ScreenSaver"] {
+        if let Ok(proxy) = zbus::Proxy::new(conn, "org.freedesktop.ScreenSaver", path, "org.freedesktop.ScreenSaver").await
+        {
+            if proxy.call::<_, _, u32>("GetActiveTime", &()).await.is_ok() {
+                log::info!("[presence] linux: idle from org.freedesktop.ScreenSaver at {path}");
+                return Some(IdleSource::ScreenSaver(proxy));
+            }
+        }
+    }
+    if let Ok(proxy) = zbus::Proxy::new(
+        conn,
+        "org.gnome.Mutter.IdleMonitor",
+        "/org/gnome/Mutter/IdleMonitor",
+        "org.gnome.Mutter.IdleMonitor",
+    )
+    .await
+    {
+        if proxy.get_property::<u64>("Idletime").await.is_ok() {
+            log::info!("[presence] linux: idle from org.gnome.Mutter.IdleMonitor");
+            return Some(IdleSource::MutterIdleMonitor(proxy));
+        }
+    }
+    None
+}
+
+async fn poll_idle_time() {
+    let conn = match zbus::Connection::session().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            log::info!("[presence] linux: no session bus ({e}); input reports unknown");
+            return;
+        }
+    };
+    let mut source: Option<IdleSource> = None;
+    let mut interval = tokio::time::interval(IDLE_POLL_INTERVAL);
+    loop {
+        interval.tick().await;
+        if source.is_none() {
+            source = probe_idle_source(&conn).await;
+            if source.is_none() {
+                continue;
+            }
+        }
+        if let Some(active) = &source {
+            match active.read_seconds().await {
+                Some(secs) => IDLE_SECONDS.store(secs, Ordering::Relaxed),
+                None => {
+                    // The source went away; drop back to unknown and re-probe.
+                    IDLE_SECONDS.store(u64::MAX, Ordering::Relaxed);
+                    source = None;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locked_hint_maps_to_the_session_states() {
+        assert_eq!(session_state_for_locked_hint(true), SESSION_LOCKED);
+        assert_eq!(session_state_for_locked_hint(false), SESSION_UNLOCKED);
+    }
+
+    #[test]
+    fn prepare_for_sleep_true_ends_and_false_resumes() {
+        assert_eq!(sleep_action_for(true), SleepAction::SendEnded);
+        assert_eq!(sleep_action_for(false), SleepAction::Resumed);
+    }
+
+    #[test]
+    fn only_the_session_interfaces_locked_hint_is_read() {
+        let mut changed = HashMap::new();
+        changed.insert("LockedHint".to_string(), zbus::zvariant::OwnedValue::from(true));
+        assert_eq!(locked_hint_from_changed(LOGIN1_SESSION_INTERFACE, &changed), Some(true));
+
+        // The same key on another interface is not our lock state.
+        assert_eq!(locked_hint_from_changed("org.freedesktop.login1.Manager", &changed), None);
+
+        // A different key leaves the state alone.
+        let mut other = HashMap::new();
+        other.insert("Active".to_string(), zbus::zvariant::OwnedValue::from(false));
+        assert_eq!(locked_hint_from_changed(LOGIN1_SESSION_INTERFACE, &other), None);
+
+        // A non-boolean value is not a lock state.
+        let mut wrong_type = HashMap::new();
+        wrong_type.insert("LockedHint".to_string(), zbus::zvariant::OwnedValue::from(7u32));
+        assert_eq!(locked_hint_from_changed(LOGIN1_SESSION_INTERFACE, &wrong_type), None);
+    }
+
+    #[test]
+    fn the_cached_idle_reading_maps_unknown_and_seconds() {
+        assert_eq!(idle_duration_for_cached(u64::MAX), None);
+        assert_eq!(idle_duration_for_cached(0), Some(Duration::from_secs(0)));
+        // Below and at the 5-minute threshold (input_word itself is tested
+        // in presence.rs).
+        assert_eq!(crate::presence::input_word(idle_duration_for_cached(299)), "recent");
+        assert_eq!(crate::presence::input_word(idle_duration_for_cached(300)), "idle");
+    }
+}

--- a/desktop/src-tauri/src/presence_mac.rs
+++ b/desktop/src-tauri/src/presence_mac.rs
@@ -1,0 +1,265 @@
+//! macOS signals for the presence reporter (SCROLLR-211).
+//!
+//! Four native sources, each mapped onto the reporter's fixed vocabulary
+//! and nothing else:
+//!
+//! * Session lock / unlock — the distributed notifications
+//!   `com.apple.screenIsLocked` / `com.apple.screenIsUnlocked`, registered
+//!   with DeliverImmediately so the callback still fires while the app is
+//!   napped. Only those two names are interpreted; anything else leaves
+//!   the state as it was.
+//! * Display sleep / wake — `NSWorkspaceScreensDidSleepNotification` /
+//!   `NSWorkspaceScreensDidWakeNotification` on the shared workspace's
+//!   notification center.
+//! * Suspend / resume — `NSWorkspaceWillSleepNotification` /
+//!   `NSWorkspaceDidWakeNotification`. WillSleep sends the final `ended`
+//!   check-in within two seconds; DidWake lets the loop start again.
+//! * Idle — `CGEventSourceSecondsSinceLastEventType`, polled by the loop:
+//!   seconds since the last keyboard or mouse event system-wide, never
+//!   what the event was. Elapsed time needs no accessibility or
+//!   input-monitoring permission.
+//!
+//! The initial session state is `unlocked`: a user session that launches a
+//! GUI app is not locked at that moment, and macOS exposes the lock only
+//! as transitions. Display starts `unknown` until the first sleep/wake
+//! notification — macOS offers no "is the display on right now" query that
+//! reads honestly here.
+
+use std::sync::atomic::Ordering;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use objc2::rc::Retained;
+use objc2::runtime::NSObject;
+use objc2::{AnyThread, define_class, msg_send, sel};
+use objc2_app_kit::NSWorkspace;
+use objc2_foundation::{
+    NSDistributedNotificationCenter, NSNotification, NSNotificationSuspensionBehavior, NSString,
+};
+use tauri::AppHandle;
+
+use crate::presence::{
+    DISPLAY_ASLEEP, DISPLAY_AWAKE, DISPLAY_STATE, SESSION_LOCKED, SESSION_STATE, SESSION_UNLOCKED,
+};
+
+static APP: OnceLock<AppHandle> = OnceLock::new();
+
+/// What one OS notification means to the reporter. Every notification the
+/// app observes resolves to exactly one of these; anything else is ignored
+/// so an unrelated name can never masquerade as a state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OsSignal {
+    SessionLocked,
+    SessionUnlocked,
+    DisplayAsleep,
+    DisplayAwake,
+    Suspending,
+    Resumed,
+}
+
+/// Map a notification name to the reporter's signal, or None when the name
+/// is not one we observe — the state is then left alone.
+pub fn signal_for_name(name: &str) -> Option<OsSignal> {
+    match name {
+        "com.apple.screenIsLocked" => Some(OsSignal::SessionLocked),
+        "com.apple.screenIsUnlocked" => Some(OsSignal::SessionUnlocked),
+        "NSWorkspaceScreensDidSleepNotification" => Some(OsSignal::DisplayAsleep),
+        "NSWorkspaceScreensDidWakeNotification" => Some(OsSignal::DisplayAwake),
+        "NSWorkspaceWillSleepNotification" => Some(OsSignal::Suspending),
+        "NSWorkspaceDidWakeNotification" => Some(OsSignal::Resumed),
+        _ => None,
+    }
+}
+
+/// The FFI value is a CFTimeInterval; a negative or non-finite reading is
+/// not an answer, so the field reports unknown rather than a guess.
+pub fn idle_duration_for(seconds_since_input: f64) -> Option<Duration> {
+    if !seconds_since_input.is_finite() || seconds_since_input < 0.0 {
+        return None;
+    }
+    Some(Duration::from_secs_f64(seconds_since_input))
+}
+
+/// Seconds since the last input, from CoreGraphics' HID event source.
+pub fn idle_for() -> Option<Duration> {
+    let seconds = unsafe {
+        CGEventSourceSecondsSinceLastEventType(K_CG_EVENT_SOURCE_STATE_HID_SYSTEM_STATE, K_CG_ANY_INPUT_EVENT_TYPE)
+    };
+    idle_duration_for(seconds)
+}
+
+// CGEventSource.h: kCGEventSourceStateHIDSystemState, the physical
+// keyboard/mouse event source.
+const K_CG_EVENT_SOURCE_STATE_HID_SYSTEM_STATE: u32 = 1;
+// CGEventTypes.h: kCGAnyInputEventType = (CGEventType)(~0).
+const K_CG_ANY_INPUT_EVENT_TYPE: u32 = u32::MAX;
+
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+    fn CGEventSourceSecondsSinceLastEventType(source_state_id: u32, event_type: u32) -> f64;
+}
+
+define_class!(
+    // SAFETY: NSObject has no subclassing requirements; the class holds no
+    // state (unit ivars) and does not implement Drop.
+    #[unsafe(super(NSObject))]
+    #[name = "ScrollrPresenceObserver"]
+    pub struct PresenceObserver;
+
+    impl PresenceObserver {
+        #[unsafe(method(handlePresenceNotification:))]
+        fn handle_presence_notification(&self, notification: &NSNotification) {
+            let name = notification.name().to_string();
+            match signal_for_name(&name) {
+                Some(signal) => apply(signal),
+                None => log::debug!("[presence] ignoring notification {name}"),
+            }
+        }
+    }
+);
+
+impl PresenceObserver {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(());
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// One notification center callback: store the new state, and for the
+/// sleep/wake pair run the reporter's ended/resume bookkeeping.
+fn apply(signal: OsSignal) {
+    match signal {
+        OsSignal::SessionLocked => {
+            SESSION_STATE.store(SESSION_LOCKED, Ordering::Relaxed);
+            log::info!("[presence] session locked");
+        }
+        OsSignal::SessionUnlocked => {
+            SESSION_STATE.store(SESSION_UNLOCKED, Ordering::Relaxed);
+            log::info!("[presence] session unlocked");
+        }
+        OsSignal::DisplayAsleep => {
+            DISPLAY_STATE.store(DISPLAY_ASLEEP, Ordering::Relaxed);
+            log::info!("[presence] display asleep");
+        }
+        OsSignal::DisplayAwake => {
+            DISPLAY_STATE.store(DISPLAY_AWAKE, Ordering::Relaxed);
+            log::info!("[presence] display awake");
+        }
+        OsSignal::Suspending => {
+            log::info!("[presence] suspend: sending ended check-in");
+            if let Some(app) = APP.get() {
+                crate::presence::send_ended_blocking(app);
+            }
+        }
+        OsSignal::Resumed => {
+            log::info!("[presence] resume");
+            if let Some(app) = APP.get() {
+                crate::presence::resumed(app);
+            }
+        }
+    }
+}
+
+/// Install every hook. Called once from `presence::start`, which runs in
+/// Tauri's setup on the main thread — NSWorkspace and the notification
+/// centers expect that, and delivery needs the main run loop the app
+/// already runs.
+pub fn install(app: AppHandle) {
+    if APP.set(app).is_err() {
+        return;
+    }
+    // A GUI app that is launching is in an unlocked session; macOS exposes
+    // only the transitions from here on.
+    SESSION_STATE.store(SESSION_UNLOCKED, Ordering::Relaxed);
+    let observer = PresenceObserver::new();
+
+    // Session lock/unlock arrive as distributed notifications.
+    let distributed = NSDistributedNotificationCenter::defaultCenter();
+    for name in ["com.apple.screenIsLocked", "com.apple.screenIsUnlocked"] {
+        let name = NSString::from_str(name);
+        // SAFETY: `observer` outlives the process (leaked below) and the
+        // selector is defined on its class with the matching signature.
+        unsafe {
+            distributed.addObserver_selector_name_object_suspensionBehavior(
+                &observer,
+                sel!(handlePresenceNotification:),
+                Some(&name),
+                None,
+                NSNotificationSuspensionBehavior::DeliverImmediately,
+            );
+        }
+    }
+
+    // Suspend/resume and display sleep/wake arrive on the workspace center.
+    let workspace = NSWorkspace::sharedWorkspace();
+    let center = workspace.notificationCenter();
+    for name in [
+        "NSWorkspaceWillSleepNotification",
+        "NSWorkspaceDidWakeNotification",
+        "NSWorkspaceScreensDidSleepNotification",
+        "NSWorkspaceScreensDidWakeNotification",
+    ] {
+        let name = NSString::from_str(name);
+        // SAFETY: as above.
+        unsafe {
+            center.addObserver_selector_name_object(
+                &observer,
+                sel!(handlePresenceNotification:),
+                Some(&name),
+                None,
+            );
+        }
+    }
+
+    // Selector-based observers are not retained by the centers; the
+    // reporter is a process-lifetime singleton, so the observer simply
+    // lives forever.
+    std::mem::forget(observer);
+    log::info!("[presence] macOS signals installed");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_lock_notifications_change_the_session_state() {
+        assert_eq!(signal_for_name("com.apple.screenIsLocked"), Some(OsSignal::SessionLocked));
+        assert_eq!(signal_for_name("com.apple.screenIsUnlocked"), Some(OsSignal::SessionUnlocked));
+        // Near-miss names and other notifications leave the state alone.
+        assert_eq!(signal_for_name("com.apple.screenIsLockedByRequest"), None);
+        assert_eq!(signal_for_name("com.apple.sessionDidMoveFromConsole"), None);
+        assert_eq!(signal_for_name(""), None);
+    }
+
+    #[test]
+    fn display_sleep_notifications_map_to_the_display_states() {
+        assert_eq!(signal_for_name("NSWorkspaceScreensDidSleepNotification"), Some(OsSignal::DisplayAsleep));
+        assert_eq!(signal_for_name("NSWorkspaceScreensDidWakeNotification"), Some(OsSignal::DisplayAwake));
+        // Session sleep is not display sleep.
+        assert_eq!(signal_for_name("NSWorkspaceWillSleepNotification"), Some(OsSignal::Suspending));
+        assert_eq!(signal_for_name("NSWorkspaceDidWakeNotification"), Some(OsSignal::Resumed));
+        assert_eq!(signal_for_name("NSWorkspaceWillPowerOffNotification"), None);
+    }
+
+    #[test]
+    fn idle_rejects_readings_that_are_not_elapsed_time() {
+        assert_eq!(idle_duration_for(-1.0), None);
+        assert_eq!(idle_duration_for(f64::NAN), None);
+        assert_eq!(idle_duration_for(f64::INFINITY), None);
+        assert_eq!(idle_duration_for(0.0), Some(Duration::from_secs(0)));
+        assert_eq!(idle_duration_for(299.5), Some(Duration::from_millis(299_500)));
+        // ...and the 5-minute threshold itself stays in presence.rs's
+        // input_word, tested there.
+        assert_eq!(crate::presence::input_word(idle_duration_for(299.0)), "recent");
+        assert_eq!(crate::presence::input_word(idle_duration_for(300.0)), "idle");
+    }
+
+    #[test]
+    fn idle_reads_a_duration_on_a_real_desktop() {
+        // The HID event source answers on any logged-in session; on a
+        // headless runner it may not. Either answer is acceptable, a panic
+        // is not.
+        let _ = idle_for();
+    }
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Scrollr",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "identifier": "com.scrollr.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/analytics/ADMIN_DASHBOARD.md
+++ b/docs/analytics/ADMIN_DASHBOARD.md
@@ -78,9 +78,9 @@ Every ~30 s the reporter `POST`s `/users/me/presence` with:
 |---|---|
 | `session_id` | random 128-bit id (32 hex characters) minted at app launch; never persisted, never derived from hardware |
 | `seq` | monotonically increasing per session |
-| `session` | `unlocked` / `locked` / `unknown` (Windows: `WM_WTSSESSION_CHANGE`) |
-| `input` | `recent` / `idle` / `unknown` (Windows: `GetLastInputInfo`; idle = no input for 5 minutes) |
-| `display` | `awake` / `asleep` / `unknown` (Windows: `GUID_CONSOLE_DISPLAY_STATE`) |
+| `session` | `unlocked` / `locked` / `unknown` (Windows: `WM_WTSSESSION_CHANGE`; macOS: screen lock/unlock distributed notifications; Linux: logind `LockedHint`) |
+| `input` | `recent` / `idle` / `unknown` (Windows: `GetLastInputInfo`; macOS: `CGEventSourceSecondsSinceLastEventType`; Linux: the desktop's screensaver idle time over D-Bus where provided; idle = no input for 5 minutes) |
+| `display` | `awake` / `asleep` / `unknown` (Windows: `GUID_CONSOLE_DISPLAY_STATE`; macOS: `NSWorkspace` screen sleep/wake; Linux: no reliable cross-desktop signal, stays `unknown`) |
 | `ticker` | `disabled` / `shown` / `hidden` — the Show ticker preference and whether any ticker window is visible |
 | `screens[]` | one entry per ticker window: `{ screen, shown, widgets[] }`; `widgets` is the set of catalog widget types currently rendered on that screen |
 | `ended` | `true` on quit and on system suspend |
@@ -106,9 +106,30 @@ the event. Quit (`RunEvent::ExitRequested`) sends `ended` the same way. If the
 stored token has expired or the server answers 401, the reporter asks the main
 window to refresh it and skips that tick; nothing is sent unauthenticated.
 
-On macOS and Linux the session, input and display dimensions report `unknown`
-in this release. They are not interpreted as unlocked or awake. Sleep on those
-platforms is not reported; the session expires naturally.
+macOS signals (`desktop/src-tauri/src/presence_mac.rs`): lock/unlock from the
+distributed notifications `com.apple.screenIsLocked`/
+`com.apple.screenIsUnlocked`, registered deliver-immediately so the callback
+still fires while the app is napped (the session starts `unlocked` because
+launching a GUI app implies an unlocked session and macOS exposes only the
+transitions); display sleep/wake from `NSWorkspace`'s screen notifications;
+suspend/resume from `NSWorkspaceWillSleepNotification`/
+`NSWorkspaceDidWakeNotification` — WillSleep sends the `ended` check-in within
+2 s and DidWake lets the loop start a fresh interval; idle from
+`CGEventSourceSecondsSinceLastEventType`, the time since the last keyboard or
+mouse event and nothing about the event.
+
+Linux signals (`desktop/src-tauri/src/presence_linux.rs`): lock/unlock from
+logind's `LockedHint` on the current session, read once at startup and then
+watched via `PropertiesChanged`; suspend/resume from logind's
+`PrepareForSleep` — `true` sends the `ended` check-in within 2 s and `false`
+lets the loop start a fresh interval; idle from
+`org.freedesktop.ScreenSaver.GetActiveTime` (or GNOME's
+`org.gnome.Mutter.IdleMonitor`) where the desktop provides it, re-read every
+10 s. Display sleep has no reliable cross-desktop signal and reports
+`unknown`. On machines without systemd/logind or a D-Bus session bus every
+OS-derived field reports `unknown`, and a signal the platform cannot read is
+never guessed on any OS — `unknown` is never interpreted as unlocked or
+awake.
 
 The server accepts a check-in only for an account with usage analytics enabled
 (`product_analytics_enrollments`), the same enrollment that governs the daily


### PR DESCRIPTION
## SCROLLR-211 — macOS and Linux presence signals + desktop 1.6.7

Yesterday's SCROLLR-210 shipped the desktop presence reporter with OS signals only on Windows (`presence_win.rs`). On macOS and Linux the `session`, `input` and `display` fields could only ever report `unknown`, so those users counted as "running the app" but never as "ticker shown", and sleep did not end their sessions promptly. This PR adds the two missing platform modules, wired exactly like the Windows one, and cuts desktop 1.6.7.

### The contract is unchanged

Payload shape, field names, enums (`unlocked/locked/unknown`, `recent/idle/unknown`, `awake/asleep/unknown`), the 30 s cadence and the 90 s expiry are untouched; the server validator and its tests see nothing new. A signal the platform cannot read stays `unknown` — never guessed, never defaulted. Idle is elapsed time only (5-minute threshold in `presence.rs`, unchanged). Nothing under `api/` changed except the kb regeneration for the version bump; `presence_win.rs` and the reporter's networking/tick logic are untouched.

### What each platform reports now

| | session | input | display | suspend/resume |
|---|---|---|---|---|
| Windows (unchanged) | `WM_WTSSESSION_CHANGE` | `GetLastInputInfo` | `GUID_CONSOLE_DISPLAY_STATE` | power callback |
| macOS (new) | `com.apple.screenIsLocked`/`Unlocked` distributed notifications (deliver-immediately; starts `unlocked`, macOS exposes only transitions) | `CGEventSourceSecondsSinceLastEventType` | `NSWorkspace` ScreensDidSleep/Wake | `NSWorkspaceWillSleepNotification` sends `ended`, DidWake resumes |
| Linux (new) | logind `LockedHint` (initial read + `PropertiesChanged`) | `org.freedesktop.ScreenSaver.GetActiveTime` or GNOME `org.gnome.Mutter.IdleMonitor`, polled every 10 s | **`unknown`** — no reliable cross-desktop signal | `PrepareForSleep(true)` sends `ended`, `false` resumes |

On Linux machines without systemd/logind or a D-Bus session bus, every OS-derived field honestly reports `unknown`. Linux `display` stays `unknown` by design.

### Tests

Per the `presence_win.rs` pattern, the mapping logic is pure and unit-tested; the notification plumbing is a thin shell over it. macOS: lock/unlock/other → state mapping, display mapping, WillSleep→ended / DidWake→resume, idle conversion (rejects negative/NaN/∞). Linux: LockedHint mapping, `PrepareForSleep(true)`→ended / `false`→resume, PropertiesChanged extraction (right interface, right key, right type only), cached-idle sentinel mapping including below/at the 5-minute threshold.

### Dependencies

- Linux: `zbus` 5 (tokio flavor). **Adds no new crate to the build graph** — `tauri-plugin-single-instance` already compiles zbus 5.14.0 into Linux builds; this PR only makes it a direct dependency. No open advisories (cargo-audit in the release workflow stays clean).
- macOS: no new binding stack. `objc2`/`objc2-app-kit` pins unchanged; `NSWorkspace` feature enabled; `objc2-foundation` 0.3 added from the same objc2 generation for the notification centers.

### CI

`desktop-rust-tests` in `backend-tests.yml` is now a matrix over `ubuntu-latest` and `macos-latest`, so the cfg-gated macOS module compiles and tests on every PR instead of first compiling in the post-merge release build. Linux webkit deps stay Linux-only; the macOS leg gets the `$CARGO_HOME/bin` PATH workaround for the Homebrew rustup stub (same as desktop-release.yml) and `cache-bin: false`. Windows stays out — the `STATUS_ENTRYPOINT_NOT_FOUND` note still applies.

### Verification — read this before trusting it

- **Windows (this machine):** `cargo check` + `cargo test --lib` — 41 passed. `npx tsc --noEmit` clean, `npx vitest run` 791 passed.
- **macOS + Linux (cross-checked from Windows, not CI):** the real `presence_mac.rs` / `presence_linux.rs` files were compiled verbatim (lib + tests) via a scratch crate against the **exact locked dependency versions** (objc2 0.6.4 / objc2-app-kit 0.3.2 / objc2-foundation 0.3.2 for `aarch64-apple-darwin`; zbus 5.14.0 / zbus_macros 5.14.0 / zvariant 5.10.0 for `x86_64-unknown-linux-gnu`). This caught and fixed real errors (objc2 `AnyThread` import, `set_ivars(())` init, zbus `deserialize` error type) before push.
- **CI** compiles and runs the suites on real `ubuntu-latest` and `macos-latest` runners — see the checks below.
- **Not done:** nobody has run this build on a real Mac or a real Linux desktop. The OS signals are **unproven on real hardware** — notification delivery, logind session resolution and the screensaver idle interfaces should be smoke-tested on real machines before/after release. That's the honest state of it.

### Release (Task B)

Bumps 1.6.6 → 1.6.7 in `tauri.conf.json`, `Cargo.toml`, `package.json` (+ both lockfiles; kb regenerated for the embedded version). Merging to `main` triggers `desktop-release.yml`, whose preflight sees no published `desktop-v1.6.7` and builds all three platforms into a **draft** release. The workflow cannot publish; release notes go on the draft after it exists, and publishing is left to Brandon.
