### PR TITLE
feat(admin): rebuild Overview as five sentences with verdicts [SCROLLR-215]

### DIFF
--- a/api/internal/support/admin_summary.go
+++ b/api/internal/support/admin_summary.go
@@ -65,9 +65,15 @@ type SupportSummaryResponse struct {
 	CompletionMedianHours    platform.Metric `json:"completion_median_hours"`
 	// PayingCreated is how many of the window's new tickets came from a
 	// verified paying account.
-	PayingCreated int               `json:"paying_created"`
-	Coverage      platform.Coverage `json:"coverage"`
-	HistoryNote   string            `json:"history_note"`
+	PayingCreated int `json:"paying_created"`
+	// CasesWithAccount of Cases arrived from a signed-in app session. The
+	// Overview states the pair rather than the ratio: it is the reason no
+	// ticket can be matched to a paying customer, and a percentage of 59
+	// reads as a measurement of a population rather than as "almost none".
+	CasesWithAccount int               `json:"cases_with_account"`
+	Cases            int               `json:"cases"`
+	Coverage         platform.Coverage `json:"coverage"`
+	HistoryNote      string            `json:"history_note"`
 }
 
 // HandleAdminSupportSummary - GET /admin/support/summary?period=
@@ -146,6 +152,7 @@ func loadSupportSummary(ctx context.Context, period platform.Period, now time.Ti
 		out.OldestNeedsAttention = platform.Unmeasured(fmt.Sprintf("%d tickets need attention, but none has a customer message on record to measure the wait from.", out.NeedsAttention.Total))
 	}
 	accounts := queueAccounts(ctx)
+	out.CasesWithAccount, out.Cases = accounts.CasesWithAccount, accounts.Cases
 	out.PayingNote = payingSectionNote(accounts, out.Total.Paying)
 	if out.Total.Paying > 0 {
 		out.PayingNote = ""

--- a/myscrollr.com/src/api/adminDashboard.ts
+++ b/myscrollr.com/src/api/adminDashboard.ts
@@ -375,6 +375,9 @@ export interface SupportSummary {
   first_response_median_hours: Metric
   completion_median_hours: Metric
   paying_created: number
+  /** How many of `cases` arrived from a signed-in app session. */
+  cases_with_account: number
+  cases: number
   coverage: Coverage
   history_note: string
 }

--- a/myscrollr.com/src/components/admin/OverviewPage.test.tsx
+++ b/myscrollr.com/src/components/admin/OverviewPage.test.tsx
@@ -2,17 +2,14 @@ import { describe, expect, it } from 'vitest'
 import { OverviewContent } from './OverviewPage'
 import { renderWithRouter } from './testRouter'
 import {
-  audience,
   desktop,
   failed,
   loaded,
   loading,
-  notComparable,
   overview,
   presence,
   revenue,
   support,
-  unavailable,
   website,
 } from './dashboardFixtures'
 import type { OverviewContentProps } from './OverviewPage'
@@ -20,9 +17,7 @@ import type { OverviewContentProps } from './OverviewPage'
 function render(overrides: Partial<OverviewContentProps> = {}) {
   return renderWithRouter(
     <OverviewContent
-      period="7d"
       presence={loaded(presence)}
-      audience={loaded(audience)}
       desktop={loaded(desktop)}
       website={loaded(website)}
       revenue={loaded(revenue)}
@@ -33,201 +28,208 @@ function render(overrides: Partial<OverviewContentProps> = {}) {
   )
 }
 
+/** Strip tags so a sentence split across spans still reads as a sentence. */
+function text(html: string): string {
+  return html.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ')
+}
+
 describe('OverviewContent', () => {
-  it('leads with the live headline verbatim and labels now versus period', async () => {
-    const html = await render()
-    expect(html).toContain('12 active users · 9 with ticker(s) · 14 screens')
-    expect(html).toContain('refreshed every 30 s')
-    expect(html).toContain('Current')
-    expect(html).toContain('Last 7 days')
-    // Breakdown chips, in their fixed order.
-    expect(html).toContain('unlocked 11 · locked 1 · unknown 1')
-    expect(html).toContain('0 3 · 1 7 · 2+ 2')
-    // The legacy figure stays secondary and available.
-    expect(html).toContain('Recently seen (legacy, 15 min)')
-    expect(html).toContain('>21<')
+  it('leads with the two headline lines and the five sentences', async () => {
+    const body = text(await render())
+    expect(body).toContain('Running fine.')
+    expect(body).toContain('Support needs you.')
+    expect(body).toContain('12people have Scrollr open right now,')
+    expect(body).toContain('9 with the ticker on screen.')
+    expect(body).toContain('3people are waiting for a reply from us,')
+    expect(body).toContain('2customers pay.')
+    expect(body).toContain('1person signed up in the last 24 hours,')
+    expect(body).toContain('Scores, prices, markets and news are up to date,')
+    expect(body).toContain('all within the last few minutes.')
   })
 
-  it('shows the staff-excluded badge linking to settings when any report says so', async () => {
-    const html = await render()
-    expect(html).toContain('Staff excluded')
-    expect(html).toContain('href="/admin/settings"')
-    expect(html).toContain('4 staff/test excluded')
+  it('shows one verdict per row', async () => {
+    const body = text(await render())
+    expect(body).toContain('Live')
+    expect(body).toContain('Needs you')
+    expect(body).toContain('New money')
+    expect(body).toContain('Growing')
+    expect(body).toContain('All good')
 
-    const none = await render({
-      presence: loaded({ ...presence, staff_excluded: false }),
-      audience: loaded({ ...audience, staff_excluded: false }),
-      desktop: loaded({ ...desktop, staff_excluded: false }),
-      website: loaded({ ...website, staff_excluded: false }),
-    })
-    expect(none).not.toContain('Staff excluded')
-  })
-
-  it('carries the period into every analytics link', async () => {
-    const html = await render({ period: '30d' })
-    expect(html).toContain('href="/admin/analytics?period=30d&amp;view=growth"')
-    expect(html).toContain(
-      'href="/admin/analytics?period=30d&amp;view=desktop"',
+    // A day with nothing to compare against is judged, not guessed at.
+    const early = text(
+      await render({
+        service: loaded({
+          ...overview,
+          accounts: {
+            ...overview.accounts,
+            new_today: { value: 1, delta: 1, available: true },
+          },
+        }),
+      }),
     )
-    expect(html).toContain(
-      'href="/admin/analytics?period=30d&amp;view=revenue"',
+    expect(early).toContain('Too early to compare')
+  })
+
+  it('colours the number only when the verdict is red or amber', async () => {
+    const html = await render({
+      service: loaded({
+        ...overview,
+        ingest: [{ table: 'trades', age_seconds: 7200, has_data: true }],
+      }),
+    })
+    // Support is red, so its number carries the error colour.
+    expect(html).toContain('text-error')
+    // A green row's number stays base-content: no primary-coloured number.
+    expect(html).not.toContain('tracking-[-0.04em] tabular-nums text-primary')
+  })
+
+  it('opens no detail panel until a row asks for one', async () => {
+    const closed = text(await render())
+    expect(closed).not.toContain('Waiting for the customer to reply')
+    expect(closed).not.toContain('Monitors showing a ticker')
+
+    const open = text(await render({ initialOpen: 'support' }))
+    expect(open).toContain('Waiting for the customer to reply')
+    expect(open).not.toContain('Monitors showing a ticker')
+  })
+
+  it('shows the support facts, note and queue action when that row is open', async () => {
+    const html = await render({ initialOpen: 'support' })
+    const body = text(html)
+    expect(body).toContain('Waiting for us to reply')
+    expect(body).toContain('Finished without a reply (spam, duplicates)')
+    expect(body).toContain('All tickets ever')
+    expect(body).toContain('#104')
+    expect(body).toContain('on, sent after a 30 min hold')
+    expect(body).toContain('only 1 of the 59 were sent from inside the app')
+    expect(html).toContain('href="/admin/support"')
+  })
+
+  it('makes the support action the only filled button', async () => {
+    const supportPanel = await render({ initialOpen: 'support' })
+    expect(supportPanel).toContain('bg-error')
+    for (const row of ['right_now', 'money', 'growth', 'feeds'] as const) {
+      const html = await render({ initialOpen: row })
+      expect(html).not.toContain('bg-error px-4')
+    }
+  })
+
+  it('never renders a number a row cannot back', async () => {
+    const body = text(
+      await render({
+        initialOpen: 'right_now',
+        presence: loaded({
+          ...presence,
+          available: false,
+          note: 'Live presence is unavailable right now.',
+          active_users: 0,
+          ticker_users: 0,
+          screens: 0,
+        }),
+        revenue: loaded({
+          ...revenue,
+          paying_now: { ...revenue.paying_now, available: false, paying: 0 },
+          paying_now_note: 'The customer snapshot could not be read.',
+        }),
+      }),
     )
-    expect(html).toContain(
-      'href="/admin/analytics?period=30d&amp;view=support"',
+    expect(body).toContain('Nobody is reporting yet.')
+    expect(body).toContain('Live presence is unavailable right now.')
+    expect(body).toContain('The customer snapshot could not be read.')
+    expect(body).not.toContain('0people have Scrollr open')
+    expect(body).not.toContain('0customers pay')
+    expect(body).toContain('Not reporting yet')
+  })
+
+  it('goes grey and quiet when nobody is here, and amber on a stale feed', async () => {
+    const body = text(
+      await render({
+        presence: loaded({ ...presence, active_users: 0, ticker_users: 0 }),
+        service: loaded({
+          ...overview,
+          ingest: [
+            { table: 'games', age_seconds: 90, has_data: true },
+            { table: 'trades', age_seconds: 7200, has_data: true },
+            { table: 'markets', age_seconds: 120, has_data: true },
+            { table: 'rss_items', age_seconds: 200, has_data: true },
+          ],
+        }),
+      }),
     )
-    expect(html).toContain('Last 30 days')
+    expect(body).toContain('Quiet')
+    expect(body).toContain('Stale')
+    expect(body).toContain('Stock prices have not updated for 2 hours.')
+    // Stale is not broken, so the headline still says things run.
+    expect(body).toContain('Running fine.')
   })
 
-  it('renders a delta only when the API called it comparable', async () => {
+  it('says something is broken when a feed has no data at all', async () => {
+    const body = text(
+      await render({
+        service: loaded({
+          ...overview,
+          ingest: [
+            { table: 'games', age_seconds: 90, has_data: true },
+            { table: 'trades', age_seconds: 0, has_data: false },
+          ],
+        }),
+      }),
+    )
+    expect(body).toContain('Something is broken.')
+    expect(body).toContain('A feed is broken')
+    expect(body).toContain('Stock prices are not reporting any data.')
+  })
+
+  it('spells the feed ages out in words when the row is open', async () => {
+    const body = text(await render({ initialOpen: 'feeds' }))
+    expect(body).toContain('Sports scores last updated')
+    expect(body).toContain('1 minute ago')
+    expect(body).toContain('Our servers running')
+    expect(body).toContain('2 of 2')
+    expect(body).toContain('1.6.7')
+  })
+
+  it('formats money from minor units and never sums currencies', async () => {
+    const body = text(await render({ initialOpen: 'money' }))
+    expect(body).toContain('$113.46 USD came in today.')
+    expect(body).toContain('$979.02 USD earned ever.')
+    expect(body).toContain('Earned today after Stripe fees')
+    expect(body).not.toContain('$133.46')
+  })
+
+  it('carries no period selector and no definitions accordion', async () => {
     const html = await render()
-    // New accounts: comparable, with a percentage.
-    expect(html).toContain('+4')
-    expect(html).toContain('(+50%)')
-    // Website visitors: not comparable — the note, never a delta.
-    expect(html).toContain('nothing complete to compare with')
-
-    const none = await render({
-      audience: loaded({
-        ...audience,
-        new: { ...audience.new, comparison: notComparable },
-      }),
-      desktop: loaded({
-        ...desktop,
-        unique_users: { ...desktop.unique_users, comparison: notComparable },
-      }),
-    })
-    expect(none).not.toContain('(+50%)')
-    expect(none).not.toContain('+4<')
+    expect(html).not.toContain('Last 7 days')
+    expect(html).not.toContain('How to read these numbers')
+    expect(html).not.toContain('period=')
   })
 
-  it('never renders an unavailable metric as a number, not even zero', async () => {
+  it('keeps a failed source inside its own row', async () => {
     const html = await render({
-      audience: loaded({
-        ...audience,
-        new: unavailable('Logto could not be reached.'),
-      }),
-      desktop: loaded({
-        ...desktop,
-        unique_users: unavailable('Presence has no rows yet.'),
-      }),
-      revenue: loaded({
-        ...revenue,
-        earnings: {
-          ...revenue.earnings,
-          available: false,
-          note: 'Stripe is not configured.',
-        },
-        new_paying: {
-          ...revenue.new_paying,
-          available: false,
-          note: 'Charge history is unavailable.',
-        },
-      }),
-    })
-    expect(html).toContain('Logto could not be reached.')
-    expect(html).toContain('Presence has no rows yet.')
-    expect(html).toContain('Stripe is not configured.')
-    expect(html).toContain('Charge history is unavailable.')
-    expect(html).not.toContain('text-3xl font-bold tabular-nums">0<')
-    expect(html).not.toContain('$0.00')
-  })
-
-  it('formats earnings from minor units with the currency code and never sums currencies', async () => {
-    const html = await render()
-    expect(html).toContain('$113.46 USD')
-    expect(html).toContain('€20.00 EUR')
-    expect(html).toContain('Lifetime net (USD)')
-    expect(html).toContain('$979.02 USD')
-    expect(html).toContain('never added together')
-    // 11346 + 2000 in either presentation.
-    expect(html).not.toContain('13346')
-    expect(html).not.toContain('$133.46')
-  })
-
-  it('shows the paying snapshot as unavailable, not zero, when Stripe rows could not be read', async () => {
-    const html = await render({
-      revenue: loaded({
-        ...revenue,
-        paying_now: {
-          ...revenue.paying_now,
-          available: false,
-          paying: 0,
-          free: 0,
-        },
-        paying_now_note: 'The customer snapshot could not be read.',
-      }),
-    })
-    expect(html).toContain('The customer snapshot could not be read.')
-    expect(html).not.toContain('0 free')
-  })
-
-  it('overlays paying counts on support buckets only when non-zero', async () => {
-    const html = await render()
-    expect(html).toContain('2 paying')
-    expect(html).toContain('3 paying')
-    expect(html).toContain('40 closed')
-    expect(html).toContain('2d 2h')
-    expect(html).toContain('Ticket #104')
-    expect(html).toContain('armed · 30 min hold')
-    expect(html).toContain('verified account association')
-    expect(html).not.toContain('0 paying')
-  })
-
-  it('says when live presence is unavailable instead of showing zeros', async () => {
-    const html = await render({
-      presence: loaded({
-        ...presence,
-        available: false,
-        headline: 'unavailable',
-        note: 'Live presence is unavailable right now (Redis could not be read).',
-        active_users: 0,
-        ticker_users: 0,
-        screens: 0,
-        session_state: null,
-      }),
-    })
-    expect(html).toContain('Redis could not be read')
-    expect(html).not.toContain('0 active users')
-  })
-
-  it('renders each area independently while loading and on error', async () => {
-    const html = await render({
-      presence: loading(),
-      audience: loading(),
-      desktop: failed('Desktop usage took too long. Please retry.'),
-      website: loading(),
+      initialOpen: 'money',
       revenue: failed('Could not load revenue'),
       support: loading(),
-      service: loading(),
     })
-    expect(html).toContain('Reading live presence')
-    expect(html).toContain('Loading registered accounts')
-    expect(html).toContain('Desktop usage took too long')
     expect(html).toContain('Could not load revenue')
     expect(html).toContain('Retry')
-    expect(html).not.toContain('active users ·')
+    expect(text(html)).toContain('Support is not reporting yet.')
+    // The other rows are unharmed.
+    expect(text(html)).toContain('people have Scrollr open right now,')
   })
 
-  it('keeps the last presence reading on screen when a poll fails', async () => {
-    const html = await render({
-      presence: {
-        data: presence,
-        error: 'stream refused',
-        loading: false,
-        retry: () => {},
-      },
-    })
-    expect(html).toContain('12 active users · 9 with ticker(s) · 14 screens')
-    expect(html).toContain('Last refresh failed: stream refused')
-  })
-
-  it('flags partial history and the service caveats', async () => {
-    const html = await render()
-    expect(html).toContain('Partial history')
-    expect(html).toContain('Presence reporting began 10 September 2026.')
-    expect(html).toContain('Summed across 2 replicas.')
-    expect(html).toContain('Downloads, not installs.')
-    expect(html).toContain('>empty<')
-    expect(html).toContain('How to read these numbers')
+  it('drops a clause it has no second half for', async () => {
+    const body = text(
+      await render({
+        presence: loaded({ ...presence, ticker_users: 0 }),
+        support: loaded({
+          ...support,
+          needs_attention: { total: 0, paying: 0 },
+        }),
+      }),
+    )
+    expect(body).toContain('people have Scrollr open right now.')
+    expect(body).toContain('0people are waiting for a reply from us.')
+    expect(body).not.toContain('one of them since')
+    expect(body).toContain('Clear')
   })
 })

--- a/myscrollr.com/src/components/admin/OverviewPage.tsx
+++ b/myscrollr.com/src/components/admin/OverviewPage.tsx
@@ -1,41 +1,20 @@
-import { Link, useNavigate, useSearch } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useState } from 'react'
-import { AlertTriangle } from 'lucide-react'
-import {
-  Big,
-  Breakdown,
-  Card,
-  CoverageNote,
-  DefinitionDisclosure,
-  DeltaBadge,
-  LINK,
-  Loaded,
-  MetricValue,
-  PeriodSelector,
-  RefreshButton,
-  Row,
-  Section,
-  Sparkline,
-  StaffExcludedBadge,
-  Stat,
-  Unmeasurable,
-  num,
-  useReport,
-} from './ui'
+import { AlertTriangle, Check, ChevronDown } from 'lucide-react'
+import { ErrorPanel, RefreshButton, num, useReport } from './ui'
+import type { ReactNode } from 'react'
 import type { AdminOverview } from '@/api/admin'
 import type {
-  Audience,
   DesktopUsage,
-  Period,
   PresenceLive,
   Revenue,
   SupportSummary,
   Website,
 } from '@/api/adminDashboard'
 import type { Report } from './ui'
+import type { Verdict, VerdictTone } from '@/lib/overviewVerdicts'
 import { loadBoundedAdminReport } from '@/api/adminAnalytics'
 import {
-  loadAudience,
   loadDesktopUsage,
   loadPresenceLive,
   loadRevenue,
@@ -44,48 +23,64 @@ import {
 } from '@/api/adminDashboard'
 import { useGetToken } from '@/hooks/useGetToken'
 import {
-  DOWNLOADS_CAVEAT,
-  connectedCaveat,
-  formatAge,
+  EXPECTED_REPLICAS,
+  formatAgeWords,
   formatHours,
   formatMinor,
-  ingestHealth,
-  measuredValue,
-  periodLabel,
+  plural,
 } from '@/lib/adminFormat'
+import { isStale, verdicts } from '@/lib/overviewVerdicts'
 
 /**
- * "Everything about Scrollr in one spot." (SCROLLR-210)
+ * The Overview, at a glance (SCROLLR-215).
  *
- * Four questions, in order: who is using the desktop app right now; how the
- * audience and the website moved in the window; who pays and what came in;
- * what support owes people. Each answer loads on its own, so one slow source
- * never blanks the page, and each is either a number we hold or an explicit
- * admission that we do not.
+ * Five sentences a person who has never seen this console can read, each with
+ * one big number and a verdict, each expanding into the plain-language facts
+ * behind it. Everything technical — periods, charts, per-widget usage,
+ * presence tables — lives in Analytics, Versions and Support; this page is
+ * "now and the last 24 hours" and nothing else.
  *
- * "Current" cards ignore the period selector and say so; period cards carry
- * the window in their label.
+ * Two promises from SCROLLR-210 carry over unchanged: a row never renders a
+ * number it cannot back, and colour means state, never decoration.
  */
 
 /** How often the live strip re-reads presence while the tab is visible. */
 const PRESENCE_POLL_MS = 30_000
 
-const SESSION_ORDER = ['unlocked', 'locked', 'unknown'] as const
-const INPUT_ORDER = ['recent', 'idle', 'unknown'] as const
-const DISPLAY_ORDER = ['awake', 'asleep', 'unknown'] as const
-const TICKER_ORDER = ['shown', 'hidden', 'disabled'] as const
-const SCREENS_ORDER = ['0', '1', '2+'] as const
+/** The Overview asks one question of time, so every fetch is pinned to it. */
+const WINDOW = '24h' as const
 
-/** Hours as "3d 4h" past a day, so a week-old ticket does not read as 170. */
-function waitingFor(hours: number): string {
-  const whole = Math.max(0, Math.round(hours))
-  return whole >= 24 ? `${Math.floor(whole / 24)}d ${whole % 24}h` : `${whole}h`
+type RowKey = 'right_now' | 'support' | 'money' | 'growth' | 'feeds'
+
+/**
+ * Verdict colours as whole class strings.
+ *
+ * Never built by interpolation: a Tailwind class assembled at runtime is not
+ * in the source, so it compiles to nothing and the pill silently loses its
+ * colour.
+ */
+const TONE: Record<
+  VerdictTone,
+  { dot: string; label: string; number: string }
+> = {
+  good: { dot: 'bg-primary', label: 'text-primary', number: '' },
+  warn: { dot: 'bg-warning', label: 'text-warning', number: 'text-warning' },
+  bad: { dot: 'bg-error', label: 'text-error', number: 'text-error' },
+  none: { dot: 'bg-base-400', label: 'text-base-content/45', number: '' },
 }
+
+/** The four content feeds, in the order the sentence names them. */
+const FEEDS: ReadonlyArray<{ table: string; name: string }> = [
+  { table: 'games', name: 'Sports scores' },
+  { table: 'trades', name: 'Stock prices' },
+  { table: 'markets', name: 'Prediction markets' },
+  { table: 'rss_items', name: 'News headlines' },
+]
 
 /**
  * Live presence, re-read every 30 s while the page is visible. A poll error
- * keeps the last good reading on screen with the error beside it; the strip
- * only goes blank when it never had one.
+ * keeps the last good reading on screen; the row only loses it when it never
+ * had one.
  */
 function usePresenceLive(
   getToken: () => Promise<string | null>,
@@ -141,54 +136,43 @@ function usePresenceLive(
 
 export default function OverviewPage() {
   const getToken = useGetToken()
-  const { period } = useSearch({ from: '/admin/' })
-  const navigate = useNavigate({ from: '/admin/' })
   const [refresh, setRefresh] = useState(0)
 
   const presence = usePresenceLive(getToken, refresh)
-  const audience = useReport(
-    useCallback(
-      (signal: AbortSignal) => {
-        void refresh
-        return loadAudience(getToken, period, signal)
-      },
-      [getToken, period, refresh],
-    ),
-  )
   const desktop = useReport(
     useCallback(
       (signal: AbortSignal) => {
         void refresh
-        return loadDesktopUsage(getToken, period, {}, signal)
+        return loadDesktopUsage(getToken, WINDOW, {}, signal)
       },
-      [getToken, period, refresh],
+      [getToken, refresh],
     ),
   )
   const website = useReport(
     useCallback(
       (signal: AbortSignal) => {
         void refresh
-        return loadWebsite(getToken, period, signal)
+        return loadWebsite(getToken, WINDOW, signal)
       },
-      [getToken, period, refresh],
+      [getToken, refresh],
     ),
   )
   const revenue = useReport(
     useCallback(
       (signal: AbortSignal) => {
         void refresh
-        return loadRevenue(getToken, period, signal)
+        return loadRevenue(getToken, WINDOW, signal)
       },
-      [getToken, period, refresh],
+      [getToken, refresh],
     ),
   )
   const support = useReport(
     useCallback(
       (signal: AbortSignal) => {
         void refresh
-        return loadSupportSummary(getToken, period, signal)
+        return loadSupportSummary(getToken, WINDOW, signal)
       },
-      [getToken, period, refresh],
+      [getToken, refresh],
     ),
   )
   const service = useReport(
@@ -209,789 +193,643 @@ export default function OverviewPage() {
 
   return (
     <OverviewContent
-      period={period}
       presence={presence}
-      audience={audience}
       desktop={desktop}
       website={website}
       revenue={revenue}
       support={support}
       service={service}
-      onPeriodChange={(next) =>
-        navigate({ search: { period: next }, replace: true })
-      }
       onRefresh={() => setRefresh((n) => n + 1)}
     />
   )
 }
 
 export interface OverviewContentProps {
-  period: Period
   presence: Report<PresenceLive>
-  audience: Report<Audience>
   desktop: Report<DesktopUsage>
   website: Report<Website>
   revenue: Report<Revenue>
   support: Report<SupportSummary>
   service: Report<AdminOverview>
-  onPeriodChange?: (period: Period) => void
+  /** Which row starts open. Tests and the preview harness set it; nothing else. */
+  initialOpen?: RowKey
   onRefresh?: () => void
 }
 
 export function OverviewContent({
-  period,
   presence,
-  audience,
   desktop,
   website,
   revenue,
   support,
   service,
-  onPeriodChange = () => {},
+  initialOpen,
   onRefresh,
 }: OverviewContentProps) {
-  const windowLabel = periodLabel(period)
-  const staffExcluded = [presence, audience, desktop, website].some(
-    (r) => r.data?.staff_excluded,
-  )
+  const [open, setOpen] = useState<RowKey | null>(initialOpen ?? null)
+  const rows = buildRows({ presence, desktop, website, revenue, support, service })
   const anyLoading = [
     presence,
-    audience,
     desktop,
     website,
     revenue,
     support,
     service,
   ].some((r) => r.loading)
+  const headline = rows.headline
 
   return (
-    <div className="space-y-8">
-      <header className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Overview</h1>
-          <p className="mt-1 text-sm text-base-content/70">
-            Who is here now, how the window moved, who pays, and what support
-            owes.
-          </p>
-          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-base-content/65">
-            <span>
-              Period cards read <strong>{windowLabel}</strong>. Cards marked
-              “Current” ignore the selector.
-            </span>
-            {staffExcluded && <StaffExcludedBadge />}
-          </div>
-        </div>
-        <div className="flex flex-wrap gap-3">
-          <PeriodSelector value={period} onChange={onPeriodChange} />
-          <RefreshButton onClick={onRefresh} loading={anyLoading} />
-        </div>
-      </header>
+    <div className="mx-auto w-full max-w-[960px]">
+      <div className="flex items-start justify-between gap-6">
+        <h1 className="text-[48px] leading-[1.05] font-extrabold tracking-[-0.035em]">
+          {headline[0]}
+          <br />
+          {headline[1]}
+        </h1>
+        <RefreshButton onClick={onRefresh} loading={anyLoading} />
+      </div>
 
-      <LiveStrip presence={presence} />
+      <ul className="mt-10 border-t border-base-300/70">
+        {rows.rows.map((row) => (
+          <OverviewRow
+            key={row.key}
+            row={row}
+            open={open === row.key}
+            onToggle={() =>
+              setOpen((current) => (current === row.key ? null : row.key))
+            }
+          />
+        ))}
+      </ul>
 
-      <Section
-        id="audience"
-        title="Users & website"
-        action={
-          <Link
-            to="/admin/analytics"
-            search={{ period, view: 'growth' }}
-            className={LINK}
-          >
-            Growth analytics →
-          </Link>
-        }
-      >
-        <div className="grid items-start gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          <Loaded report={audience} label="registered accounts">
-            {(a) => (
-              <Card
-                title="Registered accounts"
-                label="Current"
-                note={a.source === 'local' ? a.note : undefined}
-              >
-                {a.available ? (
-                  <>
-                    <Big>{num(a.total)}</Big>
-                    <p className="mt-1 text-sm text-base-content/60">
-                      {a.source === 'local'
-                        ? 'accounts with local data — Logto unreachable'
-                        : 'accounts in Logto'}
-                      {a.staff_excluded && a.excluded > 0
-                        ? ` · ${num(a.excluded)} staff/test excluded`
-                        : ''}
-                    </p>
-                    <div className="mt-3 border-t border-base-300/60 pt-2">
-                      <Row label="Set up the app" value={num(a.set_up)} />
-                      <Row
-                        label="Never set up"
-                        value={
-                          <span className="text-warning">
-                            {num(Math.max(0, a.total - a.set_up))}
-                          </span>
-                        }
-                      />
-                    </div>
-                  </>
-                ) : (
-                  <Unmeasurable note={a.note} />
-                )}
-              </Card>
-            )}
-          </Loaded>
-          <Loaded report={audience} label="new accounts">
-            {(a) => (
-              <Card title="New accounts" label={windowLabel}>
-                <MetricValue metric={a.new}>
-                  <p className="mt-1 text-sm text-base-content/60">
-                    <DeltaBadge comparison={a.new.comparison} />
-                  </p>
-                </MetricValue>
-                <div className="mt-3">
-                  <Sparkline
-                    buckets={a.new_curve}
-                    step={a.curve_step}
-                    label="New accounts per bucket"
-                  />
-                </div>
-                <CoverageNote coverage={a.coverage} />
-              </Card>
-            )}
-          </Loaded>
-          <Loaded report={desktop} label="desktop usage">
-            {(d) => (
-              <Card
-                title="App users"
-                label={windowLabel}
-                action={
-                  <Link
-                    to="/admin/analytics"
-                    search={{ period, view: 'desktop' }}
-                    className={LINK}
-                  >
-                    Desktop →
-                  </Link>
-                }
-              >
-                <MetricValue metric={d.unique_users}>
-                  <p className="mt-1 text-sm text-base-content/60">
-                    unique app-running users{' '}
-                    <DeltaBadge comparison={d.unique_users.comparison} />
-                  </p>
-                </MetricValue>
-                <div className="mt-3 border-t border-base-300/60 pt-2">
-                  <Row
-                    label="App-running user-hours"
-                    value={
-                      <MetricValue
-                        metric={d.user_hours}
-                        format={formatHours}
-                        size="inline"
-                      />
-                    }
-                  />
-                  <Row
-                    label="Ticker-shown user-hours"
-                    value={
-                      <MetricValue
-                        metric={d.ticker_user_hours}
-                        format={formatHours}
-                        size="inline"
-                      />
-                    }
-                  />
-                </div>
-                <CoverageNote coverage={d.coverage} />
-              </Card>
-            )}
-          </Loaded>
-          <Loaded report={website} label="website analytics">
-            {(w) => (
-              <Card title="Website" label={windowLabel}>
-                {w.available ? (
-                  <>
-                    <MetricValue metric={w.visitors}>
-                      <p className="mt-1 text-sm text-base-content/60">
-                        unique visitors{' '}
-                        <DeltaBadge comparison={w.visitors.comparison} />
-                      </p>
-                    </MetricValue>
-                    <div className="mt-3 border-t border-base-300/60 pt-2">
-                      <Row
-                        label="Pageviews"
-                        value={
-                          <span className="inline-flex items-baseline gap-2">
-                            <MetricValue metric={w.pageviews} size="inline" />
-                            <DeltaBadge comparison={w.pageviews.comparison} />
-                          </span>
-                        }
-                      />
-                    </div>
-                    <CoverageNote coverage={w.coverage} />
-                  </>
-                ) : (
-                  <Unmeasurable note={w.note} />
-                )}
-              </Card>
-            )}
-          </Loaded>
-        </div>
-      </Section>
-
-      <Section
-        id="revenue"
-        title="Paying customers & earnings"
-        action={
-          <Link
-            to="/admin/analytics"
-            search={{ period, view: 'revenue' }}
-            className={LINK}
-          >
-            Revenue analytics →
-          </Link>
-        }
-      >
-        <div className="grid items-start gap-4 sm:grid-cols-2 xl:grid-cols-3">
-          <Loaded report={revenue} label="paying customers">
-            {(r) => (
-              <Card
-                title="Paying customers"
-                label="Current"
-                note={r.paying_now.available ? r.paying_now_note : undefined}
-              >
-                {r.paying_now.available ? (
-                  <>
-                    <Big>{num(r.paying_now.paying)}</Big>
-                    <p className="mt-1 text-sm text-base-content/60">
-                      paying · {num(r.paying_now.free)} free
-                    </p>
-                    <div className="mt-3 border-t border-base-300/60 pt-2">
-                      <Row
-                        label="Lifetime"
-                        value={num(r.paying_now.lifetime)}
-                      />
-                      <Row
-                        label="Trialing"
-                        value={num(r.paying_now.trialing)}
-                      />
-                      <Row
-                        label="Past due"
-                        value={num(r.paying_now.past_due)}
-                      />
-                      <Row
-                        label="Canceling"
-                        value={num(r.paying_now.canceling)}
-                      />
-                    </div>
-                  </>
-                ) : (
-                  <Unmeasurable
-                    note={
-                      r.paying_now_note ??
-                      'The customer snapshot could not be read.'
-                    }
-                  />
-                )}
-                <DefinitionDisclosure>
-                  <p>{r.paying_now.definition}</p>
-                </DefinitionDisclosure>
-              </Card>
-            )}
-          </Loaded>
-          <Loaded report={revenue} label="new paying customers">
-            {(r) => (
-              <Card title="New paying customers" label={windowLabel}>
-                {r.new_paying.available ? (
-                  <>
-                    <MetricValue metric={r.new_paying.in_period}>
-                      <p className="mt-1 text-sm text-base-content/60">
-                        <DeltaBadge
-                          comparison={r.new_paying.in_period.comparison}
-                        />
-                      </p>
-                    </MetricValue>
-                    <div className="mt-3 border-t border-base-300/60 pt-2">
-                      <Row
-                        label="Lifetime"
-                        value={num(r.new_paying.lifetime)}
-                      />
-                    </div>
-                  </>
-                ) : (
-                  <Unmeasurable note={r.new_paying.note} />
-                )}
-                <DefinitionDisclosure>
-                  <p>{r.new_paying.definition}</p>
-                </DefinitionDisclosure>
-              </Card>
-            )}
-          </Loaded>
-          <Loaded report={revenue} label="earnings">
-            {(r) => <EarningsCard revenue={r} windowLabel={windowLabel} />}
-          </Loaded>
-        </div>
-      </Section>
-
-      <Section
-        id="support"
-        title="Support workload"
-        action={
-          <span className="flex flex-wrap gap-4">
-            <Link to="/admin/support" className={LINK}>
-              Open support →
-            </Link>
-            <Link
-              to="/admin/analytics"
-              search={{ period, view: 'support' }}
-              className={LINK}
-            >
-              Support analytics →
-            </Link>
-          </span>
-        }
-      >
-        <Loaded report={support} label="support summary">
-          {(s) => (
-            <Card title="Queue" label="Current" note={s.paying_note}>
-              <div className="grid gap-4 sm:grid-cols-4">
-                <Stat
-                  label="Needs attention"
-                  value={num(s.needs_attention.total)}
-                  sub={payingOverlay(s.needs_attention.paying)}
-                />
-                <Stat
-                  label="Waiting on customer"
-                  value={num(s.waiting_on_customer.total)}
-                  sub={payingOverlay(s.waiting_on_customer.paying)}
-                />
-                <Stat
-                  label="Completed"
-                  value={num(s.completed.total)}
-                  sub={
-                    <>
-                      {payingOverlay(s.completed.paying)}
-                      {num(s.completed_closed)} closed ·{' '}
-                      {num(s.completed_dismissed)} dismissed
-                    </>
-                  }
-                />
-                <Stat
-                  label="Total"
-                  value={num(s.total.total)}
-                  sub={payingOverlay(s.total.paying)}
-                />
-              </div>
-              <div className="mt-4 border-t border-base-300/60 pt-2">
-                <Row
-                  label="Oldest waiting for us"
-                  value={
-                    <MetricValue
-                      metric={s.oldest_needs_attention_hours}
-                      format={waitingFor}
-                      size="inline"
-                    />
-                  }
-                />
-                {s.oldest_ticket && (
-                  <p className="text-xs text-base-content/65">
-                    Ticket #{s.oldest_ticket}
-                  </p>
-                )}
-                <Row
-                  label="Auto-send"
-                  value={
-                    s.autosend.armed
-                      ? `armed · ${s.autosend.hold_minutes} min hold`
-                      : s.autosend.paused
-                        ? 'paused'
-                        : 'off'
-                  }
-                />
-                <p className="text-xs text-base-content/65">
-                  {s.autosend.note}
-                </p>
-              </div>
-            </Card>
-          )}
-        </Loaded>
-      </Section>
-
-      <Section
-        id="service"
-        title="Service & releases"
-        lede="Operational readings. Downloads are not installs; connections are not people."
-      >
-        <Loaded report={service} label="service readings">
-          {(o) => <ServiceStrip overview={o} />}
-        </Loaded>
-      </Section>
-
-      <HowToRead />
+      <p className="mt-6 text-sm text-base-content/45">
+        Now and the last 24 hours. Staff and test accounts are left out.
+        Anything over a longer period lives in Analytics.
+      </p>
     </div>
   )
 }
 
-function payingOverlay(paying: number) {
-  return paying > 0 ? (
-    <span className="mr-1 font-semibold text-base-content">
-      {num(paying)} paying ·{' '}
-    </span>
-  ) : null
+// ── One row ───────────────────────────────────────────────────────
+
+interface Fact {
+  label: string
+  value: string
 }
 
-function LiveStrip({ presence }: { presence: Report<PresenceLive> }) {
-  const p = presence.data
-  return (
-    <section
-      aria-labelledby="live-heading"
-      className="rounded-xl bg-base-200/40 p-4 ring-1 ring-base-300/70 sm:p-5"
-    >
-      <div className="flex flex-wrap items-baseline justify-between gap-2">
-        <h2 id="live-heading" className="text-base font-semibold">
-          Desktop right now
-          <span className="ml-2 rounded bg-base-300/50 px-1.5 py-0.5 text-[10px] font-medium text-base-content/60">
-            Current
-          </span>
-        </h2>
-        {p && (
-          <p className="text-xs text-base-content/50">
-            as of {new Date(p.generated_at).toLocaleTimeString()} · refreshed
-            every {PRESENCE_POLL_MS / 1000} s
-          </p>
-        )}
-      </div>
-      {!p && presence.error && (
-        <div role="alert" className="mt-3 text-sm text-error">
-          {presence.error}{' '}
-          {presence.retry && (
-            <button
-              type="button"
-              onClick={presence.retry}
-              className="cursor-pointer font-semibold underline underline-offset-4"
-            >
-              Retry
-            </button>
-          )}
-        </div>
-      )}
-      {!p && !presence.error && (
-        <p role="status" className="mt-3 text-sm text-base-content/60">
-          Reading live presence…
-        </p>
-      )}
-      {p && (
-        <>
-          {p.available ? (
-            <p className="mt-3 text-2xl font-bold tabular-nums sm:text-3xl">
-              {p.headline}
-            </p>
-          ) : (
-            <div className="mt-3">
-              <Unmeasurable note={p.note} />
-            </div>
-          )}
-          {presence.error && (
-            <p role="alert" className="mt-2 text-xs text-error">
-              Last refresh failed: {presence.error}. Showing the previous
-              reading.
-            </p>
-          )}
-          {p.available && (
-            <div className="mt-3 flex flex-wrap gap-2">
-              <Breakdown
-                title="Sessions"
-                values={{ total: p.sessions }}
-                order={['total']}
-              />
-              <Breakdown
-                title="Session"
-                values={p.session_state}
-                order={SESSION_ORDER}
-              />
-              <Breakdown
-                title="Input"
-                values={p.input_state}
-                order={INPUT_ORDER}
-              />
-              <Breakdown
-                title="Display"
-                values={p.display_state}
-                order={DISPLAY_ORDER}
-              />
-              <Breakdown
-                title="Ticker"
-                values={p.ticker_state}
-                order={TICKER_ORDER}
-              />
-              <Breakdown
-                title="Screens per user"
-                values={p.screens_per_user}
-                order={SCREENS_ORDER}
-              />
-              {p.os && Object.keys(p.os).length > 0 && (
-                <Breakdown title="OS" values={p.os} />
-              )}
-              {p.app_version && Object.keys(p.app_version).length > 0 && (
-                <Breakdown title="Version" values={p.app_version} />
-              )}
-            </div>
-          )}
-          <div className="mt-3 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm text-base-content/70">
-            <span>Recently seen (legacy, 15 min):</span>
-            <MetricValue metric={p.legacy_recent_presence} size="inline" />
-            {p.legacy_recent_presence.available &&
-              p.legacy_recent_presence.note && (
-                <span className="text-xs text-base-content/55">
-                  {p.legacy_recent_presence.note}
-                </span>
-              )}
-            {p.staff_excluded && <StaffExcludedBadge />}
-          </div>
-          <DefinitionDisclosure summary="What active, ticker and screens mean">
-            <p>{p.definition}</p>
-            <p>{p.ticker_definition}</p>
-            <p>{p.coverage}</p>
-            <p>
-              Sessions check in every {p.check_in_seconds} s and expire after{' '}
-              {p.expiry_seconds} s without one.
-            </p>
-          </DefinitionDisclosure>
-        </>
-      )}
-    </section>
-  )
+interface RowSpec {
+  key: RowKey
+  /** The big number, already formatted. Null when there is none to show. */
+  number: string | null
+  /** The Feeds row draws a state icon where the others draw a number. */
+  icon?: VerdictTone
+  main: string
+  secondary?: string
+  verdict: Verdict
+  facts: Array<Fact>
+  note: string
+  action: ReactNode
+  /** Set when the row's own source could not be read at all. */
+  problem?: { message: string; retry?: () => void }
+  loading?: boolean
 }
 
-function EarningsCard({
-  revenue,
-  windowLabel,
+function OverviewRow({
+  row,
+  open,
+  onToggle,
 }: {
-  revenue: Revenue
-  windowLabel: string
+  row: RowSpec
+  open: boolean
+  onToggle: () => void
 }) {
-  const e = revenue.earnings
-  const money = (minor: number) => formatMinor(minor, e.primary_currency)
-  const currencies = e.currencies ?? []
-  const lifetime = e.lifetime ?? []
+  const tone = TONE[row.verdict.tone]
+  const panelId = `overview-${row.key}`
   return (
-    <Card
-      title="Net earnings"
-      label={windowLabel}
-      note={
-        e.available
-          ? [
-              e.partial ? 'Stripe returned a partial ledger.' : null,
-              e.cached && e.fetched_at
-                ? `Cached from Stripe at ${new Date(e.fetched_at).toLocaleString()}.`
-                : null,
-              revenue.account_note,
-            ]
-              .filter(Boolean)
-              .join(' ')
-          : revenue.account_note
-      }
-    >
-      {e.available ? (
-        <>
-          <MetricValue metric={e.net} format={money}>
-            <p className="mt-1 text-sm text-base-content/60">
-              net of fees, {e.primary_currency.toUpperCase()}{' '}
-              <DeltaBadge comparison={e.net.comparison} format={money} />
-            </p>
-          </MetricValue>
-          {currencies.length > 1 && (
-            <div className="mt-3 border-t border-base-300/60 pt-2">
-              <p className="text-xs text-base-content/60">
-                Per currency — never added together
-              </p>
-              {currencies.map((c) => (
-                <Row
-                  key={c.currency}
-                  label={c.currency.toUpperCase()}
-                  value={formatMinor(c.net, c.currency)}
-                />
-              ))}
-            </div>
-          )}
-          <div className="mt-3 border-t border-base-300/60 pt-2">
-            {lifetime.length === 0 ? (
-              <Row label="Lifetime net" value="—" />
+    <li className="border-b border-base-300/70">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className="grid w-full cursor-pointer grid-cols-[120px_1fr_132px_24px] items-center gap-7 py-2 text-left focus-visible:outline-2 focus-visible:outline-primary"
+        style={{ minHeight: '104px' }}
+      >
+        <span
+          className={`flex justify-end text-[56px] leading-none font-extrabold tracking-[-0.04em] tabular-nums ${tone.number}`}
+        >
+          {row.icon ? (
+            row.icon === 'good' ? (
+              <Check size={44} className="text-primary" aria-hidden />
             ) : (
-              lifetime.map((c) => (
-                <Row
-                  key={c.currency}
-                  label={`Lifetime net (${c.currency.toUpperCase()})`}
-                  value={formatMinor(c.net, c.currency)}
-                />
-              ))
-            )}
-          </div>
-          <CoverageNote coverage={e.coverage} />
-        </>
-      ) : (
-        <Unmeasurable note={e.note} />
-      )}
-      <DefinitionDisclosure>
-        <p>{e.definition}</p>
-      </DefinitionDisclosure>
-    </Card>
-  )
-}
-
-function ServiceStrip({ overview }: { overview: AdminOverview }) {
-  const ingest = overview.ingest ?? []
-  const releases = (overview.downloads.releases ?? []).slice(0, 3)
-  const installs = measuredValue(overview.installs)
-  return (
-    <div className="grid items-start gap-4 sm:grid-cols-2 xl:grid-cols-3">
-      <Card
-        title="Ingest freshness"
-        note="Time since each content table was last written. Sports can legitimately sit still overnight."
-      >
-        {ingest.length === 0 && (
-          <p className="text-sm text-base-content/70">
-            No ingest readings in this snapshot.
-          </p>
-        )}
-        {ingest.map((row) => {
-          const health = ingestHealth(row)
-          return (
-            <Row
-              key={row.table}
-              label={
-                <span className="inline-flex items-center gap-1">
-                  {health !== 'fresh' && (
-                    <AlertTriangle size={12} aria-hidden />
-                  )}
-                  {row.table}
-                </span>
-              }
-              value={
-                <span
-                  className={
-                    health === 'empty'
-                      ? 'text-error'
-                      : health === 'stale'
-                        ? 'text-warning'
-                        : 'text-success'
-                  }
-                >
-                  {health === 'empty' ? 'empty' : formatAge(row.age_seconds)}
-                </span>
-              }
+              <AlertTriangle
+                size={44}
+                className={row.icon === 'bad' ? 'text-error' : 'text-warning'}
+                aria-hidden
+              />
+            )
+          ) : (
+            row.number
+          )}
+        </span>
+        <span className="text-[22px] leading-snug font-semibold">
+          {row.main}
+          {row.secondary && (
+            <span className="font-medium text-base-content/50">
+              {' '}
+              {row.secondary}
+            </span>
+          )}
+        </span>
+        <span className="flex items-center justify-end gap-2">
+          <span
+            className={`size-2.5 shrink-0 rounded-full ${tone.dot}`}
+            aria-hidden
+          />
+          <span className={`text-[14px] font-bold ${tone.label}`}>
+            {row.verdict.label}
+          </span>
+        </span>
+        <ChevronDown
+          size={20}
+          aria-hidden
+          className={
+            open
+              ? 'rotate-180 text-base-content transition-transform'
+              : 'text-base-content/35 transition-transform'
+          }
+        />
+      </button>
+      {open && (
+        <div id={panelId} style={{ padding: '4px 0 32px 148px' }}>
+          {row.problem ? (
+            <ErrorPanel
+              message={row.problem.message}
+              onRetry={row.problem.retry}
             />
-          )
-        })}
-      </Card>
-      <Card
-        title="Connected now"
-        label="Current"
-        note={connectedCaveat(overview.connected_now)}
-      >
-        <p className="text-2xl font-bold tabular-nums">
-          {num(overview.connected_now.count)}
-        </p>
-        <p className="mt-1 text-sm text-base-content/60">
-          open SSE connections
-        </p>
-      </Card>
-      <Card
-        title="Downloads"
-        note={
-          overview.downloads.stale
-            ? `${DOWNLOADS_CAVEAT} These figures are cached — GitHub was unreachable on the last refresh.`
-            : DOWNLOADS_CAVEAT
-        }
-      >
-        {overview.downloads.error ? (
-          <Unmeasurable note={overview.downloads.error} />
-        ) : (
-          <>
-            <p className="text-2xl font-bold tabular-nums">
-              {num(overview.downloads.total)}
-            </p>
-            <p className="mt-1 mb-2 text-sm text-base-content/60">
-              across all releases
-            </p>
-            {releases.map((r) => (
-              <Row key={r.tag} label={r.tag} value={num(r.downloads)} />
-            ))}
-          </>
-        )}
-        <DefinitionDisclosure summary="Why downloads are not active installs">
-          <p>{installs.note ?? 'Active installs are not measurable.'}</p>
-        </DefinitionDisclosure>
-      </Card>
-    </div>
+          ) : (
+            <>
+              <dl className="grid grid-cols-3 gap-x-10">
+                {row.facts.map((fact) => (
+                  <div
+                    key={fact.label}
+                    className="flex items-baseline justify-between gap-4 border-b border-base-200 py-[9px] leading-[1.3]"
+                  >
+                    <dt className="text-base-content/60">{fact.label}</dt>
+                    <dd className="pl-4 text-right font-mono font-medium">
+                      {fact.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+              <p className="mt-6 max-w-[640px] text-sm text-base-content/55">
+                {row.note}
+              </p>
+              <div className="mt-5">{row.action}</div>
+            </>
+          )}
+        </div>
+      )}
+    </li>
   )
 }
 
-function HowToRead() {
-  return (
-    <details className="rounded-xl border border-base-300/60 p-4 text-sm text-base-content/75">
-      <summary className="cursor-pointer font-semibold focus-visible:outline-2 focus-visible:outline-primary">
-        How to read these numbers
-      </summary>
-      <div className="mt-3 space-y-2 leading-relaxed">
-        <p>
-          <strong>Time.</strong> One selector — 24h, 7d, 30d, Lifetime — shared
-          by every period card. A period is a rolling window ending at the
-          moment the report was generated; 24h is the last 24 hours, not today
-          since midnight. Finite periods are compared with the equal window
-          immediately before them. A comparison is shown only when the previous
-          window is fully inside the source's coverage and its value is not
-          zero; otherwise the card says why. Cards marked “Current” do not
-          depend on the selector.
-        </p>
-        <p>
-          <strong>Missing data</strong> is shown as a note, never as zero.
-          Partial history says so and names when measurement began.
-        </p>
-        <p>
-          <strong>Staff exclusion.</strong> With the Settings toggle on
-          (default), admin and test accounts are removed from account totals,
-          growth, desktop presence and usage, widget analytics, and identified
-          website analytics. It never changes payments, earnings, or operational
-          support totals. Measurements suppressed before the toggle existed
-          cannot be restored.
-        </p>
-        <p>
-          <strong>Desktop right now</strong> is presence, not attention: the app
-          is running and reported within 90 seconds. “With ticker(s)” means at
-          least one ticker window is shown on an unlocked, awake computer.
-          Screens add across computers; users do not. Only builds with the
-          presence reporter (1.6.7+) appear; older builds still count in the
-          legacy 15-minute figure.
-        </p>
-        <p>
-          <strong>Registered accounts</strong> come from Logto, the system of
-          record. “Set up the app” is a local count of who ever saved a
-          preference. New accounts are Logto sign-ups in the window. App users
-          are distinct accounts with app-running time in the window, never a sum
-          of daily counts.
-        </p>
-        <p>
-          <strong>Website</strong> visitors are distinct PostHog persons with a
-          pageview in the window; a person is a browser profile, not guaranteed
-          to be one human. Collection began 11 September 2026.
-        </p>
-        <p>
-          <strong>Paying</strong> is a Stripe customer with lifetime access or
-          an active non-free plan. Trialing, past due and canceling are their
-          own rows and are not paying. Net earnings are Stripe balance
-          transactions in the window: payments, refunds, refund reversals,
-          disputes and fees, net of fees exactly once, grouped by currency and
-          never converted. Payouts and transfers are movements, not earnings. A
-          new paying customer is a first successful positive charge.
-        </p>
-        <p>
-          <strong>Support</strong> buckets are the whole queue as the pipeline
-          classifies it. Paying overlays count only tickets with a verified
-          account; email-only contacts are unknown, never inferred. Response and
-          completion times use retained timestamps only.
-        </p>
-        <p>{DOWNLOADS_CAVEAT}</p>
-      </div>
-    </details>
-  )
+const ACTION =
+  'inline-flex min-h-10 items-center rounded-[10px] px-4 text-sm font-semibold ring-1 ring-base-300 hover:bg-base-200 focus-visible:outline-2 focus-visible:outline-primary'
+
+const ACTION_FILLED =
+  'inline-flex min-h-10 items-center rounded-[10px] bg-error px-4 text-sm font-semibold text-white hover:bg-error/90 focus-visible:outline-2 focus-visible:outline-primary'
+
+// ── Building the rows ─────────────────────────────────────────────
+
+/** A fact whose value could not be read shows a dash, never a zero. */
+function fact(label: string, value: string | null | undefined): Fact {
+  return { label, value: value ?? '—' }
+}
+
+/** The busiest version key, which is the newest build that can report. */
+function latestVersion(versions: Record<string, number> | null): string | null {
+  const keys = Object.keys(versions ?? {})
+  if (keys.length === 0) return null
+  return keys.sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true }),
+  )[keys.length - 1]
+}
+
+function count(values: Record<string, number> | null, ...keys: Array<string>) {
+  if (!values) return null
+  return keys.reduce((total, key) => total + (values[key] ?? 0), 0)
+}
+
+/** A duration without the "ago": "3 hours", for "has not updated for …". */
+function duration(seconds: number): string {
+  return formatAgeWords(seconds).replace(' ago', '')
+}
+
+function problemOf<T>(report: Report<T>) {
+  if (report.data) return undefined
+  return {
+    message: report.error ?? 'Still reading…',
+    retry: report.error ? report.retry : undefined,
+  }
+}
+
+function buildRows({
+  presence,
+  desktop,
+  website,
+  revenue,
+  support,
+  service,
+}: Omit<OverviewContentProps, 'initialOpen' | 'onRefresh'>) {
+  const p = presence.data
+  const svc = service.data
+  const rev = revenue.data
+  const sup = support.data
+
+  const newToday = svc?.accounts.new_today
+  const previousDay = newToday ? newToday.value - newToday.delta : 0
+  const netToday = rev?.earnings.available ? rev.earnings.net.value : 0
+  const everNet = rev?.earnings.lifetime?.[0]
+
+  const v = verdicts({
+    presence: p ? { available: p.available, active_users: p.active_users } : null,
+    support: sup ? { open_cases: sup.needs_attention.total } : null,
+    money: rev
+      ? {
+          available: rev.paying_now.available,
+          past_due: rev.paying_now.past_due,
+          new_paying_today: rev.new_paying.available
+            ? rev.new_paying.in_period.value
+            : 0,
+          net_today: netToday,
+        }
+      : null,
+    growth: newToday
+      ? {
+          available: newToday.available,
+          value: newToday.value,
+          previous: previousDay,
+          // A previous day of zero is not something to be above (SCROLLR-210).
+          comparable: newToday.available && previousDay > 0,
+        }
+      : null,
+    feeds: svc?.ingest ?? null,
+  })
+
+  return {
+    headline: v.headline,
+    rows: [
+      rightNowRow(presence, svc, v.right_now),
+      supportRow(support, v.support),
+      moneyRow(revenue, v.money, netToday, everNet),
+      growthRow(service, desktop, website, v.growth, previousDay),
+      feedsRow(service, p, v.feeds),
+    ],
+  }
+}
+
+function rightNowRow(
+  presence: Report<PresenceLive>,
+  svc: AdminOverview | null,
+  verdict: Verdict,
+): RowSpec {
+  const p = presence.data
+  const connected = svc?.connected_now.count ?? 0
+  const version = latestVersion(p?.app_version ?? null)
+  const legacy = p?.legacy_recent_presence
+  const extra = p ? Math.max(0, connected - p.active_users) : 0
+
+  const reporting = p?.available === true
+  const ticker =
+    reporting && p.ticker_users > 0
+      ? p.ticker_users === p.active_users
+        ? 'with the ticker on screen.'
+        : `${num(p.ticker_users)} with the ticker on screen.`
+      : undefined
+  return {
+    key: 'right_now',
+    number: reporting ? num(p.active_users) : null,
+    main: reporting
+      ? `${p.active_users === 1 ? 'person has' : 'people have'} Scrollr open right now${ticker ? ',' : '.'}`
+      : 'Nobody is reporting yet.',
+    secondary: reporting ? ticker : (p?.note ?? undefined),
+    verdict,
+    facts: [
+      fact('People with the app open', p ? num(p.active_users) : null),
+      fact('Ticker visible on their screen', p ? num(p.ticker_users) : null),
+      fact('Monitors showing a ticker', p ? num(p.screens) : null),
+      fact(
+        'Actively using their computer',
+        numberOrNull(count(p?.input_state ?? null, 'recent')),
+      ),
+      fact(
+        'Computer locked or screen asleep',
+        numberOrNull(
+          add(
+            count(p?.session_state ?? null, 'locked'),
+            count(p?.display_state ?? null, 'asleep'),
+          ),
+        ),
+      ),
+      fact(
+        'Ticker hidden or turned off',
+        numberOrNull(count(p?.ticker_state ?? null, 'hidden', 'disabled')),
+      ),
+      fact('On Windows', numberOrNull(count(p?.os ?? null, 'windows'))),
+      fact(
+        'On Mac or Linux',
+        numberOrNull(count(p?.os ?? null, 'macos', 'linux')),
+      ),
+      fact(
+        version
+          ? `Running the latest version (${version})`
+          : 'Running the latest version',
+        version ? num(p?.app_version?.[version] ?? 0) : null,
+      ),
+    ],
+    note: [
+      version
+        ? `Only version ${version} and later can report this.`
+        : 'Only recent versions can report this.',
+      extra > 0
+        ? `${plural(connected, 'app')} are connected to our servers in total; the other ${num(extra)} are older versions, staff, or admin tabs, which is why that number is bigger than the number of people.`
+        : `${plural(connected, 'app')} are connected to our servers in total.`,
+      legacy?.available
+        ? `${plural(legacy.value, 'older-version account')} was seen in the last 15 minutes.`.replace(
+            'accounts was',
+            'accounts were',
+          )
+        : null,
+    ]
+      .filter(Boolean)
+      .join(' '),
+    action: (
+      <Link to="/admin/analytics" className={ACTION}>
+        See who is here over time
+      </Link>
+    ),
+    problem: problemOf(presence),
+    loading: presence.loading,
+  }
+}
+
+function supportRow(
+  support: Report<SupportSummary>,
+  verdict: Verdict,
+): RowSpec {
+  const s = support.data
+  const waiting = s?.needs_attention.total ?? 0
+  const oldest = s?.oldest_needs_attention_hours
+  const hold = s?.autosend.hold_minutes ?? 0
+  const since =
+    s && waiting > 0 && oldest?.available ? oldestClause(oldest.value) : undefined
+
+  return {
+    key: 'support',
+    number: s ? num(waiting) : null,
+    main: s
+      ? `${waiting === 1 ? 'person is' : 'people are'} waiting for a reply from us${since ? ',' : '.'}`
+      : 'Support is not reporting yet.',
+    secondary: since,
+    verdict,
+    facts: [
+      fact('Waiting for us to reply', s ? num(s.needs_attention.total) : null),
+      fact(
+        'Waiting for the customer to reply',
+        s ? num(s.waiting_on_customer.total) : null,
+      ),
+      fact('Finished', s ? num(s.completed.total) : null),
+      fact('Finished and answered', s ? num(s.completed_closed) : null),
+      fact(
+        'Finished without a reply (spam, duplicates)',
+        s ? num(s.completed_dismissed) : null,
+      ),
+      fact('All tickets ever', s ? num(s.total.total) : null),
+      fact(
+        'Longest wait',
+        oldest?.available ? plural(Math.floor(oldest.value / 24), 'day') : null,
+      ),
+      fact('Ticket waiting the longest', s?.oldest_ticket ? `#${s.oldest_ticket}` : null),
+      fact(
+        'Auto-replies',
+        s
+          ? s.autosend.armed
+            ? `on, sent after a ${hold} min hold`
+            : 'off'
+          : null,
+      ),
+    ],
+    note: `A drafted reply goes out by itself after ${hold} minutes unless you stop it, so doing nothing still sends it. Tickets cannot be matched to paying customers yet, because only ${num(s?.cases_with_account ?? 0)} of the ${num(s?.cases ?? 0)} were sent from inside the app while signed in.`,
+    action: (
+      <Link to="/admin/support" className={ACTION_FILLED}>
+        Open the queue
+      </Link>
+    ),
+    problem: problemOf(support),
+    loading: support.loading,
+  }
+}
+
+function moneyRow(
+  revenue: Report<Revenue>,
+  verdict: Verdict,
+  netToday: number,
+  everNet: { currency: string; net: number } | undefined,
+): RowSpec {
+  const r = revenue.data
+  const snapshot = r?.paying_now
+  const earnings = r?.earnings
+  const money = (minor: number, currency?: string) =>
+    formatMinor(minor, currency ?? earnings?.primary_currency ?? 'usd')
+  const ever = everNet ? money(everNet.net, everNet.currency) : null
+  const fetched = earnings?.fetched_at ?? r?.generated_at
+
+  return {
+    key: 'money',
+    number: snapshot?.available ? num(snapshot.paying) : null,
+    main: snapshot?.available
+      ? snapshot.paying === 1
+        ? 'customer pays.'
+        : 'customers pay.'
+      : 'The customer snapshot could not be read.',
+    secondary: snapshot?.available
+      ? [
+          netToday > 0 ? `${money(netToday)} came in today.` : 'Nothing came in today.',
+          ever ? `${ever} earned ever.` : null,
+        ]
+          .filter(Boolean)
+          .join(' ')
+      : r?.paying_now_note,
+    verdict,
+    facts: [
+      fact('Paying customers', snapshot?.available ? num(snapshot.paying) : null),
+      fact(
+        'Of those on the one-time lifetime plan',
+        snapshot?.available ? num(snapshot.lifetime) : null,
+      ),
+      fact(
+        'Accounts on the free plan',
+        snapshot?.available ? num(snapshot.free) : null,
+      ),
+      fact('On a free trial', snapshot?.available ? num(snapshot.trialing) : null),
+      fact('Payment failed', snapshot?.available ? num(snapshot.past_due) : null),
+      fact('Cancelling', snapshot?.available ? num(snapshot.canceling) : null),
+      fact(
+        'Became a customer today',
+        r?.new_paying.available ? num(r.new_paying.in_period.value) : null,
+      ),
+      fact(
+        'Earned today after Stripe fees',
+        earnings?.available ? money(earnings.net.value) : null,
+      ),
+      fact('Earned ever after Stripe fees', ever),
+    ],
+    note: `Figures come from Stripe and were last fetched at ${fetched ? new Date(fetched).toLocaleString() : 'an unknown time'}. “Ever” means since the Stripe account was opened.`,
+    action: (
+      <Link to="/admin/analytics" search={{ view: 'revenue' }} className={ACTION}>
+        See revenue over time
+      </Link>
+    ),
+    problem: problemOf(revenue),
+    loading: revenue.loading,
+  }
+}
+
+function growthRow(
+  service: Report<AdminOverview>,
+  desktop: Report<DesktopUsage>,
+  website: Report<Website>,
+  verdict: Verdict,
+  previousDay: number,
+): RowSpec {
+  const svc = service.data
+  const accounts = svc?.accounts
+  const newToday = accounts?.new_today
+  const dau = svc?.active.dau
+  const hours = desktop.data?.user_hours
+  const visitors = website.data?.visitors
+  const neverSetUp = accounts ? Math.max(0, accounts.total - accounts.set_up) : 0
+
+  return {
+    key: 'growth',
+    number: newToday?.available ? num(newToday.value) : null,
+    main: newToday?.available
+      ? `${newToday.value === 1 ? 'person' : 'people'} signed up in the last 24 hours,`
+      : 'Sign-ups are not reporting yet.',
+    // DAU is everyone who opened the app today, not a subset of today's
+    // sign-ups, so the clause says so rather than calling them "of them".
+    secondary: newToday?.available
+      ? dau?.available
+        ? `${plural(dau.value, 'person', 'people')} opened the app.`
+        : undefined
+      : newToday?.note,
+    verdict,
+    facts: [
+      fact(
+        'Signed up in the last 24 hours',
+        newToday?.available ? num(newToday.value) : null,
+      ),
+      fact(
+        'Signed up in the 24 hours before that',
+        newToday?.available ? num(previousDay) : null,
+      ),
+      fact('Accounts in total', accounts ? num(accounts.total) : null),
+      fact('Finished setting up the app', accounts ? num(accounts.set_up) : null),
+      fact(
+        'Signed up but never set up the app',
+        accounts ? num(neverSetUp) : null,
+      ),
+      fact(
+        'Opened the app in the last 24 hours',
+        dau?.available ? num(dau.value) : null,
+      ),
+      fact(
+        'Hours the app was open, all users added up',
+        hours?.available ? formatHours(hours.value) : null,
+      ),
+      fact(
+        'Website visitors in the last 24 hours',
+        visitors?.available ? num(visitors.value) : null,
+      ),
+      fact(
+        'Downloads ever (not installs)',
+        svc && !svc.downloads.error ? num(svc.downloads.total) : null,
+      ),
+    ],
+    note: `The ${num(neverSetUp)} who never finished setting up are the biggest thing to fix. Most signed up from inside the desktop app, opened it once, and never came back.`,
+    action: (
+      <Link to="/admin/analytics" className={ACTION}>
+        See signups over time
+      </Link>
+    ),
+    problem: problemOf(service),
+    loading: service.loading,
+  }
+}
+
+function feedsRow(
+  service: Report<AdminOverview>,
+  presence: PresenceLive | null,
+  verdict: Verdict,
+): RowSpec {
+  const svc = service.data
+  const ingest = svc?.ingest ?? []
+  const reading = (table: string) => ingest.find((row) => row.table === table)
+  const broken = FEEDS.find((f) => reading(f.table)?.has_data === false)
+  const stale = FEEDS.find((f) => {
+    const row = reading(f.table)
+    return row ? isStale(row) : false
+  })
+  const version = latestVersion(presence?.app_version ?? null)
+
+  return {
+    key: 'feeds',
+    number: null,
+    icon: verdict.tone,
+    main: broken
+      ? `${broken.name} are not reporting any data.`
+      : stale
+        ? `${stale.name} have not updated for ${duration(reading(stale.table)?.age_seconds ?? 0)}.`
+        : 'Scores, prices, markets and news are up to date,',
+    secondary: broken || stale ? undefined : 'all within the last few minutes.',
+    verdict,
+    facts: [
+      ...FEEDS.map((feed) => {
+        const row = reading(feed.table)
+        return fact(
+          `${feed.name} last updated`,
+          row ? (row.has_data ? formatAgeWords(row.age_seconds) : 'no data yet') : null,
+        )
+      }),
+      fact(
+        'Our servers running',
+        svc ? `${svc.connected_now.replicas} of ${EXPECTED_REPLICAS}` : null,
+      ),
+      fact('Latest app version', version),
+    ],
+    note: 'How long since each feed last received new data. Sports scores can sit for hours overnight when no games are being played, and that is normal.',
+    action: (
+      <Link to="/admin/versions" className={ACTION}>
+        Technical details
+      </Link>
+    ),
+    problem: problemOf(service),
+    loading: service.loading,
+  }
+}
+
+function oldestClause(hours: number): string {
+  if (hours < 48) return `the longest for ${plural(hours, 'hour')}.`
+  const since = new Date(Date.now() - hours * 3600_000)
+  return `one of them since ${since.toLocaleString(undefined, { month: 'long' })}.`
+}
+
+function add(a: number | null, b: number | null): number | null {
+  if (a === null && b === null) return null
+  return (a ?? 0) + (b ?? 0)
+}
+
+function numberOrNull(value: number | null): string | null {
+  return value === null ? null : num(value)
 }

--- a/myscrollr.com/src/components/admin/dashboardFixtures.ts
+++ b/myscrollr.com/src/components/admin/dashboardFixtures.ts
@@ -471,6 +471,8 @@ export const support: SupportSummary = {
   }),
   completion_median_hours: unavailable('No ticket completed in this window.'),
   paying_created: 1,
+  cases_with_account: 1,
+  cases: 59,
   coverage: { from: '2026-05-01T00:00:00Z', partial: false },
   history_note:
     'Created per day uses opened_at; completed per day uses closed_at.',
@@ -499,10 +501,13 @@ export const overview: AdminOverview = {
     auto_sent_30d: 4,
     intervened_30d: 1,
     oldest_open_hours: 2,
+    oldest_open_ticket: '104',
   },
   ingest: [
     { table: 'games', age_seconds: 90, has_data: true },
-    { table: 'news', age_seconds: 0, has_data: false },
+    { table: 'trades', age_seconds: 45, has_data: true },
+    { table: 'markets', age_seconds: 120, has_data: true },
+    { table: 'rss_items', age_seconds: 200, has_data: true },
   ],
   downloads: {
     total: 1234,

--- a/myscrollr.com/src/components/admin/ui.tsx
+++ b/myscrollr.com/src/components/admin/ui.tsx
@@ -674,28 +674,5 @@ export function Stamp({ at, children }: { at: string; children?: ReactNode }) {
   )
 }
 
-/** "locked 2 · unlocked 5 · unknown 0", for the presence strip. */
-export function Breakdown({
-  title,
-  values,
-  order,
-}: {
-  title: string
-  values: Record<string, number> | null | undefined
-  order?: ReadonlyArray<string>
-}) {
-  const keys = order ?? Object.keys(values ?? {}).sort()
-  return (
-    <div className="rounded-lg bg-base-200/60 px-2.5 py-1.5 text-xs">
-      <span className="font-semibold text-base-content/70">{title}</span>{' '}
-      <span className="tabular-nums text-base-content/80">
-        {keys
-          .map((key) => `${key} ${(values?.[key] ?? 0).toLocaleString()}`)
-          .join(' · ')}
-      </span>
-    </div>
-  )
-}
-
 export const num = (value: number) => value.toLocaleString()
 export const pct = (value: number) => `${Math.round(value * 100)}%`

--- a/myscrollr.com/src/lib/adminFormat.ts
+++ b/myscrollr.com/src/lib/adminFormat.ts
@@ -68,6 +68,24 @@ export function formatAge(seconds: number): string {
 }
 
 /**
+ * The same age spelled out, for the Overview — which is read by people who do
+ * not already know that "90m" is a duration (SCROLLR-215). Rounds down, so a
+ * feed is never reported as fresher than it is.
+ */
+export function formatAgeWords(seconds: number): string {
+  if (seconds < 0) return 'in the future'
+  if (seconds < 60) return plural(seconds, 'second') + ' ago'
+  if (seconds < 3600) return plural(Math.floor(seconds / 60), 'minute') + ' ago'
+  if (seconds < 86400) return plural(Math.floor(seconds / 3600), 'hour') + ' ago'
+  return plural(Math.floor(seconds / 86400), 'day') + ' ago'
+}
+
+/** "1 person", "2 people" — the Overview writes sentences, not labels. */
+export function plural(count: number, one: string, many = `${one}s`): string {
+  return `${count.toLocaleString()} ${count === 1 ? one : many}`
+}
+
+/**
  * Ingest health. The thresholds are deliberately loose: this answers "has
  * this feed stopped", not "is it a few seconds behind". Sports rows can
  * legitimately sit still overnight, so a stale table is a warning, never an

--- a/myscrollr.com/src/lib/overviewVerdicts.test.ts
+++ b/myscrollr.com/src/lib/overviewVerdicts.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+import { isStale, verdicts } from './overviewVerdicts'
+import type { VerdictInput } from './overviewVerdicts'
+
+const healthy: VerdictInput = {
+  presence: { available: true, active_users: 3 },
+  support: { open_cases: 0 },
+  money: {
+    available: true,
+    past_due: 0,
+    new_paying_today: 0,
+    net_today: 0,
+  },
+  growth: { available: true, value: 4, previous: 2, comparable: true },
+  feeds: [
+    { table: 'games', age_seconds: 120, has_data: true },
+    { table: 'trades', age_seconds: 60, has_data: true },
+    { table: 'markets', age_seconds: 90, has_data: true },
+    { table: 'rss_items', age_seconds: 200, has_data: true },
+  ],
+}
+
+function only(overrides: Partial<VerdictInput>) {
+  return verdicts({ ...healthy, ...overrides })
+}
+
+describe('verdicts', () => {
+  it('reads a healthy page as live, clear, growing and all good', () => {
+    const v = verdicts(healthy)
+    expect(v.right_now).toEqual({ tone: 'good', label: 'Live' })
+    expect(v.support).toEqual({ tone: 'good', label: 'Clear' })
+    expect(v.money).toEqual({ tone: 'none', label: 'Nothing new' })
+    expect(v.growth).toEqual({ tone: 'good', label: 'Growing' })
+    expect(v.feeds).toEqual({ tone: 'good', label: 'All good' })
+    expect(v.headline).toEqual(['Running fine.', 'Nothing needs you.'])
+  })
+
+  it('calls nobody being here quiet, and presence that cannot report grey', () => {
+    expect(only({ presence: { available: true, active_users: 0 } }).right_now)
+      .toEqual({ tone: 'none', label: 'Quiet' })
+    expect(only({ presence: { available: false, active_users: 0 } }).right_now)
+      .toEqual({ tone: 'none', label: 'Not reporting yet' })
+    expect(only({ presence: null }).right_now.tone).toBe('none')
+  })
+
+  it('turns support red as soon as one person is waiting', () => {
+    const v = only({ support: { open_cases: 1 } })
+    expect(v.support).toEqual({ tone: 'bad', label: 'Needs you' })
+    expect(v.headline[1]).toBe('Support needs you.')
+  })
+
+  it('puts a failed payment ahead of new money, and names it in the headline', () => {
+    const v = only({
+      money: {
+        available: true,
+        past_due: 1,
+        new_paying_today: 1,
+        net_today: 900,
+      },
+    })
+    expect(v.money).toEqual({ tone: 'bad', label: 'Payment failed' })
+    expect(v.headline[1]).toBe('A payment failed.')
+  })
+
+  it('lets support outrank a failed payment in the second line', () => {
+    const v = only({
+      support: { open_cases: 2 },
+      money: {
+        available: true,
+        past_due: 1,
+        new_paying_today: 0,
+        net_today: 0,
+      },
+    })
+    expect(v.headline[1]).toBe('Support needs you.')
+  })
+
+  it('counts either a new customer or money in as new money', () => {
+    const base = { available: true, past_due: 0 }
+    expect(
+      only({ money: { ...base, new_paying_today: 1, net_today: 0 } }).money,
+    ).toEqual({ tone: 'good', label: 'New money' })
+    expect(
+      only({ money: { ...base, new_paying_today: 0, net_today: 500 } }).money,
+    ).toEqual({ tone: 'good', label: 'New money' })
+    expect(
+      only({ money: { ...base, new_paying_today: 0, net_today: -500 } }).money
+        .label,
+    ).toBe('Nothing new')
+    expect(only({ money: null }).money.label).toBe('Not reporting yet')
+  })
+
+  it('refuses to judge growth it cannot compare', () => {
+    expect(
+      only({
+        growth: { available: true, value: 4, previous: 0, comparable: false },
+      }).growth,
+    ).toEqual({ tone: 'none', label: 'Too early to compare' })
+    expect(
+      only({
+        growth: { available: false, value: 0, previous: 0, comparable: false },
+      }).growth,
+    ).toEqual({ tone: 'none', label: 'Not reporting yet' })
+  })
+
+  it('calls flat growth growing and a fall slow', () => {
+    expect(
+      only({
+        growth: { available: true, value: 2, previous: 2, comparable: true },
+      }).growth.label,
+    ).toBe('Growing')
+    expect(
+      only({
+        growth: { available: true, value: 1, previous: 2, comparable: true },
+      }).growth,
+    ).toEqual({ tone: 'warn', label: 'Slow' })
+  })
+
+  it('gives sports scores half a day and every other feed half an hour', () => {
+    expect(isStale({ table: 'games', age_seconds: 11 * 3600, has_data: true }))
+      .toBe(false)
+    expect(isStale({ table: 'games', age_seconds: 13 * 3600, has_data: true }))
+      .toBe(true)
+    expect(isStale({ table: 'trades', age_seconds: 29 * 60, has_data: true }))
+      .toBe(false)
+    expect(isStale({ table: 'trades', age_seconds: 31 * 60, has_data: true }))
+      .toBe(true)
+    // An empty table is broken, not stale — the age of nothing is not a wait.
+    expect(isStale({ table: 'trades', age_seconds: 0, has_data: false })).toBe(
+      false,
+    )
+  })
+
+  it('says something is broken only for a feed with no data at all', () => {
+    const stale = only({
+      feeds: [{ table: 'trades', age_seconds: 3600, has_data: true }],
+    })
+    expect(stale.feeds).toEqual({ tone: 'warn', label: 'Stale' })
+    expect(stale.headline[0]).toBe('Running fine.')
+
+    const broken = only({
+      feeds: [{ table: 'trades', age_seconds: 0, has_data: false }],
+    })
+    expect(broken.feeds).toEqual({ tone: 'bad', label: 'A feed is broken' })
+    expect(broken.headline[0]).toBe('Something is broken.')
+  })
+
+  it('does not claim things are running fine with no readings', () => {
+    expect(only({ feeds: null }).feeds).toEqual({
+      tone: 'none',
+      label: 'No readings',
+    })
+    expect(only({ feeds: [] }).headline[0]).toBe('Nothing to report.')
+  })
+})

--- a/myscrollr.com/src/lib/overviewVerdicts.ts
+++ b/myscrollr.com/src/lib/overviewVerdicts.ts
@@ -1,0 +1,161 @@
+/**
+ * The Overview's five verdicts and its headline, decided in one place
+ * (SCROLLR-215).
+ *
+ * A verdict is a colour plus two words, and colour on this page means state —
+ * never decoration. The thresholds below are the whole ruleset: nothing else
+ * on the page may invent one, and a rule that cannot be evaluated from the
+ * data returns `none` (grey) rather than guessing, exactly as an unavailable
+ * metric renders its note instead of a zero.
+ *
+ * The input is primitives rather than the API types on purpose: the rules are
+ * the same whichever endpoint a figure arrived from, and a test of them should
+ * not have to build a `Revenue`.
+ */
+
+export type VerdictTone = 'good' | 'warn' | 'bad' | 'none'
+
+export interface Verdict {
+  tone: VerdictTone
+  label: string
+}
+
+/** One content table's freshness, as the ingest reading reports it. */
+export interface FeedReading {
+  table: string
+  age_seconds: number
+  has_data: boolean
+}
+
+export interface VerdictInput {
+  /** Live desktop presence. Null while it is still loading or failed. */
+  presence: { available: boolean; active_users: number } | null
+  /** Cases waiting on a reply from us. */
+  support: { open_cases: number } | null
+  money: {
+    available: boolean
+    past_due: number
+    new_paying_today: number
+    /** Net of Stripe fees, in minor units, over the last 24 hours. */
+    net_today: number
+  } | null
+  growth: {
+    available: boolean
+    /** Sign-ups in the last 24 hours. */
+    value: number
+    /** Sign-ups in the 24 hours before that. */
+    previous: number
+    /** False when the previous day cannot honestly be compared against. */
+    comparable: boolean
+  } | null
+  feeds: Array<FeedReading> | null
+}
+
+export interface OverviewVerdicts {
+  right_now: Verdict
+  support: Verdict
+  money: Verdict
+  growth: Verdict
+  feeds: Verdict
+  /** The two headline lines, in order. */
+  headline: [string, string]
+}
+
+/**
+ * How long a feed may sit still before it is called stale.
+ *
+ * Sports scores legitimately go quiet overnight when no games are being
+ * played, so they get half a day; everything else is a continuous feed and
+ * half an hour of silence is already a stoppage.
+ */
+const GAMES_STALE_SECONDS = 12 * 60 * 60
+const FEED_STALE_SECONDS = 30 * 60
+
+function staleAfter(table: string): number {
+  return table === 'games' ? GAMES_STALE_SECONDS : FEED_STALE_SECONDS
+}
+
+export function isStale(feed: FeedReading): boolean {
+  return feed.has_data && feed.age_seconds > staleAfter(feed.table)
+}
+
+function rightNowVerdict(presence: VerdictInput['presence']): Verdict {
+  if (!presence || !presence.available) {
+    return { tone: 'none', label: 'Not reporting yet' }
+  }
+  return presence.active_users >= 1
+    ? { tone: 'good', label: 'Live' }
+    : { tone: 'none', label: 'Quiet' }
+}
+
+function supportVerdict(support: VerdictInput['support']): Verdict {
+  if (!support) return { tone: 'none', label: 'Not reporting yet' }
+  return support.open_cases > 0
+    ? { tone: 'bad', label: 'Needs you' }
+    : { tone: 'good', label: 'Clear' }
+}
+
+function moneyVerdict(money: VerdictInput['money']): Verdict {
+  if (!money || !money.available) {
+    return { tone: 'none', label: 'Not reporting yet' }
+  }
+  if (money.past_due > 0) return { tone: 'bad', label: 'Payment failed' }
+  if (money.new_paying_today > 0 || money.net_today > 0) {
+    return { tone: 'good', label: 'New money' }
+  }
+  return { tone: 'none', label: 'Nothing new' }
+}
+
+function growthVerdict(growth: VerdictInput['growth']): Verdict {
+  if (!growth || !growth.available) {
+    return { tone: 'none', label: 'Not reporting yet' }
+  }
+  if (!growth.comparable) {
+    return { tone: 'none', label: 'Too early to compare' }
+  }
+  return growth.value >= growth.previous
+    ? { tone: 'good', label: 'Growing' }
+    : { tone: 'warn', label: 'Slow' }
+}
+
+function feedsVerdict(feeds: VerdictInput['feeds']): Verdict {
+  if (!feeds || feeds.length === 0) {
+    return { tone: 'none', label: 'No readings' }
+  }
+  if (feeds.some((f) => !f.has_data)) {
+    return { tone: 'bad', label: 'A feed is broken' }
+  }
+  if (feeds.some(isStale)) return { tone: 'warn', label: 'Stale' }
+  return { tone: 'good', label: 'All good' }
+}
+
+export function verdicts(input: VerdictInput): OverviewVerdicts {
+  const feeds = feedsVerdict(input.feeds)
+  const support = supportVerdict(input.support)
+  const money = moneyVerdict(input.money)
+
+  // Line one is the product: is anything actually broken. Line two is the
+  // reader: is anything waiting on them. Grey feeds are neither — claiming
+  // "running fine" from readings we do not have would be the page lying.
+  const first =
+    feeds.tone === 'bad'
+      ? 'Something is broken.'
+      : feeds.tone === 'none'
+        ? 'Nothing to report.'
+        : 'Running fine.'
+  const second =
+    support.tone === 'bad'
+      ? 'Support needs you.'
+      : money.tone === 'bad'
+        ? 'A payment failed.'
+        : 'Nothing needs you.'
+
+  return {
+    right_now: rightNowVerdict(input.presence),
+    support,
+    money,
+    growth: growthVerdict(input.growth),
+    feeds,
+    headline: [first, second],
+  }
+}


### PR DESCRIPTION
Rebuilds the admin Overview to the "Numbers + checklist" design Brandon approved on 12 Sep: a two-line headline, then five rows — **Right now · Support · Money · Growth · Feeds** — each a big number, one plain sentence and a verdict, each expanding into a grid of plain-language facts, one note and one action. Everything technical stays in Analytics, Versions and Support.

Closes SCROLLR-215.

## What changed

- **`src/lib/overviewVerdicts.ts`** (new, + unit tests): one pure function holds every rule. Nothing on the page invents a threshold, and a rule that cannot be evaluated from the data returns grey rather than guessing.
- **`OverviewPage.tsx`** rewritten. No period selector — the page is "now and the last 24 hours" and every fetch is pinned to `24h`. The Refresh button stays.
- **`ui.tsx`**: drops `Breakdown`, which only the old presence strip used.
- **`api/internal/support/admin_summary.go`**: `SupportSummaryResponse` gains `cases_with_account` / `cases`, the pair the Support note states.

The two SCROLLR-210 promises carry over unchanged: a row never renders a number it cannot back, and colour means state, never decoration. Verdict colours are whole class strings in a keyed table — never interpolated, so none of them silently compiles away.

## Screenshots

Real component, real CSS, typed fixtures, dark theme. Nothing here is production data.

**Collapsed**

![collapsed](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-215/overview-collapsed.png)

**Support row open** — the 3-column fact grid, the note and the one filled (red) action

![support open](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-215/overview-support-open.png)

**Nobody here, a feed gone quiet, support clear** — the grey and amber verdicts, and the headline's second line changing

![quiet and stale](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-215/overview-quiet-stale.png)

## Two judgement calls, both away from the letter of the issue

1. **Support facts come from `/admin/support/summary`, not a new query in `handlers_overview.go`.** The issue offered "add it to `SupportTile`; it is one query on `support_cases.status`" — but it is not. The queue buckets are decided by `loadQueueRows` (draft state, last customer message, disposition), so a status query would have produced an Overview that disagrees with the Support page about how many people are waiting. Reusing the endpoint costs one fetch the page was already making the equivalent of, and keeps one definition of "waiting".
2. **Two sentences say what the number actually is.** "N of them opened the app" would have labelled DAU as a subset of today's sign-ups (31 of 1); it reads "N people opened the app." And the ticker clause is the verbatim "with the ticker on screen." only when every active user has one, otherwise it carries its own count. Both are the same promise the rest of the page keeps.

Smaller notes: the Feeds row draws a warning triangle instead of a check when its verdict is amber or red; grey Feeds (no readings at all) gives the headline "Nothing to report." rather than claiming things run fine; and the analytics links go to the Analytics view by search param rather than a `#revenue` hash, which would scroll to nothing.

Not touched: Analytics, Support, Users, Versions, and the trades freshness column (SCROLLR-214, already merged — this branch is rebased on it).

## Verification

`npm ci && npm test && npm run build` green (225 tests). Typecheck clean apart from the pre-existing `motion-plus/react` resolution failures. The Go change is two struct fields and one assignment, gofmt'd; Docker is down on this box so it is verified by CI rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
