### PR TITLE
refactor(admin): delete the Overview's dead support tile [SCROLLR-217]

### DIFF
--- a/api/internal/admin/handlers_overview.go
+++ b/api/internal/admin/handlers_overview.go
@@ -47,7 +47,6 @@ type OverviewResponse struct {
 	Downloads    DownloadsTile `json:"downloads"`
 	Installs     Measured      `json:"installs"`
 	ConnectedNow ConnectedTile `json:"connected_now"`
-	Support      SupportTile   `json:"support"`
 	Demand       DemandTile    `json:"demand"`
 	Ingest       []IngestRow   `json:"ingest"`
 }
@@ -140,15 +139,6 @@ type ConnectedTile struct {
 	Replicas int `json:"replicas"`
 }
 
-type SupportTile struct {
-	OpenCases        int    `json:"open_cases"`
-	PendingDrafts    int    `json:"pending_drafts"`
-	AutoSent30d      int    `json:"auto_sent_30d"`
-	Intervened30d    int    `json:"intervened_30d"`
-	OldestOpenHours  int    `json:"oldest_open_hours"`
-	OldestOpenTicket string `json:"oldest_open_ticket,omitempty"`
-}
-
 type DemandTile struct {
 	CatalogRequests []CatalogRequestRow `json:"catalog_requests"`
 	BusinessLeads   int                 `json:"business_leads"`
@@ -211,7 +201,6 @@ func HandleGetOverview(c *fiber.Ctx) error {
 	})
 	run("plans", func() { out.Plans = plansTile(ctx) })
 	run("downloads", func() { out.Downloads = downloadsTile(ctx) })
-	run("support", func() { out.Support = supportTile(ctx) })
 	run("demand", func() { out.Demand = demandTile(ctx) })
 	run("ingest", func() { out.Ingest = ingestRows(ctx) })
 	run("connected", func() {
@@ -327,40 +316,6 @@ func plansTile(ctx context.Context) PlansTile {
 		 WHERE plan <> 'free' AND status IN ('active', 'trialing', 'past_due')`).
 		Scan(&t.Paying); err != nil {
 		log.Printf("[Admin] plans paying count: %v", err)
-	}
-	return t
-}
-
-func supportTile(ctx context.Context) SupportTile {
-	var t SupportTile
-	var oldest *time.Time
-	var ticket *string
-
-	if err := platform.DBPool.QueryRow(ctx, `
-		SELECT count(*) FILTER (WHERE status <> 'closed'),
-		       min(opened_at) FILTER (WHERE status <> 'closed'),
-		       (SELECT ticket_number FROM support_cases
-		         WHERE status <> 'closed' ORDER BY opened_at LIMIT 1)
-		  FROM support_cases`).Scan(&t.OpenCases, &oldest, &ticket); err != nil {
-		log.Printf("[Admin] support cases: %v", err)
-	}
-	if oldest != nil {
-		t.OldestOpenHours = int(time.Since(*oldest).Hours())
-	}
-	if ticket != nil {
-		t.OldestOpenTicket = *ticket
-	}
-
-	if err := platform.DBPool.QueryRow(ctx, `
-		SELECT count(*) FILTER (WHERE status = 'pending'),
-		       count(*) FILTER (WHERE status = 'sent'
-		                          AND disposition = 'auto_send'
-		                          AND created_at >= now() - interval '30 days'),
-		       count(*) FILTER (WHERE intervened
-		                          AND created_at >= now() - interval '30 days')
-		  FROM support_drafts`).
-		Scan(&t.PendingDrafts, &t.AutoSent30d, &t.Intervened30d); err != nil {
-		log.Printf("[Admin] support drafts: %v", err)
 	}
 	return t
 }

--- a/myscrollr.com/src/api/admin.ts
+++ b/myscrollr.com/src/api/admin.ts
@@ -150,15 +150,6 @@ export interface ConnectedTile {
   replicas: number
 }
 
-export interface SupportTile {
-  open_cases: number
-  pending_drafts: number
-  auto_sent_30d: number
-  intervened_30d: number
-  oldest_open_hours: number
-  oldest_open_ticket?: string
-}
-
 export interface CatalogRequestRow {
   query: string
   people: number
@@ -185,7 +176,6 @@ export interface AdminOverview {
   downloads: DownloadsTile
   installs: Measured
   connected_now: ConnectedTile
-  support: SupportTile
   demand: DemandTile
   ingest: Array<IngestRow> | null
 }

--- a/myscrollr.com/src/components/admin/dashboardFixtures.ts
+++ b/myscrollr.com/src/components/admin/dashboardFixtures.ts
@@ -495,14 +495,6 @@ export const overview: AdminOverview = {
   },
   plans: { paying: 2, rows: [] },
   connected_now: { count: 8, replicas: 2 },
-  support: {
-    open_cases: 3,
-    pending_drafts: 1,
-    auto_sent_30d: 4,
-    intervened_30d: 1,
-    oldest_open_hours: 2,
-    oldest_open_ticket: '104',
-  },
   ingest: [
     { table: 'games', age_seconds: 90, has_data: true },
     { table: 'trades', age_seconds: 45, has_data: true },


### PR DESCRIPTION
Closes [SCROLLR-217](https://linear.app/relentnet/issue/SCROLLR-217).

`/admin/overview` computed a `support` tile that nothing read, and its headline number was wrong in a way that would mislead whoever wired it up next: `SupportTile.OpenCases` counted `status <> 'closed'`, which lumps tickets waiting on the customer in with tickets waiting on us.

Since [SCROLLR-215](https://linear.app/relentnet/issue/SCROLLR-215) the Overview reads `/admin/support/summary`, whose buckets come from `loadQueueRows` and therefore agree with the Support page. So this is a deletion, not a better query — correcting the bucketing in `handlers_overview.go` would mean implementing `loadQueueRows`' logic a second time, which is how the two pages would drift apart again.

## What goes

- `api/internal/admin/handlers_overview.go` — the `SupportTile` type, the `Support` member of `OverviewResponse`, the `support_cases` / `support_drafts` queries in `supportTile`, and the `run("support", …)` call site.
- `myscrollr.com/src/api/admin.ts` — the `SupportTile` interface and the `support:` member of `AdminOverview`.
- `myscrollr.com/src/components/admin/dashboardFixtures.ts` — the `support: {…}` fixture block.

63 lines deleted, nothing added.

## What stays

`api.generated.ts` carries none of these types (they are hand-written in `admin.ts`), so there was nothing to regenerate. `/admin/support/summary`, the Support page and `loadQueueRows` are untouched, as is `DemandTile`.

`overviewVerdicts.ts` keeps its own inline `{ open_cases: number } | null` shape — it looks like a reader but is not: `OverviewPage.tsx:457` builds it from `sup.needs_attention.total`, the summary endpoint.

## Verification

- `git grep -n "open_cases\|SupportTile"` on the base commit found readers only in the two trees above plus the `overviewVerdicts` shape explained above.
- Go: `go build ./...` clean, `go test ./...` green in a `golang:1.25-alpine` pod with a `postgres:16` sidecar (Docker Desktop's engine won't start on this box). `internal/admin` ran 52 tests against the live DB with zero skips.
- Website: `npm test` 225 passed / 21 files, `npm run build` green — the TypeScript build is what proves no reader was missed.
- Overview against the fixtures: `OverviewPage.test.tsx` "leads with the two headline lines and the five sentences" and "shows the support facts, note and queue action when that row is open" both pass. Invisible on screen, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)