### PR TITLE
ci(support): regenerate the knowledge base when a release is published [SCROLLR-216]

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -111,7 +111,25 @@ jobs:
       - run: go run ./cmd/kbgen
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - run: git diff --exit-code -- internal/support/kb/
+      - name: Fail if the committed knowledge base is stale
+        run: |
+          if git diff --quiet -- internal/support/kb/; then exit 0; fi
+          git diff -- internal/support/kb/
+
+          # Everything above "## Recent release notes" comes from tracked
+          # sources; that last section comes from the published GitHub
+          # releases. A diff confined to it means a release was published
+          # since the KB was last committed — nothing on this branch caused
+          # it (SCROLLR-216).
+          strip='/^## Recent release notes$/,$d'
+          if diff -q \
+            <(git show HEAD:api/internal/support/kb/kb.generated.md | sed "$strip") \
+            <(sed "$strip" internal/support/kb/kb.generated.md) >/dev/null; then
+            echo "::error::Only the release-notes section changed, so a release was probably just published. Fix: run 'make kb' and commit api/internal/support/kb/kb.generated.md, or wait for the Refresh Support Knowledge Base workflow to push the regenerated copy to main and rebase onto it."
+          else
+            echo "::error::The committed support knowledge base is out of date. Run 'make kb' and commit api/internal/support/kb/kb.generated.md."
+          fi
+          exit 1
 
   # ── Go tests (5 independent jobs, run in parallel) ─────────────
   go-tests:

--- a/.github/workflows/support-kb-refresh.yml
+++ b/.github/workflows/support-kb-refresh.yml
@@ -1,0 +1,85 @@
+# Regenerate the committed support knowledge base after a release is published.
+#
+# `api/cmd/kbgen` builds `api/internal/support/kb/kb.generated.md` partly from
+# the last eight *published* GitHub releases. Publishing a release therefore
+# changes the generator's input without any commit, so the committed copy goes
+# stale and the `support-kb` guard in backend-tests.yml fails on every branch
+# until someone runs `make kb` by hand. Nothing outside the repo should be able
+# to turn `main` red, so the event that breaks it repairs it: this regenerates
+# the KB on `release: published` and commits the result to `main`.
+#
+# It also fixes a second bug. deploy.yml already runs on `release: published`,
+# so publishing deploys core-api carrying the *stale* KB and the support bot
+# serves a knowledge base that does not know about the release that just
+# shipped. The last step below redeploys core-api once the fresh KB has landed.
+# SCROLLR-216.
+name: Refresh Support Knowledge Base
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  # Pushes made with the default GITHUB_TOKEN do not trigger workflow runs, so
+  # the commit below cannot set deploy.yml off by itself; the final step
+  # dispatches it explicitly.
+  actions: write
+
+# Two releases published back to back must not race each other's push.
+concurrency:
+  group: support-kb-refresh
+
+jobs:
+  refresh:
+    name: Regenerate and commit the knowledge base
+    if: startsWith(github.event.release.tag_name, 'desktop-v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # `main`, not the release tag: the event's ref is the tag, and the KB is
+      # only useful where CI and deploys read it from (SCROLLR-206).
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: api/go.mod
+          cache: true
+          cache-dependency-path: api/go.sum
+
+      - run: go run ./cmd/kbgen
+        working-directory: api
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and push the regenerated knowledge base
+        id: push
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if git diff --quiet -- api/internal/support/kb/kb.generated.md; then
+            echo "Knowledge base is already current for $TAG; nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add api/internal/support/kb/kb.generated.md
+          # No [skip ci]: the deploy this commit leads to is the point.
+          git commit -m "chore(support): regenerate knowledge base for $TAG [SCROLLR-216]"
+
+          # A commit that landed while the generator ran must not fail the job.
+          if ! git push origin HEAD:main; then
+            git pull --rebase origin main
+            git push origin HEAD:main
+          fi
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy core-api with the fresh knowledge base
+        if: steps.push.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy.yml --ref main -f services=core-api


### PR DESCRIPTION
Publishing a GitHub release changes `kbgen`'s input without any commit — it reads the last eight *published* releases — so the committed `api/internal/support/kb/kb.generated.md` goes stale the moment a release goes out, and the `support-kb` guard fails on **every** branch until someone runs `make kb` by hand. No commit caused it, and it lands on whoever's PR hits it first (SCROLLR-214's #394, 12 Sep).

Per the decision in the issue: the event that breaks the repo now repairs it.

## What's here

**`.github/workflows/support-kb-refresh.yml`** — `on: release: published`, gated to `desktop-v*` tags the same way `discord-release.yml` is, `permissions: contents: write`, `concurrency: support-kb-refresh` so two releases in quick succession cannot race a push. It checks out `ref: main` (not the release tag — the event's ref is the tag), reruns `cd api && go run ./cmd/kbgen`, and only if the KB actually changed commits it as the actions bot and pushes to `main`. A failed push pull-rebases once and retries once, so a commit landing mid-job does not fail the job. **No diff is a pass**, not a warning. No `[skip ci]`.

**`backend-tests.yml`** — the `support-kb` guard is unchanged in what it checks; only its failure message got better. Everything above `## Recent release notes` comes from tracked sources, so if the diff is confined to that last section the job now says a release was probably just published and that `make kb` (or rebasing onto the refresh commit) is the fix, rather than leaving a human to work it out from a diff.

## One correction to the brief

The issue assumed the regen commit would re-trigger `deploy.yml` through its `push` path and carry the new KB to the support bot. It would not: **a push made with the default `GITHUB_TOKEN` does not trigger workflow runs.** The KB would have landed in the repo and never reached production, which is the half of the bug this was supposed to close. So the workflow explicitly dispatches `deploy.yml` (`--ref main -f services=core-api`) after a successful push, under `permissions: actions: write`. `deploy.yml`'s `workflow_dispatch` path checks out `github.sha`, so it picks up the commit that was just pushed. The step is skipped when there was nothing to commit.

## How this was exercised

A `release`-triggered workflow can't be started with `gh workflow run` (and `workflow_dispatch` only registers once the file is on the default branch), so on this branch I temporarily swapped the trigger for `push: branches: [this branch]`, pointed the checkout and push at the branch instead of `main`, guarded the deploy dispatch to `release` events only, and reverted the KB one commit:

- **Run [34730552196](https://github.com/doughknee/myscrollr/actions/runs/34730552196)** — regenerated and pushed `chore(support): regenerate knowledge base for desktop-vTEST [SCROLLR-216]` (commit `52b797d4`) as `github-actions[bot]`. ✅
- **Run [34730581714](https://github.com/doughknee/myscrollr/actions/runs/34730581714)** — second run against the now-current KB: `Knowledge base is already current for desktop-vTEST; nothing to commit.` ✅ clean pass, no-diff path.

Those temporary commits have been stripped; this branch is one commit touching only the two workflow files. `actionlint` isn't on the box, but both files parse and both ran green on a real runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
