### PR TITLE
feat(website): give the staff console its own full-width shell [SCROLLR-218]

### DIFF
--- a/myscrollr.com/scripts/check-mobile-viewport.mjs
+++ b/myscrollr.com/scripts/check-mobile-viewport.mjs
@@ -45,7 +45,9 @@ const VIEWPORTS = [
 // Running the check against an empty <main> would silently pass and
 // hide real bugs.
 const ROUTES = [
-  { path: '/account', file: '_shell.html', authShell: true },
+  { path: '/account', file: '_shell.html', authShell: true, siteNav: true },
+  // The staff console replaces the site header with its own bar (SCROLLR-218),
+  // so there is no "Open menu" to open here — only the shell checks apply.
   { path: '/admin', file: '_shell.html', authShell: true },
   { path: '/', file: 'index.html' },
   { path: '/widgets', file: 'widgets/index.html' },
@@ -264,19 +266,25 @@ try {
           )
           failures += 1
         }
-        await page
-          .getByRole('button', { name: 'Open menu', exact: true })
-          .click()
-        if (
-          !(await page
-            .getByRole('dialog', { name: 'Mobile navigation' })
-            .getByRole('button', { name: 'SIGN IN', exact: true })
-            .isVisible())
-        )
+        if (route.siteNav) {
+          await page
+            .getByRole('button', { name: 'Open menu', exact: true })
+            .click()
+          if (
+            !(await page
+              .getByRole('dialog', { name: 'Mobile navigation' })
+              .getByRole('button', { name: 'SIGN IN', exact: true })
+              .isVisible())
+          )
+            failures += 1
+          await page
+            .getByRole('button', { name: 'Close menu', exact: true })
+            .click()
+        } else if (await page.locator('header a[href="/download"]').count()) {
+          // The console must not be wearing the marketing header.
+          console.error(`✗ ${route.path}: the site header is still rendered`)
           failures += 1
-        await page
-          .getByRole('button', { name: 'Close menu', exact: true })
-          .click()
+        }
       }
 
       const result = await page.evaluate(() => {

--- a/myscrollr.com/src/components/admin/AdminShell.test.tsx
+++ b/myscrollr.com/src/components/admin/AdminShell.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AdminShell, { AdminChrome } from './AdminShell'
+import type { ReactNode } from 'react'
+import { usesSiteChrome } from '@/lib/siteChrome'
+import { AdminApiError } from '@/api/admin'
+
+/**
+ * The console's shell (SCROLLR-218).
+ *
+ * Two things are worth a test here. The first is the rule that the site's
+ * chrome stops at /admin — a predicate, so it can be asserted without booting
+ * the whole root layout. The second is that the new bar still offers every
+ * section and the gate still says what it used to say, because those are the
+ * two ways a chrome rewrite quietly loses something.
+ */
+
+const mocks = vi.hoisted(() => ({
+  me: vi.fn(),
+  token: vi.fn(),
+  signIn: vi.fn(),
+  authenticated: true,
+}))
+vi.mock('@/hooks/useScrollrAuth', () => ({
+  useScrollrAuth: () => ({
+    isAuthenticated: mocks.authenticated,
+    isLoading: false,
+    signIn: mocks.signIn,
+    signOut: vi.fn(),
+  }),
+}))
+vi.mock('@/hooks/useGetToken', () => ({ useGetToken: () => mocks.token }))
+vi.mock('@/api/admin', async () => {
+  const actual = await vi.importActual('@/api/admin')
+  return { ...actual, adminApi: { me: mocks.me } }
+})
+
+/** Render on the client inside a throwaway memory router, so Links resolve. */
+async function render(node: ReactNode, path = '/admin'): Promise<HTMLElement> {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+  const rootRoute = createRootRoute({ component: () => <>{node}</> })
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  })
+  await router.load()
+  const host = document.createElement('div')
+  document.body.append(host)
+  await act(async () => {
+    createRoot(host).render(<RouterProvider router={router} />)
+  })
+  return host
+}
+
+const SECTION_LABELS = [
+  'Overview',
+  'Analytics',
+  'Support',
+  'Versions',
+  'Users',
+  'Admins',
+  'Settings',
+]
+
+beforeEach(() => {
+  mocks.authenticated = true
+  mocks.me.mockReset()
+  document.body.innerHTML = ''
+})
+
+describe('site chrome', () => {
+  it('does not wrap the staff console', () => {
+    for (const path of ['/admin', '/admin/', '/admin/support', '/admin/users'])
+      expect(usesSiteChrome(path)).toBe(false)
+  })
+
+  it('still wraps every public route', () => {
+    for (const path of ['/', '/pricing', '/account', '/business', '/u/bob'])
+      expect(usesSiteChrome(path)).toBe(true)
+  })
+})
+
+describe('AdminChrome', () => {
+  it('offers all seven sections and a way back to the site', async () => {
+    const host = await render(
+      <AdminChrome email="staff@myscrollr.com">
+        <p>page</p>
+      </AdminChrome>,
+    )
+    // Every section is a link with its full label; two copies of the row
+    // exist (the bar, and the scrolling row for phones), so assert presence.
+    for (const label of SECTION_LABELS)
+      expect(host.textContent).toContain(label)
+    expect(host.textContent).toContain('/ admin')
+    expect(host.textContent).toContain('staff@myscrollr.com')
+    expect(host.textContent).toContain('Back to site')
+    expect(host.querySelector('a[href="/admin/support"]')).not.toBeNull()
+    expect(host.querySelector('a[href="/"]')).not.toBeNull()
+    // No site chrome came along for the ride.
+    expect(host.textContent).not.toContain('SIGN IN')
+    expect(host.querySelector('footer')).toBeNull()
+  })
+
+  it('renders the optional status slot', async () => {
+    const host = await render(
+      <AdminChrome email="staff@myscrollr.com" status={<b>3 waiting</b>}>
+        <p>page</p>
+      </AdminChrome>,
+    )
+    expect(host.textContent).toContain('3 waiting')
+  })
+
+  it('leaves the page area full-bleed', async () => {
+    const host = await render(
+      <AdminChrome email="staff@myscrollr.com">
+        <p>page</p>
+      </AdminChrome>,
+    )
+    const main = host.querySelector('main')!
+    expect(main.className).toContain('min-h-[calc(100dvh-48px)]')
+    expect(main.className).not.toContain('max-w-')
+  })
+})
+
+describe('the gate', () => {
+  it('keeps the signed-out copy', async () => {
+    mocks.authenticated = false
+    const host = await render(<AdminShell />)
+    expect(host.textContent).toContain('Sign in to continue')
+    expect(host.textContent).toContain(
+      'only available to signed-in staff accounts',
+    )
+  })
+
+  it('keeps the denied copy', async () => {
+    mocks.me.mockRejectedValue(new AdminApiError('forbidden', 403))
+    const host = await render(<AdminShell />)
+    expect(host.textContent).toContain('Staff only')
+    expect(host.textContent).toContain('limited to the Scrollr admin list')
+  })
+
+  it('keeps the error copy and the message the API gave', async () => {
+    mocks.me.mockRejectedValue(new Error('Could not reach the API'))
+    const host = await render(<AdminShell />)
+    expect(host.textContent).toContain('Could not check access')
+    expect(host.textContent).toContain('Could not reach the API')
+    expect(host.textContent).toContain('Retry access check')
+  })
+})

--- a/myscrollr.com/src/components/admin/AdminShell.tsx
+++ b/myscrollr.com/src/components/admin/AdminShell.tsx
@@ -1,16 +1,7 @@
 import { Link, Outlet, useLocation } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
-import {
-  Activity,
-  BarChart3,
-  Layers,
-  LifeBuoy,
-  Loader2,
-  Lock,
-  Settings,
-  ShieldCheck,
-  Users,
-} from 'lucide-react'
+import { Loader2, Lock } from 'lucide-react'
+import ScrollrSVG from '@/components/ScrollrSVG'
 import { AdminApiError, adminApi } from '@/api/admin'
 import { useGetToken } from '@/hooks/useGetToken'
 import { useScrollrAuth } from '@/hooks/useScrollrAuth'
@@ -25,13 +16,13 @@ import { useScrollrAuth } from '@/hooks/useScrollrAuth'
  */
 
 const SECTIONS = [
-  { to: '/admin', label: 'Overview', Icon: BarChart3, exact: true },
-  { to: '/admin/analytics', label: 'Analytics', Icon: Activity },
-  { to: '/admin/support', label: 'Support', Icon: LifeBuoy },
-  { to: '/admin/versions', label: 'Versions', Icon: Layers },
-  { to: '/admin/users', label: 'Users', Icon: Users },
-  { to: '/admin/admins', label: 'Admins', Icon: ShieldCheck },
-  { to: '/admin/settings', label: 'Settings', Icon: Settings },
+  { to: '/admin', label: 'Overview', exact: true },
+  { to: '/admin/analytics', label: 'Analytics' },
+  { to: '/admin/support', label: 'Support' },
+  { to: '/admin/versions', label: 'Versions' },
+  { to: '/admin/users', label: 'Users' },
+  { to: '/admin/admins', label: 'Admins' },
+  { to: '/admin/settings', label: 'Settings' },
 ] as const
 
 type GateState =
@@ -169,61 +160,100 @@ export default function AdminShell() {
  */
 export function AdminChrome({
   email,
+  status,
   children,
 }: {
   email: string
+  /** Right-hand slot on the bar. Support fills it in SCROLLR-219. */
+  status?: React.ReactNode
   children: React.ReactNode
 }) {
   const location = useLocation()
+  const links = SECTIONS.map(({ to, label, ...rest }) => {
+    const exact = 'exact' in rest && rest.exact
+    const active = exact
+      ? location.pathname === '/admin' || location.pathname === '/admin/'
+      : location.pathname.startsWith(to)
+    return { to, label, active }
+  })
+
   return (
-    /* Wide enough for the Support console's two panes to sit as drawn at
-       1440, and capped so an ultrawide gives the extra width to margin
-       instead of stretching a line of prose across 3440 pixels. The reading
-       measure inside each pane is capped again, at 75ch, where it matters. */
-    <div className="mx-auto flex w-full max-w-[104rem] flex-col gap-6 px-4 py-8 sm:px-6 md:flex-row md:gap-6 lg:py-10 xl:gap-10">
-      {/* Under 768px the nav is a scrolling row of full labels. From 768 to
-          1279 it collapses to an icon rail, which is where the width has to
-          come from for the queue and the case to stay side by side. From 1280
-          the labels come back. */}
-      <nav className="md:w-14 md:shrink-0 xl:w-52">
-        <p className="px-3 text-xs font-semibold tracking-wide text-base-content/40 uppercase md:hidden xl:block">
-          Staff
-        </p>
-        <p
-          className="mt-1 truncate px-3 text-xs text-base-content/60 md:hidden xl:block"
-          title={email}
+    <div className="flex min-h-dvh flex-col">
+      <header className="flex h-12 shrink-0 items-center gap-4 border-b border-hairline bg-base-75 px-4">
+        <Link
+          to="/admin"
+          className="flex shrink-0 items-center gap-2 text-[15px] font-extrabold tracking-[-0.02em] text-base-content hover:text-base-content hover:opacity-100"
         >
-          {email}
-        </p>
-        <ul className="flex gap-1 overflow-x-auto md:mt-0 md:flex-col md:overflow-visible xl:mt-4">
-          {SECTIONS.map(({ to, label, Icon, ...rest }) => {
-            const exact = 'exact' in rest && rest.exact
-            const active = exact
-              ? location.pathname === '/admin' ||
-                location.pathname === '/admin/'
-              : location.pathname.startsWith(to)
-            return (
+          <ScrollrSVG width={20} height={20} />
+          <span className="flex items-baseline">
+            scrollr<span className="text-primary">.</span>
+          </span>
+          <span className="ml-1 text-[13px] font-medium text-base-content/45">
+            / admin
+          </span>
+        </Link>
+
+        {/* From 768 the sections sit in the bar. Below it they get their own
+            scrolling row underneath, where a tap target can be 44px tall. */}
+        <nav className="hidden min-w-0 flex-1 md:block">
+          <ul className="flex items-center gap-0.5">
+            {links.map(({ to, label, active }) => (
               <li key={to}>
                 <Link
                   to={to}
-                  title={label}
-                  aria-label={label}
-                  className={`flex min-h-11 items-center gap-2.5 rounded-lg px-3 text-sm font-medium whitespace-nowrap transition-colors md:justify-center md:px-0 xl:justify-start xl:px-3 ${
+                  className={`rounded-lg px-2.5 py-1.5 text-[13px] font-semibold whitespace-nowrap transition-colors ${
                     active
                       ? 'bg-base-200 text-base-content'
                       : 'text-base-content/60 hover:bg-base-200/60 hover:text-base-content'
                   }`}
                 >
-                  <Icon size={16} strokeWidth={2} className="shrink-0" />
-                  <span className="md:hidden xl:inline">{label}</span>
+                  {label}
                 </Link>
               </li>
-            )
-          })}
+            ))}
+          </ul>
+        </nav>
+
+        <div className="ml-auto flex min-w-0 shrink-0 items-center gap-4 md:ml-0">
+          {status}
+          <span
+            className="hidden max-w-[18rem] truncate text-xs text-base-content/45 sm:block"
+            title={email}
+          >
+            {email}
+          </span>
+          <Link
+            to="/"
+            className="text-xs font-semibold whitespace-nowrap text-base-content/60 hover:text-base-content"
+          >
+            Back to site
+          </Link>
+        </div>
+      </header>
+
+      <nav className="shrink-0 border-b border-hairline bg-base-75 md:hidden">
+        <ul className="flex gap-0.5 overflow-x-auto px-2">
+          {links.map(({ to, label, active }) => (
+            <li key={to}>
+              <Link
+                to={to}
+                className={`flex min-h-11 items-center rounded-lg px-3 text-[13px] font-semibold whitespace-nowrap transition-colors ${
+                  active
+                    ? 'text-base-content'
+                    : 'text-base-content/60 hover:text-base-content'
+                }`}
+              >
+                {label}
+              </Link>
+            </li>
+          ))}
         </ul>
       </nav>
 
-      <main className="min-w-0 flex-1">{children}</main>
+      {/* Full-bleed. Each page brings its own PageFrame if it wants a cap. */}
+      <main className="min-h-[calc(100dvh-48px)] min-w-0 flex-1">
+        {children}
+      </main>
     </div>
   )
 }

--- a/myscrollr.com/src/components/admin/AdminsPage.tsx
+++ b/myscrollr.com/src/components/admin/AdminsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Loader2, Trash2, UserPlus } from 'lucide-react'
+import { PageFrame } from './ui'
 import type { AdminRow } from '@/api/admin'
 import { adminApi } from '@/api/admin'
 import { useGetToken } from '@/hooks/useGetToken'
@@ -70,136 +71,139 @@ export default function AdminsPage() {
   const removable = (row: AdminRow) => !row.self && (admins?.length ?? 0) > 1
 
   return (
-    <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-bold tracking-tight">Admins</h1>
-        <p className="mt-1 text-sm text-base-content/60">
-          Staff access is this list and nothing else — not a subscription tier,
-          not a Stripe plan, not <code className="text-xs">super_user</code>.
-        </p>
-      </header>
+    <PageFrame>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-2xl font-bold tracking-tight">Admins</h1>
+          <p className="mt-1 text-sm text-base-content/60">
+            Staff access is this list and nothing else — not a subscription
+            tier, not a Stripe plan, not{' '}
+            <code className="text-xs">super_user</code>.
+          </p>
+        </header>
 
-      {error && (
-        <p className="rounded-lg bg-error/5 p-3 text-sm text-error ring-1 ring-error/20">
-          {error}
-        </p>
-      )}
+        {error && (
+          <p className="rounded-lg bg-error/5 p-3 text-sm text-error ring-1 ring-error/20">
+            {error}
+          </p>
+        )}
 
-      <form
-        onSubmit={add}
-        className="flex flex-col gap-3 rounded-xl bg-base-200/40 p-4 ring-1 ring-base-300/60 sm:flex-row sm:items-end"
-      >
-        <label className="flex-1">
-          <span className="text-xs font-semibold text-base-content/50 uppercase">
-            Email
-          </span>
-          <input
-            type="email"
-            required
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="person@example.com"
-            className="mt-1 w-full rounded-lg bg-base-100 px-3 py-2 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
-          />
-        </label>
-        <label className="flex-1">
-          <span className="text-xs font-semibold text-base-content/50 uppercase">
-            Note (optional)
-          </span>
-          <input
-            type="text"
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            placeholder="why they need access"
-            className="mt-1 w-full rounded-lg bg-base-100 px-3 py-2 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
-          />
-        </label>
-        <button
-          type="submit"
-          disabled={busy}
-          className="flex cursor-pointer items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-content transition-[filter] hover:brightness-110 disabled:opacity-50"
+        <form
+          onSubmit={add}
+          className="flex flex-col gap-3 rounded-xl bg-base-200/40 p-4 ring-1 ring-base-300/60 sm:flex-row sm:items-end"
         >
-          {busy ? (
-            <Loader2 size={16} className="animate-spin" />
-          ) : (
-            <UserPlus size={16} />
-          )}
-          Add admin
-        </button>
-      </form>
+          <label className="flex-1">
+            <span className="text-xs font-semibold text-base-content/50 uppercase">
+              Email
+            </span>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="person@example.com"
+              className="mt-1 w-full rounded-lg bg-base-100 px-3 py-2 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
+            />
+          </label>
+          <label className="flex-1">
+            <span className="text-xs font-semibold text-base-content/50 uppercase">
+              Note (optional)
+            </span>
+            <input
+              type="text"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="why they need access"
+              className="mt-1 w-full rounded-lg bg-base-100 px-3 py-2 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={busy}
+            className="flex cursor-pointer items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-content transition-[filter] hover:brightness-110 disabled:opacity-50"
+          >
+            {busy ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <UserPlus size={16} />
+            )}
+            Add admin
+          </button>
+        </form>
 
-      {!admins ? (
-        <Loader2 className="size-5 animate-spin text-base-content/40" />
-      ) : (
-        <div className="overflow-x-auto rounded-xl ring-1 ring-base-300/60">
-          <table className="w-full min-w-[38rem] text-left text-sm">
-            <thead className="text-xs text-base-content/50 uppercase">
-              <tr className="border-b border-base-300/60">
-                <th className="p-3 font-semibold">Email</th>
-                <th className="p-3 font-semibold">Added</th>
-                <th className="p-3 font-semibold">Last seen</th>
-                <th className="p-3" />
-              </tr>
-            </thead>
-            <tbody>
-              {admins.map((row) => (
-                <tr
-                  key={row.id}
-                  className="border-b border-base-300/40 last:border-0"
-                >
-                  <td className="p-3">
-                    <span className="font-medium">{row.email}</span>
-                    {row.self && (
-                      <span className="ml-2 rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary">
-                        you
-                      </span>
-                    )}
-                    {!row.claimed && (
-                      <span className="ml-2 rounded bg-base-300/60 px-1.5 py-0.5 text-xs text-base-content/60">
-                        not signed in yet
-                      </span>
-                    )}
-                    {row.note && (
-                      <span className="block text-xs text-base-content/45">
-                        {row.note}
-                      </span>
-                    )}
-                  </td>
-                  <td className="p-3 text-base-content/60">
-                    {new Date(row.added_at).toLocaleDateString()}
-                    {row.added_by && (
-                      <span className="block text-xs text-base-content/45">
-                        by {row.added_by}
-                      </span>
-                    )}
-                  </td>
-                  <td className="p-3 text-base-content/60">
-                    {row.last_seen_at
-                      ? new Date(row.last_seen_at).toLocaleString()
-                      : '—'}
-                  </td>
-                  <td className="p-3 text-right">
-                    {removable(row) ? (
-                      <button
-                        type="button"
-                        onClick={() => remove(row)}
-                        aria-label={`Remove ${row.email}`}
-                        className="cursor-pointer rounded-lg p-1.5 text-base-content/50 transition-colors hover:bg-error/10 hover:text-error"
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    ) : (
-                      <span className="text-xs text-base-content/35">
-                        {row.self ? 'cannot remove yourself' : 'last admin'}
-                      </span>
-                    )}
-                  </td>
+        {!admins ? (
+          <Loader2 className="size-5 animate-spin text-base-content/40" />
+        ) : (
+          <div className="overflow-x-auto rounded-xl ring-1 ring-base-300/60">
+            <table className="w-full min-w-[38rem] text-left text-sm">
+              <thead className="text-xs text-base-content/50 uppercase">
+                <tr className="border-b border-base-300/60">
+                  <th className="p-3 font-semibold">Email</th>
+                  <th className="p-3 font-semibold">Added</th>
+                  <th className="p-3 font-semibold">Last seen</th>
+                  <th className="p-3" />
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
+              </thead>
+              <tbody>
+                {admins.map((row) => (
+                  <tr
+                    key={row.id}
+                    className="border-b border-base-300/40 last:border-0"
+                  >
+                    <td className="p-3">
+                      <span className="font-medium">{row.email}</span>
+                      {row.self && (
+                        <span className="ml-2 rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary">
+                          you
+                        </span>
+                      )}
+                      {!row.claimed && (
+                        <span className="ml-2 rounded bg-base-300/60 px-1.5 py-0.5 text-xs text-base-content/60">
+                          not signed in yet
+                        </span>
+                      )}
+                      {row.note && (
+                        <span className="block text-xs text-base-content/45">
+                          {row.note}
+                        </span>
+                      )}
+                    </td>
+                    <td className="p-3 text-base-content/60">
+                      {new Date(row.added_at).toLocaleDateString()}
+                      {row.added_by && (
+                        <span className="block text-xs text-base-content/45">
+                          by {row.added_by}
+                        </span>
+                      )}
+                    </td>
+                    <td className="p-3 text-base-content/60">
+                      {row.last_seen_at
+                        ? new Date(row.last_seen_at).toLocaleString()
+                        : '—'}
+                    </td>
+                    <td className="p-3 text-right">
+                      {removable(row) ? (
+                        <button
+                          type="button"
+                          onClick={() => remove(row)}
+                          aria-label={`Remove ${row.email}`}
+                          className="cursor-pointer rounded-lg p-1.5 text-base-content/50 transition-colors hover:bg-error/10 hover:text-error"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      ) : (
+                        <span className="text-xs text-base-content/35">
+                          {row.self ? 'cannot remove yourself' : 'last admin'}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </PageFrame>
   )
 }

--- a/myscrollr.com/src/components/admin/AnalyticsPage.tsx
+++ b/myscrollr.com/src/components/admin/AnalyticsPage.tsx
@@ -10,6 +10,7 @@ import {
   LINK,
   Loaded,
   MetricValue,
+  PageFrame,
   PeriodSelector,
   RefreshButton,
   Row,
@@ -127,58 +128,60 @@ export default function AnalyticsPage() {
     })
 
   return (
-    <div className="space-y-6">
-      <header className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Analytics</h1>
-          <p className="mt-1 max-w-3xl text-sm text-base-content/65">
-            Growth, desktop usage, revenue and support on one time window. Each
-            card names its source and its limits.
-          </p>
+    <PageFrame>
+      <div className="space-y-6">
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Analytics</h1>
+            <p className="mt-1 max-w-3xl text-sm text-base-content/65">
+              Growth, desktop usage, revenue and support on one time window.
+              Each card names its source and its limits.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <PeriodSelector
+              value={period}
+              onChange={(next) => setSearch({ period: next })}
+            />
+            <RefreshButton
+              onClick={() => setRefresh((n) => n + 1)}
+              label="Refresh"
+            />
+          </div>
+        </header>
+        <Tabs view={view} onChange={(next) => setSearch({ view: next })} />
+        <div
+          role="tabpanel"
+          id={`panel-${view}`}
+          aria-labelledby={`tab-${view}`}
+          tabIndex={0}
+          className="focus-visible:outline-2 focus-visible:outline-primary"
+        >
+          {view === 'growth' && (
+            <GrowthTab getToken={getToken} period={period} refresh={refresh} />
+          )}
+          {view === 'desktop' && (
+            <DesktopTab
+              getToken={getToken}
+              period={period}
+              refresh={refresh}
+              filters={{
+                os: search.os,
+                version: search.version,
+                plan: search.plan,
+              }}
+              onFilterChange={(next) => setSearch(next)}
+            />
+          )}
+          {view === 'revenue' && (
+            <RevenueTab getToken={getToken} period={period} refresh={refresh} />
+          )}
+          {view === 'support' && (
+            <SupportTab getToken={getToken} period={period} refresh={refresh} />
+          )}
         </div>
-        <div className="flex flex-wrap gap-3">
-          <PeriodSelector
-            value={period}
-            onChange={(next) => setSearch({ period: next })}
-          />
-          <RefreshButton
-            onClick={() => setRefresh((n) => n + 1)}
-            label="Refresh"
-          />
-        </div>
-      </header>
-      <Tabs view={view} onChange={(next) => setSearch({ view: next })} />
-      <div
-        role="tabpanel"
-        id={`panel-${view}`}
-        aria-labelledby={`tab-${view}`}
-        tabIndex={0}
-        className="focus-visible:outline-2 focus-visible:outline-primary"
-      >
-        {view === 'growth' && (
-          <GrowthTab getToken={getToken} period={period} refresh={refresh} />
-        )}
-        {view === 'desktop' && (
-          <DesktopTab
-            getToken={getToken}
-            period={period}
-            refresh={refresh}
-            filters={{
-              os: search.os,
-              version: search.version,
-              plan: search.plan,
-            }}
-            onFilterChange={(next) => setSearch(next)}
-          />
-        )}
-        {view === 'revenue' && (
-          <RevenueTab getToken={getToken} period={period} refresh={refresh} />
-        )}
-        {view === 'support' && (
-          <SupportTab getToken={getToken} period={period} refresh={refresh} />
-        )}
       </div>
-    </div>
+    </PageFrame>
   )
 }
 

--- a/myscrollr.com/src/components/admin/OverviewPage.tsx
+++ b/myscrollr.com/src/components/admin/OverviewPage.tsx
@@ -239,7 +239,10 @@ export function OverviewContent({
   const headline = rows.headline
 
   return (
-    <div className="mx-auto w-full max-w-[960px]">
+    /* Overview brings its own frame rather than PageFrame's: it wants the
+       narrower 960 measure, but the same gutters and top margin, now that
+       the console's <main> is full-bleed (SCROLLR-218). */
+    <div className="mx-auto w-full max-w-[960px] px-4 py-8 sm:px-6 lg:px-12">
       <div className="flex items-start justify-between gap-6">
         <h1 className="text-[48px] leading-[1.05] font-extrabold tracking-[-0.035em]">
           {headline[0]}

--- a/myscrollr.com/src/components/admin/SettingsPage.tsx
+++ b/myscrollr.com/src/components/admin/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { Loader2 } from 'lucide-react'
-import { ErrorPanel, Loaded, useReport } from './ui'
+import { ErrorPanel, Loaded, PageFrame, useReport } from './ui'
 import type { AdminSettings, Setting } from '@/api/admin'
 import type { Report } from './ui'
 import { EXCLUDE_STAFF_SETTING, adminApi } from '@/api/admin'
@@ -64,12 +64,14 @@ export default function SettingsPage() {
   }
 
   return (
-    <SettingsContent
-      settings={{ ...settings, data: current }}
-      saving={saving}
-      saveError={saveError}
-      onToggle={onToggle}
-    />
+    <PageFrame>
+      <SettingsContent
+        settings={{ ...settings, data: current }}
+        saving={saving}
+        saveError={saveError}
+        onToggle={onToggle}
+      />
+    </PageFrame>
   )
 }
 

--- a/myscrollr.com/src/components/admin/SupportPage.tsx
+++ b/myscrollr.com/src/components/admin/SupportPage.tsx
@@ -17,6 +17,7 @@ import {
   Search,
   Star,
 } from 'lucide-react'
+import { PageFrame } from './ui'
 import type {
   AdminFix,
   AdminHold,
@@ -1280,210 +1281,212 @@ export default function SupportPage() {
   const needsYou = queue?.counts.needs_you ?? 0
 
   return (
-    <div className="space-y-4">
-      {/* On a phone the header is the queue's header, and it steps aside once
+    <PageFrame>
+      <div className="space-y-4">
+        {/* On a phone the header is the queue's header, and it steps aside once
           a person is open so the whole viewport is the thing you came to
           read. */}
-      <header className={selected ? 'hidden md:block' : ''}>
-        <div className="flex flex-wrap items-baseline gap-x-3">
-          <h1 className="text-2xl font-bold tracking-tight">Support</h1>
-          <span className="text-sm text-base-content/50">
-            {needsYou === 1 ? '1 needs you' : `${needsYou} need you`}
-          </span>
-        </div>
-        {queue && (
-          <div
-            className={`mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg px-3 py-2 ring-1 ${
-              queue.autosend.armed
-                ? 'bg-warning/10 ring-warning/30'
-                : 'bg-base-200/50 ring-base-300/60'
-            }`}
-          >
-            <p className="text-xs">{queue.autosend.note}</p>
-            {/* Pause and resume, the same switch /pause and /resume throw. */}
-            {queue.autosend.enabled && (
-              <button
-                type="button"
-                onClick={toggleAutoSend}
-                disabled={switching}
-                className="inline-flex min-h-11 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-base-100 px-3 text-xs font-medium ring-1 ring-base-300/60 hover:bg-base-200/60 disabled:opacity-50"
-              >
-                {switching ? (
-                  <Loader2 size={12} className="animate-spin" />
-                ) : queue.autosend.paused ? (
-                  <Play size={12} />
-                ) : (
-                  <Pause size={12} />
-                )}
-                {queue.autosend.paused ? 'Resume sending' : 'Pause sending'}
-              </button>
-            )}
+        <header className={selected ? 'hidden md:block' : ''}>
+          <div className="flex flex-wrap items-baseline gap-x-3">
+            <h1 className="text-2xl font-bold tracking-tight">Support</h1>
+            <span className="text-sm text-base-content/50">
+              {needsYou === 1 ? '1 needs you' : `${needsYou} need you`}
+            </span>
           </div>
+          {queue && (
+            <div
+              className={`mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg px-3 py-2 ring-1 ${
+                queue.autosend.armed
+                  ? 'bg-warning/10 ring-warning/30'
+                  : 'bg-base-200/50 ring-base-300/60'
+              }`}
+            >
+              <p className="text-xs">{queue.autosend.note}</p>
+              {/* Pause and resume, the same switch /pause and /resume throw. */}
+              {queue.autosend.enabled && (
+                <button
+                  type="button"
+                  onClick={toggleAutoSend}
+                  disabled={switching}
+                  className="inline-flex min-h-11 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-base-100 px-3 text-xs font-medium ring-1 ring-base-300/60 hover:bg-base-200/60 disabled:opacity-50"
+                >
+                  {switching ? (
+                    <Loader2 size={12} className="animate-spin" />
+                  ) : queue.autosend.paused ? (
+                    <Play size={12} />
+                  ) : (
+                    <Pause size={12} />
+                  )}
+                  {queue.autosend.paused ? 'Resume sending' : 'Pause sending'}
+                </button>
+              )}
+            </div>
+          )}
+          <p className="mt-2 flex items-center gap-1.5 text-xs text-base-content/45">
+            <Radio
+              size={12}
+              className={live ? 'text-success' : 'text-base-content/40'}
+            />
+            {live
+              ? 'Live — holds and replies appear here without a refresh.'
+              : 'Not connected to the live stream; this page is showing what it last read.'}
+          </p>
+        </header>
+
+        {error && <p className="text-sm text-error">{error}</p>}
+        {!queue && !error && (
+          <Loader2 className="size-5 animate-spin text-base-content/40" />
         )}
-        <p className="mt-2 flex items-center gap-1.5 text-xs text-base-content/45">
-          <Radio
-            size={12}
-            className={live ? 'text-success' : 'text-base-content/40'}
-          />
-          {live
-            ? 'Live — holds and replies appear here without a refresh.'
-            : 'Not connected to the live stream; this page is showing what it last read.'}
-        </p>
-      </header>
 
-      {error && <p className="text-sm text-error">{error}</p>}
-      {!queue && !error && (
-        <Loader2 className="size-5 animate-spin text-base-content/40" />
-      )}
-
-      {queue && (
-        <div className="flex flex-col gap-5 md:flex-row md:gap-5 lg:gap-8">
-          {/* Under 768px the queue IS the page; picking someone pushes their
+        {queue && (
+          <div className="flex flex-col gap-5 md:flex-row md:gap-5 lg:gap-8">
+            {/* Under 768px the queue IS the page; picking someone pushes their
               view over it and the back control returns. From 768 up the two
               panes sit side by side, with the queue narrowed. */}
-          <div
-            className={`min-w-0 md:w-64 md:shrink-0 lg:w-80 xl:w-96 ${
-              selected ? 'hidden md:block' : 'block'
-            }`}
-          >
-            <SortBar
-              sort={sort}
-              dir={dir}
-              rowsMode={rowsMode}
-              search={search}
-              onSort={(s) => setSort(s)}
-              onDir={(d) => setDir(d)}
-              onRowsMode={(m) => {
-                setRowsMode(m)
-                back()
-              }}
-              onSearch={setSearch}
-            />
+            <div
+              className={`min-w-0 md:w-64 md:shrink-0 lg:w-80 xl:w-96 ${
+                selected ? 'hidden md:block' : 'block'
+              }`}
+            >
+              <SortBar
+                sort={sort}
+                dir={dir}
+                rowsMode={rowsMode}
+                search={search}
+                onSort={(s) => setSort(s)}
+                onDir={(d) => setDir(d)}
+                onRowsMode={(m) => {
+                  setRowsMode(m)
+                  back()
+                }}
+                onSearch={setSearch}
+              />
 
-            <div className="mt-4 space-y-5">
-              {QUEUE_SECTIONS.map((section) => {
-                const count = queue.sections[section.key] ?? 0
-                const inSection =
-                  rowsMode === 'person'
-                    ? people.filter((p) => p.section === section.key)
-                    : rows.filter((r) => r.section === section.key)
+              <div className="mt-4 space-y-5">
+                {QUEUE_SECTIONS.map((section) => {
+                  const count = queue.sections[section.key] ?? 0
+                  const inSection =
+                    rowsMode === 'person'
+                      ? people.filter((p) => p.section === section.key)
+                      : rows.filter((r) => r.section === section.key)
 
-                // Resolved is a count that opens. Forty-six closed tickets are
-                // not what anybody came here to read.
-                const collapsed = section.key === 'resolved' && !showResolved
+                  // Resolved is a count that opens. Forty-six closed tickets are
+                  // not what anybody came here to read.
+                  const collapsed = section.key === 'resolved' && !showResolved
 
-                return (
-                  <section key={section.key}>
-                    <div className="flex items-center gap-2 px-1 pb-2">
-                      {section.key === 'paying' && (
-                        <Star size={13} className="shrink-0 text-success" />
-                      )}
-                      <h2
-                        className={`text-[11px] font-bold tracking-wider uppercase ${SECTION_STYLE[section.key]}`}
-                      >
-                        {section.label}
-                      </h2>
-                      <span className="ml-auto text-[11px] tabular-nums text-base-content/40">
-                        {section.key === 'paying' && queue.accounts.paying > 0
-                          ? `${rowsMode === 'person' ? count : inSection.length} of ${queue.accounts.paying} paying`
-                          : rowsMode === 'person'
-                            ? count
-                            : inSection.length}
-                      </span>
-                      {section.key === 'resolved' && (
-                        <button
-                          type="button"
-                          onClick={() => setShowResolved((v) => !v)}
-                          aria-expanded={showResolved}
-                          className="cursor-pointer text-base-content/40 hover:text-base-content"
+                  return (
+                    <section key={section.key}>
+                      <div className="flex items-center gap-2 px-1 pb-2">
+                        {section.key === 'paying' && (
+                          <Star size={13} className="shrink-0 text-success" />
+                        )}
+                        <h2
+                          className={`text-[11px] font-bold tracking-wider uppercase ${SECTION_STYLE[section.key]}`}
                         >
-                          <ChevronRight
-                            size={14}
-                            className={`transition-transform ${showResolved ? 'rotate-90' : ''}`}
-                          />
-                        </button>
-                      )}
-                    </div>
-
-                    {!collapsed && (
-                      <div className="flex flex-col gap-2">
-                        {inSection.length === 0 ? (
-                          /* An empty paying section is a fact about the data,
-                             not a blank box: almost no ticket is joined to an
-                             account, and the server says so in a sentence. */
-                          <p className="px-1 text-xs text-base-content/45">
-                            {section.key === 'paying'
-                              ? queue.accounts.note || section.empty
-                              : section.empty}
-                          </p>
-                        ) : rowsMode === 'person' ? (
-                          (inSection as Array<QueuePerson>).map((p) => (
-                            <PersonCard
-                              key={p.key}
-                              person={p}
-                              active={selectedPerson === p.key}
-                              onSelect={() => {
-                                setSelectedPerson(p.key)
-                                setSelectedTicket(null)
-                              }}
+                          {section.label}
+                        </h2>
+                        <span className="ml-auto text-[11px] tabular-nums text-base-content/40">
+                          {section.key === 'paying' && queue.accounts.paying > 0
+                            ? `${rowsMode === 'person' ? count : inSection.length} of ${queue.accounts.paying} paying`
+                            : rowsMode === 'person'
+                              ? count
+                              : inSection.length}
+                        </span>
+                        {section.key === 'resolved' && (
+                          <button
+                            type="button"
+                            onClick={() => setShowResolved((v) => !v)}
+                            aria-expanded={showResolved}
+                            className="cursor-pointer text-base-content/40 hover:text-base-content"
+                          >
+                            <ChevronRight
+                              size={14}
+                              className={`transition-transform ${showResolved ? 'rotate-90' : ''}`}
                             />
-                          ))
-                        ) : (
-                          (inSection as Array<QueueRow>).map((r) => (
-                            <TicketCard
-                              key={r.ticket_number}
-                              row={r}
-                              active={selectedTicket === r.ticket_number}
-                              onSelect={() => {
-                                setSelectedTicket(r.ticket_number)
-                                setSelectedPerson(null)
-                              }}
-                            />
-                          ))
+                          </button>
                         )}
                       </div>
-                    )}
-                  </section>
-                )
-              })}
+
+                      {!collapsed && (
+                        <div className="flex flex-col gap-2">
+                          {inSection.length === 0 ? (
+                            /* An empty paying section is a fact about the data,
+                             not a blank box: almost no ticket is joined to an
+                             account, and the server says so in a sentence. */
+                            <p className="px-1 text-xs text-base-content/45">
+                              {section.key === 'paying'
+                                ? queue.accounts.note || section.empty
+                                : section.empty}
+                            </p>
+                          ) : rowsMode === 'person' ? (
+                            (inSection as Array<QueuePerson>).map((p) => (
+                              <PersonCard
+                                key={p.key}
+                                person={p}
+                                active={selectedPerson === p.key}
+                                onSelect={() => {
+                                  setSelectedPerson(p.key)
+                                  setSelectedTicket(null)
+                                }}
+                              />
+                            ))
+                          ) : (
+                            (inSection as Array<QueueRow>).map((r) => (
+                              <TicketCard
+                                key={r.ticket_number}
+                                row={r}
+                                active={selectedTicket === r.ticket_number}
+                                onSelect={() => {
+                                  setSelectedTicket(r.ticket_number)
+                                  setSelectedPerson(null)
+                                }}
+                              />
+                            ))
+                          )}
+                        </div>
+                      )}
+                    </section>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div
+              className={`min-w-0 flex-1 ${selected ? 'block' : 'hidden md:block'}`}
+            >
+              {selected && (
+                <button
+                  type="button"
+                  onClick={back}
+                  className="mb-3 inline-flex min-h-11 cursor-pointer items-center gap-1.5 text-sm font-medium text-base-content/70 hover:text-base-content md:hidden"
+                >
+                  <ArrowLeft size={16} /> All of support
+                </button>
+              )}
+
+              {rowsMode === 'person' && person ? (
+                <PersonView
+                  person={person}
+                  rows={rows}
+                  reloadKey={caseKey}
+                  openTicket={selectedTicket}
+                  onOpenTicket={setSelectedTicket}
+                />
+              ) : rowsMode === 'ticket' && selectedTicket ? (
+                <CaseView ticket={selectedTicket} reloadKey={caseKey} />
+              ) : (
+                <div className="rounded-xl bg-base-200/30 px-6 py-16 text-center ring-1 ring-base-300/60">
+                  <p className="mx-auto max-w-[50ch] text-sm text-base-content/60">
+                    Pick someone. Their identity and history come first, then
+                    their threads newest first — the one needing an answer open
+                    with its draft, the rest underneath.
+                  </p>
+                </div>
+              )}
             </div>
           </div>
-
-          <div
-            className={`min-w-0 flex-1 ${selected ? 'block' : 'hidden md:block'}`}
-          >
-            {selected && (
-              <button
-                type="button"
-                onClick={back}
-                className="mb-3 inline-flex min-h-11 cursor-pointer items-center gap-1.5 text-sm font-medium text-base-content/70 hover:text-base-content md:hidden"
-              >
-                <ArrowLeft size={16} /> All of support
-              </button>
-            )}
-
-            {rowsMode === 'person' && person ? (
-              <PersonView
-                person={person}
-                rows={rows}
-                reloadKey={caseKey}
-                openTicket={selectedTicket}
-                onOpenTicket={setSelectedTicket}
-              />
-            ) : rowsMode === 'ticket' && selectedTicket ? (
-              <CaseView ticket={selectedTicket} reloadKey={caseKey} />
-            ) : (
-              <div className="rounded-xl bg-base-200/30 px-6 py-16 text-center ring-1 ring-base-300/60">
-                <p className="mx-auto max-w-[50ch] text-sm text-base-content/60">
-                  Pick someone. Their identity and history come first, then
-                  their threads newest first — the one needing an answer open
-                  with its draft, the rest underneath.
-                </p>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </PageFrame>
   )
 }

--- a/myscrollr.com/src/components/admin/UsersPage.tsx
+++ b/myscrollr.com/src/components/admin/UsersPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { ChevronLeft, Loader2, Search } from 'lucide-react'
+import { PageFrame } from './ui'
 import type { AccountDetail, AccountRow, AccountsPage } from '@/api/admin'
 import { adminApi } from '@/api/admin'
 import { useGetToken } from '@/hooks/useGetToken'
@@ -205,7 +206,11 @@ export default function UsersPage() {
   }, [getToken, query, page])
 
   if (selected) {
-    return <DetailPanel sub={selected} onBack={() => setSelected(null)} />
+    return (
+      <PageFrame>
+        <DetailPanel sub={selected} onBack={() => setSelected(null)} />
+      </PageFrame>
+    )
   }
 
   const pageCount = data ? Math.ceil(data.total / data.page_size) : 0
@@ -214,162 +219,169 @@ export default function UsersPage() {
   const neverSetUp = data ? Math.max(0, data.total - data.set_up) : 0
 
   return (
-    <div className="space-y-5">
-      <header>
-        <h1 className="text-2xl font-bold tracking-tight">Users</h1>
-        {data?.source === 'local' ? (
-          <p className="mt-1 text-sm text-warning">
-            {data.note ?? 'Logto is unreachable.'} Showing{' '}
-            {data.total.toLocaleString()} accounts with local data.
-          </p>
-        ) : (
-          data && (
-            <p className="mt-1 text-sm text-base-content/60">
-              <span className="font-semibold text-base-content">
-                {data.total.toLocaleString()}
-              </span>{' '}
-              {query ? 'accounts match' : 'accounts'}
-              {/* set_up is a count of the whole database, so pairing it with a
-                  filtered total would read as a gap within the search. */}
-              {!query && (
-                <>
-                  {' · '}
-                  <span className="font-semibold text-base-content">
-                    {data.set_up.toLocaleString()}
-                  </span>{' '}
-                  have set up the app ·{' '}
-                  <span className="font-semibold text-warning">
-                    {neverSetUp.toLocaleString()}
-                  </span>{' '}
-                  never did
-                </>
-              )}
+    <PageFrame>
+      <div className="space-y-5">
+        <header>
+          <h1 className="text-2xl font-bold tracking-tight">Users</h1>
+          {data?.source === 'local' ? (
+            <p className="mt-1 text-sm text-warning">
+              {data.note ?? 'Logto is unreachable.'} Showing{' '}
+              {data.total.toLocaleString()} accounts with local data.
             </p>
-          )
-        )}
-        <p className="mt-1 text-sm text-base-content/60">
-          Read-only — this console does not edit anyone&apos;s account.
-        </p>
-      </header>
-
-      <div className="relative">
-        <Search
-          size={16}
-          className="absolute top-1/2 left-3 -translate-y-1/2 text-base-content/40"
-        />
-        <input
-          type="search"
-          value={query}
-          onChange={(e) => {
-            setQuery(e.target.value)
-            setPage(0)
-          }}
-          placeholder="Search by email or username"
-          className="w-full rounded-lg bg-base-200/50 py-2.5 pr-3 pl-9 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
-        />
-      </div>
-
-      {error && <p className="text-sm text-error">{error}</p>}
-      {!data && !error && (
-        <Loader2 className="size-5 animate-spin text-base-content/40" />
-      )}
-
-      {data && (
-        <>
-          <div className="overflow-x-auto rounded-xl ring-1 ring-base-300/60">
-            <table className="w-full min-w-[42rem] text-left text-sm">
-              <thead className="text-xs text-base-content/50 uppercase">
-                <tr className="border-b border-base-300/60">
-                  <th className="p-3 font-semibold">User</th>
-                  <th className="p-3 font-semibold">Plan</th>
-                  <th className="p-3 font-semibold">Widgets</th>
-                  <th className="p-3 font-semibold">Tickets</th>
-                  <th className="p-3 font-semibold">Signed up</th>
-                  <th className="p-3 font-semibold">Last sign-in</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.accounts.length === 0 && (
-                  <tr>
-                    <td
-                      colSpan={6}
-                      className="p-6 text-center text-base-content/50"
-                    >
-                      No accounts match that search.
-                    </td>
-                  </tr>
+          ) : (
+            data && (
+              <p className="mt-1 text-sm text-base-content/60">
+                <span className="font-semibold text-base-content">
+                  {data.total.toLocaleString()}
+                </span>{' '}
+                {query ? 'accounts match' : 'accounts'}
+                {/* set_up is a count of the whole database, so pairing it with a
+                  filtered total would read as a gap within the search. */}
+                {!query && (
+                  <>
+                    {' · '}
+                    <span className="font-semibold text-base-content">
+                      {data.set_up.toLocaleString()}
+                    </span>{' '}
+                    have set up the app ·{' '}
+                    <span className="font-semibold text-warning">
+                      {neverSetUp.toLocaleString()}
+                    </span>{' '}
+                    never did
+                  </>
                 )}
-                {data.accounts.map((a) => (
-                  <tr
-                    key={a.logto_sub}
-                    onClick={() => setSelected(a.logto_sub)}
-                    className="cursor-pointer border-b border-base-300/40 transition-colors last:border-0 hover:bg-base-200/50"
-                  >
-                    <td className="max-w-[18rem] p-3">
-                      <span className="block truncate font-medium">
-                        {a.email ?? a.name ?? '—'}
-                      </span>
-                      <span className="block truncate font-mono text-xs text-base-content/45">
-                        {a.logto_sub}
-                        {!a.set_up && (
-                          <span className="text-warning"> · never set up</span>
-                        )}
-                      </span>
-                    </td>
-                    <td className="p-3 text-base-content/70">{planLabel(a)}</td>
-                    <td className="p-3 tabular-nums">
-                      {a.widgets}
-                      {a.on_ticker > 0 && (
-                        <span className="text-base-content/45">
-                          {' '}
-                          ({a.on_ticker} on bar)
-                        </span>
-                      )}
-                    </td>
-                    <td className="p-3 tabular-nums">{a.tickets}</td>
-                    <td className="p-3 text-base-content/60">
-                      {day(a.signed_up_at)}
-                    </td>
-                    <td className="p-3 text-base-content/60">
-                      {day(a.last_sign_in_at)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <p className="text-xs text-base-content/45">
-            Ordered by Logto; search matches email and username. Widgets and
-            tickets come from this database and cannot be sorted or searched
-            across the whole set — those columns describe only this page.
-          </p>
-
-          {pageCount > 1 && (
-            <div className="flex items-center justify-between text-sm">
-              <button
-                type="button"
-                disabled={page === 0}
-                onClick={() => setPage((p) => p - 1)}
-                className="cursor-pointer rounded-lg px-3 py-1.5 ring-1 ring-base-300 disabled:cursor-default disabled:opacity-40"
-              >
-                Previous
-              </button>
-              <span className="text-base-content/60">
-                Page {page + 1} of {pageCount}
-              </span>
-              <button
-                type="button"
-                disabled={page + 1 >= pageCount}
-                onClick={() => setPage((p) => p + 1)}
-                className="cursor-pointer rounded-lg px-3 py-1.5 ring-1 ring-base-300 disabled:cursor-default disabled:opacity-40"
-              >
-                Next
-              </button>
-            </div>
+              </p>
+            )
           )}
-        </>
-      )}
-    </div>
+          <p className="mt-1 text-sm text-base-content/60">
+            Read-only — this console does not edit anyone&apos;s account.
+          </p>
+        </header>
+
+        <div className="relative">
+          <Search
+            size={16}
+            className="absolute top-1/2 left-3 -translate-y-1/2 text-base-content/40"
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value)
+              setPage(0)
+            }}
+            placeholder="Search by email or username"
+            className="w-full rounded-lg bg-base-200/50 py-2.5 pr-3 pl-9 text-sm ring-1 ring-base-300/60 outline-none focus:ring-primary/50"
+          />
+        </div>
+
+        {error && <p className="text-sm text-error">{error}</p>}
+        {!data && !error && (
+          <Loader2 className="size-5 animate-spin text-base-content/40" />
+        )}
+
+        {data && (
+          <>
+            <div className="overflow-x-auto rounded-xl ring-1 ring-base-300/60">
+              <table className="w-full min-w-[42rem] text-left text-sm">
+                <thead className="text-xs text-base-content/50 uppercase">
+                  <tr className="border-b border-base-300/60">
+                    <th className="p-3 font-semibold">User</th>
+                    <th className="p-3 font-semibold">Plan</th>
+                    <th className="p-3 font-semibold">Widgets</th>
+                    <th className="p-3 font-semibold">Tickets</th>
+                    <th className="p-3 font-semibold">Signed up</th>
+                    <th className="p-3 font-semibold">Last sign-in</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.accounts.length === 0 && (
+                    <tr>
+                      <td
+                        colSpan={6}
+                        className="p-6 text-center text-base-content/50"
+                      >
+                        No accounts match that search.
+                      </td>
+                    </tr>
+                  )}
+                  {data.accounts.map((a) => (
+                    <tr
+                      key={a.logto_sub}
+                      onClick={() => setSelected(a.logto_sub)}
+                      className="cursor-pointer border-b border-base-300/40 transition-colors last:border-0 hover:bg-base-200/50"
+                    >
+                      <td className="max-w-[18rem] p-3">
+                        <span className="block truncate font-medium">
+                          {a.email ?? a.name ?? '—'}
+                        </span>
+                        <span className="block truncate font-mono text-xs text-base-content/45">
+                          {a.logto_sub}
+                          {!a.set_up && (
+                            <span className="text-warning">
+                              {' '}
+                              · never set up
+                            </span>
+                          )}
+                        </span>
+                      </td>
+                      <td className="p-3 text-base-content/70">
+                        {planLabel(a)}
+                      </td>
+                      <td className="p-3 tabular-nums">
+                        {a.widgets}
+                        {a.on_ticker > 0 && (
+                          <span className="text-base-content/45">
+                            {' '}
+                            ({a.on_ticker} on bar)
+                          </span>
+                        )}
+                      </td>
+                      <td className="p-3 tabular-nums">{a.tickets}</td>
+                      <td className="p-3 text-base-content/60">
+                        {day(a.signed_up_at)}
+                      </td>
+                      <td className="p-3 text-base-content/60">
+                        {day(a.last_sign_in_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <p className="text-xs text-base-content/45">
+              Ordered by Logto; search matches email and username. Widgets and
+              tickets come from this database and cannot be sorted or searched
+              across the whole set — those columns describe only this page.
+            </p>
+
+            {pageCount > 1 && (
+              <div className="flex items-center justify-between text-sm">
+                <button
+                  type="button"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => p - 1)}
+                  className="cursor-pointer rounded-lg px-3 py-1.5 ring-1 ring-base-300 disabled:cursor-default disabled:opacity-40"
+                >
+                  Previous
+                </button>
+                <span className="text-base-content/60">
+                  Page {page + 1} of {pageCount}
+                </span>
+                <button
+                  type="button"
+                  disabled={page + 1 >= pageCount}
+                  onClick={() => setPage((p) => p + 1)}
+                  className="cursor-pointer rounded-lg px-3 py-1.5 ring-1 ring-base-300 disabled:cursor-default disabled:opacity-40"
+                >
+                  Next
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </PageFrame>
   )
 }

--- a/myscrollr.com/src/components/admin/VersionsPage.tsx
+++ b/myscrollr.com/src/components/admin/VersionsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { AlertTriangle, Loader2 } from 'lucide-react'
+import { PageFrame } from './ui'
 import type { AdminVersions } from '@/api/admin'
 import { adminApi } from '@/api/admin'
 import { useGetToken } from '@/hooks/useGetToken'
@@ -64,188 +65,197 @@ export default function VersionsPage() {
   useEffect(load, [load])
 
   return (
-    <div className="space-y-6">
-      <header className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Versions</h1>
-          <p className="mt-1 max-w-2xl text-sm text-base-content/60">
-            What the fleet is running, and which builds are erroring. Counted
-            from the app version and OS every request already carries — never
-            from anything on a user's ticker.
+    <PageFrame>
+      <div className="space-y-6">
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Versions</h1>
+            <p className="mt-1 max-w-2xl text-sm text-base-content/60">
+              What the fleet is running, and which builds are erroring. Counted
+              from the app version and OS every request already carries — never
+              from anything on a user's ticker.
+            </p>
+          </div>
+          <div
+            role="group"
+            aria-label="Time window"
+            className="flex shrink-0 rounded-lg ring-1 ring-base-300"
+          >
+            {WINDOWS.map((d) => (
+              <button
+                key={d}
+                type="button"
+                onClick={() => setDays(d)}
+                aria-pressed={days === d}
+                className={`min-h-9 cursor-pointer px-3 text-sm font-medium first:rounded-l-lg last:rounded-r-lg transition-colors ${
+                  days === d
+                    ? 'bg-base-200 text-base-content'
+                    : 'text-base-content/60 hover:bg-base-200/60'
+                }`}
+              >
+                {d}d
+              </button>
+            ))}
+          </div>
+        </header>
+
+        {error && (
+          <p className="rounded-lg bg-error/5 p-3 text-sm text-error ring-1 ring-error/20">
+            {error}
           </p>
-        </div>
-        <div
-          role="group"
-          aria-label="Time window"
-          className="flex shrink-0 rounded-lg ring-1 ring-base-300"
-        >
-          {WINDOWS.map((d) => (
-            <button
-              key={d}
-              type="button"
-              onClick={() => setDays(d)}
-              aria-pressed={days === d}
-              className={`min-h-9 cursor-pointer px-3 text-sm font-medium first:rounded-l-lg last:rounded-r-lg transition-colors ${
-                days === d
-                  ? 'bg-base-200 text-base-content'
-                  : 'text-base-content/60 hover:bg-base-200/60'
-              }`}
-            >
-              {d}d
-            </button>
-          ))}
-        </div>
-      </header>
+        )}
 
-      {error && (
-        <p className="rounded-lg bg-error/5 p-3 text-sm text-error ring-1 ring-error/20">
-          {error}
-        </p>
-      )}
+        {!data && !error && (
+          <div className="flex min-h-[40vh] items-center justify-center">
+            <Loader2 className="size-6 animate-spin text-base-content/40" />
+          </div>
+        )}
 
-      {!data && !error && (
-        <div className="flex min-h-[40vh] items-center justify-center">
-          <Loader2 className="size-6 animate-spin text-base-content/40" />
-        </div>
-      )}
+        {data && data.desktop_total === 0 && (
+          <p className="rounded-xl bg-base-200/40 p-4 text-sm text-base-content/70 ring-1 ring-base-300/60">
+            No desktop requests in the last {data.days} days carried a
+            recognisable Scrollr user agent
+            {data.unrecognized > 0 && (
+              <> (though {num(data.unrecognized)} other requests arrived)</>
+            )}
+            . Installs only start reporting once they have updated to a build
+            that sends one — before then this page is correctly empty rather
+            than wrong.
+          </p>
+        )}
 
-      {data && data.desktop_total === 0 && (
-        <p className="rounded-xl bg-base-200/40 p-4 text-sm text-base-content/70 ring-1 ring-base-300/60">
-          No desktop requests in the last {data.days} days carried a recognisable
-          Scrollr user agent
-          {data.unrecognized > 0 && (
-            <> (though {num(data.unrecognized)} other requests arrived)</>
-          )}
-          . Installs only start reporting once they have updated to a build that
-          sends one — before then this page is correctly empty rather than
-          wrong.
-        </p>
-      )}
-
-      {data && data.desktop_total > 0 && (
-        <>
-          {/* Adoption. The headline is the share on the newest build seen. */}
-          <section className="rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60">
-            <div className="flex flex-wrap items-baseline justify-between gap-2">
-              <h2 className="text-sm font-semibold">Version adoption</h2>
-              <p className="text-xs text-base-content/50">
-                Share of desktop API requests, not of installs — no per-user
-                data is stored.
-              </p>
-            </div>
-            <p className="mt-3 text-3xl font-bold tabular-nums">
-              {pct(data.current_share)}
-            </p>
-            <p className="text-sm text-base-content/60">
-              on {data.current_release}, the newest build calling the API
-            </p>
-
-            <ul className="mt-5 space-y-3">
-              {data.versions.map((v) => (
-                <li key={v.version}>
-                  <div className="flex items-baseline justify-between gap-3 text-sm">
-                    <span className="font-medium tabular-nums">{v.version}</span>
-                    <span className="text-base-content/50 tabular-nums">
-                      {pct(v.share)} · {num(v.requests)} req
-                    </span>
-                  </div>
-                  <div className="mt-1.5">
-                    <Bar share={v.share} tone="bg-primary" />
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <div className="grid gap-6 lg:grid-cols-2">
-            {/* Platform mix. */}
+        {data && data.desktop_total > 0 && (
+          <>
+            {/* Adoption. The headline is the share on the newest build seen. */}
             <section className="rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60">
-              <h2 className="text-sm font-semibold">Platform mix</h2>
-              <ul className="mt-4 space-y-3">
-                {data.platforms.map((p) => (
-                  <li key={p.platform}>
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <h2 className="text-sm font-semibold">Version adoption</h2>
+                <p className="text-xs text-base-content/50">
+                  Share of desktop API requests, not of installs — no per-user
+                  data is stored.
+                </p>
+              </div>
+              <p className="mt-3 text-3xl font-bold tabular-nums">
+                {pct(data.current_share)}
+              </p>
+              <p className="text-sm text-base-content/60">
+                on {data.current_release}, the newest build calling the API
+              </p>
+
+              <ul className="mt-5 space-y-3">
+                {data.versions.map((v) => (
+                  <li key={v.version}>
                     <div className="flex items-baseline justify-between gap-3 text-sm">
-                      <span className="font-medium capitalize">
-                        {p.platform}
+                      <span className="font-medium tabular-nums">
+                        {v.version}
                       </span>
                       <span className="text-base-content/50 tabular-nums">
-                        {pct(p.share)} · {num(p.requests)} req
+                        {pct(v.share)} · {num(v.requests)} req
                       </span>
                     </div>
                     <div className="mt-1.5">
-                      <Bar share={p.share} tone="bg-secondary" />
+                      <Bar share={v.share} tone="bg-primary" />
                     </div>
                   </li>
                 ))}
               </ul>
             </section>
 
-            {/* Error rate by version — the reason the page exists. */}
-            <section className="rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60">
-              <div className="flex flex-wrap items-baseline justify-between gap-2">
-                <h2 className="text-sm font-semibold">Error rate by version</h2>
-                <p className="text-xs text-base-content/50">4xx + 5xx</p>
-              </div>
-              <table className="mt-4 w-full text-sm">
-                <thead>
-                  <tr className="text-left text-xs text-base-content/50">
-                    <th className="pb-2 font-medium">Build</th>
-                    <th className="pb-2 text-right font-medium">4xx</th>
-                    <th className="pb-2 text-right font-medium">5xx</th>
-                    <th className="pb-2 text-right font-medium">Rate</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.versions.map((v) => {
-                    const hot = v.error_rate >= ERROR_RATE_WARN
-                    return (
-                      <tr key={v.version} className="border-t border-base-300/50">
-                        <td className="py-2 font-medium tabular-nums">
-                          {v.version}
-                        </td>
-                        <td className="py-2 text-right tabular-nums text-base-content/60">
-                          {num(v.client_errors)}
-                        </td>
-                        <td className="py-2 text-right tabular-nums text-base-content/60">
-                          {num(v.server_errors)}
-                        </td>
-                        <td
-                          className={`py-2 text-right font-semibold tabular-nums ${
-                            hot ? 'text-error' : 'text-base-content/70'
-                          }`}
-                        >
-                          {hot && (
-                            <AlertTriangle
-                              size={13}
-                              className="mr-1 inline-block align-[-1px]"
-                              aria-hidden
-                            />
-                          )}
-                          {pct(v.error_rate)}
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-              <p className="mt-3 text-xs text-base-content/50">
-                A build erroring well above the others is a build to reproduce
-                on — this is what scopes "some users report X" to a version and
-                an OS.
-              </p>
-            </section>
-          </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              {/* Platform mix. */}
+              <section className="rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60">
+                <h2 className="text-sm font-semibold">Platform mix</h2>
+                <ul className="mt-4 space-y-3">
+                  {data.platforms.map((p) => (
+                    <li key={p.platform}>
+                      <div className="flex items-baseline justify-between gap-3 text-sm">
+                        <span className="font-medium capitalize">
+                          {p.platform}
+                        </span>
+                        <span className="text-base-content/50 tabular-nums">
+                          {pct(p.share)} · {num(p.requests)} req
+                        </span>
+                      </div>
+                      <div className="mt-1.5">
+                        <Bar share={p.share} tone="bg-secondary" />
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
 
-          <p className="text-xs text-base-content/50">
-            {num(data.unrecognized)} request
-            {data.unrecognized === 1 ? '' : 's'} in this window came from
-            something other than a Scrollr build — the website, the extension,
-            uptime probes. Counted separately and excluded from every share
-            above. If this number swallows desktop traffic, the app has stopped
-            sending its user agent.
-          </p>
-        </>
-      )}
-    </div>
+              {/* Error rate by version — the reason the page exists. */}
+              <section className="rounded-xl bg-base-200/40 p-5 ring-1 ring-base-300/60">
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <h2 className="text-sm font-semibold">
+                    Error rate by version
+                  </h2>
+                  <p className="text-xs text-base-content/50">4xx + 5xx</p>
+                </div>
+                <table className="mt-4 w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-xs text-base-content/50">
+                      <th className="pb-2 font-medium">Build</th>
+                      <th className="pb-2 text-right font-medium">4xx</th>
+                      <th className="pb-2 text-right font-medium">5xx</th>
+                      <th className="pb-2 text-right font-medium">Rate</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.versions.map((v) => {
+                      const hot = v.error_rate >= ERROR_RATE_WARN
+                      return (
+                        <tr
+                          key={v.version}
+                          className="border-t border-base-300/50"
+                        >
+                          <td className="py-2 font-medium tabular-nums">
+                            {v.version}
+                          </td>
+                          <td className="py-2 text-right tabular-nums text-base-content/60">
+                            {num(v.client_errors)}
+                          </td>
+                          <td className="py-2 text-right tabular-nums text-base-content/60">
+                            {num(v.server_errors)}
+                          </td>
+                          <td
+                            className={`py-2 text-right font-semibold tabular-nums ${
+                              hot ? 'text-error' : 'text-base-content/70'
+                            }`}
+                          >
+                            {hot && (
+                              <AlertTriangle
+                                size={13}
+                                className="mr-1 inline-block align-[-1px]"
+                                aria-hidden
+                              />
+                            )}
+                            {pct(v.error_rate)}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+                <p className="mt-3 text-xs text-base-content/50">
+                  A build erroring well above the others is a build to reproduce
+                  on — this is what scopes "some users report X" to a version
+                  and an OS.
+                </p>
+              </section>
+            </div>
+
+            <p className="text-xs text-base-content/50">
+              {num(data.unrecognized)} request
+              {data.unrecognized === 1 ? '' : 's'} in this window came from
+              something other than a Scrollr build — the website, the extension,
+              uptime probes. Counted separately and excluded from every share
+              above. If this number swallows desktop traffic, the app has
+              stopped sending its user agent.
+            </p>
+          </>
+        )}
+      </div>
+    </PageFrame>
   )
 }

--- a/myscrollr.com/src/components/admin/ui.tsx
+++ b/myscrollr.com/src/components/admin/ui.tsx
@@ -187,6 +187,21 @@ export const LINK =
   'rounded text-sm font-semibold text-base-content underline decoration-base-content/30 underline-offset-4 hover:decoration-base-content focus-visible:outline-2 focus-visible:outline-primary'
 
 /**
+ * A page's own frame inside the console's full-bleed <main> (SCROLLR-218).
+ *
+ * The shell stopped capping anything when it became a top bar, so a page that
+ * wants a measure asks for one. Overview centres itself at 960 and skips this;
+ * Support keeps it only until SCROLLR-219 gives it the whole <main>.
+ */
+export function PageFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="mx-auto w-full max-w-[1400px] px-6 py-8 lg:px-12">
+      {children}
+    </div>
+  )
+}
+
+/**
  * A card. `label` is the window the numbers describe — "Current" for a now
  * figure, "Last 7 days" for a period one — so a reader never has to guess
  * which of the two a number is.

--- a/myscrollr.com/src/lib/adminFormat.ts
+++ b/myscrollr.com/src/lib/adminFormat.ts
@@ -76,7 +76,8 @@ export function formatAgeWords(seconds: number): string {
   if (seconds < 0) return 'in the future'
   if (seconds < 60) return plural(seconds, 'second') + ' ago'
   if (seconds < 3600) return plural(Math.floor(seconds / 60), 'minute') + ' ago'
-  if (seconds < 86400) return plural(Math.floor(seconds / 3600), 'hour') + ' ago'
+  if (seconds < 86400)
+    return plural(Math.floor(seconds / 3600), 'hour') + ' ago'
   return plural(Math.floor(seconds / 86400), 'day') + ' ago'
 }
 

--- a/myscrollr.com/src/lib/overviewVerdicts.test.ts
+++ b/myscrollr.com/src/lib/overviewVerdicts.test.ts
@@ -36,10 +36,12 @@ describe('verdicts', () => {
   })
 
   it('calls nobody being here quiet, and presence that cannot report grey', () => {
-    expect(only({ presence: { available: true, active_users: 0 } }).right_now)
-      .toEqual({ tone: 'none', label: 'Quiet' })
-    expect(only({ presence: { available: false, active_users: 0 } }).right_now)
-      .toEqual({ tone: 'none', label: 'Not reporting yet' })
+    expect(
+      only({ presence: { available: true, active_users: 0 } }).right_now,
+    ).toEqual({ tone: 'none', label: 'Quiet' })
+    expect(
+      only({ presence: { available: false, active_users: 0 } }).right_now,
+    ).toEqual({ tone: 'none', label: 'Not reporting yet' })
     expect(only({ presence: null }).right_now.tone).toBe('none')
   })
 
@@ -117,14 +119,18 @@ describe('verdicts', () => {
   })
 
   it('gives sports scores half a day and every other feed half an hour', () => {
-    expect(isStale({ table: 'games', age_seconds: 11 * 3600, has_data: true }))
-      .toBe(false)
-    expect(isStale({ table: 'games', age_seconds: 13 * 3600, has_data: true }))
-      .toBe(true)
-    expect(isStale({ table: 'trades', age_seconds: 29 * 60, has_data: true }))
-      .toBe(false)
-    expect(isStale({ table: 'trades', age_seconds: 31 * 60, has_data: true }))
-      .toBe(true)
+    expect(
+      isStale({ table: 'games', age_seconds: 11 * 3600, has_data: true }),
+    ).toBe(false)
+    expect(
+      isStale({ table: 'games', age_seconds: 13 * 3600, has_data: true }),
+    ).toBe(true)
+    expect(
+      isStale({ table: 'trades', age_seconds: 29 * 60, has_data: true }),
+    ).toBe(false)
+    expect(
+      isStale({ table: 'trades', age_seconds: 31 * 60, has_data: true }),
+    ).toBe(true)
     // An empty table is broken, not stale — the age of nothing is not a wait.
     expect(isStale({ table: 'trades', age_seconds: 0, has_data: false })).toBe(
       false,

--- a/myscrollr.com/src/lib/siteChrome.ts
+++ b/myscrollr.com/src/lib/siteChrome.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether the site's own chrome — Header, Footer, consent banner and the 60px
+ * header reservation — wraps a route.
+ *
+ * Only the staff console opts out (SCROLLR-218): it paints its own 48px bar
+ * and owns the full viewport under it. Consent goes with the rest because
+ * SCROLLR-193 made pageview capture public-routes-only, so there is nothing to
+ * consent to on /admin, and a fixed bottom banner would sit on the console's
+ * action row.
+ *
+ * It lives here rather than in `__root.tsx` so a test can assert the rule
+ * without importing the whole root layout (and with it every generated file
+ * the build writes).
+ */
+export function usesSiteChrome(pathname: string): boolean {
+  return !pathname.startsWith('/admin')
+}

--- a/myscrollr.com/src/routes/__root.tsx
+++ b/myscrollr.com/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import {
   createRootRoute,
   useLocation,
 } from '@tanstack/react-router'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { MotionConfig } from 'motion/react'
 import type { ReactNode } from 'react'
 import Header from '@/components/Header'
@@ -16,6 +16,7 @@ import DemoTickerBar from '@/components/DemoTickerBar'
 import AnalyticsConsent from '@/components/AnalyticsConsent'
 import { useDemoTicker } from '@/hooks/useDemoTicker'
 import { captureWebsitePageview } from '@/lib/posthog'
+import { usesSiteChrome } from '@/lib/siteChrome'
 import appCss from '@/styles.css?url'
 
 const themeScript = `;(function () {
@@ -172,6 +173,14 @@ function RootLayout() {
   const { pathname } = useLocation()
   const mainRef = useRef<HTMLElement>(null)
   const isFirstRender = useRef(true)
+  // /admin has no prerendered HTML of its own: nginx serves it the shared
+  // `_shell.html`, which was rendered for `/tss-spa-shell` and therefore
+  // carries the site chrome. Dropping that chrome during the first client
+  // render would be a hydration mismatch, and React answers one by rebuilding
+  // <html> — which throws away the `dark` class the pre-hydration theme script
+  // just put there. So the console's shell takes over one tick later instead.
+  const [hydrated, setHydrated] = useState(false)
+  useEffect(() => setHydrated(true), [])
 
   useEffect(() => {
     captureWebsitePageview(pathname)
@@ -195,6 +204,7 @@ function RootLayout() {
   // layout purposes (padding, header offset, drawer insets) it counts
   // as a bar-having route like any other.
   const hasAnyBar = hasDemoBar || pathname.startsWith('/business')
+  const isConsole = hydrated && !usesSiteChrome(pathname)
   const { theme: demoFamily, density, pos } = useDemoTicker()
 
   // Site-wide theme family: picking a family in MAKE IT YOURS re-skins
@@ -239,23 +249,29 @@ function RootLayout() {
           </a>
 
           {/* Navigation */}
-          <Header hasBar={hasAnyBar} />
+          {!isConsole && <Header hasBar={hasAnyBar} />}
 
-          {/* Reserve the viewport below the 60px header, even while Outlet is empty. */}
+          {/* Reserve the viewport below the 60px header, even while Outlet is
+              empty. The console reserves nothing — AdminChrome's own 48px bar
+              is inside the Outlet. */}
           <main
             ref={mainRef}
             id="main-content"
-            className="relative min-h-[calc(100dvh-60px)]"
+            className={
+              isConsole ? 'relative' : 'relative min-h-[calc(100dvh-60px)]'
+            }
             tabIndex={-1}
           >
             <Outlet />
           </main>
 
           {/* Footer */}
-          <Footer />
-          <ClientOnly>
-            <AnalyticsConsent />
-          </ClientOnly>
+          {!isConsole && <Footer />}
+          {!isConsole && (
+            <ClientOnly>
+              <AnalyticsConsent />
+            </ClientOnly>
+          )}
 
           {/* Persistent demo ticker bar — the brand's connective tissue.
               /business mounts its own white-label variant instead. */}


### PR DESCRIPTION
Link 1 of 3 in the console redesign. [SCROLLR-218](https://linear.app/relentnet/issue/SCROLLR-218). SCROLLR-219 (Support workbench) and SCROLLR-220 (Analytics as questions) build on this and run in parallel once it lands.

`/admin` rendered inside the marketing layout and `AdminChrome` then capped the console at `104rem` with a left nav beside it. At 1440 the Support queue got ~385px; on a 3440 monitor the whole console sat in a column in the middle. Both directions Brandon picked from the canvas assume the console owns its shell. This builds that shell — chrome only, no page content, no gate logic, no `adminApi`.

### What changed

**`__root.tsx`** — on `/admin` there is no `Header`, no `Footer` and no `AnalyticsConsent`, and `<main>` drops the `min-h-[calc(100dvh-60px)]` reservation. The skip link stays.

**Dropping the consent banner was deliberate.** SCROLLR-193 made pageview capture public-routes-only, so no capture runs on `/admin` and there is nothing to consent to; a fixed bottom banner would also cover the console's action row. Nothing about consent on public routes changes — `usesSiteChrome` returns true for every non-`/admin` path, asserted in the new test.

**The swap waits one tick for hydration**, and this is worth a look. `/admin` has no prerendered HTML of its own: nginx serves it the shared `_shell.html`, which was rendered for `/tss-spa-shell` and therefore carries the site chrome. Removing that chrome during the *first* client render is a hydration mismatch, and React answers a root mismatch by rebuilding `<html>` — which throws away the `dark` class the pre-hydration theme script had just put there. Caught by `check-mobile-viewport` (React error #418 plus a light page where dark was asked for). So `isConsole` is gated on a `hydrated` flag and the console's shell takes over on the next tick.

**`AdminChrome`** is now the 48px top bar from the canvas: mint mark + `scrollr.` + `/ admin`, the seven `SECTIONS` as 13px/600 links with an 8px-radius `base-200` pill on the active one (same `exact` logic as before), an optional `status` slot on the right for SCROLLR-219, the staff email at 12px/45%, and `Back to site`. Under 768px the section links become a horizontally scrolling row directly under the bar, full labels, `min-h-11` targets. `<main>` is `min-h-[calc(100dvh-48px)]`, full-bleed, uncapped. The icons left `SECTIONS` with the icon rail.

**`PageFrame`** in `ui.tsx` (`mx-auto w-full max-w-[1400px] px-6 py-8 lg:px-12`) wraps Analytics, Users, Versions, Admins, Settings and — for now — Support. Overview keeps its own 960 measure and picks up `px-4 py-8 sm:px-6 lg:px-12` so it gets the gutters the old shell used to supply; it is otherwise unchanged.

**`check-mobile-viewport.mjs`** no longer clicks `Open menu` on `/admin` (there is no site header to open), and now fails if the marketing header is still rendered there.

The wrapped pages have large diffs: adding one wrapper element re-indents the whole JSX tree. No content moved.

### Verified

`npm ci && npm test && npm run build` — 233 tests pass (8 new), `eslint` clean, build plus all prerender and mobile-viewport checks pass.

Rendered with the fixture harness (temp `/admin-preview` route + `PreviewHarness`, both deleted before this commit), served from this worktree.

| | 1440 | 390 |
|---|---|---|
| Overview | ![](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-218/overview.png) | ![](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-218/overview-390.png) |
| Analytics | ![](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-218/analytics.png) | ![](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-218/analytics-390.png) |
| Support | ![](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-218/support.png) | ![](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-218/support-390.png) |

Gate, no site chrome around it: ![](https://raw.githubusercontent.com/doughknee/myscrollr/captures/scrollr-218/gate-denied.png)

Two honest caveats on the captures. The harness route is `/admin-preview`, so no section reads as active in them — the pill uses the same `exact`/`startsWith` logic as before and is covered by the test, not by a screenshot. And Support is showing its own error state: it is fetch-driven with no props-only variant, so without a staff token there is no queue to draw. The bar, the status slot and the frame around it are what these prove. The `denied` gate copy needs a signed-in non-staff account to reach, so it is asserted in `AdminShell.test.tsx` alongside `signed-out` and `error`; the capture above is the `signed-out` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)